### PR TITLE
Remove wildcard redirect rule from list

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -110,11 +110,6 @@ const nextConfig = withNextra({
         permanent: true,
       },
       {
-        source: "/docs/:path*",
-        permanent: true,
-        destination: "/repo/docs/:path*",
-      },
-      {
         source: "/docs/guides/workspaces",
         destination: "/docs/handbook/workspaces",
         permanent: true,


### PR DESCRIPTION
Otherwise, the rules listed below it are never reached.
Examples: `/docs/guides/workspaces` `/docs/changelog` `/docs/glossary`
We just need to make sure all our cases are still covered without the need of the wildcard. @mattpocock
