### PR TITLE
Use swc for vite in bundlers benchmark

### DIFF
--- a/crates/next-dev/benches/bundlers/vite/mod.rs
+++ b/crates/next-dev/benches/bundlers/vite/mod.rs
@@ -33,7 +33,7 @@ impl Bundler for Vite {
             install_dir,
             &[
                 NpmPackage::new("vite", "3.0.9"),
-                NpmPackage::new("@vitejs/plugin-react", "2.1.0"),
+                NpmPackage::new("vite-plugin-swc-react-refresh", "2.2.0"),
             ],
         )
         .context("failed to install from npm")?;

--- a/crates/next-dev/benches/bundlers/vite/vite.config.js
+++ b/crates/next-dev/benches/bundlers/vite/vite.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from "vite";
-import react from "@vitejs/plugin-react";
+import { swcReactRefresh } from "vite-plugin-swc-react-refresh";
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [swcReactRefresh()],
+  esbuild: { jsx: "automatic" }
 });


### PR DESCRIPTION
In the next-dev bundlers benchmark, the Vite config is using Babel-based React transforms. Although it's the default when creating a Vite React project, the transforms are not inherent to Vite and can be trivially swapped to leverage SWC.

Assuming the purpose of the benchmark is comparing the inherent, framework-agnostic performance of the tools, we should aim to equalize the variables that are not part of the core implementations of the tools. Note that the [Webpack implementation](https://github.com/vercel/turbo/blob/main/crates/next-dev/benches/bundlers/webpack/mod.rs#L31) is also using SWC, so it makes sense to use SWC for the Vite implementation as well.

[Benchmark page](https://github.com/vercel/turbo/blob/main/docs/pages/pack/docs/benchmarks.mdx) should be updated accordingly if this is merged.