### PR TITLE
Update Next.js dependency for the TP benchmark

### DIFF
--- a/crates/next-dev/benches/bundlers/turbopack.rs
+++ b/crates/next-dev/benches/bundlers/turbopack.rs
@@ -47,7 +47,7 @@ impl Bundler for Turbopack {
         npm::install(
             install_dir,
             &[
-                NpmPackage::new("next", "12.3.2-canary.33"),
+                NpmPackage::new("next", "13.0.0"),
                 // Dependency on this is inserted by swc's preset_env
                 NpmPackage::new("@swc/helpers", "^0.4.11"),
             ],


### PR DESCRIPTION
[ijjk/add-require-hook](https://github.com/vercel/turbo/pull/2434) broke the Turbopack benchmarks because they are using an older canary version of Next.js. This bumps the dependency to 13.0.0 to fix it.