### PR TITLE
docs: Remove callout now that we support prune w/npm

### DIFF
--- a/docs/pages/repo/docs/reference/command-line-reference.mdx
+++ b/docs/pages/repo/docs/reference/command-line-reference.mdx
@@ -480,8 +480,6 @@ turbo run build -vvv
 
 Generate a sparse/partial monorepo with a pruned lockfile for a target workspace.
 
-<Callout>This command is not yet implemented for `npm`.</Callout>
-
 This command will generate folder called `out` with the following inside of it:
 
 - The full source code of all internal workspaces that are needed to build the target


### PR DESCRIPTION
We now support `prune` w/ npm as of https://github.com/vercel/turbo/pull/2203