### PR TITLE
use `workspace:` protocol explicitly to avoid pnpm vs. npm confusion

### DIFF
--- a/examples/basic/apps/docs/package.json
+++ b/examples/basic/apps/docs/package.json
@@ -12,15 +12,15 @@
     "next": "latest",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "ui": "*"
+    "ui": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "^17.0.12",
     "@types/react": "^17.0.37",
     "@types/react-dom": "^17.0.11",
-    "eslint-config-custom": "*",
+    "eslint-config-custom": "workspace:*",
     "next-transpile-modules": "^9.0.0",
-    "tsconfig": "*",
+    "tsconfig": "workspace:*",
     "typescript": "^4.5.3"
   }
 }

--- a/examples/basic/apps/web/package.json
+++ b/examples/basic/apps/web/package.json
@@ -12,15 +12,15 @@
     "next": "latest",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "ui": "*"
+    "ui": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "^17.0.12",
     "@types/react": "^17.0.37",
     "@types/react-dom": "^17.0.11",
-    "eslint-config-custom": "*",
+    "eslint-config-custom": "workspace:*",
     "next-transpile-modules": "^9.0.0",
-    "tsconfig": "*",
+    "tsconfig": "workspace:*",
     "typescript": "^4.5.3"
   }
 }

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "eslint": "^7.32.0",
-    "eslint-config-custom": "*",
+    "eslint-config-custom": "workspace:*",
     "prettier": "^2.5.1",
     "turbo": "latest"
   }

--- a/examples/basic/packages/ui/package.json
+++ b/examples/basic/packages/ui/package.json
@@ -11,9 +11,9 @@
     "@types/react": "^17.0.37",
     "@types/react-dom": "^17.0.11",
     "eslint": "^7.32.0",
-    "eslint-config-custom": "*",
+    "eslint-config-custom": "workspace:*",
     "react": "^17.0.2",
-    "tsconfig": "*",
+    "tsconfig": "workspace:*",
     "typescript": "^4.5.2"
   }
 }

--- a/examples/design-system/apps/docs/package.json
+++ b/examples/design-system/apps/docs/package.json
@@ -9,12 +9,12 @@
     "clean": "rm -rf .turbo && rm -rf node_modules"
   },
   "dependencies": {
-    "@acme/core": "*",
+    "@acme/core": "workspace:*",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
   },
   "devDependencies": {
-    "@acme/tsconfig": "*",
+    "@acme/tsconfig": "workspace:*",
     "@storybook/addon-actions": "^6.4.18",
     "@storybook/addon-docs": "^6.4.22",
     "@storybook/addon-essentials": "^6.4.18",
@@ -22,7 +22,7 @@
     "@storybook/builder-vite": "^0.1.33",
     "@storybook/react": "^6.4.18",
     "@vitejs/plugin-react": "^1.3.2",
-    "eslint-config-acme": "*",
+    "eslint-config-acme": "workspace:*",
     "serve": "^13.0.2",
     "typescript": "^4.5.4",
     "vite": "^2.9.9"

--- a/examples/design-system/package.json
+++ b/examples/design-system/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@changesets/cli": "^2.22.0",
     "eslint": "^8.15.0",
-    "eslint-config-acme": "*",
+    "eslint-config-acme": "workspace:*",
     "prettier": "^2.5.1",
     "turbo": "latest"
   }

--- a/examples/design-system/packages/acme-core/package.json
+++ b/examples/design-system/packages/acme-core/package.json
@@ -16,11 +16,11 @@
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist"
   },
   "devDependencies": {
-    "@acme/tsconfig": "*",
+    "@acme/tsconfig": "workspace:*",
     "@types/react": "^18.0.9",
     "@types/react-dom": "^18.0.4",
     "eslint": "^8.15.0",
-    "eslint-config-acme": "*",
+    "eslint-config-acme": "workspace:*",
     "react": "^18.1.0",
     "tsup": "^5.10.1",
     "typescript": "^4.5.3"

--- a/examples/design-system/packages/acme-utils/package.json
+++ b/examples/design-system/packages/acme-utils/package.json
@@ -16,11 +16,11 @@
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist"
   },
   "devDependencies": {
-    "@acme/tsconfig": "*",
+    "@acme/tsconfig": "workspace:*",
     "@types/react": "^18.0.9",
     "@types/react-dom": "^18.0.4",
     "eslint": "^8.15.0",
-    "eslint-config-acme": "*",
+    "eslint-config-acme": "workspace:*",
     "react": "^18.1.0",
     "tsup": "^5.10.1",
     "typescript": "^4.5.3"

--- a/examples/kitchen-sink/apps/admin/package.json
+++ b/examples/kitchen-sink/apps/admin/package.json
@@ -12,15 +12,15 @@
   "dependencies": {
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "ui": "*"
+    "ui": "workspace:*"
   },
   "devDependencies": {
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
     "@vitejs/plugin-react": "^2.1.0",
     "eslint": "^7.32.0",
-    "eslint-config-custom": "*",
-    "tsconfig": "*",
+    "eslint-config-custom": "workspace:*",
+    "tsconfig": "workspace:*",
     "typescript": "^4.8.3",
     "vite": "^3.1.0"
   }

--- a/examples/kitchen-sink/apps/api/package.json
+++ b/examples/kitchen-sink/apps/api/package.json
@@ -17,7 +17,7 @@
     "body-parser": "^1.19.0",
     "cors": "^2.8.5",
     "express": "^4.17.1",
-    "logger": "*",
+    "logger": "workspace:*",
     "morgan": "^1.10.0"
   },
   "devDependencies": {
@@ -29,11 +29,11 @@
     "@types/node": "^15.12.2",
     "@types/supertest": "^2.0.12",
     "eslint": "^7.32.0",
-    "eslint-config-custom-server": "*",
+    "eslint-config-custom-server": "workspace:*",
     "jest": "^26.6.3",
-    "jest-presets": "*",
+    "jest-presets": "workspace:*",
     "supertest": "^6.2.4",
-    "tsconfig": "*",
+    "tsconfig": "workspace:*",
     "tsup": "^6.2.3",
     "typescript": "^4.8.3"
   }

--- a/examples/kitchen-sink/apps/blog/package.json
+++ b/examples/kitchen-sink/apps/blog/package.json
@@ -15,14 +15,14 @@
     "@vercel/node": "^2.5.14",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "ui": "*"
+    "ui": "workspace:*"
   },
   "devDependencies": {
     "@remix-run/dev": "^1.7.0",
     "@remix-run/serve": "^1.7.0",
     "@types/react": "^17.0.47",
     "@types/react-dom": "^17.0.17",
-    "tsconfig": "*",
+    "tsconfig": "workspace:*",
     "typescript": "^4.8.3"
   },
   "engines": {

--- a/examples/kitchen-sink/apps/storefront/package.json
+++ b/examples/kitchen-sink/apps/storefront/package.json
@@ -10,19 +10,19 @@
     "start": "next start "
   },
   "dependencies": {
-    "logger": "*",
+    "logger": "workspace:*",
     "next": "^12.3.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "ui": "*"
+    "ui": "workspace:*"
   },
   "devDependencies": {
     "@types/jest": "^26.0.22",
     "@types/node": "^17.0.12",
     "@types/react": "^17.0.13",
     "@types/react-dom": "^17.0.8",
-    "eslint-config-custom": "*",
-    "tsconfig": "*",
+    "eslint-config-custom": "workspace:*",
+    "tsconfig": "workspace:*",
     "typescript": "^4.8.3"
   }
 }

--- a/examples/kitchen-sink/packages/logger/package.json
+++ b/examples/kitchen-sink/packages/logger/package.json
@@ -21,10 +21,10 @@
   "devDependencies": {
     "@types/jest": "^26.0.22",
     "eslint": "^7.32.0",
-    "eslint-config-custom": "*",
+    "eslint-config-custom": "workspace:*",
     "jest": "^26.6.3",
-    "jest-presets": "*",
-    "tsconfig": "*",
+    "jest-presets": "workspace:*",
+    "tsconfig": "workspace:*",
     "typescript": "^4.8.3"
   }
 }

--- a/examples/kitchen-sink/packages/ui/package.json
+++ b/examples/kitchen-sink/packages/ui/package.json
@@ -25,11 +25,11 @@
     "@types/react": "^17.0.13",
     "@types/react-dom": "^17.0.8",
     "eslint": "^7.32.0",
-    "eslint-config-custom": "*",
+    "eslint-config-custom": "workspace:*",
     "jest": "^26.6.3",
-    "jest-presets": "*",
+    "jest-presets": "workspace:*",
     "react": "^17.0.2",
-    "tsconfig": "*",
+    "tsconfig": "workspace:*",
     "tsup": "^6.2.3",
     "typescript": "^4.8.3"
   }

--- a/examples/with-changesets/apps/docs/package.json
+++ b/examples/with-changesets/apps/docs/package.json
@@ -10,18 +10,18 @@
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf .next"
   },
   "dependencies": {
-    "@acme/core": "*",
-    "@acme/utils": "*",
+    "@acme/core": "workspace:*",
+    "@acme/utils": "workspace:*",
     "next": "^12.0.8",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
-    "@acme/tsconfig": "*",
+    "@acme/tsconfig": "workspace:*",
     "@types/node": "^17.0.12",
     "@types/react": "^17.0.37",
     "@types/react-dom": "^17.0.11",
-    "eslint-preset-acme": "*",
+    "eslint-preset-acme": "workspace:*",
     "typescript": "^4.5.4"
   }
 }

--- a/examples/with-changesets/package.json
+++ b/examples/with-changesets/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@changesets/cli": "^2.22.0",
     "eslint": "^7.32.0",
-    "eslint-config-acme": "*",
+    "eslint-config-acme": "workspace:*",
     "prettier": "^2.5.1",
     "turbo": "latest"
   }

--- a/examples/with-changesets/packages/acme-core/package.json
+++ b/examples/with-changesets/packages/acme-core/package.json
@@ -16,9 +16,9 @@
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist"
   },
   "devDependencies": {
-    "@acme/tsconfig": "*",
+    "@acme/tsconfig": "workspace:*",
     "eslint": "^7.32.0",
-    "eslint-config-acme": "*",
+    "eslint-config-acme": "workspace:*",
     "@types/react": "^17.0.13",
     "@types/react-dom": "^17.0.8",
     "react": "^17.0.2",

--- a/examples/with-changesets/packages/acme-utils/package.json
+++ b/examples/with-changesets/packages/acme-utils/package.json
@@ -16,11 +16,11 @@
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist"
   },
   "devDependencies": {
-    "@acme/tsconfig": "*",
+    "@acme/tsconfig": "workspace:*",
     "@types/react": "^17.0.13",
     "@types/react-dom": "^17.0.8",
     "eslint": "^7.32.0",
-    "eslint-config-acme": "*",
+    "eslint-config-acme": "workspace:*",
     "react": "^17.0.2",
     "tsup": "^5.10.1",
     "typescript": "^4.5.3"

--- a/examples/with-create-react-app/apps/docs/package.json
+++ b/examples/with-create-react-app/apps/docs/package.json
@@ -12,7 +12,7 @@
     "clean": "rm -rf build"
   },
   "dependencies": {
-    "ui": "*",
+    "ui": "workspace:*",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-scripts": "5.0.0",
@@ -26,7 +26,7 @@
     "@types/node": "^16.11.14",
     "@types/react": "^17.0.37",
     "@types/react-dom": "^17.0.11",
-    "tsconfig": "*",
+    "tsconfig": "workspace:*",
     "typescript": "^4.5.4"
   },
   "eslintConfig": {

--- a/examples/with-create-react-app/apps/web/package.json
+++ b/examples/with-create-react-app/apps/web/package.json
@@ -12,7 +12,7 @@
     "clean": "rm -rf build"
   },
   "dependencies": {
-    "ui": "*",
+    "ui": "workspace:*",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-scripts": "5.0.0",
@@ -26,7 +26,7 @@
     "@types/node": "^16.11.14",
     "@types/react": "^17.0.37",
     "@types/react-dom": "^17.0.11",
-    "tsconfig": "*",
+    "tsconfig": "workspace:*",
     "typescript": "^4.5.4"
   },
   "eslintConfig": {

--- a/examples/with-create-react-app/packages/ui/package.json
+++ b/examples/with-create-react-app/packages/ui/package.json
@@ -16,9 +16,9 @@
     "@types/react": "^17.0.13",
     "@types/react-dom": "^17.0.8",
     "eslint": "^8.4.1",
-    "eslint-config-custom": "*",
+    "eslint-config-custom": "workspace:*",
     "react": "^17.0.2",
-    "tsconfig": "*",
+    "tsconfig": "workspace:*",
     "tsup": "^5.10.1",
     "typescript": "^4.5.3"
   }

--- a/examples/with-docker/apps/api/package.json
+++ b/examples/with-docker/apps/api/package.json
@@ -17,7 +17,7 @@
     "body-parser": "^1.19.0",
     "cors": "^2.8.5",
     "express": "^4.17.1",
-    "logger": "*",
+    "logger": "workspace:*",
     "morgan": "^1.10.0"
   },
   "devDependencies": {
@@ -31,12 +31,12 @@
     "esbuild": "^0.14.38",
     "esbuild-register": "^3.3.2",
     "eslint": "^7.32.0",
-    "eslint-config-custom-server": "*",
+    "eslint-config-custom-server": "workspace:*",
     "jest": "^26.6.3",
-    "jest-presets": "*",
+    "jest-presets": "workspace:*",
     "nodemon": "^2.0.15",
     "supertest": "^6.1.3",
-    "tsconfig": "*",
+    "tsconfig": "workspace:*",
     "typescript": "^4.5.3"
   }
 }

--- a/examples/with-docker/apps/web/package.json
+++ b/examples/with-docker/apps/web/package.json
@@ -12,15 +12,15 @@
     "next": "latest",
     "react": "17.0.2",
     "react-dom": "17.0.2",
-    "ui": "*"
+    "ui": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "^17.0.12",
     "@types/react": "17.0.37",
     "eslint": "7.32.0",
-    "eslint-config-custom": "*",
+    "eslint-config-custom": "workspace:*",
     "next-transpile-modules": "9.0.0",
-    "tsconfig": "*",
+    "tsconfig": "workspace:*",
     "typescript": "^4.5.3"
   }
 }

--- a/examples/with-docker/package.json
+++ b/examples/with-docker/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "eslint-config-custom": "*",
+    "eslint-config-custom": "workspace:*",
     "prettier": "latest",
     "turbo": "latest"
   },

--- a/examples/with-docker/packages/logger/package.json
+++ b/examples/with-docker/packages/logger/package.json
@@ -21,10 +21,10 @@
   "devDependencies": {
     "@types/jest": "^26.0.22",
     "eslint": "^7.32.0",
-    "eslint-config-custom": "*",
+    "eslint-config-custom": "workspace:*",
     "jest": "^26.6.3",
-    "jest-presets": "*",
-    "tsconfig": "*",
+    "jest-presets": "workspace:*",
+    "tsconfig": "workspace:*",
     "typescript": "^4.5.3"
   }
 }

--- a/examples/with-docker/packages/ui/package.json
+++ b/examples/with-docker/packages/ui/package.json
@@ -11,9 +11,9 @@
     "@types/react": "^17.0.37",
     "@types/react-dom": "^17.0.11",
     "eslint": "^7.32.0",
-    "eslint-config-custom": "*",
+    "eslint-config-custom": "workspace:*",
     "react": "^17.0.2",
-    "tsconfig": "*",
+    "tsconfig": "workspace:*",
     "typescript": "^4.5.2"
   }
 }

--- a/examples/with-prisma/apps/web/package.json
+++ b/examples/with-prisma/apps/web/package.json
@@ -17,10 +17,10 @@
     "@types/node": "^17.0.12",
     "@types/react": "^17.0.37",
     "@types/react-dom": "^17.0.11",
-    "config": "*",
-    "database": "*",
+    "config": "workspace:*",
+    "database": "workspace:*",
     "eslint": "^7.32.0",
-    "tsconfig": "*",
+    "tsconfig": "workspace:*",
     "typescript": "^4.5.3"
   }
 }

--- a/examples/with-prisma/packages/database/package.json
+++ b/examples/with-prisma/packages/database/package.json
@@ -27,11 +27,11 @@
     "@prisma/client": "^3.10.0"
   },
   "devDependencies": {
-    "config": "*",
+    "config": "workspace:*",
     "eslint": "^8.12.0",
     "prisma": "^3.10.0",
     "rimraf": "^3.0.2",
-    "tsconfig": "*",
+    "tsconfig": "workspace:*",
     "tsup": "^5.11.13",
     "tsx": "^3.7.1",
     "typescript": "^4.5.5"

--- a/examples/with-react-native-web/apps/native/package.json
+++ b/examples/with-react-native-web/apps/native/package.json
@@ -17,7 +17,7 @@
     "react-dom": "17.0.2",
     "react-native": "0.68.2",
     "react-native-web": "0.17.7",
-    "ui": "*"
+    "ui": "workspace:*"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",

--- a/examples/with-react-native-web/apps/web/package.json
+++ b/examples/with-react-native-web/apps/web/package.json
@@ -13,7 +13,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-native-web": "^0.18.4",
-    "ui": "*"
+    "ui": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "^17.0.12",
@@ -21,7 +21,7 @@
     "@types/react-dom": "^17.0.11",
     "babel-plugin-react-native-web": "^0.18.4",
     "eslint": "^8.19.0",
-    "tsconfig": "*",
+    "tsconfig": "workspace:*",
     "typescript": "^4.7.4"
   }
 }

--- a/examples/with-react-native-web/packages/ui/package.json
+++ b/examples/with-react-native-web/packages/ui/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@types/react": "^18.0.14",
     "@types/react-native": "^0.67.7",
-    "tsconfig": "*",
+    "tsconfig": "workspace:*",
     "tsup": "^6.0.1",
     "typescript": "^4.7.4"
   },

--- a/examples/with-svelte/apps/docs/package.json
+++ b/examples/with-svelte/apps/docs/package.json
@@ -13,12 +13,12 @@
     "format": "prettier --write --ignore-path=../../.prettierignore ."
   },
   "dependencies": {
-    "ui": "*"
+    "ui": "workspace:*"
   },
   "devDependencies": {
     "@sveltejs/adapter-auto": "latest",
     "@sveltejs/kit": "latest",
-    "eslint-config-custom": "*",
+    "eslint-config-custom": "workspace:*",
     "svelte": "^3.44.0",
     "svelte-check": "^2.7.1",
     "svelte-preprocess": "^4.10.6",

--- a/examples/with-svelte/apps/web/package.json
+++ b/examples/with-svelte/apps/web/package.json
@@ -13,12 +13,12 @@
     "format": "prettier --write --ignore-path=../../.prettierignore ."
   },
   "dependencies": {
-    "ui": "*"
+    "ui": "workspace:*"
   },
   "devDependencies": {
     "@sveltejs/adapter-auto": "latest",
     "@sveltejs/kit": "latest",
-    "eslint-config-custom": "*",
+    "eslint-config-custom": "workspace:*",
     "svelte": "^3.44.0",
     "svelte-check": "^2.7.1",
     "svelte-preprocess": "^4.10.6",

--- a/examples/with-svelte/package.json
+++ b/examples/with-svelte/package.json
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "eslint": "^8.0.0",
-    "eslint-config-custom": "*",
+    "eslint-config-custom": "workspace:*",
     "prettier": "^2.7.1",
     "prettier-plugin-svelte": "^2.7.0",
     "turbo": "latest"

--- a/examples/with-svelte/packages/ui/package.json
+++ b/examples/with-svelte/packages/ui/package.json
@@ -11,7 +11,7 @@
     "format": "prettier --write --ignore-path=../../.prettierignore ."
   },
   "devDependencies": {
-    "eslint-config-custom": "*",
+    "eslint-config-custom": "workspace:*",
     "svelte": "^3.9.2"
   }
 }

--- a/examples/with-tailwind/apps/docs/package.json
+++ b/examples/with-tailwind/apps/docs/package.json
@@ -12,18 +12,18 @@
     "next": "latest",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "ui": "*"
+    "ui": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "^17.0.12",
     "@types/react": "^17.0.37",
     "@types/react-dom": "^17.0.11",
     "autoprefixer": "^10.4.0",
-    "eslint-config-custom": "*",
+    "eslint-config-custom": "workspace:*",
     "postcss": "^8.4.4",
-    "tailwind-config": "*",
+    "tailwind-config": "workspace:*",
     "tailwindcss": "^3.0.0",
-    "tsconfig": "*",
+    "tsconfig": "workspace:*",
     "typescript": "^4.5.3"
   }
 }

--- a/examples/with-tailwind/apps/web/package.json
+++ b/examples/with-tailwind/apps/web/package.json
@@ -12,18 +12,18 @@
     "next": "latest",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "ui": "*"
+    "ui": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "^17.0.12",
     "@types/react": "^17.0.37",
     "@types/react-dom": "^17.0.11",
     "autoprefixer": "^10.4.0",
-    "eslint-config-custom": "*",
+    "eslint-config-custom": "workspace:*",
     "postcss": "^8.4.4",
-    "tailwind-config": "*",
+    "tailwind-config": "workspace:*",
     "tailwindcss": "^3.0.0",
-    "tsconfig": "*",
+    "tsconfig": "workspace:*",
     "typescript": "^4.5.3"
   }
 }

--- a/examples/with-tailwind/package.json
+++ b/examples/with-tailwind/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "eslint": "^7.32.0",
-    "eslint-config-custom": "*",
+    "eslint-config-custom": "workspace:*",
     "prettier": "^2.7.1",
     "prettier-plugin-tailwindcss": "^0.1.11",
     "turbo": "latest"

--- a/examples/with-tailwind/packages/ui/package.json
+++ b/examples/with-tailwind/packages/ui/package.json
@@ -18,11 +18,11 @@
     "@types/react-dom": "^17.0.11",
     "concurrently": "^7.2.2",
     "eslint": "^7.32.0",
-    "eslint-config-custom": "*",
+    "eslint-config-custom": "workspace:*",
     "react": "^17.0.2",
-    "tailwind-config": "*",
+    "tailwind-config": "workspace:*",
     "tailwindcss": "^3.1.5",
-    "tsconfig": "*",
+    "tsconfig": "workspace:",
     "tsup": "^6.1.3",
     "typescript": "^4.5.2"
   }

--- a/examples/with-vite/apps/docs/package.json
+++ b/examples/with-vite/apps/docs/package.json
@@ -10,12 +10,12 @@
     "lint": "eslint src/**/*.ts"
   },
   "dependencies": {
-    "ui": "*"
+    "ui": "workspace:*"
   },
   "devDependencies": {
     "eslint": "^7.32.0",
-    "eslint-config-custom": "*",
-    "tsconfig": "*",
+    "eslint-config-custom": "workspace:*",
+    "tsconfig": "workspace:*",
     "typescript": "^4.6.4",
     "vite": "^3.0.0"
   }

--- a/examples/with-vite/apps/web/package.json
+++ b/examples/with-vite/apps/web/package.json
@@ -10,12 +10,12 @@
     "lint": "eslint src/**/*.ts"
   },
   "dependencies": {
-    "ui": "*"
+    "ui": "workspace:"
   },
   "devDependencies": {
     "eslint": "^7.32.0",
-    "eslint-config-custom": "*",
-    "tsconfig": "*",
+    "eslint-config-custom": "workspace:*",
+    "tsconfig": "workspace:*",
     "typescript": "^4.6.4",
     "vite": "^3.0.0"
   }

--- a/examples/with-vite/package.json
+++ b/examples/with-vite/package.json
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "eslint": "^7.32.0",
-    "eslint-config-custom": "*",
+    "eslint-config-custom": "workspace:*",
     "prettier": "^2.5.1",
     "turbo": "latest"
   }

--- a/examples/with-vite/packages/ui/package.json
+++ b/examples/with-vite/packages/ui/package.json
@@ -9,8 +9,8 @@
   },
   "devDependencies": {
     "eslint": "^7.32.0",
-    "eslint-config-custom": "*",
-    "tsconfig": "*",
+    "eslint-config-custom": "workspace:*",
+    "tsconfig": "workspace:*",
     "typescript": "^4.5.2"
   }
 }


### PR DESCRIPTION
pnpm [requires the `workspace:` protocol explicitly](https://github.com/vercel/turborepo/pull/2105#issue-1389488199). 

Since this protocol is compatible with npm as well, I'm wondering if it's a good idea to just use this protocal explicitly everywhere?

This makes it easier to reuse some npm-written examples in a pnpm context as well. 