### PR TITLE
Update integration test workflows

### DIFF
--- a/.github/workflows/pr-go-e2e-all.yml
+++ b/.github/workflows/pr-go-e2e-all.yml
@@ -1,4 +1,4 @@
-name: CLI E2E tests
+name: Turborepo E2E tests
 on:
   push:
     branches: ["main"]

--- a/.github/workflows/pr-go-e2e-filtered.yml
+++ b/.github/workflows/pr-go-e2e-filtered.yml
@@ -1,4 +1,4 @@
-name: CLI E2E tests
+name: Turborepo E2E tests
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/pr-go-integration-all.yml
+++ b/.github/workflows/pr-go-integration-all.yml
@@ -1,4 +1,4 @@
-name: CLI E2E tests
+name: Turborepo Integration tests
 on:
   push:
     branches: ["main"]

--- a/.github/workflows/pr-go-integration-all.yml
+++ b/.github/workflows/pr-go-integration-all.yml
@@ -1,0 +1,16 @@
+name: CLI E2E tests
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    types: [opened, edited, synchronize]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - run: 'echo "No test run required"'

--- a/.github/workflows/pr-go-integration-filtered.yml
+++ b/.github/workflows/pr-go-integration-filtered.yml
@@ -31,5 +31,24 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      - name: E2E Tests
-        run: pnpm -- turbo run e2e --filter=cli
+      - name: Setup rust
+        if: matrix.os != 'windows-latest'
+        uses: actions-rs/toolchain@v1
+
+      - name: Setup rust cache
+        if: matrix.os != 'windows-latest'
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: test
+
+      - name: Cache Prysk
+        if: matrix.os != 'windows-latest'
+        id: cache-prysk
+        uses: actions/cache@v3
+        with:
+          path: cli/.cram_env
+          key: ${{ runner.os }}-prysk
+
+      - name: Integration Tests
+        if: matrix.os != 'windows-latest'
+        run: pnpm -- turbo run integration-tests --filter=cli

--- a/.github/workflows/pr-go-integration-filtered.yml
+++ b/.github/workflows/pr-go-integration-filtered.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
 
     steps:
       - uses: actions/checkout@v3
@@ -32,17 +32,14 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Setup rust
-        if: matrix.os != 'windows-latest'
         uses: actions-rs/toolchain@v1
 
       - name: Setup rust cache
-        if: matrix.os != 'windows-latest'
         uses: Swatinem/rust-cache@v2
         with:
           key: test
 
       - name: Cache Prysk
-        if: matrix.os != 'windows-latest'
         id: cache-prysk
         uses: actions/cache@v3
         with:
@@ -50,5 +47,4 @@ jobs:
           key: ${{ runner.os }}-prysk
 
       - name: Integration Tests
-        if: matrix.os != 'windows-latest'
         run: pnpm -- turbo run integration-tests --filter=cli

--- a/.github/workflows/pr-go-integration-filtered.yml
+++ b/.github/workflows/pr-go-integration-filtered.yml
@@ -1,4 +1,4 @@
-name: CLI E2E tests
+name: Turborepo Integration tests
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/pr-go-integration-filtered.yml
+++ b/.github/workflows/pr-go-integration-filtered.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
e2e tests are very slow, and integration tests are sometimes flakey. It is a pain to wait for all e2e tests to run and then find out the integration tests failed. Separating them will parallelize the two.