### PR TITLE
Specify node@16 in engines for docs workspace

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -57,5 +57,8 @@
   "prettier": {
     "embeddedLanguageFormatting": "off",
     "htmlWhitespaceSensitivity": "strict"
+  },
+  "engines": {
+    "node": "16.x"
   }
 }


### PR DESCRIPTION
- [x] Check that Node 16 was detected
- [x] Deploy successful
- [x] Site works

<img width="1223" alt="CleanShot 2022-11-02 at 16 03 50@2x" src="https://user-images.githubusercontent.com/490968/199618727-4076a1f4-f66d-4ed7-b7c0-5f8ff2f8b8c7.png">
