### PR TITLE
Update metro.config.js 

### DIFF
--- a/examples/with-react-native-web/apps/native/metro.config.js
+++ b/examples/with-react-native-web/apps/native/metro.config.js
@@ -15,5 +15,7 @@ config.resolver.nodeModulesPaths = [
   path.resolve(projectRoot, "node_modules"),
   path.resolve(workspaceRoot, "node_modules"),
 ];
+// 3. Force Metro to resolve (sub)dependencies only from the `nodeModulesPaths`
+config.resolver.disableHierarchicalLookup = true;
 
 module.exports = config;


### PR DESCRIPTION
Force Metro to resolve (sub)dependencies only from the `nodeModulesPaths`. Without this line, the native app was crashing due to the following error: 

```
Error: Unable to resolve module ./packages/ui/node_modules/react-native/Libraries/HeapCapture/NativeJSCHeapCapture from /Users/username/code/turbo/with-react-native-web/apps/native/.

"Failed to call into JavaScript module method RCTDeviceEventEmitter.emit(). Module has not been registered as callable. Registered callable JavaScript modules (n = 0): .
        A frequent cause of the error is that the application entry file path is incorrect. This can also happen when the JS bundle is corrupt or there is an early initialization error when loading React Native."
```

I followed the Expo docs and added step 3 to get this example working again for me. 

https://docs.expo.dev/guides/monorepos/#modify-the-metro-config:~:text=%2C%0A%5D%3B-,//%203.%20Force%20Metro%20to%20resolve%20(sub)dependencies%20only%20from%20the%20%60nodeModulesPaths%60%0Aconfig.resolver.disableHierarchicalLookup%20%3D%20true%3B,-module.exports