### PR TITLE
Disable clippy::too_many_arguments globally

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -9,3 +9,6 @@ linker = "rust-lld"
 
 [alias]
 xtask = "run --package xtask --"
+
+[target.'cfg(all())']
+rustflags = ["-Aclippy::too_many_arguments"]

--- a/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/crates/turbopack-ecmascript/src/references/mod.rs
@@ -408,7 +408,6 @@ pub(crate) async fn analyze_ecmascript_module(
 
             analysis.set_exports(exports);
 
-            #[allow(clippy::too_many_arguments)]
             fn handle_call_boxed<
                 'a,
                 FF: Future<Output = Result<JsValue>> + Send + 'a,
@@ -443,7 +442,6 @@ pub(crate) async fn analyze_ecmascript_module(
                 ))
             }
 
-            #[allow(clippy::too_many_arguments)]
             async fn handle_call<
                 FF: Future<Output = Result<JsValue>> + Send,
                 F: Fn(JsValue) -> FF + Sync,

--- a/crates/turbopack-mdx/src/lib.rs
+++ b/crates/turbopack-mdx/src/lib.rs
@@ -58,7 +58,7 @@ async fn into_ecmascript_module_asset(
     );
     Ok(EcmascriptModuleAssetVc::new(
         source.into(),
-        this.context.into(),
+        this.context,
         Value::new(EcmascriptModuleAssetType::Typescript),
         this.transforms,
         this.context.environment(),


### PR DESCRIPTION
Clippy has gone too far, and I don't want to refactor the remaining functions to take less arguments and pass a struct.

With an unrelated small fix, this puts us at 0 clippy warnings!