### PR TITLE
fix: twitter handle for Tobias in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Follow [@turborepo](https://twitter.com/turborepo) on Twitter and for project up
 
 **Turbopack and Turboengine**
 
-- Tobias Koppers ([@sokra](https://twitter.com/sokra))
+- Tobias Koppers ([@sokra](https://twitter.com/wsokra))
 - Maia Teegarden ([@padmaia](https://twitter.com/padmaia))
 
 ## Security


### PR DESCRIPTION
The title says it all!

(Also, `wSokra` instead of `wsokra` because that's the capitalization the twitter handle shows when opened up on Twitter)