### PR TITLE
TURBO prefix is required.

### DIFF
--- a/crates/turbo-updater/src/lib.rs
+++ b/crates/turbo-updater/src/lib.rs
@@ -12,7 +12,7 @@ const DEFAULT_TIMEOUT: Duration = Duration::from_millis(800);
 // 1 day
 const DEFAULT_INTERVAL: Duration = Duration::from_secs(60 * 60 * 24);
 
-const NO_UPDATE_NOTIFIER: &str = "NO_UPDATE_NOTIFIER";
+const TURBO_NO_UPDATE_NOTIFIER: &str = "TURBO_NO_UPDATE_NOTIFIER";
 
 #[derive(ThisError, Debug)]
 pub enum UpdateNotifierError {
@@ -61,7 +61,12 @@ pub fn check_for_updates(
     interval: Option<Duration>,
 ) -> Result<(), UpdateNotifierError> {
     // bail early if the user has disabled update notifications
-    if std::env::var(NO_UPDATE_NOTIFIER).is_ok() {
+    let use_update_notifier = match std::env::var(TURBO_NO_UPDATE_NOTIFIER) {
+        Ok(v) => v == "1",
+        Err(_) => false,
+    };
+
+    if use_update_notifier {
         return Ok(());
     }
 


### PR DESCRIPTION
Updates the env var for notifications to have a `TURBO` prefix.