### PR TITLE
fix: Yarn 2+ no longer include peer dependencies in AllDependencies

### DIFF
--- a/cli/internal/lockfile/berry_lockfile.go
+++ b/cli/internal/lockfile/berry_lockfile.go
@@ -119,9 +119,6 @@ func (l *BerryLockfile) AllDependencies(key string) (map[string]string, bool) {
 	for name, version := range entry.Dependencies {
 		deps[name] = version
 	}
-	for name, version := range entry.PeerDependencies {
-		deps[name] = version
-	}
 
 	return deps, true
 }

--- a/cli/internal/lockfile/berry_lockfile_test.go
+++ b/cli/internal/lockfile/berry_lockfile_test.go
@@ -85,7 +85,7 @@ func Test_AllDependencies(t *testing.T) {
 	assert.Assert(t, pkg.Found, "expected to find react-dom")
 	deps, found := lockfile.AllDependencies(pkg.Key)
 	assert.Assert(t, found, "expected lockfile key for react-dom to be present")
-	assert.Equal(t, len(deps), 3, "expected to find all react-dom direct dependencies")
+	assert.Equal(t, len(deps), 2, "expected to find all react-dom direct dependencies")
 	for pkgName, version := range deps {
 		pkg, err := lockfile.ResolvePackage("some-pkg", pkgName, version)
 		assert.NilError(t, err, "error finding %s@%s", pkgName, version)


### PR DESCRIPTION
Solves the issue that @jsbrain found in #2313. Still unable get reproduce the original issue.

The underlying issue was that `refine-antd` listed `antd` as a peer dependency and direct dependency with different version constraints and the `peerDependency` version was overriding the direct version.

We ran into a similar issue with pnpm that I fixed in #2151. I'll be investigating if we need to do something similar for npm as well.