### PR TITLE
Update Getting Started link in README.md

### DIFF
--- a/packages/turbo/README.md
+++ b/packages/turbo/README.md
@@ -25,7 +25,7 @@
 
 ## Getting Started
 
-Visit https://turbo.build/repo/docs/getting-started to get started with Turborepo.
+Visit https://turbo.build/repo/docs/getting-started/add-to-project to get started with Turborepo.
 
 ## Documentation
 


### PR DESCRIPTION
https://turbo.build/repo/docs/getting-started returns a 404 so I updated it to https://turbo.build/repo/docs/getting-started/add-to-project. Is this the correct fix or would you like the docs site (https://github.com/vercel/turbo/tree/main/docs/pages/repo/docs/getting-started) updated? Thanks.