### PR TITLE
chore(ci): skip e2e on examples changes

### DIFF
--- a/.github/workflows/pr-go-e2e-filtered.yml
+++ b/.github/workflows/pr-go-e2e-filtered.yml
@@ -13,6 +13,7 @@ on:
       - "**.md"
       - "**.mdx"
       - "docs/**"
+      - "examples/**"
 
 jobs:
   test:

--- a/.github/workflows/pr-js-tests-filtered.yml
+++ b/.github/workflows/pr-js-tests-filtered.yml
@@ -13,6 +13,7 @@ on:
       - "**.md"
       - "**.mdx"
       - "docs/**"
+      - "examples/**"
 
 jobs:
   test:


### PR DESCRIPTION
Skip e2e on examples changes. Examples are not used for these flows. So we can speed up CI by skipping them. 