### PR TITLE
make lazy bundling for dynamic import more lazy

### DIFF
--- a/crates/turbopack-core/src/chunk/mod.rs
+++ b/crates/turbopack-core/src/chunk/mod.rs
@@ -458,8 +458,8 @@ async fn chunk_content_internal<I: FromChunkableAsset>(
                                 inner_chunk_items.push(manifest_loader_item);
                                 inner_chunk_groups
                                     .push(ChunkGroupVc::from_asset(manifest_chunk, context));
-                                inner_chunk_groups
-                                    .push(ChunkGroupVc::from_asset(chunkable_asset, context));
+                                // inner_chunk_groups
+                                //     .push(ChunkGroupVc::from_asset(chunkable_asset, context));
                             } else {
                                 external_asset_references.push(reference);
                                 continue 'outer;

--- a/crates/turbopack-core/src/chunk/mod.rs
+++ b/crates/turbopack-core/src/chunk/mod.rs
@@ -458,8 +458,6 @@ async fn chunk_content_internal<I: FromChunkableAsset>(
                                 inner_chunk_items.push(manifest_loader_item);
                                 inner_chunk_groups
                                     .push(ChunkGroupVc::from_asset(manifest_chunk, context));
-                                // inner_chunk_groups
-                                //     .push(ChunkGroupVc::from_asset(chunkable_asset, context));
                             } else {
                                 external_asset_references.push(reference);
                                 continue 'outer;


### PR DESCRIPTION
For example:

```js
// index.js
setTimeout(() => {
  import('./async.js').then(() => console.log('async.js loaded'))
}, 1000)
```

```js
// async.js
import './async.css';
console.log('async.js content')
```

For now the graph generated by above code will be like this:

<img width="1461" alt="Screen Shot 2022-12-03 at 21 22 24" src="https://user-images.githubusercontent.com/42857895/205442932-ebfd5126-ef3d-4205-b5b5-434126ad46f7.png">

The `ChunkGroup_async` will be a async chunk group of `ChunkGroup_index`, pushed at [turbopack-core/src/chunk/mod.rs#L462](https://github.com/vercel/turbo/blob/b7bcfc312e41367e2ec7f5fb37a6ee88a6b6545a/crates/turbopack-core/src/chunk/mod.rs#L462), and it will have a reference between `ChunkGroup_index` and `ChunkGroup_async`, but `ChunkGroup_async` will also be a chunk group of `ChunkGroup_async-manifest-chunk` created at [turbopack-ecmascript/src/chunk/loader.rs#L165](https://github.com/vercel/turbo/blob/b7bcfc312e41367e2ec7f5fb37a6ee88a6b6545a/crates/turbopack-ecmascript/src/chunk/loader.rs#L165), and will have a reference between `ChunkGroup_async-manifest-chunk` and `ChunkGroup_async`.

This leads to when the browser request '/_a8a837.js', turbopack will compile chunks in `ChunkGroup_index` ('/_a8a837.js'), `ChunkGroup_async-manifest-chunk` ('/src_async.js_manifest-chunk.js'), and also chunks in `ChunkGroup_async` ('/src_async.js', '/src_async.css'), because of the reference between `ChunkGroup_index` and `ChunkGroup_async`.

But the expected behavior is only compile chunks in `ChunkGroup_index` and `ChunkGroup_async-manifest-chunk`, so this PR deleted the reference between `ChunkGroup_index` and `ChunkGroup_async`, makes the graph be like this:

<img width="1461" alt="Screen Shot 2022-12-03 at 21 50 29" src="https://user-images.githubusercontent.com/42857895/205444165-7b266dce-9aa6-4829-b8dc-d2bf74642aff.png">

And makes chunks in `ChunkGroup_async` to be compiled only when the browser request '/src_async.js_manifest-chunk.js'.