### PR TITLE
fix HMR for RSC benchmarking

### DIFF
--- a/.github/workflows/bench-turbopack-scheduled.yml
+++ b/.github/workflows/bench-turbopack-scheduled.yml
@@ -23,6 +23,13 @@ jobs:
           # One of Turbopack CSR or SSR with 1000 modules is benchmarked in every run
           # to create a baseline result for normalization (should the runners performance vary between jobs)
 
+          # This measures Next.js 13
+          - name: next 13
+            cache_key: next-dev
+            args: -p next-dev -- "(Turbopack SSR/1000|Next.js 13)"
+            TURBOPACK_BENCH_COUNTS: 100,500,1000
+            TURBOPACK_BENCH_BUNDLERS: all
+
           # This measures Next.js 12
           - name: next 12
             cache_key: next-dev

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,6 +74,13 @@ jobs:
             rust-toolchain
             !**.md
             !**.mdx
+      - name: Rust Benchmark related changes
+        id: rust_bench
+        uses: technote-space/get-diff-action@v6
+        with:
+          PATTERNS: |
+            crates/next-dev/benches/**
+            !*.md
       - name: Go related changes
         id: go
         uses: technote-space/get-diff-action@v6
@@ -118,6 +125,7 @@ jobs:
 
     outputs:
       rust: ${{ steps.ci.outputs.diff != '' || steps.rust.outputs.diff != '' }}
+      rust_bench: ${{ steps.ci.outputs.diff != '' || steps.rust_bench.outputs.diff != '' }}
       go: ${{ steps.ci.outputs.diff != '' || steps.go.outputs.diff != '' }}
       examples: ${{ steps.ci.outputs.diff != '' || steps.examples.outputs.diff != '' }}
       node: ${{ steps.ci.outputs.diff != '' || steps.node.outputs.diff != '' }}
@@ -495,6 +503,19 @@ jobs:
         timeout-minutes: 120
         env:
           TURBOPACK_BENCH_COUNTS: "100"
+          TURBOPACK_BENCH_PROGRESS: "1"
+        with:
+          command: test
+          args: --benches --release
+
+      - name: Run cargo test on benchmarks for other bundlers
+        uses: actions-rs/cargo@v1
+        if: needs.determine_jobs.outputs.rust_bench == 'true'
+        timeout-minutes: 120
+        env:
+          TURBOPACK_BENCH_COUNTS: "100"
+          TURBOPACK_BENCH_PROGRESS: "1"
+          TURBOPACK_BENCH_BUNDLERS: "others"
         with:
           command: test
           args: --benches --release
@@ -609,7 +630,7 @@ jobs:
 
   rust_bench:
     needs: [determine_jobs, rust_prepare]
-    if: needs.determine_jobs.outputs.rust == 'true' && needs.determine_jobs.outputs.push == 'true'
+    if: (needs.determine_jobs.outputs.rust == 'true' && needs.determine_jobs.outputs.push == 'true') || needs.determine_jobs.outputs.rust_bench == 'true'
     strategy:
       fail-fast: false
       matrix:

--- a/crates/next-dev/benches/bundlers/mod.rs
+++ b/crates/next-dev/benches/bundlers/mod.rs
@@ -16,6 +16,20 @@ mod turbopack;
 mod vite;
 mod webpack;
 
+#[derive(Debug, Clone, Copy)]
+pub enum RenderType {
+    /// App is completely rendered on client side, the initial HTML is empty.
+    ClientSideRendered,
+    /// App is intially rendered on server side, then hydrated on client side.
+    ServerSidePrerendered,
+    /// App is rendered on server side, but additional client side javascript
+    /// emits events on hydration and changes
+    ServerSideRenderedWithEvents,
+    /// App is rendered on server side, without any client side events.
+    #[allow(dead_code)]
+    ServerSideRenderedWithoutInteractivity,
+}
+
 pub trait Bundler {
     fn get_name(&self) -> &str;
     fn get_path(&self) -> &str {
@@ -24,15 +38,17 @@ pub trait Bundler {
     fn react_version(&self) -> &str {
         "^18.2.0"
     }
-    /// The initial HTML is enough to render the page even without JavaScript
-    /// loaded
-    fn has_server_rendered_html(&self) -> bool {
-        false
+    fn render_type(&self) -> RenderType {
+        RenderType::ClientSideRendered
     }
     /// There is a hydration done event emitted by client side JavaScript
-    fn has_interactivity(&self) -> bool {
-        true
+    fn has_hydration_event(&self) -> bool {
+        !matches!(
+            self.render_type(),
+            RenderType::ServerSideRenderedWithoutInteractivity
+        )
     }
+
     fn prepare(&self, _template_dir: &Path) -> Result<()> {
         Ok(())
     }
@@ -59,30 +75,59 @@ pub fn get_bundlers() -> Vec<Box<dyn Bundler>> {
     }
     let mut bundlers: Vec<Box<dyn Bundler>> = Vec::new();
     if turbopack {
-        bundlers.push(Box::new(Turbopack::new("Turbopack CSR", "/", false, true)));
+        bundlers.push(Box::new(Turbopack::new(
+            "Turbopack CSR",
+            "/",
+            RenderType::ClientSideRendered,
+        )));
         bundlers.push(Box::new(Turbopack::new(
             "Turbopack SSR",
             "/page",
-            true,
-            true,
+            RenderType::ServerSidePrerendered,
         )));
         bundlers.push(Box::new(Turbopack::new(
             "Turbopack RSC",
             "/app",
-            true,
-            false,
+            RenderType::ServerSideRenderedWithEvents,
         )));
         bundlers.push(Box::new(Turbopack::new(
             "Turbopack RCC",
             "/client",
-            true,
-            true,
+            RenderType::ServerSidePrerendered,
         )));
     }
 
     if others {
-        bundlers.push(Box::new(NextJs::new(NextJsVersion::V12)));
-        bundlers.push(Box::new(NextJs::new(NextJsVersion::V11)));
+        bundlers.push(Box::new(NextJs::new(
+            NextJsVersion::V13,
+            "Next.js 13 SSR",
+            "/page",
+            RenderType::ServerSidePrerendered,
+        )));
+        bundlers.push(Box::new(NextJs::new(
+            NextJsVersion::V13,
+            "Next.js 13 RSC",
+            "/app",
+            RenderType::ServerSideRenderedWithEvents,
+        )));
+        bundlers.push(Box::new(NextJs::new(
+            NextJsVersion::V13,
+            "Next.js 13 RCC",
+            "/client",
+            RenderType::ServerSidePrerendered,
+        )));
+        bundlers.push(Box::new(NextJs::new(
+            NextJsVersion::V12,
+            "Next.js 12 SSR",
+            "/page",
+            RenderType::ServerSidePrerendered,
+        )));
+        bundlers.push(Box::new(NextJs::new(
+            NextJsVersion::V11,
+            "Next.js 11 SSR",
+            "/page",
+            RenderType::ServerSidePrerendered,
+        )));
         bundlers.push(Box::new(Parcel {}));
         bundlers.push(Box::new(Vite::new()));
         bundlers.push(Box::new(Webpack {}));

--- a/crates/next-dev/benches/bundlers/nextjs/next.config.js
+++ b/crates/next-dev/benches/bundlers/nextjs/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  experimental: {
+    appDir: true,
+  },
+};

--- a/crates/next-dev/benches/bundlers/turbopack.rs
+++ b/crates/next-dev/benches/bundlers/turbopack.rs
@@ -6,6 +6,7 @@ use std::{
 use anyhow::{anyhow, Context, Result};
 use regex::Regex;
 
+use super::RenderType;
 use crate::{
     bundlers::Bundler,
     util::{
@@ -17,22 +18,15 @@ use crate::{
 pub struct Turbopack {
     name: String,
     path: String,
-    has_server_rendered_html: bool,
-    has_interactivity: bool,
+    render_type: RenderType,
 }
 
 impl Turbopack {
-    pub fn new(
-        name: &str,
-        path: &str,
-        has_server_rendered_html: bool,
-        has_interactivity: bool,
-    ) -> Self {
+    pub fn new(name: &str, path: &str, render_type: RenderType) -> Self {
         Turbopack {
             name: name.to_owned(),
             path: path.to_owned(),
-            has_server_rendered_html,
-            has_interactivity,
+            render_type,
         }
     }
 }
@@ -46,12 +40,8 @@ impl Bundler for Turbopack {
         &self.path
     }
 
-    fn has_server_rendered_html(&self) -> bool {
-        self.has_server_rendered_html
-    }
-
-    fn has_interactivity(&self) -> bool {
-        self.has_interactivity
+    fn render_type(&self) -> RenderType {
+        self.render_type
     }
 
     fn prepare(&self, install_dir: &Path) -> Result<()> {

--- a/crates/next-dev/benches/util/mod.rs
+++ b/crates/next-dev/benches/util/mod.rs
@@ -117,8 +117,14 @@ pub async fn create_browser() -> Browser {
 
 pub fn resume_on_error<F: FnOnce() + UnwindSafe>(f: F) {
     let runs_as_bench = std::env::args().find(|a| a == "--bench");
+    let ignore_errors = !matches!(
+        std::env::var("TURBOPACK_BENCH_IGNORE_ERRORS")
+            .ok()
+            .as_deref(),
+        None | Some("") | Some("no") | Some("false")
+    );
 
-    if runs_as_bench.is_some() {
+    if runs_as_bench.is_some() || ignore_errors {
         use std::panic::catch_unwind;
         // panics are already printed to the console, so no need to handle the result.
         let _ = catch_unwind(f);

--- a/xtask/src/visualize_bundler_bench.rs
+++ b/xtask/src/visualize_bundler_bench.rs
@@ -60,10 +60,7 @@ pub fn generate(summary_path: PathBuf) -> Result<()> {
                 .parse()?,
             // we want to use slope instead of mean when available since this is a better
             // estimation of the real performance values when iterations go to infinity
-            bench
-                .estimates
-                .slope
-                .unwrap_or_else(|| bench.estimates.mean),
+            bench.estimates.slope.unwrap_or(bench.estimates.mean),
         );
     }
 


### PR DESCRIPTION
measure hmr_to_commit with detector component

add Next.js 13 to benchmarks with RSC and RCC measurements

this tests RSC HMR

make HMR warmup faster

make browser launch lazy

test benchmarks for other bundlers on CI too