### PR TITLE
add RSC and RCC for turbopack to benchmarks

### DIFF
--- a/crates/next-core/src/app_source.rs
+++ b/crates/next-core/src/app_source.rs
@@ -500,7 +500,7 @@ impl NodeEntry for AppRenderer {
 
         for (_, import) in segments.iter() {
             if let Some((p, identifier, chunks_identifier)) = import {
-                result += r#"("TURBOPACK {{ transition: next-layout-entry; chunking-type: parallel }}");
+                result += r#"("TURBOPACK { transition: next-layout-entry; chunking-type: parallel }");
 "#;
                 writeln!(
                     result,

--- a/crates/next-dev/benches/bundlers/mod.rs
+++ b/crates/next-dev/benches/bundlers/mod.rs
@@ -29,6 +29,10 @@ pub trait Bundler {
     fn has_server_rendered_html(&self) -> bool {
         false
     }
+    /// There is a hydration done event emitted by client side JavaScript
+    fn has_interactivity(&self) -> bool {
+        true
+    }
     fn prepare(&self, _template_dir: &Path) -> Result<()> {
         Ok(())
     }
@@ -55,8 +59,25 @@ pub fn get_bundlers() -> Vec<Box<dyn Bundler>> {
     }
     let mut bundlers: Vec<Box<dyn Bundler>> = Vec::new();
     if turbopack {
-        bundlers.push(Box::new(Turbopack::new("Turbopack CSR", "/", false)));
-        bundlers.push(Box::new(Turbopack::new("Turbopack SSR", "/page", true)));
+        bundlers.push(Box::new(Turbopack::new("Turbopack CSR", "/", false, true)));
+        bundlers.push(Box::new(Turbopack::new(
+            "Turbopack SSR",
+            "/page",
+            true,
+            true,
+        )));
+        bundlers.push(Box::new(Turbopack::new(
+            "Turbopack RSC",
+            "/app",
+            true,
+            false,
+        )));
+        bundlers.push(Box::new(Turbopack::new(
+            "Turbopack RCC",
+            "/client",
+            true,
+            true,
+        )));
     }
 
     if others {

--- a/crates/next-dev/benches/bundlers/turbopack.rs
+++ b/crates/next-dev/benches/bundlers/turbopack.rs
@@ -18,14 +18,21 @@ pub struct Turbopack {
     name: String,
     path: String,
     has_server_rendered_html: bool,
+    has_interactivity: bool,
 }
 
 impl Turbopack {
-    pub fn new(name: &str, path: &str, has_server_rendered_html: bool) -> Self {
+    pub fn new(
+        name: &str,
+        path: &str,
+        has_server_rendered_html: bool,
+        has_interactivity: bool,
+    ) -> Self {
         Turbopack {
             name: name.to_owned(),
             path: path.to_owned(),
             has_server_rendered_html,
+            has_interactivity,
         }
     }
 }
@@ -41,6 +48,10 @@ impl Bundler for Turbopack {
 
     fn has_server_rendered_html(&self) -> bool {
         self.has_server_rendered_html
+    }
+
+    fn has_interactivity(&self) -> bool {
+        self.has_interactivity
     }
 
     fn prepare(&self, install_dir: &Path) -> Result<()> {

--- a/crates/next-dev/benches/util/page_guard.rs
+++ b/crates/next-dev/benches/util/page_guard.rs
@@ -100,7 +100,8 @@ impl<'a> PageGuard<'a> {
             self.wait_for_binding(TEST_APP_HYDRATION_DONE),
         )
         .await
-        .context("Timeout happened while waiting for hydration")??;
+        .context("Timeout happened while waiting for hydration")?
+        .context("Error happened while waiting for hydration")?;
         Ok(())
     }
 }

--- a/crates/turbopack-create-test-app/src/test_app_builder.rs
+++ b/crates/turbopack-create-test-app/src/test_app_builder.rs
@@ -253,6 +253,65 @@ export function getStaticProps() {
             .write_all(bootstrap_static_page.as_bytes())
             .context("writing bootstrap static page")?;
 
+        let app_dir = src.join("app");
+        create_dir_all(app_dir.join("app"))?;
+        create_dir_all(app_dir.join("client"))?;
+
+        // The page is e. g. used by Next.js
+        let bootstrap_app_page = r#"import React from "react";
+import Triangle from "../../triangle.jsx";
+
+export default function Page() {
+    return <svg height="100%" viewBox="-5 -4.33 10 8.66" style={{ backgroundColor: "black" }}>
+        <Triangle style={{ fill: "white" }}/>
+    </svg>
+}
+"#;
+        File::create(app_dir.join("app/page.jsx"))
+            .context("creating bootstrap app page")?
+            .write_all(bootstrap_app_page.as_bytes())
+            .context("writing bootstrap app page")?;
+
+        // The page is e. g. used by Next.js
+        let bootstrap_app_client_page = r#""use client";
+import React from "react";
+import Triangle from "../../triangle.jsx";
+
+export default function Page() {
+    React.useEffect(() => {
+        globalThis.__turbopackBenchBinding && globalThis.__turbopackBenchBinding("Hydration done");
+    })
+    return <svg height="100%" viewBox="-5 -4.33 10 8.66" style={{ backgroundColor: "black" }}>
+        <Triangle style={{ fill: "white" }}/>
+    </svg>
+}
+"#;
+        File::create(app_dir.join("client/page.jsx"))
+            .context("creating bootstrap app client page")?
+            .write_all(bootstrap_app_client_page.as_bytes())
+            .context("writing bootstrap app client page")?;
+
+        // This root layout is e. g. used by Next.js
+        let bootstrap_layout = r#"export default function RootLayout({ children }) {
+    return (
+        <html lang="en">
+            <head>
+                <meta charSet="UTF-8" />
+                <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+                <title>Turbopack Test App</title>
+            </head>
+            <body>
+                {children}
+            </body>
+        </html>
+    );
+}
+        "#;
+        File::create(app_dir.join("layout.jsx"))
+            .context("creating bootstrap html in root")?
+            .write_all(bootstrap_layout.as_bytes())
+            .context("writing bootstrap html in root")?;
+
         // This HTML is used e. g. by Vite
         let bootstrap_html = r#"<!DOCTYPE html>
 <html lang="en">


### PR DESCRIPTION
RSC: whole page is a server component
RCC: whole page is a client component

add `app` directory to test app

This also makes sure that app dir is tested as part of the benchmark tests