### PR TITLE
Fixes #2280 adds a client timeout

### DIFF
--- a/cli/internal/client/client.go
+++ b/cli/internal/client/client.go
@@ -55,6 +55,7 @@ type RemoteConfig struct {
 	TeamID   string
 	TeamSlug string
 	APIURL   string
+	Timeout  uint64
 }
 
 // Opts holds values for configuring the behavior of the API client
@@ -74,7 +75,7 @@ func NewClient(remoteConfig RemoteConfig, logger hclog.Logger, turboVersion stri
 		turboVersion: turboVersion,
 		HttpClient: &retryablehttp.Client{
 			HTTPClient: &http.Client{
-				Timeout: time.Duration(20 * time.Second),
+				Timeout: time.Duration(time.Duration(remoteConfig.Timeout) * time.Second),
 			},
 			RetryWaitMin: 2 * time.Second,
 			RetryWaitMax: 10 * time.Second,

--- a/cli/internal/client/client_test.go
+++ b/cli/internal/client/client_test.go
@@ -34,6 +34,7 @@ func Test_sendToServer(t *testing.T) {
 		TeamSlug: "my-team-slug",
 		APIURL:   ts.URL,
 		Token:    "my-token",
+		Timeout:  20,
 	}
 	apiClient := NewClient(remoteConfig, hclog.Default(), "v1", Opts{})
 
@@ -89,6 +90,7 @@ func Test_PutArtifact(t *testing.T) {
 		TeamSlug: "my-team-slug",
 		APIURL:   ts.URL,
 		Token:    "my-token",
+		Timeout:  20,
 	}
 	apiClient := NewClient(remoteConfig, hclog.Default(), "v1", Opts{})
 	expectedArtifactBody := []byte("My string artifact")
@@ -115,6 +117,7 @@ func Test_PutWhenCachingDisabled(t *testing.T) {
 		TeamSlug: "my-team-slug",
 		APIURL:   ts.URL,
 		Token:    "my-token",
+		Timeout:  20,
 	}
 	apiClient := NewClient(remoteConfig, hclog.Default(), "v1", Opts{})
 	expectedArtifactBody := []byte("My string artifact")
@@ -142,6 +145,7 @@ func Test_FetchWhenCachingDisabled(t *testing.T) {
 		TeamSlug: "my-team-slug",
 		APIURL:   ts.URL,
 		Token:    "my-token",
+		Timeout:  20,
 	}
 	apiClient := NewClient(remoteConfig, hclog.Default(), "v1", Opts{})
 	// Test Put Artifact

--- a/cli/internal/config/config_file.go
+++ b/cli/internal/config/config_file.go
@@ -41,6 +41,7 @@ func (rc *RepoConfig) GetRemoteConfig(token string) client.RemoteConfig {
 		TeamID:   rc.repoViper.GetString("teamid"),
 		TeamSlug: rc.repoViper.GetString("teamslug"),
 		APIURL:   rc.repoViper.GetString("apiurl"),
+		Timeout:  rc.repoViper.GetUint64("timeout"),
 	}
 }
 
@@ -128,6 +129,7 @@ func DefaultUserConfigPath() turbopath.AbsoluteSystemPath {
 
 const (
 	_defaultAPIURL   = "https://vercel.com/api"
+	_defaultTimeout  = uint64(20)
 	_defaultLoginURL = "https://vercel.com"
 )
 
@@ -141,10 +143,12 @@ func ReadRepoConfigFile(path turbopath.AbsoluteSystemPath, flags *pflag.FlagSet)
 	repoViper.SetConfigType("json")
 	repoViper.SetEnvPrefix("turbo")
 	repoViper.MustBindEnv("apiurl", "TURBO_API")
+	repoViper.MustBindEnv("timeout", "TURBO_TIMEOUT")
 	repoViper.MustBindEnv("loginurl", "TURBO_LOGIN")
 	repoViper.MustBindEnv("teamslug", "TURBO_TEAM")
 	repoViper.MustBindEnv("teamid")
 	repoViper.SetDefault("apiurl", _defaultAPIURL)
+	repoViper.SetDefault("timeout", _defaultTimeout)
 	repoViper.SetDefault("loginurl", _defaultLoginURL)
 	if err := repoViper.BindPFlag("loginurl", flags.Lookup("login")); err != nil {
 		return nil, err
@@ -153,6 +157,9 @@ func ReadRepoConfigFile(path turbopath.AbsoluteSystemPath, flags *pflag.FlagSet)
 		return nil, err
 	}
 	if err := repoViper.BindPFlag("teamslug", flags.Lookup("team")); err != nil {
+		return nil, err
+	}
+	if err := repoViper.BindPFlag("timeout", flags.Lookup("timeout")); err != nil {
 		return nil, err
 	}
 	if err := repoViper.ReadInConfig(); err != nil && !os.IsNotExist(err) {
@@ -174,6 +181,7 @@ func AddRepoConfigFlags(flags *pflag.FlagSet) {
 	flags.String("team", "", "Set the team slug for API calls")
 	flags.String("api", "", "Override the endpoint for API calls")
 	flags.String("login", "", "Override the login endpoint")
+	flags.String("timeout", "20", "Override the timeout")
 }
 
 // GetRepoConfigPath reads the user-specific configuration values

--- a/cli/internal/config/config_file_test.go
+++ b/cli/internal/config/config_file_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/spf13/pflag"
@@ -35,6 +36,8 @@ func TestReadRepoConfigSetTeamAndAPIFlag(t *testing.T) {
 	assert.NilError(t, flags.Set("team", slug), "flags.Set")
 	apiURL := "http://my-login-url"
 	assert.NilError(t, flags.Set("api", apiURL), "flags.Set")
+	timeout := "20"
+	assert.NilError(t, flags.Set("timeout", timeout), "flags.Set")
 
 	config, err := ReadRepoConfigFile(testConfigFile, flags)
 	if err != nil {
@@ -50,6 +53,10 @@ func TestReadRepoConfigSetTeamAndAPIFlag(t *testing.T) {
 	if remoteConfig.APIURL != apiURL {
 		t.Errorf("APIURL got %v, want %v", remoteConfig.APIURL, apiURL)
 	}
+	number, err := strconv.ParseUint(string(timeout), 10, 64)
+	if remoteConfig.Timeout != number {
+		t.Errorf("Timeout got %v, want %v", remoteConfig.Timeout, number)
+	}
 }
 
 func TestRepoConfigIncludesDefaults(t *testing.T) {
@@ -58,6 +65,7 @@ func TestRepoConfigIncludesDefaults(t *testing.T) {
 	AddRepoConfigFlags(flags)
 
 	expectedTeam := "my-team"
+	expectedTimeout := uint64(20)
 
 	assert.NilError(t, testConfigFile.EnsureDir(), "EnsureDir")
 	assert.NilError(t, testConfigFile.WriteFile([]byte(fmt.Sprintf(`{"teamSlug":"%v"}`, expectedTeam)), 0644), "WriteFile")
@@ -73,6 +81,9 @@ func TestRepoConfigIncludesDefaults(t *testing.T) {
 	}
 	if remoteConfig.TeamSlug != expectedTeam {
 		t.Errorf("team slug got %v, want %v", remoteConfig.TeamSlug, expectedTeam)
+	}
+	if remoteConfig.Timeout != expectedTimeout {
+		t.Errorf("timeout got %v, want %v", remoteConfig.Timeout, expectedTimeout)
 	}
 }
 


### PR DESCRIPTION
This fixes #2280 by adding a client timeout config option.

This is my *first* attempt at go, FYI. So I'll take any feedback you can give me (and I'm also going to have my coworkers who work in Go daily give me some feedback too)

All tests passed and so did the e2e tests