### PR TITLE
build(cargo): update swc_core, dependencies to resolve circular deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,9 +349,9 @@ dependencies = [
 
 [[package]]
 name = "binding_macros"
-version = "0.20.106"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f4a9532d2267c46172d1512ee75a36060a2c419d3ec261055b200d389f1ed10"
+checksum = "ed77133e200d50a2aeda13541256b00e104f4b1398d79bd45245202e23e6c28e"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -361,9 +361,9 @@ dependencies = [
  "serde-wasm-bindgen",
  "swc",
  "swc_common",
- "swc_ecma_ast",
+ "swc_ecma_ast 0.95.1",
  "swc_ecma_transforms",
- "swc_ecma_visit",
+ "swc_ecma_visit 0.81.1",
  "wasm-bindgen",
  "wasm-bindgen-futures",
 ]
@@ -399,9 +399,9 @@ dependencies = [
 
 [[package]]
 name = "browserslist-rs"
-version = "0.11.0"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c689fb4e42bd511c1927856b078d8a582690f5be196199d1c9005b9d4feae8c"
+checksum = "421478dde88feb4281328dea29dbf6d2b57bc19a8968214fc3694c8c574bc47f"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2902,7 +2902,7 @@ dependencies = [
  "node-file-trace",
  "styled_components",
  "styled_jsx",
- "swc_core 0.43.23",
+ "swc_core 0.44.4",
  "swc_emotion",
  "testing",
 ]
@@ -3584,9 +3584,9 @@ dependencies = [
 
 [[package]]
 name = "preset_env_base"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "371fa3d5cd3a90724d8e8ad1e3201854dded11e79b5365dabd5e1e389274d001"
+checksum = "97cc85a18e7f8246f3ccdd764d1f51fa3c910293942f84483a1cf1647df47198"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4593,9 +4593,9 @@ dependencies = [
 
 [[package]]
 name = "swc"
-version = "0.232.103"
+version = "0.233.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3bff0919bab888c9d6a2d57bf22cf277a3f2292f1573462d9dae5392149239b"
+checksum = "9864c625f32a24fe3be6aa7f861d75e2ab43bc98d237fd1231aab60fda518fdd"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4619,20 +4619,20 @@ dependencies = [
  "swc_cached",
  "swc_common",
  "swc_config",
- "swc_ecma_ast",
- "swc_ecma_codegen",
+ "swc_ecma_ast 0.95.1",
+ "swc_ecma_codegen 0.128.2",
  "swc_ecma_ext_transforms",
  "swc_ecma_lints",
  "swc_ecma_loader",
- "swc_ecma_minifier",
- "swc_ecma_parser",
+ "swc_ecma_minifier 0.160.2",
+ "swc_ecma_parser 0.123.2",
  "swc_ecma_preset_env",
  "swc_ecma_transforms",
- "swc_ecma_transforms_base",
+ "swc_ecma_transforms_base 0.112.2",
  "swc_ecma_transforms_compat",
- "swc_ecma_transforms_optimization",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_transforms_optimization 0.168.2",
+ "swc_ecma_utils 0.106.2",
+ "swc_ecma_visit 0.81.1",
  "swc_error_reporters",
  "swc_node_comments",
  "swc_plugin_proxy",
@@ -4650,7 +4650,7 @@ dependencies = [
  "clap 4.0.18",
  "owo-colors",
  "regex",
- "swc_core 0.43.23",
+ "swc_core 0.44.4",
 ]
 
 [[package]]
@@ -4670,9 +4670,9 @@ dependencies = [
 
 [[package]]
 name = "swc_bundler"
-version = "0.192.89"
+version = "0.193.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc34dfeaaf7efdd7ebe3a7d6b5864289635ee7a531229a8b74a1e34f6dfeb36"
+checksum = "5a67acb8bb8f01cfecb98a4517f9ce9d02c4bf4c02ab5dfbba020f2dbfabdbce"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4689,14 +4689,14 @@ dependencies = [
  "retain_mut",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_codegen",
+ "swc_ecma_ast 0.95.1",
+ "swc_ecma_codegen 0.128.2",
  "swc_ecma_loader",
- "swc_ecma_parser",
- "swc_ecma_transforms_base",
- "swc_ecma_transforms_optimization",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_parser 0.123.2",
+ "swc_ecma_transforms_base 0.112.2",
+ "swc_ecma_transforms_optimization 0.168.2",
+ "swc_ecma_utils 0.106.2",
+ "swc_ecma_visit 0.81.1",
  "swc_fast_graph",
  "swc_graph_analyzer",
  "tracing",
@@ -4718,9 +4718,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.29.15"
+version = "0.29.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "270c8551babaeafa4fc33ab06548ae454532af88a7c650860909dd574042b921"
+checksum = "295fb6ecf5c33599941e5dc38bf74517c9bfc9e1fd368db4fc4ca718e9005ee1"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4787,13 +4787,13 @@ dependencies = [
  "swc_css_parser 0.133.18",
  "swc_css_prefixer",
  "swc_css_visit 0.123.6",
- "swc_ecma_ast",
- "swc_ecma_codegen",
- "swc_ecma_minifier",
- "swc_ecma_parser",
- "swc_ecma_transforms_base",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_ast 0.94.20",
+ "swc_ecma_codegen 0.127.36",
+ "swc_ecma_minifier 0.159.89",
+ "swc_ecma_parser 0.122.27",
+ "swc_ecma_transforms_base 0.111.50",
+ "swc_ecma_utils 0.105.37",
+ "swc_ecma_visit 0.80.20",
  "swc_trace_macro",
  "vergen",
 ]
@@ -4804,34 +4804,51 @@ version = "0.43.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afdf3bc89454223076b8992ec1e17f9827fcc6139c34488c2be8d3189c2f7dbd"
 dependencies = [
+ "swc_atoms",
+ "swc_cached",
+ "swc_common",
+ "swc_ecma_ast 0.94.20",
+ "swc_ecma_codegen 0.127.36",
+ "swc_ecma_parser 0.122.27",
+ "swc_ecma_transforms_base 0.111.50",
+ "swc_ecma_visit 0.80.20",
+ "vergen",
+]
+
+[[package]]
+name = "swc_core"
+version = "0.44.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0930f364c4cfff05d3dbda1afadc8bbf714905d0e7f1cc1c7599866e88e329fe"
+dependencies = [
  "binding_macros",
  "swc",
  "swc_atoms",
  "swc_bundler",
  "swc_cached",
  "swc_common",
- "swc_css_ast 0.127.2",
- "swc_css_codegen 0.137.3",
+ "swc_css_ast 0.128.1",
+ "swc_css_codegen 0.138.3",
  "swc_css_compat",
  "swc_css_modules",
- "swc_css_parser 0.136.3",
- "swc_css_utils 0.124.2",
- "swc_css_visit 0.126.2",
- "swc_ecma_ast",
- "swc_ecma_codegen",
+ "swc_css_parser 0.137.3",
+ "swc_css_utils 0.125.1",
+ "swc_css_visit 0.127.1",
+ "swc_ecma_ast 0.95.1",
+ "swc_ecma_codegen 0.128.2",
  "swc_ecma_loader",
- "swc_ecma_minifier",
- "swc_ecma_parser",
+ "swc_ecma_minifier 0.160.2",
+ "swc_ecma_parser 0.123.2",
  "swc_ecma_preset_env",
  "swc_ecma_quote_macros",
- "swc_ecma_transforms_base",
+ "swc_ecma_transforms_base 0.112.2",
  "swc_ecma_transforms_module",
- "swc_ecma_transforms_optimization",
+ "swc_ecma_transforms_optimization 0.168.2",
  "swc_ecma_transforms_react",
  "swc_ecma_transforms_testing",
  "swc_ecma_transforms_typescript",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_utils 0.106.2",
+ "swc_ecma_visit 0.81.1",
  "swc_node_base",
  "swc_nodejs_common",
  "swc_plugin_proxy",
@@ -4857,9 +4874,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_ast"
-version = "0.127.2"
+version = "0.128.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4ce75d995faa827296c2d87ef2ad7fa9a92132383588d2a78aaadd8b98bc18"
+checksum = "77f193297ef3eb2c76052dbcf3a9c42bc509563f0943c875d783db71798cb514"
 dependencies = [
  "is-macro",
  "serde",
@@ -4887,9 +4904,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_codegen"
-version = "0.137.3"
+version = "0.138.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aae0a2d68b1777c121eba0a2b5ecf2f130db75784e6522aa61cefaf1ee426767"
+checksum = "a183ce66593dc14be82378a6e647caab79c7b76d7e6169ec2e5f458e38022baf"
 dependencies = [
  "auto_impl",
  "bitflags",
@@ -4897,9 +4914,9 @@ dependencies = [
  "serde",
  "swc_atoms",
  "swc_common",
- "swc_css_ast 0.127.2",
+ "swc_css_ast 0.128.1",
  "swc_css_codegen_macros",
- "swc_css_utils 0.124.2",
+ "swc_css_utils 0.125.1",
 ]
 
 [[package]]
@@ -4917,34 +4934,34 @@ dependencies = [
 
 [[package]]
 name = "swc_css_compat"
-version = "0.12.3"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac42855a6175ff947f13810d407c3576feb6e863e37e7afe56d1330360d4c1bc"
+checksum = "4a468a59b5dc5f8dd0d338e7cd3dab09128a5abf2d9bedd7cd4bfd9f9136f077"
 dependencies = [
  "once_cell",
  "serde",
  "serde_json",
  "swc_atoms",
  "swc_common",
- "swc_css_ast 0.127.2",
- "swc_css_utils 0.124.2",
- "swc_css_visit 0.126.2",
+ "swc_css_ast 0.128.1",
+ "swc_css_utils 0.125.1",
+ "swc_css_visit 0.127.1",
 ]
 
 [[package]]
 name = "swc_css_modules"
-version = "0.13.3"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32818d3936a1c9c0d2caa27bb17b22788443be55031843cf2bd91051a8ae5b1e"
+checksum = "1f06de7293ca37fb7691d76469a716623bc35c00af0e1e9a25548197d271ebda"
 dependencies = [
  "rustc-hash",
  "serde",
  "swc_atoms",
  "swc_common",
- "swc_css_ast 0.127.2",
- "swc_css_codegen 0.137.3",
- "swc_css_parser 0.136.3",
- "swc_css_visit 0.126.2",
+ "swc_css_ast 0.128.1",
+ "swc_css_codegen 0.138.3",
+ "swc_css_parser 0.137.3",
+ "swc_css_visit 0.127.1",
 ]
 
 [[package]]
@@ -4963,16 +4980,16 @@ dependencies = [
 
 [[package]]
 name = "swc_css_parser"
-version = "0.136.3"
+version = "0.137.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "769288b2560c0e69b9f38a64bcb2d1676d0694552d3eedef174f97e0bd17247c"
+checksum = "969ba35f9770eab6d867bc2f0603fd1b133ad59c6b219608fbf0550fadbb6a4c"
 dependencies = [
  "bitflags",
  "lexical",
  "serde",
  "swc_atoms",
  "swc_common",
- "swc_css_ast 0.127.2",
+ "swc_css_ast 0.128.1",
 ]
 
 [[package]]
@@ -5009,17 +5026,17 @@ dependencies = [
 
 [[package]]
 name = "swc_css_utils"
-version = "0.124.2"
+version = "0.125.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2d469f544ee09811abf06a85e58c04608656fa9ed96f452397b627e91581ca5"
+checksum = "4d318c70fef968243de15285368328b3aeb8499c436a483a9ec8b3e19b2a4281"
 dependencies = [
  "once_cell",
  "serde",
  "serde_json",
  "swc_atoms",
  "swc_common",
- "swc_css_ast 0.127.2",
- "swc_css_visit 0.126.2",
+ "swc_css_ast 0.128.1",
+ "swc_css_visit 0.127.1",
 ]
 
 [[package]]
@@ -5037,14 +5054,14 @@ dependencies = [
 
 [[package]]
 name = "swc_css_visit"
-version = "0.126.2"
+version = "0.127.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be7c7515663deb892c3735140587565bb945ec12bb90e1dbd85d5a6cf56d3d4f"
+checksum = "fc6fc6af0899bb054ac17b7cfaf1cd5c1efbd594b95aefa5260ae8a08f528600"
 dependencies = [
  "serde",
  "swc_atoms",
  "swc_common",
- "swc_css_ast 0.127.2",
+ "swc_css_ast 0.128.1",
  "swc_visit",
 ]
 
@@ -5053,6 +5070,23 @@ name = "swc_ecma_ast"
 version = "0.94.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2e2786dccb1e68c26b3b67efa124d37055dae27fbe42a25bb541ce00ab9eaa5"
+dependencies = [
+ "bitflags",
+ "is-macro",
+ "num-bigint",
+ "scoped-tls",
+ "serde",
+ "string_enum",
+ "swc_atoms",
+ "swc_common",
+ "unicode-id",
+]
+
+[[package]]
+name = "swc_ecma_ast"
+version = "0.95.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04fc3a7fafe8506b19506b455f18c875f2b5f546f6ecc7a6d22032c281b24888"
 dependencies = [
  "bitflags",
  "is-macro",
@@ -5080,7 +5114,26 @@ dependencies = [
  "sourcemap",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
+ "swc_ecma_ast 0.94.20",
+ "swc_ecma_codegen_macros",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_codegen"
+version = "0.128.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5be18c834f2fb158c88b4ae5dc0320663bb11fe4913a37f10355001194d41d0"
+dependencies = [
+ "memchr",
+ "num-bigint",
+ "once_cell",
+ "rustc-hash",
+ "serde",
+ "sourcemap",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast 0.95.1",
  "swc_ecma_codegen_macros",
  "tracing",
 ]
@@ -5100,23 +5153,23 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ext_transforms"
-version = "0.91.37"
+version = "0.92.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "174b61dbb706cb1abc9eafa90faef3b2978c9a3e695bea944bd00c1fc192807e"
+checksum = "fd9365760d251cd79e80fbe1c612c37e23fd2a6687bee46671ab7a17aad8c416"
 dependencies = [
  "phf",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_ast 0.95.1",
+ "swc_ecma_utils 0.106.2",
+ "swc_ecma_visit 0.81.1",
 ]
 
 [[package]]
 name = "swc_ecma_lints"
-version = "0.66.55"
+version = "0.67.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "293ae840c0e27b0f703725bad7591f33c19b46ad6c8df3b5a98b6e3d133eb452"
+checksum = "7f83b7441598759492030801130127dfd0a39d236d641c1d466cfecf69d94c27"
 dependencies = [
  "ahash",
  "auto_impl",
@@ -5128,16 +5181,16 @@ dependencies = [
  "swc_atoms",
  "swc_common",
  "swc_config",
- "swc_ecma_ast",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_ast 0.95.1",
+ "swc_ecma_utils 0.106.2",
+ "swc_ecma_visit 0.81.1",
 ]
 
 [[package]]
 name = "swc_ecma_loader"
-version = "0.41.16"
+version = "0.41.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70b019b735b4aea596baf98d22878579478e1aeb4a2fe41acc93a6b049735b93"
+checksum = "801077c673830f07f4418969397ddb0c92413c0d6fb8b5a73b977ddb7d19b046"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5169,6 +5222,40 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "radix_fmt",
+ "regex",
+ "retain_mut",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "swc_atoms",
+ "swc_cached",
+ "swc_common",
+ "swc_config",
+ "swc_ecma_ast 0.94.20",
+ "swc_ecma_codegen 0.127.36",
+ "swc_ecma_parser 0.122.27",
+ "swc_ecma_transforms_base 0.111.50",
+ "swc_ecma_transforms_optimization 0.167.54",
+ "swc_ecma_utils 0.105.37",
+ "swc_ecma_visit 0.80.20",
+ "swc_timer",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_minifier"
+version = "0.160.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d6ec9450992c70f0db8ebb0527efbf43d35a203a100fc749b78374a65fd7340"
+dependencies = [
+ "ahash",
+ "arrayvec 0.7.2",
+ "indexmap",
+ "num-bigint",
+ "num_cpus",
+ "once_cell",
+ "parking_lot",
+ "radix_fmt",
  "rayon",
  "regex",
  "retain_mut",
@@ -5179,13 +5266,13 @@ dependencies = [
  "swc_cached",
  "swc_common",
  "swc_config",
- "swc_ecma_ast",
- "swc_ecma_codegen",
- "swc_ecma_parser",
- "swc_ecma_transforms_base",
- "swc_ecma_transforms_optimization",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_ast 0.95.1",
+ "swc_ecma_codegen 0.128.2",
+ "swc_ecma_parser 0.123.2",
+ "swc_ecma_transforms_base 0.112.2",
+ "swc_ecma_transforms_optimization 0.168.2",
+ "swc_ecma_utils 0.106.2",
+ "swc_ecma_visit 0.81.1",
  "swc_timer",
  "tracing",
 ]
@@ -5204,16 +5291,35 @@ dependencies = [
  "smallvec",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
+ "swc_ecma_ast 0.94.20",
+ "tracing",
+ "typed-arena",
+]
+
+[[package]]
+name = "swc_ecma_parser"
+version = "0.123.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf9948268edb75b2a02cb5c919d791344f8a7379ec726039c04e437fe5eac1e7"
+dependencies = [
+ "either",
+ "enum_kind",
+ "lexical",
+ "num-bigint",
+ "serde",
+ "smallvec",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast 0.95.1",
  "tracing",
  "typed-arena",
 ]
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "0.174.54"
+version = "0.175.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c174f059ec8f684bdca6b1e723f2ae70c053efe79b094645a062a445f58b18b6"
+checksum = "0630d4bc64d096049a5ee300b7eb0e27c0edba83130fa7de08813403be3c2599"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5228,17 +5334,17 @@ dependencies = [
  "string_enum",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
+ "swc_ecma_ast 0.95.1",
  "swc_ecma_transforms",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_utils 0.106.2",
+ "swc_ecma_visit 0.81.1",
 ]
 
 [[package]]
 name = "swc_ecma_quote_macros"
-version = "0.33.28"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2727e9b6dc65396f847ceb4f5e4a91823f0083636a22ca16b7a7116e0ca9fe85"
+checksum = "ba912948f24aa3eb6bd72ce33235a97954873b61299bc0ec8fb7fddb486fa394"
 dependencies = [
  "anyhow",
  "pmutil",
@@ -5246,46 +5352,42 @@ dependencies = [
  "quote 1.0.21",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_parser",
+ "swc_ecma_ast 0.95.1",
+ "swc_ecma_parser 0.123.2",
  "swc_macros_common",
  "syn 1.0.99",
 ]
 
 [[package]]
 name = "swc_ecma_testing"
-version = "0.20.7"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21ecc467eff7ef4ec0a64919402b94da637003015d019de4d649e8efeceafd3f"
+checksum = "25198f96ef93c4bb4cc8fa13c9b22a018cf2c0c7609ee91f7abc7968ebc2e2df"
 dependencies = [
  "anyhow",
  "hex",
  "sha-1",
- "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
- "testing",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.198.54"
+version = "0.199.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb2f6317bf464fc4c5cbc413f831dbdedae26f72e75751d9c2219bd260a7d6b8"
+checksum = "19d727e0210e883a9da91906871771bcd3e4ecfc24464e4560891abea1a9a2f2"
 dependencies = [
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_transforms_base",
+ "swc_ecma_ast 0.95.1",
+ "swc_ecma_transforms_base 0.112.2",
  "swc_ecma_transforms_compat",
  "swc_ecma_transforms_module",
- "swc_ecma_transforms_optimization",
+ "swc_ecma_transforms_optimization 0.168.2",
  "swc_ecma_transforms_proposal",
  "swc_ecma_transforms_react",
  "swc_ecma_transforms_typescript",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_utils 0.106.2",
+ "swc_ecma_visit 0.81.1",
 ]
 
 [[package]]
@@ -5298,38 +5400,60 @@ dependencies = [
  "bitflags",
  "once_cell",
  "phf",
+ "rustc-hash",
+ "serde",
+ "smallvec",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast 0.94.20",
+ "swc_ecma_parser 0.122.27",
+ "swc_ecma_utils 0.105.37",
+ "swc_ecma_visit 0.80.20",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_transforms_base"
+version = "0.112.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8154f2ba2b3e27e995188d3d0ecd80068987b5d56b5e0c7f64ccf8926e7bb8e"
+dependencies = [
+ "better_scoped_tls",
+ "bitflags",
+ "once_cell",
+ "phf",
  "rayon",
  "rustc-hash",
  "serde",
  "smallvec",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_parser",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_ast 0.95.1",
+ "swc_ecma_parser 0.123.2",
+ "swc_ecma_utils 0.106.2",
+ "swc_ecma_visit 0.81.1",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "0.100.49"
+version = "0.101.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81adaaf6e04a7a3e2ed9ae137bcc31fef749825efb21d507b8392e2ef50f5c5"
+checksum = "86024dc3ca060348cc016a880986cf8f147bcfb174875787a870fded970f5b25"
 dependencies = [
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_transforms_base",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_ast 0.95.1",
+ "swc_ecma_transforms_base 0.112.2",
+ "swc_ecma_utils 0.106.2",
+ "swc_ecma_visit 0.81.1",
 ]
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "0.136.43"
+version = "0.137.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06a706aa64921dcb9e7028713579e2d8feca0bf70cbc43e993839a704ba74d02"
+checksum = "5f9c9fa2b790b85aaf4d9acc9558e40e92b7508331ee971972c301f58b688bba"
 dependencies = [
  "ahash",
  "arrayvec 0.7.2",
@@ -5342,12 +5466,12 @@ dependencies = [
  "swc_atoms",
  "swc_common",
  "swc_config",
- "swc_ecma_ast",
- "swc_ecma_transforms_base",
+ "swc_ecma_ast 0.95.1",
+ "swc_ecma_transforms_base 0.112.2",
  "swc_ecma_transforms_classes",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_utils 0.106.2",
+ "swc_ecma_visit 0.81.1",
  "swc_trace_macro",
  "tracing",
 ]
@@ -5367,9 +5491,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "0.153.47"
+version = "0.154.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a5de110b193ff19023fd15c14b986719c9493ae450eda35a36b3d9ca3ab5483"
+checksum = "7bcf903603f02e2f3824b8aaabc8515198db988bd738012c68713f486c6e189e"
 dependencies = [
  "Inflector",
  "ahash",
@@ -5384,12 +5508,12 @@ dependencies = [
  "swc_atoms",
  "swc_cached",
  "swc_common",
- "swc_ecma_ast",
+ "swc_ecma_ast 0.95.1",
  "swc_ecma_loader",
- "swc_ecma_parser",
- "swc_ecma_transforms_base",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_parser 0.123.2",
+ "swc_ecma_transforms_base 0.112.2",
+ "swc_ecma_utils 0.106.2",
+ "swc_ecma_visit 0.81.1",
  "tracing",
 ]
 
@@ -5404,45 +5528,70 @@ dependencies = [
  "indexmap",
  "once_cell",
  "petgraph",
+ "rustc-hash",
+ "serde_json",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast 0.94.20",
+ "swc_ecma_parser 0.122.27",
+ "swc_ecma_transforms_base 0.111.50",
+ "swc_ecma_transforms_macros",
+ "swc_ecma_utils 0.105.37",
+ "swc_ecma_visit 0.80.20",
+ "swc_fast_graph",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_transforms_optimization"
+version = "0.168.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3edeb43c8bf28cc190b29a9229811df8c0ee1fc9cf704fbd2b297a36de791961"
+dependencies = [
+ "ahash",
+ "dashmap",
+ "indexmap",
+ "once_cell",
+ "petgraph",
  "rayon",
  "rustc-hash",
  "serde_json",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_parser",
- "swc_ecma_transforms_base",
+ "swc_ecma_ast 0.95.1",
+ "swc_ecma_parser 0.123.2",
+ "swc_ecma_transforms_base 0.112.2",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_utils 0.106.2",
+ "swc_ecma_visit 0.81.1",
  "swc_fast_graph",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "0.144.43"
+version = "0.145.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1954b8e786132ee82bb0562516f7c18a79a9130b98e8e6dae0bc0b876ad9c7b0"
+checksum = "87c0afe63785d15d4bdf404ff1e83360cfb1537aad7a207cf3fb349b28f37837"
 dependencies = [
  "either",
  "serde",
  "smallvec",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_transforms_base",
+ "swc_ecma_ast 0.95.1",
+ "swc_ecma_transforms_base 0.112.2",
  "swc_ecma_transforms_classes",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_utils 0.106.2",
+ "swc_ecma_visit 0.81.1",
 ]
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.155.47"
+version = "0.156.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5b7d4860caf43a2ba5b6ae405f04060b01f30be3853e38edcba23fa26d15d8a"
+checksum = "cb642721f6d960c84898677c7ea14c689537ae335f6431e9640f33bc9ed58dc1"
 dependencies = [
  "ahash",
  "base64 0.13.0",
@@ -5457,19 +5606,19 @@ dependencies = [
  "swc_atoms",
  "swc_common",
  "swc_config",
- "swc_ecma_ast",
- "swc_ecma_parser",
- "swc_ecma_transforms_base",
+ "swc_ecma_ast 0.95.1",
+ "swc_ecma_parser 0.123.2",
+ "swc_ecma_transforms_base 0.112.2",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_utils 0.106.2",
+ "swc_ecma_visit 0.81.1",
 ]
 
 [[package]]
 name = "swc_ecma_transforms_testing"
-version = "0.114.35"
+version = "0.115.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a17359705d6ada954a9cf8509d7cdebf57e98932d0036f5b2bd1ef3252adee62"
+checksum = "b4b16828650b5431e28a83e83edfb6f52ba7c85bf63d2880ff6de0bdebb08ed0"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -5480,31 +5629,31 @@ dependencies = [
  "sha-1",
  "sourcemap",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_codegen",
- "swc_ecma_parser",
+ "swc_ecma_ast 0.95.1",
+ "swc_ecma_codegen 0.128.2",
+ "swc_ecma_parser 0.123.2",
  "swc_ecma_testing",
- "swc_ecma_transforms_base",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_transforms_base 0.112.2",
+ "swc_ecma_utils 0.106.2",
+ "swc_ecma_visit 0.81.1",
  "tempfile",
  "testing",
 ]
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.159.49"
+version = "0.160.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "050df008d6371dd706537d7833bb2dbccbcc1fc31878b94869c2a7be934f6bc9"
+checksum = "e9c0190167b7adc388c6e62fc40a316ed851a09102f144e744f235b63ecbe899"
 dependencies = [
  "serde",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_transforms_base",
+ "swc_ecma_ast 0.95.1",
+ "swc_ecma_transforms_base 0.112.2",
  "swc_ecma_transforms_react",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_utils 0.106.2",
+ "swc_ecma_visit 0.81.1",
 ]
 
 [[package]]
@@ -5516,11 +5665,28 @@ dependencies = [
  "indexmap",
  "num_cpus",
  "once_cell",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast 0.94.20",
+ "swc_ecma_visit 0.80.20",
+ "tracing",
+ "unicode-id",
+]
+
+[[package]]
+name = "swc_ecma_utils"
+version = "0.106.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ff832d27c2b8a5957853094c09e1b596f18b31160a4daf004f29f0e4f5bdc21"
+dependencies = [
+ "indexmap",
+ "num_cpus",
+ "once_cell",
  "rayon",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_visit",
+ "swc_ecma_ast 0.95.1",
+ "swc_ecma_visit 0.81.1",
  "tracing",
  "unicode-id",
 ]
@@ -5534,7 +5700,21 @@ dependencies = [
  "num-bigint",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
+ "swc_ecma_ast 0.94.20",
+ "swc_visit",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_visit"
+version = "0.81.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfce55b92a36aac12309518604ee46106177266bb5fd09cd2bb6b4a1210533f9"
+dependencies = [
+ "num-bigint",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast 0.95.1",
  "swc_visit",
  "tracing",
 ]
@@ -5571,9 +5751,9 @@ dependencies = [
 
 [[package]]
 name = "swc_error_reporters"
-version = "0.13.15"
+version = "0.13.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c500999360900f1f36838549e1a4faf1a3499a2d70cc5c24edd9ba3134448b9f"
+checksum = "119a391045e3c31ab38ff8e16428248bd0734626e19be28c9e9de4d6a6bb9c3a"
 dependencies = [
  "anyhow",
  "miette",
@@ -5584,9 +5764,9 @@ dependencies = [
 
 [[package]]
 name = "swc_fast_graph"
-version = "0.17.16"
+version = "0.17.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13830b02764bf532d347118283393fe6f2b6b5a93c6948af443d2891958705f9"
+checksum = "28a0d380e2d53fd6d166e8f06ddf3846a3c9bb9d12bdd0fe123e820483c5be2c"
 dependencies = [
  "ahash",
  "indexmap",
@@ -5596,9 +5776,9 @@ dependencies = [
 
 [[package]]
 name = "swc_graph_analyzer"
-version = "0.18.16"
+version = "0.18.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63b62c9ad9d603ed820c36d62c956c3dc6d30ab321f9a9af345c23638b4cca42"
+checksum = "b52fdb35f6289ca961d5fca80f2e1e284e3dcb6f0424c428cf00c1779c80fdfc"
 dependencies = [
  "ahash",
  "auto_impl",
@@ -5631,9 +5811,9 @@ dependencies = [
 
 [[package]]
 name = "swc_node_comments"
-version = "0.16.15"
+version = "0.16.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ad0ec8c52bc0ed6225805117688abe890313d491c36de5665dcc2e80a643f08"
+checksum = "5fdebc066a603b2256957707e8127942cbc25a2d07a28d90747b5fd90a51caaa"
 dependencies = [
  "ahash",
  "dashmap",
@@ -5658,23 +5838,23 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_proxy"
-version = "0.22.22"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d13c031d1f262ddd8cf93fb0c019e664f12541930b8ed408ad60d7b43179cd"
+checksum = "624e53ccde0582e844b545df87dc3e8850fe813813c50c93a05ea4245fc381ba"
 dependencies = [
  "better_scoped_tls",
  "rkyv",
  "swc_common",
- "swc_ecma_ast",
+ "swc_ecma_ast 0.95.1",
  "swc_trace_macro",
  "tracing",
 ]
 
 [[package]]
 name = "swc_plugin_runner"
-version = "0.77.36"
+version = "0.78.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c3b1484dcc70c37f28975c905b8acb675692e13c35c2da10802d00f22a1d48"
+checksum = "83fdfcc530821aac2902d0a060a4efe8647160ebb0196688a7fac2447ae7d0c3"
 dependencies = [
  "anyhow",
  "enumset",
@@ -5683,7 +5863,6 @@ dependencies = [
  "serde",
  "serde_json",
  "swc_common",
- "swc_ecma_ast",
  "swc_plugin_proxy",
  "tracing",
  "wasmer",
@@ -5695,9 +5874,9 @@ dependencies = [
 
 [[package]]
 name = "swc_timer"
-version = "0.17.15"
+version = "0.17.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5d2783e7023fcf40687ac2700ec4ad98e31851f4c5efc55291ebd13ae374e6a"
+checksum = "328057c7f54f30534add2ac9e6570ff16e757cba5b20dd669148bba71eac6bf7"
 dependencies = [
  "tracing",
 ]
@@ -5849,9 +6028,9 @@ dependencies = [
 
 [[package]]
 name = "testing"
-version = "0.31.15"
+version = "0.31.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f12fb28543f97ba6ad7784af03b469184803ee930542b5fc4caf9278861fea8"
+checksum = "3e1bf3e1197f0dd71ea09b8540be7f735df3f86f7b7ce41304acb79fcf52f8fb"
 dependencies = [
  "ansi_term",
  "difference",
@@ -6537,7 +6716,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_regex",
- "swc_core 0.43.23",
+ "swc_core 0.44.4",
  "test-generator",
  "tokio",
  "turbo-malloc",
@@ -6593,7 +6772,7 @@ dependencies = [
  "serde_json",
  "serde_regex",
  "sourcemap",
- "swc_core 0.43.23",
+ "swc_core 0.44.4",
  "tokio",
  "turbo-tasks",
  "turbo-tasks-build",
@@ -6624,7 +6803,7 @@ dependencies = [
  "indexmap",
  "once_cell",
  "serde",
- "swc_core 0.43.23",
+ "swc_core 0.44.4",
  "turbo-tasks",
  "turbo-tasks-build",
  "turbo-tasks-fs",
@@ -6686,7 +6865,7 @@ dependencies = [
  "serde_regex",
  "styled_components",
  "styled_jsx",
- "swc_core 0.43.23",
+ "swc_core 0.44.4",
  "swc_emotion",
  "tokio",
  "tracing",
@@ -6777,7 +6956,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "swc_core 0.43.23",
+ "swc_core 0.44.4",
  "turbo-tasks",
  "turbo-tasks-build",
  "turbo-tasks-fs",
@@ -7036,8 +7215,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
 dependencies = [
  "cfg-if 1.0.0",
- "serde",
- "serde_json",
  "wasm-bindgen-macro",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,9 +361,9 @@ dependencies = [
  "serde-wasm-bindgen",
  "swc",
  "swc_common",
- "swc_ecma_ast 0.95.1",
+ "swc_ecma_ast",
  "swc_ecma_transforms",
- "swc_ecma_visit 0.81.1",
+ "swc_ecma_visit",
  "wasm-bindgen",
  "wasm-bindgen-futures",
 ]
@@ -633,9 +633,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.22"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
+checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -1908,12 +1908,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
-
-[[package]]
-name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
@@ -2144,12 +2138,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.6.2"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
+checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
- "hashbrown 0.9.1",
+ "hashbrown 0.12.3",
  "rayon",
  "serde",
 ]
@@ -2539,13 +2533,13 @@ dependencies = [
 
 [[package]]
 name = "mdxjs"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d435840f18b935364ac7c16a8e636f956f3b125a08c63ab21938a445953fa024"
+checksum = "0c4bbd566f0dd80e0701ef5ca305e4404805eb37b95a6246ac1605acb71a6e9b"
 dependencies = [
  "markdown",
  "serde",
- "swc_core 0.43.23",
+ "swc_core",
 ]
 
 [[package]]
@@ -2720,16 +2714,16 @@ dependencies = [
 
 [[package]]
 name = "modularize_imports"
-version = "0.25.5"
+version = "0.25.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43debe5ab48d5c1400c4311dbc534554cad214566416a28bf64ced1b6548a28"
+checksum = "86ac677f509eabb57a5796bb363cb3141b64a5a215a693fd84e5349cb34de4d3"
 dependencies = [
  "convert_case",
  "handlebars",
  "once_cell",
  "regex",
  "serde",
- "swc_core 0.43.23",
+ "swc_core",
 ]
 
 [[package]]
@@ -2902,7 +2896,7 @@ dependencies = [
  "node-file-trace",
  "styled_components",
  "styled_jsx",
- "swc_core 0.44.4",
+ "swc_core",
  "swc_emotion",
  "testing",
 ]
@@ -4534,26 +4528,26 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "styled_components"
-version = "0.52.1"
+version = "0.52.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa9bb5dc721603ce35225910c0442b552369cf9e7322a6083e0ac101cef37da2"
+checksum = "de9278187c95d3fba086db8121b2de60d1d41c7d7f6e2e826738b9f002a3b834"
 dependencies = [
  "Inflector",
  "once_cell",
  "regex",
  "serde",
- "swc_core 0.40.56",
+ "swc_core",
  "tracing",
 ]
 
 [[package]]
 name = "styled_jsx"
-version = "0.29.1"
+version = "0.29.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9caea170c8166e302071b1261a4797048df244da30c00560636d70cd0557dd85"
+checksum = "be22d79d6861fc5358b14d39aa6b3227573996ce76fecd0ce8252fab46143494"
 dependencies = [
  "easy-error",
- "swc_core 0.40.56",
+ "swc_core",
  "tracing",
 ]
 
@@ -4619,20 +4613,20 @@ dependencies = [
  "swc_cached",
  "swc_common",
  "swc_config",
- "swc_ecma_ast 0.95.1",
- "swc_ecma_codegen 0.128.2",
+ "swc_ecma_ast",
+ "swc_ecma_codegen",
  "swc_ecma_ext_transforms",
  "swc_ecma_lints",
  "swc_ecma_loader",
- "swc_ecma_minifier 0.160.2",
- "swc_ecma_parser 0.123.2",
+ "swc_ecma_minifier",
+ "swc_ecma_parser",
  "swc_ecma_preset_env",
  "swc_ecma_transforms",
- "swc_ecma_transforms_base 0.112.2",
+ "swc_ecma_transforms_base",
  "swc_ecma_transforms_compat",
- "swc_ecma_transforms_optimization 0.168.2",
- "swc_ecma_utils 0.106.2",
- "swc_ecma_visit 0.81.1",
+ "swc_ecma_transforms_optimization",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_error_reporters",
  "swc_node_comments",
  "swc_plugin_proxy",
@@ -4650,7 +4644,7 @@ dependencies = [
  "clap 4.0.18",
  "owo-colors",
  "regex",
- "swc_core 0.44.4",
+ "swc_core",
 ]
 
 [[package]]
@@ -4689,14 +4683,14 @@ dependencies = [
  "retain_mut",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.95.1",
- "swc_ecma_codegen 0.128.2",
+ "swc_ecma_ast",
+ "swc_ecma_codegen",
  "swc_ecma_loader",
- "swc_ecma_parser 0.123.2",
- "swc_ecma_transforms_base 0.112.2",
- "swc_ecma_transforms_optimization 0.168.2",
- "swc_ecma_utils 0.106.2",
- "swc_ecma_visit 0.81.1",
+ "swc_ecma_parser",
+ "swc_ecma_transforms_base",
+ "swc_ecma_transforms_optimization",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_fast_graph",
  "swc_graph_analyzer",
  "tracing",
@@ -4776,47 +4770,6 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "0.40.56"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41db203afa295de19a075d39072de64d408fde740d9bd0c9e3a95b50d422b9fd"
-dependencies = [
- "swc_atoms",
- "swc_common",
- "swc_css_ast 0.124.6",
- "swc_css_codegen 0.134.18",
- "swc_css_parser 0.133.18",
- "swc_css_prefixer",
- "swc_css_visit 0.123.6",
- "swc_ecma_ast 0.94.20",
- "swc_ecma_codegen 0.127.36",
- "swc_ecma_minifier 0.159.89",
- "swc_ecma_parser 0.122.27",
- "swc_ecma_transforms_base 0.111.50",
- "swc_ecma_utils 0.105.37",
- "swc_ecma_visit 0.80.20",
- "swc_trace_macro",
- "vergen",
-]
-
-[[package]]
-name = "swc_core"
-version = "0.43.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afdf3bc89454223076b8992ec1e17f9827fcc6139c34488c2be8d3189c2f7dbd"
-dependencies = [
- "swc_atoms",
- "swc_cached",
- "swc_common",
- "swc_ecma_ast 0.94.20",
- "swc_ecma_codegen 0.127.36",
- "swc_ecma_parser 0.122.27",
- "swc_ecma_transforms_base 0.111.50",
- "swc_ecma_visit 0.80.20",
- "vergen",
-]
-
-[[package]]
-name = "swc_core"
 version = "0.44.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0930f364c4cfff05d3dbda1afadc8bbf714905d0e7f1cc1c7599866e88e329fe"
@@ -4827,49 +4780,38 @@ dependencies = [
  "swc_bundler",
  "swc_cached",
  "swc_common",
- "swc_css_ast 0.128.1",
- "swc_css_codegen 0.138.3",
+ "swc_css_ast",
+ "swc_css_codegen",
  "swc_css_compat",
  "swc_css_modules",
- "swc_css_parser 0.137.3",
- "swc_css_utils 0.125.1",
- "swc_css_visit 0.127.1",
- "swc_ecma_ast 0.95.1",
- "swc_ecma_codegen 0.128.2",
+ "swc_css_parser",
+ "swc_css_prefixer",
+ "swc_css_utils",
+ "swc_css_visit",
+ "swc_ecma_ast",
+ "swc_ecma_codegen",
  "swc_ecma_loader",
- "swc_ecma_minifier 0.160.2",
- "swc_ecma_parser 0.123.2",
+ "swc_ecma_minifier",
+ "swc_ecma_parser",
  "swc_ecma_preset_env",
  "swc_ecma_quote_macros",
- "swc_ecma_transforms_base 0.112.2",
+ "swc_ecma_transforms_base",
  "swc_ecma_transforms_module",
- "swc_ecma_transforms_optimization 0.168.2",
+ "swc_ecma_transforms_optimization",
  "swc_ecma_transforms_react",
  "swc_ecma_transforms_testing",
  "swc_ecma_transforms_typescript",
- "swc_ecma_utils 0.106.2",
- "swc_ecma_visit 0.81.1",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_node_base",
  "swc_nodejs_common",
  "swc_plugin_proxy",
  "swc_plugin_runner",
+ "swc_trace_macro",
  "testing",
  "vergen",
  "wasmer",
  "wasmer-wasi",
-]
-
-[[package]]
-name = "swc_css_ast"
-version = "0.124.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3033e4a969316046ab5e83c525a252b761ad8f5530504c77ca39f7114ce8902"
-dependencies = [
- "is-macro",
- "serde",
- "string_enum",
- "swc_atoms",
- "swc_common",
 ]
 
 [[package]]
@@ -4887,23 +4829,6 @@ dependencies = [
 
 [[package]]
 name = "swc_css_codegen"
-version = "0.134.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b65b5e9a295fa54b7554f327af560803fb3f696ec7a48640269cff4fe0841d"
-dependencies = [
- "auto_impl",
- "bitflags",
- "rustc-hash",
- "serde",
- "swc_atoms",
- "swc_common",
- "swc_css_ast 0.124.6",
- "swc_css_codegen_macros",
- "swc_css_utils 0.121.6",
-]
-
-[[package]]
-name = "swc_css_codegen"
 version = "0.138.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a183ce66593dc14be82378a6e647caab79c7b76d7e6169ec2e5f458e38022baf"
@@ -4914,9 +4839,9 @@ dependencies = [
  "serde",
  "swc_atoms",
  "swc_common",
- "swc_css_ast 0.128.1",
+ "swc_css_ast",
  "swc_css_codegen_macros",
- "swc_css_utils 0.125.1",
+ "swc_css_utils",
 ]
 
 [[package]]
@@ -4943,9 +4868,9 @@ dependencies = [
  "serde_json",
  "swc_atoms",
  "swc_common",
- "swc_css_ast 0.128.1",
- "swc_css_utils 0.125.1",
- "swc_css_visit 0.127.1",
+ "swc_css_ast",
+ "swc_css_utils",
+ "swc_css_visit",
 ]
 
 [[package]]
@@ -4958,24 +4883,10 @@ dependencies = [
  "serde",
  "swc_atoms",
  "swc_common",
- "swc_css_ast 0.128.1",
- "swc_css_codegen 0.138.3",
- "swc_css_parser 0.137.3",
- "swc_css_visit 0.127.1",
-]
-
-[[package]]
-name = "swc_css_parser"
-version = "0.133.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ade593c78e5ed5cfa8fbe7900c712a2f75549fe35c0fb727c217e017ddb5a61"
-dependencies = [
- "bitflags",
- "lexical",
- "serde",
- "swc_atoms",
- "swc_common",
- "swc_css_ast 0.124.6",
+ "swc_css_ast",
+ "swc_css_codegen",
+ "swc_css_parser",
+ "swc_css_visit",
 ]
 
 [[package]]
@@ -4989,14 +4900,14 @@ dependencies = [
  "serde",
  "swc_atoms",
  "swc_common",
- "swc_css_ast 0.128.1",
+ "swc_css_ast",
 ]
 
 [[package]]
 name = "swc_css_prefixer"
-version = "0.135.18"
+version = "0.139.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05018a82cb8a0e534c92c4d44a0f8b138de463dad1cc24a304630d1ba16fa8d"
+checksum = "608b2b72a3b672d60e14ceff6e981b8def774dd84fd0714c020da5704487370f"
 dependencies = [
  "once_cell",
  "preset_env_base",
@@ -5004,24 +4915,9 @@ dependencies = [
  "serde_json",
  "swc_atoms",
  "swc_common",
- "swc_css_ast 0.124.6",
- "swc_css_utils 0.121.6",
- "swc_css_visit 0.123.6",
-]
-
-[[package]]
-name = "swc_css_utils"
-version = "0.121.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0ec05d001d7049df8fc59e3baba7b7dca35740edd9a1e29d6dd40fd16b8473b"
-dependencies = [
- "once_cell",
- "serde",
- "serde_json",
- "swc_atoms",
- "swc_common",
- "swc_css_ast 0.124.6",
- "swc_css_visit 0.123.6",
+ "swc_css_ast",
+ "swc_css_utils",
+ "swc_css_visit",
 ]
 
 [[package]]
@@ -5035,21 +4931,8 @@ dependencies = [
  "serde_json",
  "swc_atoms",
  "swc_common",
- "swc_css_ast 0.128.1",
- "swc_css_visit 0.127.1",
-]
-
-[[package]]
-name = "swc_css_visit"
-version = "0.123.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6240147e0069dd802f06d57714c3eee7694a8464289aa8631aaf1a42e3567873"
-dependencies = [
- "serde",
- "swc_atoms",
- "swc_common",
- "swc_css_ast 0.124.6",
- "swc_visit",
+ "swc_css_ast",
+ "swc_css_visit",
 ]
 
 [[package]]
@@ -5061,25 +4944,8 @@ dependencies = [
  "serde",
  "swc_atoms",
  "swc_common",
- "swc_css_ast 0.128.1",
+ "swc_css_ast",
  "swc_visit",
-]
-
-[[package]]
-name = "swc_ecma_ast"
-version = "0.94.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2e2786dccb1e68c26b3b67efa124d37055dae27fbe42a25bb541ce00ab9eaa5"
-dependencies = [
- "bitflags",
- "is-macro",
- "num-bigint",
- "scoped-tls",
- "serde",
- "string_enum",
- "swc_atoms",
- "swc_common",
- "unicode-id",
 ]
 
 [[package]]
@@ -5102,25 +4968,6 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.127.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76601c9cfcb1a63ef0fd83dde314ddda9d6fd2d0583cd4149990550d87bb555b"
-dependencies = [
- "memchr",
- "num-bigint",
- "once_cell",
- "rustc-hash",
- "serde",
- "sourcemap",
- "swc_atoms",
- "swc_common",
- "swc_ecma_ast 0.94.20",
- "swc_ecma_codegen_macros",
- "tracing",
-]
-
-[[package]]
-name = "swc_ecma_codegen"
 version = "0.128.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5be18c834f2fb158c88b4ae5dc0320663bb11fe4913a37f10355001194d41d0"
@@ -5133,7 +4980,7 @@ dependencies = [
  "sourcemap",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.95.1",
+ "swc_ecma_ast",
  "swc_ecma_codegen_macros",
  "tracing",
 ]
@@ -5160,9 +5007,9 @@ dependencies = [
  "phf",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.95.1",
- "swc_ecma_utils 0.106.2",
- "swc_ecma_visit 0.81.1",
+ "swc_ecma_ast",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
 ]
 
 [[package]]
@@ -5181,9 +5028,9 @@ dependencies = [
  "swc_atoms",
  "swc_common",
  "swc_config",
- "swc_ecma_ast 0.95.1",
- "swc_ecma_utils 0.106.2",
- "swc_ecma_visit 0.81.1",
+ "swc_ecma_ast",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
 ]
 
 [[package]]
@@ -5205,40 +5052,6 @@ dependencies = [
  "serde_json",
  "swc_cached",
  "swc_common",
- "tracing",
-]
-
-[[package]]
-name = "swc_ecma_minifier"
-version = "0.159.89"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a95931d6b27c018cb89f638e0029b0c3bc2456c412a6436bfbfbd475deb986ce"
-dependencies = [
- "ahash",
- "arrayvec 0.7.2",
- "indexmap",
- "num-bigint",
- "num_cpus",
- "once_cell",
- "parking_lot",
- "radix_fmt",
- "regex",
- "retain_mut",
- "rustc-hash",
- "serde",
- "serde_json",
- "swc_atoms",
- "swc_cached",
- "swc_common",
- "swc_config",
- "swc_ecma_ast 0.94.20",
- "swc_ecma_codegen 0.127.36",
- "swc_ecma_parser 0.122.27",
- "swc_ecma_transforms_base 0.111.50",
- "swc_ecma_transforms_optimization 0.167.54",
- "swc_ecma_utils 0.105.37",
- "swc_ecma_visit 0.80.20",
- "swc_timer",
  "tracing",
 ]
 
@@ -5266,34 +5079,15 @@ dependencies = [
  "swc_cached",
  "swc_common",
  "swc_config",
- "swc_ecma_ast 0.95.1",
- "swc_ecma_codegen 0.128.2",
- "swc_ecma_parser 0.123.2",
- "swc_ecma_transforms_base 0.112.2",
- "swc_ecma_transforms_optimization 0.168.2",
- "swc_ecma_utils 0.106.2",
- "swc_ecma_visit 0.81.1",
+ "swc_ecma_ast",
+ "swc_ecma_codegen",
+ "swc_ecma_parser",
+ "swc_ecma_transforms_base",
+ "swc_ecma_transforms_optimization",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_timer",
  "tracing",
-]
-
-[[package]]
-name = "swc_ecma_parser"
-version = "0.122.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0b35ce974dd789d06e6ee4bca89b8d0c4313e952543e0ac89c2bbb33111d742"
-dependencies = [
- "either",
- "enum_kind",
- "lexical",
- "num-bigint",
- "serde",
- "smallvec",
- "swc_atoms",
- "swc_common",
- "swc_ecma_ast 0.94.20",
- "tracing",
- "typed-arena",
 ]
 
 [[package]]
@@ -5310,7 +5104,7 @@ dependencies = [
  "smallvec",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.95.1",
+ "swc_ecma_ast",
  "tracing",
  "typed-arena",
 ]
@@ -5334,10 +5128,10 @@ dependencies = [
  "string_enum",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.95.1",
+ "swc_ecma_ast",
  "swc_ecma_transforms",
- "swc_ecma_utils 0.106.2",
- "swc_ecma_visit 0.81.1",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
 ]
 
 [[package]]
@@ -5352,8 +5146,8 @@ dependencies = [
  "quote 1.0.21",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.95.1",
- "swc_ecma_parser 0.123.2",
+ "swc_ecma_ast",
+ "swc_ecma_parser",
  "swc_macros_common",
  "syn 1.0.99",
 ]
@@ -5378,38 +5172,16 @@ checksum = "19d727e0210e883a9da91906871771bcd3e4ecfc24464e4560891abea1a9a2f2"
 dependencies = [
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.95.1",
- "swc_ecma_transforms_base 0.112.2",
+ "swc_ecma_ast",
+ "swc_ecma_transforms_base",
  "swc_ecma_transforms_compat",
  "swc_ecma_transforms_module",
- "swc_ecma_transforms_optimization 0.168.2",
+ "swc_ecma_transforms_optimization",
  "swc_ecma_transforms_proposal",
  "swc_ecma_transforms_react",
  "swc_ecma_transforms_typescript",
- "swc_ecma_utils 0.106.2",
- "swc_ecma_visit 0.81.1",
-]
-
-[[package]]
-name = "swc_ecma_transforms_base"
-version = "0.111.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a6bec94a996b2001e19a1b28c758a2b6f5052dd4bddb03e5f45d01dd1291d9c"
-dependencies = [
- "better_scoped_tls",
- "bitflags",
- "once_cell",
- "phf",
- "rustc-hash",
- "serde",
- "smallvec",
- "swc_atoms",
- "swc_common",
- "swc_ecma_ast 0.94.20",
- "swc_ecma_parser 0.122.27",
- "swc_ecma_utils 0.105.37",
- "swc_ecma_visit 0.80.20",
- "tracing",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
 ]
 
 [[package]]
@@ -5428,10 +5200,10 @@ dependencies = [
  "smallvec",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.95.1",
- "swc_ecma_parser 0.123.2",
- "swc_ecma_utils 0.106.2",
- "swc_ecma_visit 0.81.1",
+ "swc_ecma_ast",
+ "swc_ecma_parser",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "tracing",
 ]
 
@@ -5443,10 +5215,10 @@ checksum = "86024dc3ca060348cc016a880986cf8f147bcfb174875787a870fded970f5b25"
 dependencies = [
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.95.1",
- "swc_ecma_transforms_base 0.112.2",
- "swc_ecma_utils 0.106.2",
- "swc_ecma_visit 0.81.1",
+ "swc_ecma_ast",
+ "swc_ecma_transforms_base",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
 ]
 
 [[package]]
@@ -5466,12 +5238,12 @@ dependencies = [
  "swc_atoms",
  "swc_common",
  "swc_config",
- "swc_ecma_ast 0.95.1",
- "swc_ecma_transforms_base 0.112.2",
+ "swc_ecma_ast",
+ "swc_ecma_transforms_base",
  "swc_ecma_transforms_classes",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils 0.106.2",
- "swc_ecma_visit 0.81.1",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_trace_macro",
  "tracing",
 ]
@@ -5508,37 +5280,12 @@ dependencies = [
  "swc_atoms",
  "swc_cached",
  "swc_common",
- "swc_ecma_ast 0.95.1",
+ "swc_ecma_ast",
  "swc_ecma_loader",
- "swc_ecma_parser 0.123.2",
- "swc_ecma_transforms_base 0.112.2",
- "swc_ecma_utils 0.106.2",
- "swc_ecma_visit 0.81.1",
- "tracing",
-]
-
-[[package]]
-name = "swc_ecma_transforms_optimization"
-version = "0.167.54"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2623434be6cc5abc4ac65aa96263cc80fbcf6e078ad9676fff50fe51816a78cb"
-dependencies = [
- "ahash",
- "dashmap",
- "indexmap",
- "once_cell",
- "petgraph",
- "rustc-hash",
- "serde_json",
- "swc_atoms",
- "swc_common",
- "swc_ecma_ast 0.94.20",
- "swc_ecma_parser 0.122.27",
- "swc_ecma_transforms_base 0.111.50",
- "swc_ecma_transforms_macros",
- "swc_ecma_utils 0.105.37",
- "swc_ecma_visit 0.80.20",
- "swc_fast_graph",
+ "swc_ecma_parser",
+ "swc_ecma_transforms_base",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "tracing",
 ]
 
@@ -5558,12 +5305,12 @@ dependencies = [
  "serde_json",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.95.1",
- "swc_ecma_parser 0.123.2",
- "swc_ecma_transforms_base 0.112.2",
+ "swc_ecma_ast",
+ "swc_ecma_parser",
+ "swc_ecma_transforms_base",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils 0.106.2",
- "swc_ecma_visit 0.81.1",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_fast_graph",
  "tracing",
 ]
@@ -5579,12 +5326,12 @@ dependencies = [
  "smallvec",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.95.1",
- "swc_ecma_transforms_base 0.112.2",
+ "swc_ecma_ast",
+ "swc_ecma_transforms_base",
  "swc_ecma_transforms_classes",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils 0.106.2",
- "swc_ecma_visit 0.81.1",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
 ]
 
 [[package]]
@@ -5606,12 +5353,12 @@ dependencies = [
  "swc_atoms",
  "swc_common",
  "swc_config",
- "swc_ecma_ast 0.95.1",
- "swc_ecma_parser 0.123.2",
- "swc_ecma_transforms_base 0.112.2",
+ "swc_ecma_ast",
+ "swc_ecma_parser",
+ "swc_ecma_transforms_base",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils 0.106.2",
- "swc_ecma_visit 0.81.1",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
 ]
 
 [[package]]
@@ -5629,13 +5376,13 @@ dependencies = [
  "sha-1",
  "sourcemap",
  "swc_common",
- "swc_ecma_ast 0.95.1",
- "swc_ecma_codegen 0.128.2",
- "swc_ecma_parser 0.123.2",
+ "swc_ecma_ast",
+ "swc_ecma_codegen",
+ "swc_ecma_parser",
  "swc_ecma_testing",
- "swc_ecma_transforms_base 0.112.2",
- "swc_ecma_utils 0.106.2",
- "swc_ecma_visit 0.81.1",
+ "swc_ecma_transforms_base",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "tempfile",
  "testing",
 ]
@@ -5649,28 +5396,11 @@ dependencies = [
  "serde",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.95.1",
- "swc_ecma_transforms_base 0.112.2",
+ "swc_ecma_ast",
+ "swc_ecma_transforms_base",
  "swc_ecma_transforms_react",
- "swc_ecma_utils 0.106.2",
- "swc_ecma_visit 0.81.1",
-]
-
-[[package]]
-name = "swc_ecma_utils"
-version = "0.105.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac9a42eb8a8d4d0ce9d623e3b64691deee7690a1d3a725b2d0088658679ae09b"
-dependencies = [
- "indexmap",
- "num_cpus",
- "once_cell",
- "swc_atoms",
- "swc_common",
- "swc_ecma_ast 0.94.20",
- "swc_ecma_visit 0.80.20",
- "tracing",
- "unicode-id",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
 ]
 
 [[package]]
@@ -5685,24 +5415,10 @@ dependencies = [
  "rayon",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.95.1",
- "swc_ecma_visit 0.81.1",
+ "swc_ecma_ast",
+ "swc_ecma_visit",
  "tracing",
  "unicode-id",
-]
-
-[[package]]
-name = "swc_ecma_visit"
-version = "0.80.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ec255eeefb6a5146800047d1ee86c44326b9198f98c54988b2740fb40ec3f9"
-dependencies = [
- "num-bigint",
- "swc_atoms",
- "swc_common",
- "swc_ecma_ast 0.94.20",
- "swc_visit",
- "tracing",
 ]
 
 [[package]]
@@ -5714,16 +5430,16 @@ dependencies = [
  "num-bigint",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.95.1",
+ "swc_ecma_ast",
  "swc_visit",
  "tracing",
 ]
 
 [[package]]
 name = "swc_emotion"
-version = "0.28.1"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "277695628e9adf28202bb6a5c0fb72f3cf0b695f3fc5bcec2fff059a5e56e45b"
+checksum = "459955b8b106831cf6ea59682b6be65bcdd65c813a5204203973c55a80841067"
 dependencies = [
  "base64 0.13.0",
  "byteorder",
@@ -5733,7 +5449,7 @@ dependencies = [
  "regex",
  "serde",
  "sourcemap",
- "swc_core 0.40.56",
+ "swc_core",
  "tracing",
 ]
 
@@ -5845,7 +5561,7 @@ dependencies = [
  "better_scoped_tls",
  "rkyv",
  "swc_common",
- "swc_ecma_ast 0.95.1",
+ "swc_ecma_ast",
  "swc_trace_macro",
  "tracing",
 ]
@@ -6716,7 +6432,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_regex",
- "swc_core 0.44.4",
+ "swc_core",
  "test-generator",
  "tokio",
  "turbo-malloc",
@@ -6772,7 +6488,7 @@ dependencies = [
  "serde_json",
  "serde_regex",
  "sourcemap",
- "swc_core 0.44.4",
+ "swc_core",
  "tokio",
  "turbo-tasks",
  "turbo-tasks-build",
@@ -6803,7 +6519,7 @@ dependencies = [
  "indexmap",
  "once_cell",
  "serde",
- "swc_core 0.44.4",
+ "swc_core",
  "turbo-tasks",
  "turbo-tasks-build",
  "turbo-tasks-fs",
@@ -6865,7 +6581,7 @@ dependencies = [
  "serde_regex",
  "styled_components",
  "styled_jsx",
- "swc_core 0.44.4",
+ "swc_core",
  "swc_emotion",
  "tokio",
  "tracing",
@@ -6956,7 +6672,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "swc_core 0.44.4",
+ "swc_core",
  "turbo-tasks",
  "turbo-tasks-build",
  "turbo-tasks-fs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,9 @@ opt-level = 3
 [workspace.dependencies]
 # This version pin is workaround for https://github.com/tkaitchuck/aHash/issues/95
 indexmap = { version = "=1.6.2" }
-swc_core = { version = "0.43.23" }
+# Keep consistent with preset_env_base through swc_core
+browserslist-rs = { version = "0.12.2" }
+swc_core = { version = "0.44.2" }
 testing = { version = "0.31.14" }
 swc_emotion = { version = "0.28.1" }
 styled_jsx = { version = "0.29.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,8 +81,7 @@ opt-level = 3
 # Declare dependencies used across workspace packages requires single version bump.
 # ref: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#inheriting-a-dependency-from-a-workspace
 [workspace.dependencies]
-# This version pin is workaround for https://github.com/tkaitchuck/aHash/issues/95
-indexmap = { version = "=1.6.2" }
+indexmap = { version = "1.9.2" }
 # Keep consistent with preset_env_base through swc_core
 browserslist-rs = { version = "0.12.2" }
 swc_core = { version = "0.44.2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,10 +86,10 @@ indexmap = { version = "1.9.2" }
 browserslist-rs = { version = "0.12.2" }
 swc_core = { version = "0.44.2" }
 testing = { version = "0.31.14" }
-swc_emotion = { version = "0.28.1" }
-styled_jsx = { version = "0.29.1" }
-styled_components = { version = "0.52.1" }
-modularize_imports = { version = "0.25.5" }
-mdxjs = { version = "0.1.1" }
+swc_emotion = { version = "0.28.3" }
+styled_jsx = { version = "0.29.7" }
+styled_components = { version = "0.52.7" }
+modularize_imports = { version = "0.25.7" }
+mdxjs = { version = "0.1.3" }
 next-dev = { path = "crates/next-dev", version = "0.1.0" }
 node-file-trace = { path = "crates/node-file-trace", version = "0.1.0" }

--- a/crates/turbopack-core/Cargo.toml
+++ b/crates/turbopack-core/Cargo.toml
@@ -10,27 +10,27 @@ autobenches = false
 bench = false
 
 [dependencies]
-anyhow = "1.0.47"
-async-trait = "0.1.56"
-auto-hash-map = { path = "../auto-hash-map" }
-browserslist-rs = "=0.11.0"                                               # Keep consistent with preset_env_base through swc_core
-futures = "0.3.24"
-indexmap = { workspace = true }
-lazy_static = "1.4.0"
-patricia_tree = "0.3.1"
-rand = "0.8.5"
-regex = "1.5.4"
-serde = { version = "1.0.136", features = ["rc"] }
-serde_json = { version = "1.0.85", features = ["preserve_order"] }
-serde_regex = "1.1.0"
-sourcemap = "6.0.2"
-swc_core = { workspace = true, features = ["ecma_preset_env", "common"] }
-tokio = "1.21.2"
-turbo-tasks = { path = "../turbo-tasks" }
-turbo-tasks-env = { path = "../turbo-tasks-env" }
-turbo-tasks-fs = { path = "../turbo-tasks-fs" }
+anyhow           = "1.0.47"
+async-trait      = "0.1.56"
+auto-hash-map    = { path = "../auto-hash-map" }
+browserslist-rs  = { workspace = true }
+futures          = "0.3.24"
+indexmap         = { workspace = true }
+lazy_static      = "1.4.0"
+patricia_tree    = "0.3.1"
+rand             = "0.8.5"
+regex            = "1.5.4"
+serde            = { version = "1.0.136", features = ["rc"] }
+serde_json       = { version = "1.0.85", features = ["preserve_order"] }
+serde_regex      = "1.1.0"
+sourcemap        = "6.0.2"
+swc_core         = { workspace = true, features = ["ecma_preset_env", "common"] }
+tokio            = "1.21.2"
+turbo-tasks      = { path = "../turbo-tasks" }
+turbo-tasks-env  = { path = "../turbo-tasks-env" }
+turbo-tasks-fs   = { path = "../turbo-tasks-fs" }
 turbo-tasks-hash = { path = "../turbo-tasks-hash" }
-url = "2.2.2"
+url              = "2.2.2"
 
 [build-dependencies]
 turbo-tasks-build = { path = "../turbo-tasks-build" }

--- a/crates/turbopack-core/Cargo.toml
+++ b/crates/turbopack-core/Cargo.toml
@@ -10,27 +10,27 @@ autobenches = false
 bench = false
 
 [dependencies]
-anyhow           = "1.0.47"
-async-trait      = "0.1.56"
-auto-hash-map    = { path = "../auto-hash-map" }
-browserslist-rs  = { workspace = true }
-futures          = "0.3.24"
-indexmap         = { workspace = true }
-lazy_static      = "1.4.0"
-patricia_tree    = "0.3.1"
-rand             = "0.8.5"
-regex            = "1.5.4"
-serde            = { version = "1.0.136", features = ["rc"] }
-serde_json       = { version = "1.0.85", features = ["preserve_order"] }
-serde_regex      = "1.1.0"
-sourcemap        = "6.0.2"
-swc_core         = { workspace = true, features = ["ecma_preset_env", "common"] }
-tokio            = "1.21.2"
-turbo-tasks      = { path = "../turbo-tasks" }
-turbo-tasks-env  = { path = "../turbo-tasks-env" }
-turbo-tasks-fs   = { path = "../turbo-tasks-fs" }
+anyhow = "1.0.47"
+async-trait = "0.1.56"
+auto-hash-map = { path = "../auto-hash-map" }
+browserslist-rs = { workspace = true }
+futures = "0.3.24"
+indexmap = { workspace = true }
+lazy_static = "1.4.0"
+patricia_tree = "0.3.1"
+rand = "0.8.5"
+regex = "1.5.4"
+serde = { version = "1.0.136", features = ["rc"] }
+serde_json = { version = "1.0.85", features = ["preserve_order"] }
+serde_regex = "1.1.0"
+sourcemap = "6.0.2"
+swc_core = { workspace = true, features = ["ecma_preset_env", "common"] }
+tokio = "1.21.2"
+turbo-tasks = { path = "../turbo-tasks" }
+turbo-tasks-env = { path = "../turbo-tasks-env" }
+turbo-tasks-fs = { path = "../turbo-tasks-fs" }
 turbo-tasks-hash = { path = "../turbo-tasks-hash" }
-url              = "2.2.2"
+url = "2.2.2"
 
 [build-dependencies]
 turbo-tasks-build = { path = "../turbo-tasks-build" }

--- a/crates/turbopack-ecmascript/src/parse.rs
+++ b/crates/turbopack-ecmascript/src/parse.rs
@@ -202,7 +202,6 @@ async fn parse_content(
                             decorators_before_export: true,
                             export_default_from: true,
                             import_assertions: true,
-                            private_in_object: true,
                             allow_super_outside_method: true,
                             allow_return_outside_function: true,
                         }),


### PR DESCRIPTION
Fixes WEB-155

This is the final piece in turbopack resolves circular deps with indexmap. This can go next.js with swc_core bump.

Prerequisites:

- https://github.com/swc-project/plugins/pull/114
- https://github.com/wooorm/mdxjs-rs/pull/7