### PR TITLE
Fix rounding issue and use proper units

### DIFF
--- a/docs/components/pages/pack-home/PackBenchmarksGraph.tsx
+++ b/docs/components/pages/pack-home/PackBenchmarksGraph.tsx
@@ -269,8 +269,6 @@ const Time = ({
   value: number;
   maxValue: number;
 }): JSX.Element => {
-  const ROUND_DECIMALS = 1;
-
   let unitValue: string;
   let unit: string;
   if (maxValue < 1000) {

--- a/docs/components/pages/pack-home/PackBenchmarksGraph.tsx
+++ b/docs/components/pages/pack-home/PackBenchmarksGraph.tsx
@@ -139,7 +139,7 @@ function GraphBar({
       .then(() => {
         setFinished(true);
       });
-    const timerAnimationRef = animate(0, duration / 1000, {
+    const timerAnimationRef = animate(0, duration, {
       ...transition,
       ease: "linear",
       onUpdate(value) {
@@ -203,14 +203,26 @@ function GraphBar({
           className="pr-2"
           transition={{ duration: 0.1 }}
         >
-          <GraphTimer turbo={turbo} timer={pinTime ? duration / 1000 : timer} />
+          <GraphTimer
+            turbo={turbo}
+            timer={pinTime ? duration : timer}
+            duration={duration}
+          />
         </motion.div>
       </div>
     </div>
   );
 }
 
-const GraphTimer = ({ turbo, timer }: { turbo: boolean; timer: number }) => {
+const GraphTimer = ({
+  turbo,
+  timer,
+  duration,
+}: {
+  turbo: boolean;
+  timer: number;
+  duration: number;
+}) => {
   return (
     <div className={`flex flex-row gap-2 w-24 justify-end items-center z-10`}>
       {turbo && (
@@ -238,8 +250,43 @@ const GraphTimer = ({ turbo, timer }: { turbo: boolean; timer: number }) => {
           />
         </div>
       )}
-      <p className="font-mono">{timer.toFixed(2)}s</p>
+      <p className="font-mono">
+        <Time value={timer} maxValue={duration} />
+      </p>
     </div>
+  );
+};
+
+function roundTo(num: number, decimals: number) {
+  const factor = Math.pow(10, decimals);
+  return Math.round(num * factor) / factor;
+}
+
+const Time = ({
+  value,
+  maxValue,
+}: {
+  value: number;
+  maxValue: number;
+}): JSX.Element => {
+  const ROUND_DECIMALS = 1;
+
+  let unitValue: string;
+  let unit: string;
+  if (maxValue < 1000) {
+    unitValue = Math.round(value).toFixed(0);
+    unit = "ms";
+  } else {
+    const roundedValue = roundTo(value / 1000, 1);
+    unitValue = roundedValue.toFixed(1);
+    unit = "s";
+  }
+
+  return (
+    <>
+      {unitValue}
+      {unit}
+    </>
   );
 };
 


### PR DESCRIPTION
This PR increases the precision of numbers shown on the benchmarks bar charts and displays `ms` instead of `s` when the value is < 1s. It also fixes a rounding error where some values would be rounded down instead of up. For instance, 0.015s was incorrectly rounded down to 0.01s.

![image](https://user-images.githubusercontent.com/1621758/199020463-85107d52-3234-498f-807f-677d01cd5549.png)
