### PR TITLE
pass params to dynamic pages

### DIFF
--- a/crates/next-core/js/src/entry/server-renderer.tsx
+++ b/crates/next-core/js/src/entry/server-renderer.tsx
@@ -130,6 +130,9 @@ async function runOperation(
     },
   };
 
+  if ("getStaticPaths" in otherExports) {
+    renderOpts.getStaticPaths = otherExports.getStaticPaths;
+  }
   if ("getStaticProps" in otherExports) {
     renderOpts.getStaticProps = otherExports.getStaticProps;
   }

--- a/crates/next-core/src/app_source.rs
+++ b/crates/next-core/src/app_source.rs
@@ -3,7 +3,7 @@ use std::{
     io::Write,
 };
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, Result};
 use turbo_tasks::{
     primitives::{StringVc, StringsVc},
     TryJoinIterExt, Value, ValueToString,
@@ -66,7 +66,7 @@ use crate::{
         get_server_environment, get_server_module_options_context,
         get_server_resolve_options_context, ServerContextType,
     },
-    util::regular_expression_for_path,
+    util::{pathname_for_path, regular_expression_for_path},
 };
 
 #[turbo_tasks::function]
@@ -315,12 +315,12 @@ async fn create_app_source_for_directory(
 
         let layout = files.get("layout");
 
+        // If a page exists but no layout exists, create a basic root layout
+        // in `app/layout.js` or `app/layout.tsx`.
+        //
         // TODO: Use let Some(page_file) = page in expression below when
         // https://rust-lang.github.io/rfcs/2497-if-let-chains.html lands
-        if page.is_some() && layout.is_none() && target == server_root {
-            // If a page exists but no layout exists, create a basic root layout
-            // in `app/layout.js` or `app/layout.tsx`.
-            let page_file = page.context("page must not be none")?;
+        if let (Some(page_file), None, true) = (page, layout, target == server_root) {
             // Use the extension to determine if the page file is TypeScript.
             // TODO: Use the presence of a tsconfig.json instead, like Next.js
             // stable does.
@@ -358,10 +358,14 @@ async fn create_app_source_for_directory(
         list.push(LayoutSegment { files, target }.cell());
         layouts = LayoutSegmentsVc::cell(list);
         if let Some(page_path) = page {
+            let pathname = pathname_for_path(server_root, target, false);
+            let path_regex = regular_expression_for_path(server_root, target, false);
+
             sources.push(create_node_rendered_source(
                 specificity,
                 server_root,
-                regular_expression_for_path(server_root, target, false),
+                pathname,
+                path_regex,
                 AppRenderer {
                     context_ssr,
                     context,

--- a/crates/next-core/src/server_rendered_source.rs
+++ b/crates/next-core/src/server_rendered_source.rs
@@ -51,7 +51,7 @@ use crate::{
         get_server_environment, get_server_module_options_context,
         get_server_resolve_options_context, ServerContextType,
     },
-    util::regular_expression_for_path,
+    util::{pathname_for_path, regular_expression_for_path},
 };
 
 /// Create a content source serving the `pages` or `src/pages` directory as
@@ -166,11 +166,14 @@ async fn create_server_rendered_source_for_file(
     )
     .build();
 
+    let pathname = pathname_for_path(server_root, server_path, true);
+    let path_regex = regular_expression_for_path(server_root, server_path, true);
+
     Ok(if *is_api_path.await? {
         create_node_api_source(
             specificity,
             server_root,
-            regular_expression_for_path(server_root, server_path, true),
+            path_regex,
             SsrEntry {
                 context,
                 entry_asset,
@@ -186,7 +189,8 @@ async fn create_server_rendered_source_for_file(
         create_node_rendered_source(
             specificity,
             server_root,
-            regular_expression_for_path(server_root, server_path, true),
+            pathname,
+            path_regex,
             SsrEntry {
                 context,
                 entry_asset,

--- a/crates/turbopack-node/src/node_rendered_source.rs
+++ b/crates/turbopack-node/src/node_rendered_source.rs
@@ -38,6 +38,7 @@ use crate::path_regex::PathRegexVc;
 pub fn create_node_rendered_source(
     specificity: SpecificityVc,
     server_root: FileSystemPathVc,
+    pathname: StringVc,
     path_regex: PathRegexVc,
     entry: NodeEntryVc,
     runtime_entries: EcmascriptChunkPlaceablesVc,
@@ -46,6 +47,7 @@ pub fn create_node_rendered_source(
     let source = NodeRenderContentSource {
         specificity,
         server_root,
+        pathname,
         path_regex,
         entry,
         runtime_entries,
@@ -68,6 +70,7 @@ pub fn create_node_rendered_source(
 struct NodeRenderContentSource {
     specificity: SpecificityVc,
     server_root: FileSystemPathVc,
+    pathname: StringVc,
     path_regex: PathRegexVc,
     entry: NodeEntryVc,
     runtime_entries: EcmascriptChunkPlaceablesVc,
@@ -176,7 +179,7 @@ impl ContentSource for NodeRenderContentSource {
                                 .headers
                                 .clone()
                                 .ok_or_else(|| anyhow!("headers needs to be provided"))?,
-                            path: format!("/{path}"),
+                            path: format!("/{}", this.pathname.await?),
                         }
                         .cell(),
                     );


### PR DESCRIPTION
The next.js client code looks for the `[id]` segments in the pathname and only then passes `params`, previously we only passed the resolved path