### PR TITLE
fix: adding `PeerDependenciesMeta` to `NpmLockfile` to fix issue with `turbo prune`

### DIFF
--- a/cli/internal/lockfile/npm_lockfile.go
+++ b/cli/internal/lockfile/npm_lockfile.go
@@ -44,6 +44,9 @@ type NpmPackage struct {
 	Dependencies         map[string]string `json:"dependencies,omitempty"`
 	DevDependencies      map[string]string `json:"devDependencies,omitempty"`
 	PeerDependencies     map[string]string `json:"peerDependencies,omitempty"`
+	PeerDependenciesMeta map[string]struct {
+		Optional bool `json:"optional"`
+	} `json:"peerDependenciesMeta,omitempty"`
 	OptionalDependencies map[string]string `json:"optionalDependencies,omitempty"`
 
 	Bin map[string]string `json:"bin,omitempty"`

--- a/cli/internal/lockfile/npm_lockfile.go
+++ b/cli/internal/lockfile/npm_lockfile.go
@@ -45,7 +45,7 @@ type NpmPackage struct {
 	DevDependencies      map[string]string `json:"devDependencies,omitempty"`
 	PeerDependencies     map[string]string `json:"peerDependencies,omitempty"`
 	PeerDependenciesMeta map[string]struct {
-		Optional bool `json:"optional"`
+		Optional bool `json:"optional,omitempty"`
 	} `json:"peerDependenciesMeta,omitempty"`
 	OptionalDependencies map[string]string `json:"optionalDependencies,omitempty"`
 

--- a/cli/internal/lockfile/npm_lockfile_test.go
+++ b/cli/internal/lockfile/npm_lockfile_test.go
@@ -1,7 +1,9 @@
 package lockfile
 
 import (
+	"bytes"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/vercel/turbo/cli/internal/turbopath"
@@ -202,4 +204,42 @@ func Test_NpmAllDependencies(t *testing.T) {
 		assert.DeepEqual(t, depKeys, tc.expected)
 	}
 
+}
+
+func Test_NpmPeerDependenciesMeta(t *testing.T) {
+	var buf bytes.Buffer
+
+	lockfile := getNpmLockfile(t)
+	lockfile.Encode(&buf)
+	s := buf.String()
+
+	expected := `"node_modules/eslint-config-next": {
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-12.3.1.tgz",
+      "integrity": "sha512-EN/xwKPU6jz1G0Qi6Bd/BqMnHLyRAL0VsaQaWA7F3KkjAgZHi4f1uL1JKGWNxdQpHTW/sdGONBd0bzxUka/DJg==",
+      "dependencies": {
+        "@next/eslint-plugin-next": "12.3.1",
+        "@rushstack/eslint-patch": "^1.1.3",
+        "@typescript-eslint/parser": "^5.21.0",
+        "eslint-import-resolver-node": "^0.3.6",
+        "eslint-import-resolver-typescript": "^2.7.1",
+        "eslint-plugin-import": "^2.26.0",
+        "eslint-plugin-jsx-a11y": "^6.5.1",
+        "eslint-plugin-react": "^7.31.7",
+        "eslint-plugin-react-hooks": "^4.5.0"
+      },
+      "peerDependencies": {
+        "eslint": "^7.23.0 || ^8.0.0",
+        "typescript": ">=3.3.1"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },`
+
+	if !strings.Contains(s, expected) {
+		t.Error("failed to persist \"peerDependenciesMeta\" in npm lockfile")
+	}
 }

--- a/cli/internal/lockfile/npm_lockfile_test.go
+++ b/cli/internal/lockfile/npm_lockfile_test.go
@@ -210,7 +210,9 @@ func Test_NpmPeerDependenciesMeta(t *testing.T) {
 	var buf bytes.Buffer
 
 	lockfile := getNpmLockfile(t)
-	lockfile.Encode(&buf)
+	if err := lockfile.Encode(&buf); err != nil {
+		t.Error(err)
+	}
 	s := buf.String()
 
 	expected := `"node_modules/eslint-config-next": {


### PR DESCRIPTION
When unmarshalling the package-lock.json, since `PeerDependenciesMeta` is not present on the `NpmPackage` struct it gets dropped when `turbo prune` does its thing. This caused `npm ci` to complain due to the package and lock-file being out of sync as described in #2739 

By adding this property to the struct, it gets preserved when unmarshalling and persists in the lockfile after the prune, resulting in a pruned package and lock-file that remain in sync according to `npm`.