### PR TITLE
feat: add shim to help and version integration tests

### DIFF
--- a/cli/Makefile
+++ b/cli/Makefile
@@ -274,7 +274,7 @@ $(CRAM_ENV)/bin/prysk: $(CRAM_ENV)/bin/pip
 
 INTEGRATION_TEST_FILES = $(shell find integration_tests -name "*.t")
 
-integration-tests: $(CRAM_ENV)/bin/prysk turbo $(INTEGRATION_TEST_FILES) corepack
+integration-tests: $(CRAM_ENV)/bin/prysk turbo $(INTEGRATION_TEST_FILES) corepack shim
 	$(CRAM_ENV)/bin/prysk --shell=`which bash` $(INTEGRATION_TEST_FILES)
 
 # use target testbed-<some directory under integration_tests> to set up the testbed directory

--- a/cli/integration_tests/setup.sh
+++ b/cli/integration_tests/setup.sh
@@ -5,3 +5,5 @@ while [ $(basename $DIR) != "cli" ]; do
   DIR=$(dirname $DIR)
 done
 TURBO=${DIR}/turbo
+SHIM=${DIR}/../shim/target/debug/turbo
+VERSION=${DIR}/../version.txt

--- a/cli/integration_tests/turbo_help.t
+++ b/cli/integration_tests/turbo_help.t
@@ -73,3 +73,84 @@ Test help flag
         --version             version for turbo
   
   Use "turbo [command] --help" for more information about a command.
+
+Test help flag for shim
+  $ ${SHIM} -h
+  turbo 
+  The build system that makes ship happen
+  
+  USAGE:
+      turbo [OPTIONS] [TASKS]... [SUBCOMMAND]
+  
+  ARGS:
+      <TASKS>...    
+  
+  OPTIONS:
+          --api <API>                  Override the endpoint for API calls
+          --color                      Force color usage in the terminal
+          --cpuprofile <CPUPROFILE>    Specify a file to save a cpu profile
+          --cwd <CWD>                  The directory in which to run turbo
+      -h, --help                       
+          --heap <HEAP>                Specify a file to save a pprof heap profile
+          --login <LOGIN>              Override the login endpoint
+          --no-color                   Suppress color usage in the terminal
+          --preflight                  When enabled, turbo will precede HTTP requests with an OPTIONS
+                                       request for authorization
+          --team <TEAM>                Set the team slug for API calls
+          --token <TOKEN>              Set the auth token for API calls
+          --trace <TRACE>              Specify a file to save a pprof trace
+      -V, --verbosity <VERBOSITY>      verbosity
+          --version                    
+  
+  SUBCOMMANDS:
+      bin           Get the path to the Turbo binary
+      completion    Generate the autocompletion script for the specified shell
+      daemon        Runs the Turborepo background daemon
+      help          Help about any command
+      link          Link your local directory to a Vercel organization and enable remote caching
+      login         Login to your Vercel account
+      logout        Logout to your Vercel account
+      prune         Prepare a subset of your monorepo
+      run           Run tasks across projects in your monorepo
+      unlink        Unlink the current directory from your Vercel organization and disable Remote
+                        Caching
+
+  $ ${SHIM} --help
+  turbo 
+  The build system that makes ship happen
+  
+  USAGE:
+      turbo [OPTIONS] [TASKS]... [SUBCOMMAND]
+  
+  ARGS:
+      <TASKS>...    
+  
+  OPTIONS:
+          --api <API>                  Override the endpoint for API calls
+          --color                      Force color usage in the terminal
+          --cpuprofile <CPUPROFILE>    Specify a file to save a cpu profile
+          --cwd <CWD>                  The directory in which to run turbo
+      -h, --help                       
+          --heap <HEAP>                Specify a file to save a pprof heap profile
+          --login <LOGIN>              Override the login endpoint
+          --no-color                   Suppress color usage in the terminal
+          --preflight                  When enabled, turbo will precede HTTP requests with an OPTIONS
+                                       request for authorization
+          --team <TEAM>                Set the team slug for API calls
+          --token <TOKEN>              Set the auth token for API calls
+          --trace <TRACE>              Specify a file to save a pprof trace
+      -V, --verbosity <VERBOSITY>      verbosity
+          --version                    
+  
+  SUBCOMMANDS:
+      bin           Get the path to the Turbo binary
+      completion    Generate the autocompletion script for the specified shell
+      daemon        Runs the Turborepo background daemon
+      help          Help about any command
+      link          Link your local directory to a Vercel organization and enable remote caching
+      login         Login to your Vercel account
+      logout        Logout to your Vercel account
+      prune         Prepare a subset of your monorepo
+      run           Run tasks across projects in your monorepo
+      unlink        Unlink the current directory from your Vercel organization and disable Remote
+                        Caching

--- a/cli/integration_tests/turbo_version.t
+++ b/cli/integration_tests/turbo_version.t
@@ -1,10 +1,10 @@
 Setup
   $ . ${TESTDIR}/setup.sh
 
-Test version
-  $ ${TURBO} --version
-  (?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$ (re)
+Test version matches that of version.txt
+  $ diff <(head -n 1 ${VERSION}) <(${TURBO} --version)
 
-Semver Regex source: https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+  $ diff <(head -n 1 ${VERSION}) <(${SHIM} --version)
+
 TODO: resolve ambiguity
 $ ${TURBO} -v


### PR DESCRIPTION
A quick PR that should add some tests to make sure we're aware of how we're changing the help text with the Rust shim.

Also updated the version test so we check the version against the contents of `version.txt` instead of just making sure it matches the semver regexp.