### PR TITLE
Update lint-staged behavior.

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [
-      "pnpm run lint --quiet --fix --",
+      "eslint --ext js,jsx,ts,tsx --quiet --fix --",
       "prettier --write"
     ],
     "*.{md,mdx,mjs,yml,yaml,css}": [


### PR DESCRIPTION
Before #2859:
`eslint --quiet --fix`

After #2859:
`pnpm run lint --quiet --fix --`
=>
`eslint . --ext js,jsx,ts,tsx --quiet --fix --`

After this:
`eslint --ext js,jsx,ts,tsx --quiet --fix --`

Removes the sneaky `.`.