### PR TITLE
Closes #1476 : Change config parser to be aware of `--`

### DIFF
--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -138,7 +138,9 @@ func ParseAndValidate(args []string, ui cli.Ui, turboVersion string) (c *Config,
 	// Process arguments looking for `-v` flags to control the log level.
 	// This overrides whatever the env var set.
 	for _, arg := range args {
-		if len(arg) != 0 && arg[0] != '-' {
+		if arg == "--" {
+			break
+		} else if len(arg) != 0 && arg[0] != '-' {
 			continue
 		}
 		switch {


### PR DESCRIPTION
This will change args for loop to be aware of -- (ignore-option), ignoring parsing of all parameters after that.