### PR TITLE
Remove default task outputs when outputs is not defined

### DIFF
--- a/cli/internal/fs/turbo_json.go
+++ b/cli/internal/fs/turbo_json.go
@@ -277,7 +277,7 @@ func (c *TaskDefinition) UnmarshalJSON(data []byte) error {
 
 	for _, dependency := range task.DependsOn {
 		if strings.HasPrefix(dependency, envPipelineDelimiter) {
-			// log.Printf("[DEPRECATED] Declaring an environment variable in \"dependsOn\" is deprecated, found %s. Use the \"env\" key or use `npx @turbo/codemod migrate-env-var-dependencies`.\n", dependency)
+			log.Printf("[DEPRECATED] Declaring an environment variable in \"dependsOn\" is deprecated, found %s. Use the \"env\" key or use `npx @turbo/codemod migrate-env-var-dependencies`.\n", dependency)
 			envVarDependencies.Add(strings.TrimPrefix(dependency, envPipelineDelimiter))
 		} else if strings.HasPrefix(dependency, topologicalPipelineDelimiter) {
 			c.TopologicalDependencies = append(c.TopologicalDependencies, strings.TrimPrefix(dependency, topologicalPipelineDelimiter))

--- a/cli/internal/fs/turbo_json.go
+++ b/cli/internal/fs/turbo_json.go
@@ -21,8 +21,6 @@ const (
 	topologicalPipelineDelimiter = "^"
 )
 
-var defaultOutputs = TaskOutputs{Inclusions: []string{"dist/**/*", "build/**/*"}}
-
 type rawTurboJSON struct {
 	// Global root filesystem dependencies
 	GlobalDependencies []string `json:"globalDependencies,omitempty"`
@@ -50,9 +48,7 @@ type RemoteCacheOptions struct {
 }
 
 type rawTask struct {
-	// We can't use omitempty for Outputs, because it will
-	// always unmarshal into an empty array, which means something different from nil.
-	Outputs *[]string `json:"outputs"`
+	Outputs *[]string `json:"outputs,omitempty"`
 
 	Cache      *bool               `json:"cache,omitempty"`
 	DependsOn  []string            `json:"dependsOn,omitempty"`
@@ -248,12 +244,10 @@ func (c *TaskDefinition) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// We actually need a nil value to be able to unmarshal the json
-	// because we interpret the omission of outputs to be different
-	// from an empty array.
+	var inclusions []string
+	var exclusions []string
+
 	if task.Outputs != nil {
-		var inclusions []string
-		var exclusions []string
 		for _, glob := range *task.Outputs {
 			if strings.HasPrefix(glob, "!") {
 				exclusions = append(exclusions, glob[1:])
@@ -261,14 +255,13 @@ func (c *TaskDefinition) UnmarshalJSON(data []byte) error {
 				inclusions = append(inclusions, glob)
 			}
 		}
-
-		c.Outputs = TaskOutputs{
-			Inclusions: inclusions,
-			Exclusions: exclusions,
-		}
-	} else {
-		c.Outputs = defaultOutputs
 	}
+
+	c.Outputs = TaskOutputs{
+		Inclusions: inclusions,
+		Exclusions: exclusions,
+	}
+
 	sort.Strings(c.Outputs.Inclusions)
 	sort.Strings(c.Outputs.Exclusions)
 	if task.Cache == nil {
@@ -284,7 +277,7 @@ func (c *TaskDefinition) UnmarshalJSON(data []byte) error {
 
 	for _, dependency := range task.DependsOn {
 		if strings.HasPrefix(dependency, envPipelineDelimiter) {
-			log.Printf("[DEPRECATED] Declaring an environment variable in \"dependsOn\" is deprecated, found %s. Use the \"env\" key or use `npx @turbo/codemod migrate-env-var-dependencies`.\n", dependency)
+			// log.Printf("[DEPRECATED] Declaring an environment variable in \"dependsOn\" is deprecated, found %s. Use the \"env\" key or use `npx @turbo/codemod migrate-env-var-dependencies`.\n", dependency)
 			envVarDependencies.Add(strings.TrimPrefix(dependency, envPipelineDelimiter))
 		} else if strings.HasPrefix(dependency, topologicalPipelineDelimiter) {
 			c.TopologicalDependencies = append(c.TopologicalDependencies, strings.TrimPrefix(dependency, topologicalPipelineDelimiter))

--- a/cli/internal/fs/turbo_json_test.go
+++ b/cli/internal/fs/turbo_json_test.go
@@ -61,7 +61,7 @@ func Test_ReadTurboConfig(t *testing.T) {
 			OutputMode:              util.NewTaskOutput,
 		},
 		"dev": {
-			Outputs:                 defaultOutputs,
+			Outputs:                 TaskOutputs{},
 			TopologicalDependencies: []string{},
 			EnvVarDependencies:      []string{},
 			TaskDependencies:        []string{},
@@ -103,7 +103,7 @@ func Test_ReadTurboConfig_Legacy(t *testing.T) {
 
 	pipelineExpected := map[string]TaskDefinition{
 		"build": {
-			Outputs:                 TaskOutputs{Inclusions: []string{"build/**/*", "dist/**/*"}},
+			Outputs:                 TaskOutputs{},
 			TopologicalDependencies: []string{},
 			EnvVarDependencies:      []string{},
 			TaskDependencies:        []string{},


### PR DESCRIPTION
This behavior is frameworks-specific and unintuitive to new users.
Specifically, this removes the confusion between omitting the outputs
key and setting to an empty array. Additionally, this will allow us to
more clearly define turbo.json composition, so locally-scoped turbo.json
configs can override outputs, without rationalizing what happens to this
implicit behavior.

Stacked PRs:

- [ ] **(This one)** #2712 
- [ ] #2714
- [ ] Release `turbo@1.7`
- [ ] #2713 