### PR TITLE
Prune tasks that don't have the specified command

### DIFF
--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -235,7 +235,7 @@ func (c *RunCommand) runOperation(g *completeGraph, rs *runSpec, packageManager 
 		vertexSet.Add(v)
 	}
 
-	engine, err := buildTaskGraph(&g.TopologicalGraph, g.Pipeline, rs)
+	engine, err := buildTaskGraph(&g.TopologicalGraph, g.Pipeline, rs, g.PackageInfos)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error preparing engine: %s", err))
 		return 1
@@ -256,7 +256,7 @@ func (c *RunCommand) runOperation(g *completeGraph, rs *runSpec, packageManager 
 				g.TopologicalGraph.RemoveEdge(edge)
 			}
 		}
-		engine, err = buildTaskGraph(&g.TopologicalGraph, g.Pipeline, rs)
+		engine, err = buildTaskGraph(&g.TopologicalGraph, g.Pipeline, rs, g.PackageInfos)
 		if err != nil {
 			c.Ui.Error(fmt.Sprintf("Error preparing engine: %s", err))
 			return 1
@@ -334,8 +334,8 @@ func (c *RunCommand) runOperation(g *completeGraph, rs *runSpec, packageManager 
 	return exitCode
 }
 
-func buildTaskGraph(topoGraph *dag.AcyclicGraph, pipeline fs.Pipeline, rs *runSpec) (*core.Scheduler, error) {
-	engine := core.NewScheduler(topoGraph)
+func buildTaskGraph(topoGraph *dag.AcyclicGraph, pipeline fs.Pipeline, rs *runSpec, packageInfos map[interface{}]*fs.PackageJSON) (*core.Scheduler, error) {
+	engine := core.NewScheduler(topoGraph, packageInfos)
 	for taskName, taskDefinition := range pipeline {
 		topoDeps := make(util.Set)
 		deps := make(util.Set)

--- a/cli/internal/run/run_test.go
+++ b/cli/internal/run/run_test.go
@@ -330,7 +330,14 @@ func Test_dontSquashTasks(t *testing.T) {
 		Targets:      []string{"build"},
 		Opts:         &RunOptions{},
 	}
-	engine, err := buildTaskGraph(topoGraph, pipeline, rs)
+	engine, err := buildTaskGraph(topoGraph, pipeline, rs, map[interface{}]*fs.PackageJSON{
+		"a": {
+			Scripts: map[string]string{"build": "build-command", "generate": "generate-command"},
+		},
+		"b": {
+			Scripts: map[string]string{"build": "build-command", "generate": "generate-command"},
+		},
+	})
 	if err != nil {
 		t.Fatalf("failed to build task graph: %v", err)
 	}
@@ -363,7 +370,11 @@ func Test_taskSelfRef(t *testing.T) {
 		Targets:      []string{"build"},
 		Opts:         &RunOptions{},
 	}
-	_, err := buildTaskGraph(topoGraph, pipeline, rs)
+	_, err := buildTaskGraph(topoGraph, pipeline, rs, map[interface{}]*fs.PackageJSON{
+		"a": {
+			Scripts: map[string]string{"build": "build-command"},
+		},
+	})
 	if err == nil {
 		t.Fatalf("expected to failed to build task graph: %v", err)
 	}


### PR DESCRIPTION
With this change, `turbo` will no longer schedule tasks for which no `scripts` entry exists. This includes not scheduling dependencies of those tasks.

Note that this is a breaking change. Some tasks that are run currently (dependencies of non-existent tasks) will no longer be run. The workaround is to add no-op scripts to packages to opt into the old behavior.

Fixes #937 