### PR TITLE
fix:Non-exhaustive PID error check

### DIFF
--- a/cli/internal/daemon/connector/connector.go
+++ b/cli/internal/daemon/connector/connector.go
@@ -3,6 +3,7 @@ package connector
 import (
 	"context"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"time"
@@ -269,23 +270,29 @@ func (c *Connector) connectInternal(ctx context.Context) (*Client, error) {
 // the daemon if it doesn't find one running.
 func (c *Connector) getOrStartDaemon() (int, error) {
 	lockFile := c.lockFile()
-	if daemonProcess, err := lockFile.GetOwner(); errors.Is(err, lockfile.ErrDeadOwner) {
-		// If we've found a pid file but no corresponding process, there's nothing we can do.
-		// We defer to the user to clean up the pid file.
-		return 0, errors.Wrapf(err, "pid file appears stale. If no daemon is running, please remove it: %v", c.PidPath)
-	} else if os.IsNotExist(err) {
-		if c.Opts.DontStart {
-			return 0, ErrDaemonNotRunning
+	daemonProcess, getDaemonProcessErr := lockFile.GetOwner()
+	if getDaemonProcessErr != nil {
+		// If we're in a clean state this isn't an "error" per se.
+		// We attempt to start a daemon.
+		if errors.Is(getDaemonProcessErr, fs.ErrNotExist) {
+			if c.Opts.DontStart {
+				return 0, ErrDaemonNotRunning
+			}
+			pid, startDaemonErr := c.startDaemon()
+			if startDaemonErr != nil {
+				return 0, startDaemonErr
+			}
+			return pid, nil
 		}
-		// The pid file doesn't exist. Start a daemon
-		pid, err := c.startDaemon()
-		if err != nil {
-			return 0, err
-		}
-		return pid, nil
-	} else {
-		return daemonProcess.Pid, nil
+
+		// We could have hit any number of errors.
+		// - Failed to read the file for permission reasons.
+		// - User emptied the file's contents.
+		// - etc.
+		return 0, errors.Wrapf(getDaemonProcessErr, "An issue was encountered with the pid file. Please remove it and try again: %v", c.PidPath)
 	}
+
+	return daemonProcess.Pid, nil
 }
 
 func (c *Connector) getClientConn() (*Client, error) {

--- a/cli/internal/daemon/connector/connector_test.go
+++ b/cli/internal/daemon/connector/connector_test.go
@@ -41,6 +41,26 @@ func getPidFile(dir turbopath.AbsoluteSystemPath) turbopath.AbsoluteSystemPath {
 	return dir.UntypedJoin("turbod-test.pid")
 }
 
+func TestGetOrStartDaemonInvalidPIDFile(t *testing.T) {
+	logger := hclog.Default()
+	dir := t.TempDir()
+	dirPath := fs.AbsoluteSystemPathFromUpstream(dir)
+
+	pidPath := getPidFile(dirPath)
+	writeFileErr := pidPath.WriteFile(nil, 0777)
+	assert.NilError(t, writeFileErr, "WriteFile")
+
+	c := &Connector{
+		Logger:  logger,
+		Opts:    Opts{},
+		PidPath: pidPath,
+	}
+
+	pid, err := c.getOrStartDaemon()
+	assert.Equal(t, pid, 0)
+	assert.ErrorContains(t, err, "issue was encountered with the pid file")
+}
+
 func TestConnectFailsWithoutGrpcServer(t *testing.T) {
 	// We aren't starting a server that is going to write
 	// to our socket file, so we should see a series of connection


### PR DESCRIPTION
As reported by Jesse, we had a non-exhaustive PID error check. This is a Red/Green PR with test recreating the panic, and then a test demonstrating that the panic no longer exists.

https://discord.com/channels/818588653005176832/854119566413922365/1036524672046604359