### PR TITLE
fix: invalid json in integration test

### DIFF
--- a/cli/integration_tests/global_turbo/repo_with_local/package.json
+++ b/cli/integration_tests/global_turbo/repo_with_local/package.json
@@ -1,4 +1,4 @@
 {
   "name": "test-turbo-project",
-  "version" "0.0.1"
+  "version": "0.0.1"
 }


### PR DESCRIPTION
I committed some invalid JSON in #3011 as the node linter doesn't run on json changes. I'll put up another PR fixing that, but I just wanted to get this out since it's making all PR's that change JS red.