### PR TITLE
Remove by_glob from ImportMap

### DIFF
--- a/crates/turbopack/src/resolve.rs
+++ b/crates/turbopack/src/resolve.rs
@@ -103,7 +103,7 @@ async fn base_resolve_options(
         }
     }
 
-    let mut import_map = ImportMap::new(direct_mappings, Default::default());
+    let mut import_map = ImportMap::new(direct_mappings);
     if let Some(additional_import_map) = opt.import_map {
         let additional_import_map = additional_import_map.await?;
         import_map.extend(&additional_import_map);


### PR DESCRIPTION
@sokra I can't remember us ever using it. I think we should remove it until we find a use for it again in the future (if ever).