### PR TITLE
docs: include --workspace-root on pnpm add command

### DIFF
--- a/docs/pages/repo/docs/getting-started/add-to-project.mdx
+++ b/docs/pages/repo/docs/getting-started/add-to-project.mdx
@@ -40,7 +40,7 @@ npm create vite@latest
   </Tab>
   <Tab>
     ```bash
-    pnpm install turbo --save-dev
+    pnpm install turbo --save-dev --workspace-root
     ```
   </Tab>
 </Tabs>


### PR DESCRIPTION
Given Turborepo is intended to use on workspaces, it is very likely users are adding it to the root of an already configured workspace.

If you run `pnpm add` on a workspace root, you get an error:

```
 ERR_PNPM_ADDING_TO_ROOT  Running this command will add the dependency to the workspace root, which might not be what you want - if you really meant it, make it explicit by running this command again with the -w flag (or --workspace-root). If you don't want to see this warning anymore, you may set the ignore-workspace-root-check setting to true.
```

This adds the `--workspace-root` flag to the docs command so this is skipped.

This might also be needed for yarn but I'm not sure if they have a stable option besides `--ignore-workspace-root-check` on 1.x.