### PR TITLE
chore(docs): correct supported os list

### DIFF
--- a/docs/pages/repo/docs/getting-started/existing-monorepo.mdx
+++ b/docs/pages/repo/docs/getting-started/existing-monorepo.mdx
@@ -11,11 +11,8 @@ import { Tabs, Tab } from "../../../../components/Tabs";
 `turbo` works with [Yarn](https://classic.yarnpkg.com/lang/en/), [npm](https://www.npmjs.com/), and [pnpm](https://pnpm.io/) on the following operating systems:
 
 - macOS darwin 64-bit (Intel), ARM 64-bit (Apple Silicon)
-- Linux 32-bit, 64-bit, ARM, ARM 64-bit, MIPS 64-bit Little Endian, PowerPC 64-bit Little Endian, IBM Z 64-bit Big Endian
-- Windows 32-bit, 64-bit, ARM 64-bit
-- FreeBSD 64-bit, ARM 64-bit
-- NetBSD AMD64
-- Android ARM 64-bit
+- Linux 64-bit, ARM 64-bit
+- Windows 64-bit, ARM 64-bit
 
 ## Configure workspaces
 


### PR DESCRIPTION
Change implemented https://github.com/vercel/turbo/pull/1903 from discussion https://github.com/vercel/turbo/discussions/1891