### PR TITLE
Fix publish workflow

### DIFF
--- a/.github/workflows/publish-docs-rs.yml
+++ b/.github/workflows/publish-docs-rs.yml
@@ -36,6 +36,7 @@ jobs:
           path: ./target/doc
       - run: ls -a
       - run: rm -rf ./docs/docs.rs
+      - run: mkdir docs || true # || true to make sure exit code is 0 even if dir exists
       - run: cp -r ./target/doc ./docs/docs.rs
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:


### PR DESCRIPTION
All the commits in `main` have ❌ s because this publish workflow is failing. It seem the `docs` directory doesn't exist in https://github.com/vercel/turbo/tree/gh-pages. Not sure if that's intentional or not, but creating it on the fly should work. I could also add it to the branch directly if it should always be there.