### PR TITLE
fix(docs): fix typo in code blocks

### DIFF
--- a/docs/pages/repo/docs/reference/codemods.mdx
+++ b/docs/pages/repo/docs/reference/codemods.mdx
@@ -171,6 +171,7 @@ For example:
     }
   }
 }
+````
 
 #### Usage
 
@@ -178,7 +179,7 @@ Go to your project:
 
 ```sh
 cd path-to-your-turborepo/
-````
+```
 
 Run the codemod:
 

--- a/docs/pages/repo/docs/reference/codemods.mdx
+++ b/docs/pages/repo/docs/reference/codemods.mdx
@@ -149,7 +149,7 @@ For example:
 }
 ```
 
-````diff
+```diff
 // After, turbo.json
 {
   "$schema": "https://turbo.build/schema.json",
@@ -171,7 +171,7 @@ For example:
     }
   }
 }
-````
+```
 
 #### Usage
 


### PR DESCRIPTION
Fixes code blocks in [Turborepo Codemods](https://turbo.build/repo/docs/reference/codemods#migrate-env-var-dependencies).

![Screenshot 2022-11-12 at 14 50 42](https://user-images.githubusercontent.com/11066224/201477205-1ef74176-46c7-4a57-9c58-6a7cd191c054.png)
