### PR TITLE
Docs: add benchmark links for each heading

### DIFF
--- a/docs/components/LinkButton.tsx
+++ b/docs/components/LinkButton.tsx
@@ -1,0 +1,24 @@
+import Link from "next/link";
+import { ReactNode } from "react";
+import cn from "classnames";
+
+type LinkButtonProps = {
+  href: string;
+  children: ReactNode;
+  size?: "sm";
+};
+
+export default function LinkButton({ href, children, size }: LinkButtonProps) {
+  return (
+    <Link href={href}>
+      <a
+        className={cn(
+          "px-4 py-2 text-gray-600 hover:text-black no-underline bg-gray-100 rounded-full dark:bg-opacity-5 dark:text-gray-300 dark:hover:text-white",
+          { "text-sm": size === "sm" }
+        )}
+      >
+        {children}
+      </a>
+    </Link>
+  );
+}

--- a/docs/components/pages/pack-home/BenchmarkHeading.tsx
+++ b/docs/components/pages/pack-home/BenchmarkHeading.tsx
@@ -1,0 +1,28 @@
+import LinkButton from "../../LinkButton";
+
+type BenchmarkHeadingProps = {
+  name: string;
+  href: string;
+};
+
+export default function BenchmarkHeading({
+  name,
+  href,
+}: BenchmarkHeadingProps) {
+  const nameIdSlug = name.toLowerCase().split(/\s+/).join("-");
+
+  return (
+    <div className="flex items-start nx-mt-8">
+      <div className="flex-auto">
+        <h3 className="nx-font-semibold nx-tracking-tight nx-text-2xl">
+          {name}
+          <span id={nameIdSlug} className="nx-absolute -nx-mt-20"></span>
+          <a href={`#${nameIdSlug}`} className="subheading-anchor"></a>
+        </h3>
+      </div>
+      <LinkButton href={href} size="sm">
+        View <span className="hidden md:inline">benchmark</span> source
+      </LinkButton>
+    </div>
+  );
+}

--- a/docs/pages/pack/docs/benchmarks.mdx
+++ b/docs/pages/pack/docs/benchmarks.mdx
@@ -3,6 +3,7 @@ import { DocsBenchmarksGraph } from '../../../components/pages/pack-home/DocsBen
 import Callout from '../../../components/Callout';
 import { ThemedImageFigure } from '../../../components/image/ThemedImageFigure';
 import { HMR_BARS } from '../../../components/pages/pack-home/PackBenchmarks'
+import BenchmarkHeading from '../../../components/pages/pack-home/BenchmarkHeading';
 
 # Benchmarks
 
@@ -39,7 +40,7 @@ Let's break down exactly what each of these metrics mean, and how they'll impact
   Curious about how these benchmarks are implemented, or want to run them yourself? Check out [our benchmark suite documentation in the Turbo monorepo](https://github.com/vercel/turbo/blob/main/crates/next-dev/benches/README.md).
 </Callout>
 
-### Cold startup time
+<BenchmarkHeading name="Cold startup time" href="https://github.com/vercel/turbo/blob/main/crates/next-dev/benches/mod.rs"></BenchmarkHeading>
 
 This test measures how fast a local development server starts up on an application of various sizes. We measure this as the time from startup (without cache) until the app is rendered in the browser. We do not wait for the app to be interactive or hydrated in the browser for this dataset.
 
@@ -90,7 +91,7 @@ bench_startup/Vite CSR/10000 modules                  37.2±0.29s
 bench_startup/Vite CSR/30000 modules                 109.5±1.14s
 ```
 
-### File updates (HMR)
+<BenchmarkHeading name="File updates (HMR)" href="https://github.com/vercel/turbo/blob/main/crates/next-dev/benches/mod.rs"></BenchmarkHeading>
 
 We also measure how quickly the development server works from when an update is applied to a source file to when we receive a custom browser event that the modified code was executed.
 


### PR DESCRIPTION
This adds links to benchmark source for each benchmark described at https://turbo.build/pack/docs/benchmarks. It also introduces a reusable LinkButton component in our docs.