### PR TITLE
Reduce the number of Strings and wrapper tasks

### DIFF
--- a/crates/turbo-tasks-macros/src/value_impl_macro.rs
+++ b/crates/turbo-tasks-macros/src/value_impl_macro.rs
@@ -183,7 +183,7 @@ pub fn value_impl(_args: TokenStream, input: TokenStream) -> TokenStream {
                 let internal_function_ident =
                     get_internal_trait_impl_function_ident(trait_ident, ident);
                 trait_registers.push(quote! {
-                    value.register_trait_method(<#trait_ref_path as turbo_tasks::ValueTraitVc>::get_trait_type_id(), stringify!(#ident).to_string(), *#function_id_ident);
+                    value.register_trait_method(<#trait_ref_path as turbo_tasks::ValueTraitVc>::get_trait_type_id(), stringify!(#ident).into(), *#function_id_ident);
                 });
                 let name = Literal::string(&(struct_ident.to_string() + "::" + &ident.to_string()));
                 let (native_function_code, mut input_raw_vc_arguments) = gen_native_function_code(

--- a/crates/turbo-tasks-macros/src/value_trait_macro.rs
+++ b/crates/turbo-tasks-macros/src/value_trait_macro.rs
@@ -126,7 +126,7 @@ pub fn value_trait(args: TokenStream, input: TokenStream) -> TokenStream {
 
             if let Some(block) = default.take() {
                 default_method_registers.push(quote! {
-                    trait_type.register_default_trait_method(stringify!(#method_ident).to_string(), *#function_id_ident);
+                    trait_type.register_default_trait_method(stringify!(#method_ident).into(), *#function_id_ident);
                 });
                 native_functions.push(quote! {
                     impl #ref_ident {

--- a/crates/turbo-tasks/src/task_input.rs
+++ b/crates/turbo-tasks/src/task_input.rs
@@ -401,7 +401,7 @@ impl TaskInput {
             TaskInput::SharedValue(SharedValue(ty, _))
             | TaskInput::SharedReference(SharedReference(ty, _)) => {
                 if let Some(ty) = *ty {
-                    let key = (trait_type, name.into_owned());
+                    let key = (trait_type, name);
                     if let Some(func) = registry::get_value_type(ty).get_trait_method(&key) {
                         Ok(*func)
                     } else if let Some(func) = registry::get_trait(trait_type)
@@ -410,7 +410,7 @@ impl TaskInput {
                     {
                         Ok(*func)
                     } else {
-                        Err(Cow::Owned(key.1))
+                        Err(key.1)
                     }
                 } else {
                     Err(name)

--- a/crates/turbo-tasks/src/value_type.rs
+++ b/crates/turbo-tasks/src/value_type.rs
@@ -1,5 +1,6 @@
 use std::{
     any::{type_name, Any},
+    borrow::Cow,
     fmt::{self, Debug, Display, Formatter},
     hash::Hash,
     sync::Arc,
@@ -74,7 +75,7 @@ pub struct ValueType {
     /// List of traits available
     pub traits: AutoSet<TraitTypeId>,
     /// List of trait methods available
-    pub trait_methods: AutoMap<(TraitTypeId, String), FunctionId>,
+    pub trait_methods: AutoMap<(TraitTypeId, Cow<'static, str>), FunctionId>,
 
     /// Functors for serialization
     magic_serialization: Option<(MagicSerializationFn, MagicAnyDeserializeSeed)>,
@@ -205,7 +206,7 @@ impl ValueType {
     pub fn register_trait_method(
         &mut self,
         trait_type: TraitTypeId,
-        name: String,
+        name: Cow<'static, str>,
         native_fn: FunctionId,
     ) {
         self.trait_methods.insert((trait_type, name), native_fn);
@@ -213,7 +214,7 @@ impl ValueType {
 
     pub fn get_trait_method(
         &self,
-        trait_method_key: &(TraitTypeId, String),
+        trait_method_key: &(TraitTypeId, Cow<'static, str>),
     ) -> Option<&FunctionId> {
         self.trait_methods.get(trait_method_key)
     }
@@ -239,7 +240,7 @@ impl ValueType {
 #[derive(Debug)]
 pub struct TraitType {
     pub name: String,
-    pub(crate) default_trait_methods: AutoMap<String, FunctionId>,
+    pub(crate) default_trait_methods: AutoMap<Cow<'static, str>, FunctionId>,
 }
 
 impl Hash for TraitType {
@@ -282,7 +283,11 @@ impl TraitType {
         }
     }
 
-    pub fn register_default_trait_method(&mut self, name: String, native_fn: FunctionId) {
+    pub fn register_default_trait_method(
+        &mut self,
+        name: Cow<'static, str>,
+        native_fn: FunctionId,
+    ) {
         self.default_trait_methods.insert(name, native_fn);
     }
 


### PR DESCRIPTION
* use Cow to avoid creating Strings for trait function names
* trait calls avoid the resolve trait wrapper task when called on a resolved VC
* eagerly resolve some Vc that would otherwise create a lot of wrapper tasks

Depends on #2416 