### PR TITLE
Sync example Dockerfile from `with-docker` example

### DIFF
--- a/docs/pages/docs/handbook/deploying-with-docker.mdx
+++ b/docs/pages/docs/handbook/deploying-with-docker.mdx
@@ -112,6 +112,8 @@ Our detailed [`with-docker` example](https://github.com/vercel/turborepo/tree/ma
 
 ```docker
 FROM node:alpine AS builder
+# Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
+RUN apk add --no-cache libc6-compat
 RUN apk update
 # Set working directory
 WORKDIR /app
@@ -146,7 +148,7 @@ USER nextjs
 COPY --from=installer /app/apps/web/next.config.js .
 COPY --from=installer /app/apps/web/package.json .
 
-# Automatically leverage output traces to reduce image size
+# Automatically leverage output traces to reduce image size 
 # https://nextjs.org/docs/advanced-features/output-file-tracing
 COPY --from=installer --chown=nextjs:nodejs /app/apps/web/.next/standalone ./
 COPY --from=installer --chown=nextjs:nodejs /app/apps/web/.next/static ./apps/web/.next/static


### PR DESCRIPTION
This PR updates the example Dockerfile with changes from [its reference source file](https://github.com/vercel/turborepo/blob/6896a02def4cfb5b82d6f69fe928a043e2ad94fd/examples/with-docker/apps/web/Dockerfile), after it was updated in https://github.com/vercel/turborepo/pull/2228.