### PR TITLE
fix: normalize current directory to non-UNC path on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1697,6 +1697,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03d8c417d7a8cb362e0c37e5d815f5eb7c37f79ff93707329d5a194e42e54ca0"
 
 [[package]]
+name = "dunce"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bd4b30a6560bbd9b4620f4de34c3f14f60848e58a9b7216801afcb4c7b31c3c"
+
+[[package]]
 name = "dwrote"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7554,6 +7560,7 @@ dependencies = [
  "assert_cmd",
  "clap 4.0.29",
  "clap_complete",
+ "dunce",
  "itertools",
  "predicates",
  "pretty_assertions",

--- a/crates/turborepo-lib/Cargo.toml
+++ b/crates/turborepo-lib/Cargo.toml
@@ -14,6 +14,7 @@ pretty_assertions = "1.3.0"
 anyhow = { version = "1.0.65", features = ["backtrace"] }
 clap = { version = "4.0.22", features = ["derive"] }
 clap_complete = "4.0.6"
+dunce = "1.0"
 predicates = "2.1.1"
 semver = "1.0"
 serde = { version = "1.0.145", features = ["derive"] }

--- a/crates/turborepo-lib/src/shim.rs
+++ b/crates/turborepo-lib/src/shim.rs
@@ -222,7 +222,7 @@ impl RepoState {
         if should_run_current_turbo(&local_turbo_path)? {
             cli::run(Some(self))
         } else {
-            let canonical_local_turbo = local_turbo_path.canonicalize()?;
+            let canonical_local_turbo = fs_canonicalize(&local_turbo_path)?;
             // Otherwise we spawn the local turbo process.
             Ok(Payload::Rust(
                 self.spawn_local_turbo(&canonical_local_turbo, shim_args),


### PR DESCRIPTION
The Windows kernel normalizes paths by converting them to UNC, but silly things like starting a process with a working directory given as a UNC path don't work on Windows:
```
'\\?\C:\Users\Chris\Documents\code\junk\yarn-test'
CMD.EXE was started with the above path as the current directory.
UNC paths are not supported.  Defaulting to Windows directory.
```

This PR uses `dunce` when normalizing paths on windows so we produce non-UNC paths which are better supported by the Windows ecosystem.