### PR TITLE
chore: add step to cache prysk

### DIFF
--- a/.github/workflows/pr-go-e2e-filtered.yml
+++ b/.github/workflows/pr-go-e2e-filtered.yml
@@ -33,6 +33,14 @@ jobs:
       - name: E2E Tests
         run: pnpm -- turbo run e2e --filter=cli
 
+      - name: Cache Prysk
+        if: matrix.os != 'windows-latest'
+        id: cache-prysk
+        uses: actions/cache@v3
+        with:
+          path: cli/.cram_env
+          key: ${{ runner.os }}-prysk
+
       - name: Integration Tests
         if: matrix.os != 'windows-latest'
         run: pnpm -- turbo run integration-tests --filter=cli


### PR DESCRIPTION
`prysk` doesn't change often. Hopefully hitting GH servers saves some time compared to using `pip` to install