### PR TITLE
Fix source map tracing for HMR updates

### DIFF
--- a/crates/next-dev/src/turbo_tasks_viz.rs
+++ b/crates/next-dev/src/turbo_tasks_viz.rs
@@ -1,7 +1,7 @@
-use std::{str::FromStr, sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration};
 
 use anyhow::Result;
-use mime::Mime;
+use mime::TEXT_HTML_UTF_8;
 use turbo_tasks::{get_invalidator, TurboTasks, TurboTasksBackendApi, Value};
 use turbo_tasks_fs::File;
 use turbo_tasks_memory::{
@@ -115,10 +115,7 @@ impl ContentSource for TurboTasksSource {
         };
         Ok(ContentSourceResultVc::exact(
             ContentSourceContent::Static(
-                AssetContentVc::from(
-                    File::from(html).with_content_type(Mime::from_str("text/html")?),
-                )
-                .into(),
+                AssetContentVc::from(File::from(html).with_content_type(TEXT_HTML_UTF_8)).into(),
             )
             .cell(),
         ))

--- a/crates/turbopack-core/src/source_map.rs
+++ b/crates/turbopack-core/src/source_map.rs
@@ -179,6 +179,8 @@ impl SourceMapVc {
         let token = match &*self.await? {
             SourceMap::Regular(map) => map
                 .lookup_token(line as u32, column as u32)
+                // The sourcemap crate incorrectly returns a previous line's token when there's
+                // not a match on this line.
                 .filter(|t| t.get_dst_line() == line as u32)
                 .map(Token::from),
 
@@ -205,10 +207,10 @@ impl SourceMapVc {
                 if low > 0 && low <= len {
                     let SourceMapSection { map, offset } = &map.sections[low - 1];
                     // We're looking for the position `l` lines into region covered by this
-                    // sourcemap s section.
+                    // sourcemap's section.
                     let l = line - offset.line;
-                    // The source map starts if offset by the column only on its first line. On
-                    // the 2nd+ line, the section covers starting at column 0.
+                    // The source map starts offset by the section's column only on its first line.
+                    // On the 2nd+ line, the source map covers starting at column 0.
                     let c = if line == offset.line {
                         column - offset.column
                     } else {

--- a/crates/turbopack-core/src/source_map.rs
+++ b/crates/turbopack-core/src/source_map.rs
@@ -180,7 +180,7 @@ impl SourceMapVc {
             SourceMap::Regular(map) => map
                 .lookup_token(line as u32, column as u32)
                 .filter(|t| t.get_dst_line() == line as u32)
-                .map(From::from),
+                .map(Token::from),
 
             SourceMap::Sectioned(map) => {
                 let len = map.sections.len();

--- a/crates/turbopack-ecmascript/js/src/runtime.js
+++ b/crates/turbopack-ecmascript/js/src/runtime.js
@@ -510,9 +510,9 @@
    * @returns {ModuleFactory}
    * @private
    */
-  function _eval(factory) {
-    let code = factory.code;
-    if (factory.map) code += `\n\n//# sourceMappingURL=${factory.map}`;
+  function _eval({ code, url, map }) {
+    code += `\n\n//# sourceURL=${location.origin}${url}`;
+    if (map) code += `\n//# sourceMappingURL=${map}`;
     return eval(code);
   }
 

--- a/crates/turbopack-ecmascript/js/types/protocol.d.ts
+++ b/crates/turbopack-ecmascript/js/types/protocol.d.ts
@@ -30,6 +30,7 @@ export type EcmascriptChunkUpdate = {
 
 export type HmrUpdateEntry = {
   code: ModuleFactoryString;
+  url: string,
   map?: string;
 };
 

--- a/crates/turbopack-ecmascript/js/types/protocol.d.ts
+++ b/crates/turbopack-ecmascript/js/types/protocol.d.ts
@@ -30,7 +30,7 @@ export type EcmascriptChunkUpdate = {
 
 export type HmrUpdateEntry = {
   code: ModuleFactoryString;
-  url: string,
+  url: string;
   map?: string;
 };
 

--- a/crates/turbopack-ecmascript/src/chunk/mod.rs
+++ b/crates/turbopack-ecmascript/src/chunk/mod.rs
@@ -760,6 +760,7 @@ impl GenerateSourceMap for EcmascriptChunkContent {
 #[derive(serde::Serialize)]
 struct HmrUpdateEntry<'a> {
     code: &'a Rope,
+    url: String,
     map: Option<String>,
 }
 
@@ -770,15 +771,14 @@ impl<'a> HmrUpdateEntry<'a> {
         struct Id<'a> {
             id: &'a ModuleId,
         }
+        let id = serde_qs::to_string(&Id { id: &entry.id }).unwrap();
         HmrUpdateEntry {
             code: entry.source_code(),
-            map: entry.code.has_source_map().then(|| {
-                format!(
-                    "/__turbopack_sourcemap__/{}.map?{}",
-                    chunk_path,
-                    serde_qs::to_string(&Id { id: &entry.id }).unwrap()
-                )
-            }),
+            url: format!("/{}?{}", chunk_path, &id),
+            map: entry
+                .code
+                .has_source_map()
+                .then(|| format!("/__turbopack_sourcemap__/{}.map?{}", chunk_path, &id)),
         }
     }
 }

--- a/crates/turbopack-node/src/source_map/trace.rs
+++ b/crates/turbopack-node/src/source_map/trace.rs
@@ -1,6 +1,7 @@
 use std::fmt::Display;
 
 use anyhow::Result;
+use mime::APPLICATION_JAVASCRIPT_UTF_8;
 use serde_json::json;
 use turbo_tasks_fs::File;
 use turbopack_core::{
@@ -141,8 +142,7 @@ impl SourceMapTraceVc {
             })
             .to_string(),
         };
-        let mut file = File::from(result);
-        file = file.with_content_type("application/json".parse().unwrap());
+        let file = File::from(result).with_content_type(APPLICATION_JAVASCRIPT_UTF_8);
         Ok(file.into())
     }
 }

--- a/crates/turbopack-node/src/source_map/trace.rs
+++ b/crates/turbopack-node/src/source_map/trace.rs
@@ -111,13 +111,13 @@ impl SourceMapTraceVc {
 
         let token = this
             .map
-            .lookup_token(this.line.saturating_sub(1), this.column)
+            .lookup_token(this.line.saturating_sub(1), this.column.saturating_sub(1))
             .await?;
         let result = match &*token {
             Some(Token::Original(t)) => TraceResult::Found(StackFrame {
                 file: t.original_file.clone(),
                 line: Some(t.original_line.saturating_add(1)),
-                column: Some(t.original_column),
+                column: Some(t.original_column.saturating_add(1)),
                 name: t.name.clone().or_else(|| this.name.clone()),
             }),
             _ => TraceResult::NotFound,
@@ -141,6 +141,8 @@ impl SourceMapTraceVc {
             })
             .to_string(),
         };
-        Ok(File::from(result).into())
+        let mut file = File::from(result);
+        file = file.with_content_type("application/json".parse().unwrap());
+        Ok(file.into())
     }
 }

--- a/crates/turbopack-tests/tests/snapshot/basic/async_chunk/output/crates_turbopack-tests_tests_snapshot_basic_async_chunk_input_index_9be35c.js
+++ b/crates/turbopack-tests/tests/snapshot/basic/async_chunk/output/crates_turbopack-tests_tests_snapshot_basic_async_chunk_input_index_9be35c.js
@@ -532,9 +532,9 @@ __turbopack_export_value__((__turbopack_import__) => {
    * @returns {ModuleFactory}
    * @private
    */
-  function _eval(factory) {
-    let code = factory.code;
-    if (factory.map) code += `\n\n//# sourceMappingURL=${factory.map}`;
+  function _eval({ code, url, map }) {
+    code += `\n\n//# sourceURL=${location.origin}${url}`;
+    if (map) code += `\n//# sourceMappingURL=${map}`;
     return eval(code);
   }
 

--- a/crates/turbopack-tests/tests/snapshot/basic/chunked/output/crates_turbopack-tests_tests_snapshot_basic_chunked_input_index_b11d49.js
+++ b/crates/turbopack-tests/tests/snapshot/basic/chunked/output/crates_turbopack-tests_tests_snapshot_basic_chunked_input_index_b11d49.js
@@ -524,9 +524,9 @@ __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests$2f$
    * @returns {ModuleFactory}
    * @private
    */
-  function _eval(factory) {
-    let code = factory.code;
-    if (factory.map) code += `\n\n//# sourceMappingURL=${factory.map}`;
+  function _eval({ code, url, map }) {
+    code += `\n\n//# sourceURL=${location.origin}${url}`;
+    if (map) code += `\n//# sourceMappingURL=${map}`;
     return eval(code);
   }
 

--- a/crates/turbopack-tests/tests/snapshot/css/absolute-uri-import/output/crates_turbopack-tests_tests_snapshot_css_absolute-uri-import_input_index_e03a4b.js
+++ b/crates/turbopack-tests/tests/snapshot/css/absolute-uri-import/output/crates_turbopack-tests_tests_snapshot_css_absolute-uri-import_input_index_e03a4b.js
@@ -521,9 +521,9 @@
    * @returns {ModuleFactory}
    * @private
    */
-  function _eval(factory) {
-    let code = factory.code;
-    if (factory.map) code += `\n\n//# sourceMappingURL=${factory.map}`;
+  function _eval({ code, url, map }) {
+    code += `\n\n//# sourceURL=${location.origin}${url}`;
+    if (map) code += `\n//# sourceMappingURL=${map}`;
     return eval(code);
   }
 

--- a/crates/turbopack-tests/tests/snapshot/css/css/output/crates_turbopack-tests_tests_snapshot_css_css_input_index_907a50.js
+++ b/crates/turbopack-tests/tests/snapshot/css/css/output/crates_turbopack-tests_tests_snapshot_css_css_input_index_907a50.js
@@ -537,9 +537,9 @@ __turbopack_export_value__({
    * @returns {ModuleFactory}
    * @private
    */
-  function _eval(factory) {
-    let code = factory.code;
-    if (factory.map) code += `\n\n//# sourceMappingURL=${factory.map}`;
+  function _eval({ code, url, map }) {
+    code += `\n\n//# sourceURL=${location.origin}${url}`;
+    if (map) code += `\n//# sourceMappingURL=${map}`;
     return eval(code);
   }
 

--- a/crates/turbopack-tests/tests/snapshot/emotion/emotion/output/crates_turbopack-tests_tests_snapshot_emotion_emotion_input_index_b6dbf3.js
+++ b/crates/turbopack-tests/tests/snapshot/emotion/emotion/output/crates_turbopack-tests_tests_snapshot_emotion_emotion_input_index_b6dbf3.js
@@ -544,9 +544,9 @@ console.log(StyledButton, ClassNameButton);
    * @returns {ModuleFactory}
    * @private
    */
-  function _eval(factory) {
-    let code = factory.code;
-    if (factory.map) code += `\n\n//# sourceMappingURL=${factory.map}`;
+  function _eval({ code, url, map }) {
+    code += `\n\n//# sourceURL=${location.origin}${url}`;
+    if (map) code += `\n//# sourceMappingURL=${map}`;
     return eval(code);
   }
 

--- a/crates/turbopack-tests/tests/snapshot/env/env/output/crates_turbopack-tests_tests_snapshot_env_env_input_480486.js
+++ b/crates/turbopack-tests/tests/snapshot/env/env/output/crates_turbopack-tests_tests_snapshot_env_env_input_480486.js
@@ -530,9 +530,9 @@ instantiateRuntimeModule("[project]/crates/turbopack-tests/tests/snapshot/env/en
    * @returns {ModuleFactory}
    * @private
    */
-  function _eval(factory) {
-    let code = factory.code;
-    if (factory.map) code += `\n\n//# sourceMappingURL=${factory.map}`;
+  function _eval({ code, url, map }) {
+    code += `\n\n//# sourceURL=${location.origin}${url}`;
+    if (map) code += `\n//# sourceMappingURL=${map}`;
     return eval(code);
   }
 

--- a/crates/turbopack-tests/tests/snapshot/evaluated_entrry/runtime_entry/output/a587c_tests_snapshot_evaluated_entrry_runtime_entry_input_index_50fbca.js
+++ b/crates/turbopack-tests/tests/snapshot/evaluated_entrry/runtime_entry/output/a587c_tests_snapshot_evaluated_entrry_runtime_entry_input_index_50fbca.js
@@ -521,9 +521,9 @@ console.log("hello world");
    * @returns {ModuleFactory}
    * @private
    */
-  function _eval(factory) {
-    let code = factory.code;
-    if (factory.map) code += `\n\n//# sourceMappingURL=${factory.map}`;
+  function _eval({ code, url, map }) {
+    code += `\n\n//# sourceURL=${location.origin}${url}`;
+    if (map) code += `\n//# sourceMappingURL=${map}`;
     return eval(code);
   }
 

--- a/crates/turbopack-tests/tests/snapshot/example/example/output/crates_turbopack-tests_tests_snapshot_example_example_input_index_a7beb7.js
+++ b/crates/turbopack-tests/tests/snapshot/example/example/output/crates_turbopack-tests_tests_snapshot_example_example_input_index_a7beb7.js
@@ -521,9 +521,9 @@ console.log("hello world");
    * @returns {ModuleFactory}
    * @private
    */
-  function _eval(factory) {
-    let code = factory.code;
-    if (factory.map) code += `\n\n//# sourceMappingURL=${factory.map}`;
+  function _eval({ code, url, map }) {
+    code += `\n\n//# sourceURL=${location.origin}${url}`;
+    if (map) code += `\n//# sourceMappingURL=${map}`;
     return eval(code);
   }
 

--- a/crates/turbopack-tests/tests/snapshot/import-meta/cjs/output/crates_turbopack-tests_tests_snapshot_import-meta_cjs_input_index_859774.js
+++ b/crates/turbopack-tests/tests/snapshot/import-meta/cjs/output/crates_turbopack-tests_tests_snapshot_import-meta_cjs_input_index_859774.js
@@ -532,9 +532,9 @@ console.log(__TURBOPACK__import$2e$meta__.url);
    * @returns {ModuleFactory}
    * @private
    */
-  function _eval(factory) {
-    let code = factory.code;
-    if (factory.map) code += `\n\n//# sourceMappingURL=${factory.map}`;
+  function _eval({ code, url, map }) {
+    code += `\n\n//# sourceURL=${location.origin}${url}`;
+    if (map) code += `\n//# sourceMappingURL=${map}`;
     return eval(code);
   }
 

--- a/crates/turbopack-tests/tests/snapshot/import-meta/esm-multiple/output/79fb1_turbopack-tests_tests_snapshot_import-meta_esm-multiple_input_index_a53493.js
+++ b/crates/turbopack-tests/tests/snapshot/import-meta/esm-multiple/output/79fb1_turbopack-tests_tests_snapshot_import-meta_esm-multiple_input_index_a53493.js
@@ -539,9 +539,9 @@ bar();
    * @returns {ModuleFactory}
    * @private
    */
-  function _eval(factory) {
-    let code = factory.code;
-    if (factory.map) code += `\n\n//# sourceMappingURL=${factory.map}`;
+  function _eval({ code, url, map }) {
+    code += `\n\n//# sourceURL=${location.origin}${url}`;
+    if (map) code += `\n//# sourceMappingURL=${map}`;
     return eval(code);
   }
 

--- a/crates/turbopack-tests/tests/snapshot/import-meta/esm-mutable/output/crates_turbopack-tests_tests_snapshot_import-meta_esm-mutable_input_index_bbd10b.js
+++ b/crates/turbopack-tests/tests/snapshot/import-meta/esm-mutable/output/crates_turbopack-tests_tests_snapshot_import-meta_esm-mutable_input_index_bbd10b.js
@@ -532,9 +532,9 @@ __TURBOPACK__import$2e$meta__.foo = 1;
    * @returns {ModuleFactory}
    * @private
    */
-  function _eval(factory) {
-    let code = factory.code;
-    if (factory.map) code += `\n\n//# sourceMappingURL=${factory.map}`;
+  function _eval({ code, url, map }) {
+    code += `\n\n//# sourceURL=${location.origin}${url}`;
+    if (map) code += `\n//# sourceMappingURL=${map}`;
     return eval(code);
   }
 

--- a/crates/turbopack-tests/tests/snapshot/import-meta/esm-object/output/crates_turbopack-tests_tests_snapshot_import-meta_esm-object_input_index_31d622.js
+++ b/crates/turbopack-tests/tests/snapshot/import-meta/esm-object/output/crates_turbopack-tests_tests_snapshot_import-meta_esm-object_input_index_31d622.js
@@ -532,9 +532,9 @@ console.log(__TURBOPACK__import$2e$meta__);
    * @returns {ModuleFactory}
    * @private
    */
-  function _eval(factory) {
-    let code = factory.code;
-    if (factory.map) code += `\n\n//# sourceMappingURL=${factory.map}`;
+  function _eval({ code, url, map }) {
+    code += `\n\n//# sourceURL=${location.origin}${url}`;
+    if (map) code += `\n//# sourceMappingURL=${map}`;
     return eval(code);
   }
 

--- a/crates/turbopack-tests/tests/snapshot/import-meta/esm/output/crates_turbopack-tests_tests_snapshot_import-meta_esm_input_index_7072f9.js
+++ b/crates/turbopack-tests/tests/snapshot/import-meta/esm/output/crates_turbopack-tests_tests_snapshot_import-meta_esm_input_index_7072f9.js
@@ -532,9 +532,9 @@ console.log(__TURBOPACK__import$2e$meta__.url);
    * @returns {ModuleFactory}
    * @private
    */
-  function _eval(factory) {
-    let code = factory.code;
-    if (factory.map) code += `\n\n//# sourceMappingURL=${factory.map}`;
+  function _eval({ code, url, map }) {
+    code += `\n\n//# sourceURL=${location.origin}${url}`;
+    if (map) code += `\n//# sourceMappingURL=${map}`;
     return eval(code);
   }
 

--- a/crates/turbopack-tests/tests/snapshot/import-meta/url/output/crates_turbopack-tests_tests_snapshot_import-meta_url_input_index_94525c.js
+++ b/crates/turbopack-tests/tests/snapshot/import-meta/url/output/crates_turbopack-tests_tests_snapshot_import-meta_url_input_index_94525c.js
@@ -538,9 +538,9 @@ __turbopack_export_value__("/crates/turbopack-tests/tests/snapshot/import-meta/u
    * @returns {ModuleFactory}
    * @private
    */
-  function _eval(factory) {
-    let code = factory.code;
-    if (factory.map) code += `\n\n//# sourceMappingURL=${factory.map}`;
+  function _eval({ code, url, map }) {
+    code += `\n\n//# sourceURL=${location.origin}${url}`;
+    if (map) code += `\n//# sourceMappingURL=${map}`;
     return eval(code);
   }
 

--- a/crates/turbopack-tests/tests/snapshot/imports/json/output/crates_turbopack-tests_tests_snapshot_imports_json_input_index_e24981.js
+++ b/crates/turbopack-tests/tests/snapshot/imports/json/output/crates_turbopack-tests_tests_snapshot_imports_json_input_index_e24981.js
@@ -535,9 +535,9 @@ throw new Error("An error occurred while importing a JSON module: \"File is not 
    * @returns {ModuleFactory}
    * @private
    */
-  function _eval(factory) {
-    let code = factory.code;
-    if (factory.map) code += `\n\n//# sourceMappingURL=${factory.map}`;
+  function _eval({ code, url, map }) {
+    code += `\n\n//# sourceURL=${location.origin}${url}`;
+    if (map) code += `\n//# sourceMappingURL=${map}`;
     return eval(code);
   }
 

--- a/crates/turbopack-tests/tests/snapshot/imports/resolve_error_cjs/output/79fb1_turbopack-tests_tests_snapshot_imports_resolve_error_cjs_input_index_e00120.js
+++ b/crates/turbopack-tests/tests/snapshot/imports/resolve_error_cjs/output/79fb1_turbopack-tests_tests_snapshot_imports_resolve_error_cjs_input_index_e00120.js
@@ -526,9 +526,9 @@ console.log(dne);
    * @returns {ModuleFactory}
    * @private
    */
-  function _eval(factory) {
-    let code = factory.code;
-    if (factory.map) code += `\n\n//# sourceMappingURL=${factory.map}`;
+  function _eval({ code, url, map }) {
+    code += `\n\n//# sourceURL=${location.origin}${url}`;
+    if (map) code += `\n//# sourceMappingURL=${map}`;
     return eval(code);
   }
 

--- a/crates/turbopack-tests/tests/snapshot/imports/resolve_error_esm/output/79fb1_turbopack-tests_tests_snapshot_imports_resolve_error_esm_input_index_1a5dd4.js
+++ b/crates/turbopack-tests/tests/snapshot/imports/resolve_error_esm/output/79fb1_turbopack-tests_tests_snapshot_imports_resolve_error_esm_input_index_1a5dd4.js
@@ -529,9 +529,9 @@ console.log({}[dne]);
    * @returns {ModuleFactory}
    * @private
    */
-  function _eval(factory) {
-    let code = factory.code;
-    if (factory.map) code += `\n\n//# sourceMappingURL=${factory.map}`;
+  function _eval({ code, url, map }) {
+    code += `\n\n//# sourceURL=${location.origin}${url}`;
+    if (map) code += `\n//# sourceMappingURL=${map}`;
     return eval(code);
   }
 

--- a/crates/turbopack-tests/tests/snapshot/imports/static/output/crates_turbopack-tests_tests_snapshot_imports_static_input_index_b8717b.js
+++ b/crates/turbopack-tests/tests/snapshot/imports/static/output/crates_turbopack-tests_tests_snapshot_imports_static_input_index_b8717b.js
@@ -528,9 +528,9 @@ __turbopack_export_value__("/crates/turbopack-tests/tests/snapshot/imports/stati
    * @returns {ModuleFactory}
    * @private
    */
-  function _eval(factory) {
-    let code = factory.code;
-    if (factory.map) code += `\n\n//# sourceMappingURL=${factory.map}`;
+  function _eval({ code, url, map }) {
+    code += `\n\n//# sourceURL=${location.origin}${url}`;
+    if (map) code += `\n//# sourceMappingURL=${map}`;
     return eval(code);
   }
 

--- a/crates/turbopack-tests/tests/snapshot/node/node_protocol_external/output/79fb1_turbopack-tests_tests_snapshot_node_node_protocol_external_input_index_6a3d80.js
+++ b/crates/turbopack-tests/tests/snapshot/node/node_protocol_external/output/79fb1_turbopack-tests_tests_snapshot_node_node_protocol_external_input_index_6a3d80.js
@@ -523,9 +523,9 @@ var __TURBOPACK__external__node$3a$fs__ = __turbopack_external_require__("node:f
    * @returns {ModuleFactory}
    * @private
    */
-  function _eval(factory) {
-    let code = factory.code;
-    if (factory.map) code += `\n\n//# sourceMappingURL=${factory.map}`;
+  function _eval({ code, url, map }) {
+    code += `\n\n//# sourceURL=${location.origin}${url}`;
+    if (map) code += `\n//# sourceMappingURL=${map}`;
     return eval(code);
   }
 

--- a/crates/turbopack-tests/tests/snapshot/styled_components/styled_components/output/a587c_tests_snapshot_styled_components_styled_components_input_index_7b57d9.js
+++ b/crates/turbopack-tests/tests/snapshot/styled_components/styled_components/output/a587c_tests_snapshot_styled_components_styled_components_input_index_7b57d9.js
@@ -530,9 +530,9 @@ console.log(MyButton);
    * @returns {ModuleFactory}
    * @private
    */
-  function _eval(factory) {
-    let code = factory.code;
-    if (factory.map) code += `\n\n//# sourceMappingURL=${factory.map}`;
+  function _eval({ code, url, map }) {
+    code += `\n\n//# sourceURL=${location.origin}${url}`;
+    if (map) code += `\n//# sourceMappingURL=${map}`;
     return eval(code);
   }
 

--- a/crates/turbopack-tests/tests/snapshot/swc_transforms/mono_transforms/output/a587c_tests_snapshot_swc_transforms_mono_transforms_input_packages_app_index_739f58.js
+++ b/crates/turbopack-tests/tests/snapshot/swc_transforms/mono_transforms/output/a587c_tests_snapshot_swc_transforms_mono_transforms_input_packages_app_index_739f58.js
@@ -526,9 +526,9 @@ console.log(__TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$
    * @returns {ModuleFactory}
    * @private
    */
-  function _eval(factory) {
-    let code = factory.code;
-    if (factory.map) code += `\n\n//# sourceMappingURL=${factory.map}`;
+  function _eval({ code, url, map }) {
+    code += `\n\n//# sourceURL=${location.origin}${url}`;
+    if (map) code += `\n//# sourceMappingURL=${map}`;
     return eval(code);
   }
 

--- a/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/output/79fb1_turbopack-tests_tests_snapshot_swc_transforms_preset_env_input_index_44c34f.js
+++ b/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/output/79fb1_turbopack-tests_tests_snapshot_swc_transforms_preset_env_input_index_44c34f.js
@@ -528,9 +528,9 @@ console.log(Foo, [].includes("foo"));
    * @returns {ModuleFactory}
    * @private
    */
-  function _eval(factory) {
-    let code = factory.code;
-    if (factory.map) code += `\n\n//# sourceMappingURL=${factory.map}`;
+  function _eval({ code, url, map }) {
+    code += `\n\n//# sourceURL=${location.origin}${url}`;
+    if (map) code += `\n//# sourceMappingURL=${map}`;
     return eval(code);
   }
 

--- a/crates/turbopack-tests/tests/snapshot/tsconfig/baseurl/output/crates_turbopack-tests_tests_snapshot_tsconfig_baseurl_input_index_5906e5.js
+++ b/crates/turbopack-tests/tests/snapshot/tsconfig/baseurl/output/crates_turbopack-tests_tests_snapshot_tsconfig_baseurl_input_index_5906e5.js
@@ -522,9 +522,9 @@ throw e;
    * @returns {ModuleFactory}
    * @private
    */
-  function _eval(factory) {
-    let code = factory.code;
-    if (factory.map) code += `\n\n//# sourceMappingURL=${factory.map}`;
+  function _eval({ code, url, map }) {
+    code += `\n\n//# sourceURL=${location.origin}${url}`;
+    if (map) code += `\n//# sourceMappingURL=${map}`;
     return eval(code);
   }
 


### PR DESCRIPTION
HMR is handled via an `eval(newCode)`, and that eval will inherit the filepath of the currently running file (in our case, the chunk file that contains the runtime code). To properly trace, we need to know both the chunk and the item ids, so we trace via the correct item's source map.

Thankfully, we can use the (underspecified) [`//# sourceUrl` ](https://learn.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/javascript/source-maps#use--sourceurl-to-name-evaluated-files-in-the-sources-tool) meta comment to name the file we're currently evaluating. That'll get used as the stack frame's file. We can then encode the chunk path and item id into the filename, and let next's stack tracing code handle the rest.

This also fixes an off-by-one on the column. Source maps are 0-based, but the line/column of a file as displayed in an editor or dev tools are 1-based.