### PR TITLE
Fix filter to avoid building the docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "build": "pnpm -- turbo run build --filter=docs",
+    "build": "pnpm -- turbo run build --filter=-docs",
     "build:ts": "tsc -b tsconfig.project.json",
     "check:prettier": "prettier -c .",
     "check:toml": "taplo format --check",


### PR DESCRIPTION
Without this patch, I get the following error:

```
make: 'turbo' is up to date.                                                                                                                                                                                         
• Packages in scope: docs                                                                                                                                                                                            
• Running build in 1 packages                                                                                                                                                                                        
• Remote caching disabled                                                                                                                                                                                            
docs:rss: cache miss, executing 0693f5a9c8651ac8                                                                                                                                                                     
docs:schema: cache miss, executing 852fa6a306b7cac6
docs:schema: 
docs:schema: > docs@1.0.0 schema /usr/home/yonas/git/make-cd/files/turbo/docs
docs:schema: > turbo-gen ./public/schema.json
docs:schema: 
docs:rss: 
docs:rss: > docs@1.0.0 rss /usr/home/yonas/git/make-cd/files/turbo/docs
docs:rss: > node scripts/generate-rss.js
docs:rss: 
docs:schema: sh: turbo-gen: not found
docs:schema:  ELIFECYCLE  Command failed.
docs:schema: ERROR: command finished with error: command (/usr/home/yonas/git/make-cd/files/turbo/docs) pnpm run schema exited (1)
command (/usr/home/yonas/git/make-cd/files/turbo/docs) pnpm run schema exited (1)
```