### PR TITLE
Increase HMR sampling to a default of 100 per iteration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2379,6 +2379,7 @@ dependencies = [
  "once_cell",
  "owo-colors",
  "portpicker",
+ "rand",
  "regex",
  "serde",
  "serde_json",

--- a/crates/next-dev/Cargo.toml
+++ b/crates/next-dev/Cargo.toml
@@ -60,6 +60,7 @@ criterion = { version = "0.3.5", features = ["async_tokio"] }
 fs_extra = "1.2.0"
 lazy_static = "1.4.0"
 once_cell = "1.13.0"
+rand = "0.8.5"
 regex = "1.6.0"
 tempfile = "3.3.0"
 test-generator = "0.3.0"

--- a/crates/next-dev/benches/util/env.rs
+++ b/crates/next-dev/benches/util/env.rs
@@ -1,0 +1,43 @@
+use std::{error::Error, str::FromStr};
+
+use anyhow::{anyhow, Context, Result};
+
+pub fn read_env<T>(name: &str, default: T) -> Result<T>
+where
+    T: FromStr,
+    <T as FromStr>::Err: Error + Send + Sync + 'static,
+{
+    let config = std::env::var(name).ok();
+    match config.as_deref() {
+        None | Some("") => Ok(default),
+        Some(config) => config
+            .parse()
+            .with_context(|| anyhow!("Invalid value for {}", name)),
+    }
+}
+
+pub fn read_env_bool(name: &str) -> bool {
+    let config = std::env::var(name).ok();
+    match config.as_deref() {
+        None | Some("") | Some("no") | Some("false") => false,
+        _ => true,
+    }
+}
+
+pub fn read_env_list<T>(name: &str, default: Vec<T>) -> Result<Vec<T>>
+where
+    T: FromStr,
+    <T as FromStr>::Err: Error + Send + Sync + 'static,
+{
+    let config = std::env::var(name).ok();
+    match config.as_deref() {
+        None | Some("") => Ok(default),
+        Some(config) => config
+            .split(',')
+            .map(|s| {
+                s.parse()
+                    .with_context(|| anyhow!("Invalid value for {}", name))
+            })
+            .collect(),
+    }
+}

--- a/crates/next-dev/benches/util/page_guard.rs
+++ b/crates/next-dev/benches/util/page_guard.rs
@@ -44,12 +44,6 @@ impl<'a> PageGuard<'a> {
         }
     }
 
-    /// Returns a reference to the app.
-    pub fn app(&self) -> &PreparedApp<'a> {
-        // Invariant: app is always Some while the guard is alive.
-        self.app.as_ref().unwrap()
-    }
-
     /// Returns a reference to the page.
     pub fn page(&self) -> &Page {
         // Invariant: page is always Some while the guard is alive.

--- a/crates/next-dev/benches/util/rand.rs
+++ b/crates/next-dev/benches/util/rand.rs
@@ -1,0 +1,16 @@
+use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
+
+/// Picks `count` items from `vec` at random.
+///
+/// Calling this function with the same `count` and `vec` items will always
+/// return the same items.
+pub fn deterministic_random_pick<T>(mut vec: Vec<T>, count: usize) -> Vec<T>
+where
+    T: Ord,
+{
+    let mut rng = StdRng::seed_from_u64(42);
+    vec.sort();
+    vec.shuffle(&mut rng);
+    vec.truncate(count);
+    vec
+}


### PR DESCRIPTION
This increases the HMR sampling to 100 randomly--but deterministically the same across bundlers/benchmark executions--files per benchmark iteration, for a minimum of 10*100 samples overall.

This is particularly difficult to do with Criterion because it will always count startup time as part of total execution time when calculating how many iterations of the routine it should do as part of each benchmark sample. Since our startup times are very slow and take up most of the benchmark's overall time, it would end up only running a single iteration per sample. Changing the startup and routine logic to reuse the same bundler instance across routines does not help here as Criterion will still only ask for a single iteration.

This PR works around this issue by sampling 100 different file changes per benchmark iteration and returning the average duration. A side effect of this workaround is that our statistics will no longer represent the time it takes to do one update, but rather the average time it takes per update in a batch of 100 updates. For instance, the computed standard error will be different than if we were considering all 100 iterations separately.