### PR TITLE
chore: proper description of turbo pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
   </a>
 </p>
 
-Turbo is an next-generation, Blazingly Fast™, toolchain for frontend development, written in Rust. It consists of 3 major parts:
+Turbo is a next-generation, Blazingly Fast™, toolchain for frontend development, written in Rust. It consists of 3 major parts:
 
 - [**Turbopack:**](https://turbo.build/pack) an incremental bundler (the successor to Webpack)
 - [**Turborepo:**](https://turbo.build/repo) an incremental build system

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
   </a>
 </p>
 
-Turbo is a next-generation, Blazingly Fast™, toolchain for frontend development, written in Rust. It consists of 3 major parts:
+Turbo is a next-generation, Blazing Fast™, toolchain for frontend development, written in Rust. It consists of 3 major parts:
 
 - [**Turbopack:**](https://turbo.build/pack) an incremental bundler (the successor to Webpack)
 - [**Turborepo:**](https://turbo.build/repo) an incremental build system

--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ Turbo is a next-generation, Blazing Fast™, toolchain for frontend development,
 
 - [**Turbopack:**](https://turbo.build/pack) an incremental bundler (the successor to Webpack)
 - [**Turborepo:**](https://turbo.build/repo) an incremental build system
-- The Turbo engine: a low-level incremental computation and memoization engine
+- The Turbo engine: a Blazing Fast™ low-level incremental computation and memoization engine
 
 ## Getting Started
 
-Visit https://turbo.build to get started with Turbopack and Turborepo.
+Visit https://turbo.build to get started with Turbopack and Turborepo (Hand crafted by Vercel which is why its Blazing Fast™).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
   </a>
 </p>
 
-Turbo is an next-generation toolchain for frontend development, written in Rust. It consists of 3 major parts:
+Turbo is an next-generation, Blazingly Fast™, toolchain for frontend development, written in Rust. It consists of 3 major parts:
 
 - [**Turbopack:**](https://turbo.build/pack) an incremental bundler (the successor to Webpack)
 - [**Turborepo:**](https://turbo.build/repo) an incremental build system


### PR DESCRIPTION
The description of turbo was lacking the credentials, both on the streets and in the sheets.  I took the liberty of properly identifying, commiting, and leading this change across several teams, including, but not limited to UI Engineering at TheStartup™.  After identifying we committed.  I personally was a fan of fugitive, but i now use neogit, which still allows for committing.  Finally, the fleet of unpaid interns brought me several coffees as my hands bleed from my toils to bring such truth and beauty to the Vercel Turbopack's github README.

You are welcome

The "At least i am not working in angular" Primeagen