### PR TITLE
Allowing for headless devices to login (this requires some server-side tweaks)

### DIFF
--- a/cli/internal/login/login.go
+++ b/cli/internal/login/login.go
@@ -38,6 +38,7 @@ Usage: turbo login
 	return strings.TrimSpace(helpText)
 }
 
+// This lets us get the preferred local address
 const DEFAULT_HOSTNAME = "127.0.0.1"
 const DEFAULT_PORT = 9789
 
@@ -63,7 +64,8 @@ func (c *LoginCommand) Run(args []string) int {
 		cancel()
 	})
 
-	srv := &http.Server{Addr: "127.0.0.1:9789"}
+	// OK, not sure if we want to be listening on all interfaces in all circumstances - maybe add a check for browser failure?
+	srv := &http.Server{Addr: ":9789"}
 	go func() {
 		if err := srv.ListenAndServe(); err != nil {
 			if err != nil {

--- a/cli/internal/login/login.go
+++ b/cli/internal/login/login.go
@@ -38,7 +38,6 @@ Usage: turbo login
 	return strings.TrimSpace(helpText)
 }
 
-// This lets us get the preferred local address
 const DEFAULT_HOSTNAME = "127.0.0.1"
 const DEFAULT_PORT = 9789
 

--- a/cli/internal/util/browser/open.go
+++ b/cli/internal/util/browser/open.go
@@ -24,7 +24,7 @@ func OpenBrowser(url string) {
 	}
 	if err != nil {
 		var preferredHost = util.GetOutboundIP().String()
-		// Sorry don't know enough Golang to get the logger going
+		// this replaces the default hostname with the preferred outbound ip
 		log.Println("Could not open browser. Please visit:", strings.Replace(url, "127.0.0.1", preferredHost, -1))
 	}
 

--- a/cli/internal/util/browser/open.go
+++ b/cli/internal/util/browser/open.go
@@ -5,6 +5,8 @@ import (
 	"log"
 	"os/exec"
 	"runtime"
+	"strings"
+	"turbo/internal/util"
 )
 
 func OpenBrowser(url string) {
@@ -21,7 +23,9 @@ func OpenBrowser(url string) {
 		err = fmt.Errorf("unsupported platform")
 	}
 	if err != nil {
-		log.Fatal(err)
+		var preferredHost = util.GetOutboundIP().String()
+		// Sorry don't know enough Golang to get the logger going
+		log.Println("Could not open browser. Please visit:", strings.Replace(url, "127.0.0.1", preferredHost, -1))
 	}
 
 }

--- a/cli/internal/util/ip.go
+++ b/cli/internal/util/ip.go
@@ -1,0 +1,20 @@
+// https://stackoverflow.com/questions/23558425/how-do-i-get-the-local-ip-address-in-go
+package util
+
+import (
+	"log"
+	"net"
+)
+
+// Get preferred outbound ip of this machine
+func GetOutboundIP() net.IP {
+	conn, err := net.Dial("udp", "8.8.8.8:80")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer conn.Close()
+
+	localAddr := conn.LocalAddr().(*net.UDPAddr)
+
+	return localAddr.IP
+}


### PR DESCRIPTION
Hey! This PR is a very rough draft for addressing #479. It has some issues, such as not using the proper logger in `open.go`. 

This PR would also expose port 9789 for any device running `turbo login` to all interfaces as well. Therefore, I do not recommend a merge as-is. I am not very good at Golang and therefore created this PR as mostly a reference, as well as a simple workaround for me to use for the time being.

The one catch to this PR's functionality is the fact that there is a server-side check that redirects any `/turborepo/token` string that has an IP address other than `127.0.0.1` as the `redirect_uri` to the getting started page. I'm assuming this is for security, but it breaks the functionality of this PR irreparably. A workaround is to take the URL that the CLI tool spits out and temporarily replacing your local IP with `127.0.0.1` then changing it back to your local IP after the redirect fails upon authorization.

Please let me know your thoughts! Sorry again for the bad Golang \:)