### PR TITLE
build(cargo): bump up swc_core*

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,9 +506,9 @@ dependencies = [
 
 [[package]]
 name = "binding_macros"
-version = "0.21.8"
+version = "0.24.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0946623dfcacf16ff5ebc00a469d936c9e92a09961000ad16873845a42234e81"
+checksum = "8b5d298ee40337c7e5892d969e01dbebb1e2f4c6be0421b8194a88985526d9b7"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -3064,14 +3064,11 @@ dependencies = [
 
 [[package]]
 name = "markdown"
-version = "1.0.0-alpha.4"
+version = "1.0.0-alpha.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f1bec93d41bf1ce695437433e87126cb127e147c3e5c3f35184282f97825cd9"
+checksum = "e15a8b67b7a9cb4bfbda3131ab091529c338174c78da8d46adbce1e510daf191"
 dependencies = [
  "log",
- "regex",
- "reqwest",
- "tokio",
  "unicode-id",
 ]
 
@@ -3101,13 +3098,13 @@ dependencies = [
 
 [[package]]
 name = "mdxjs"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4bbd566f0dd80e0701ef5ca305e4404805eb37b95a6246ac1605acb71a6e9b"
+checksum = "ef8fe87f878e5addc514155cdd3fec49cf8f11d287f007a0af34039672e9fc1d"
 dependencies = [
  "markdown",
  "serde",
- "swc_core 0.44.6",
+ "swc_core",
 ]
 
 [[package]]
@@ -3300,16 +3297,16 @@ dependencies = [
 
 [[package]]
 name = "modularize_imports"
-version = "0.25.8"
+version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d840b5cc8f0ba7e0c339c14c7626a4588a41915503f41009f1f27fd01e096cf"
+checksum = "b964a7316f3ff748c1893d59e0de29cb1cfad73222de8cf49ddce9a2e443dc18"
 dependencies = [
  "convert_case",
  "handlebars",
  "once_cell",
  "regex",
  "serde",
- "swc_core 0.45.4",
+ "swc_core",
 ]
 
 [[package]]
@@ -3485,7 +3482,7 @@ dependencies = [
  "node-file-trace",
  "styled_components",
  "styled_jsx",
- "swc_core 0.45.4",
+ "swc_core",
  "swc_emotion",
  "testing",
 ]
@@ -3566,7 +3563,7 @@ dependencies = [
  "fxhash",
  "serde",
  "serde_json",
- "swc_core 0.45.4",
+ "swc_core",
 ]
 
 [[package]]
@@ -5257,26 +5254,26 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "styled_components"
-version = "0.52.8"
+version = "0.52.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4e02c22491fd278caf0438b8875e726eebdc35f5cf7e12c799c04358bf3f33d"
+checksum = "1dd0a45d1f3db41c3c2cfbaa9003f3b0184a0d96cd7b5eebd8cc79b6bbd7e68e"
 dependencies = [
  "Inflector",
  "once_cell",
  "regex",
  "serde",
- "swc_core 0.45.4",
+ "swc_core",
  "tracing",
 ]
 
 [[package]]
 name = "styled_jsx"
-version = "0.29.8"
+version = "0.29.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04ea011d0e2e1344a23e28ec262bca7954100268475399f6890ef2f86cc2667b"
+checksum = "a955a3540d247f23f6e5df586c1127aaba72c8a31ce09548a76c13307fb354b2"
 dependencies = [
  "easy-error",
- "swc_core 0.45.4",
+ "swc_core",
  "tracing",
 ]
 
@@ -5316,9 +5313,9 @@ dependencies = [
 
 [[package]]
 name = "swc"
-version = "0.233.8"
+version = "0.236.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19de5dc9d4fb108b8bd23362a09ae31a84b448468844c917342b8fe6a7fba975"
+checksum = "a322dfff57d6e38325ed968a75c99a00b471ea5ad506bbdf0292f8e7ed23d459"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5374,14 +5371,14 @@ dependencies = [
  "clap 4.0.29",
  "owo-colors",
  "regex",
- "swc_core 0.45.4",
+ "swc_core",
 ]
 
 [[package]]
 name = "swc_atoms"
-version = "0.4.25"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63b8033a868fbebf5829797ac0c543499622b657e2d33a08ca6ab12547b8bafc"
+checksum = "cef7796df1985447f1fb8803ca2a00b445b20abbc65c8e73acb08835d7651ff0"
 dependencies = [
  "once_cell",
  "rkyv",
@@ -5394,9 +5391,9 @@ dependencies = [
 
 [[package]]
 name = "swc_bundler"
-version = "0.193.7"
+version = "0.193.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec70ab5459770d11485ebc3491a784bc660b575911e0289d0015752128dc07fa"
+checksum = "a560b9afd8cc914c125cd7fb1db5e4b0484cf9c4f9cc61978d5df6ed6c1a12e8"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5442,9 +5439,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.29.19"
+version = "0.29.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e2328ba5e7c8f83ff8273b352c890f981d80d215ee29cddcbe19aa789d3592"
+checksum = "811faf77280a5f43fedf06769c391d4f2ed274b1ce9267e3a47e9b13527930b7"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5500,25 +5497,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "0.44.6"
+version = "0.48.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9593e3d1dca44da09b4601bdf74f2eb5ade8768a31656834036aa5d3754ba9c0"
-dependencies = [
- "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_codegen",
- "swc_ecma_parser",
- "swc_ecma_transforms_base",
- "swc_ecma_visit",
- "vergen",
-]
-
-[[package]]
-name = "swc_core"
-version = "0.45.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8186ca543f4b0137bd63077933dd8a37b207b7d71c21f12d297e321b2f9093dd"
+checksum = "7354f4e3070914ba114aac0a28fc7afa3ee135f4ed2ddc5a04c6e93d511a75d5"
 dependencies = [
  "binding_macros",
  "swc",
@@ -5562,9 +5543,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_ast"
-version = "0.128.3"
+version = "0.131.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "757343607819915125d715aa071be58d84cbec91782b0fc401264c2ecbbc9ba1"
+checksum = "894fb6d6c166de1791ffe55d1ac109ad668cf3abc1f93161f99f938afd02c139"
 dependencies = [
  "is-macro",
  "serde",
@@ -5575,9 +5556,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_codegen"
-version = "0.138.5"
+version = "0.141.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "651d0dbd5bdc54426537d44795f3ea9227abb4207c9878e699b52c8dc6e4b5ec"
+checksum = "f26ede11ec39a66880160d8da726280edf6dd1f29a07ed88a70b2b55ff600b51"
 dependencies = [
  "auto_impl",
  "bitflags",
@@ -5605,10 +5586,11 @@ dependencies = [
 
 [[package]]
 name = "swc_css_compat"
-version = "0.13.5"
+version = "0.16.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79a0199fbe012b2b54e35c6c171b371f86cec26358c8e86c891215600fcb529b"
+checksum = "9e6ca74c3622cc7d55fb5a5de2d91356cc161274ef96128c3ea475e82c272084"
 dependencies = [
+ "bitflags",
  "once_cell",
  "serde",
  "serde_json",
@@ -5621,9 +5603,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_modules"
-version = "0.14.5"
+version = "0.17.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af22ea54dbc32c3a3b3e36b33c02f844b56bd67b2133a180af06e3707be6b580"
+checksum = "a42c990cd28cf87ac83d4f6aa622ed43c2920ecc37a8b8fe97a57a122cf5ed70"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -5637,9 +5619,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_parser"
-version = "0.137.5"
+version = "0.140.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d6bb244bc9147c20c8cfe3265e65462b50bc7567a3a134bf22ddaf6f5188402"
+checksum = "06d54cfdf75f93fb38e977beaf3162c22dd91b94771755fd325ef1ac2544a215"
 dependencies = [
  "bitflags",
  "lexical",
@@ -5651,9 +5633,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_prefixer"
-version = "0.139.5"
+version = "0.142.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3e1852ed0453d928ec16c71b94bef3a11e75a3e3993f8e774691859a7d3fa2c"
+checksum = "94f1a9c18181f403ec718dd7bbf81a126ae37b7fcaa0ed820dc710fafc9538a0"
 dependencies = [
  "once_cell",
  "preset_env_base",
@@ -5668,9 +5650,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_utils"
-version = "0.125.3"
+version = "0.128.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "985b7696db4c874bbd4018ac6647a056733f2c0b29cd212df37be125e4d3559c"
+checksum = "ca6ff8ec9406f49a26a7902af695b5be84a25c4d42ef5b1808734fd0bfb60be1"
 dependencies = [
  "once_cell",
  "serde",
@@ -5683,9 +5665,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_visit"
-version = "0.127.3"
+version = "0.130.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b776f203c7e68097a6aebfa9c1e4fe381260aeea5dad61cb5c7063f63ce33e6"
+checksum = "8d11cea17eec9822b62319e7fe71d545e8410519d0953605e7d33dcea2e1adcd"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -5696,9 +5678,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.95.3"
+version = "0.95.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420947496193d5d7f47999ea2d438a3a41e1042393520e28dfb978655f5cacc8"
+checksum = "724a26e6f2c9fdbeee174ebfd9941c52ed13169b59afa2b056d45a731af10dc1"
 dependencies = [
  "bitflags",
  "is-macro",
@@ -5714,9 +5696,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.128.5"
+version = "0.128.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f63f42f1df360e1228867bfe2cfaeec098b8ba44cc48b122b9eb47041804318"
+checksum = "e4efb3e85c0c8ff5ef8164397f571afb6b7ccd40d29191fa6fe1deef9503db3a"
 dependencies = [
  "memchr",
  "num-bigint",
@@ -5746,9 +5728,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ext_transforms"
-version = "0.92.5"
+version = "0.92.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2257948c8acea312281f314ad86e944cfe85f1d718b3af4a238f6e9fe24ebea5"
+checksum = "952c2023394e4585751f829874e3f90c1ed8378c66a52dafd76da50cc5cc6439"
 dependencies = [
  "phf",
  "swc_atoms",
@@ -5760,9 +5742,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_lints"
-version = "0.67.5"
+version = "0.67.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28a4d1d2a7e1800de3a666391865446533d65b68448af6a47422bdff3a86451"
+checksum = "8825e741afd2267bb1190629b312362098532ad4e0b07cb3895567318fe14f07"
 dependencies = [
  "ahash",
  "auto_impl",
@@ -5781,9 +5763,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_loader"
-version = "0.41.20"
+version = "0.41.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41890cd5ae5718fea62576fc507026e1c905bc0a0fe9a87a91b014a1ea096b65"
+checksum = "c1256d24d66594cd11f5e7ed12fde994b23c6fadc5df5f05a1a18b28c5fc7239"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5803,9 +5785,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "0.160.7"
+version = "0.160.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e605159ad3081d886f24764f93fc41b2375efd66f03ef552321d28ef9fda04"
+checksum = "d2889e2f72fbb67d41fc12a5103a4454412e52ae685524e677f9216e6284eaa0"
 dependencies = [
  "ahash",
  "arrayvec 0.7.2",
@@ -5839,9 +5821,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.123.5"
+version = "0.123.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36e1f25619baa61f14bf19fcdf71b2608ff8e1ddfc3049c568d77be156db147d"
+checksum = "da6b8e8a20fedc5fb981a78e2e4b2654b90bc6e080e0339e8bc9f8341ee11ccb"
 dependencies = [
  "either",
  "enum_kind",
@@ -5858,9 +5840,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "0.175.5"
+version = "0.175.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7016974886c7eb086b3fceaa3551db3b11d53bd39ad63f6c893bb96bdf2166a0"
+checksum = "6bb75c62a6c6dabc5a7fd3dee32a4a66953b2b8209d2ed3891d30424b2e97129"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5883,9 +5865,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_quote_macros"
-version = "0.34.5"
+version = "0.34.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81d5d4d2e0f592011f6ee75775995e4605aec31d518bfb2f52619f75e25a637b"
+checksum = "4c0d9c42ff71d11397393275c699349e08634d036776be6f61012a1018bf5691"
 dependencies = [
  "anyhow",
  "pmutil",
@@ -5913,9 +5895,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.199.5"
+version = "0.199.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f705a7f8cc9d7f40134cd6be59b2850429ae515fd3c738d3e73dd3a23edaba6"
+checksum = "11af4ad5fc187308312757dec19dce74f81c3562c43e6d236882f1d985d023c9"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -5933,9 +5915,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.112.5"
+version = "0.112.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d464e86b5273482f934142928def1e2dd9ba8ff586d04977acf28e95ee636700"
+checksum = "7d6b38b6df37d25c4dd1faa4fdf9149eb19dc493e43deacd79ac8834d5afbe65"
 dependencies = [
  "better_scoped_tls",
  "bitflags",
@@ -5956,9 +5938,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "0.101.5"
+version = "0.101.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86c6bf18a5697a23bc79ba54189f88cd98ff460c8617aabbf79fdc3a510b5040"
+checksum = "4f601b41a3d1482a03c2c560e79cef0f496adb8a9ff3eb1157511df163df4036"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -5970,9 +5952,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "0.137.5"
+version = "0.137.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac757cdaab095e162782eabf851a374ef63420c2d7551a3447c074a4476ba3f6"
+checksum = "2fcfc1420c092fb45760dd615b1f3e29499371f8188b3d88dbf85ac35b5020c9"
 dependencies = [
  "ahash",
  "arrayvec 0.7.2",
@@ -6010,9 +5992,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "0.154.5"
+version = "0.154.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84be62279b77c509a6c3daf631c6dffed698864cc49b8dbb6e667ea4905dc50b"
+checksum = "1ac2f2869576ae4859294f07cc26809a027345359b5ecd9c71eef0114a51ec96"
 dependencies = [
  "Inflector",
  "ahash",
@@ -6038,9 +6020,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.168.5"
+version = "0.168.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "594072a93c2fda207efc082495e4f51596effd551ad0656047627622ecde3faa"
+checksum = "5cc33b6d03f18066730d07615ef7317fd12ae72c814792978612dab20dc6054d"
 dependencies = [
  "ahash",
  "dashmap",
@@ -6064,9 +6046,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "0.145.5"
+version = "0.145.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e88e2d421d18256b7ffbe3e9ff4fe83d88520c18de4480ce45fd28d381e4e0"
+checksum = "44f1f8ca548616af6a2081dfe699202f5abadcc0045fc85f219ba83a5b960844"
 dependencies = [
  "either",
  "serde",
@@ -6083,9 +6065,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.156.5"
+version = "0.156.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "605af05b19558d1211834f0aae0c45cbcd2b18089395175f948bd1e7a2669739"
+checksum = "54746247c87a02c2c4006ec21502cfa9e9d72dfa897b1603a3c1b460ee2f90bf"
 dependencies = [
  "ahash",
  "base64",
@@ -6110,9 +6092,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_testing"
-version = "0.115.6"
+version = "0.115.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92b38d353a1b45949b2ce1451d6362fa429e5861cc74935a2728c5c18a82327e"
+checksum = "3a1ac71733e6a77374523d66aa3bda6fbb6e2aeda3ec3c2ab2fb3251ca1e5aea"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -6136,9 +6118,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.160.5"
+version = "0.160.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0908244d2eb1a1d649419cc2bdce8f94ec70bc40b5543140cefd2ce96145acaa"
+checksum = "964aa70be0218e8d3a89b8600818f9ba798884322b19094dfdb35a684f2728c6"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -6152,9 +6134,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_usage_analyzer"
-version = "0.1.0"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f25f82674e4eb0d47c22b571b256fe536be53caee5a3f94179261ecfe4ed7e19"
+checksum = "54e7e7291e380c3030a1340d14bdbf99da915e4b789b17e13f06a63cbd9d7646"
 dependencies = [
  "ahash",
  "indexmap",
@@ -6170,9 +6152,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.106.5"
+version = "0.106.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d350bea15d0c71c36a65af37217b32f2675e9d88cd484c11e48beaf9dd2057a"
+checksum = "a0c47371c25d2cb110d71e351376be57a718d3a64710ac79b3169ab24165c54f"
 dependencies = [
  "indexmap",
  "num_cpus",
@@ -6188,9 +6170,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.81.3"
+version = "0.81.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e4b92aa87251452508165d5e86100d35454857cd0c985a9a3bed3dd15a2eb24"
+checksum = "6fa0f5e65af0764045ef268c19d8e0f7fed27ff95c69c198427dcfd5b10685a8"
 dependencies = [
  "num-bigint",
  "swc_atoms",
@@ -6202,9 +6184,9 @@ dependencies = [
 
 [[package]]
 name = "swc_emotion"
-version = "0.28.4"
+version = "0.28.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d438e7d17d254b0dc74f407086e3dbcb76321fb7c41508c94dfc12f83c27a1d3"
+checksum = "1e915f002a846c478883a479f2cdc7c6c4d4687cdf0386d6b04119f3e76951ef"
 dependencies = [
  "base64",
  "byteorder",
@@ -6214,7 +6196,7 @@ dependencies = [
  "regex",
  "serde",
  "sourcemap",
- "swc_core 0.45.4",
+ "swc_core",
  "tracing",
 ]
 
@@ -6232,9 +6214,9 @@ dependencies = [
 
 [[package]]
 name = "swc_error_reporters"
-version = "0.13.20"
+version = "0.13.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b8dba54343538503f4e8f8110b569dcf2ac0781b0afd7a950fdc97814f14a4c"
+checksum = "035712357b19deefa23cec538f5cca48e6a799b1f37f6bf7cfbf1328f035c030"
 dependencies = [
  "anyhow",
  "miette",
@@ -6245,9 +6227,9 @@ dependencies = [
 
 [[package]]
 name = "swc_fast_graph"
-version = "0.17.20"
+version = "0.17.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42fcf78c0d5bf767a862a125184b9e3e53dfd44a78e17df1a08eefe030712cae"
+checksum = "e69603ddc8607e2ea0b8482f868c6b0f30269e790c6cea227b9ae288a35f7d04"
 dependencies = [
  "ahash",
  "indexmap",
@@ -6257,9 +6239,9 @@ dependencies = [
 
 [[package]]
 name = "swc_graph_analyzer"
-version = "0.18.21"
+version = "0.18.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "859cc82647ccec27aacc4333c7c8c4436c9f6cf0df0ab42c8e0ee2510a9144d7"
+checksum = "7f2a4ce445c1be86aa22e1be6991ff5974a8047b3e02a9a11fdeb13fdaa757bf"
 dependencies = [
  "ahash",
  "auto_impl",
@@ -6292,9 +6274,9 @@ dependencies = [
 
 [[package]]
 name = "swc_node_comments"
-version = "0.16.19"
+version = "0.16.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef09fe835c26209bad4844d4dddf74f07659dc877af38e2a1878e6532b237eaf"
+checksum = "ba3fddb25502adcfe78b4802ae3704f3d32f38412be55961034ab7361e73d943"
 dependencies = [
  "ahash",
  "dashmap",
@@ -6319,9 +6301,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_proxy"
-version = "0.23.3"
+version = "0.23.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3e86675e04908eb81ba42376166cb3bf9360b2f11b26d33ebd165f5d62a5d89"
+checksum = "dc201c805d2a36b216decc718d538c176aec96c917a513c28874e3de07070958"
 dependencies = [
  "better_scoped_tls",
  "rkyv",
@@ -6333,9 +6315,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_runner"
-version = "0.78.7"
+version = "0.81.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5108ad0a3c7c92bfb9c2f8b7c7f700a86a0128388a92f6873dba9ebdc0d47fc9"
+checksum = "4f6ed921e82207da744e99f74c5cd3fff1e42ae4d3dcb101d1c345f4aeb3c12e"
 dependencies = [
  "anyhow",
  "enumset",
@@ -6356,9 +6338,9 @@ dependencies = [
 
 [[package]]
 name = "swc_timer"
-version = "0.17.20"
+version = "0.17.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c76685d10cf9f94f69b193729830dc2e8cc8e840daa1f9bd2aada773ea6064e"
+checksum = "cec4226d8a7a27aef59a5694912f01dcc90dd2c688d07aa00a118a13eb2ea74e"
 dependencies = [
  "tracing",
 ]
@@ -6531,9 +6513,9 @@ dependencies = [
 
 [[package]]
 name = "testing"
-version = "0.31.20"
+version = "0.31.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b96c1192fef3c7f6c7962e5861c3c90982ee0cfba5a5fbb1c666ab8df4b495e"
+checksum = "fae24fe7e30a2c9774168db8ac116f0258da877c42ed02a267432c935672fef6"
 dependencies = [
  "ansi_term",
  "difference",
@@ -7325,7 +7307,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sourcemap",
- "swc_core 0.45.4",
+ "swc_core",
  "turbo-tasks",
  "turbo-tasks-build",
  "turbo-tasks-env",
@@ -7353,7 +7335,7 @@ dependencies = [
  "async-trait",
  "indexmap",
  "serde",
- "swc_core 0.45.4",
+ "swc_core",
  "turbo-tasks",
  "turbo-tasks-build",
  "turbo-tasks-fs",
@@ -7412,7 +7394,7 @@ dependencies = [
  "serde_json",
  "styled_components",
  "styled_jsx",
- "swc_core 0.45.4",
+ "swc_core",
  "swc_emotion",
  "tokio",
  "tracing",
@@ -7497,7 +7479,7 @@ dependencies = [
 name = "turbopack-swc-utils"
 version = "0.1.0"
 dependencies = [
- "swc_core 0.45.4",
+ "swc_core",
  "turbo-tasks",
  "turbo-tasks-build",
  "turbopack-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,12 +87,12 @@ opt-level = 3
 indexmap = { version = "1.9.2" }
 # Keep consistent with preset_env_base through swc_core
 browserslist-rs = { version = "0.12.2" }
-swc_core = { version = "0.45.4" }
-testing = { version = "0.31.14" }
-swc_emotion = { version = "0.28.4" }
-styled_jsx = { version = "0.29.8" }
-styled_components = { version = "0.52.8" }
-modularize_imports = { version = "0.25.8" }
-mdxjs = { version = "0.1.3" }
+swc_core = { version = "0.48.12" }
+testing = { version = "0.31.25" }
+swc_emotion = { version = "0.28.6" }
+styled_jsx = { version = "0.29.10" }
+styled_components = { version = "0.52.10" }
+modularize_imports = { version = "0.25.10" }
+mdxjs = { version = "0.1.4" }
 next-dev = { path = "crates/next-dev", version = "0.1.0" }
 node-file-trace = { path = "crates/node-file-trace", version = "0.1.0" }

--- a/crates/turbopack-css/src/references/import.rs
+++ b/crates/turbopack-css/src/references/import.rs
@@ -47,7 +47,7 @@ impl ImportAttributes {
                 assert_eq!(f.value.len(), 1);
                 assert!(matches!(&f.value[0], ComponentValue::LayerName(_)));
                 if let ComponentValue::LayerName(layer_name) = &f.value[0] {
-                    layer_name.clone()
+                    *layer_name.clone()
                 } else {
                     unreachable!()
                 }
@@ -68,12 +68,12 @@ impl ImportAttributes {
 
                     if let Some(supports) = v {
                         match &supports {
-                            ComponentValue::SupportsCondition(s) => Some(s.clone()),
+                            ComponentValue::SupportsCondition(s) => Some(*s.clone()),
                             ComponentValue::Declaration(d) => Some(SupportsCondition {
                                 span: DUMMY_SP,
                                 conditions: vec![SupportsConditionType::SupportsInParens(
                                     SupportsInParens::Feature(SupportsFeature::Declaration(
-                                        Box::new(d.clone()),
+                                        d.clone(),
                                     )),
                                 )],
                             }),
@@ -110,10 +110,12 @@ impl ImportAttributes {
         // something random that's never gonna be in real css
         let mut rule = Rule::ListOfComponentValues(box ListOfComponentValues {
             span: DUMMY_SP,
-            children: vec![ComponentValue::PreservedToken(token(Token::String {
-                value: Default::default(),
-                raw: r#""""__turbopack_placeholder__""""#.into(),
-            }))],
+            children: vec![ComponentValue::PreservedToken(Box::new(token(
+                Token::String {
+                    value: Default::default(),
+                    raw: r#""""__turbopack_placeholder__""""#.into(),
+                },
+            )))],
         });
 
         fn at_rule(name: &str, prelude: AtRulePrelude, inner_rule: Rule) -> Rule {
@@ -128,7 +130,7 @@ impl ImportAttributes {
                 block: Some(SimpleBlock {
                     span: DUMMY_SP,
                     name: token(Token::LBrace),
-                    value: vec![ComponentValue::Rule(inner_rule)],
+                    value: vec![ComponentValue::from(inner_rule)],
                 }),
             })
         }

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/declarations/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/declarations/graph.snapshot
@@ -79,7 +79,7 @@
         "dd",
         Variable(
             (
-                Atom('d' type=inline),
+                Atom('d' type=static),
                 #1,
             ),
         ),

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/fn-array-2/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/fn-array-2/graph.snapshot
@@ -75,7 +75,7 @@
             3,
             Variable(
                 (
-                    Atom('d' type=inline),
+                    Atom('d' type=static),
                     #1,
                 ),
             ),
@@ -94,7 +94,7 @@
             3,
             Variable(
                 (
-                    Atom('d' type=inline),
+                    Atom('d' type=static),
                     #1,
                 ),
             ),

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/fn-array/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/fn-array/graph.snapshot
@@ -75,7 +75,7 @@
             3,
             Variable(
                 (
-                    Atom('d' type=inline),
+                    Atom('d' type=static),
                     #1,
                 ),
             ),
@@ -94,7 +94,7 @@
             3,
             Variable(
                 (
-                    Atom('d' type=inline),
+                    Atom('d' type=static),
                     #1,
                 ),
             ),

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/iife/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/iife/graph.snapshot
@@ -36,7 +36,7 @@
         "e",
         Variable(
             (
-                Atom('d' type=inline),
+                Atom('d' type=static),
                 #4,
             ),
         ),

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/md5-reduced/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/md5-reduced/graph.snapshot
@@ -40,7 +40,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #2,
                             ),
                         ),
@@ -101,7 +101,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #2,
                             ),
                         ),
@@ -174,7 +174,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #2,
                             ),
                         ),
@@ -250,7 +250,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #2,
                             ),
                         ),
@@ -344,7 +344,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #2,
                             ),
                         ),
@@ -417,7 +417,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #2,
                             ),
                         ),
@@ -490,7 +490,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #2,
                             ),
                         ),
@@ -563,7 +563,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #2,
                             ),
                         ),
@@ -657,7 +657,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #2,
                             ),
                         ),
@@ -733,7 +733,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #2,
                             ),
                         ),
@@ -806,7 +806,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #2,
                             ),
                         ),
@@ -879,7 +879,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #2,
                             ),
                         ),
@@ -967,7 +967,7 @@
                     [
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #2,
                             ),
                         ),
@@ -1040,7 +1040,7 @@
                     [
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #2,
                             ),
                         ),
@@ -1116,7 +1116,7 @@
                     [
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #2,
                             ),
                         ),
@@ -1189,7 +1189,7 @@
                     [
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #2,
                             ),
                         ),
@@ -1528,7 +1528,7 @@
                 ),
                 Variable(
                     (
-                        Atom('d' type=inline),
+                        Atom('d' type=static),
                         #2,
                     ),
                 ),
@@ -1592,7 +1592,7 @@
                     ),
                     Variable(
                         (
-                            Atom('d' type=inline),
+                            Atom('d' type=static),
                             #2,
                         ),
                     ),

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/md5/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/md5/graph.snapshot
@@ -64,7 +64,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -125,7 +125,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -198,7 +198,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -274,7 +274,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -350,7 +350,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -423,7 +423,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -496,7 +496,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -572,7 +572,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -645,7 +645,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -718,7 +718,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -791,7 +791,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -867,7 +867,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -940,7 +940,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -1001,7 +1001,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -1077,7 +1077,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -1153,7 +1153,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -1285,7 +1285,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -1358,7 +1358,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -1431,7 +1431,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -1504,7 +1504,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -1580,7 +1580,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -1641,7 +1641,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -1714,7 +1714,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -1790,7 +1790,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -1863,7 +1863,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -1936,7 +1936,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -2009,7 +2009,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -2085,7 +2085,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -2158,7 +2158,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -2231,7 +2231,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -2304,7 +2304,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -2380,7 +2380,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -2549,7 +2549,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -2625,7 +2625,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -2698,7 +2698,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -2771,7 +2771,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -2844,7 +2844,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -2920,7 +2920,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -2993,7 +2993,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -3066,7 +3066,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -3142,7 +3142,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -3218,7 +3218,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -3291,7 +3291,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -3364,7 +3364,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -3440,7 +3440,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -3513,7 +3513,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -3586,7 +3586,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -3659,7 +3659,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -3797,7 +3797,7 @@
                     [
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -3870,7 +3870,7 @@
                     [
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -3946,7 +3946,7 @@
                     [
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -4019,7 +4019,7 @@
                     [
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -4092,7 +4092,7 @@
                     [
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -4165,7 +4165,7 @@
                     [
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -4241,7 +4241,7 @@
                     [
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -4314,7 +4314,7 @@
                     [
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -4387,7 +4387,7 @@
                     [
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -4460,7 +4460,7 @@
                     [
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -4536,7 +4536,7 @@
                     [
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -4597,7 +4597,7 @@
                     [
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -4670,7 +4670,7 @@
                     [
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -4746,7 +4746,7 @@
                     [
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -4819,7 +4819,7 @@
                     [
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -4892,7 +4892,7 @@
                     [
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -4965,7 +4965,7 @@
                     [
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #5,
                             ),
                         ),
@@ -5715,7 +5715,7 @@
                 ),
                 Variable(
                     (
-                        Atom('d' type=inline),
+                        Atom('d' type=static),
                         #5,
                     ),
                 ),
@@ -5839,7 +5839,7 @@
                     ),
                     Variable(
                         (
-                            Atom('d' type=inline),
+                            Atom('d' type=static),
                             #5,
                         ),
                     ),

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/md5_2/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/md5_2/graph.snapshot
@@ -40,7 +40,7 @@
                             ),
                             Variable(
                                 (
-                                    Atom('d' type=inline),
+                                    Atom('d' type=static),
                                     #3,
                                 ),
                             ),
@@ -304,7 +304,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -377,7 +377,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -450,7 +450,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -526,7 +526,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -602,7 +602,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -675,7 +675,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -748,7 +748,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -824,7 +824,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -897,7 +897,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -970,7 +970,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -1043,7 +1043,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -1119,7 +1119,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -1192,7 +1192,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -1265,7 +1265,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -1341,7 +1341,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -1417,7 +1417,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -1533,7 +1533,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -1606,7 +1606,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -1679,7 +1679,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -1752,7 +1752,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -1828,7 +1828,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -1901,7 +1901,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -1974,7 +1974,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -2050,7 +2050,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -2123,7 +2123,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -2196,7 +2196,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -2269,7 +2269,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -2345,7 +2345,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -2418,7 +2418,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -2491,7 +2491,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -2564,7 +2564,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -2640,7 +2640,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -2776,7 +2776,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -2852,7 +2852,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -2925,7 +2925,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -2998,7 +2998,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -3071,7 +3071,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -3147,7 +3147,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -3220,7 +3220,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -3293,7 +3293,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -3369,7 +3369,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -3445,7 +3445,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -3518,7 +3518,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -3591,7 +3591,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -3667,7 +3667,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -3740,7 +3740,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -3813,7 +3813,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -3886,7 +3886,7 @@
                         ),
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -4020,7 +4020,7 @@
                     [
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -4093,7 +4093,7 @@
                     [
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -4169,7 +4169,7 @@
                     [
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -4242,7 +4242,7 @@
                     [
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -4315,7 +4315,7 @@
                     [
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -4388,7 +4388,7 @@
                     [
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -4464,7 +4464,7 @@
                     [
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -4537,7 +4537,7 @@
                     [
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -4610,7 +4610,7 @@
                     [
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -4683,7 +4683,7 @@
                     [
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -4759,7 +4759,7 @@
                     [
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -4832,7 +4832,7 @@
                     [
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -4905,7 +4905,7 @@
                     [
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -4981,7 +4981,7 @@
                     [
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -5054,7 +5054,7 @@
                     [
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -5127,7 +5127,7 @@
                     [
                         Variable(
                             (
-                                Atom('d' type=inline),
+                                Atom('d' type=static),
                                 #3,
                             ),
                         ),
@@ -5224,7 +5224,7 @@
         "dd",
         Variable(
             (
-                Atom('d' type=inline),
+                Atom('d' type=static),
                 #3,
             ),
         ),
@@ -5409,7 +5409,7 @@
                         ),
                         Constant(
                             StrWord(
-                                Atom('slice' type=inline),
+                                Atom('slice' type=static),
                             ),
                         ),
                     ),

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/nested/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/nested/graph.snapshot
@@ -215,7 +215,7 @@
         "z#5",
         Variable(
             (
-                Atom('d' type=inline),
+                Atom('d' type=static),
                 #1,
             ),
         ),
@@ -224,7 +224,7 @@
         "z#6",
         Variable(
             (
-                Atom('d' type=inline),
+                Atom('d' type=static),
                 #1,
             ),
         ),

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/object/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/object/graph.snapshot
@@ -317,7 +317,7 @@
             ),
             Constant(
                 StrWord(
-                    Atom('d' type=inline),
+                    Atom('d' type=static),
                 ),
             ),
         ),
@@ -334,7 +334,7 @@
             ),
             Constant(
                 StrWord(
-                    Atom('d' type=inline),
+                    Atom('d' type=static),
                 ),
             ),
         ),
@@ -351,7 +351,7 @@
             ),
             Constant(
                 StrWord(
-                    Atom('d' type=inline),
+                    Atom('d' type=static),
                 ),
             ),
         ),
@@ -368,7 +368,7 @@
             ),
             Constant(
                 StrWord(
-                    Atom('d' type=inline),
+                    Atom('d' type=static),
                 ),
             ),
         ),
@@ -385,7 +385,7 @@
             ),
             Constant(
                 StrWord(
-                    Atom('d' type=inline),
+                    Atom('d' type=static),
                 ),
             ),
         ),

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/peg/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/peg/graph.snapshot
@@ -689,12 +689,12 @@
                     KeyValue(
                         Constant(
                             StrWord(
-                                Atom('alternate' type=dynamic),
+                                Atom('alternate' type=static),
                             ),
                         ),
                         Variable(
                             (
-                                Atom('alternate' type=dynamic),
+                                Atom('alternate' type=static),
                                 #63,
                             ),
                         ),
@@ -816,12 +816,12 @@
                     KeyValue(
                         Constant(
                             StrWord(
-                                Atom('begin' type=inline),
+                                Atom('begin' type=static),
                             ),
                         ),
                         Variable(
                             (
-                                Atom('begin' type=inline),
+                                Atom('begin' type=static),
                                 #66,
                             ),
                         ),
@@ -1844,12 +1844,12 @@
                     KeyValue(
                         Constant(
                             StrWord(
-                                Atom('order' type=inline),
+                                Atom('order' type=static),
                             ),
                         ),
                         Variable(
                             (
-                                Atom('order' type=inline),
+                                Atom('order' type=static),
                                 #39,
                             ),
                         ),
@@ -6901,7 +6901,7 @@
         "peg$c75",
         Constant(
             StrWord(
-                Atom('order' type=inline),
+                Atom('order' type=static),
             ),
         ),
     ),


### PR DESCRIPTION
Implement / fixes WEB-308

Bumps up all of swc_core* transitive deps, and update test fixtures with latest updates.