### PR TITLE
chore(turborepo): drop deprecated run flags

### DIFF
--- a/cli/integration_tests/bad_flag.t
+++ b/cli/integration_tests/bad_flag.t
@@ -13,3 +13,16 @@ Bad flag should print misuse text
   
   For more information try '--help'
   [1]
+
+Bad flag with an implied run command should display run flags
+  $ ${TURBO} build --bad-flag
+  Repository inference failed: Unable to find `turbo.json` or `package.json` in current path
+  Running command as global turbo
+  error: Found argument '--bad-flag' which wasn't expected, or isn't valid in this context
+  
+    If you tried to supply '--bad-flag' as a value rather than a flag, use '-- --bad-flag'
+  
+  Usage: turbo <--cache-dir <CACHE_DIR>|--cache-workers <CACHE_WORKERS>|--concurrency <CONCURRENCY>|--continue|--dry-run [<DRY_RUN>]|--single-package|--filter <FILTER>|--force|--global-deps <GLOBAL_DEPS>|--graph [<GRAPH>]|--ignore <IGNORE>|--include-dependencies|--no-cache|--no-daemon|--no-deps|--output-logs <OUTPUT_LOGS>|--only|--parallel|--profile <PROFILE>|--remote-only|--scope <SCOPE>|--since <SINCE>|TASKS|PASS_THROUGH_ARGS>
+  
+  For more information try '--help'
+  [1]

--- a/cli/scripts/monorepo.ts
+++ b/cli/scripts/monorepo.ts
@@ -328,12 +328,6 @@ fs.copyFileSync(
   ) {
     const resolvedArgs = [...args];
 
-    // Include these to make sure we don't error.
-    if (command == "run") {
-      resolvedArgs.unshift("--experimental-use-daemon");
-      resolvedArgs.unshift("--stream");
-    }
-
     return execa.sync(turboPath, [command, ...resolvedArgs], {
       cwd: this.root,
       shell: true,

--- a/crates/turborepo-lib/src/cli.rs
+++ b/crates/turborepo-lib/src/cli.rs
@@ -220,15 +220,9 @@ pub struct RunArgs {
     pub continue_execution: bool,
     #[clap(alias = "dry", long = "dry-run", num_args = 0..=1, default_missing_value = "text")]
     pub dry_run: Option<DryRunMode>,
-    #[clap(long, hide = true)]
-    #[serde(skip)]
-    pub experimental_use_daemon: bool,
     /// Run turbo in single-package mode
     #[clap(long, global = true)]
     pub single_package: bool,
-    #[clap(long, hide = true)]
-    #[serde(skip)]
-    pub stream: bool,
     /// Use the given selector to specify package(s) to act as
     /// entry points. The syntax mirrors pnpm's syntax, and
     /// additional documentation and examples can be found in


### PR DESCRIPTION
Drop deprecated flags that are no longer respected. If a user passes these to a 1.7 binary it will now error instead of silently throwing away the values.

These flags no longer appear in run command misuse text as the snapshot shows.