### PR TITLE
feat: support specifying a turbo version in turbo.json

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.5
 	github.com/DataDog/zstd v1.5.2
-	github.com/Masterminds/semver v1.5.0
+	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/adrg/xdg v0.3.3
 	github.com/andybalholm/crlf v0.0.0-20171020200849-670099aa064f
 	github.com/briandowns/spinner v1.18.1
@@ -49,6 +49,7 @@ require (
 
 require (
 	github.com/Masterminds/goutils v1.1.0 // indirect
+	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/Masterminds/sprig v2.22.0+incompatible // indirect
 	github.com/armon/go-radix v1.0.0 // indirect
 	github.com/bgentry/speakeasy v0.1.0 // indirect

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -60,6 +60,8 @@ github.com/Masterminds/goutils v1.1.0 h1:zukEsf/1JZwCMgHiK3GZftabmxiCw4apj3a28RP
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
+github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
+github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Masterminds/sprig v2.22.0+incompatible h1:z4yfnGrZ7netVz+0EDJ0Wi+5VZCSYp4Z0m2dk6cEM60=
 github.com/Masterminds/sprig v2.22.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63nhn5WAunQHLTznkw5W8b1Xc0dNjp83s=

--- a/cli/internal/context/context.go
+++ b/cli/internal/context/context.go
@@ -15,7 +15,7 @@ import (
 	"github.com/vercel/turbo/cli/internal/turbopath"
 	"github.com/vercel/turbo/cli/internal/util"
 
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 	mapset "github.com/deckarep/golang-set"
 	"github.com/pyr-sh/dag"
 	"golang.org/x/sync/errgroup"

--- a/cli/internal/fs/package_json.go
+++ b/cli/internal/fs/package_json.go
@@ -44,6 +44,17 @@ type WorkspacesAlt struct {
 	Packages []string `json:"packages,omitempty"`
 }
 
+// TurboVersion returns the listed version of turbo listed as a regular or dev dependency
+func (p *PackageJSON) TurboVersion() (string, bool) {
+	if version, ok := p.Dependencies["turbo"]; ok {
+		return version, true
+	}
+	if version, ok := p.DevDependencies["turbo"]; ok {
+		return version, true
+	}
+	return "", false
+}
+
 func (r *Workspaces) UnmarshalJSON(data []byte) error {
 	var tmp = &WorkspacesAlt{}
 	if err := json.Unmarshal(data, tmp); err == nil {

--- a/cli/internal/fs/testdata/correct/turbo.json
+++ b/cli/internal/fs/testdata/correct/turbo.json
@@ -1,5 +1,6 @@
 // mocked test comment
 {
+  "turboVersion": "1.7.0",
   "pipeline": {
     "build": {
       // mocked test comment

--- a/cli/internal/fs/testdata/double_version/package.json
+++ b/cli/internal/fs/testdata/double_version/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "double_version",
+  "devDependencies": {
+    "turbo": "1.7.0"
+  }
+}

--- a/cli/internal/fs/testdata/double_version/turbo.json
+++ b/cli/internal/fs/testdata/double_version/turbo.json
@@ -1,0 +1,19 @@
+// mocked test comment
+{
+  "turboVersion": "1.7.0",
+  "pipeline": {
+    "build": {
+      // mocked test comment
+      "dependsOn": [
+        // mocked test comment
+        "^build"
+      ],
+      "outputs": ["dist/**", ".next/**", "!dist/assets/**"],
+      "outputMode": "new-only"
+    } // mocked test comment
+  },
+  "remoteCache": {
+    "teamId": "team_id",
+    "signature": true
+  }
+}

--- a/cli/internal/fs/testdata/vague_version/package.json
+++ b/cli/internal/fs/testdata/vague_version/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "test-vague"
+}

--- a/cli/internal/fs/testdata/vague_version/turbo.json
+++ b/cli/internal/fs/testdata/vague_version/turbo.json
@@ -1,0 +1,19 @@
+// mocked test comment
+{
+  "turboVersion": "1.6",
+  "pipeline": {
+    "build": {
+      // mocked test comment
+      "dependsOn": [
+        // mocked test comment
+        "^build"
+      ],
+      "outputs": ["dist/**", ".next/**", "!dist/assets/**"],
+      "outputMode": "new-only"
+    } // mocked test comment
+  },
+  "remoteCache": {
+    "teamId": "team_id",
+    "signature": true
+  }
+}

--- a/cli/internal/lockfile/berry_lockfile.go
+++ b/cli/internal/lockfile/berry_lockfile.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/andybalholm/crlf"
 	"github.com/pkg/errors"
 	"github.com/vercel/turbo/cli/internal/turbopath"

--- a/cli/internal/packagemanager/berry.go
+++ b/cli/internal/packagemanager/berry.go
@@ -5,7 +5,7 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/pkg/errors"
 	"github.com/vercel/turbo/cli/internal/fs"
 	"github.com/vercel/turbo/cli/internal/lockfile"

--- a/cli/internal/packagemanager/pnpm.go
+++ b/cli/internal/packagemanager/pnpm.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/vercel/turbo/cli/internal/fs"
 	"github.com/vercel/turbo/cli/internal/lockfile"
 	"github.com/vercel/turbo/cli/internal/turbopath"

--- a/cli/internal/packagemanager/pnpm6.go
+++ b/cli/internal/packagemanager/pnpm6.go
@@ -3,7 +3,7 @@ package packagemanager
 import (
 	"fmt"
 
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/vercel/turbo/cli/internal/lockfile"
 	"github.com/vercel/turbo/cli/internal/turbopath"
 )

--- a/cli/internal/packagemanager/yarn.go
+++ b/cli/internal/packagemanager/yarn.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/vercel/turbo/cli/internal/fs"
 	"github.com/vercel/turbo/cli/internal/lockfile"
 	"github.com/vercel/turbo/cli/internal/turbopath"

--- a/packages/turbo-types/src/types/config.ts
+++ b/packages/turbo-types/src/types/config.ts
@@ -4,6 +4,15 @@ export interface Schema {
   $schema?: string;
 
   /**
+   * A version of turbo that should be used with this project
+   *
+   * If turbo is invoked in a project with turboVersion specified, turbo will make
+   * sure to use the correct version. Only semver versions that include patch
+   * numbers are allowed.
+   */
+  turboVersion?: string;
+
+  /**
    * A list of globs for implicit global hash dependencies.
    *
    * The contents of these files will be included in the global hashing


### PR DESCRIPTION
Add support and update schema for specifying `turboVersion` in `turbo.json`. We also verify that the listed version is an exact version and that turbo isn't listed as a dev dependency since the presence of `turboVersion` implies the use of global turbo.

I also updated our semver library to 3 in order to use their exact semver function. I think this is the version we want as one of the primary breaking changes was to modify how `^` is handled to be closer to `npm` and `Cargo`: https://github.com/Masterminds/semver/blob/master/CHANGELOG.md#changed-1.

Added some tests to make sure that the verification logic errors as expected.