### PR TITLE
Fixed the link in a documentation

### DIFF
--- a/docs/pages/repo/docs/handbook/dev.mdx
+++ b/docs/pages/repo/docs/handbook/dev.mdx
@@ -91,7 +91,7 @@ This means that users of your `dev` task _don't need to worry about codegen or m
 
 ## Running `dev` only in certain workspaces
 
-To run a `dev` task in only certain workspaces, you should use the [`--filter` syntax](/repo/docs/core-concepts/filtering). For example:
+To run a `dev` task in only certain workspaces, you should use the [`--filter` syntax](/repo/docs/core-concepts/monorepos/filtering). For example:
 
 ```bash
 turbo run dev --filter docs


### PR DESCRIPTION
Link for  filtering a workspace was anchoring to a wrong documentation page