### PR TITLE
ci(action): bump up rust cache

### DIFF
--- a/.github/workflows/bench-turbopack.yml
+++ b/.github/workflows/bench-turbopack.yml
@@ -79,7 +79,7 @@ jobs:
 
       - uses: ./.github/actions/setup-node
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
         with:
           key: benchmark-${{ matrix.bench.cache_key }}
 

--- a/.github/workflows/bench-turbotrace-against-node-nft.yml
+++ b/.github/workflows/bench-turbotrace-against-node-nft.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
         with:
           key: bench_nft
 

--- a/.github/workflows/check-codestyle-filtered.yml
+++ b/.github/workflows/check-codestyle-filtered.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
         with:
           key: check
 
@@ -62,7 +62,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
         with:
           key: clippy
 

--- a/.github/workflows/dispatch-next-dev-custom-bench.yml
+++ b/.github/workflows/dispatch-next-dev-custom-bench.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: ./.github/actions/setup-node
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
         with:
           key: benchmark-next-dev
 

--- a/.github/workflows/dispatch-next-dev-matrix-bench.yml
+++ b/.github/workflows/dispatch-next-dev-matrix-bench.yml
@@ -43,7 +43,7 @@ jobs:
 
       - uses: ./.github/actions/setup-node
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
         with:
           key: benchmark-next-dev
 

--- a/.github/workflows/pr-turbopack-bench.yml
+++ b/.github/workflows/pr-turbopack-bench.yml
@@ -40,7 +40,7 @@ jobs:
 
       - uses: ./.github/actions/setup-node
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
         with:
           key: benchmark
 

--- a/.github/workflows/quick-test-cargo.yml
+++ b/.github/workflows/quick-test-cargo.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
         with:
           key: test
 
@@ -63,7 +63,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
         with:
           key: test-bench
 

--- a/.github/workflows/release-turbopack.yml
+++ b/.github/workflows/release-turbopack.yml
@@ -49,7 +49,7 @@ jobs:
           rustup component add llvm-tools-preview
         if: matrix.os.target == 'x86_64-pc-windows-msvc'
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
         with:
           key: release-${{ matrix.os.target }}
 
@@ -110,7 +110,7 @@ jobs:
         run: ls -R artifacts
         shell: bash
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
         with:
           key: debug
 

--- a/.github/workflows/test-cargo.yml
+++ b/.github/workflows/test-cargo.yml
@@ -68,7 +68,7 @@ jobs:
         uses: actions-rs/toolchain@v1
 
       - name: Setup rust cache
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
         with:
           key: test
 
@@ -171,7 +171,7 @@ jobs:
         uses: actions-rs/toolchain@v1
 
       - name: Setup rust cache
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
         with:
           key: test-bench
 


### PR DESCRIPTION
There's a deprecate warning 

https://github.com/vercel/turbo/actions/runs/3356892324/jobs/5562302817#step:3:7

> Warning: The `save-state` command is deprecated and will be disabled soon

in current rust-action cache. Bump up to resolve.