### PR TITLE
Support comments in tsconfig.json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1889,6 +1889,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41ee439ee368ba4a77ac70d04f14015415af8600d6c894dc1f11bd79758c57d5"
 
 [[package]]
+name = "jsonc-parser"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a1853e40333206f9a685358046d13ab200169e3ee573019bddf0ede0dc29307"
+dependencies = [
+ "serde_json",
+]
+
+[[package]]
 name = "kernel32-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5100,6 +5109,7 @@ dependencies = [
  "futures",
  "futures-retry",
  "include_dir",
+ "jsonc-parser",
  "lazy_static",
  "mime",
  "notify",

--- a/crates/turbo-tasks-fs/Cargo.toml
+++ b/crates/turbo-tasks-fs/Cargo.toml
@@ -15,6 +15,7 @@ concurrent-queue = "1.2.2"
 futures = "0.3.24"
 futures-retry = "0.6.0"
 include_dir = { version = "0.7.2", features = ["nightly"] }
+jsonc-parser = { version = "0.21.0", features = ["serde"] }
 lazy_static = "1.4.0"
 mime = "0.3.16"
 notify = "4.0.17"

--- a/crates/turbopack/tests/node-file-trace/integration/ts-package/tsconfig.json
+++ b/crates/turbopack/tests/node-file-trace/integration/ts-package/tsconfig.json
@@ -15,5 +15,5 @@
   */
   "ts-node": {
     "require": ["tsconfig-paths/register"]
-  }
+  }, // trailing comma
 }


### PR DESCRIPTION
Adds support for trailing commas in tsconfig.json to match the behavior of TypeScript. Uses the [jsonc-parser](https://crates.io/crates/jsonc-parser) crate from dprint, which is used by Deno to parse config files. Deno differs from TypeScript in that it allows unquoted property names, the default behavior of jsonc-parser. Since there's no specification for JSONC there's no real right answer, although being conservative and matching TypeScript seems reasonable.

An alternative would be to extend `skip_json_comments` to remove trailing commas as well, but IMO this is a reasonable dependency.

References:
- [jsonc-parser in Deno](https://github.com/denoland/deno/blob/a189c5393e1b106687736635fea0b8aeca283826/cli/args/config_file.rs#L582)
- [Quoted property requirement in TypeScript](https://github.com/microsoft/TypeScript/blob/2625c1feae25aede35465ca835440fc57bf13d52/src/compiler/commandLineParser.ts#L2239)

Fixes #2412