### PR TITLE
Fix tasks hanging when waiting for foreground tasks to be done

### DIFF
--- a/crates/turbo-tasks/src/manager.rs
+++ b/crates/turbo-tasks/src/manager.rs
@@ -460,7 +460,7 @@ impl<B: Backend> TurboTasks<B> {
         if self
             .currently_scheduled_foreground_jobs
             .load(Ordering::Acquire)
-            != 0
+            == 0
         {
             return;
         }
@@ -789,7 +789,7 @@ impl<B: Backend> TurboTasksBackendApi for TurboTasks<B> {
         if self
             .currently_scheduled_foreground_jobs
             .load(Ordering::Acquire)
-            != 0
+            == 0
         {
             return Ok(());
         }


### PR DESCRIPTION
The current behavior is broken: when the scheduled foreground task count becomes 0 in between the two atomic loads, we return an event listener that will _never_ be notified if there are no other foreground tasks left to schedule.  