### PR TITLE
Mark next/head as supported

### DIFF
--- a/crates/turbopack/src/lib.rs
+++ b/crates/turbopack/src/lib.rs
@@ -65,8 +65,7 @@ use self::{
 lazy_static! {
     static ref UNSUPPORTED_PACKAGES: HashSet<String> =
         ["@vercel/og".to_owned(), "@next/font".to_owned()].into();
-    static ref UNSUPPORTED_PACKAGE_PATHS: HashSet<(String, String)> =
-        [("next".to_owned(), "/head".to_owned())].into();
+    static ref UNSUPPORTED_PACKAGE_PATHS: HashSet<(String, String)> = [].into();
 }
 
 #[turbo_tasks::value]


### PR DESCRIPTION
Looking at https://github.com/vercel/next.js/blob/canary/packages/next/shared/lib/head.tsx, next/head doesn't depend on any bundler-specific logic. Testing shows it working properly.