### PR TITLE
Fix the missing links.

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -160,7 +160,11 @@ const nextConfig = withNextra({
         destination: "/repo/docs/handbook/migrating-to-a-monorepo",
         permanent: true,
       },
-
+      {
+        source: "/docs/getting-started",
+        destination: "/repo/docs",
+        permanent: true,
+      },
       {
         source: "/discord{/}?",
         permanent: true,

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -91,18 +91,8 @@ const nextConfig = withNextra({
         permanent: true,
       })),
       {
-        source: "/repo/docs/getting-started",
-        destination: "/repo/docs",
-        permanent: true,
-      },
-      {
         source: "/docs/getting-started",
         destination: "/repo/docs",
-        permanent: true,
-      },
-      {
-        source: "/repo/docs/guides/workspaces",
-        destination: "/repo/docs/handbook/workspaces",
         permanent: true,
       },
       {
@@ -116,18 +106,8 @@ const nextConfig = withNextra({
         permanent: true,
       },
       {
-        source: "/repo/docs/core-concepts/why-turborepo",
-        destination: "/repo/docs/core-concepts/monorepos",
-        permanent: true,
-      },
-      {
         source: "/docs/core-concepts/why-turborepo",
         destination: "/repo/docs/core-concepts/monorepos",
-        permanent: true,
-      },
-      {
-        source: "/repo/docs/core-concepts/filtering",
-        destination: "/repo/docs/core-concepts/monorepos/filtering",
         permanent: true,
       },
       {
@@ -141,21 +121,8 @@ const nextConfig = withNextra({
         permanent: true,
       },
       {
-        // Somehow this URL got created, probably in error during transition.
-        // It has _never_ resolved, so we should be able to remove this rule.
-        // Eventually.
-        source: "/repo/docs/guides/workspaces",
-        destination: "/repo/docs/handbook/workspaces",
-        permanent: true,
-      },
-      {
         source: "/docs/core-concepts/workspaces",
         destination: "/repo/docs/handbook/workspaces",
-        permanent: true,
-      },
-      {
-        source: "/repo/docs/core-concepts/pipelines",
-        destination: "/repo/docs/core-concepts/monorepos/running-tasks",
         permanent: true,
       },
       {
@@ -166,11 +133,6 @@ const nextConfig = withNextra({
       {
         source: "/docs/guides/migrate-from-lerna",
         destination: "/repo/docs/handbook/migrating-to-a-monorepo",
-        permanent: true,
-      },
-      {
-        source: "/docs/getting-started",
-        destination: "/repo/docs",
         permanent: true,
       },
       {
@@ -223,16 +185,12 @@ const nextConfig = withNextra({
       },
       {
         // Accidentally created, eventually removable. See below.
-        source: "/repo/docs/guides/workspaces",
-        destination: "/repo/docs/handbook/workspaces",
+        source: "/repo/docs/core-concepts/pipelines",
+        destination: "/repo/docs/core-concepts/monorepos/running-tasks",
         permanent: true,
       },
       {
-        // This rule accidentally created these four URLs:
-        // - /repo/docs/core-concepts/why-turborepo
-        // - /repo/docs/core-concepts/running-tasks
-        // - /repo/docs/core-concepts/filtering
-        // - /repo/docs/core-concepts/pipelines
+        // This rule accidentally created a bunch of URLs.
         //
         // They've _never_ resolved, so _eventually_ we should be able to remove the
         // redirects we added above to fix them.
@@ -241,6 +199,22 @@ const nextConfig = withNextra({
         destination: "/repo/docs/core-concepts/:path*",
       },
       {
+        // Accidentally created, eventually removable. See below.
+        source: "/repo/docs/getting-started",
+        destination: "/repo/docs",
+        permanent: true,
+      },
+      {
+        // Accidentally created, eventually removable. See below.
+        source: "/repo/docs/guides/workspaces",
+        destination: "/repo/docs/handbook/workspaces",
+        permanent: true,
+      },
+      {
+        // This rule accidentally created a bunch of URLs.
+        //
+        // They've _never_ resolved, so _eventually_ we should be able to remove the
+        // redirects we added above to fix them.
         source: "/docs/:path*",
         permanent: true,
         destination: "/repo/docs/:path*",

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -141,6 +141,14 @@ const nextConfig = withNextra({
         permanent: true,
       },
       {
+        // Somehow this URL got created, probably in error during transition.
+        // It has _never_ resolved, so we should be able to remove this rule.
+        // Eventually.
+        source: "/repo/docs/guides/workspaces",
+        destination: "/repo/docs/handbook/workspaces",
+        permanent: true,
+      },
+      {
         source: "/docs/core-concepts/workspaces",
         destination: "/repo/docs/handbook/workspaces",
         permanent: true,
@@ -196,6 +204,38 @@ const nextConfig = withNextra({
         destination: "/repo/docs/ci",
       },
       {
+        // Accidentally created, eventually removable. See below.
+        source: "/repo/docs/core-concepts/running-tasks",
+        destination: "/repo/docs/core-concepts/monorepos/running-tasks",
+        permanent: true,
+      },
+      {
+        // Accidentally created, eventually removable. See below.
+        source: "/repo/docs/core-concepts/why-turborepo",
+        destination: "/repo/docs/core-concepts/monorepos",
+        permanent: true,
+      },
+      {
+        // Accidentally created, eventually removable. See below.
+        source: "/repo/docs/core-concepts/filtering",
+        destination: "/repo/docs/core-concepts/monorepos/filtering",
+        permanent: true,
+      },
+      {
+        // Accidentally created, eventually removable. See below.
+        source: "/repo/docs/guides/workspaces",
+        destination: "/repo/docs/handbook/workspaces",
+        permanent: true,
+      },
+      {
+        // This rule accidentally created these four URLs:
+        // - /repo/docs/core-concepts/why-turborepo
+        // - /repo/docs/core-concepts/running-tasks
+        // - /repo/docs/core-concepts/filtering
+        // - /repo/docs/core-concepts/pipelines
+        //
+        // They've _never_ resolved, so _eventually_ we should be able to remove the
+        // redirects we added above to fix them.
         source: "/docs/features/:path*",
         permanent: true,
         destination: "/repo/docs/core-concepts/:path*",


### PR DESCRIPTION
This PR does three things:
1. Prevents double redirects by setting the correct destination the first time.
2. Redirects URLs accidentally recreated in the new scope. 🤦‍♂️
3. Removes a catch-all to trigger any additional missing links to appear.

Changes are easy to review commit-by-commit.