### PR TITLE
Include trailing newline when serializing package.json

### DIFF
--- a/packages/turbo/bump-version.js
+++ b/packages/turbo/bump-version.js
@@ -18,4 +18,4 @@ pkg.optionalDependencies = Object.fromEntries(
     .map((x) => [x, pkg.version])
 );
 
-fs.writeFileSync(file, JSON.stringify(pkg, null, 2)+ "\n");
+fs.writeFileSync(file, JSON.stringify(pkg, null, 2) + "\n");

--- a/packages/turbo/bump-version.js
+++ b/packages/turbo/bump-version.js
@@ -18,4 +18,4 @@ pkg.optionalDependencies = Object.fromEntries(
     .map((x) => [x, pkg.version])
 );
 
-fs.writeFileSync(file, JSON.stringify(pkg, null, 2));
+fs.writeFileSync(file, JSON.stringify(pkg, null, 2)+ "\n");


### PR DESCRIPTION
This prevents Prettier from getting into a fight with our release process.