### PR TITLE
Add area label to turbopack bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-turbopack-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-turbopack-bug-report.yml
@@ -3,7 +3,7 @@
 name: Turbopack Bug Report
 description: Create a bug report for the Turbopack team
 title: "[Turbopack] "
-labels: ["kind: bug"]
+labels: ["kind: bug", "area: turbopack"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
these are being manually added right now: https://github.com/vercel/turbo/labels/area%3A%20turbopack. We also have `pkg: *` prefixes, but it's not super clear how they are different from `area: `.