### PR TITLE
@next/font [1/n] Add query structure to module requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3720,6 +3720,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "qstring"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d464fae65fff2680baf48019211ce37aaec0c78e9264c84a3e484717f965104e"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "quote"
 version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6485,6 +6494,7 @@ dependencies = [
  "indexmap",
  "lazy_static",
  "patricia_tree",
+ "qstring",
  "rand",
  "regex",
  "rstest",

--- a/crates/next-dev/src/lib.rs
+++ b/crates/next-dev/src/lib.rs
@@ -29,7 +29,10 @@ use turbo_tasks::{
 use turbo_tasks_fs::{DiskFileSystemVc, FileSystemVc};
 use turbo_tasks_memory::MemoryBackend;
 use turbopack_cli_utils::issue::{ConsoleUi, ConsoleUiVc, LogOptions};
-use turbopack_core::{issue::IssueSeverity, resolve::parse::RequestVc};
+use turbopack_core::{
+    issue::IssueSeverity,
+    resolve::{parse::RequestVc, pattern::QueryMapVc},
+};
 use turbopack_dev_server::{
     fs::DevServerFileSystemVc,
     introspect::IntrospectionSource,
@@ -290,9 +293,11 @@ async fn source(
         .iter()
         .map(|r| match r {
             EntryRequest::Relative(p) => RequestVc::relative(Value::new(p.clone().into()), false),
-            EntryRequest::Module(m, p) => {
-                RequestVc::module(m.clone(), Value::new(p.clone().into()))
-            }
+            EntryRequest::Module(m, p) => RequestVc::module(
+                m.clone(),
+                Value::new(p.clone().into()),
+                QueryMapVc::cell(None),
+            ),
         })
         .collect();
 

--- a/crates/next-dev/src/lib.rs
+++ b/crates/next-dev/src/lib.rs
@@ -293,11 +293,9 @@ async fn source(
         .iter()
         .map(|r| match r {
             EntryRequest::Relative(p) => RequestVc::relative(Value::new(p.clone().into()), false),
-            EntryRequest::Module(m, p) => RequestVc::module(
-                m.clone(),
-                Value::new(p.clone().into()),
-                QueryMapVc::cell(None),
-            ),
+            EntryRequest::Module(m, p) => {
+                RequestVc::module(m.clone(), Value::new(p.clone().into()), QueryMapVc::none())
+            }
         })
         .collect();
 

--- a/crates/turbopack-core/Cargo.toml
+++ b/crates/turbopack-core/Cargo.toml
@@ -18,6 +18,7 @@ futures = "0.3.25"
 indexmap = { workspace = true }
 lazy_static = "1.4.0"
 patricia_tree = "0.3.1"
+qstring = "0.7.2"
 rand = "0.8.5"
 regex = "1.5.4"
 serde = { version = "1.0.136", features = ["rc"] }

--- a/crates/turbopack-core/src/resolve/mod.rs
+++ b/crates/turbopack-core/src/resolve/mod.rs
@@ -27,6 +27,7 @@ use self::{
     },
     origin::ResolveOriginVc,
     parse::{Request, RequestVc},
+    pattern::QueryMapVc,
 };
 use crate::{
     asset::{AssetVc, AssetsVc},
@@ -649,9 +650,11 @@ pub async fn resolve(
                 options,
             )
         }
-        Request::Module { module, path } => {
-            resolve_module_request(context, options, options_value, module, path).await?
-        }
+        Request::Module {
+            module,
+            path,
+            query,
+        } => resolve_module_request(context, options, options_value, module, path, query).await?,
         Request::ServerRelative { path } => {
             let mut new_pat = path.clone();
             new_pat.push_front(".".to_string().into());
@@ -803,6 +806,7 @@ async fn resolve_module_request(
     options_value: &ResolveOptions,
     module: &str,
     path: &Pattern,
+    _: &QueryMapVc,
 ) -> Result<ResolveResultVc> {
     let result = find_package(
         context,

--- a/crates/turbopack-core/src/resolve/pattern.rs
+++ b/crates/turbopack-core/src/resolve/pattern.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashSet, fmt::Display, mem::take};
 
 use anyhow::Result;
+use indexmap::IndexMap;
 use lazy_static::lazy_static;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -10,6 +11,17 @@ use turbo_tasks::{
 use turbo_tasks_fs::{
     DirectoryContent, DirectoryEntry, FileSystemEntryType, FileSystemPathVc, LinkContent, LinkType,
 };
+
+#[turbo_tasks::value(transparent)]
+pub struct QueryMap(#[turbo_tasks(trace_ignore)] Option<IndexMap<String, String>>);
+
+#[turbo_tasks::value_impl]
+impl QueryMapVc {
+    #[turbo_tasks::function]
+    pub fn none() -> Self {
+        Self::cell(None)
+    }
+}
 
 #[turbo_tasks::value(shared, serialization = "auto_for_input")]
 #[derive(PartialOrd, Ord, Hash, Clone, Debug)]

--- a/crates/turbopack-ecmascript/src/references/typescript.rs
+++ b/crates/turbopack-ecmascript/src/references/typescript.rs
@@ -3,7 +3,10 @@ use turbo_tasks::{primitives::StringVc, Value, ValueToString, ValueToStringVc};
 use turbo_tasks_fs::FileSystemPathVc;
 use turbopack_core::{
     reference::{AssetReference, AssetReferenceVc},
-    resolve::{origin::ResolveOriginVc, parse::RequestVc, ResolveResult, ResolveResultVc},
+    resolve::{
+        origin::ResolveOriginVc, parse::RequestVc, pattern::QueryMapVc, ResolveResult,
+        ResolveResultVc,
+    },
     source_asset::SourceAssetVc,
 };
 
@@ -121,7 +124,11 @@ impl AssetReference for TsReferenceTypeAssetReference {
     fn resolve_reference(&self) -> ResolveResultVc {
         type_resolve(
             self.origin,
-            RequestVc::module(self.module.clone(), Value::new("".to_string().into())),
+            RequestVc::module(
+                self.module.clone(),
+                Value::new("".to_string().into()),
+                QueryMapVc::none(),
+            ),
         )
     }
 }

--- a/crates/turbopack-ecmascript/src/typescript/mod.rs
+++ b/crates/turbopack-ecmascript/src/typescript/mod.rs
@@ -8,7 +8,10 @@ use turbo_tasks_fs::FileSystemPathVc;
 use turbopack_core::{
     asset::{Asset, AssetContentVc, AssetVc},
     reference::{AssetReference, AssetReferenceVc, AssetReferencesVc},
-    resolve::{origin::ResolveOriginVc, parse::RequestVc, ResolveResult, ResolveResultVc},
+    resolve::{
+        origin::ResolveOriginVc, parse::RequestVc, pattern::QueryMapVc, ResolveResult,
+        ResolveResultVc,
+    },
 };
 
 use self::resolve::{read_from_tsconfigs, read_tsconfigs, type_resolve};
@@ -114,7 +117,11 @@ impl Asset for TsConfigModuleAsset {
                 references.push(
                     TsConfigTypesReferenceVc::new(
                         self.origin,
-                        RequestVc::module(name, Value::new("".to_string().into())),
+                        RequestVc::module(
+                            name,
+                            Value::new("".to_string().into()),
+                            QueryMapVc::none(),
+                        ),
                     )
                     .into(),
                 );

--- a/crates/turbopack-ecmascript/src/typescript/resolve.rs
+++ b/crates/turbopack-ecmascript/src/typescript/resolve.rs
@@ -16,6 +16,7 @@ use turbopack_core::{
         },
         origin::ResolveOriginVc,
         parse::{Request, RequestVc},
+        pattern::QueryMapVc,
         resolve, AliasPattern, ResolveResult, ResolveResultVc,
     },
     source_asset::SourceAssetVc,
@@ -235,7 +236,12 @@ pub async fn type_resolve(origin: ResolveOriginVc, request: RequestVc) -> Result
     let context_path = origin.origin_path().parent();
     let options = origin.resolve_options();
     let options = apply_typescript_types_options(options);
-    let types_request = if let Request::Module { module: m, path: p } = &*request.await? {
+    let types_request = if let Request::Module {
+        module: m,
+        path: p,
+        query: _,
+    } = &*request.await?
+    {
         let m = if let Some(stripped) = m.strip_prefix('@') {
             stripped.replace('/', "__")
         } else {
@@ -244,6 +250,7 @@ pub async fn type_resolve(origin: ResolveOriginVc, request: RequestVc) -> Result
         Some(RequestVc::module(
             format!("@types/{m}"),
             Value::new(p.clone()),
+            QueryMapVc::none(),
         ))
     } else {
         None

--- a/crates/turbopack/src/lib.rs
+++ b/crates/turbopack/src/lib.rs
@@ -521,7 +521,12 @@ async fn warn_on_unsupported_modules(
     request: RequestVc,
     origin_path: FileSystemPathVc,
 ) -> Result<()> {
-    if let Request::Module { module, path } = &*request.await? {
+    if let Request::Module {
+        module,
+        path,
+        query: _,
+    } = &*request.await?
+    {
         // Warn if the package is known not to be supported by Turbopack at the moment.
         if UNSUPPORTED_PACKAGES.contains(module) {
             UnsupportedModuleIssue {


### PR DESCRIPTION
This adds a query field to the module struct in the request enum. Currently, specifiers that include a queryparam-like `?foo=bar` are treated as literal parts of the filename. This change means that (at least for module requests for the time being), this query param is no part of the file name during resolving.