### PR TITLE
fix: add support for --skip-infer

### DIFF
--- a/cli/integration_tests/global_turbo/uses_global.t
+++ b/cli/integration_tests/global_turbo/uses_global.t
@@ -1,0 +1,6 @@
+Setup
+  $ . ${TESTDIR}/../setup.sh
+
+When --skip-infer is used we use the current binary and output no global/local message
+  $ ${TURBO} --skip-infer --help | head -n 1
+  The build system that makes ship happen

--- a/cli/integration_tests/no_args.t
+++ b/cli/integration_tests/no_args.t
@@ -22,6 +22,7 @@ Make sure exit code is 2 when no args are passed
   
   Options:
         --version                    
+        --skip-infer                 Skip any attempts to infer which version of Turbo the project is configured to use
         --api <API>                  Override the endpoint for API calls
         --color                      Force color usage in the terminal
         --cpu-profile <CPU_PROFILE>  Specify a file to save a cpu profile

--- a/cli/integration_tests/turbo_help.t
+++ b/cli/integration_tests/turbo_help.t
@@ -22,6 +22,7 @@ Test help flag
   
   Options:
         --version                    
+        --skip-infer                 Skip any attempts to infer which version of Turbo the project is configured to use
         --api <API>                  Override the endpoint for API calls
         --color                      Force color usage in the terminal
         --cpu-profile <CPU_PROFILE>  Specify a file to save a cpu profile
@@ -84,6 +85,7 @@ Test help flag
   
   Options:
         --version                    
+        --skip-infer                 Skip any attempts to infer which version of Turbo the project is configured to use
         --api <API>                  Override the endpoint for API calls
         --color                      Force color usage in the terminal
         --cpu-profile <CPU_PROFILE>  Specify a file to save a cpu profile
@@ -132,6 +134,7 @@ Test help flag for link command
   Options:
         --no-gitignore               Do not create or modify .gitignore (default false)
         --version                    
+        --skip-infer                 Skip any attempts to infer which version of Turbo the project is configured to use
         --api <API>                  Override the endpoint for API calls
         --color                      Force color usage in the terminal
         --cpu-profile <CPU_PROFILE>  Specify a file to save a cpu profile
@@ -159,6 +162,7 @@ Test help flag for unlink command
   
   Options:
         --version                    
+        --skip-infer                 Skip any attempts to infer which version of Turbo the project is configured to use
         --api <API>                  Override the endpoint for API calls
         --color                      Force color usage in the terminal
         --cpu-profile <CPU_PROFILE>  Specify a file to save a cpu profile
@@ -187,6 +191,7 @@ Test help flag for login command
   Options:
         --sso-team <SSO_TEAM>        
         --version                    
+        --skip-infer                 Skip any attempts to infer which version of Turbo the project is configured to use
         --api <API>                  Override the endpoint for API calls
         --color                      Force color usage in the terminal
         --cpu-profile <CPU_PROFILE>  Specify a file to save a cpu profile
@@ -214,6 +219,7 @@ Test help flag for logout command
   
   Options:
         --version                    
+        --skip-infer                 Skip any attempts to infer which version of Turbo the project is configured to use
         --api <API>                  Override the endpoint for API calls
         --color                      Force color usage in the terminal
         --cpu-profile <CPU_PROFILE>  Specify a file to save a cpu profile

--- a/crates/turborepo-lib/src/cli.rs
+++ b/crates/turborepo-lib/src/cli.rs
@@ -48,6 +48,11 @@ pub enum DryRunMode {
 pub struct Args {
     #[clap(long, global = true)]
     pub version: bool,
+    #[clap(long, global = true)]
+    #[serde(skip)]
+    /// Skip any attempts to infer which version of Turbo the project is
+    /// configured to use
+    pub skip_infer: bool,
     /// Override the endpoint for API calls
     #[clap(long, global = true, value_parser)]
     pub api: Option<String>,


### PR DESCRIPTION
Somehow we didn't support parsing `--skip-infer`, the shim parser would allow it, but the actual parser didn't.