### PR TITLE
Support task globs

### DIFF
--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -797,7 +797,7 @@ func hasGlobMeta(s string) bool {
 	return strings.ContainsAny(s, "*?[{")
 }
 
-// swapColonAndSlash replaces : with / and vice versa, leaving other characters alone
+// swapColonAndSlash replaces : with / and vice versa, leaving other characters alone.
 func swapColonAndSlash(r rune) rune {
 	switch {
 	case r == ':':

--- a/cli/internal/run/run_test.go
+++ b/cli/internal/run/run_test.go
@@ -328,6 +328,9 @@ func TestGetTargetsFromGlobArguments(t *testing.T) {
 		"foxtrot:update":        {},
 		"foxtrot:build":         {},
 		"foxtrot:aaa:update":    {},
+		"foxtrot:aaa:clean":     {},
+		"foxtrot:aaa:456":       {},
+		"foxtrot:123:clean":     {},
 	}
 	tests := []struct {
 		name    string
@@ -382,6 +385,22 @@ func TestGetTargetsFromGlobArguments(t *testing.T) {
 				},
 			},
 			want:    []string{"alpha:bbb:build", "alpha:bbb:check", "alpha:ccc:iii:build", "alpha:ccc:jjj:build", "delta:check", "echo:check", "foxtrot:aaa:update", "foxtrot:update"},
+			wantErr: false,
+		},
+		{
+			name: "handles wildcards, braces, and character class glob targets",
+			args: args{
+				arguments: []string{
+					"alpha:{a*,b*}:check",             // alpha:aaa:check alpha:bbb:check
+					"alpha:ccc:{iii,jjj}:build",       // alpha:ccc:iii:build alpha:ccc:jjj:build
+					"foxtrot:[a-z][a-z][a-z]:[^0-9]*", // foxtrot:aaa:clean foxtrot:aaa:update
+					"beta:a?:update",                  // beta:a*:update
+				},
+				configJson: &fs.TurboConfigJSON{
+					Pipeline: pipelineConfig,
+				},
+			},
+			want:    []string{"alpha:aaa:check", "alpha:bbb:check", "alpha:ccc:iii:build", "alpha:ccc:jjj:build", "beta:a*:update", "foxtrot:aaa:clean", "foxtrot:aaa:update"},
 			wantErr: false,
 		},
 	}

--- a/cli/internal/run/run_test.go
+++ b/cli/internal/run/run_test.go
@@ -307,7 +307,7 @@ func TestGetTargetsFromArguments(t *testing.T) {
 func TestGetTargetsFromGlobArguments(t *testing.T) {
 	type args struct {
 		arguments  []string
-		configJson *fs.TurboConfigJSON
+		configJSON *fs.TurboConfigJSON
 	}
 	pipelineConfig := map[string]fs.TaskDefinition{
 		"alpha:aaa:check":       {},
@@ -349,7 +349,7 @@ func TestGetTargetsFromGlobArguments(t *testing.T) {
 					"beta:a\\*:update", // beta:a*:update
 					"foxtrot:*",        // foxtrot:build foxtrot:update
 				},
-				configJson: &fs.TurboConfigJSON{
+				configJSON: &fs.TurboConfigJSON{
 					Pipeline: pipelineConfig,
 				},
 			},
@@ -364,7 +364,7 @@ func TestGetTargetsFromGlobArguments(t *testing.T) {
 					"alpha:**:update", // alpha:aaa:update alpha:ccc:iii:update
 					"beta:**build",    // no results
 				},
-				configJson: &fs.TurboConfigJSON{
+				configJSON: &fs.TurboConfigJSON{
 					Pipeline: pipelineConfig,
 				},
 			},
@@ -380,7 +380,7 @@ func TestGetTargetsFromGlobArguments(t *testing.T) {
 					"alpha:ccc:**:build", // alpha:ccc:iii:build alpha:ccc:jjj:build
 					"alpha:bbb:*",        // alpha:bbb:build alpha:bbb:check
 				},
-				configJson: &fs.TurboConfigJSON{
+				configJSON: &fs.TurboConfigJSON{
 					Pipeline: pipelineConfig,
 				},
 			},
@@ -396,7 +396,7 @@ func TestGetTargetsFromGlobArguments(t *testing.T) {
 					"foxtrot:[a-z][a-z][a-z]:[^0-9]*", // foxtrot:aaa:clean foxtrot:aaa:update
 					"beta:a?:update",                  // beta:a*:update
 				},
-				configJson: &fs.TurboConfigJSON{
+				configJSON: &fs.TurboConfigJSON{
 					Pipeline: pipelineConfig,
 				},
 			},
@@ -407,7 +407,7 @@ func TestGetTargetsFromGlobArguments(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := getTargetsFromArguments(tt.args.arguments, tt.args.configJson)
+			got, err := getTargetsFromArguments(tt.args.arguments, tt.args.configJSON)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetTargetsFromArguments() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/docs/pages/docs/reference/command-line-reference.mdx
+++ b/docs/pages/docs/reference/command-line-reference.mdx
@@ -75,6 +75,18 @@ Run NPM scripts across all packages in specified scope. Tasks must be specified 
 to the tasks to be executed. Note that these additional arguments will _not_ be passed to
 any additional tasks that are run due to dependencies from the [pipeline](/docs/reference/configuration#pipeline) configuration.
 
+Uses glob patterns via [`doublestar`](https://github.com/bmatcuk/doublestar) under the hood. Specifying multiple glob patterns adds to the result.
+
+##### doublestar globbing patterns
+
+Just a quick overview.
+
+- `*` matches any number of characters, but not `:`
+- `?` matches a single character, but not `:`
+- `:**:` matches any number of characters, including `:`
+- `[class]` matches any single character (but not `:`) in the class of characters (abc or a-z)
+- `{alt1,...}` allows for a comma-separated list of "or" expressions
+
 ### Options
 
 #### `--cache-dir`
@@ -232,7 +244,7 @@ Positive patterns (e.g. `foo` or `*`) add to the results, while negative pattern
 
 Therefore a lone negation (e.g. `['!foo']`) will never match anything – use `['*', '!foo']` instead.
 
-##### Globbing patterns
+##### multimatch globbing patterns
 
 Just a quick overview.
 


### PR DESCRIPTION
Uses the already-in-use [doublestar](https://github.com/bmatcuk/doublestar) library to enable task globbing, supporting most glob features.

Given the following tasks:
```
alpha:aaa:check
alpha:aaa:update
alpha:aaa:build
alpha:bbb:check
alpha:bbb:build
alpha:ccc:iii:update
alpha:ccc:iii:build
alpha:ccc:jjj:check
alpha:ccc:jjj:build
beta:a*:update
beta:a*:build
charlie:ijk:xyz:check
charlie:build
delta:check
echo:check
foxtrot:update
foxtrot:build
foxtrot:aaa:update
foxtrot:aaa:clean
foxtrot:aaa:456
foxtrot:123:clean
```

This PR adds support for the following:
```
$ ... alpha:*:build beta:a\*:update foxtrot:*
# runs: alpha:aaa:build alpha:bbb:build beta:a*:update foxtrot:build foxtrot:update

$ ... *:**:check alpha:**:update
# runs: alpha:aaa:check alpha:aaa:update alpha:bbb:check alpha:ccc:iii:update alpha:ccc:jjj:check charlie:ijk:xyz:check delta:check echo:check

$ ... foxtrot:**:*update *:check alpha:ccc:**:build alpha:bbb:*
# runs: alpha:bbb:build alpha:bbb:check alpha:ccc:iii:build alpha:ccc:jjj:build delta:check echo:check foxtrot:aaa:update foxtrot:update

$ ... alpha:{a*,b*}:check alpha:ccc:{iii,jjj}:build foxtrot:[a-z][a-z][a-z]:[^0-9]* beta:a?:update
# runs: alpha:aaa:check alpha:bbb:check alpha:ccc:iii:build alpha:ccc:jjj:build beta:a*:update foxtrot:aaa:clean foxtrot:aaa:update
```

Closes: #1029 