### PR TITLE
fix: create-turbo update next version in templates

### DIFF
--- a/packages/create-turbo/templates/_shared_ts/apps/docs/package.json
+++ b/packages/create-turbo/templates/_shared_ts/apps/docs/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "next": "12.3.1",
+    "next": "13.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "ui": "*"

--- a/packages/create-turbo/templates/_shared_ts/apps/web/package.json
+++ b/packages/create-turbo/templates/_shared_ts/apps/web/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "next": "12.3.1",
+    "next": "13.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "ui": "*"

--- a/packages/create-turbo/templates/_shared_ts/packages/eslint-config-custom/package.json
+++ b/packages/create-turbo/templates/_shared_ts/packages/eslint-config-custom/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "dependencies": {
     "eslint": "^7.23.0",
-    "eslint-config-next": "^12.0.8",
+    "eslint-config-next": "13.0.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-react": "7.31.8",
     "eslint-config-turbo": "latest"

--- a/packages/create-turbo/templates/pnpm/apps/docs/package.json
+++ b/packages/create-turbo/templates/pnpm/apps/docs/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "next": "12.3.1",
+    "next": "13.0.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "ui": "workspace:*"

--- a/packages/create-turbo/templates/pnpm/apps/web/package.json
+++ b/packages/create-turbo/templates/pnpm/apps/web/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "next": "12.3.2-canary.40",
+    "next": "13.0.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "ui": "workspace:*"


### PR DESCRIPTION
Follow up to #2317 where these packages didn't get their next version updated, but started using the [`transpilePackages`](https://github.com/vercel/next.js/pull/41583) config option which isn't in `12.3.1`.

Fixes #2499 #2493 #2513