### PR TITLE
feat(mdx): initial turbopack-mdx asset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7309,6 +7309,7 @@ dependencies = [
  "turbopack-ecmascript",
  "turbopack-env",
  "turbopack-json",
+ "turbopack-mdx",
  "turbopack-static",
 ]
 
@@ -7468,6 +7469,20 @@ dependencies = [
  "anyhow",
  "serde",
  "serde_json",
+ "turbo-tasks",
+ "turbo-tasks-build",
+ "turbo-tasks-fs",
+ "turbopack-core",
+ "turbopack-ecmascript",
+]
+
+[[package]]
+name = "turbopack-mdx"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "mdxjs",
+ "serde",
  "turbo-tasks",
  "turbo-tasks-build",
  "turbo-tasks-fs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = [
   "crates/turbopack-dev-server",
   "crates/turbopack-ecmascript",
   "crates/turbopack-env",
+  "crates/turbopack-mdx",
   "crates/turbopack-node",
   "crates/turbopack-json",
   "crates/turbopack-static",

--- a/crates/next-core/src/server_rendered_source.rs
+++ b/crates/next-core/src/server_rendered_source.rs
@@ -290,7 +290,7 @@ async fn create_server_rendered_source_for_directory(
                         match extension {
                             // pageExtensions option from next.js
                             // defaults: https://github.com/vercel/next.js/blob/611e13f5159457fedf96d850845650616a1f75dd/packages/next/server/config-shared.ts#L499
-                            "js" | "ts" | "jsx" | "tsx" => {
+                            "js" | "ts" | "jsx" | "tsx" | "mdx" => {
                                 let (dev_server_path, intermediate_output_path, specificity) =
                                     if basename == "index" {
                                         (

--- a/crates/turbopack-ecmascript/src/lib.rs
+++ b/crates/turbopack-ecmascript/src/lib.rs
@@ -49,13 +49,11 @@ use turbopack_core::{
     resolve::origin::{ResolveOrigin, ResolveOriginVc},
 };
 
-use self::{
-    chunk::{
-        EcmascriptChunkItemContent, EcmascriptChunkItemContentVc, EcmascriptChunkItemOptions,
-        EcmascriptExportsVc,
-    },
-    references::AnalyzeEcmascriptModuleResultVc,
+use self::chunk::{
+    EcmascriptChunkItemContent, EcmascriptChunkItemContentVc, EcmascriptChunkItemOptions,
+    EcmascriptExportsVc,
 };
+pub use self::references::AnalyzeEcmascriptModuleResultVc;
 use crate::{
     chunk::{EcmascriptChunkPlaceable, EcmascriptChunkPlaceableVc},
     references::analyze_ecmascript_module,

--- a/crates/turbopack-mdx/Cargo.toml
+++ b/crates/turbopack-mdx/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "turbopack-mdx"
+version = "0.1.0"
+description = "TBD"
+license = "MPL-2.0"
+edition = "2021"
+autobenches = false
+
+[lib]
+bench = false
+
+[dependencies]
+anyhow = "1.0.47"
+
+turbo-tasks = { path = "../turbo-tasks" }
+turbo-tasks-fs = { path = "../turbo-tasks-fs" }
+turbopack-core = { path = "../turbopack-core" }
+turbopack-ecmascript = { path = "../turbopack-ecmascript" }
+
+serde = "1.0.136"
+
+mdxjs = { workspace = true }
+
+[build-dependencies]
+turbo-tasks-build = { path = "../turbo-tasks-build" }

--- a/crates/turbopack-mdx/build.rs
+++ b/crates/turbopack-mdx/build.rs
@@ -1,0 +1,5 @@
+use turbo_tasks_build::generate_register;
+
+fn main() {
+    generate_register();
+}

--- a/crates/turbopack-mdx/src/lib.rs
+++ b/crates/turbopack-mdx/src/lib.rs
@@ -1,0 +1,192 @@
+#![feature(min_specialization)]
+
+use anyhow::{anyhow, Result};
+use mdxjs::compile;
+use turbo_tasks::{primitives::StringVc, Value, ValueToString, ValueToStringVc};
+use turbo_tasks_fs::{rope::Rope, File, FileContent, FileSystemPathVc};
+use turbopack_core::{
+    asset::{Asset, AssetContent, AssetContentVc, AssetVc},
+    chunk::{ChunkItem, ChunkItemVc, ChunkVc, ChunkableAsset, ChunkableAssetVc, ChunkingContextVc},
+    context::AssetContextVc,
+    reference::AssetReferencesVc,
+    resolve::origin::{ResolveOrigin, ResolveOriginVc},
+    virtual_asset::VirtualAssetVc,
+};
+use turbopack_ecmascript::{
+    chunk::{
+        EcmascriptChunkItem, EcmascriptChunkItemContentVc, EcmascriptChunkItemVc,
+        EcmascriptChunkPlaceable, EcmascriptChunkPlaceableVc, EcmascriptChunkVc,
+    },
+    AnalyzeEcmascriptModuleResultVc, EcmascriptInputTransformsVc, EcmascriptModuleAssetType,
+    EcmascriptModuleAssetVc,
+};
+
+#[turbo_tasks::value]
+#[derive(Clone, Copy)]
+pub struct MdxModuleAsset {
+    pub source: AssetVc,
+    pub context: AssetContextVc,
+    pub transforms: EcmascriptInputTransformsVc,
+}
+
+/// MDX components should be treated as normal j|tsx components to analyze
+/// its imports or run ecma transforms,
+/// only difference is it is not a valid ecmascript AST we
+/// can't pass it forward directly. Internally creates an jsx from mdx
+/// via mdxrs, then pass it through existing ecmascript analyzer.
+async fn interop_ecma_asset_from_mdx(
+    current_context: &MdxModuleAssetVc,
+) -> Result<EcmascriptModuleAssetVc> {
+    let content = current_context.content();
+    let this = current_context.await?;
+
+    if let AssetContent::File(file) = &*content.await? {
+        if let FileContent::Content(file) = &*file.await? {
+            let file_conent = file.content().to_str()?;
+            // TODO: upstream mdx currently bubbles error as string
+            let mdx_jdx_component =
+                compile(&file_conent, &Default::default()).map_err(|e| anyhow!("{}", e))?;
+
+            let source = VirtualAssetVc::new(
+                this.source.path(),
+                File::from(Rope::from(mdx_jdx_component)).into(),
+            );
+            Ok(EcmascriptModuleAssetVc::new(
+                source.into(),
+                this.context.into(),
+                Value::new(EcmascriptModuleAssetType::Typescript),
+                this.transforms,
+                this.context.environment(),
+            ))
+        } else {
+            Err(anyhow!("Not able to read mdx file content"))
+        }
+    } else {
+        Err(anyhow!("Unexpected mdx asset content"))
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl MdxModuleAssetVc {
+    #[turbo_tasks::function]
+    pub fn new(
+        source: AssetVc,
+        context: AssetContextVc,
+        transforms: EcmascriptInputTransformsVc,
+    ) -> Self {
+        Self::cell(MdxModuleAsset {
+            source,
+            context,
+            transforms,
+        })
+    }
+
+    #[turbo_tasks::function]
+    pub async fn analyze(self) -> Result<AnalyzeEcmascriptModuleResultVc> {
+        Ok(interop_ecma_asset_from_mdx(&self).await?.analyze())
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl Asset for MdxModuleAsset {
+    #[turbo_tasks::function]
+    fn path(&self) -> FileSystemPathVc {
+        self.source.path()
+    }
+
+    #[turbo_tasks::function]
+    fn content(&self) -> AssetContentVc {
+        self.source.content()
+    }
+
+    #[turbo_tasks::function]
+    async fn references(self_vc: MdxModuleAssetVc) -> Result<AssetReferencesVc> {
+        Ok(self_vc.analyze().await?.references)
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl ChunkableAsset for MdxModuleAsset {
+    #[turbo_tasks::function]
+    fn as_chunk(self_vc: MdxModuleAssetVc, context: ChunkingContextVc) -> ChunkVc {
+        EcmascriptChunkVc::new(context, self_vc.as_ecmascript_chunk_placeable()).into()
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl EcmascriptChunkPlaceable for MdxModuleAsset {
+    #[turbo_tasks::function]
+    fn as_chunk_item(
+        self_vc: MdxModuleAssetVc,
+        context: ChunkingContextVc,
+    ) -> EcmascriptChunkItemVc {
+        MdxChunkItemVc::cell(MdxChunkItem {
+            module: self_vc,
+            context,
+        })
+        .into()
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl ResolveOrigin for MdxModuleAsset {
+    #[turbo_tasks::function]
+    fn origin_path(&self) -> FileSystemPathVc {
+        self.source.path()
+    }
+
+    #[turbo_tasks::function]
+    fn context(&self) -> AssetContextVc {
+        self.context
+    }
+}
+
+#[turbo_tasks::value]
+struct MdxChunkItem {
+    module: MdxModuleAssetVc,
+    context: ChunkingContextVc,
+}
+
+#[turbo_tasks::value_impl]
+impl ValueToString for MdxChunkItem {
+    #[turbo_tasks::function]
+    async fn to_string(&self) -> Result<StringVc> {
+        Ok(StringVc::cell(format!(
+            "{} (mdx)",
+            self.module.await?.source.path().to_string().await?
+        )))
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl ChunkItem for MdxChunkItem {
+    #[turbo_tasks::function]
+    fn references(&self) -> AssetReferencesVc {
+        self.module.references()
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl EcmascriptChunkItem for MdxChunkItem {
+    #[turbo_tasks::function]
+    fn chunking_context(&self) -> ChunkingContextVc {
+        self.context
+    }
+
+    /// Once we have mdx contents, we should treat it as j|tsx components and
+    /// apply all of the ecma transforms
+    #[turbo_tasks::function]
+    async fn content(&self) -> Result<EcmascriptChunkItemContentVc> {
+        Ok(interop_ecma_asset_from_mdx(&self.module)
+            .await?
+            .as_chunk_item(self.context)
+            .content())
+    }
+}
+
+pub fn register() {
+    turbo_tasks::register();
+    turbo_tasks_fs::register();
+    turbopack_core::register();
+    include!(concat!(env!("OUT_DIR"), "/register.rs"));
+}

--- a/crates/turbopack/Cargo.toml
+++ b/crates/turbopack/Cargo.toml
@@ -27,6 +27,7 @@ turbopack-css = { path = "../turbopack-css" }
 turbopack-ecmascript = { path = "../turbopack-ecmascript" }
 turbopack-env = { path = "../turbopack-env" }
 turbopack-json = { path = "../turbopack-json" }
+turbopack-mdx = { path = "../turbopack-mdx" }
 turbopack-static = { path = "../turbopack-static" }
 # turbo-tasks-rocksdb could be a dev dependencies, but optional dev dependencies are not allowed
 # turbo-tasks-rocksdb = { path = "../turbo-tasks-rocksdb", optional = true }

--- a/crates/turbopack/src/lib.rs
+++ b/crates/turbopack/src/lib.rs
@@ -56,6 +56,7 @@ pub mod transition;
 pub use turbopack_css as css;
 pub use turbopack_ecmascript as ecmascript;
 use turbopack_json::JsonModuleAssetVc;
+use turbopack_mdx::MdxModuleAssetVc;
 use turbopack_static::StaticModuleAssetVc;
 
 use self::{
@@ -210,6 +211,9 @@ async fn module(
             ModuleCssModuleAssetVc::new(source, context.into(), *transforms).into()
         }
         ModuleType::Static => StaticModuleAssetVc::new(source, context.into()).into(),
+        ModuleType::Mdx(transforms) => {
+            MdxModuleAssetVc::new(source, context.into(), *transforms).into()
+        }
         ModuleType::Custom(_) => todo!(),
     })
 }
@@ -587,6 +591,7 @@ pub fn register() {
     turbopack_css::register();
     turbopack_ecmascript::register();
     turbopack_env::register();
+    turbopack_mdx::register();
     turbopack_json::register();
     turbopack_static::register();
     include!(concat!(env!("OUT_DIR"), "/register.rs"));

--- a/crates/turbopack/src/module_options/mod.rs
+++ b/crates/turbopack/src/module_options/mod.rs
@@ -77,11 +77,24 @@ impl ModuleOptionsVc {
         };
 
         let css_transforms = CssInputTransformsVc::cell(vec![CssInputTransform::Nested]);
+        let mdx_transforms = EcmascriptInputTransformsVc::cell(
+            vec![EcmascriptInputTransform::TypeScript]
+                .iter()
+                .chain(app_transforms.await?.iter())
+                .cloned()
+                .collect(),
+        );
 
         let mut rules = vec![
             ModuleRule::new(
                 ModuleRuleCondition::ResourcePathEndsWith(".json".to_string()),
                 vec![ModuleRuleEffect::ModuleType(ModuleType::Json)],
+            ),
+            ModuleRule::new(
+                ModuleRuleCondition::ResourcePathEndsWith(".mdx".to_string()),
+                vec![ModuleRuleEffect::ModuleType(ModuleType::Mdx(
+                    mdx_transforms,
+                ))],
             ),
             ModuleRule::new(
                 ModuleRuleCondition::ResourcePathEndsWith(".css".to_string()),

--- a/crates/turbopack/src/module_options/module_rule.rs
+++ b/crates/turbopack/src/module_options/module_rule.rs
@@ -115,6 +115,7 @@ pub enum ModuleType {
     TypescriptDeclaration(EcmascriptInputTransformsVc),
     Json,
     Raw,
+    Mdx(EcmascriptInputTransformsVc),
     Css(CssInputTransformsVc),
     CssModule(CssInputTransformsVc),
     Static,


### PR DESCRIPTION
Implements / fix WEB-86. This PR is an initial attempt to support mdx natively inside of turbopack. 

It uses mdxrs (https://github.com/wooorm/mdxjs-rs) internally to interop - compile - mdx inputs into renderable ecma outputs. PR creates a new type of asset `MDXAsset`, and then let its extension (`.mdx`) can be consumed by turbopack. 

Since mdx is a variant of ecma asset to be rendered, it requires to perform all of the ecma transforms in the current running turbopack session. But since its AST is not compatible to plain swc (or ecma), it also cannot be passed into existing ecmaassets. MDXAsset does interop for those, by creating a virtualasset for the ecma once mdx is compiled into plain ecma. This might not be feasible appoarch and requires different way to chain asset types, something I'd like to address in this PR. I guess this will be needed for other types of assets in a long run - where input is not an ecma but requires ecma transforms (i.e vue, ng templates).