### PR TITLE
chore(renovate): skip turbopack crate tests

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -22,7 +22,8 @@
   ],
   "ignorePaths": [
     "**/node_modules/**",
-    "cli/integration_tests/**"
+    "cli/integration_tests/**",
+    "crates/turbopack/tests**"
   ],
   "prCreation": "not-pending",
   "prConcurrentLimit": 5,

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -82,7 +82,7 @@ e2e: corepack install turbo
 	node -r esbuild-register scripts/e2e/e2e.ts
 
 cmd/turbo/version.go: ../version.txt
-	# Update this automatically to avoid issues with this being overwritten during use
+	# Update this atomically to avoid issues with this being overwritten during use
 	node -e 'console.log(`package main\n\nconst turboVersion = "$(TURBO_VERSION)"`)' > cmd/turbo/version.go.txt
 	mv cmd/turbo/version.go.txt cmd/turbo/version.go
 


### PR DESCRIPTION
We don't need renovate to be auto update these. 