### PR TITLE
try/catch wrap gitTimestamp's useEffect

### DIFF
--- a/docs/theme.config.js
+++ b/docs/theme.config.js
@@ -45,13 +45,18 @@ const theme = {
 
     // eslint-disable-next-line react-hooks/rules-of-hooks
     useEffect(() => {
-      setDateString(
-        timestamp.toLocaleDateString(navigator.language, {
-          day: "numeric",
-          month: "long",
-          year: "numeric",
-        })
-      );
+      try {
+        setDateString(
+          timestamp.toLocaleDateString(navigator.language, {
+            day: "numeric",
+            month: "long",
+            year: "numeric",
+          })
+        );
+      } catch (e) {
+        // Ignore errors here; they get the ISO string.
+        // At least one person out there has manually misconfigured navigator.language.
+      }
     }, [timestamp]);
 
     return <>Last updated on {dateString}</>;


### PR DESCRIPTION
At least one person out there has misconfigured their browser such that `navigator.language` is an array, not a locale string.

Event ID [9857031a464d4493a3d1ac6932611794](https://sentry.io/organizations/vercel/issues/3731718814/events/9857031a464d4493a3d1ac6932611794/)