### PR TITLE
get rid of CellMappings

### DIFF
--- a/crates/turbo-tasks-macros/src/value_macro.rs
+++ b/crates/turbo-tasks-macros/src/value_macro.rs
@@ -332,18 +332,6 @@ pub fn value(args: TokenStream, input: TokenStream) -> TokenStream {
             #cell_update_op
             #ref_ident { node: cell.into() }
         }
-
-        /// Places a value in a cell of the current task.
-        ///
-        /// Cell is selected by the provided `key`. `key` must not be used twice during the current task.
-        #cell_prefix fn keyed_cell<
-            K: std::fmt::Debug + std::cmp::Eq + std::cmp::Ord + std::hash::Hash + turbo_tasks::Typed + turbo_tasks::TypedForInput + Send + Sync + 'static,
-        >(key: K, content: #cell_arg_type) -> #ref_ident {
-            let cell = turbo_tasks::macro_helpers::find_cell_by_key(*#value_type_id_ident, key);
-            #cell_convert_content
-            #cell_update_op
-            #ref_ident { node: cell.into() }
-        }
     };
 
     let cell_struct = quote! {
@@ -353,16 +341,6 @@ pub fn value(args: TokenStream, input: TokenStream) -> TokenStream {
         #cell_prefix fn cell(self) -> #ref_ident {
             let content = self;
             #ref_ident::cell(#cell_access_content)
-        }
-
-        /// Places a value in a cell of the current task.
-        ///
-        /// Cell is selected by the provided `key`. `key` must not be used twice during the current task.
-        #cell_prefix fn keyed_cell<
-            K: std::fmt::Debug + std::cmp::Eq + std::cmp::Ord + std::hash::Hash + turbo_tasks::Typed + turbo_tasks::TypedForInput + Send + Sync + 'static,
-        >(self, key: K) -> #ref_ident {
-            let content = self;
-            #ref_ident::keyed_cell(key, #cell_access_content)
         }
     };
 
@@ -637,13 +615,6 @@ pub fn value(args: TokenStream, input: TokenStream) -> TokenStream {
             /// see [turbo_tasks::RawVc::cell_local]
             pub async fn cell_local(self) -> turbo_tasks::Result<Self> {
                 Ok(Self { node: self.node.cell_local().await? })
-            }
-
-            /// see [turbo_tasks::RawVc::keyed_cell_local]
-            pub async fn keyed_cell_local<
-                K: std::fmt::Debug + std::cmp::Eq + std::cmp::Ord + std::hash::Hash + turbo_tasks::Typed + turbo_tasks::TypedForInput + Send + Sync + 'static,
-            >(self, key: K) -> turbo_tasks::Result<Self> {
-                Ok(Self { node: self.node.keyed_cell_local(key).await? })
             }
 
             pub async fn resolve_from(super_trait_vc: impl std::convert::Into<turbo_tasks::RawVc>) -> Result<Option<Self>, turbo_tasks::ResolveTypeError> {

--- a/crates/turbo-tasks-macros/src/value_trait_macro.rs
+++ b/crates/turbo-tasks-macros/src/value_trait_macro.rs
@@ -217,13 +217,6 @@ pub fn value_trait(args: TokenStream, input: TokenStream) -> TokenStream {
                 Ok(Self { node: self.node.cell_local().await? })
             }
 
-            /// see [turbo_tasks::RawVc::keyed_cell_local]
-            pub async fn keyed_cell_local<
-                K: std::fmt::Debug + std::cmp::Eq + std::cmp::Ord + std::hash::Hash + turbo_tasks::Typed + turbo_tasks::TypedForInput + Send + Sync + 'static,
-            >(self, key: K) -> turbo_tasks::Result<Self> {
-                Ok(Self { node: self.node.keyed_cell_local(key).await? })
-            }
-
             pub async fn resolve_from(super_trait_vc: impl std::convert::Into<turbo_tasks::RawVc>) -> Result<Option<Self>, turbo_tasks::ResolveTypeError> {
                 let raw_vc: turbo_tasks::RawVc = super_trait_vc.into();
                 let raw_vc = raw_vc.resolve_trait(*#trait_type_id_ident).await?;

--- a/crates/turbo-tasks-memory/src/cell.rs
+++ b/crates/turbo-tasks-memory/src/cell.rs
@@ -10,14 +10,6 @@ pub struct Cell {
 }
 
 impl Cell {
-    pub fn new() -> Self {
-        Self {
-            content: CellContent(None),
-            updates: 0,
-            dependent_tasks: HashSet::new(),
-        }
-    }
-
     pub fn read_content(&mut self, reader: TaskId) -> CellContent {
         self.dependent_tasks.insert(reader);
         self.read_content_untracked()

--- a/crates/turbo-tasks-memory/src/memory_backend.rs
+++ b/crates/turbo-tasks-memory/src/memory_backend.rs
@@ -14,12 +14,12 @@ use rustc_hash::FxHasher;
 use tokio::task::futures::TaskLocalFuture;
 use turbo_tasks::{
     backend::{
-        Backend, BackendJobId, CellContent, CellMappings, PersistentTaskType, TaskExecutionSpec,
+        Backend, BackendJobId, CellContent, PersistentTaskType, TaskExecutionSpec,
         TransientTaskType,
     },
     event::EventListener,
     util::{IdFactory, NoMoveVec},
-    RawVc, TaskId, TraitTypeId, TurboTasksBackendApi,
+    CellId, RawVc, TaskId, TraitTypeId, TurboTasksBackendApi,
 };
 
 use crate::{
@@ -219,9 +219,7 @@ impl Backend for MemoryBackend {
     ) -> Option<TaskExecutionSpec> {
         self.with_task(task, |task| {
             if task.execution_started(self, turbo_tasks) {
-                let cell_mappings = task.take_cell_mappings();
                 Some(TaskExecutionSpec {
-                    cell_mappings: Some(cell_mappings),
                     future: task.execute(turbo_tasks),
                 })
             } else {
@@ -244,12 +242,11 @@ impl Backend for MemoryBackend {
     fn task_execution_completed(
         &self,
         task: TaskId,
-        cell_mappings: Option<CellMappings>,
         duration: Duration,
         turbo_tasks: &dyn TurboTasksBackendApi,
     ) -> bool {
         self.with_task(task, |task| {
-            task.execution_completed(cell_mappings, duration, self, turbo_tasks)
+            task.execution_completed(duration, self, turbo_tasks)
         })
     }
 
@@ -299,7 +296,7 @@ impl Backend for MemoryBackend {
     fn try_read_task_cell(
         &self,
         task: TaskId,
-        index: usize,
+        index: CellId,
         reader: TaskId,
         _turbo_tasks: &dyn TurboTasksBackendApi,
     ) -> Result<Result<CellContent, EventListener>> {
@@ -318,7 +315,7 @@ impl Backend for MemoryBackend {
     fn try_read_task_cell_untracked(
         &self,
         task: TaskId,
-        index: usize,
+        index: CellId,
         _turbo_tasks: &dyn TurboTasksBackendApi,
     ) -> Result<Result<CellContent, EventListener>> {
         Ok(Ok(self.with_task(task, |task| {
@@ -329,7 +326,7 @@ impl Backend for MemoryBackend {
     fn track_read_task_cell(
         &self,
         task: TaskId,
-        index: usize,
+        index: CellId,
         reader: TaskId,
         _turbo_tasks: &dyn TurboTasksBackendApi,
     ) {
@@ -377,14 +374,10 @@ impl Backend for MemoryBackend {
         });
     }
 
-    fn get_fresh_cell(&self, task: TaskId, _turbo_tasks: &dyn TurboTasksBackendApi) -> usize {
-        self.with_task(task, |task| task.get_fresh_cell())
-    }
-
     fn update_task_cell(
         &self,
         task: TaskId,
-        index: usize,
+        index: CellId,
         content: CellContent,
         turbo_tasks: &dyn TurboTasksBackendApi,
     ) {

--- a/crates/turbo-tasks-memory/src/task.rs
+++ b/crates/turbo-tasks-memory/src/task.rs
@@ -2,7 +2,7 @@ use std::{
     borrow::Cow,
     cell::RefCell,
     cmp::Ordering,
-    collections::{HashSet, VecDeque},
+    collections::{HashMap, HashSet, VecDeque},
     fmt::{self, Debug, Display, Formatter, Write},
     future::Future,
     hash::Hash,
@@ -15,10 +15,10 @@ use anyhow::Result;
 use parking_lot::{Mutex, RwLock, RwLockWriteGuard};
 use tokio::task_local;
 use turbo_tasks::{
-    backend::{CellMappings, PersistentTaskType},
+    backend::PersistentTaskType,
     event::{Event, EventListener},
-    get_invalidator, registry, FunctionId, Invalidator, RawVc, TaskId, TaskInput, TraitTypeId,
-    TurboTasksBackendApi,
+    get_invalidator, registry, CellId, FunctionId, Invalidator, RawVc, TaskId, TaskInput,
+    TraitTypeId, TurboTasksBackendApi, ValueTypeId,
 };
 pub type NativeTaskFuture = Pin<Box<dyn Future<Output = Result<RawVc>> + Send>>;
 pub type NativeTaskFn = Box<dyn Fn() -> NativeTaskFuture + Send + Sync>;
@@ -33,7 +33,7 @@ macro_rules! log_scope_update {
 #[derive(Hash, Copy, Clone, PartialEq, Eq)]
 pub enum TaskDependency {
     TaskOutput(TaskId),
-    TaskCell(TaskId, usize),
+    TaskCell(TaskId, CellId),
     ScopeChildren(TaskScopeId),
     ScopeCollectibles(TaskScopeId, TraitTypeId),
 }
@@ -128,10 +128,6 @@ struct TaskExecutionData {
     ///
     /// This back-edge is [Cell] `dependent_tasks`, which is a weak edge.
     dependencies: HashSet<TaskDependency>,
-
-    /// Mappings from key or data type to cell index, to store the data in the
-    /// same cell again.
-    cell_mappings: CellMappings,
 }
 
 impl Debug for Task {
@@ -162,7 +158,8 @@ struct TaskState {
     collectibles: MaybeCollectibles,
 
     output: Output,
-    created_cells: Vec<Cell>,
+    // TODO use AutoMap here
+    cells: HashMap<ValueTypeId, Vec<Cell>>,
     event: Event,
 
     // Stats:
@@ -179,7 +176,7 @@ impl TaskState {
             children: Default::default(),
             collectibles: Default::default(),
             output: Default::default(),
-            created_cells: Default::default(),
+            cells: Default::default(),
             event: Event::new(move || format!("TaskState({id})::event")),
             executions: Default::default(),
             total_duration: Default::default(),
@@ -196,7 +193,7 @@ impl TaskState {
             children: Default::default(),
             collectibles: Default::default(),
             output: Default::default(),
-            created_cells: Default::default(),
+            cells: Default::default(),
             event: Event::new(move || format!("TaskState({id})::event")),
             executions: Default::default(),
             total_duration: Default::default(),
@@ -567,16 +564,12 @@ impl Task {
     #[must_use]
     pub(crate) fn execution_completed(
         &self,
-        cell_mappings: Option<CellMappings>,
         duration: Duration,
         backend: &MemoryBackend,
         turbo_tasks: &dyn TurboTasksBackendApi,
     ) -> bool {
         DEPENDENCIES_TO_TRACK.with(|deps| {
             let mut execution_data = self.execution_data.lock();
-            if let Some(cell_mappings) = cell_mappings {
-                execution_data.cell_mappings = cell_mappings;
-            }
             execution_data.dependencies = deps.take();
         });
         let mut schedule_task = false;
@@ -1114,15 +1107,6 @@ impl Task {
         }
     }
 
-    pub(crate) fn take_cell_mappings(&self) -> CellMappings {
-        let mut execution_data = self.execution_data.lock();
-        let mut cell_mappings = take(&mut execution_data.cell_mappings);
-        for list in cell_mappings.by_type.values_mut() {
-            list.0 = 0;
-        }
-        cell_mappings
-    }
-
     pub(crate) fn add_dependency_to_current(dep: TaskDependency) {
         DEPENDENCIES_TO_TRACK.with(|list| {
             let mut list = list.borrow_mut();
@@ -1182,15 +1166,25 @@ impl Task {
     }
 
     /// Access to a cell.
-    pub(crate) fn with_cell_mut<T>(&self, index: usize, func: impl FnOnce(&mut Cell) -> T) -> T {
+    pub(crate) fn with_cell_mut<T>(&self, index: CellId, func: impl FnOnce(&mut Cell) -> T) -> T {
         let mut state = self.state.write();
-        func(&mut state.created_cells[index])
+        let list = state.cells.entry(index.type_id).or_default();
+        let i = index.index as usize;
+        if list.len() <= i {
+            list.resize_with(i + 1, Default::default);
+        }
+        func(&mut list[i])
     }
 
     /// Access to a cell.
-    pub(crate) fn with_cell<T>(&self, index: usize, func: impl FnOnce(&Cell) -> T) -> T {
+    pub(crate) fn with_cell<T>(&self, index: CellId, func: impl FnOnce(&Cell) -> T) -> T {
         let state = self.state.read();
-        func(&state.created_cells[index])
+        if let Some(list) = state.cells.get(&index.type_id) {
+            if let Some(cell) = list.get(index.index as usize) {
+                return func(cell);
+            }
+        }
+        func(&Default::default())
     }
 
     /// For testing purposes
@@ -1503,13 +1497,6 @@ impl Task {
             drop(state);
             turbo_tasks.schedule_notify_tasks_set(&tasks);
         }
-    }
-
-    pub(crate) fn get_fresh_cell(&self) -> usize {
-        let mut state = self.state.write();
-        let index = state.created_cells.len();
-        state.created_cells.push(Cell::new());
-        index
     }
 }
 

--- a/crates/turbo-tasks-rocksdb/src/db.rs
+++ b/crates/turbo-tasks-rocksdb/src/db.rs
@@ -2,7 +2,7 @@ use std::ops::Add;
 
 use serde::{Deserialize, Serialize};
 use turbo_tasks::{
-    backend::{CellMappings, PersistentTaskType},
+    backend::PersistentTaskType,
     persisted_graph::{TaskCell, TaskData},
     without_task_id_mapping, RawVc,
 };
@@ -197,7 +197,6 @@ impl Add for TaskStateChange {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct PartialTaskData {
     pub cells: Vec<TaskCell>,
-    pub cell_mappings: Option<CellMappings>,
     pub output: RawVc,
 }
 

--- a/crates/turbo-tasks-rocksdb/src/old_version/db.rs
+++ b/crates/turbo-tasks-rocksdb/src/old_version/db.rs
@@ -2,12 +2,13 @@ use std::fmt::Debug;
 
 use serde::{Deserialize, Serialize};
 use turbo_tasks::{
-    backend::{PersistentTaskType, CellMappings},
-    without_task_id_mapping, RawVc, SharedReference, TaskId,
+    backend::PersistentTaskType, without_task_id_mapping, RawVc, SharedReference, TaskId,
 };
 
-use crate::sortable_index::SortableIndex;
-use crate::table::{database, table};
+use crate::{
+    sortable_index::SortableIndex,
+    table::{database, table},
+};
 
 #[derive(Serialize, Deserialize)]
 pub struct SessionKey {
@@ -105,9 +106,6 @@ table!(task_state, (TaskId) => (TaskFreshness, Option<TaskOutput>), merge(
     without_task_id_mapping
 ), prefix(full));
 
-// This stores the mappings of the cellted data to cell indicies
-table!(task_cell_mappings, (TaskId) => (CellMappings), prefix(full));
-
 // This stores the dependencies of a task.
 // When processing this from a RawVc, flag all listed tasks as dirty.
 table!(task_dependencies, [TaskId] <=> [RawVc], prefix(u8));
@@ -176,7 +174,6 @@ database!(
     task_cell,
     task_state,
     task_next_cell,
-    task_cell_mappings,
     task_dependencies,
     task_children,
     task_generations,

--- a/crates/turbo-tasks/src/lib.rs
+++ b/crates/turbo-tasks/src/lib.rs
@@ -76,7 +76,7 @@ pub use manager::{
 };
 pub use native_function::{NativeFunction, NativeFunctionVc};
 pub use nothing::{Nothing, NothingVc};
-pub use raw_vc::{CollectiblesFuture, RawVc, ReadRawVcFuture, ResolveTypeError};
+pub use raw_vc::{CellId, CollectiblesFuture, RawVc, ReadRawVcFuture, ResolveTypeError};
 pub use read_ref::ReadRef;
 pub use task_input::{FromTaskInput, SharedReference, SharedValue, TaskInput};
 pub use turbo_tasks_macros::{function, value, value_impl, value_trait};
@@ -93,7 +93,7 @@ pub mod macro_helpers {
 }
 
 pub mod test_helpers {
-    pub use super::manager::with_turbo_tasks_for_testing;
+    pub use super::manager::{current_task_for_testing, with_turbo_tasks_for_testing};
 }
 
 pub fn register() {

--- a/crates/turbo-tasks/src/lib.rs
+++ b/crates/turbo-tasks/src/lib.rs
@@ -89,7 +89,7 @@ pub use value_type::{
 pub mod macro_helpers {
     pub use once_cell::sync::{Lazy, OnceCell};
 
-    pub use super::manager::{find_cell_by_key, find_cell_by_type};
+    pub use super::manager::find_cell_by_type;
 }
 
 pub mod test_helpers {

--- a/crates/turbo-tasks/src/manager.rs
+++ b/crates/turbo-tasks/src/manager.rs
@@ -1157,33 +1157,9 @@ impl From<CurrentCellRef> for RawVc {
     }
 }
 
-pub fn find_cell_by_key<
-    K: Debug + Eq + Ord + Hash + Typed + TypedForInput + Send + Sync + 'static,
->(
-    type_id: ValueTypeId,
-    key: K,
-) -> CurrentCellRef {
-    PREVIOUS_CELLS.with(|c| {
-        let current_task = current_task("cellting turbo_tasks values");
-        let mut map = c.borrow_mut();
-        let index = *map
-            .by_key
-            .entry((
-                type_id,
-                SharedValue(Some(K::get_value_type_id()), Arc::new(key)),
-            ))
-            .or_insert_with(|| with_turbo_tasks(|tt| tt.get_fresh_cell(current_task)));
-        CurrentCellRef {
-            current_task,
-            index,
-            type_id,
-        }
-    })
-}
-
 pub fn find_cell_by_type(type_id: ValueTypeId) -> CurrentCellRef {
     PREVIOUS_CELLS.with(|cell| {
-        let current_task = current_task("cellting turbo_tasks values");
+        let current_task = current_task("celling turbo_tasks values");
         let mut map = cell.borrow_mut();
         let (ref mut current_index, ref mut list) = map.by_type.entry(type_id).or_default();
         let index = if let Some(i) = list.get(*current_index) {

--- a/crates/turbo-tasks/src/manager.rs
+++ b/crates/turbo-tasks/src/manager.rs
@@ -1,11 +1,9 @@
 use std::{
     borrow::Cow,
     cell::RefCell,
-    collections::HashSet,
-    fmt::Debug,
+    collections::{HashMap, HashSet},
     future::Future,
     hash::Hash,
-    mem::take,
     panic::AssertUnwindSafe,
     pin::Pin,
     sync::{
@@ -18,20 +16,21 @@ use std::{
 
 use anyhow::{anyhow, Result};
 use futures::FutureExt;
+use nohash_hasher::BuildNoHashHasher;
 use serde::{de::Visitor, Deserialize, Serialize};
 use tokio::{runtime::Handle, select, task_local};
 
 use crate::{
-    backend::{Backend, CellContent, CellMappings, PersistentTaskType, TransientTaskType},
+    backend::{Backend, CellContent, PersistentTaskType, TransientTaskType},
     event::{Event, EventListener},
     id::{BackendJobId, FunctionId, TraitTypeId},
     id_factory::IdFactory,
-    raw_vc::RawVc,
-    task_input::{SharedReference, SharedValue, TaskInput},
+    raw_vc::{CellId, RawVc},
+    task_input::{SharedReference, TaskInput},
     timed_future::{self, TimedFuture},
     trace::TraceRawVcs,
     util::FormatDuration,
-    Nothing, NothingVc, TaskId, Typed, TypedForInput, ValueTraitVc, ValueTypeId,
+    Nothing, NothingVc, TaskId, ValueTraitVc, ValueTypeId,
 };
 
 pub trait TurboTasksCallApi: Sync + Send {
@@ -78,7 +77,7 @@ pub trait TurboTasksApi: TurboTasksCallApi + Sync + Send {
     fn try_read_task_cell(
         &self,
         task: TaskId,
-        index: usize,
+        index: CellId,
     ) -> Result<Result<CellContent, EventListener>>;
 
     /// INVALIDATION: Be careful with this, it will not track dependencies, so
@@ -86,7 +85,7 @@ pub trait TurboTasksApi: TurboTasksCallApi + Sync + Send {
     fn try_read_task_cell_untracked(
         &self,
         task: TaskId,
-        index: usize,
+        index: CellId,
     ) -> Result<Result<CellContent, EventListener>>;
 
     fn try_read_task_collectibles(
@@ -104,12 +103,11 @@ pub trait TurboTasksApi: TurboTasksCallApi + Sync + Send {
     fn try_read_own_task_cell_untracked(
         &self,
         current_task: TaskId,
-        index: usize,
+        index: CellId,
     ) -> Result<CellContent>;
 
-    fn get_fresh_cell(&self, task: TaskId) -> usize;
-    fn read_current_task_cell(&self, index: usize) -> Result<CellContent>;
-    fn update_current_task_cell(&self, index: usize, content: CellContent);
+    fn read_current_task_cell(&self, index: CellId) -> Result<CellContent>;
+    fn update_current_task_cell(&self, index: CellId, content: CellContent);
 }
 
 pub trait TaskIdProvider {
@@ -189,7 +187,7 @@ task_local! {
     /// The current TurboTasks instance
     static TURBO_TASKS: Arc<dyn TurboTasksApi>;
 
-    static PREVIOUS_CELLS: RefCell<CellMappings>;
+    static CELL_COUNTERS: RefCell<HashMap<ValueTypeId, u32, BuildNoHashHasher<ValueTypeId>>>;
 
     static CURRENT_TASK_ID: TaskId;
 
@@ -332,20 +330,12 @@ impl<B: Backend> TurboTasks<B> {
                 }
                 if let Some(execution) = this.backend.try_start_task_execution(task_id, &*this) {
                     // Setup thread locals
-                    let has_cell_mappings = execution.cell_mappings.is_some();
-
-                    let cell_mappings = RefCell::new(execution.cell_mappings.unwrap_or_default());
-                    let (result, duration, cell_mappings) = PREVIOUS_CELLS
-                        .scope(cell_mappings, async {
+                    let (result, duration) = CELL_COUNTERS
+                        .scope(Default::default(), async {
                             let (result, duration) =
                                 TimedFuture::new(AssertUnwindSafe(execution.future).catch_unwind())
                                     .await;
-                            let cell_mappings = if has_cell_mappings {
-                                Some(PREVIOUS_CELLS.with(|s| take(&mut *s.borrow_mut())))
-                            } else {
-                                None
-                            };
-                            (result, duration, cell_mappings)
+                            (result, duration)
                         })
                         .await;
                     if cfg!(feature = "log_function_stats") && duration.as_millis() > 1000 {
@@ -364,12 +354,9 @@ impl<B: Backend> TurboTasks<B> {
                     });
                     this.backend.task_execution_result(task_id, result, &*this);
                     this.notify_scheduled_tasks_internal();
-                    let reexecute = this.backend.task_execution_completed(
-                        task_id,
-                        cell_mappings,
-                        duration,
-                        &*this,
-                    );
+                    let reexecute = this
+                        .backend
+                        .task_execution_completed(task_id, duration, &*this);
                     if !reexecute {
                         break;
                     }
@@ -678,7 +665,7 @@ impl<B: Backend> TurboTasksApi for TurboTasks<B> {
     fn try_read_task_cell(
         &self,
         task: TaskId,
-        index: usize,
+        index: CellId,
     ) -> Result<Result<CellContent, EventListener>> {
         self.backend
             .try_read_task_cell(task, index, current_task("reading Vcs"), self)
@@ -687,7 +674,7 @@ impl<B: Backend> TurboTasksApi for TurboTasks<B> {
     fn try_read_task_cell_untracked(
         &self,
         task: TaskId,
-        index: usize,
+        index: CellId,
     ) -> Result<Result<CellContent, EventListener>> {
         self.backend.try_read_task_cell_untracked(task, index, self)
     }
@@ -695,7 +682,7 @@ impl<B: Backend> TurboTasksApi for TurboTasks<B> {
     fn try_read_own_task_cell_untracked(
         &self,
         current_task: TaskId,
-        index: usize,
+        index: CellId,
     ) -> Result<CellContent> {
         self.backend
             .try_read_own_task_cell_untracked(current_task, index, self)
@@ -743,16 +730,12 @@ impl<B: Backend> TurboTasksApi for TurboTasks<B> {
         }
     }
 
-    fn get_fresh_cell(&self, task: TaskId) -> usize {
-        self.backend.get_fresh_cell(task, self)
-    }
-
-    fn read_current_task_cell(&self, index: usize) -> Result<CellContent> {
+    fn read_current_task_cell(&self, index: CellId) -> Result<CellContent> {
         // INVALIDATION: don't need to track a dependency to itself
         self.try_read_own_task_cell_untracked(current_task("reading Vcs"), index)
     }
 
-    fn update_current_task_cell(&self, index: usize, content: CellContent) {
+    fn update_current_task_cell(&self, index: CellId, content: CellContent) {
         self.backend.update_task_cell(
             current_task("cellting turbo_tasks values"),
             index,
@@ -978,8 +961,12 @@ pub fn with_turbo_tasks_for_testing<T>(
 ) -> impl Future<Output = T> {
     TURBO_TASKS.scope(
         tt,
-        CURRENT_TASK_ID.scope(current_task, PREVIOUS_CELLS.scope(Default::default(), f)),
+        CURRENT_TASK_ID.scope(current_task, CELL_COUNTERS.scope(Default::default(), f)),
     )
+}
+
+pub fn current_task_for_testing() -> TaskId {
+    CURRENT_TASK_ID.with(|id| *id)
 }
 
 /// Get an [Invalidator] that can be used to invalidate the current [Task]
@@ -1049,7 +1036,7 @@ pub(crate) async fn read_task_output_untracked(
 pub(crate) async fn read_task_cell(
     this: &dyn TurboTasksApi,
     id: TaskId,
-    index: usize,
+    index: CellId,
 ) -> Result<CellContent> {
     loop {
         match this.try_read_task_cell(id, index)? {
@@ -1064,7 +1051,7 @@ pub(crate) async fn read_task_cell(
 pub(crate) async fn read_task_cell_untracked(
     this: &dyn TurboTasksApi,
     id: TaskId,
-    index: usize,
+    index: CellId,
 ) -> Result<CellContent> {
     loop {
         match this.try_read_task_cell_untracked(id, index)? {
@@ -1089,8 +1076,7 @@ pub(crate) async fn read_task_collectibles(
 
 pub struct CurrentCellRef {
     current_task: TaskId,
-    index: usize,
-    type_id: ValueTypeId,
+    index: CellId,
 }
 
 impl CurrentCellRef {
@@ -1110,7 +1096,10 @@ impl CurrentCellRef {
         if let Some(update) = update {
             tt.update_current_task_cell(
                 self.index,
-                CellContent(Some(SharedReference(Some(self.type_id), Arc::new(update)))),
+                CellContent(Some(SharedReference(
+                    Some(self.index.type_id),
+                    Arc::new(update),
+                ))),
             )
         }
     }
@@ -1131,7 +1120,7 @@ impl CurrentCellRef {
         tt.update_current_task_cell(
             self.index,
             CellContent(Some(SharedReference(
-                Some(self.type_id),
+                Some(self.index.type_id),
                 Arc::new(new_content),
             ))),
         )
@@ -1158,22 +1147,15 @@ impl From<CurrentCellRef> for RawVc {
 }
 
 pub fn find_cell_by_type(type_id: ValueTypeId) -> CurrentCellRef {
-    PREVIOUS_CELLS.with(|cell| {
+    CELL_COUNTERS.with(|cell| {
         let current_task = current_task("celling turbo_tasks values");
         let mut map = cell.borrow_mut();
-        let (ref mut current_index, ref mut list) = map.by_type.entry(type_id).or_default();
-        let index = if let Some(i) = list.get(*current_index) {
-            *i
-        } else {
-            let index = turbo_tasks().get_fresh_cell(current_task);
-            list.push(index);
-            index
-        };
+        let current_index = map.entry(type_id).or_default();
+        let index = *current_index;
         *current_index += 1;
         CurrentCellRef {
             current_task,
-            index,
-            type_id,
+            index: CellId { type_id, index },
         }
     })
 }

--- a/crates/turbo-tasks/src/persisted_graph.rs
+++ b/crates/turbo-tasks/src/persisted_graph.rs
@@ -2,8 +2,8 @@ use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    backend::{CellContent, CellMappings, PersistentTaskType},
-    RawVc, TaskId,
+    backend::{CellContent, PersistentTaskType},
+    CellId, RawVc, TaskId,
 };
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -22,8 +22,7 @@ impl Default for TaskCell {
 pub struct TaskData {
     pub children: Vec<TaskId>,
     pub dependencies: Vec<RawVc>,
-    pub cells: Vec<TaskCell>,
-    pub cell_mappings: Option<CellMappings>,
+    pub cells: Vec<(CellId, TaskCell)>,
     pub output: RawVc,
 }
 pub struct ReadTaskState {

--- a/crates/turbo-tasks/src/raw_vc.rs
+++ b/crates/turbo-tasks/src/raw_vc.rs
@@ -22,11 +22,10 @@ use crate::{
         read_task_output_untracked, CurrentCellRef, TurboTasksApi,
     },
     primitives::{RawVcSet, RawVcSetVc},
-    registry::get_value_type,
+    registry::{self, get_value_type},
     turbo_tasks,
     value_type::ValueTraitVc,
-    CollectiblesSource, ReadRef, SharedReference, TaskId, TraitTypeId, Typed, TypedForInput,
-    ValueTypeId,
+    CollectiblesSource, ReadRef, SharedReference, TaskId, TraitTypeId, ValueTypeId,
 };
 
 #[derive(Error, Debug)]
@@ -42,9 +41,26 @@ pub enum ResolveTypeError {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct CellId {
+    pub type_id: ValueTypeId,
+    pub index: u32,
+}
+
+impl Display for CellId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}#{}",
+            registry::get_value_type(self.type_id).name,
+            self.index
+        )
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub enum RawVc {
     TaskOutput(TaskId),
-    TaskCell(TaskId, usize),
+    TaskCell(TaskId, CellId),
 }
 
 impl RawVc {

--- a/crates/turbo-tasks/src/raw_vc.rs
+++ b/crates/turbo-tasks/src/raw_vc.rs
@@ -18,8 +18,8 @@ use crate::{
     backend::CellContent,
     event::EventListener,
     manager::{
-        find_cell_by_key, find_cell_by_type, read_task_cell, read_task_cell_untracked,
-        read_task_output, read_task_output_untracked, CurrentCellRef, TurboTasksApi,
+        find_cell_by_type, read_task_cell, read_task_cell_untracked, read_task_output,
+        read_task_output_untracked, CurrentCellRef, TurboTasksApi,
     },
     primitives::{RawVcSet, RawVcSetVc},
     registry::get_value_type,
@@ -306,26 +306,6 @@ impl RawVc {
     /// recomputations in the graph (as once tasks doesn't reexecute)
     pub async fn cell_local(self) -> Result<RawVc> {
         self.cell_local_internal(find_cell_by_type).await
-    }
-
-    /// Like [RawVc::cell_local], but allows to specify a key for selecting the
-    /// cell.
-    pub async fn keyed_cell_local<
-        K: std::fmt::Debug
-            + std::cmp::Eq
-            + std::cmp::Ord
-            + std::hash::Hash
-            + Typed
-            + TypedForInput
-            + Send
-            + Sync
-            + 'static,
-    >(
-        self,
-        key: K,
-    ) -> Result<RawVc> {
-        self.cell_local_internal(|ty| find_cell_by_key(ty, key))
-            .await
     }
 
     pub fn get_task_id(&self) -> TaskId {

--- a/crates/turbo-tasks/src/task_input.rs
+++ b/crates/turbo-tasks/src/task_input.rs
@@ -19,7 +19,7 @@ use crate::{
     registry, turbo_tasks,
     value::{TransientInstance, TransientValue, Value},
     value_type::TypedForInput,
-    RawVc, TaskId, TraitType, Typed, ValueTypeId,
+    CellId, RawVc, TaskId, TraitType, Typed, ValueTypeId,
 };
 
 #[derive(Clone)]
@@ -325,7 +325,7 @@ impl<'de> Deserialize<'de> for SharedValue {
 #[derive(Debug, Hash, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum TaskInput {
     TaskOutput(TaskId),
-    TaskCell(TaskId, usize),
+    TaskCell(TaskId, CellId),
     List(Vec<TaskInput>),
     String(String),
     Bool(bool),


### PR DESCRIPTION
We used to keep some state about the assignments of cells in Tasks between executions, but that has some problems:
* Executions are not pure anymore, bad for distributed execution
* We need to store the state for each task (high memory usage)
* We can't fully unload task state as we always need to keep the state.

This PR removes the state in favor of
* no more keyed_cell. It was only used in 3 places, these were converted to `cell()` instead. If we need the ability to key cells in future we might need to add the key to `CellId` (potentially converting it to an enum).
* `RawVc` stores the ValueTypeId in addition to the index and Tasks have cell arrays keyed by value type.

This makes tasks pure and allows to drop CellMappings from TaskState.

As it's very likely that Tasks only store cells of a single ValueType we will benfit from #2416 

6.08GB -> 5.92GB