### PR TITLE
Speed up `NoMoveVec` allocations

### DIFF
--- a/crates/turbo-tasks/src/lib.rs
+++ b/crates/turbo-tasks/src/lib.rs
@@ -31,6 +31,8 @@
 #![feature(box_syntax)]
 #![feature(error_generic_member_access)]
 #![feature(provide_any)]
+#![feature(new_uninit)]
+#![feature(arbitrary_enum_discriminant)]
 
 pub mod backend;
 mod collectibles;


### PR DESCRIPTION
This speeds up `NoMoveVec` allocations by ensuring that new bucket initialization is just as fast as `calloc`. Before, we would initialize everything as `Option<T>::None`, which is not guaranteed to match a zeroed value because of niche optimization[1]. This comes at the cost of slightly higher memory usage, but that should be more than offset by https://github.com/vercel/turbo/pull/2395.

[1] https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=e60c0bfa4d32a3609fd39299a1c79c29