### PR TITLE
feat(turbo-updater): only request latest for now

### DIFF
--- a/crates/turbo-updater/src/lib.rs
+++ b/crates/turbo-updater/src/lib.rs
@@ -10,8 +10,8 @@ mod ui;
 
 // 800ms
 const DEFAULT_TIMEOUT: Duration = Duration::from_millis(800);
-// 1 day
-const DEFAULT_INTERVAL: Duration = Duration::from_secs(60 * 60 * 24);
+// 6 hours
+const DEFAULT_INTERVAL: Duration = Duration::from_secs(60 * 60 * 6);
 
 const NOTIFIER_DISABLE_VARS: [&str; 2] = ["NO_UPDATE_NOTIFIER", "TURBO_NO_UPDATE_NOTIFIER"];
 const ENVIRONMENTAL_DISABLE_VARS: [&str; 1] = ["CI"];
@@ -33,20 +33,14 @@ impl Registry for NPMRegistry {
     const NAME: &'static str = "npm_registry";
     fn get_latest_version(
         pkg: &Package,
-        version: &Version,
+        _version: &Version,
         timeout: Duration,
     ) -> UpdateResult<Option<String>> {
-        // determine tag to request
-        let tag = match &version.get().pre {
-            t if t.contains("canary") => "canary",
-            t if t.contains("next") => "next",
-            _ => "latest",
-        };
-
+        // TODO: request by tag when update_informer supports storing multiple versions
+        // per package
         let url = format!(
-            "https://turbo.build/api/binaries/version?name={name}&tag={tag}",
-            name = pkg,
-            tag = tag
+            "https://turbo.build/api/binaries/version?name={name}",
+            name = pkg
         );
         let resp = ureq::get(&url).timeout(timeout).call()?;
         let result = resp.into_json::<NpmVersionData>().unwrap();

--- a/crates/turborepo-lib/src/shim.rs
+++ b/crates/turborepo-lib/src/shim.rs
@@ -309,7 +309,7 @@ pub fn run() -> Result<Payload> {
             "https://github.com/vercel/turbo",
             Some(&footer),
             get_version(),
-            // use defaults for timeout and refresh interval (800ms and 1 day respectively)
+            // use defaults for timeout and refresh interval (800ms and 6 hours respectively)
             None,
             None,
         );


### PR DESCRIPTION
Right now, update_informer does not support caching the correct version per tag. There's only one file right now that is storing the latest known version, so if a canary version makes it way in there (if you ran with a canary first, or if you were running a canary when the interval expired and it refetched latest) then that's going to be the latest for all other versions until the interval expires and we reach out to the registry again. 

We need to update this on the update-informer side, but for now I think we should yank updates per tag, stick with latest only, and drop our interval to 6 hours (implemented in this PR)

This will guarantee that the only users who will see this update notification incorrectly are users who have both 1.7.0-canary.x and 1.7.0. AND they run 1.7.0-canary.x first, and then go back to running  1.7.0. Even if this does occur, it would auto fix in 6 hours when the first check to the registry goes out and we return and store the real latest version. 