### PR TITLE
turbo-tasks-fetch: Emit issues on failed fetches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7050,8 +7050,10 @@ dependencies = [
  "tokio",
  "turbo-tasks",
  "turbo-tasks-build",
+ "turbo-tasks-fs",
  "turbo-tasks-memory",
  "turbo-tasks-testing",
+ "turbopack-core",
 ]
 
 [[package]]

--- a/crates/next-core/src/next_font_google/mod.rs
+++ b/crates/next-core/src/next_font_google/mod.rs
@@ -146,8 +146,7 @@ impl ImportMappingReplacement for NextFontGoogleCssModuleReplacer {
         let css_virtual_path = attached_next_js_package_path(self.project_path)
             .join("internal/font/google/cssmodule.module.css");
 
-        // TODO(WEB-274): Handle this failing (e.g. connection issues). This should be
-        // an Issue.
+        // TODO(WEB-283): Use fallback in dev if this fails
         let stylesheet_res = fetch(
             stylesheet_url,
             OptionStringVc::cell(Some(
@@ -158,11 +157,6 @@ impl ImportMappingReplacement for NextFontGoogleCssModuleReplacer {
             css_virtual_path,
         )
         .await?;
-
-        // TODO(WEB-274): Emit an issue instead
-        if stylesheet_res.status >= 400 {
-            bail!("Expected a successful response for Google fonts stylesheet");
-        }
 
         let stylesheet = &*stylesheet_res.body.to_string().await?;
         let properties = get_font_css_properties(options).await?;

--- a/crates/next-core/src/next_font_google/mod.rs
+++ b/crates/next-core/src/next_font_google/mod.rs
@@ -143,6 +143,8 @@ impl ImportMappingReplacement for NextFontGoogleCssModuleReplacer {
 
         let options = font_options_from_query_map(*query);
         let stylesheet_url = get_stylesheet_url_from_options(options);
+        let css_virtual_path = attached_next_js_package_path(self.project_path)
+            .join("internal/font/google/cssmodule.module.css");
 
         // TODO(WEB-274): Handle this failing (e.g. connection issues). This should be
         // an Issue.
@@ -153,6 +155,7 @@ impl ImportMappingReplacement for NextFontGoogleCssModuleReplacer {
                  Gecko) Chrome/104.0.0.0 Safari/537.36"
                     .to_owned(),
             )),
+            css_virtual_path,
         )
         .await?;
 
@@ -165,8 +168,7 @@ impl ImportMappingReplacement for NextFontGoogleCssModuleReplacer {
         let properties = get_font_css_properties(options).await?;
 
         let css_asset = VirtualAssetVc::new(
-            attached_next_js_package_path(self.project_path)
-                .join("internal/font/google/cssmodule.module.css"),
+            css_virtual_path,
             FileContent::Content(
                 formatdoc!(
                     r#"

--- a/crates/next-core/src/next_font_google/mod.rs
+++ b/crates/next-core/src/next_font_google/mod.rs
@@ -3,7 +3,7 @@ use indexmap::IndexMap;
 use indoc::formatdoc;
 use once_cell::sync::Lazy;
 use turbo_tasks::primitives::{OptionStringVc, OptionU16Vc, StringVc};
-use turbo_tasks_fetch::{fetch, FetchResult};
+use turbo_tasks_fetch::fetch;
 use turbo_tasks_fs::{FileContent, FileSystemPathVc};
 use turbopack_core::{
     issue::IssueSeverity,
@@ -158,8 +158,8 @@ impl ImportMappingReplacement for NextFontGoogleCssModuleReplacer {
         .await?;
 
         let stylesheet = match &*stylesheet_res {
-            FetchResult::Ok(r) => Some(r.await?.body.to_string().await?.clone()),
-            FetchResult::Err(err) => {
+            Ok(r) => Some(r.await?.body.to_string().await?.clone()),
+            Err(err) => {
                 // Inform the user of the failure to retreive the stylesheet, but don't
                 // propagate this error. We don't want e.g. offline connections to prevent page
                 // renders during development. During production builds, however, this error

--- a/crates/turbo-tasks-fetch/Cargo.toml
+++ b/crates/turbo-tasks-fetch/Cargo.toml
@@ -16,7 +16,9 @@ reqwest = "0.11.13"
 serde = "1.0.136"
 tokio = "1.11.0"
 turbo-tasks = { path = "../turbo-tasks" }
+turbo-tasks-fs = { path = "../turbo-tasks-fs" }
 turbo-tasks-memory = { path = "../turbo-tasks-memory" }
+turbopack-core = { path = "../turbopack-core" }
 
 [dev-dependencies]
 httpmock = "0.6.6"

--- a/crates/turbo-tasks-fetch/src/lib.rs
+++ b/crates/turbo-tasks-fetch/src/lib.rs
@@ -2,9 +2,12 @@
 
 use anyhow::Result;
 use turbo_tasks::primitives::{OptionStringVc, StringVc};
+use turbo_tasks_fs::FileSystemPathVc;
+use turbopack_core::issue::{Issue, IssueSeverityVc, IssueVc};
 
 pub fn register() {
     turbo_tasks::register();
+    turbopack_core::register();
     include!(concat!(env!("OUT_DIR"), "/register.rs"));
 }
 
@@ -29,23 +32,128 @@ impl HttpResponseBodyVc {
 }
 
 #[turbo_tasks::function]
-pub async fn fetch(url: StringVc, user_agent: OptionStringVc) -> Result<HttpResponseVc> {
+pub async fn fetch(
+    url: StringVc,
+    user_agent: OptionStringVc,
+    context: FileSystemPathVc,
+) -> Result<HttpResponseVc> {
     let url = url.await?.clone();
     let user_agent = &*user_agent.await?;
     let client = reqwest::Client::new();
 
-    let mut builder = client.get(url);
+    let mut builder = client.get(&url);
     if let Some(user_agent) = user_agent {
         builder = builder.header("User-Agent", user_agent);
     }
 
-    let response = builder.send().await?;
-    let status = response.status().as_u16();
-    let body = response.bytes().await?.to_vec();
+    let response = builder.send().await;
+    match response {
+        Ok(response) => {
+            let status = response.status().as_u16();
+            let body = response.bytes().await?.to_vec();
 
-    Ok(HttpResponse {
-        status,
-        body: HttpResponseBodyVc::cell(HttpResponseBody(body)),
+            Ok(HttpResponse {
+                status,
+                body: HttpResponseBodyVc::cell(HttpResponseBody(body)),
+            }
+            .into())
+        }
+        Err(err) => {
+            FetchIssue::from_reqwest_error(&err, &url, context)
+                .cell()
+                .as_issue()
+                .emit();
+            Err(err.into())
+        }
     }
-    .into())
+}
+
+#[turbo_tasks::value(shared)]
+enum FetchIssueKind {
+    Connect,
+    Timeout,
+    Status(u16),
+    Other,
+}
+
+#[turbo_tasks::value(shared)]
+struct FetchIssue {
+    pub context: FileSystemPathVc,
+    pub url: StringVc,
+    pub kind: FetchErrorKindVc,
+    pub detail: StringVc,
+}
+
+impl FetchIssue {
+    fn from_reqwest_error(
+        error: &reqwest::Error,
+        url: &str,
+        issue_context: FileSystemPathVc,
+    ) -> FetchIssue {
+        let kind = if error.is_connect() {
+            FetchErrorKind::Connect
+        } else if error.is_timeout() {
+            FetchErrorKind::Timeout
+        } else if let Some(status) = error.status() {
+            FetchErrorKind::Status(status.as_u16())
+        } else {
+            FetchErrorKind::Other
+        };
+
+        FetchIssue {
+            context: issue_context,
+            detail: StringVc::cell(error.to_string()),
+            url: StringVc::cell(url.to_owned()),
+            kind: kind.into(),
+        }
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl Issue for FetchIssue {
+    #[turbo_tasks::function]
+    fn context(&self) -> FileSystemPathVc {
+        self.context
+    }
+
+    #[turbo_tasks::function]
+    fn severity(&self) -> IssueSeverityVc {
+        self.severity
+    }
+
+    #[turbo_tasks::function]
+    fn title(&self) -> StringVc {
+        StringVc::cell("Error while requesting resource".to_string())
+    }
+
+    #[turbo_tasks::function]
+    fn category(&self) -> StringVc {
+        StringVc::cell("fetch".to_string())
+    }
+
+    #[turbo_tasks::function]
+    async fn description(&self) -> Result<StringVc> {
+        let url = &*self.url.await?;
+        let kind = &*self.kind.await?;
+
+        Ok(StringVc::cell(match kind {
+            FetchErrorKind::Connect => format!(
+                "There was an issue establishing a connection while requesting {}.",
+                url
+            ),
+            FetchErrorKind::Status(status) => {
+                format!(
+                    "Received response with status {} when requesting {}",
+                    status, url
+                )
+            }
+            FetchErrorKind::Timeout => format!("Connection timed out when requesting {}", url),
+            FetchErrorKind::Other => format!("There was an issue requesting {}", url),
+        }))
+    }
+
+    #[turbo_tasks::function]
+    fn detail(&self) -> StringVc {
+        self.detail
+    }
 }

--- a/crates/turbo-tasks-fetch/tests/fetch.rs
+++ b/crates/turbo-tasks-fetch/tests/fetch.rs
@@ -1,8 +1,10 @@
 #![cfg(test)]
+
 use turbo_tasks::primitives::{OptionStringVc, StringVc};
-use turbo_tasks_fetch::{fetch, register};
+use turbo_tasks_fetch::{fetch, register, FetchErrorKind, FetchResult};
 use turbo_tasks_fs::{DiskFileSystemVc, FileSystemPathVc, FileSystemVc};
 use turbo_tasks_testing::{register, run};
+use turbopack_core::issue::{Issue, IssueSeverity};
 
 register!();
 
@@ -19,10 +21,17 @@ async fn basic_get() {
         });
 
 
-        let response = &*fetch(StringVc::cell(server.url("/foo.woff")), OptionStringVc::cell(None), get_issue_context()).await?;
+        let result = &*fetch(StringVc::cell(server.url("/foo.woff")), OptionStringVc::cell(None)).await?;
         resource_mock.assert();
-        assert_eq!(response.status, 200);
-        assert_eq!(*response.body.to_string().await?, "responsebody");
+
+        match result {
+            FetchResult::Err(_) => panic!(),
+            FetchResult::Ok(response) => {
+                let response = response.await?;
+                assert_eq!(response.status, 200);
+                assert_eq!(*response.body.to_string().await?, "responsebody");
+            }
+        }
     }
 }
 
@@ -38,8 +47,14 @@ async fn sends_user_agent() {
                 .body("responsebody");
         });
 
-        let response = fetch(StringVc::cell(server.url("/foo.woff")), OptionStringVc::cell(Some("foo".to_owned())), get_issue_context()).await?;
+        let result = &*fetch(StringVc::cell(server.url("/foo.woff")), OptionStringVc::cell(Some("foo".to_owned()))).await?;
         resource_mock.assert();
+
+        let FetchResult::Ok(response) = result else {
+            panic!()
+        };
+
+        let response = response.await?;
         assert_eq!(response.status, 200);
         assert_eq!(*response.body.to_string().await?, "responsebody");
     }
@@ -58,19 +73,71 @@ async fn invalidation_does_not_invalidate() {
             then.status(200)
                 .body("responsebody");
         });
-        let issue_context = get_issue_context();
 
         let url = StringVc::cell(server.url("/foo.woff"));
         let user_agent = OptionStringVc::cell(Some("foo".to_owned()));
-        let response = fetch(url, user_agent, issue_context).await?;
+        let result = &*fetch(url, user_agent).await?;
         resource_mock.assert();
+
+        let FetchResult::Ok(response_vc) = result else {
+            panic!()
+        };
+        let response = response_vc.await?;
         assert_eq!(response.status, 200);
         assert_eq!(*response.body.to_string().await?, "responsebody");
 
-        let second_response = fetch(url, user_agent, issue_context).await?;
+        let second_result = &*fetch(url, user_agent).await?;
+        let FetchResult::Ok(second_response_vc) = second_result else {
+            panic!()
+        };
+        let second_response = second_response_vc.await?;
+
         // Assert that a second request is never sent -- the result is cached via turbo tasks
         resource_mock.assert_hits(1);
         assert_eq!(response, second_response);
+    }
+}
+
+#[tokio::test]
+async fn errors_on_failed_connection() {
+    run! {
+        register();
+
+        let url = "https://doesnotexist/foo.woff";
+        let result = &*fetch(StringVc::cell(url.to_owned()), OptionStringVc::cell(None)).await?;
+        let FetchResult::Err(err_vc) = result else {
+            panic!()
+        };
+        let err = &*err_vc.await?;
+        assert_eq!(*err.kind.await?, FetchErrorKind::Connect);
+        assert_eq!(*err.url.await?, url);
+
+        let issue = err_vc.to_issue(IssueSeverity::Error.into(), get_issue_context());
+        assert_eq!(*issue.severity().await?, IssueSeverity::Error);
+        assert_eq!(*issue.category().await?, "fetch");
+        assert_eq!(*issue.description().await?, "There was an issue establishing a connection while requesting https://doesnotexist/foo.woff.");
+    }
+}
+
+#[tokio::test]
+async fn errors_on_404() {
+    run! {
+        register();
+
+        let server = httpmock::MockServer::start();
+        let resource_url = server.url("/");
+        let result = &*fetch(StringVc::cell(resource_url.clone()), OptionStringVc::cell(None)).await?;
+        let FetchResult::Err(err_vc) = result else {
+            panic!()
+        };
+        let err = &*err_vc.await?;
+        assert!(matches!(*err.kind.await?, FetchErrorKind::Status(404)));
+        assert_eq!(*err.url.await?, resource_url);
+
+        let issue = err_vc.to_issue(IssueSeverity::Error.into(), get_issue_context());
+        assert_eq!(*issue.severity().await?, IssueSeverity::Error);
+        assert_eq!(*issue.category().await?, "fetch");
+        assert_eq!(*issue.description().await?, format!("Received response with status 404 when requesting {}", &resource_url));
     }
 }
 

--- a/crates/turbo-tasks-fetch/tests/fetch.rs
+++ b/crates/turbo-tasks-fetch/tests/fetch.rs
@@ -1,7 +1,7 @@
 #![cfg(test)]
 
 use turbo_tasks::primitives::{OptionStringVc, StringVc};
-use turbo_tasks_fetch::{fetch, register, FetchErrorKind, FetchResult};
+use turbo_tasks_fetch::{fetch, register, FetchErrorKind};
 use turbo_tasks_fs::{DiskFileSystemVc, FileSystemPathVc, FileSystemVc};
 use turbo_tasks_testing::{register, run};
 use turbopack_core::issue::{Issue, IssueSeverity};
@@ -25,8 +25,8 @@ async fn basic_get() {
         resource_mock.assert();
 
         match result {
-            FetchResult::Err(_) => panic!(),
-            FetchResult::Ok(response) => {
+            Err(_) => panic!(),
+            Ok(response) => {
                 let response = response.await?;
                 assert_eq!(response.status, 200);
                 assert_eq!(*response.body.to_string().await?, "responsebody");
@@ -50,7 +50,7 @@ async fn sends_user_agent() {
         let result = &*fetch(StringVc::cell(server.url("/foo.woff")), OptionStringVc::cell(Some("foo".to_owned()))).await?;
         resource_mock.assert();
 
-        let FetchResult::Ok(response) = result else {
+        let Ok(response) = result else {
             panic!()
         };
 
@@ -79,7 +79,7 @@ async fn invalidation_does_not_invalidate() {
         let result = &*fetch(url, user_agent).await?;
         resource_mock.assert();
 
-        let FetchResult::Ok(response_vc) = result else {
+        let Ok(response_vc) = result else {
             panic!()
         };
         let response = response_vc.await?;
@@ -87,7 +87,7 @@ async fn invalidation_does_not_invalidate() {
         assert_eq!(*response.body.to_string().await?, "responsebody");
 
         let second_result = &*fetch(url, user_agent).await?;
-        let FetchResult::Ok(second_response_vc) = second_result else {
+        let Ok(second_response_vc) = second_result else {
             panic!()
         };
         let second_response = second_response_vc.await?;
@@ -105,7 +105,7 @@ async fn errors_on_failed_connection() {
 
         let url = "https://doesnotexist/foo.woff";
         let result = &*fetch(StringVc::cell(url.to_owned()), OptionStringVc::cell(None)).await?;
-        let FetchResult::Err(err_vc) = result else {
+        let Err(err_vc) = result else {
             panic!()
         };
         let err = &*err_vc.await?;
@@ -127,7 +127,7 @@ async fn errors_on_404() {
         let server = httpmock::MockServer::start();
         let resource_url = server.url("/");
         let result = &*fetch(StringVc::cell(resource_url.clone()), OptionStringVc::cell(None)).await?;
-        let FetchResult::Err(err_vc) = result else {
+        let Err(err_vc) = result else {
             panic!()
         };
         let err = &*err_vc.await?;


### PR DESCRIPTION
Fixes WEB-274.

This emits issues whenever a fetch fails. This happens within fetch itself, and it's still up to the caller to handle the results of errors.

Note that there is a change in behavior: turbo-tasks-fetch now uses reqwest's `error_for_status`, meaning that `Error`s will be returned if a status of >= 400 is received in a response. This trades a bit of control from the caller for better handling the common need of informing the user when bad responses are received.

Test Plan: Added unit tests for failed connetion and bad response statuses.
