### PR TITLE
[7/n] @next/font/google: Add font weight, style to css and js properties

### DIFF
--- a/crates/next-core/src/next_font_google/options.rs
+++ b/crates/next-core/src/next_font_google/options.rs
@@ -26,7 +26,7 @@ pub struct NextFontGoogleOptions {
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, TraceRawVcs)]
 pub enum FontWeights {
     Variable,
-    Fixed(IndexSet<String>),
+    Fixed(IndexSet<u16>),
 }
 
 #[derive(Debug, Deserialize)]
@@ -64,7 +64,7 @@ pub fn options_from_request(
     let font_family = request.import.replace('_', " ");
     let font_data = data.get(&font_family).context("Unknown font")?;
 
-    let requested_weights = argument
+    let requested_weights: IndexSet<String> = argument
         .and_then(|argument| {
             argument.weight.as_ref().map(|w| match w {
                 OneOrManyStrings::One(one) => indexset! {one.to_owned()},
@@ -114,7 +114,12 @@ pub fn options_from_request(
             }
         }
 
-        FontWeights::Fixed(requested_weights)
+        let mut weights = indexset! {};
+        for weight in requested_weights {
+            weights.insert(weight.parse()?);
+        }
+
+        FontWeights::Fixed(weights)
     };
 
     if styles.is_empty() {

--- a/crates/next-core/src/next_font_google/util.rs
+++ b/crates/next-core/src/next_font_google/util.rs
@@ -94,8 +94,9 @@ pub(crate) fn get_font_axes(
                 variable_axes: Some(variable_axes),
             })
         }
+
         FontWeights::Fixed(weights) => Ok(FontAxes {
-            wght: weights.clone(),
+            wght: IndexSet::from_iter(weights.iter().map(|w| w.to_string())),
             ital,
             variable_axes: None,
         }),

--- a/crates/turbo-tasks/src/primitives.rs
+++ b/crates/turbo-tasks/src/primitives.rs
@@ -17,6 +17,9 @@ impl StringVc {
 }
 
 #[turbo_tasks::value(transparent)]
+pub struct OptionU16(Option<u16>);
+
+#[turbo_tasks::value(transparent)]
 pub struct U64(u64);
 
 #[turbo_tasks::value(transparent)]


### PR DESCRIPTION
This adds `font-weight`, `font-style`, and a fallback font both to the css styled by the exported `className` as well as to the exported `style` object.

Test Plan:

Given `const inter = Inter({weight: "500", fallback: ["Arial"]});`, verified the following css properties were generated and the following js was exported:

```css
.className◽\[project-with-next\]... {
    font-family: 'Inter', 'Arial';
    font-weight: 500;
    font-style: normal;
}
```

```js
{ 
  className: ".className◽\[project-with-next\]...",
  style: {
    "fontFamily": "'Inter', 'Arial'",
    "fontWeight": 500,
    "fontStyle": "normal"
  }
}
```