### PR TITLE
Document `persistent` key

### DIFF
--- a/docs/pages/repo/docs/core-concepts/caching.mdx
+++ b/docs/pages/repo/docs/core-concepts/caching.mdx
@@ -118,7 +118,7 @@ Sometimes you really don't want to write the cache output (e.g. when you're usin
 ```shell
 # Run `dev` npm script in all workspaces in parallel,
 # but don't cache the output
-turbo run dev --parallel --no-cache
+turbo run dev --no-cache
 ```
 
 Note that `--no-cache` disables cache writes but does not disable cache reads. If you want to disable cache reads, use the `--force` flag.
@@ -130,7 +130,8 @@ You can also disable caching on specific tasks by setting the [`pipeline.<task>.
   "$schema": "https://turbo.build/schema.json",
   "pipeline": {
     "dev": {
-      "cache": false
+      "cache": false,
+      "persistent": true
     }
   }
 }

--- a/docs/pages/repo/docs/getting-started/create-new.mdx
+++ b/docs/pages/repo/docs/getting-started/create-new.mdx
@@ -283,7 +283,7 @@ To see this in action, let's add a script to the root `package.json`:
 {
   "scripts": {
     "build": "turbo run build",
-    "dev": "turbo run dev --parallel",
+    "dev": "turbo run dev",
     "lint": "turbo run lint",
 +   "hello": "turbo run hello"
   }
@@ -509,13 +509,19 @@ Take a look at `turbo.json`:
 {
   "pipeline": {
     "dev": {
-      "cache": false
+      "cache": false,
+      "persistent": true
     }
   }
 }
 ```
 
-Inside `dev`, we've specified `"cache": false`. This means we're telling Turborepo _not_ to cache the results of the `dev` script. `dev` runs a persistent dev server and produces no outputs, so caching it makes no sense. Learn more about in our docs on [turning off caching](/repo/docs/core-concepts/caching#turn-off-caching).
+Inside `dev`, we've specified `"cache": false`. This means we're telling Turborepo _not_ to cache the
+results of the `dev` script. `dev` runs a persistent dev server and produces no outputs, so there
+is nothing to cache. Learn more about in our docs on [turning off caching](/repo/docs/core-concepts/caching#turn-off-caching).
+Additionally, we set `"persistent": true`, to let turbo know that this is a long-running dev server,
+so that turbo can ensure that no other tasks depend on it. You can read more in the [docs for the
+`persistent` option](/repo/docs/reference/configuration#persistent).
 
 #### Running `dev` on only one workspace at a time
 

--- a/docs/pages/repo/docs/handbook/dev.mdx
+++ b/docs/pages/repo/docs/handbook/dev.mdx
@@ -27,13 +27,17 @@ You should specify your `dev` task like this in your `turbo.json`.
 {
   "pipeline": {
     "dev": {
-      "cache": false
+      "cache": false,
+      "persistent": true
     }
   }
 }
 ```
 
-Since `dev` tasks don't produce outputs, `outputs` is empty. `dev` tasks are also unique in that you rarely want to [cache](/repo/docs/core-concepts/caching) them, so we set `cache` as `false`.
+Since `dev` tasks don't produce outputs, `outputs` is empty. `dev` tasks are also unique in that you
+rarely want to [cache](/repo/docs/core-concepts/caching) them, so we set `cache` as `false`.
+We also set `persistent` to `true`, because `dev` tasks are long-running tasks, and we want to ensure
+that it doesn't block any other task from executing.
 
 ### Setting up `package.json`
 

--- a/docs/pages/repo/docs/reference/codemods.mdx
+++ b/docs/pages/repo/docs/reference/codemods.mdx
@@ -143,7 +143,8 @@ For example:
       "outputs": []
     },
     "dev": {
-      "cache": false
+      "cache": false,
+      "persistent": true
     }
   }
 }
@@ -167,7 +168,8 @@ For example:
       "outputs": []
     },
     "dev": {
-      "cache": false
+      "cache": false,
+      "persistent": true
     }
   }
 }

--- a/docs/pages/repo/docs/reference/command-line-reference.mdx
+++ b/docs/pages/repo/docs/reference/command-line-reference.mdx
@@ -274,7 +274,7 @@ Default `false`. Do not cache results of the task. This is useful for watch comm
 
 ```shell
 turbo run build --no-cache
-turbo run dev --parallel --no-cache
+turbo run dev --no-cache
 ```
 
 #### `--no-daemon`
@@ -326,7 +326,13 @@ Will execute _only_ the `test` tasks in each workspace. It will not `build`.
 
 #### `--parallel`
 
-Default `false`. Run commands in parallel across workspaces and ignore the dependency graph. This is useful for developing with live reloading.
+Default `false`. Run commands in parallel across workspaces and ignore the task dependency graph.
+
+<Callout type="info">
+  The `--parallel` flag is typically used for "dev" or `--watch` mode tasks that don't exit.
+  Starting in `turbo@1.7`, we recommend configuring these tasks using the
+  [`persistent`](/repo/docs/reference/configuration#persistent) config instead.
+</Callout>
 
 ```sh
 turbo run lint --parallel --no-cache
@@ -356,7 +362,7 @@ Specify/filter workspaces to act as entry points for execution. Globs against `p
 
 ```sh
 turbo run lint --scope="@example/**"
-turbo run dev --parallel --scope="@example/a" --scope="@example/b" --no-cache --no-deps
+turbo run dev --scope="@example/a" --scope="@example/b" --no-cache --no-deps
 ```
 
 #### `--serial`

--- a/docs/pages/repo/docs/reference/configuration.mdx
+++ b/docs/pages/repo/docs/reference/configuration.mdx
@@ -72,7 +72,8 @@ Each key in the `pipeline` object is the name of a task that can be executed by 
       "outputMode": "full"
     },
     "dev": {
-      "cache": false
+      "cache": false,
+      "persistent": true
     }
   }
 }
@@ -199,7 +200,8 @@ Passing an empty array can be used to tell `turbo` that a task is a side-effect 
     "dev": {
       // Never cache anything (including logs) emitted by a
       // `dev` task
-      "cache": false
+      "cache": false,
+      "persistent": true
     }
   }
 }
@@ -225,7 +227,8 @@ Defaults to `true`. Whether or not to cache the task [`outputs`](#outputs). Sett
       "dependsOn": ["build"]
     },
     "dev": {
-      "cache": false
+      "cache": false,
+      "persistent": true
     }
   }
 }
@@ -288,6 +291,28 @@ Set type of output logging.
     "test": {
       "outputs": [],
       "dependsOn": ["build"]
+    }
+  }
+}
+```
+
+### `persistent`
+
+`type: boolean`
+
+Label a task as `persistent` if it is a long-running process, such as a dev server or `--watch` mode.
+Turbo will prevent other tasks from depending on persistent tasks. Without setting this
+config, if any other task depends on `dev`, it will never run, because `dev` never exits. With this
+option, `turbo` can warn you about an invalid configuration.
+
+**Example**
+
+```jsonc
+{
+  "$schema": "https://turbo.build/schema.json",
+  "pipeline": {
+    "dev": {
+      "persistent": true
     }
   }
 }

--- a/packages/create-turbo/templates/_shared_ts/package.json
+++ b/packages/create-turbo/templates/_shared_ts/package.json
@@ -8,7 +8,7 @@
   ],
   "scripts": {
     "build": "turbo run build",
-    "dev": "turbo run dev --parallel",
+    "dev": "turbo run dev",
     "lint": "turbo run lint",
     "format": "prettier --write \"**/*.{ts,tsx,md}\""
   },

--- a/packages/create-turbo/templates/pnpm/package.json
+++ b/packages/create-turbo/templates/pnpm/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build": "turbo run build",
-    "dev": "turbo run dev --parallel",
+    "dev": "turbo run dev",
     "lint": "turbo run lint",
     "format": "prettier --write \"**/*.{ts,tsx,md}\""
   },

--- a/packages/create-turbo/templates/yarn/package.json
+++ b/packages/create-turbo/templates/yarn/package.json
@@ -8,7 +8,7 @@
   ],
   "scripts": {
     "build": "turbo run build",
-    "dev": "turbo run dev --parallel",
+    "dev": "turbo run dev",
     "lint": "turbo run lint",
     "format": "prettier --write \"**/*.{ts,tsx,md}\""
   },

--- a/packages/turbo-types/src/types/config.ts
+++ b/packages/turbo-types/src/types/config.ts
@@ -117,6 +117,14 @@ export interface Pipeline {
    * @default full
    */
   outputMode?: string;
+
+  /**
+   * Indicates whether the task exits or not. Setting `persistent` to `true`, tells
+   * Turbo that this is a long-running task. Turbo will ensure that other tasks do not
+   * depend on it.
+   * @default false
+   */
+  persistent?: boolean;
 }
 
 export interface RemoteCache {


### PR DESCRIPTION
This adds documentation for the `persistent` key, adds it into
documentation examples, and removes `--parallel` where it isn't
necessary. It also updates `examples/` where `dev` tasks are used.

⚠️ This PR should be merged **after** `turbo@1.7` is released to npm.

Stacked PRs:
1. #2546
2. #2258
3. #2669 (this one)
4. #2738

Separate PR so we can merge docs in after the feature has been released.