### PR TITLE
fix(release): build ubuntu in xenial for GLIBC

### DIFF
--- a/.github/workflows/build_rust.yml
+++ b/.github/workflows/build_rust.yml
@@ -27,19 +27,26 @@ jobs:
             lib-cache-key: turbo-lib-cross-${{ inputs.release_branch }}
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian
           - host: ubuntu-latest
+            container: ubuntu:xenial
+            container-setup: "apt-get update && apt-get install -y curl"
             target: "aarch64-unknown-linux-gnu"
             lib-cache-key: turbo-lib-cross-${{ inputs.release_branch }}
             rustflags: 'RUSTFLAGS="-C linker=aarch64-linux-gnu-gcc"'
-            setup: "sudo apt-get update && sudo apt-get install -y gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu"
+            setup: "apt-get install -y build-essential clang-5.0 lldb-5.0 llvm-5.0-dev libclang-5.0-dev gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu"
           - host: windows-latest
             target: x86_64-pc-windows-gnu
             lib-cache-key: turbo-lib-cross-${{ inputs.release_branch }}
             setup: "mv cli/libturbo/turbo-windows_windows_amd64_v1/lib/turbo.exe cli/libturbo/turbo-windows_windows_amd64_v1/lib/libturbo.a && mv cli/libturbo/turbo-windows_windows_amd64_v1/lib/turbo.h cli/libturbo/turbo-windows_windows_amd64_v1/lib/libturbo.h && rustup set default-host x86_64-pc-windows-gnu"
     runs-on: ${{ matrix.settings.host }}
+    container: ${{ matrix.settings.container }}
     steps:
       - uses: actions/checkout@v3
         with:
           ref: "${{ inputs.release_branch }}"
+
+      - name: Setup Container
+        if: ${{ matrix.settings.container-setup }}
+        run: ${{ matrix.settings.container-setup }}
 
       - name: Install
         uses: actions-rs/toolchain@v1


### PR DESCRIPTION
Fixes an issue with our release process where we need to build the Rust binary for Ubuntu in an environment with an old version of GLIBC because Rust dynamically links to it. So if we build in an environment with a new version, it will fail when run on older systems (for example - the binary we build on ubuntu latest in github actions (2.35) fails on Vercel (2.26), and on ubuntu 18 because of GLIBC differences