### PR TITLE
Corepack less strict

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -2,6 +2,7 @@ name: CI Go
 
 env:
   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+  COREPACK_ENABLE_STRICT: 0
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci-js.yml
+++ b/.github/workflows/ci-js.yml
@@ -6,6 +6,7 @@ concurrency:
 
 env:
   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+  COREPACK_ENABLE_STRICT: 0
 
 on:
   push:

--- a/.github/workflows/large-monorepo.yml
+++ b/.github/workflows/large-monorepo.yml
@@ -1,5 +1,8 @@
 name: Large Repo Benchmark
 
+env:
+  COREPACK_ENABLE_STRICT: 0
+
 on:
   workflow_dispatch:
   workflow_run:

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -67,7 +67,7 @@ install: | ./package.json
 	pnpm install --filter=cli
 
 corepack:
-	which corepack || npm install -g corepack@latest
+	npm install -g corepack@latest
 	corepack enable
 
 e2e: corepack install turbo

--- a/packages/create-turbo/__tests__/cli.test.ts
+++ b/packages/create-turbo/__tests__/cli.test.ts
@@ -95,7 +95,7 @@ describe("create-turbo cli", () => {
       1000 * 30
     );
 
-    it.concurrent.each(Object.values(PACKAGE_MANAGERS).flat())(
+    it.each(Object.values(PACKAGE_MANAGERS).flat())(
       `--use-$command: guides the user through the process ($name)`,
       async (packageManager) => {
         configurePackageManager(packageManager);
@@ -176,7 +176,7 @@ describe("create-turbo cli", () => {
       1000 * 60 * 5
     );
 
-    it.concurrent.each(Object.values(PACKAGE_MANAGERS).flat())(
+    it.each(Object.values(PACKAGE_MANAGERS).flat())(
       `--use-$command ($name)`,
       async (packageManager) => {
         configurePackageManager(packageManager);


### PR DESCRIPTION
Adopt `COREPACK_ENABLE_STRICT=0` for CI since we regularly toggle between package managers in our tests.