### PR TITLE
Add addStatusHandler/removeStatusHandler to hot API

### DIFF
--- a/crates/turbopack-ecmascript/js/src/runtime.js
+++ b/crates/turbopack-ecmascript/js/src/runtime.js
@@ -891,6 +891,10 @@
       // implement, but the Next.js React Refresh runtime uses this to decide
       // whether to schedule an update.
       status: () => "idle",
+
+      // NOTE(alexkirsz) Since we always return "idle" for now, these are no-ops.
+      addStatusHandler: (_handler) => {},
+      removeStatusHandler: (_handler) => {},
     };
 
     return { hot, hotState };

--- a/crates/turbopack-ecmascript/js/types/hot.d.ts
+++ b/crates/turbopack-ecmascript/js/types/hot.d.ts
@@ -4,6 +4,8 @@ export const enum HotUpdateStatus {
   idle = "idle",
 }
 
+export type HotUpdateStatusHandler = (status: HotUpdateStatus) => void;
+
 export interface HotData {
   prevExports?: Exports;
 }
@@ -37,8 +39,6 @@ export interface Hot {
   active: boolean;
   data: HotData;
 
-  status: () => keyof typeof HotUpdateStatus;
-
   accept: AcceptFunction;
 
   decline: (module?: string | string[]) => void;
@@ -50,4 +50,8 @@ export interface Hot {
   removeDisposeHandler: (callback: (data: object) => void) => void;
 
   invalidate: () => void;
+
+  status: () => keyof typeof HotUpdateStatus;
+  addStatusHandler: (handler: HotUpdateStatusHandler) => void;
+  removeStatusHandler: (handler: HotUpdateStatusHandler) => void;
 }


### PR DESCRIPTION
addStatusHandler and removeStatusHandler are part of the [HMR management API](https://webpack.js.org/api/hot-module-replacement/#addstatushandler), which we currently do not implement save for `status()`

These two additions are necessary for https://github.com/vercel/next.js/pull/42350 to work properly with Turbopack.