### PR TITLE
Remove parallel flag from all examples

### DIFF
--- a/docs/pages/repo/docs/getting-started/create-new.mdx
+++ b/docs/pages/repo/docs/getting-started/create-new.mdx
@@ -283,7 +283,7 @@ To see this in action, let's add a script to the root `package.json`:
 {
   "scripts": {
     "build": "turbo run build",
-    "dev": "turbo run dev --parallel",
+    "dev": "turbo run dev",
     "lint": "turbo run lint",
 +   "hello": "turbo run hello"
   }

--- a/docs/pages/repo/docs/reference/command-line-reference.mdx
+++ b/docs/pages/repo/docs/reference/command-line-reference.mdx
@@ -274,7 +274,7 @@ Default `false`. Do not cache results of the task. This is useful for watch comm
 
 ```shell
 turbo run build --no-cache
-turbo run dev --parallel --no-cache
+turbo run dev --no-cache
 ```
 
 #### `--no-daemon`
@@ -356,7 +356,7 @@ Specify/filter workspaces to act as entry points for execution. Globs against `p
 
 ```sh
 turbo run lint --scope="@example/**"
-turbo run dev --parallel --scope="@example/a" --scope="@example/b" --no-cache --no-deps
+turbo run dev --scope="@example/a" --scope="@example/b" --no-cache --no-deps
 ```
 
 #### `--serial`

--- a/examples/design-system/package.json
+++ b/examples/design-system/package.json
@@ -6,7 +6,7 @@
   ],
   "scripts": {
     "build": "turbo run build",
-    "dev": "turbo run dev --no-cache --parallel --continue",
+    "dev": "turbo run dev --no-cache --continue",
     "lint": "turbo run lint",
     "clean": "turbo run clean && rm -rf node_modules",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",

--- a/examples/kitchen-sink/package.json
+++ b/examples/kitchen-sink/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "turbo run build",
     "clean": "turbo run clean",
-    "dev": "turbo run dev --no-cache --parallel --continue",
+    "dev": "turbo run dev --no-cache  --continue",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "lint": "turbo run lint",
     "test": "turbo run test"

--- a/examples/with-changesets/package.json
+++ b/examples/with-changesets/package.json
@@ -6,7 +6,7 @@
   ],
   "scripts": {
     "build": "turbo run build",
-    "dev": "turbo run dev --no-cache --parallel --continue",
+    "dev": "turbo run dev --no-cache --continue",
     "lint": "turbo run lint",
     "clean": "turbo run clean && rm -rf node_modules",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",

--- a/examples/with-create-react-app/package.json
+++ b/examples/with-create-react-app/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "turbo run build",
     "clean": "turbo run clean",
-    "dev": "turbo run dev --no-cache --parallel --continue",
+    "dev": "turbo run dev --no-cache --continue",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "lint": "turbo run lint",
     "test": "turbo run test"

--- a/examples/with-docker/README.md
+++ b/examples/with-docker/README.md
@@ -40,7 +40,7 @@ This repo is configured to be built with Docker, and Docker compose. To build al
 docker network create app_network
 
 # Build prod using new BuildKit engine
-COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose -f docker-compose.yml build --parallel
+COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose -f docker-compose.yml build
 
 # Start prod in detached mode
 docker-compose -f docker-compose.yml up -d

--- a/examples/with-docker/package.json
+++ b/examples/with-docker/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "turbo run build",
     "clean": "turbo run clean",
-    "dev": "turbo run dev --parallel",
+    "dev": "turbo run dev",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "lint": "turbo run lint",
     "test": "turbo run test"

--- a/examples/with-pnpm/package.json
+++ b/examples/with-pnpm/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "scripts": {
     "build": "turbo run build",
-    "dev": "turbo run dev --parallel",
+    "dev": "turbo run dev",
     "lint": "turbo run lint"
   },
   "devDependencies": {

--- a/examples/with-prisma/package.json
+++ b/examples/with-prisma/package.json
@@ -13,7 +13,7 @@
     "db:migrate:deploy": "turbo run db:migrate:deploy",
     "db:push": "turbo run db:push",
     "db:seed": "turbo run db:seed",
-    "dev": "turbo run dev --parallel",
+    "dev": "turbo run dev",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "generate": "turbo run generate",
     "lint": "turbo run lint"

--- a/examples/with-svelte/package.json
+++ b/examples/with-svelte/package.json
@@ -6,7 +6,7 @@
   ],
   "scripts": {
     "build": "turbo run build",
-    "dev": "turbo run dev --parallel",
+    "dev": "turbo run dev",
     "lint": "turbo run lint",
     "format": "prettier --write ."
   },

--- a/examples/with-tailwind/package.json
+++ b/examples/with-tailwind/package.json
@@ -6,7 +6,7 @@
   ],
   "scripts": {
     "build": "turbo run build",
-    "dev": "turbo run dev --parallel",
+    "dev": "turbo run dev",
     "lint": "turbo run lint",
     "clean": "turbo run clean",
     "format": "prettier --write \"**/*.{ts,tsx,md}\""

--- a/examples/with-vite/package.json
+++ b/examples/with-vite/package.json
@@ -6,7 +6,7 @@
   ],
   "scripts": {
     "build": "turbo run build",
-    "dev": "turbo run dev --parallel",
+    "dev": "turbo run dev",
     "lint": "turbo run lint",
     "format": "prettier --write \"**/*.{ts,tsx,md}\""
   },

--- a/packages/create-turbo/templates/_shared_ts/package.json
+++ b/packages/create-turbo/templates/_shared_ts/package.json
@@ -8,7 +8,7 @@
   ],
   "scripts": {
     "build": "turbo run build",
-    "dev": "turbo run dev --parallel",
+    "dev": "turbo run dev",
     "lint": "turbo run lint",
     "format": "prettier --write \"**/*.{ts,tsx,md}\""
   },

--- a/packages/create-turbo/templates/pnpm/package.json
+++ b/packages/create-turbo/templates/pnpm/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build": "turbo run build",
-    "dev": "turbo run dev --parallel",
+    "dev": "turbo run dev",
     "lint": "turbo run lint",
     "format": "prettier --write \"**/*.{ts,tsx,md}\""
   },

--- a/packages/create-turbo/templates/yarn/package.json
+++ b/packages/create-turbo/templates/yarn/package.json
@@ -8,7 +8,7 @@
   ],
   "scripts": {
     "build": "turbo run build",
-    "dev": "turbo run dev --parallel",
+    "dev": "turbo run dev",
     "lint": "turbo run lint",
     "format": "prettier --write \"**/*.{ts,tsx,md}\""
   },


### PR DESCRIPTION
This will be overtaken by `persistent: true` in 1.7, so I've removed `--parallel` from all examples

Related: #2669

⚠️ This PR should be merged after turbo@1.7 is released to npm.