### PR TITLE
Basic support for basePath

### DIFF
--- a/crates/next-core/js/src/entry/server-renderer.tsx
+++ b/crates/next-core/js/src/entry/server-renderer.tsx
@@ -127,7 +127,8 @@ async function runOperation(
       previewModeEncryptionKey: "",
       previewModeSigningKey: "",
     },
-    basePath: "",
+    // This is currently passed in from next.config.js through `ProcessEnvAsset`.
+    basePath: process.env.__NEXT_ROUTER_BASEPATH ?? "",
     optimizeFonts: false,
     optimizeCss: false,
     nextScriptWorkers: false,

--- a/crates/next-core/src/env.rs
+++ b/crates/next-core/src/env.rs
@@ -57,6 +57,7 @@ pub async fn env_for_js(
     };
     let env = EmbeddableProcessEnvVc::new(env).into();
     let image_config = next_config.image_config().await?;
+    let base_path = next_config.base_path().await?;
 
     Ok(CustomProcessEnvVc::new(
         env,
@@ -64,7 +65,9 @@ pub async fn env_for_js(
             // We need to overload the __NEXT_IMAGE_OPTS to override the default remotePatterns field.
             // This allows us to support loading from remote hostnames until we properly support reading
             // the next.config.js file.
-            "__NEXT_IMAGE_OPTS".to_string() => serde_json::to_string(&image_config).unwrap()
+            "__NEXT_IMAGE_OPTS".to_string() => serde_json::to_string(&image_config).unwrap(),
+            // This ensures next/link and the Next.js router work properly when a basePath is configured.
+            "__NEXT_ROUTER_BASEPATH".to_string() => serde_json::to_string(&base_path).unwrap(),
         }),
     )
     .into())

--- a/crates/next-core/src/env.rs
+++ b/crates/next-core/src/env.rs
@@ -67,6 +67,7 @@ pub async fn env_for_js(
             // the next.config.js file.
             "__NEXT_IMAGE_OPTS".to_string() => serde_json::to_string(&image_config).unwrap(),
             // This ensures next/link and the Next.js router work properly when a basePath is configured.
+            // This is also used in server-renderer.tsx.
             "__NEXT_ROUTER_BASEPATH".to_string() => serde_json::to_string(&base_path).unwrap(),
         }),
     )

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -255,7 +255,7 @@ async fn validate_next_config(
     if let Some(base_path) = next_config_ref.base_path.as_deref() {
         if !base_path.starts_with('/') {
             emit_and_bail!(NextConfigIssue {
-                severity: IssueSeverityVc::cell(IssueSeverity::Error),
+                severity: IssueSeverityVc::cell(IssueSeverity::Fatal),
                 path,
                 message: StringVc::cell(format!(
                     "Specified basePath has to start with a /, found {}",
@@ -267,7 +267,7 @@ async fn validate_next_config(
 
         if base_path.ends_with('/') {
             emit_and_bail!(NextConfigIssue {
-                severity: IssueSeverityVc::cell(IssueSeverity::Error),
+                severity: IssueSeverityVc::cell(IssueSeverity::Fatal),
                 path,
                 message: StringVc::cell(format!(
                     "Specified basePath has to start with a /, found {}",

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -252,31 +252,35 @@ async fn validate_next_config(
     path: FileSystemPathVc,
 ) -> Result<NextConfigVc> {
     let next_config_ref = next_config.await?;
-    if let Some(base_path) = next_config_ref.base_path.as_deref() {
-        if !base_path.starts_with('/') {
-            emit_and_bail!(NextConfigIssue {
-                severity: IssueSeverityVc::cell(IssueSeverity::Fatal),
-                path,
-                message: StringVc::cell(format!(
-                    "Specified basePath has to start with a /, found {}",
-                    base_path
-                )),
-            }
-            .cell());
-        }
 
-        if base_path.ends_with('/') {
-            emit_and_bail!(NextConfigIssue {
-                severity: IssueSeverityVc::cell(IssueSeverity::Fatal),
-                path,
-                message: StringVc::cell(format!(
-                    "Specified basePath has to start with a /, found {}",
-                    base_path
-                )),
+    if let Some(base_path) = next_config_ref.base_path.as_deref() {
+        if !base_path.is_empty() {
+            if !base_path.starts_with('/') {
+                emit_and_bail!(NextConfigIssue {
+                    severity: IssueSeverityVc::cell(IssueSeverity::Fatal),
+                    path,
+                    message: StringVc::cell(format!(
+                        "Specified basePath has to start with a /, found {}",
+                        base_path
+                    )),
+                }
+                .cell());
             }
-            .cell());
+
+            if base_path.ends_with('/') {
+                emit_and_bail!(NextConfigIssue {
+                    severity: IssueSeverityVc::cell(IssueSeverity::Fatal),
+                    path,
+                    message: StringVc::cell(format!(
+                        "Specified basePath has to start with a /, found {}",
+                        base_path
+                    )),
+                }
+                .cell());
+            }
         }
     }
+
     Ok(next_config)
 }
 

--- a/crates/next-dev/src/lib.rs
+++ b/crates/next-dev/src/lib.rs
@@ -350,6 +350,7 @@ async fn source(
     )
     .into();
     let source = RouterContentSource {
+        base_path: next_config.base_path(),
         routes: vec![
             ("__turbopack__/".to_string(), introspect),
             ("__turbo_tasks__/".to_string(), viz),

--- a/crates/turbopack-core/src/issue/mod.rs
+++ b/crates/turbopack-core/src/issue/mod.rs
@@ -132,6 +132,17 @@ pub trait Issue {
     }
 }
 
+/// Emits an issue and then exits the current function with an error.
+#[macro_export]
+macro_rules! emit_and_bail {
+    ($issue:expr) => {
+        let issue = $issue.as_issue();
+        let description = issue.description().await?;
+        issue.emit();
+        anyhow::bail!(description.clone())
+    };
+}
+
 #[turbo_tasks::value_trait]
 trait IssueProcessingPath {
     fn shortest_path(&self, issue: IssueVc) -> OptionIssueProcessingPathItemsVc;

--- a/crates/turbopack-dev-server/src/source/router.rs
+++ b/crates/turbopack-dev-server/src/source/router.rs
@@ -36,8 +36,13 @@ impl RouterContentSource {
 }
 
 /// Strips a base path from a given path. The path must not start with a slash.
-/// The base path must start with a slash and must not end with a slash.
+/// The base path must start with a slash and must not end with a slash, or be
+/// the empty string.
 fn strip_base_path<'a, 'b>(path: &'a str, base_path: &'b str) -> Result<&'a str> {
+    if base_path.is_empty() {
+        return Ok(path);
+    }
+
     let base_path = base_path.strip_prefix('/').ok_or_else(|| {
         anyhow!(
             "invalid base path: base path must start with a slash, got {:?}",


### PR DESCRIPTION
While I expect this will work for most cases, it's missing a couple of things:

### 1. Proper issue reporting.

The issues currently look terrible. I'm not sure what's going on here, but emitting an issue from `validate_next_config` seems to work poorly:

![image](https://user-images.githubusercontent.com/1621758/208420888-7f989399-6867-47b0-b947-31bac2d4949c.png)

Furthermore, Next.js exits on startup when the `basePath` config key is invalid. In order to reproduce this behavior accurately, we would need to load next.config.js eagerly when starting the dev server, instead of lazily as is currently done.

### ~~2. Passing next.config.js to the Node.js renderers~~

**EDIT:** Went with option 3., pass the basePath through process.env (which we need for next/link and next/router anyway)

This PR doesn't pass the `basePath` config to the Node.js Next.js server renderer. In fact, it completely hides `basePath` from the renderer. However, it is necessary to pass the proper `basePath` in order for `useRouter().basePath` to return the correct value. 

I thought of a few ways we could pass next.config.js-derived values to the renderer:
1. As a field in `RenderData`. Since `RenderData` is not Next.js-specific, this would need to be a `serde_json::Value`.
2. As a server asset `@vercel/turbopack-next/config`. This would be a `JsonModuleAsset` that contains the serialized representation of `NextConfig`.

I'm leaning towards option 2. as it should only necessitate changes to next-core.

@Brooooooklyn @sokra WDYT?  

### 3. Serve all routes under the basePath

Right now, chunks, HMR and the dev manifest aren't served from under the basePath.

See https://github.com/vercel/turbo/pull/3071