### PR TITLE
Add Next.js require hook

### DIFF
--- a/crates/next-core/js/src/entry/app-renderer.tsx
+++ b/crates/next-core/js/src/entry/app-renderer.tsx
@@ -16,6 +16,7 @@ import type {
 } from "next/dist/build/webpack/plugins/flight-manifest-plugin";
 import type { RenderData } from "types/turbopack";
 
+import 'next/dist/server/initialize-require-hook'
 import "next/dist/server/node-polyfill-fetch";
 import "next/dist/server/node-polyfill-web-streams";
 import { RenderOpts, renderToHTMLOrFlight } from "next/dist/server/app-render";

--- a/crates/next-core/js/src/entry/server-api.tsx
+++ b/crates/next-core/js/src/entry/server-api.tsx
@@ -5,6 +5,7 @@ import http, { ServerResponse } from "node:http";
 import type { AddressInfo, Socket } from "node:net";
 import { Buffer } from "node:buffer";
 
+import 'next/dist/server/initialize-require-hook'
 import "next/dist/server/node-polyfill-fetch.js";
 
 import * as allExports from ".";

--- a/crates/next-core/js/src/entry/server-renderer.tsx
+++ b/crates/next-core/js/src/entry/server-renderer.tsx
@@ -2,6 +2,7 @@ import IPC, { Ipc } from "@vercel/turbopack-next/internal/ipc";
 
 import type { IncomingMessage, ServerResponse } from "node:http";
 
+import 'next/dist/server/initialize-require-hook'
 import "@vercel/turbopack-next/internal/shims";
 import "next/dist/server/node-polyfill-fetch.js";
 import { renderToHTML } from "next/dist/server/render";


### PR DESCRIPTION
This hook is needed to ensure we properly map compiled modules like `styled-jsx` correctly. 

x-ref: [slack thread](https://vercel.slack.com/archives/CGU8HUTUH/p1666824437456749?thread_ts=1666819473.031139&cid=CGU8HUTUH)