### PR TITLE
feat(next-dev): support port via env variable

### DIFF
--- a/crates/next-dev/Cargo.toml
+++ b/crates/next-dev/Cargo.toml
@@ -31,7 +31,7 @@ profile = []
 
 [dependencies]
 anyhow = "1.0.47"
-clap = { version = "4.0.18", features = ["derive"] }
+clap = { version = "4.0.18", features = ["derive", "env"] }
 console-subscriber = { version = "0.1.6", optional = true }
 futures = "0.3.21"
 mime = "0.3.16"

--- a/crates/next-dev/src/devserver_options.rs
+++ b/crates/next-dev/src/devserver_options.rs
@@ -24,9 +24,12 @@ pub struct DevServerOptions {
     pub root: Option<PathBuf>,
 
     /// The port number on which to start the application
+    /// Note: setting env PORT allows to configure port without explicit cli
+    /// args. However, this is temporary measure to conform with existing
+    /// next.js devserver and can be removed in the future.
     #[cfg_attr(
         feature = "cli",
-        clap(short, long, value_parser, default_value_t = 3000)
+        clap(short, long, value_parser, default_value_t = 3000, env = "PORT")
     )]
     #[cfg_attr(feature = "serializable", serde(default = "default_port"))]
     pub port: u16,
@@ -88,7 +91,10 @@ pub struct DevServerOptions {
 
 #[cfg(feature = "serializable")]
 fn default_port() -> u16 {
-    3000
+    std::env::var("PORT")
+        .ok()
+        .and_then(|port| port.parse().ok())
+        .unwrap_or(3000)
 }
 
 #[cfg(feature = "serializable")]


### PR DESCRIPTION
Partially related with WEB-206: current next.js test suites set port via env variable, we'd like to support it for the integration tests.