### PR TITLE
Include the directory into the task hash.

### DIFF
--- a/cli/integration_tests/monorepo_one_script_error/run.t
+++ b/cli/integration_tests/monorepo_one_script_error/run.t
@@ -8,7 +8,7 @@ Note that npm reports any failed script as exit code 1, even though we "exit 2"
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running error in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:error: cache miss, executing 15d3d7967bc433e3
+  my-app:error: cache miss, executing ab251d5df2b0cdc6
   my-app:error: 
   my-app:error: > error
   my-app:error: > echo 'intentionally failing' && exit 2
@@ -33,7 +33,7 @@ Make sure it isn't cached
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running error in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:error: cache miss, executing 15d3d7967bc433e3
+  my-app:error: cache miss, executing ab251d5df2b0cdc6
   my-app:error: 
   my-app:error: > error
   my-app:error: > echo 'intentionally failing' && exit 2

--- a/cli/integration_tests/single_package/dry-run.t
+++ b/cli/integration_tests/single_package/dry-run.t
@@ -8,7 +8,7 @@ Check
   Tasks to Run
   build
     Task            = build                  
-    Hash            = c8f3749b36e4c49f       
+    Hash            = 7bf32e1dedb04a5d       
     Cached (Local)  = false                  
     Cached (Remote) = false                  
     Command         = echo 'building' > foo  
@@ -22,7 +22,7 @@ Check
     "tasks": [
       {
         "task": "build",
-        "hash": "c8f3749b36e4c49f",
+        "hash": "7bf32e1dedb04a5d",
         "command": "echo 'building' \u003e foo",
         "outputs": [
           "foo"

--- a/cli/integration_tests/single_package/run.t
+++ b/cli/integration_tests/single_package/run.t
@@ -6,7 +6,7 @@ Check
   $ ${TURBO} run build --single-package
   \xe2\x80\xa2 Running build (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  build: cache miss, executing c8f3749b36e4c49f
+  build: cache miss, executing 7bf32e1dedb04a5d
   build: 
   build: > build
   build: > echo 'building' > foo
@@ -20,7 +20,7 @@ Run a second time, verify caching works because there is a config
   $ ${TURBO} run build --single-package
   \xe2\x80\xa2 Running build (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  build: cache hit, replaying output c8f3749b36e4c49f
+  build: cache hit, replaying output 7bf32e1dedb04a5d
   build: 
   build: > build
   build: > echo 'building' > foo

--- a/cli/integration_tests/single_package_deps/dry-run.t
+++ b/cli/integration_tests/single_package_deps/dry-run.t
@@ -8,7 +8,7 @@ Check
   Tasks to Run
   build
     Task            = build                  
-    Hash            = e04d8bf0e58a455b       
+    Hash            = 8fc80cfff3b64237       
     Cached (Local)  = false                  
     Cached (Remote) = false                  
     Command         = echo 'building' > foo  
@@ -18,7 +18,7 @@ Check
     Dependendents   = test                   
   test
     Task            = test                                         
-    Hash            = 804a9b713dc63f25                             
+    Hash            = c71366ccd6a86465                             
     Cached (Local)  = false                                        
     Cached (Remote) = false                                        
     Command         = [[ ( -f foo ) && $(cat foo) == 'building' ]] 
@@ -32,7 +32,7 @@ Check
     "tasks": [
       {
         "task": "build",
-        "hash": "e04d8bf0e58a455b",
+        "hash": "8fc80cfff3b64237",
         "command": "echo 'building' \u003e foo",
         "outputs": [
           "foo"
@@ -46,7 +46,7 @@ Check
       },
       {
         "task": "test",
-        "hash": "804a9b713dc63f25",
+        "hash": "c71366ccd6a86465",
         "command": "[[ ( -f foo ) \u0026\u0026 $(cat foo) == 'building' ]]",
         "outputs": null,
         "excludedOutputs": null,

--- a/cli/integration_tests/single_package_deps/run.t
+++ b/cli/integration_tests/single_package_deps/run.t
@@ -6,12 +6,12 @@ Check
   $ ${TURBO} run test --single-package
   \xe2\x80\xa2 Running test (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  build: cache miss, executing e04d8bf0e58a455b
+  build: cache miss, executing 8fc80cfff3b64237
   build: 
   build: > build
   build: > echo 'building' > foo
   build: 
-  test: cache miss, executing 804a9b713dc63f25
+  test: cache miss, executing c71366ccd6a86465
   test: 
   test: > test
   test: > [[ ( -f foo ) && $(cat foo) == 'building' ]]
@@ -25,12 +25,12 @@ Run a second time, verify caching works because there is a config
   $ ${TURBO} run test --single-package
   \xe2\x80\xa2 Running test (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  build: cache hit, replaying output e04d8bf0e58a455b
+  build: cache hit, replaying output 8fc80cfff3b64237
   build: 
   build: > build
   build: > echo 'building' > foo
   build: 
-  test: cache hit, replaying output 804a9b713dc63f25
+  test: cache hit, replaying output c71366ccd6a86465
   test: 
   test: > test
   test: > [[ ( -f foo ) && $(cat foo) == 'building' ]]
@@ -44,8 +44,8 @@ Run with --output-logs=hash-only
   $ ${TURBO} run test --single-package --output-logs=hash-only
   \xe2\x80\xa2 Running test (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  build: cache hit, suppressing output e04d8bf0e58a455b
-  test: cache hit, suppressing output 804a9b713dc63f25
+  build: cache hit, suppressing output 8fc80cfff3b64237
+  test: cache hit, suppressing output c71366ccd6a86465
   
    Tasks:    2 successful, 2 total
   Cached:    2 cached, 2 total

--- a/cli/integration_tests/single_package_no_config/dry-run.t
+++ b/cli/integration_tests/single_package_no_config/dry-run.t
@@ -8,7 +8,7 @@ Check
   Tasks to Run
   build
     Task            = build                  
-    Hash            = fcdc2cfedba63a1f       
+    Hash            = c7223f212c321d3b       
     Cached (Local)  = false                  
     Cached (Remote) = false                  
     Command         = echo 'building'        
@@ -22,7 +22,7 @@ Check
     "tasks": [
       {
         "task": "build",
-        "hash": "fcdc2cfedba63a1f",
+        "hash": "c7223f212c321d3b",
         "command": "echo 'building'",
         "outputs": null,
         "excludedOutputs": null,

--- a/cli/integration_tests/single_package_no_config/run.t
+++ b/cli/integration_tests/single_package_no_config/run.t
@@ -6,7 +6,7 @@ Check
   $ ${TURBO} run build --single-package
   \xe2\x80\xa2 Running build (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  build: cache bypass, force executing fcdc2cfedba63a1f
+  build: cache bypass, force executing c7223f212c321d3b
   build: 
   build: > build
   build: > echo 'building'
@@ -21,7 +21,7 @@ Run a second time, verify no caching because there is no config
   $ ${TURBO} run build --single-package
   \xe2\x80\xa2 Running build (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  build: cache bypass, force executing fcdc2cfedba63a1f
+  build: cache bypass, force executing c7223f212c321d3b
   build: 
   build: > build
   build: > echo 'building'

--- a/cli/internal/taskhash/taskhash.go
+++ b/cli/internal/taskhash/taskhash.go
@@ -222,6 +222,7 @@ func (th *Tracker) CalculateFileHashes(allTasks []dag.Vertex, workerCount int, r
 }
 
 type taskHashInputs struct {
+	packageDir           turbopath.AnchoredUnixPath
 	hashOfFiles          string
 	externalDepsHash     string
 	task                 string
@@ -290,6 +291,7 @@ func (th *Tracker) CalculateTaskHash(packageTask *nodes.PackageTask, dependencyS
 	logger.Debug(fmt.Sprintf("task hash env vars for %s:%s", packageTask.PackageName, packageTask.Task), "vars", hashableEnvPairs)
 
 	hash, err := fs.HashObject(&taskHashInputs{
+		packageDir:           packageTask.Pkg.Dir.ToUnixPath(),
 		hashOfFiles:          hashOfFiles,
 		externalDepsHash:     packageTask.Pkg.ExternalDepsHash,
 		task:                 packageTask.Task,


### PR DESCRIPTION
We should be considering the path of the task that is executing as part of its hash.

Fixes #1671