### PR TITLE
Fix large regression with turning ModuleRuleCondition::matches into a tt::fun

### DIFF
--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -8,7 +8,7 @@ use turbo_tasks_fs::FileSystemPathVc;
 use turbopack::{
     module_options::{
         module_options_context::{ModuleOptionsContext, ModuleOptionsContextVc},
-        ModuleRuleCondition, ModuleRuleEffect, ModuleRuleVc,
+        ModuleRule, ModuleRuleCondition, ModuleRuleEffect,
     },
     resolve_options_context::{ResolveOptionsContext, ResolveOptionsContextVc},
     transition::TransitionsByNameVc,
@@ -116,23 +116,19 @@ pub async fn add_next_transforms_to_pages(
 ) -> Result<ModuleOptionsContextVc> {
     let mut module_options_context = module_options_context.await?.clone_value();
     // Apply the Next SSG tranform to all pages.
-    module_options_context.custom_rules.push(ModuleRuleVc::new(
+    module_options_context.custom_rules.push(ModuleRule::new(
         ModuleRuleCondition::all(vec![
-            ModuleRuleCondition::ResourcePathInExactDirectory(pages_dir),
+            ModuleRuleCondition::ResourcePathInExactDirectory(pages_dir.await?),
             ModuleRuleCondition::any(vec![
                 ModuleRuleCondition::ResourcePathEndsWith(".js".to_string()),
                 ModuleRuleCondition::ResourcePathEndsWith(".jsx".to_string()),
                 ModuleRuleCondition::ResourcePathEndsWith(".ts".to_string()),
                 ModuleRuleCondition::ResourcePathEndsWith(".tsx".to_string()),
             ]),
-        ])
-        .cell(),
-        vec![
-            ModuleRuleEffect::AddEcmascriptTransforms(EcmascriptInputTransformsVc::cell(vec![
-                EcmascriptInputTransform::NextJs,
-            ]))
-            .cell(),
-        ],
+        ]),
+        vec![ModuleRuleEffect::AddEcmascriptTransforms(
+            EcmascriptInputTransformsVc::cell(vec![EcmascriptInputTransform::NextJs]),
+        )],
     ));
     Ok(module_options_context.cell())
 }

--- a/crates/turbo-tasks/src/primitives.rs
+++ b/crates/turbo-tasks/src/primitives.rs
@@ -50,7 +50,7 @@ impl ValueToString for JsonValue {
 }
 
 #[turbo_tasks::value(transparent, eq = "manual")]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Regex(
     #[turbo_tasks(trace_ignore)]
     #[serde(with = "serde_regex")]

--- a/crates/turbopack/src/lib.rs
+++ b/crates/turbopack/src/lib.rs
@@ -92,7 +92,7 @@ impl Issue for ModuleIssue {
 async fn get_module_type(path: FileSystemPathVc, options: ModuleOptionsVc) -> Result<ModuleTypeVc> {
     let mut current_module_type = None;
     for rule in options.await?.rules.iter() {
-        if *rule.matches(path).await? {
+        if rule.matches(path).await? {
             for (_, effect) in rule.await?.effects() {
                 match &*effect.await? {
                     ModuleRuleEffect::ModuleType(module) => {

--- a/crates/turbopack/src/lib.rs
+++ b/crates/turbopack/src/lib.rs
@@ -92,9 +92,9 @@ impl Issue for ModuleIssue {
 async fn get_module_type(path: FileSystemPathVc, options: ModuleOptionsVc) -> Result<ModuleTypeVc> {
     let mut current_module_type = None;
     for rule in options.await?.rules.iter() {
-        if rule.matches(path).await? {
-            for (_, effect) in rule.await?.effects() {
-                match &*effect.await? {
+        if rule.matches(&path.await?) {
+            for (_, effect) in rule.effects() {
+                match effect {
                     ModuleRuleEffect::ModuleType(module) => {
                         current_module_type = Some(*module);
                     }

--- a/crates/turbopack/src/module_options/mod.rs
+++ b/crates/turbopack/src/module_options/mod.rs
@@ -11,7 +11,7 @@ pub use module_rule::*;
 
 #[turbo_tasks::value(cell = "new", eq = "manual")]
 pub struct ModuleOptions {
-    pub rules: Vec<ModuleRuleVc>,
+    pub rules: Vec<ModuleRule>,
 }
 
 #[turbo_tasks::value_impl]
@@ -78,92 +78,95 @@ impl ModuleOptionsVc {
         let css_transforms = CssInputTransformsVc::cell(vec![CssInputTransform::Nested]);
 
         let mut rules = vec![
-            ModuleRuleVc::new(
-                ModuleRuleCondition::ResourcePathEndsWith(".json".to_string()).cell(),
-                vec![ModuleRuleEffect::ModuleType(ModuleType::Json).cell()],
+            ModuleRule::new(
+                ModuleRuleCondition::ResourcePathEndsWith(".json".to_string()),
+                vec![ModuleRuleEffect::ModuleType(ModuleType::Json)],
             ),
-            ModuleRuleVc::new(
-                ModuleRuleCondition::ResourcePathEndsWith(".css".to_string()).cell(),
-                vec![ModuleRuleEffect::ModuleType(ModuleType::Css(css_transforms)).cell()],
+            ModuleRule::new(
+                ModuleRuleCondition::ResourcePathEndsWith(".css".to_string()),
+                vec![ModuleRuleEffect::ModuleType(ModuleType::Css(
+                    css_transforms,
+                ))],
             ),
-            ModuleRuleVc::new(
-                ModuleRuleCondition::ResourcePathEndsWith(".module.css".to_string()).cell(),
-                vec![ModuleRuleEffect::ModuleType(ModuleType::CssModule(css_transforms)).cell()],
+            ModuleRule::new(
+                ModuleRuleCondition::ResourcePathEndsWith(".module.css".to_string()),
+                vec![ModuleRuleEffect::ModuleType(ModuleType::CssModule(
+                    css_transforms,
+                ))],
             ),
-            ModuleRuleVc::new(
+            ModuleRule::new(
                 ModuleRuleCondition::any(vec![
                     ModuleRuleCondition::ResourcePathEndsWith(".js".to_string()),
                     ModuleRuleCondition::ResourcePathEndsWith(".jsx".to_string()),
-                ])
-                .cell(),
-                vec![ModuleRuleEffect::ModuleType(ModuleType::Ecmascript(app_transforms)).cell()],
+                ]),
+                vec![ModuleRuleEffect::ModuleType(ModuleType::Ecmascript(
+                    app_transforms,
+                ))],
             ),
-            ModuleRuleVc::new(
+            ModuleRule::new(
                 ModuleRuleCondition::all(vec![
                     ModuleRuleCondition::ResourcePathEndsWith(".js".to_string()),
                     ModuleRuleCondition::ResourcePathInDirectory("node_modules".to_string()),
-                ])
-                .cell(),
-                vec![
-                    ModuleRuleEffect::ModuleType(ModuleType::Ecmascript(vendor_transforms)).cell(),
-                ],
+                ]),
+                vec![ModuleRuleEffect::ModuleType(ModuleType::Ecmascript(
+                    vendor_transforms,
+                ))],
             ),
-            ModuleRuleVc::new(
-                ModuleRuleCondition::ResourcePathEndsWith(".mjs".to_string()).cell(),
-                vec![ModuleRuleEffect::ModuleType(ModuleType::Ecmascript(app_transforms)).cell()],
+            ModuleRule::new(
+                ModuleRuleCondition::ResourcePathEndsWith(".mjs".to_string()),
+                vec![ModuleRuleEffect::ModuleType(ModuleType::Ecmascript(
+                    app_transforms,
+                ))],
             ),
-            ModuleRuleVc::new(
+            ModuleRule::new(
                 ModuleRuleCondition::all(vec![
                     ModuleRuleCondition::ResourcePathEndsWith(".mjs".to_string()),
                     ModuleRuleCondition::ResourcePathInDirectory("node_modules".to_string()),
-                ])
-                .cell(),
-                vec![
-                    ModuleRuleEffect::ModuleType(ModuleType::Ecmascript(vendor_transforms)).cell(),
-                ],
+                ]),
+                vec![ModuleRuleEffect::ModuleType(ModuleType::Ecmascript(
+                    vendor_transforms,
+                ))],
             ),
-            ModuleRuleVc::new(
-                ModuleRuleCondition::ResourcePathEndsWith(".cjs".to_string()).cell(),
-                vec![ModuleRuleEffect::ModuleType(ModuleType::Ecmascript(app_transforms)).cell()],
+            ModuleRule::new(
+                ModuleRuleCondition::ResourcePathEndsWith(".cjs".to_string()),
+                vec![ModuleRuleEffect::ModuleType(ModuleType::Ecmascript(
+                    app_transforms,
+                ))],
             ),
-            ModuleRuleVc::new(
+            ModuleRule::new(
                 ModuleRuleCondition::all(vec![
                     ModuleRuleCondition::ResourcePathEndsWith(".cjs".to_string()),
                     ModuleRuleCondition::ResourcePathInDirectory("node_modules".to_string()),
-                ])
-                .cell(),
-                vec![
-                    ModuleRuleEffect::ModuleType(ModuleType::Ecmascript(vendor_transforms)).cell(),
-                ],
+                ]),
+                vec![ModuleRuleEffect::ModuleType(ModuleType::Ecmascript(
+                    vendor_transforms,
+                ))],
             ),
-            ModuleRuleVc::new(
+            ModuleRule::new(
                 ModuleRuleCondition::any(vec![
                     ModuleRuleCondition::ResourcePathEndsWith(".ts".to_string()),
                     ModuleRuleCondition::ResourcePathEndsWith(".tsx".to_string()),
-                ])
-                .cell(),
-                vec![
-                    ModuleRuleEffect::ModuleType(ModuleType::Typescript(ts_app_transforms)).cell(),
-                ],
+                ]),
+                vec![ModuleRuleEffect::ModuleType(ModuleType::Typescript(
+                    ts_app_transforms,
+                ))],
             ),
-            ModuleRuleVc::new(
+            ModuleRule::new(
                 ModuleRuleCondition::all(vec![
                     ModuleRuleCondition::ResourcePathEndsWith(".ts".to_string()),
                     ModuleRuleCondition::ResourcePathInDirectory("node_modules".to_string()),
-                ])
-                .cell(),
-                vec![ModuleRuleEffect::ModuleType(ModuleType::Typescript(ts_transforms)).cell()],
+                ]),
+                vec![ModuleRuleEffect::ModuleType(ModuleType::Typescript(
+                    ts_transforms,
+                ))],
             ),
-            ModuleRuleVc::new(
-                ModuleRuleCondition::ResourcePathEndsWith(".d.ts".to_string()).cell(),
-                vec![
-                    ModuleRuleEffect::ModuleType(ModuleType::TypescriptDeclaration(
-                        vendor_transforms,
-                    ))
-                    .cell(),
-                ],
+            ModuleRule::new(
+                ModuleRuleCondition::ResourcePathEndsWith(".d.ts".to_string()),
+                vec![ModuleRuleEffect::ModuleType(
+                    ModuleType::TypescriptDeclaration(vendor_transforms),
+                )],
             ),
-            ModuleRuleVc::new(
+            ModuleRule::new(
                 ModuleRuleCondition::any(vec![
                     ModuleRuleCondition::ResourcePathEndsWith(".apng".to_string()),
                     ModuleRuleCondition::ResourcePathEndsWith(".avif".to_string()),
@@ -175,19 +178,18 @@ impl ModuleOptionsVc {
                     ModuleRuleCondition::ResourcePathEndsWith(".svg".to_string()),
                     ModuleRuleCondition::ResourcePathEndsWith(".webp".to_string()),
                     ModuleRuleCondition::ResourcePathEndsWith(".woff2".to_string()),
-                ])
-                .cell(),
-                vec![ModuleRuleEffect::ModuleType(ModuleType::Static).cell()],
+                ]),
+                vec![ModuleRuleEffect::ModuleType(ModuleType::Static)],
             ),
-            ModuleRuleVc::new(
-                ModuleRuleCondition::ResourcePathHasNoExtension.cell(),
-                vec![
-                    ModuleRuleEffect::ModuleType(ModuleType::Ecmascript(vendor_transforms)).cell(),
-                ],
+            ModuleRule::new(
+                ModuleRuleCondition::ResourcePathHasNoExtension,
+                vec![ModuleRuleEffect::ModuleType(ModuleType::Ecmascript(
+                    vendor_transforms,
+                ))],
             ),
         ];
 
-        rules.extend(custom_rules.iter().copied());
+        rules.extend(custom_rules.iter().cloned());
 
         Ok(ModuleOptionsVc::cell(ModuleOptions { rules }))
     }

--- a/crates/turbopack/src/module_options/module_options_context.rs
+++ b/crates/turbopack/src/module_options/module_options_context.rs
@@ -1,7 +1,7 @@
 use turbopack_core::environment::EnvironmentVc;
 use turbopack_ecmascript::EcmascriptInputTransform;
 
-use super::ModuleRuleVc;
+use super::ModuleRule;
 
 #[turbo_tasks::value(shared)]
 #[derive(Default, Clone)]
@@ -15,7 +15,7 @@ pub struct ModuleOptionsContext {
     pub custom_ecmascript_app_transforms: Vec<EcmascriptInputTransform>,
     pub custom_ecmascript_transforms: Vec<EcmascriptInputTransform>,
     /// Custom rules to be applied after all default rules.
-    pub custom_rules: Vec<ModuleRuleVc>,
+    pub custom_rules: Vec<ModuleRule>,
     pub placeholder_for_future_extensions: (),
 }
 

--- a/crates/turbopack/src/module_options/module_rule.rs
+++ b/crates/turbopack/src/module_options/module_rule.rs
@@ -1,94 +1,69 @@
-use std::{collections::HashMap, future::Future, pin::Pin};
+use std::collections::HashMap;
 
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
-use turbo_tasks::{primitives::RegexVc, trace::TraceRawVcs, TryJoinIterExt};
-use turbo_tasks_fs::FileSystemPathVc;
+use turbo_tasks::{primitives::Regex, trace::TraceRawVcs};
+use turbo_tasks_fs::FileSystemPathReadRef;
 use turbopack_css::CssInputTransformsVc;
 use turbopack_ecmascript::EcmascriptInputTransformsVc;
 
-#[turbo_tasks::value]
+#[derive(Debug, Clone, Serialize, Deserialize, TraceRawVcs, PartialEq, Eq)]
 pub struct ModuleRule {
-    condition: ModuleRuleConditionVc,
-    effects: HashMap<ModuleRuleEffectKey, ModuleRuleEffectVc>,
+    condition: ModuleRuleCondition,
+    effects: HashMap<ModuleRuleEffectKey, ModuleRuleEffect>,
 }
 
-#[turbo_tasks::value_impl]
-impl ModuleRuleVc {
-    #[turbo_tasks::function]
-    pub async fn new(
-        condition: ModuleRuleConditionVc,
-        effects: Vec<ModuleRuleEffectVc>,
-    ) -> Result<Self> {
-        Ok(ModuleRule {
+impl ModuleRule {
+    pub fn new(condition: ModuleRuleCondition, effects: Vec<ModuleRuleEffect>) -> Self {
+        ModuleRule {
             condition,
-            effects: effects
-                .into_iter()
-                .map(|e| async move { Ok((e.await?.key(), e)) })
-                .try_join()
-                .await?
-                .into_iter()
-                .collect(),
+            effects: effects.into_iter().map(|e| (e.key(), e)).collect(),
         }
-        .cell())
     }
 }
 
 impl ModuleRule {
-    pub fn effects(&self) -> impl Iterator<Item = (&ModuleRuleEffectKey, &ModuleRuleEffectVc)> {
+    pub fn effects(&self) -> impl Iterator<Item = (&ModuleRuleEffectKey, &ModuleRuleEffect)> {
         self.effects.iter()
     }
 }
 
-impl ModuleRuleVc {
-    pub async fn matches(self, path: FileSystemPathVc) -> Result<bool> {
-        Ok(self.await?.condition.matches(path).await?)
+impl ModuleRule {
+    pub fn matches(&self, path: &FileSystemPathReadRef) -> bool {
+        self.condition.matches(path)
     }
 }
 
-#[turbo_tasks::value(shared)]
+#[derive(Debug, Clone, Serialize, Deserialize, TraceRawVcs, PartialEq, Eq)]
 pub enum ModuleRuleCondition {
-    All(Vec<ModuleRuleConditionVc>),
-    Any(Vec<ModuleRuleConditionVc>),
+    All(Vec<ModuleRuleCondition>),
+    Any(Vec<ModuleRuleCondition>),
     ResourcePathHasNoExtension,
     ResourcePathEndsWith(String),
     ResourcePathInDirectory(String),
-    ResourcePathInExactDirectory(FileSystemPathVc),
-    ResourcePathRegex(RegexVc),
+    ResourcePathInExactDirectory(FileSystemPathReadRef),
+    ResourcePathRegex(#[turbo_tasks(trace_ignore)] Regex),
 }
 
 impl ModuleRuleCondition {
     pub fn all(conditions: Vec<ModuleRuleCondition>) -> ModuleRuleCondition {
-        ModuleRuleCondition::All(conditions.into_iter().map(|c| c.cell()).collect())
+        ModuleRuleCondition::All(conditions)
     }
 
     pub fn any(conditions: Vec<ModuleRuleCondition>) -> ModuleRuleCondition {
-        ModuleRuleCondition::Any(conditions.into_iter().map(|c| c.cell()).collect())
+        ModuleRuleCondition::Any(conditions)
     }
 }
 
-impl ModuleRuleConditionVc {
-    pub async fn matches(self, path: FileSystemPathVc) -> Result<bool> {
-        let path_ref = path.await?;
-        Ok(match &*self.await? {
-            ModuleRuleCondition::All(conditions) => conditions
-                .iter()
-                .map(|c| c.matches_boxed(path))
-                .try_join()
-                .await?
-                .into_iter()
-                .all(|c| c),
-            ModuleRuleCondition::Any(conditions) => conditions
-                .iter()
-                .map(|c| c.matches_boxed(path))
-                .try_join()
-                .await?
-                .into_iter()
-                .any(|c| c),
-            ModuleRuleCondition::ResourcePathEndsWith(end) => path_ref.path.ends_with(end),
+impl ModuleRuleCondition {
+    pub fn matches(&self, path: &FileSystemPathReadRef) -> bool {
+        match self {
+            ModuleRuleCondition::All(conditions) => conditions.iter().all(|c| c.matches(path)),
+            ModuleRuleCondition::Any(conditions) => conditions.iter().any(|c| c.matches(path)),
+            ModuleRuleCondition::ResourcePathEndsWith(end) => path.path.ends_with(end),
             ModuleRuleCondition::ResourcePathHasNoExtension => {
-                if let Some(i) = path_ref.path.rfind('.') {
-                    if let Some(j) = path_ref.path.rfind('/') {
+                if let Some(i) = path.path.rfind('.') {
+                    if let Some(j) = path.path.rfind('/') {
                         j > i
                     } else {
                         false
@@ -98,25 +73,18 @@ impl ModuleRuleConditionVc {
                 }
             }
             ModuleRuleCondition::ResourcePathInDirectory(dir) => {
-                path_ref.path.starts_with(&format!("{dir}/"))
-                    || path_ref.path.contains(&format!("/{dir}/"))
+                path.path.starts_with(&format!("{dir}/")) || path.path.contains(&format!("/{dir}/"))
             }
             ModuleRuleCondition::ResourcePathInExactDirectory(parent_path) => {
-                *path.is_inside(*parent_path).await?
+                path.is_inside(parent_path)
             }
             _ => todo!("not implemented yet"),
-        })
-    }
-
-    pub fn matches_boxed(
-        self,
-        path: FileSystemPathVc,
-    ) -> Pin<Box<dyn Future<Output = Result<bool>> + Send>> {
-        Box::pin(self.matches(path))
+        }
     }
 }
 
 #[turbo_tasks::value(shared)]
+#[derive(Debug, Clone)]
 pub enum ModuleRuleEffect {
     ModuleType(ModuleType),
     AddEcmascriptTransforms(EcmascriptInputTransformsVc),
@@ -150,7 +118,7 @@ impl ModuleRuleEffect {
     }
 }
 
-#[derive(TraceRawVcs, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(TraceRawVcs, Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum ModuleRuleEffectKey {
     ModuleType,
     AddEcmascriptTransforms,


### PR DESCRIPTION
Turning `ModuleRuleCondition::matches` into a `tt::fun` generates ~500,000 tasks _just_ for the 10k modules app. Our overhead per-task is quite high at the moment, so it doesn't make sense to pay that cost. On 20k modules I see a ~6% performance improvement.

TODO: We don't need to turn `ModuleRuleCondition` into a Vc at all. It could store a FileSystemPathReadRef/RegexReadRef directly. I'll do that next.

<img width="556" alt="image" src="https://user-images.githubusercontent.com/1621758/198513808-d4889cb4-a2ef-47bd-9f9e-97e8c29ccbe7.png">
