### PR TITLE
fix(release): add placeholder options

### DIFF
--- a/.github/workflows/build_rust.yml
+++ b/.github/workflows/build_rust.yml
@@ -19,9 +19,11 @@ jobs:
           - host: macos-latest
             target: "x86_64-apple-darwin"
             lib-cache-key: turbo-lib-darwin-${{ inputs.release_branch }}
+            container-options: "--rm"
           - host: macos-latest
             target: "aarch64-apple-darwin"
             lib-cache-key: turbo-lib-darwin-${{ inputs.release_branch }}
+            container-options: "--rm"
           - host: ubuntu-latest
             container: ubuntu:xenial
             container-options: "--platform=linux/amd64 --rm"
@@ -41,6 +43,7 @@ jobs:
             target: x86_64-pc-windows-gnu
             lib-cache-key: turbo-lib-cross-${{ inputs.release_branch }}
             setup: "mv cli/libturbo/turbo-windows_windows_amd64_v1/lib/turbo.exe cli/libturbo/turbo-windows_windows_amd64_v1/lib/libturbo.a && mv cli/libturbo/turbo-windows_windows_amd64_v1/lib/turbo.h cli/libturbo/turbo-windows_windows_amd64_v1/lib/libturbo.h && rustup set default-host x86_64-pc-windows-gnu"
+            container-options: "--rm"
     runs-on: ${{ matrix.settings.host }}
     container:
       image: ${{ matrix.settings.container }}


### PR DESCRIPTION
This is a hack for the items in the matrix that don't run in a container. You can specify a blank image, but not blank options. 

We should split this out into two runs in a follow up, those that need a container and those that don't.

Priority now is getting the release out