### PR TITLE
fix: use --skip-infer during install

### DIFF
--- a/packages/turbo/install.js
+++ b/packages/turbo/install.js
@@ -21,6 +21,8 @@ let isToPathJS = true;
 
 function validateBinaryVersion(...command) {
   command.push("--version");
+  // Make sure that we get the version of the binary that was just installed
+  command.push("--skip-infer");
   const stdout = child_process
     .execFileSync(command.shift(), command, {
       // Without this, this install script strangely crashes with the error


### PR DESCRIPTION
I think this should fix the install errors with the current canary since the repo inference is having trouble when being run inside of `node_modules/turbo`.

This should be valid for all installs going forward as we now support `--skip-infer`. Any previous versions that don't support it will use the old install script.