### PR TITLE
Line charts: Ensure the time range starts at 0 instead of the minimum time value

### DIFF
--- a/xtask/src/visualize_bundler_bench.rs
+++ b/xtask/src/visualize_bundler_bench.rs
@@ -91,7 +91,12 @@ fn generate_scaling(
 
         // TODO: Avoid vector allocation -- not sure why this is necessary for
         // typechecker
-        let time_range = fitting_range(time_range_iter.collect::<Vec<f64>>().iter());
+        let time_range = {
+            let mut range = fitting_range(time_range_iter.collect::<Vec<f64>>().iter());
+            // Ensure the time range starts at 0 instead of the minimum time value.
+            range.start = 0.0;
+            range
+        };
 
         let file_name = output_path.join(format!("{}.svg", bench_name));
         let root = SVGBackend::new(&file_name, (960, 720)).into_drawing_area();

--- a/xtask/src/visualize_bundler_bench.rs
+++ b/xtask/src/visualize_bundler_bench.rs
@@ -89,14 +89,10 @@ fn generate_scaling(
                 .map(|stats| ns_to_ms(stats.point_estimate))
         });
 
-        // TODO: Avoid vector allocation -- not sure why this is necessary for
-        // typechecker
-        let time_range = {
-            let mut range = fitting_range(time_range_iter.collect::<Vec<f64>>().iter());
-            // Ensure the time range starts at 0 instead of the minimum time value.
-            range.start = 0.0;
-            range
-        };
+        // Ensure the time range starts at 0 instead of the minimum time value.
+        let time_range = 0.0..time_range_iter
+            // f64 does not implement Ord.
+            .fold(0.0, |max, time| if time > max { time } else { max });
 
         let file_name = output_path.join(format!("{}.svg", bench_name));
         let root = SVGBackend::new(&file_name, (960, 720)).into_drawing_area();


### PR DESCRIPTION
Our benchmarks charts already have this change applied. This will ensure all future charts do too.