### PR TITLE
fix(create-turbo): support node 14

### DIFF
--- a/packages/create-turbo/package.json
+++ b/packages/create-turbo/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "chalk": "2.4.2",
     "execa": "5.1.1",
+    "fs-extra": "^10.1.0",
     "gradient-string": "^2.0.0",
     "inquirer": "^8.0.0",
     "meow": "^7.1.1",
@@ -34,6 +35,7 @@
   },
   "devDependencies": {
     "@types/chalk-animation": "^1.6.0",
+    "@types/fs-extra": "^9.0.13",
     "@types/gradient-string": "^1.1.2",
     "@types/inquirer": "^7.3.1",
     "@types/jest": "^27.4.0",

--- a/packages/create-turbo/src/index.ts
+++ b/packages/create-turbo/src/index.ts
@@ -2,7 +2,7 @@
 
 import * as path from "path";
 import execa from "execa";
-import fs from "fs";
+import fse from "fs-extra";
 import inquirer from "inquirer";
 import ora from "ora";
 import meow from "meow";
@@ -136,19 +136,22 @@ async function run() {
   let relativeProjectDir = path.relative(process.cwd(), projectDir);
   let projectDirIsCurrentDir = relativeProjectDir === "";
   if (!projectDirIsCurrentDir) {
-    if (fs.existsSync(projectDir) && fs.readdirSync(projectDir).length !== 0) {
+    if (
+      fse.existsSync(projectDir) &&
+      fse.readdirSync(projectDir).length !== 0
+    ) {
       console.log(
         `️🚨 Oops, "${relativeProjectDir}" already exists. Please try again with a different directory.`
       );
       process.exit(1);
     } else {
-      fs.mkdirSync(projectDir, { recursive: true });
+      fse.mkdirSync(projectDir, { recursive: true });
     }
   }
 
   // copy the shared template
   let sharedTemplate = path.resolve(__dirname, "../templates", `_shared_ts`);
-  fs.cpSync(sharedTemplate, projectDir, { recursive: true });
+  fse.copySync(sharedTemplate, projectDir, { recursive: true });
 
   let packageManagerVersion = getPackageManagerVersion(answers.packageManager);
   let packageManagerConfigs = PACKAGE_MANAGERS[answers.packageManager];
@@ -166,15 +169,15 @@ async function run() {
     "../templates",
     packageManager.template
   );
-  if (fs.existsSync(packageManagerTemplate)) {
-    fs.cpSync(packageManagerTemplate, projectDir, {
+  if (fse.existsSync(packageManagerTemplate)) {
+    fse.copySync(packageManagerTemplate, projectDir, {
       recursive: true,
-      force: true,
+      overwrite: true,
     });
   }
 
   // rename dotfiles
-  fs.renameSync(
+  fse.renameSync(
     path.join(projectDir, "gitignore"),
     path.join(projectDir, ".gitignore")
   );
@@ -196,7 +199,7 @@ async function run() {
   sharedPkg.name = projectName;
 
   // write package.json
-  fs.writeFileSync(
+  fse.writeFileSync(
     path.join(projectDir, "package.json"),
     JSON.stringify(sharedPkg, null, 2)
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -223,6 +223,7 @@ importers:
   packages/create-turbo:
     specifiers:
       '@types/chalk-animation': ^1.6.0
+      '@types/fs-extra': ^9.0.13
       '@types/gradient-string': ^1.1.2
       '@types/inquirer': ^7.3.1
       '@types/jest': ^27.4.0
@@ -232,6 +233,7 @@ importers:
       chalk: 2.4.2
       eslint: ^7.23.0
       execa: 5.1.1
+      fs-extra: ^10.1.0
       gradient-string: ^2.0.0
       inquirer: ^8.0.0
       jest: ^27.4.3
@@ -248,6 +250,7 @@ importers:
     dependencies:
       chalk: 2.4.2
       execa: 5.1.1
+      fs-extra: 10.1.0
       gradient-string: 2.0.1
       inquirer: 8.2.4
       meow: 7.1.1
@@ -257,6 +260,7 @@ importers:
       update-check: 1.5.4
     devDependencies:
       '@types/chalk-animation': 1.6.1
+      '@types/fs-extra': 9.0.13
       '@types/gradient-string': 1.1.2
       '@types/inquirer': 7.3.3
       '@types/jest': 27.5.2


### PR DESCRIPTION
Support node 14 for create-turbo. Swap from native `fs` to `fs-extra` which supports a `copySync` method in 14. 

Fixes https://github.com/vercel/turbo/issues/2602 (and a bunch of others)