### PR TITLE
fix css indent in `ImportAttributes::print_block`

### DIFF
--- a/crates/turbopack-css/src/references/import.rs
+++ b/crates/turbopack-css/src/references/import.rs
@@ -3,7 +3,10 @@ use swc_core::{
     common::DUMMY_SP,
     css::{
         ast::*,
-        codegen::{writer::basic::BasicCssWriter, CodeGenerator, Emit},
+        codegen::{
+            writer::basic::{BasicCssWriter, BasicCssWriterConfig},
+            CodeGenerator, Emit,
+        },
     },
 };
 use turbo_tasks::{primitives::StringVc, ValueToString, ValueToStringVc};
@@ -157,7 +160,14 @@ impl ImportAttributes {
 
         let mut output = String::new();
         let mut code_gen = CodeGenerator::new(
-            BasicCssWriter::new(&mut output, None, Default::default()),
+            BasicCssWriter::new(
+                &mut output,
+                None,
+                BasicCssWriterConfig {
+                    indent_width: 0,
+                    ..Default::default()
+                },
+            ),
             Default::default(),
         );
         code_gen.emit(&rule)?;

--- a/crates/turbopack-tests/tests/snapshot/css/css/output/crates_turbopack-tests_tests_snapshot_css_css_input_style.css
+++ b/crates/turbopack-tests/tests/snapshot/css/css/output/crates_turbopack-tests_tests_snapshot_css_css_input_style.css
@@ -1,7 +1,7 @@
 /* chunk [workspace]/crates/turbopack-tests/tests/snapshot/css/css/output/crates_turbopack-tests_tests_snapshot_css_css_input_style.css */
 /* import([project]/crates/turbopack-tests/tests/snapshot/css/css/input/imported.css (css)) */
 @layer layer {
-  @media print {
+@media print {
 /* [project]/crates/turbopack-tests/tests/snapshot/css/css/input/imported.css (css) */
 .imported {
   color: cyan;


### PR DESCRIPTION
fix this: https://github.com/vercel/turbo/pull/2839#discussion_r1044202479