### PR TITLE
[turbopack] Emit error issue when missing entry files (src/index.js, pages/, app/)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2429,6 +2429,7 @@ dependencies = [
  "turbo-malloc",
  "turbo-tasks",
  "turbo-tasks-build",
+ "turbo-tasks-env",
  "turbo-tasks-fs",
  "turbo-tasks-memory",
  "turbo-tasks-testing",

--- a/crates/next-core/src/issue.rs
+++ b/crates/next-core/src/issue.rs
@@ -1,0 +1,41 @@
+use anyhow::Result;
+use turbo_tasks::primitives::StringVc;
+use turbo_tasks_fs::FileSystemPathVc;
+use turbopack_core::issue::{Issue, IssueSeverityVc, IssueVc};
+
+#[turbo_tasks::value(shared)]
+pub struct NextAppIssue {
+    pub severity: IssueSeverityVc,
+    pub path: FileSystemPathVc,
+    pub message: StringVc,
+}
+
+#[turbo_tasks::value_impl]
+impl Issue for NextAppIssue {
+    #[turbo_tasks::function]
+    fn severity(&self) -> IssueSeverityVc {
+        self.severity
+    }
+
+    #[turbo_tasks::function]
+    async fn title(&self) -> Result<StringVc> {
+        Ok(StringVc::cell(
+            "An issue occurred while preparing your Next.js app".to_string(),
+        ))
+    }
+
+    #[turbo_tasks::function]
+    fn category(&self) -> StringVc {
+        StringVc::cell("next app".to_string())
+    }
+
+    #[turbo_tasks::function]
+    fn context(&self) -> FileSystemPathVc {
+        self.path
+    }
+
+    #[turbo_tasks::function]
+    fn description(&self) -> StringVc {
+        self.message
+    }
+}

--- a/crates/next-core/src/lib.rs
+++ b/crates/next-core/src/lib.rs
@@ -6,6 +6,7 @@ mod app_source;
 mod embed_js;
 pub mod env;
 mod fallback;
+pub mod issue;
 pub mod next_client;
 mod next_client_component;
 mod next_import_map;

--- a/crates/next-dev/Cargo.toml
+++ b/crates/next-dev/Cargo.toml
@@ -43,6 +43,7 @@ serde_json = "1.0.85"
 tokio = { version = "1.11.0", features = ["full"] }
 turbo-malloc = { path = "../turbo-malloc" }
 turbo-tasks = { path = "../turbo-tasks" }
+turbo-tasks-env = { path = "../turbo-tasks-env" }
 turbo-tasks-fs = { path = "../turbo-tasks-fs" }
 turbo-tasks-memory = { path = "../turbo-tasks-memory" }
 turbopack = { path = "../turbopack" }

--- a/crates/turbopack-dev-server/src/source/mod.rs
+++ b/crates/turbopack-dev-server/src/source/mod.rs
@@ -327,3 +327,6 @@ impl ContentSource for NoContentSource {
         ContentSourceResultVc::not_found()
     }
 }
+
+#[turbo_tasks::value(transparent)]
+pub struct OptionContentSource(Option<ContentSourceVc>);


### PR DESCRIPTION
Currently missing the `src/index.js` entry results in an empty page, with no feedback in the terminal about the missing entry file. This can lead to confusion if running turbopack from the wrong cwd.

This:
* Introduces `OptionContentSourceVc`, which signals this case. A custom Error type for missing entries may be an opportunity for refinement, but this is in line with @sokra's suggestion below. When all (src, pages, app) main content sources return a wrapped None, this issue is emitted.
* Publicizes and emits a `NextAppIssue`, which was previously only used for one other issue in next-core.

It now causes the following message to be written to the terminal:

```
error - [next app] path/to/testapp/
  An issue occurred while preparing your Next.js app
  Missing Next.js entry file(s): src/index.js, pages/*.js, and app/**/page.js are missing.
```

This still results in an empty page however. We should work on surfacing issues that occur before an HMR connection is established.

Test Plan: Removed src/index.js, pages/*.js, and app/**/page.js in a test app and confirmed the above message was logged to the terminal.