### PR TITLE
fix: expand semver for skip infer flag

### DIFF
--- a/crates/turborepo-lib/src/shim.rs
+++ b/crates/turborepo-lib/src/shim.rs
@@ -29,6 +29,8 @@ static TURBO_PURE_OUTPUT_ARGS: [&str; 6] = [
     "--dry-run=json",
 ];
 
+static SUPPORTS_SKIP_INFER_SEMVER: &str = ">=1.7.0-canary.0";
+
 #[derive(Debug)]
 struct ShimArgs {
     cwd: PathBuf,
@@ -236,7 +238,7 @@ impl RepoState {
         let package_json: PackageJson =
             serde_json::from_reader(File::open(local_turbo_package_path)?)?;
         let version = Version::from_str(&package_json.version)?;
-        let skip_infer_versions = VersionReq::parse(">=1.7.0").unwrap();
+        let skip_infer_versions = VersionReq::parse(SUPPORTS_SKIP_INFER_SEMVER).unwrap();
         Ok(skip_infer_versions.matches(&version))
     }
 
@@ -336,5 +338,23 @@ pub fn run() -> Result<Payload> {
             eprintln!("Running command as global turbo");
             cli::run(None)
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_skip_infer_version_constraint() {
+        let req = VersionReq::parse(SUPPORTS_SKIP_INFER_SEMVER).unwrap();
+        let canary = Version::parse("1.7.0-canary.0").unwrap();
+        let release = Version::parse("1.7.0").unwrap();
+        let old = Version::parse("1.6.3").unwrap();
+        let new = Version::parse("1.8.0").unwrap();
+        assert!(req.matches(&release));
+        assert!(req.matches(&canary));
+        assert!(req.matches(&new));
+        assert!(!req.matches(&old));
     }
 }


### PR DESCRIPTION
We're currently too restrictive with the semver as `>=1.7.0` doesn't include canaries of 1.7.0. This relaxes that constraint and adds tests to make sure it's correct now.