### PR TITLE
feat(next/dev): allow to display version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,6 +463,9 @@ name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cesu8"
@@ -1556,6 +1559,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
 
 [[package]]
+name = "git2"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0155506aab710a86160ddb504a480d2964d7ab5b9e62419be69e0032bc5931c"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1939,6 +1955,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
+name = "jobserver"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "068b1ee6743e4d11fb9c6a1e6064b3693a1b600e7f5f5988047d98b3dc9fb90b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "jpeg-decoder"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2064,6 +2089,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04c3b4822ccebfa39c02fc03d1534441b22ead323fa0f48bb7ddd8e6ba076a40"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.13.4+1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0fa6563431ede25f5cc7f6d803c6afbc1c5d3ad3d4925d12c882bf2b526f5d1"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2080,6 +2117,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc093ab289b0bfda3aa1bdfab9c9542be29c7ef385cfcbe77f8c9813588eb48"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9702761c3935f8cc2f101793272e202c72b99da8f4224a19ddcf1279a6450bbf"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2438,6 +2487,7 @@ dependencies = [
  "turbopack-create-test-app",
  "turbopack-dev-server",
  "url",
+ "vergen",
  "webbrowser",
 ]
 
@@ -5775,6 +5825,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "vergen"
 version = "7.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5784,6 +5840,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "enum-iterator",
  "getset",
+ "git2",
  "rustversion",
  "thiserror",
  "time 0.3.13",

--- a/crates/next-dev/Cargo.toml
+++ b/crates/next-dev/Cargo.toml
@@ -75,3 +75,4 @@ nix = "0.25.0"
 
 [build-dependencies]
 turbo-tasks-build = { path = "../turbo-tasks-build" }
+vergen = { version = "7.3.2", default-features = false, features = ["cargo","git"] }

--- a/crates/next-dev/build.rs
+++ b/crates/next-dev/build.rs
@@ -1,5 +1,10 @@
 use turbo_tasks_build::generate_register;
+use vergen::{vergen, Config};
 
 fn main() {
     generate_register();
+
+    // Attempt to collect some build time env values but will skip if there are any
+    // errors.
+    let _ = vergen(Config::default());
 }

--- a/crates/next-dev/src/devserver_options.rs
+++ b/crates/next-dev/src/devserver_options.rs
@@ -48,6 +48,11 @@ pub struct DevServerOptions {
     #[cfg_attr(feature = "serializable", serde(default))]
     pub eager_compile: bool,
 
+    /// Display version of the binary. Noop if used in library mode.
+    #[cfg_attr(feature = "cli", clap(long))]
+    #[cfg_attr(feature = "serializable", serde(default))]
+    pub display_version: bool,
+
     /// Don't open the browser automatically when the dev server has started.
     #[cfg_attr(feature = "cli", clap(long))]
     #[cfg_attr(feature = "serializable", serde(default))]

--- a/crates/next-dev/src/main.rs
+++ b/crates/next-dev/src/main.rs
@@ -18,5 +18,42 @@ fn main() -> Result<()> {
 async fn main() -> Result<()> {
     let options = next_dev::devserver_options::DevServerOptions::parse();
 
+    if options.display_version {
+        println!(
+            "Build Timestamp\t\t{:#?}",
+            option_env!("VERGEN_BUILD_TIMESTAMP").unwrap_or_else(|| "N/A")
+        );
+        println!(
+            "Build Version\t\t{:#?}",
+            option_env!("VERGEN_BUILD_SEMVER").unwrap_or_else(|| "N/A")
+        );
+        println!(
+            "Commit SHA\t\t{:#?}",
+            option_env!("VERGEN_GIT_SHA").unwrap_or_else(|| "N/A")
+        );
+        println!(
+            "Commit Date\t\t{:#?}",
+            option_env!("VERGEN_GIT_COMMIT_TIMESTAMP").unwrap_or_else(|| "N/A")
+        );
+        println!(
+            "Commit Branch\t\t{:#?}",
+            option_env!("VERGEN_GIT_BRANCH").unwrap_or_else(|| "N/A")
+        );
+        println!(
+            "Commit Message\t\t{:#?}",
+            option_env!("VERGEN_GIT_COMMIT_MESSAGE").unwrap_or_else(|| "N/A")
+        );
+        println!(
+            "Cargo Target Triple\t{:#?}",
+            option_env!("VERGEN_CARGO_TARGET_TRIPLE").unwrap_or_else(|| "N/A")
+        );
+        println!(
+            "Cargo Profile\t\t{:#?}",
+            option_env!("VERGEN_CARGO_PROFILE").unwrap_or_else(|| "N/A")
+        );
+
+        return Ok(());
+    }
+
     next_dev::start_server(&options).await
 }


### PR DESCRIPTION
Digging WEB-206 and I'm really not sure what's going on now, so would like to add few more diagnostic points to ensure correctly reproduce issues on the CI vs. local for the specific changesets.

PR adds new cli option `--display-version`, which attempts to print out known status of the build. This might need some touch if this'll be used in public, but for now simple println! would do the trick.