### PR TITLE
Sketch of only-turbo.

### DIFF
--- a/packages/only-turbo/README.md
+++ b/packages/only-turbo/README.md
@@ -1,0 +1,35 @@
+# `only-turbo`
+
+This is a utility program which you can use to ensure that a package script was invoked by `turbo`.
+
+It further makes an attempt to identify what command the user was trying to invoke to provide useful feedback.
+
+## Usage
+
+You would typically use this to prefix commands inside of monorepo workspaces to prevent them from being executed without `turbo`.
+
+```json /turbo.json
+{
+  "pipeline": {
+    "build": {
+      "dependsOn": ["^build"]
+    }
+  }
+}
+```
+
+```json /package.json
+{
+  "scripts": {
+    "build": "turbo run build"
+  }
+}
+```
+
+```json /apps/web/package.json
+{
+  "scripts": {
+    "build": "only-turbo next build"
+  }
+}
+```

--- a/packages/only-turbo/index.js
+++ b/packages/only-turbo/index.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+const { spawn } = require("child_process");
+
+if (!process.env.TURBO_HASH) {
+  if (process.env.npm_lifecycle_event && process.env.npm_package_name) {
+    console.log("This command should be run with `turbo`. Did you mean:");
+    console.log(
+      `turbo run ${process.env.npm_lifecycle_event} --filter=${process.env.npm_package_name}`
+    );
+  } else {
+    console.log("This command should be run with `turbo`.");
+  }
+  process.exit(1);
+}
+
+// node index.js ...command
+const command = process.argv.slice(2);
+
+// The actual command the user wanted.
+spawn(command[0], command.slice(1), {
+  cwd: process.cwd(),
+  stdio: "inherit",
+});

--- a/packages/only-turbo/package.json
+++ b/packages/only-turbo/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "only-turbo",
+  "version": "0.0.1",
+  "description": "A helper application to prevent execution of a script without `turbo`.",
+  "homepage": "https://turbo.build/repo",
+  "license": "MPL-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel/turbo",
+    "directory": "packages/only-turbo"
+  },
+  "bugs": {
+    "url": "https://github.com/vercel/turbo/issues"
+  },
+  "bin": "index.js"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -321,6 +321,9 @@ importers:
   packages/node-module-trace:
     specifiers: {}
 
+  packages/only-turbo:
+    specifiers: {}
+
   packages/tsconfig:
     specifiers: {}
 


### PR DESCRIPTION
@mrmckeb wants to be able to quickly provide feedback to users of `turbo` who may forget and directly invoke a package script via `pnpm run build`.

This sketches out a solution to enable infra teams to enable immediate feedback on how to invoke the command. (The help text is for a 1.7+ global `turbo` world.)

Example UX:
```
~/repos/samsara/apps/next-site (main)$ pnpm run dev
This command should be run with `turbo`. Did you mean:
turbo run dev --filter=next-site
```