### PR TITLE
Cover gitignored env files in docs and examples

### DIFF
--- a/docs/pages/repo/docs/core-concepts/caching.mdx
+++ b/docs/pages/repo/docs/core-concepts/caching.mdx
@@ -22,7 +22,7 @@ Let's say you run a `build` task with Turborepo using `turbo run build`:
 
 ![](../../../../public/images/docs/cache-miss.png)
 
-1. Turborepo will **evaluate the inputs to your task** (by default all non-gitignored files in the workspace folder) and **turn them into a hash** (e.g. `78awdk123`).
+1. Turborepo will **evaluate the inputs to your task** (by default all non-git-ignored files in the workspace folder) and **turn them into a hash** (e.g. `78awdk123`).
 
 2. **Check the local filesystem cache** for a folder named with the hash (e.g.`./node_modules/.cache/turbo/78awdk123`).
 
@@ -197,7 +197,7 @@ You can control `turbo`'s caching behavior based on
 the values of environment variables:
 
 - Including environment variables in the `env` key in your `pipeline` definition will impact the cache fingerprint on a per-task or per-workspace-task basis.
-- Including any gitignored environment files that are read by tasks in `globalDependencies`.
+- Including any git-ignored environment files that are read by tasks in `globalDependencies`.
 - The value of any environment variable that includes `THASH` in its name will impact the cache fingerprint of _all_ tasks.
 
 ```jsonc
@@ -370,9 +370,9 @@ Since Turborepo runs _before_ your tasks, it is possible for your tasks to creat
 
 `turbo`, having calculated a task hash prior to invoking the `build` script, will be unable to discover the `NEXT_PUBLIC_GA_ID=UA-00000000-0` environment variable and thus unable to partition the cache based upon that.
 
-When possible, be careful to ensure that all of your environment variables are configured prior to invoking `turbo`!
+Be careful to ensure that all of your environment variables are configured prior to invoking `turbo`!
 
-That may not be possible if tasks read environment variables from gitignored files like `.env.local` using a tool like `dotenv`. This is common when building apps like [Next.js][1] or [Create React App][2] that rely on secrets in environment variables. `turbo` will not partition the cache based on the values in these gitignored files. In this case, use a glob pattern to match these files with `globalDependencies`.
+That may not be possible if tasks read environment variables from git-ignored files like `.env.local` using a tool like `dotenv`. This is common when building apps like [Next.js][1] or [Create React App][2] that rely on secrets in environment variables. `turbo` will not partition the cache based on the values in these git-ignored files. In this case, use a glob pattern to match these files with `globalDependencies`.
 
 ```jsonc
 {

--- a/docs/pages/repo/docs/core-concepts/caching.mdx
+++ b/docs/pages/repo/docs/core-concepts/caching.mdx
@@ -197,11 +197,13 @@ You can control `turbo`'s caching behavior based on
 the values of environment variables:
 
 - Including environment variables in the `env` key in your `pipeline` definition will impact the cache fingerprint on a per-task or per-workspace-task basis.
+- Including any gitignored environment files that are read by tasks in `globalDependencies`.
 - The value of any environment variable that includes `THASH` in its name will impact the cache fingerprint of _all_ tasks.
 
 ```jsonc
 {
   "$schema": "https://turbo.build/schema.json",
+  "globalDependencies": ["**/.env.*local"],
   "pipeline": {
     "build": {
       "dependsOn": ["^build"],
@@ -366,9 +368,25 @@ Since Turborepo runs _before_ your tasks, it is possible for your tasks to creat
 }
 ```
 
-`turbo`, having calculated a task hash prior to invoking the `build` script, will be unable to discover the `NEXT_PUBLIC_GA_ID=UA-00000000-0` environment variable and thus unable to partition the cache based upon that, or any environment variable configured by `dotenv`.
+`turbo`, having calculated a task hash prior to invoking the `build` script, will be unable to discover the `NEXT_PUBLIC_GA_ID=UA-00000000-0` environment variable and thus unable to partition the cache based upon that.
 
-Be careful to ensure that all of your environment variables are configured prior to invoking `turbo`!
+When possible, be careful to ensure that all of your environment variables are configured prior to invoking `turbo`!
+
+That may not be possible if tasks read environment variables from gitignored files like `.env.local` using a tool like `dotenv`. This is common when building apps like [Next.js][1] or [Create React App][2] that rely on secrets in environment variables. `turbo` will not partition the cache based on the values in these gitignored files. In this case, use a glob pattern to match these files with `globalDependencies`.
+
+```jsonc
+{
+  "$schema": "https://turborepo.org/schema.json",
+  "globalDependencies": ["**/.env.*local"],
+  "pipeline": {
+    "build": {
+      "dependsOn": ["^build"],
+      "env": ["SOME_ENV_VAR"],
+      "outputs": [".next/**"],
+    },
+  }
+}
+```
 
 ## Force overwrite cache
 

--- a/examples/basic/turbo.json
+++ b/examples/basic/turbo.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "globalDependencies": ["**/.env.*local"],
   "pipeline": {
     "build": {
       "outputs": [".next/**"]

--- a/examples/kitchen-sink/turbo.json
+++ b/examples/kitchen-sink/turbo.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "globalDependencies": ["**/.env.*local"],
   "pipeline": {
     "build": {
       "outputs": [

--- a/examples/with-changesets/turbo.json
+++ b/examples/with-changesets/turbo.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "globalDependencies": ["**/.env.*local"],
   "pipeline": {
     "build": {
       "outputs": ["dist/**", ".next/**"],

--- a/examples/with-docker/turbo.json
+++ b/examples/with-docker/turbo.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "globalDependencies": ["**/.env.*local"],
   "pipeline": {
     "build": {
       "outputs": ["dist/**", ".next/**", "public/dist/**"],

--- a/examples/with-pnpm/turbo.json
+++ b/examples/with-pnpm/turbo.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "globalDependencies": ["**/.env.*local"],
   "pipeline": {
     "build": {
       "dependsOn": ["^build"],

--- a/examples/with-prisma/turbo.json
+++ b/examples/with-prisma/turbo.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "globalDependencies": ["**/.env.*local"],
   "globalEnv": ["NODE_ENV"],
   "pipeline": {
     "build": {

--- a/examples/with-react-native-web/turbo.json
+++ b/examples/with-react-native-web/turbo.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "globalDependencies": ["**/.env.*local"],
   "pipeline": {
     "build": {
       "outputs": ["dist/**", ".next/**"],

--- a/examples/with-tailwind/turbo.json
+++ b/examples/with-tailwind/turbo.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "globalDependencies": ["**/.env.*local"],
   "pipeline": {
     "build": {
       "dependsOn": ["^build"],

--- a/packages/create-turbo/templates/_shared_ts/turbo.json
+++ b/packages/create-turbo/templates/_shared_ts/turbo.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "globalDependencies": ["**/.env.*local"],
   "pipeline": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
https://twitter.com/mehulkar/status/1583316480287854592

It is common for apps built with Next.js or Create React App to read environment variables from gitignored `.env.*local` files, particularly when they can contain secrets that should not be committed to source control.

From the Next.js docs:

> Note: .env, .env.development, and .env.production files should be included in your repository as they define defaults. .env*.local should be added to .gitignore, as those files are intended to be ignored. .env.local is where secrets can be stored.

The Turborepo docs lacked examples matching these gitignored env files and had a misleading recommendation in the "Invisible Environment Variables" section. The example repositories listed these files in their `.gitignore` files, but failed to include them in `globalDependencies`. This caused me some confusion, so this is my attempt at clarifying it.