### PR TITLE
feat(next-dev): align devserver cli options to napi bindings

### DIFF
--- a/crates/next-dev/src/devserver_options.rs
+++ b/crates/next-dev/src/devserver_options.rs
@@ -66,18 +66,23 @@ pub struct DevServerOptions {
     pub log_detail: bool,
 
     // Inherited options from next-dev, need revisit later.
-    // These are not supported by CLI yet.
-    #[cfg(feature = "serializable")]
+    #[cfg_attr(feature = "cli", clap(long))]
     #[cfg_attr(feature = "serializable", serde(default))]
+    /// If port is not explicitly specified, use different port if it's already
+    /// in use.
     pub allow_retry: bool,
-    #[cfg(feature = "serializable")]
+    #[cfg_attr(feature = "cli", clap(long))]
     #[cfg_attr(feature = "serializable", serde(default))]
+    /// Internal for next.js, no specific usage yet.
     pub dev: bool,
-    #[cfg(feature = "serializable")]
+    #[cfg_attr(feature = "cli", clap(long))]
     #[cfg_attr(feature = "serializable", serde(default))]
+    /// Internal for next.js, no specific usage yet.
     pub is_next_dev_command: bool,
-    #[cfg(feature = "serializable")]
+    #[cfg_attr(feature = "cli", clap(long))]
     #[cfg_attr(feature = "serializable", serde(default))]
+    /// Specify server component external packages explicitly. This is an
+    /// experimental flag.
     pub server_components_external_packages: Vec<String>,
 }
 


### PR DESCRIPTION
This PR exposes few napi-only bindings options to next-dev cli as well.

Aligned with https://github.com/vercel/next.js/pull/42656, attempts to allow to run custom binary with next.js transparently. It is mostly for the easier CI testing (pick up next.js, run its test with turbopack PR) however also allows local dev testing bit easier since it is possible to avoid to rebuild napi bindings per each turbopack changes.

Cli options are not stablized yet, so I expect this won't cause noticeable breaking changes in the future. It'll be breaking changes, but this is more close to internal api currently.