### PR TITLE
add missing --input flag for the Tailwind command

### DIFF
--- a/docs/pages/pack/docs/features/css.mdx
+++ b/docs/pages/pack/docs/features/css.mdx
@@ -94,7 +94,7 @@ npm install --save-dev tailwindcss autoprefixer concurrently
 ```json filename="package.json"
 {
   "scripts": {
-    "dev": "concurrently \"next dev --turbo\" \"tailwindcss input.css --output output.css --watch\"",
+    "dev": "concurrently \"next dev --turbo\" \"tailwindcss --input input.css --output output.css --watch\"",
     "build": "tailwindcss input.css --output output.css && next build"
   }
 }


### PR DESCRIPTION
The command used to compile Tailwind on its own requires an "--input" flag before the input file. 
This flag was missing in the docs.

See https://tailwindcss.com/blog/standalone-cli