### PR TITLE
Fix tabs view in package installation

### DIFF
--- a/docs/pages/repo/docs/handbook/package-installation.mdx
+++ b/docs/pages/repo/docs/handbook/package-installation.mdx
@@ -25,9 +25,27 @@ When you first clone or create your monorepo, you'll need to:
 2. Run the install command:
 
 <Tabs items={["npm", "yarn", "pnpm"]} storageKey="selected-pkg-manager">
-  <Tab>```bash npm install ```</Tab>
-  <Tab>```bash yarn install ```</Tab>
-  <Tab>```bash pnpm install ```</Tab>
+  <Tab>
+
+    ```bash
+    npm install
+    ```
+
+  </Tab>
+  <Tab>
+
+    ```bash
+    yarn install
+    ```
+
+  </Tab>
+  <Tab>
+
+    ```bash
+    pnpm install
+    ```
+
+  </Tab>
 </Tabs>
 
 You'll now see `node_modules` folders appear in the root of your repository, and in each workspace.


### PR DESCRIPTION
Hi!

I noticed that bash scripts in package installation page is kinda broken. This changes should fix it.

![image](https://user-images.githubusercontent.com/25712010/198988148-f8c9235c-8e67-49b1-a005-4a1e3bbb39d4.png)
