### PR TITLE
chore(editor): do not display successful auto task terminal output

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,18 +2,26 @@
   "version": "2.0.0",
   "tasks": [
     {
-      "runOptions": { "runOn": "folderOpen" },
+      "runOptions": {
+        "runOn": "folderOpen"
+      },
       "label": "Compile protobufs",
       "type": "shell",
       "options": {
         "cwd": "${workspaceRoot}/cli"
+      },
+      "presentation": {
+        "reveal": "silent"
       },
       "command": "make compile-protos"
     },
     {
       "type": "shell",
       "label": "prepare e2e",
-      "dependsOn": ["make turbo", "make install"]
+      "dependsOn": [
+        "make turbo",
+        "make install"
+      ]
     },
     {
       "type": "shell",


### PR DESCRIPTION
There is an auto task in our vscode task config, which opens up terminal every time. Changing options to not to open terminal by default if there aren't any failures.