### PR TITLE
Skip formatting ffi.rs

### DIFF
--- a/shim/src/main.rs
+++ b/shim/src/main.rs
@@ -1,3 +1,4 @@
+#[rustfmt::skip]
 mod ffi;
 
 use std::{ffi::CString, process};


### PR DESCRIPTION
This can otherwise cause rustfmt to fail with the following when ffi.rs hasn't been generated yet:
```
Error writing files: failed to resolve mod `ffi`: /Users/alex/dev/turbo/shim/src/ffi.rs does not exist
```