### PR TITLE
Full inference of root directory.

### DIFF
--- a/cli/internal/packagemanager/infer_root_test.go
+++ b/cli/internal/packagemanager/infer_root_test.go
@@ -230,7 +230,7 @@ func TestInferRoot(t *testing.T) {
 				},
 			},
 			executionDirectory: turbopath.AnchoredUnixPath("execution/path/subdir").ToSystemPath(),
-			rootPath:           turbopath.AnchoredUnixPath("execution/path/subdir").ToSystemPath(),
+			rootPath:           turbopath.AnchoredUnixPath("").ToSystemPath(),
 			packageMode:        Multi,
 		},
 		{
@@ -239,7 +239,7 @@ func TestInferRoot(t *testing.T) {
 				{path: turbopath.AnchoredUnixPath("execution/path/subdir/.file").ToSystemPath()},
 				{
 					path:    turbopath.AnchoredUnixPath("package.json").ToSystemPath(),
-					content: []byte("{ \"workspaces\": [ \"exists\" ] }"),
+					content: []byte("{}"),
 				},
 				{
 					path:    turbopath.AnchoredUnixPath("pnpm-workspace.yaml").ToSystemPath(),
@@ -247,7 +247,7 @@ func TestInferRoot(t *testing.T) {
 				},
 			},
 			executionDirectory: turbopath.AnchoredUnixPath("execution/path/subdir").ToSystemPath(),
-			rootPath:           turbopath.AnchoredUnixPath("execution/path/subdir").ToSystemPath(),
+			rootPath:           turbopath.AnchoredUnixPath("").ToSystemPath(),
 			packageMode:        Multi,
 		},
 		// Scenario 3A
@@ -297,7 +297,7 @@ func TestInferRoot(t *testing.T) {
 				},
 			},
 			executionDirectory: turbopath.AnchoredUnixPath("one/two/three").ToSystemPath(),
-			rootPath:           turbopath.AnchoredUnixPath("one/two/three").ToSystemPath(),
+			rootPath:           turbopath.AnchoredUnixPath("").ToSystemPath(),
 			packageMode:        Multi,
 		},
 		// Scenario 3BII

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -110,8 +110,7 @@ func GetCmd(helper *cmdutil.Helper, signalWatcher *signals.Watcher) *cobra.Comma
 			if len(tasks) == 0 {
 				return errors.New("at least one task must be specified")
 			}
-			_, packageMode := packagemanager.InferRoot(base.RepoRoot)
-			opts.runOpts.singlePackage = packageMode == packagemanager.Single
+			opts.runOpts.singlePackage = base.PackageType == packagemanager.Single
 
 			opts.runOpts.passThroughArgs = passThroughArgs
 			run := configureRun(base, opts, signalWatcher)


### PR DESCRIPTION
Does: infer root directory and single vs. multi package mode.

Does not: infer tasks from `package.json` in multi package mode.
Does not: infer filter from `cwd`.