### PR TITLE
ci(action): windows ci test

### DIFF
--- a/.github/actions/setup-node/install-node-gyp.ps1
+++ b/.github/actions/setup-node/install-node-gyp.ps1
@@ -1,0 +1,29 @@
+echo "::group::add"
+pnpm add -g node-gyp
+echo "::endgroup::"
+
+echo "::group::list installed node development files"
+pnpm exec node-gyp --verbose list
+echo "::endgroup::"
+
+echo "::group::install node development files"
+pnpm exec node-gyp --verbose install $(node -v)
+echo "::endgroup::"
+
+echo "::group::list installed node development files"
+pnpm exec node-gyp --verbose list
+echo "::endgroup::"
+
+# TODO resolve "node-gyp" cache path or set it for "node-gyp" explicitly rather than hardcoding the value
+
+echo "::group::ls"
+ls "C:\Users\runneradmin\AppData\Local\node-gyp\Cache\$($(node -v).TrimStart('v'))\include\node"
+echo "::endgroup::"
+
+echo "::group::list pnpm cache dir"
+echo "$(pnpm list --global --parseable | select -First 1)"
+echo "::endgroup::"
+
+#echo "::group::set npm_config_node_gyp env var"
+#echo "npm_config_node_gyp=$(pnpm list --global --parseable | select -First 1)/node_modules/node_gyp" >> $GITHUB_ENV
+#echo "::endgroup::"

--- a/.github/actions/setup-node/install-vs-build-tools.ps1
+++ b/.github/actions/setup-node/install-vs-build-tools.ps1
@@ -1,0 +1,37 @@
+param(
+    [bool]$IncludeWin81Sdk = $false
+)
+
+$stopWatch = [Diagnostics.Stopwatch]::StartNew()
+$installerArgs = @("--norestart","--passive","--wait","--includeRecommended","--add Microsoft.VisualStudio.Workload.VCTools")
+$installerBinary = "C:\vs_buildtools_15.exe"
+
+if ($IncludeWin81Sdk -eq $true) {
+    $installerArgs += "--add Microsoft.VisualStudio.Component.Windows81SDK"
+}
+
+Invoke-WebRequest "https://aka.ms/vs/15/release/vs_BuildTools.exe" -OutFile $installerBinary
+
+$installerProcess = Start-Process -Wait -PassThru -FilePath $installerBinary -ArgumentList $installerArgs
+if ($installerProcess.ExitCode -ne 0) {
+    exit $installerProcess.ExitCode;
+}
+
+$resolvedBuildToolsItems = @(Get-VSSetupInstance | Where-Object { $_.DisplayName -eq "Visual Studio Build Tools 2017" })
+if ($resolvedBuildToolsItems.Count -eq 0) {
+    Write-Output "Failed to install: Microsoft.VisualStudio.Workload.VCTools."
+    exit 1
+}
+Write-Output $resolvedBuildToolsItems
+
+if ($IncludeWin81Sdk -eq $true) {
+    $resolvedWin81SdkItems = @($(Get-VSSetupInstance | Select-VSSetupInstance -Product *).Packages | Where-Object Id -eq "Microsoft.VisualStudio.Component.Windows81SDK")
+    if ($resolvedWin81SdkItems.Count -eq 0) {
+        Write-Output "Failed to install: Microsoft.VisualStudio.Component.Windows81SDK."
+        exit 1
+    }
+    Write-Output $resolvedWin81SdkItems
+}
+
+$stopWatch.Stop()
+$stopWatch.Elapsed

--- a/.github/workflows/test-cargo.yml
+++ b/.github/workflows/test-cargo.yml
@@ -99,10 +99,18 @@ jobs:
           url: https://github.com/vercel/turbo/actions/runs/${{ github.run_id }}
 
       - name: Run node-gyp install
-        run: npx node-gyp install
-        if: matrix.os.name == 'windows-latest'
+        run: npm install -g node-gyp
 
       - uses: ./.github/actions/setup-node
+
+      # ref: https://github.com/vladimiry/ElectronMail/blob/25520bad3adb5e57a047de7f96d1ec3e4bf9b174/scripts/ci/github/install-vs-build-tools.ps1
+      - name: Setup gyp with vs2017 toolset
+        shell: powershell
+        if: matrix.os.name == 'windows-2019'
+        run: |
+          ./.github/actions/setup-node/install-node-gyp.ps1
+          ./.github/actions/setup-node/install-vs-build-tools.ps1 -IncludeWin81Sdk $true
+          npm config set msvs_version 2017
 
       - name: Install tests dependencies
         working-directory: crates/turbopack/tests/node-file-trace


### PR DESCRIPTION
Turned out https://github.com/vercel/turbo/pull/2504 was not complete, this PR adds bit more workaround to trigger gyp correctly.

I tried to dig & include fixes for windows ci test failure as well, but it is tricker than I thought that needs more digging.