### PR TITLE
Make task stats take less memory by default

### DIFF
--- a/crates/next-dev/src/devserver_options.rs
+++ b/crates/next-dev/src/devserver_options.rs
@@ -73,6 +73,11 @@ pub struct DevServerOptions {
     /// Expand the log details.
     pub log_detail: bool,
 
+    #[cfg_attr(feature = "cli", clap(long))]
+    #[cfg_attr(feature = "serializable", serde(default))]
+    /// Whether to enable full task stats recording in Turbo Engine.
+    pub full_stats: bool,
+
     // Inherited options from next-dev, need revisit later.
     #[cfg_attr(feature = "cli", clap(long))]
     #[cfg_attr(feature = "serializable", serde(default))]

--- a/crates/next-dev/src/lib.rs
+++ b/crates/next-dev/src/lib.rs
@@ -357,6 +357,10 @@ pub async fn start_server(options: &DevServerOptions) -> Result<()> {
     console_subscriber::init();
     register();
 
+    if options.full_stats {
+        turbo_tasks_memory::enable_full_stats();
+    }
+
     let dir = options
         .dir
         .as_ref()

--- a/crates/next-dev/src/lib.rs
+++ b/crates/next-dev/src/lib.rs
@@ -22,8 +22,8 @@ use next_core::{
 };
 use owo_colors::OwoColorize;
 use turbo_tasks::{
-    primitives::StringsVc, util::FormatDuration, RawVc, TransientInstance, TransientValue,
-    TurboTasks, Value,
+    primitives::StringsVc, util::FormatDuration, RawVc, StatsType, TransientInstance,
+    TransientValue, TurboTasks, TurboTasksBackendApi, Value,
 };
 use turbo_tasks_fs::{DiskFileSystemVc, FileSystemVc};
 use turbo_tasks_memory::MemoryBackend;
@@ -357,10 +357,6 @@ pub async fn start_server(options: &DevServerOptions) -> Result<()> {
     console_subscriber::init();
     register();
 
-    if options.full_stats {
-        turbo_tasks_memory::enable_full_stats();
-    }
-
     let dir = options
         .dir
         .as_ref()
@@ -382,6 +378,13 @@ pub async fn start_server(options: &DevServerOptions) -> Result<()> {
     };
 
     let tt = TurboTasks::new(MemoryBackend::new());
+
+    let stats_type = match options.full_stats {
+        true => StatsType::Full,
+        false => StatsType::Essential,
+    };
+    tt.set_stats_type(stats_type);
+
     let tt_clone = tt.clone();
 
     #[allow(unused_mut)]

--- a/crates/next-dev/src/turbo_tasks_viz.rs
+++ b/crates/next-dev/src/turbo_tasks_viz.rs
@@ -2,7 +2,7 @@ use std::{str::FromStr, sync::Arc, time::Duration};
 
 use anyhow::Result;
 use mime::Mime;
-use turbo_tasks::{get_invalidator, TurboTasks, Value};
+use turbo_tasks::{get_invalidator, TurboTasks, TurboTasksBackendApi, Value};
 use turbo_tasks_fs::File;
 use turbo_tasks_memory::{
     stats::{ReferenceType, Stats},
@@ -53,7 +53,11 @@ impl ContentSource for TurboTasksSource {
                     stats.add_id(b, task);
                 });
                 let tree = stats.treeify(ReferenceType::Dependency);
-                let graph = viz::graph::visualize_stats_tree(tree, ReferenceType::Dependency);
+                let graph = viz::graph::visualize_stats_tree(
+                    tree,
+                    ReferenceType::Dependency,
+                    tt.stats_type(),
+                );
                 viz::graph::wrap_html(&graph)
             }
             "call-graph" => {
@@ -63,7 +67,8 @@ impl ContentSource for TurboTasksSource {
                     stats.add_id(b, task);
                 });
                 let tree = stats.treeify(ReferenceType::Child);
-                let graph = viz::graph::visualize_stats_tree(tree, ReferenceType::Child);
+                let graph =
+                    viz::graph::visualize_stats_tree(tree, ReferenceType::Child, tt.stats_type());
                 viz::graph::wrap_html(&graph)
             }
             "table" => {
@@ -81,7 +86,7 @@ impl ContentSource for TurboTasksSource {
                         });
                     });
                     let tree = stats.treeify(ReferenceType::Dependency);
-                    let table = viz::table::create_table(tree);
+                    let table = viz::table::create_table(tree, tt.stats_type());
                     viz::table::wrap_html(&table)
                 } else {
                     return Ok(ContentSourceResultVc::exact(

--- a/crates/next-dev/src/turbo_tasks_viz.rs
+++ b/crates/next-dev/src/turbo_tasks_viz.rs
@@ -73,7 +73,10 @@ impl ContentSource for TurboTasksSource {
                     let active_only = query.contains_key("active");
                     b.with_all_cached_tasks(|task| {
                         stats.add_id_conditional(b, task, |_, info| {
-                            info.executions > 0 && (!active_only || info.active)
+                            info.executions
+                                .map(|executions| executions > 0)
+                                .unwrap_or(true)
+                                && (!active_only || info.active)
                         });
                     });
                     let tree = stats.treeify(ReferenceType::Dependency);

--- a/crates/next-dev/src/turbo_tasks_viz.rs
+++ b/crates/next-dev/src/turbo_tasks_viz.rs
@@ -73,10 +73,11 @@ impl ContentSource for TurboTasksSource {
                     let active_only = query.contains_key("active");
                     b.with_all_cached_tasks(|task| {
                         stats.add_id_conditional(b, task, |_, info| {
-                            info.executions
-                                .map(|executions| executions > 0)
-                                .unwrap_or(true)
-                                && (!active_only || info.active)
+                            (!active_only || info.active)
+                                && info
+                                    .executions
+                                    .map(|executions| executions > 0)
+                                    .unwrap_or(true)
                         });
                     });
                     let tree = stats.treeify(ReferenceType::Dependency);

--- a/crates/node-file-trace/src/lib.rs
+++ b/crates/node-file-trace/src/lib.rs
@@ -22,7 +22,7 @@ use turbo_tasks::{
     backend::Backend,
     primitives::{OptionStringVc, StringsVc},
     util::FormatDuration,
-    NothingVc, TaskId, TransientInstance, TransientValue, TurboTasks, Value,
+    NothingVc, TaskId, TransientInstance, TransientValue, TurboTasks, TurboTasksBackendApi, Value,
 };
 use turbo_tasks_fs::{
     glob::GlobVc, DirectoryEntry, DiskFileSystemVc, FileSystemVc, ReadGlobResultVc,
@@ -393,7 +393,8 @@ pub async fn start(args: Arc<Args>) -> Result<Vec<String>> {
                 stats.add_id(b, root_task);
                 // stats.merge_resolve();
                 let tree = stats.treeify(ReferenceType::Child);
-                let graph = viz::graph::visualize_stats_tree(tree, ReferenceType::Child);
+                let graph =
+                    viz::graph::visualize_stats_tree(tree, ReferenceType::Child, tt.stats_type());
                 fs::write("graph.html", viz::graph::wrap_html(&graph)).unwrap();
                 println!("graph.html written");
             }

--- a/crates/turbo-tasks-memory/src/lib.rs
+++ b/crates/turbo-tasks-memory/src/lib.rs
@@ -10,7 +10,9 @@ mod output;
 mod scope;
 pub mod stats;
 mod task;
+mod task_stats;
 pub mod viz;
 
 pub use memory_backend::MemoryBackend;
 pub use memory_backend_with_pg::MemoryBackendWithPersistedGraph;
+pub use task_stats::enable_full_stats;

--- a/crates/turbo-tasks-memory/src/lib.rs
+++ b/crates/turbo-tasks-memory/src/lib.rs
@@ -15,4 +15,3 @@ pub mod viz;
 
 pub use memory_backend::MemoryBackend;
 pub use memory_backend_with_pg::MemoryBackendWithPersistedGraph;
-pub use task_stats::enable_full_stats;

--- a/crates/turbo-tasks-memory/src/memory_backend.rs
+++ b/crates/turbo-tasks-memory/src/memory_backend.rs
@@ -426,13 +426,19 @@ impl Backend for MemoryBackend {
                 PersistentTaskType::Native(fn_id, inputs) => {
                     // TODO inputs doesn't need to be cloned when are would be able to get a
                     // reference to the task type stored inside of the task
-                    Task::new_native(id, inputs.clone(), *fn_id)
+                    Task::new_native(id, inputs.clone(), *fn_id, turbo_tasks.stats_type())
                 }
                 PersistentTaskType::ResolveNative(fn_id, inputs) => {
-                    Task::new_resolve_native(id, inputs.clone(), *fn_id)
+                    Task::new_resolve_native(id, inputs.clone(), *fn_id, turbo_tasks.stats_type())
                 }
                 PersistentTaskType::ResolveTrait(trait_type, trait_fn_name, inputs) => {
-                    Task::new_resolve_trait(id, *trait_type, trait_fn_name.clone(), inputs.clone())
+                    Task::new_resolve_trait(
+                        id,
+                        *trait_type,
+                        trait_fn_name.clone(),
+                        inputs.clone(),
+                        turbo_tasks.stats_type(),
+                    )
                 }
             };
             // Safety: We have a fresh task id that nobody knows about yet
@@ -472,9 +478,10 @@ impl Backend for MemoryBackend {
             scope.increment_tasks();
             scope.increment_unfinished_tasks(self);
         });
+        let stats_type = turbo_tasks.stats_type();
         let task = match task_type {
-            TransientTaskType::Root(f) => Task::new_root(id, scope, move || f() as _),
-            TransientTaskType::Once(f) => Task::new_once(id, scope, f),
+            TransientTaskType::Root(f) => Task::new_root(id, scope, move || f() as _, stats_type),
+            TransientTaskType::Once(f) => Task::new_once(id, scope, f, stats_type),
         };
         // SAFETY: We have a fresh task id where nobody knows about yet
         #[allow(unused_variables)]

--- a/crates/turbo-tasks-memory/src/memory_backend.rs
+++ b/crates/turbo-tasks-memory/src/memory_backend.rs
@@ -5,7 +5,7 @@ use std::{
     future::Future,
     hash::BuildHasherDefault,
     pin::Pin,
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use anyhow::{bail, Result};
@@ -243,10 +243,11 @@ impl Backend for MemoryBackend {
         &self,
         task: TaskId,
         duration: Duration,
+        instant: Instant,
         turbo_tasks: &dyn TurboTasksBackendApi,
     ) -> bool {
         self.with_task(task, |task| {
-            task.execution_completed(duration, self, turbo_tasks)
+            task.execution_completed(duration, instant, self, turbo_tasks)
         })
     }
 

--- a/crates/turbo-tasks-memory/src/memory_backend_with_pg.rs
+++ b/crates/turbo-tasks-memory/src/memory_backend_with_pg.rs
@@ -9,7 +9,7 @@ use std::{
         atomic::{AtomicU32, AtomicUsize, Ordering},
         Mutex, MutexGuard,
     },
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use anyhow::{anyhow, Result};
@@ -1108,6 +1108,7 @@ impl<P: PersistedGraph> Backend for MemoryBackendWithPersistedGraph<P> {
         &self,
         task: TaskId,
         duration: Duration,
+        _instant: Instant,
         turbo_tasks: &dyn TurboTasksBackendApi,
     ) -> bool {
         #[cfg(feature = "log_running_tasks")]

--- a/crates/turbo-tasks-memory/src/stats.rs
+++ b/crates/turbo-tasks-memory/src/stats.rs
@@ -60,7 +60,7 @@ pub enum ReferenceType {
 pub struct ExportedTaskStats {
     pub count: usize,
     pub active_count: usize,
-    pub executions: Option<u64>,
+    pub executions: Option<u32>,
     pub roots: usize,
     pub scopes: usize,
     pub total_duration: Option<Duration>,

--- a/crates/turbo-tasks-memory/src/stats.rs
+++ b/crates/turbo-tasks-memory/src/stats.rs
@@ -57,7 +57,7 @@ pub enum ReferenceType {
 }
 
 #[derive(Clone, Debug)]
-pub struct TaskStats {
+pub struct ExportedTaskStats {
     pub count: usize,
     pub active_count: usize,
     pub executions: Option<u64>,
@@ -70,7 +70,7 @@ pub struct TaskStats {
     pub references: HashMap<(ReferenceType, TaskType), ReferenceStats>,
 }
 
-impl Default for TaskStats {
+impl Default for ExportedTaskStats {
     fn default() -> Self {
         Self {
             count: 0,
@@ -88,7 +88,7 @@ impl Default for TaskStats {
 }
 
 pub struct Stats {
-    tasks: HashMap<TaskType, TaskStats>,
+    tasks: HashMap<TaskType, ExportedTaskStats>,
 }
 
 impl Default for Stats {
@@ -187,7 +187,7 @@ impl Stats {
         })
     }
 
-    pub fn merge(&mut self, mut select: impl FnMut(&TaskType, &TaskStats) -> bool) {
+    pub fn merge(&mut self, mut select: impl FnMut(&TaskType, &ExportedTaskStats) -> bool) {
         let merged: HashMap<_, _> = self
             .tasks
             .drain_filter(|ty, stats| select(ty, stats))
@@ -196,7 +196,7 @@ impl Stats {
         for stats in self.tasks.values_mut() {
             fn merge_refs(
                 refs: HashMap<(ReferenceType, TaskType), ReferenceStats>,
-                merged: &HashMap<TaskType, TaskStats>,
+                merged: &HashMap<TaskType, ExportedTaskStats>,
             ) -> HashMap<(ReferenceType, TaskType), ReferenceStats> {
                 refs.into_iter()
                     .flat_map(|((ref_ty, ty), stats)| {
@@ -304,7 +304,7 @@ impl Stats {
         }
 
         fn into_group<'a>(
-            tasks: &HashMap<TaskType, TaskStats>,
+            tasks: &HashMap<TaskType, ExportedTaskStats>,
             children: &HashMap<Option<&'a TaskType>, Vec<&'a TaskType>>,
             ty: Option<&'a TaskType>,
         ) -> GroupTree {
@@ -335,7 +335,7 @@ impl Stats {
 
 #[derive(Debug)]
 pub struct GroupTree {
-    pub primary: Option<(TaskType, TaskStats)>,
+    pub primary: Option<(TaskType, ExportedTaskStats)>,
     pub children: Vec<GroupTree>,
-    pub task_types: Vec<(TaskType, TaskStats)>,
+    pub task_types: Vec<(TaskType, ExportedTaskStats)>,
 }

--- a/crates/turbo-tasks-memory/src/task_stats.rs
+++ b/crates/turbo-tasks-memory/src/task_stats.rs
@@ -5,8 +5,17 @@ use std::{
 
 static ENABLE_FULL_STATS: AtomicBool = AtomicBool::new(false);
 
+/// Enables full stats collection.
+///
+/// This is useful for debugging, but it has a slight memory and performance
+/// impact.
 pub fn enable_full_stats() {
     ENABLE_FULL_STATS.store(true, Ordering::Release);
+}
+
+/// Returns `true` if full stats collection is enabled.
+pub fn full_stats() -> bool {
+    ENABLE_FULL_STATS.load(Ordering::Acquire)
 }
 
 /// Keeps track of the number of times a task has been executed, and its
@@ -20,7 +29,7 @@ pub enum TaskStats {
 impl TaskStats {
     /// Creates a new [`TaskStats`].
     pub fn new() -> Self {
-        if ENABLE_FULL_STATS.load(Ordering::Acquire) {
+        if full_stats() {
             Self::Full(Box::new(TaskStatsFull::default()))
         } else {
             Self::Small(TaskStatsSmall::default())

--- a/crates/turbo-tasks-memory/src/task_stats.rs
+++ b/crates/turbo-tasks-memory/src/task_stats.rs
@@ -1,0 +1,114 @@
+use std::{
+    sync::atomic::{AtomicBool, Ordering},
+    time::Duration,
+};
+
+static ENABLE_FULL_STATS: AtomicBool = AtomicBool::new(false);
+
+pub fn enable_full_stats() {
+    ENABLE_FULL_STATS.store(true, Ordering::Release);
+}
+
+/// Keeps track of the number of times a task has been executed, and its
+/// duration.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum TaskStats {
+    Small(TaskStatsSmall),
+    Full(Box<TaskStatsFull>),
+}
+
+impl TaskStats {
+    /// Creates a new [`TaskStats`].
+    pub fn new() -> Self {
+        if ENABLE_FULL_STATS.load(Ordering::Acquire) {
+            Self::Full(Box::new(TaskStatsFull::default()))
+        } else {
+            Self::Small(TaskStatsSmall::default())
+        }
+    }
+
+    /// Resets the number of executions to 1 only if it was greater than 1.
+    pub fn reset_executions(&mut self) {
+        if let Self::Full(stats) = self {
+            if stats.executions > 1 {
+                stats.executions = 1;
+            }
+        }
+    }
+
+    /// Increments the number of executions by 1.
+    pub fn increment_executions(&mut self) {
+        if let Self::Full(stats) = self {
+            stats.executions += 1;
+        }
+    }
+
+    /// Registers a task duration.
+    pub fn register_duration(&mut self, duration: Duration) {
+        match self {
+            Self::Full(stats) => {
+                stats.total_duration += duration;
+                stats.last_duration = duration;
+            }
+            Self::Small(stats) => {
+                stats.last_duration = duration.as_nanos().try_into().unwrap_or(u64::MAX);
+            }
+        }
+    }
+
+    /// Resets stats to their default, zero-value.
+    pub fn reset(&mut self) {
+        match self {
+            Self::Full(stats) => {
+                stats.executions = 0;
+                stats.total_duration = Duration::ZERO;
+                stats.last_duration = Duration::ZERO;
+            }
+            Self::Small(stats) => {
+                stats.last_duration = 0;
+            }
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
+pub struct TaskStatsSmall {
+    /// The last duration of the task in nanoseconds.
+    last_duration: u64,
+}
+
+impl TaskStatsSmall {
+    /// Returns the last duration of the task.
+    pub fn last_duration(&self) -> Duration {
+        Duration::from_nanos(self.last_duration)
+    }
+}
+
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
+pub struct TaskStatsFull {
+    // While a u64 might be optimistic for executions, `TaskStatsFull` is aligned to 8 bytes
+    // anyway, so it makes no difference to the size of this struct.
+    /// The number of times the task has been executed.
+    executions: u64,
+    /// The last duration of the task.
+    last_duration: Duration,
+    /// The total duration of the task.
+    total_duration: Duration,
+}
+
+impl TaskStatsFull {
+    /// Returns the number of times the task has been executed.
+    pub fn executions(&self) -> u64 {
+        self.executions
+    }
+
+    /// Returns the last duration of the task.
+    pub fn last_duration(&self) -> Duration {
+        self.last_duration
+    }
+
+    /// Returns the total duration of the task.
+    pub fn total_duration(&self) -> Duration {
+        self.total_duration
+    }
+}

--- a/crates/turbo-tasks-memory/src/task_stats.rs
+++ b/crates/turbo-tasks-memory/src/task_stats.rs
@@ -30,7 +30,7 @@ impl TaskStats {
     /// Creates a new [`TaskStats`].
     pub fn new() -> Self {
         if full_stats() {
-            Self::Full(Box::new(TaskStatsFull::default()))
+            Self::Full(Box::default())
         } else {
             Self::Small(TaskStatsSmall::default())
         }

--- a/crates/turbo-tasks-memory/src/viz/graph.rs
+++ b/crates/turbo-tasks-memory/src/viz/graph.rs
@@ -181,7 +181,7 @@ fn visualize_stats_references_internal<'a>(
     }
 }
 
-fn get_task_label(ty: &TaskType, stats: &TaskStats, max_values: &MaxValues) -> String {
+fn get_task_label(ty: &TaskType, stats: &ExportedTaskStats, max_values: &MaxValues) -> String {
     let (total_millis, total_color) = if let Some((total_duration, max_total_duration)) =
         stats.total_duration.zip(max_values.total_duration)
     {

--- a/crates/turbo-tasks-memory/src/viz/graph.rs
+++ b/crates/turbo-tasks-memory/src/viz/graph.rs
@@ -254,8 +254,8 @@ fn get_task_label(ty: &TaskType, stats: &ExportedTaskStats, max_values: &MaxValu
     </tr>
     <tr>
         <td>exec</td>
-        <td bgcolor=\"{}\">{} ms</td>
-        <td bgcolor=\"{}\">avg {} ms</td>
+        <td bgcolor=\"{}\">{}</td>
+        <td bgcolor=\"{}\">{}</td>
     </tr>
     <tr>
         <td>scopes</td>

--- a/crates/turbo-tasks-memory/src/viz/graph.rs
+++ b/crates/turbo-tasks-memory/src/viz/graph.rs
@@ -231,7 +231,7 @@ fn get_task_label(
             total_duration.as_micros() / (executions as u128),
             max_avg_duration.as_micros(),
         ));
-        let avg = (total_duration.as_micros() as u64 / executions) as f32 / 1000.0;
+        let avg = (total_duration.as_micros() as u32 / executions) as f32 / 1000.0;
         (format!("avg {}ms", avg), avg_color)
     } else {
         ("avg N/A".to_string(), "#ffffff".to_string())
@@ -240,10 +240,10 @@ fn get_task_label(
     let (updates_label, updates_color) =
         if let Some((executions, max_updates)) = stats.executions.zip(max_values.updates) {
             let updates_color = as_color(as_frac(
-                executions.saturating_sub(stats.count as u64),
-                max_updates as u64,
+                executions.saturating_sub(stats.count as u32),
+                max_updates as u32,
             ));
-            let updates = executions - stats.count as u64;
+            let updates = executions - stats.count as u32;
             (format!("{}", updates), updates_color)
         } else {
             ("N/A".to_string(), "#ffffff".to_string())

--- a/crates/turbo-tasks-memory/src/viz/graph.rs
+++ b/crates/turbo-tasks-memory/src/viz/graph.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::task_stats::full_stats;
 
 pub fn wrap_html(graph: &str) -> String {
     format!(
@@ -229,6 +230,19 @@ fn get_task_label(ty: &TaskType, stats: &ExportedTaskStats, max_values: &MaxValu
         max_scopes,
     );
 
+    let full_stats_disclaimer = if full_stats() {
+        "".to_string()
+    } else {
+        r##"<tr>
+    <td colspan="3" align="center" border="0" cellpadding="0">
+        <font point-size="10" color="#00000090">
+            <i>Full stats collection is disabled. Pass --full-stats to enable it.</i>
+        </font>
+    </td>
+</tr>"##
+            .to_string()
+    };
+
     format!(
         "<
 <table border=\"0\" cellborder=\"1\" cellspacing=\"0\">
@@ -248,6 +262,7 @@ fn get_task_label(ty: &TaskType, stats: &ExportedTaskStats, max_values: &MaxValu
         <td bgcolor=\"{}\">{} roots</td>
         <td bgcolor=\"{}\">avg {}</td>
     </tr>
+    {}
 </table>>",
         total_color,
         escape_html(&ty.to_string()),
@@ -262,6 +277,7 @@ fn get_task_label(ty: &TaskType, stats: &ExportedTaskStats, max_values: &MaxValu
         as_color(roots),
         stats.roots,
         as_color(scopes),
-        (100 * stats.scopes / stats.count) as f32 / 100.0
+        (100 * stats.scopes / stats.count) as f32 / 100.0,
+        full_stats_disclaimer
     )
 }

--- a/crates/turbo-tasks-memory/src/viz/mod.rs
+++ b/crates/turbo-tasks-memory/src/viz/mod.rs
@@ -29,14 +29,14 @@ fn get_id<'a>(ty: &'a TaskType, ids: &mut HashMap<&'a TaskType, usize>) -> usize
 }
 
 struct MaxValues {
-    pub total_duration: Duration,
+    pub total_duration: Option<Duration>,
     pub total_current_duration: Duration,
     pub total_update_duration: Duration,
-    pub avg_duration: Duration,
+    pub avg_duration: Option<Duration>,
     pub max_duration: Duration,
     pub count: usize,
     pub active_count: usize,
-    pub updates: usize,
+    pub updates: Option<usize>,
     pub roots: usize,
     /// stored as scopes * 100
     pub scopes: usize,
@@ -61,27 +61,41 @@ pub fn get_avg_dependencies_count_times_100(stats: &TaskStats) -> usize {
 }
 
 fn get_max_values_internal(depth: u32, node: &GroupTree) -> MaxValues {
-    let mut max_total_duration = Duration::ZERO;
+    let mut max_total_duration = None;
     let mut max_total_current_duration = Duration::ZERO;
     let mut max_total_update_duration = Duration::ZERO;
-    let mut max_avg_duration = Duration::ZERO;
+    let mut max_avg_duration = None;
     let mut max_max_duration = Duration::ZERO;
     let mut max_count = 0;
     let mut max_active_count = 0;
-    let mut max_updates = 0;
+    let mut max_updates = None;
     let mut max_roots = 0;
     let mut max_scopes = 0;
     let mut max_dependencies = 0;
     let mut max_depth = 0;
     for (_, ref s) in node.task_types.iter().chain(node.primary.iter()) {
-        max_total_duration = max(max_total_duration, s.total_duration);
+        if let Some(total_duration) = s.total_duration {
+            max_total_duration = max_total_duration
+                .map(|max_total_duration| max(max_total_duration, total_duration))
+                .or(Some(total_duration));
+        }
         max_total_current_duration = max(max_total_current_duration, s.total_current_duration);
         max_total_update_duration = max(max_total_update_duration, s.total_update_duration);
-        max_avg_duration = max(max_avg_duration, s.total_duration / s.executions as u32);
+        if let Some((total_duration, executions)) = s.total_duration.zip(s.executions) {
+            let avg_duration = total_duration / executions as u32;
+            max_avg_duration = max_avg_duration
+                .map(|max_avg_duration| max(max_avg_duration, avg_duration))
+                .or(Some(avg_duration));
+        }
         max_max_duration = max(max_max_duration, s.max_duration);
         max_count = max(max_count, s.count);
         max_active_count = max(max_active_count, s.active_count);
-        max_updates = max(max_updates, s.executions.saturating_sub(s.count));
+        if let Some(executions) = s.executions {
+            let updates = (executions as usize).saturating_sub(s.count);
+            max_updates = max_updates
+                .map(|max_updates| max(max_updates, updates))
+                .or(Some(updates));
+        }
         max_roots = max(max_roots, s.roots);
         max_scopes = max(max_scopes, 100 * s.scopes / s.count);
         max_dependencies = max(max_dependencies, get_avg_dependencies_count_times_100(s));
@@ -109,14 +123,16 @@ fn get_max_values_internal(depth: u32, node: &GroupTree) -> MaxValues {
             dependencies,
             depth: inner_depth,
         } = get_max_values_internal(depth + 1, child);
-        max_total_duration = max(max_total_duration, total_duration);
+        max_total_duration = max_total_duration
+            .zip(total_duration)
+            .map(|(a, b)| max(a, b));
         max_total_current_duration = max(max_total_current_duration, total_current_duration);
         max_total_update_duration = max(max_total_update_duration, total_update_duration);
-        max_avg_duration = max(max_avg_duration, avg_duration);
+        max_avg_duration = max_avg_duration.zip(avg_duration).map(|(a, b)| max(a, b));
         max_max_duration = max(max_max_duration, max_duration);
         max_count = max(max_count, count);
         max_active_count = max(max_active_count, active_count);
-        max_updates = max(max_updates, updates);
+        max_updates = max_updates.zip(updates).map(|(a, b)| max(a, b));
         max_roots = max(max_roots, roots);
         max_scopes = max(max_scopes, scopes);
         max_dependencies = max(max_dependencies, dependencies);

--- a/crates/turbo-tasks-memory/src/viz/mod.rs
+++ b/crates/turbo-tasks-memory/src/viz/mod.rs
@@ -11,7 +11,7 @@ use std::{
 
 use turbo_tasks_hash::hash_xxh3_hash64;
 
-use crate::stats::{GroupTree, ReferenceStats, ReferenceType, TaskStats, TaskType};
+use crate::stats::{ExportedTaskStats, GroupTree, ReferenceStats, ReferenceType, TaskType};
 
 fn escape_in_template_str(s: &str) -> String {
     s.replace('\\', "\\\\")
@@ -49,7 +49,7 @@ fn get_max_values(node: &GroupTree) -> MaxValues {
     get_max_values_internal(0, node)
 }
 
-pub fn get_avg_dependencies_count_times_100(stats: &TaskStats) -> usize {
+pub fn get_avg_dependencies_count_times_100(stats: &ExportedTaskStats) -> usize {
     stats
         .references
         .iter()

--- a/crates/turbo-tasks-memory/src/viz/table.rs
+++ b/crates/turbo-tasks-memory/src/viz/table.rs
@@ -1,6 +1,7 @@
 use turbo_tasks::util::FormatDuration;
 
 use super::*;
+use crate::task_stats::full_stats;
 
 pub fn wrap_html(table_html: &str) -> String {
     format!(
@@ -9,7 +10,17 @@ pub fn wrap_html(table_html: &str) -> String {
 <head>
   <meta charset=\"utf-8\">
   <title>turbo-tasks table</title>
-  <style>{style}</style>
+  <style>
+    {style}
+
+    .full-stats-disclaimer {{
+        font-size: 0.8rem;
+        opacity: 0.6;
+        font-style: italic;
+        margin: 0;
+        padding: 0.8rem 1rem;
+    }}
+  </style>
 </head>
 <body>
   {table_html}
@@ -26,6 +37,9 @@ document.addEventListener("click",function(b){try{var p=function(a){return v&&a.
 pub fn create_table(root: GroupTree) -> String {
     let max_values = get_max_values(&root);
     let mut out = String::new();
+    if !full_stats() {
+        out += r#"<p class="full-stats-disclaimer">Full stats collection is disabled. Run with --full-stats to enable it.</p>"#;
+    }
     out += r#"<table class="sortable"><thead><tr>"#;
     out += r#"<th>function</th>"#;
     out += r#"<th>initial executions</th>"#;

--- a/crates/turbo-tasks-memory/src/viz/table.rs
+++ b/crates/turbo-tasks-memory/src/viz/table.rs
@@ -49,8 +49,8 @@ pub fn create_table(root: GroupTree) -> String {
         out: &mut String,
         max_values: &MaxValues,
         depth: u32,
-        parent: Option<&(TaskType, TaskStats)>,
-        (ty, stats): &(TaskType, TaskStats),
+        parent: Option<&(TaskType, ExportedTaskStats)>,
+        (ty, stats): &(TaskType, ExportedTaskStats),
     ) -> Result<(), std::fmt::Error> {
         *out += r#"<tr>"#;
         let name = ty.to_string();

--- a/crates/turbo-tasks-memory/src/viz/table.rs
+++ b/crates/turbo-tasks-memory/src/viz/table.rs
@@ -88,10 +88,10 @@ pub fn create_table(root: GroupTree, stats_type: StatsType) -> String {
         let (executions_label, executions_color) =
             if let Some((executions, max_updates)) = stats.executions.zip(max_values.updates) {
                 (
-                    executions.saturating_sub(stats.count as u64).to_string(),
+                    executions.saturating_sub(stats.count as u32).to_string(),
                     as_frac_color(
-                        executions.saturating_sub(stats.count as u64),
-                        max_updates as u64,
+                        executions.saturating_sub(stats.count as u32),
+                        max_updates as u32,
                     ),
                 )
             } else {

--- a/crates/turbo-tasks-memory/src/viz/table.rs
+++ b/crates/turbo-tasks-memory/src/viz/table.rs
@@ -1,7 +1,6 @@
-use turbo_tasks::util::FormatDuration;
+use turbo_tasks::{util::FormatDuration, StatsType};
 
 use super::*;
-use crate::task_stats::full_stats;
 
 pub fn wrap_html(table_html: &str) -> String {
     format!(
@@ -34,10 +33,10 @@ document.addEventListener("click",function(b){try{var p=function(a){return v&&a.
     )
 }
 
-pub fn create_table(root: GroupTree) -> String {
+pub fn create_table(root: GroupTree, stats_type: StatsType) -> String {
     let max_values = get_max_values(&root);
     let mut out = String::new();
-    if !full_stats() {
+    if !stats_type.is_full() {
         out += r#"<p class="full-stats-disclaimer">Full stats collection is disabled. Run with --full-stats to enable it.</p>"#;
     }
     out += r#"<table class="sortable"><thead><tr>"#;

--- a/crates/turbo-tasks/src/backend.rs
+++ b/crates/turbo-tasks/src/backend.rs
@@ -6,7 +6,7 @@ use std::{
     future::Future,
     pin::Pin,
     sync::Arc,
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use anyhow::{anyhow, Result};
@@ -192,6 +192,7 @@ pub trait Backend: Sync + Send {
         &self,
         task: TaskId,
         duration: Duration,
+        instant: Instant,
         turbo_tasks: &dyn TurboTasksBackendApi,
     ) -> bool;
 

--- a/crates/turbo-tasks/src/lib.rs
+++ b/crates/turbo-tasks/src/lib.rs
@@ -53,6 +53,7 @@ pub mod primitives;
 mod raw_vc;
 mod read_ref;
 pub mod registry;
+pub mod small_duration;
 mod task_input;
 mod timed_future;
 pub mod trace;

--- a/crates/turbo-tasks/src/lib.rs
+++ b/crates/turbo-tasks/src/lib.rs
@@ -71,8 +71,8 @@ pub use id::{
 pub use join_iter_ext::{JoinIterExt, TryJoinIterExt};
 pub use manager::{
     dynamic_call, emit, get_invalidator, run_once, spawn_blocking, spawn_thread, trait_call,
-    turbo_tasks, Invalidator, TaskIdProvider, TurboTasks, TurboTasksApi, TurboTasksBackendApi,
-    TurboTasksCallApi,
+    turbo_tasks, Invalidator, StatsType, TaskIdProvider, TurboTasks, TurboTasksApi,
+    TurboTasksBackendApi, TurboTasksCallApi,
 };
 pub use native_function::{NativeFunction, NativeFunctionVc};
 pub use nothing::{Nothing, NothingVc};

--- a/crates/turbo-tasks/src/small_duration.rs
+++ b/crates/turbo-tasks/src/small_duration.rs
@@ -1,0 +1,216 @@
+use std::{
+    fmt::{Debug, Display},
+    time::Duration,
+};
+
+/// Stores a [`Duration`] in a given precision (in nanoseconds) in 4 bytes.
+///
+/// For instance, for `P = 10_000` (10 microseconds), this allows a for a total
+/// duration of 11.9 hours. Values smaller than 10 microseconds are stored as 10
+/// microseconds.
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Default)]
+pub struct SmallDuration<const P: u64>(u32);
+
+impl<const P: u64> SmallDuration<P> {
+    pub const ZERO: SmallDuration<P> = SmallDuration(0);
+    // TODO(alexkirsz) Figure out if MIN should be 0 or 1.
+    pub const MIN: SmallDuration<P> = SmallDuration(1);
+    pub const MAX: SmallDuration<P> = SmallDuration(u32::MAX);
+
+    pub const fn from_nanos(nanos: u64) -> Self {
+        if nanos == 0 {
+            return SmallDuration::ZERO;
+        }
+        if nanos <= P {
+            return SmallDuration::MIN;
+        }
+        let value = nanos / P;
+        if value > u32::MAX as u64 {
+            return SmallDuration::MAX;
+        }
+        SmallDuration(value as u32)
+    }
+
+    pub const fn from_micros(micros: u64) -> Self {
+        if micros == 0 {
+            return SmallDuration::ZERO;
+        }
+        let micros_precision = P / 1_000;
+        if micros <= micros_precision {
+            return SmallDuration::MIN;
+        }
+        let value = micros * 1_000 / P;
+        if value > u32::MAX as u64 {
+            return SmallDuration::MAX;
+        }
+        SmallDuration(value as u32)
+    }
+
+    pub const fn from_millis(millis: u64) -> Self {
+        if millis == 0 {
+            return SmallDuration::ZERO;
+        }
+        let millis_precision = P / 1_000_000;
+        if millis <= millis_precision {
+            return SmallDuration::MIN;
+        }
+        let value = millis * 1_000_000 / P;
+        if value > u32::MAX as u64 {
+            return SmallDuration::MAX;
+        }
+        SmallDuration(value as u32)
+    }
+
+    pub const fn from_secs(secs: u64) -> Self {
+        if secs == 0 {
+            return SmallDuration::ZERO;
+        }
+        let secs_precision = P / 1_000_000_000;
+        if secs <= secs_precision {
+            return SmallDuration::MIN;
+        }
+        let value = secs * 1_000_000_000 / P;
+        if value > u32::MAX as u64 {
+            return SmallDuration::MAX;
+        }
+        SmallDuration(value as u32)
+    }
+
+    pub(self) fn to_duration(&self) -> Duration {
+        Duration::from_nanos(self.0 as u64 * P)
+    }
+}
+
+impl<const P: u64> From<Duration> for SmallDuration<P> {
+    fn from(duration: Duration) -> Self {
+        if duration.is_zero() {
+            return SmallDuration::ZERO;
+        }
+        let nanos = duration.as_nanos();
+        if nanos <= P as u128 {
+            return SmallDuration::MIN;
+        }
+        (nanos / P as u128)
+            .try_into()
+            .map_or(SmallDuration::MAX, SmallDuration)
+    }
+}
+
+impl<const P: u64> From<SmallDuration<P>> for Duration {
+    fn from(duration: SmallDuration<P>) -> Self {
+        duration.to_duration()
+    }
+}
+
+impl<const P: u64> Display for SmallDuration<P> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let duration = Duration::from(*self);
+        duration.fmt(f)
+    }
+}
+
+impl<const P: u64> Debug for SmallDuration<P> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let duration = Duration::from(*self);
+        duration.fmt(f)
+    }
+}
+
+impl<const P: u64> PartialEq<Duration> for SmallDuration<P> {
+    fn eq(&self, other: &Duration) -> bool {
+        self.to_duration() == *other
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::SmallDuration;
+
+    #[test]
+    fn test_1_nano() {
+        type Sd = SmallDuration<1>;
+
+        assert_eq!(Sd::from_nanos(1), Duration::from_nanos(1));
+        assert_eq!(Sd::from_nanos(42), Duration::from_nanos(42));
+
+        assert_eq!(Sd::from_micros(1), Duration::from_micros(1));
+        assert_eq!(Sd::from_micros(42), Duration::from_micros(42));
+
+        assert_eq!(Sd::from_millis(1), Duration::from_millis(1));
+        assert_eq!(Sd::from_millis(42), Duration::from_millis(42));
+
+        assert_eq!(Sd::from_secs(1), Duration::from_secs(1));
+
+        // 1ns precision can only store up to ~4.29s.
+        assert_eq!(Sd::from_secs(4), Duration::from_secs(4));
+        assert_eq!(Sd::from_secs(5), Sd::MAX);
+    }
+
+    #[test]
+    fn test_1_micro() {
+        type Sd = SmallDuration<1_000>;
+
+        // 1µs precision can't store ns-level variations.
+        assert_eq!(Sd::from_nanos(1), Sd::MIN);
+        assert_eq!(Sd::from_nanos(42), Sd::MIN);
+
+        assert_eq!(Sd::from_micros(1), Duration::from_micros(1));
+        assert_eq!(Sd::from_micros(42), Duration::from_micros(42));
+
+        assert_eq!(Sd::from_millis(1), Duration::from_millis(1));
+        assert_eq!(Sd::from_millis(42), Duration::from_millis(42));
+
+        assert_eq!(Sd::from_secs(1), Duration::from_secs(1));
+        assert_eq!(Sd::from_secs(42), Duration::from_secs(42));
+
+        // 1µs precision can only store up to ~4,294s.
+        assert_eq!(Sd::from_secs(4_000), Duration::from_secs(4_000));
+        assert_eq!(Sd::from_secs(5_000), Sd::MAX);
+    }
+
+    #[test]
+    fn test_1_milli() {
+        type Sd = SmallDuration<1_000_000>;
+
+        // 1ms precision can't store ns-or-µs-level variations.
+        assert_eq!(Sd::from_nanos(1), Sd::MIN);
+        assert_eq!(Sd::from_nanos(42), Sd::MIN);
+        assert_eq!(Sd::from_micros(1), Sd::MIN);
+        assert_eq!(Sd::from_micros(42), Sd::MIN);
+
+        assert_eq!(Sd::from_millis(1), Duration::from_millis(1));
+        assert_eq!(Sd::from_millis(42), Duration::from_millis(42));
+
+        assert_eq!(Sd::from_secs(1), Duration::from_secs(1));
+        assert_eq!(Sd::from_secs(42), Duration::from_secs(42));
+
+        // 1ms precision can only store up to ~4,294,000s.
+        assert_eq!(Sd::from_secs(4_000_000), Duration::from_secs(4_000_000));
+        assert_eq!(Sd::from_secs(5_000_000), Sd::MAX);
+    }
+
+    #[test]
+    fn test_1_sec() {
+        type Sd = SmallDuration<1_000_000_000>;
+
+        // 1ms precision can't store ns/µs/ms-level variations.
+        assert_eq!(Sd::from_nanos(1), Sd::MIN);
+        assert_eq!(Sd::from_nanos(42), Sd::MIN);
+        assert_eq!(Sd::from_micros(1), Sd::MIN);
+        assert_eq!(Sd::from_micros(42), Sd::MIN);
+        assert_eq!(Sd::from_millis(1), Sd::MIN);
+        assert_eq!(Sd::from_millis(42), Sd::MIN);
+
+        assert_eq!(Sd::from_secs(1), Duration::from_secs(1));
+        assert_eq!(Sd::from_secs(42), Duration::from_secs(42));
+
+        // 1s precision can only store up to ~4,294,000,000s.
+        assert_eq!(
+            Sd::from_secs(4_000_000_000),
+            Duration::from_secs(4_000_000_000)
+        );
+        assert_eq!(Sd::from_secs(5_000_000_000), Sd::MAX);
+    }
+}

--- a/crates/turbo-tasks/src/timed_future.rs
+++ b/crates/turbo-tasks/src/timed_future.rs
@@ -38,7 +38,7 @@ pub fn add_duration(duration: Duration) {
 }
 
 impl<T, F: Future<Output = T>> Future for TimedFuture<T, F> {
-    type Output = (T, Duration);
+    type Output = (T, Duration, Instant);
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.project();
@@ -47,7 +47,11 @@ impl<T, F: Future<Output = T>> Future for TimedFuture<T, F> {
         let elapsed = start.elapsed();
         *this.duration += elapsed;
         match result {
-            Poll::Ready(r) => Poll::Ready((r, *this.duration + *this.cell.lock().unwrap())),
+            Poll::Ready(r) => Poll::Ready((
+                r,
+                *this.duration + *this.cell.lock().unwrap(),
+                start + elapsed,
+            )),
             Poll::Pending => Poll::Pending,
         }
     }

--- a/crates/turbopack/examples/turbopack.rs
+++ b/crates/turbopack/examples/turbopack.rs
@@ -11,7 +11,7 @@ use std::{
 
 use anyhow::Result;
 use tokio::{spawn, time::sleep};
-use turbo_tasks::{util::FormatDuration, NothingVc, TurboTasks, Value};
+use turbo_tasks::{util::FormatDuration, NothingVc, TurboTasks, TurboTasksBackendApi, Value};
 use turbo_tasks_fs::{DiskFileSystemVc, FileSystemVc};
 use turbo_tasks_memory::{
     stats::{ReferenceType, Stats},
@@ -111,7 +111,11 @@ async fn main() -> Result<()> {
         // write HTML
         fs::write(
             "graph.html",
-            wrap_html(&visualize_stats_tree(tree, ReferenceType::Child)),
+            wrap_html(&visualize_stats_tree(
+                tree,
+                ReferenceType::Child,
+                tt.stats_type(),
+            )),
         )
         .unwrap();
         println!("graph.html written");


### PR DESCRIPTION
This decreases the size of the `Task` struct from 504 bytes to 488 (16 bytes saved), by only computing stats that are absolutely necessary unless `--full-stats` is passed.