### PR TITLE
build(next/core): allow to specify tls backend for reqwest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2452,6 +2452,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
+dependencies = [
+ "http",
+ "hyper",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4543,6 +4556,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "hyper-rustls",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -4552,16 +4566,20 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
  "winreg",
 ]
 
@@ -4698,6 +4716,15 @@ dependencies = [
  "ring",
  "sct",
  "webpki",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
+dependencies = [
+ "base64",
 ]
 
 [[package]]
@@ -6792,6 +6819,17 @@ checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
+dependencies = [
+ "rustls",
+ "tokio",
+ "webpki",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,3 +96,8 @@ modularize_imports = { version = "0.25.10" }
 mdxjs = { version = "0.1.4" }
 next-dev = { path = "crates/next-dev", version = "0.1.0" }
 node-file-trace = { path = "crates/node-file-trace", version = "0.1.0" }
+# Be careful when selecting tls backend, including change default tls backend.
+# If you changed, must verify with ALL build targets with next-swc to ensure
+# it works. next-swc have various platforms, some doesn't support native (using openssl-sys)
+# and some aren't buildable with rustls.
+reqwest = { version = "0.11.13", default-features = false }

--- a/crates/next-core/Cargo.toml
+++ b/crates/next-core/Cargo.toml
@@ -35,3 +35,5 @@ turbo-tasks-build = { path = "../turbo-tasks-build" }
 
 [features]
 next-font-local = []
+native-tls = ["turbo-tasks-fetch/native-tls"]
+rustls-tls = ["turbo-tasks-fetch/rustls-tls"]

--- a/crates/next-dev/Cargo.toml
+++ b/crates/next-dev/Cargo.toml
@@ -19,7 +19,12 @@ name = "mod"
 harness = false
 
 [features]
-default = ["cli", "custom_allocator"]
+# By default, we enable native-tls for reqwest downstream trasntive features.
+# This is for the convinience for all of daily dev workflow i.e running
+# `cargo xxx` without explicitly specifying features, not that we want to
+# promote this as default backend. Actual configuration is done when build next-swc,
+# and also turbopack standalone when we have it.
+default = ["cli", "custom_allocator", "native-tls"]
 cli = []
 serializable = []
 tokio_console = [
@@ -30,6 +35,8 @@ tokio_console = [
 profile = []
 custom_allocator = ["turbo-malloc/custom_allocator"]
 next-font-local = ["next-core/next-font-local"]
+native-tls = ["next-core/native-tls"]
+rustls-tls = ["next-core/rustls-tls"]
 
 [dependencies]
 anyhow = "1.0.47"

--- a/crates/turbo-tasks-fetch/Cargo.toml
+++ b/crates/turbo-tasks-fetch/Cargo.toml
@@ -8,11 +8,17 @@ edition = "2021"
 [lib]
 bench = false
 
+[features]
+# Allow to configure specific tls backend for reqwest.
+# See top level Cargo.toml for more details.
+native-tls = ["reqwest/native-tls"]
+rustls-tls = ["reqwest/rustls-tls"]
+
 [dependencies]
 anyhow = "1.0.47"
 indexmap = { workspace = true }
 lazy_static = "1.4.0"
-reqwest = "0.11.13"
+reqwest = { workspace = true }
 serde = "1.0.136"
 tokio = "1.11.0"
 turbo-tasks = { path = "../turbo-tasks" }

--- a/crates/turbo-tasks-fetch/build.rs
+++ b/crates/turbo-tasks-fetch/build.rs
@@ -1,5 +1,19 @@
 use turbo_tasks_build::generate_register;
 
+#[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
+fn check_tls_config() {
+    // do nothing
+}
+#[cfg(not(any(feature = "native-tls", feature = "rustls-tls")))]
+fn check_tls_config() {
+    panic!("You must enable one of the TLS features: native-tls or rustls-tls");
+}
+
 fn main() {
     generate_register();
+
+    // Check if tls feature for reqwest is properly configured.
+    // Technically reqwest falls back to non-tls http request if none of the tls
+    // features are enabled, But we won't allow it.
+    check_tls_config();
 }


### PR DESCRIPTION
Implement / fixes WEB-306.

We can't rely on default tls backend for reqwest and hope to work with every target platform we support, due to several constraints. Some target cannot use -sys (openssl-sys), and some can't build rustls due to trasnsitive dep support issue.

PR creates explicit opt-in features for those and let upstream application can specify what they need. `next-dev` currently sets `native-tls` as default for the general dev workflow conveniences, but that doesn't mean we promote it as default feature set - next-swc, or other like standalone turbopack will configure features by themselves when build binaries for their own.