### PR TITLE
Add proper error with doc link on failure in alpine

### DIFF
--- a/packages/turbo/install.js
+++ b/packages/turbo/install.js
@@ -317,7 +317,7 @@ checkAndPreparePackage().then(() => {
       console.error(
         `Error: Failed to run turbo binary, you may need to install glibc compat\nSee https://turbo.build/repo/docs/getting-started/existing-monorepo#install-turbo`
       );
-      throw err;
     }
+    throw err;
   }
 });

--- a/packages/turbo/install.js
+++ b/packages/turbo/install.js
@@ -300,11 +300,24 @@ this. If that fails, you need to remove the "--no-optional" flag to use turbo.
 }
 
 checkAndPreparePackage().then(() => {
-  if (isToPathJS) {
-    // We need "node" before this command since it's a JavaScript file
-    validateBinaryVersion("node", toPath);
-  } else {
-    // This is no longer a JavaScript file so don't run it using "node"
-    validateBinaryVersion(toPath);
+  try {
+    if (isToPathJS) {
+      // We need "node" before this command since it's a JavaScript file
+      validateBinaryVersion("node", toPath);
+    } else {
+      // This is no longer a JavaScript file so don't run it using "node"
+      validateBinaryVersion(toPath);
+    }
+  } catch (err) {
+    if (
+      process.platform === "linux" &&
+      err.message &&
+      err.message.includes("ENOENT")
+    ) {
+      console.error(
+        `Error: Failed to run turbo binary, you may need to install glibc compat\nSee https://turbo.build/repo/docs/getting-started/existing-monorepo#install-turbo`
+      );
+      throw err;
+    }
   }
 });


### PR DESCRIPTION
This adds a helpful error when we fail to run the turbo binary in alpine linux pointing to the related doc to help users get unblocked when failing to run with glibc compat installed as currently they will just see an `ENOENT` error which doesn't lead to the docs very well. 

x-ref: https://github.com/vercel/turbo/pull/2212
x-ref: https://github.com/vercel/turbo/issues/2198