### PR TITLE
refactor(next/dev): allow devserver args serializable

### DIFF
--- a/crates/next-dev/Cargo.toml
+++ b/crates/next-dev/Cargo.toml
@@ -19,6 +19,9 @@ name = "mod"
 harness = false
 
 [features]
+default = ["cli"]
+cli = []
+serializable = []
 tokio_console = [
   "dep:console-subscriber",
   "tokio/tracing",
@@ -59,7 +62,7 @@ regex = "1.6.0"
 tempfile = "3.3.0"
 test-generator = "0.3.0"
 # sync with chromiumoxide's tungstenite requirement.
-tungstenite = "0.17.3"                                                # For matching on errors from chromiumoxide. Keep in 
+tungstenite = "0.17.3"                                                # For matching on errors from chromiumoxide. Keep in
 turbopack-create-test-app = { path = "../turbopack-create-test-app" }
 
 [target.'cfg(unix)'.dev-dependencies]


### PR DESCRIPTION
This PR adjusts next-dev's cli args to be compatible with next.js, to consolidate implementation across places.