### PR TITLE
fix: add unplugged to Yarn 2+ lockfile

### DIFF
--- a/cli/internal/lockfile/berry_lockfile.go
+++ b/cli/internal/lockfile/berry_lockfile.go
@@ -80,7 +80,8 @@ type BerryLockfile struct {
 
 // BerryDependencyMetaEntry Structure for holding if a package is optional or not
 type BerryDependencyMetaEntry struct {
-	Optional bool `yaml:"optional,omitempty"`
+	Optional  bool `yaml:"optional,omitempty"`
+	Unplugged bool `yaml:"unplugged,omitempty"`
 }
 
 var _ Lockfile = (*BerryLockfile)(nil)
@@ -681,14 +682,17 @@ func _stringifyDepsMeta(meta map[string]BerryDependencyMetaEntry) string {
 	sort.Strings(keys)
 
 	lines := make([]string, 0, len(meta))
-	addLine := func(name string) {
-		lines = append(lines, fmt.Sprintf("    %s:\n      optional: true", _wrapString(name)))
+	addLine := func(name string, key string) {
+		lines = append(lines, fmt.Sprintf("    %s:\n      %s: true", _wrapString(name), key))
 	}
 
 	for _, name := range keys {
 		optional := meta[name]
 		if optional.Optional {
-			addLine(name)
+			addLine(name, "optional")
+		}
+		if optional.Unplugged {
+			addLine(name, "unplugged")
 		}
 	}
 

--- a/cli/internal/lockfile/testdata/berry.lock
+++ b/cli/internal/lockfile/testdata/berry.lock
@@ -1261,6 +1261,9 @@ eslint-config-turbo@latest:
   resolution: "eslint-module-utils@npm:2.7.4"
   dependencies:
     debug: ^3.2.7
+  dependenciesMeta:
+    debug@4.3.4:
+      unplugged: true
   peerDependenciesMeta:
     eslint:
       optional: true


### PR DESCRIPTION
Fixes #2590

We were producing incorrect `yarn.lock` files due to not parsing the `unplugged` field in dependency metadata.

Tested by adding `unplugged: true` to an entry in the lockfile fixture and making sure that it survives the roundtrip.