### PR TITLE
test(next): run latest next.js canary test on the CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -830,7 +830,7 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
 
-      - name: Download benchmark data
+      - name: Download binary
         uses: actions/download-artifact@v3
         with:
           path: artifacts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -827,9 +827,6 @@ jobs:
           node-version: 16
           cache: pnpm
 
-      - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
-
       - name: Download binary
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -788,6 +788,92 @@ jobs:
         with:
           commit_message: Benchmark result for ${{ steps.date.outputs.pretty }} (${{ github.sha }})
 
+  next_js_integration:
+    needs: [determine_jobs, rust_prepare, rust_build_release]
+    if: needs.determine_jobs.outputs.rust == 'true' && (github.event_name == 'pull_request' || needs.determine_jobs.outputs.push == 'true')
+    name: Next.js integration test
+    runs-on: ubuntu-latest-8-core-oss
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [16, 18]
+        group: [1, 2]
+    env:
+      # Enabling backtract will makes snapshot tests fail
+      RUST_BACKTRACE: 0
+      NEXT_TELEMETRY_DISABLED: 1
+      NEXT_TEST_JOB: 1
+      __INTERNAL_CUSTOM_TURBOPACK_BINARY: ${{ github.workspace }}/artifacts/release-x86_64-unknown-linux-musl/next-dev
+
+    steps:
+      # https://github.com/actions/virtual-environments/issues/1187
+      - name: tune linux network
+        run: sudo ethtool -K eth0 tx off rx off
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          repository: vercel/next.js
+          ref: v13.0.5-canary.5
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2.2.4
+        with:
+          version: 7.3.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: pnpm
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Download benchmark data
+        uses: actions/download-artifact@v3
+        with:
+          path: artifacts
+
+      - name: Validate next-dev binary
+        run: |
+          chmod +x ${{ github.workspace }}/artifacts/release-x86_64-unknown-linux-musl/next-dev
+          ${{ github.workspace }}/artifacts/release-x86_64-unknown-linux-musl/next-dev --display-version
+
+      - name: Install dependencies
+        run: |
+          corepack disable
+          pnpm install
+          pnpm run build
+
+      - run: npm i -g playwright-chromium@1.22.2 && npx playwright install-deps
+        timeout-minutes: 15
+
+      - run: npx @replayio/playwright install chromium
+
+      - run: |
+          chmod +x ${{ github.workspace }}/artifacts/release-x86_64-unknown-linux-musl/next-dev
+          node run-tests.js --type development --timings -g ${{ matrix.group }}/2
+        name: Run test/development
+        env:
+          RECORD_REPLAY_METADATA_TEST_RUN_TITLE: testDev / Group ${{ matrix.group }}
+
+      - run: |
+          chmod +x ${{ github.workspace }}/artifacts/release-x86_64-unknown-linux-musl/next-dev
+          node run-tests.js --type e2e --timings -g ${{ matrix.group }}/3
+        name: Run test/e2e (dev)
+        env:
+          RECORD_REPLAY_METADATA_TEST_RUN_TITLE: testDevE2E / Group ${{ matrix.group }} / Node ${{ matrix.node }}
+          NEXT_TEST_MODE: dev
+          RECORD_REPLAY_TEST_METRICS: 1
+
+      - run: |
+          chmod +x ${{ github.workspace }}/artifacts/release-x86_64-unknown-linux-musl/next-dev
+          xvfb-run node run-tests.js --timings -g ${{ matrix.group }}/20
+        name: Test Integration
+        env:
+          RECORD_REPLAY_METADATA_TEST_RUN_TITLE: testIntegration / Group ${{ matrix.group }}
+
   node_lint:
     name: Node.js linting
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -790,7 +790,7 @@ jobs:
 
   next_js_integration:
     needs: [determine_jobs, rust_prepare, rust_build_release]
-    if: needs.determine_jobs.outputs.rust == 'true' && (github.event_name == 'pull_request' || needs.determine_jobs.outputs.push == 'true')
+    if: needs.determine_jobs.outputs.rust == 'true'
     name: Next.js integration test
     runs-on: ubuntu-latest-8-core-oss
     strategy:


### PR DESCRIPTION
Part 1 for WEB-133.

I tried nearly week to create a complete PR to including running custom turbopack binary, but currently hard blocked by WEB-169 (unknown hang / timeout).

Instead, this PR starts from an obvious step to create known-working state, by running a specific canary of next.js tests on turbo CI. This seems to correctly passing, and further changes can be ensured to pass when adding new changes.