### PR TITLE
fix: unable to set verbosity via number

### DIFF
--- a/cli/integration_tests/basic_monorepo/verbosity.t
+++ b/cli/integration_tests/basic_monorepo/verbosity.t
@@ -1,0 +1,15 @@
+Setup
+  $ . ${TESTDIR}/../setup.sh
+  $ . ${TESTDIR}/setup.sh $(pwd)
+
+$ Verbosity level 1
+  $ ${TURBO} build -v --force
+  $ ${TURBO} build --verbosity=1 --force
+
+$ Verbosity level 2
+  $ ${TURBO} build -vv --force
+  $ ${TURBO} build --verbosity=2 --force
+
+$ Verbosity level 3
+  $ ${TURBO} build -vvv --force
+  $ ${TURBO} build --verbosity=3 --force

--- a/crates/turborepo-lib/src/cli.rs
+++ b/crates/turborepo-lib/src/cli.rs
@@ -85,6 +85,7 @@ pub struct Args {
     /// verbosity
     #[clap(
       short = 'v',
+      long = "verbosity",
       action = clap::ArgAction::Count,
       global = true)]
     pub verbosity: u8,


### PR DESCRIPTION
Previously users were able to set the verbosity via count (`-vvv`) or by providing a value (`--verbosity=3`), this PR gives users the ability to do the latter.

We achieve this by creating our own `Verbosity` struct that when serialized will be converted to a `u8` allowing us to not change the Go code.

Note:
This doesn't completely match the old behavior as we allowed for funky stuff like `-v --verbosity=0 --verbosity=3 --verbosity`. (Any guesses what the verbosity level was set to?)