### PR TITLE
handle dependencies reported by postcss

### DIFF
--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -253,6 +253,7 @@ pub async fn load_next_config(execution_context: ExecutionContextVc) -> Result<N
         project_root,
         load_next_config_asset,
         project_root,
+        config_asset.map_or(project_root, |c| c.path()),
         context,
         intermediate_output_path,
         runtime_entries,

--- a/crates/turbo-tasks-fs/src/glob.rs
+++ b/crates/turbo-tasks-fs/src/glob.rs
@@ -327,16 +327,14 @@ impl<'a> Iterator for GlobPartMatchesIterator<'a> {
                         self.index += 1;
                         self.glob_iterator = None;
                     }
+                } else if let Some(alternative) = alternatives.get(self.index) {
+                    self.glob_iterator = Some(Box::new(alternative.iter_matches(
+                        self.path,
+                        self.previous_part_is_path_separator_equalivalent,
+                        self.match_partial,
+                    )));
                 } else {
-                    if let Some(alternative) = alternatives.get(self.index) {
-                        self.glob_iterator = Some(Box::new(alternative.iter_matches(
-                            self.path,
-                            self.previous_part_is_path_separator_equalivalent,
-                            self.match_partial,
-                        )));
-                    } else {
-                        return None;
-                    }
+                    return None;
                 }
             },
         }

--- a/crates/turbo-tasks-fs/src/glob.rs
+++ b/crates/turbo-tasks-fs/src/glob.rs
@@ -1,4 +1,6 @@
-use anyhow::Result;
+use std::mem::take;
+
+use anyhow::{bail, Result};
 use serde::{Deserialize, Serialize};
 use turbo_tasks::trace::TraceRawVcs;
 
@@ -47,45 +49,24 @@ pub struct Glob {
 impl Glob {
     pub fn execute(&self, path: &str) -> bool {
         let match_partial = path.ends_with('/');
-        let mut stack = Vec::new();
-        let mut i = 0;
-        let mut current = path;
-        let mut is_path_separator_equalivalent = true;
-        loop {
-            if let Some(part) = self.expression.get(i) {
-                let iter = if let Some(iter) = stack.get_mut(i) {
-                    iter
-                } else {
-                    let iter = part.iter_matches(current, is_path_separator_equalivalent);
-                    stack.push(iter);
-                    stack.last_mut().unwrap()
-                };
-                if let Some((new_path, new_is_path_separator_equalivalent)) = iter.next() {
-                    current = new_path;
-                    is_path_separator_equalivalent = new_is_path_separator_equalivalent;
+        self.iter_matches(path, true, match_partial)
+            .next()
+            .is_some()
+    }
 
-                    i += 1;
-
-                    if match_partial && current.is_empty() {
-                        return true;
-                    }
-                } else {
-                    if i == 0 {
-                        // failed to match
-                        return false;
-                    }
-                    // backtrace
-                    stack.pop();
-                    i -= 1;
-                }
-            } else {
-                // end of expression, matched successfully if also end of path
-                if current.is_empty() {
-                    return true;
-                }
-                // backtrace
-                i -= 1;
-            }
+    fn iter_matches<'a>(
+        &'a self,
+        path: &'a str,
+        previous_part_is_path_separator_equalivalent: bool,
+        match_partial: bool,
+    ) -> GlobMatchesIterator<'a> {
+        GlobMatchesIterator {
+            current: path,
+            glob: self,
+            match_partial,
+            is_path_separator_equalivalent: previous_part_is_path_separator_equalivalent,
+            stack: Vec::new(),
+            index: 0,
         }
     }
 
@@ -103,17 +84,81 @@ impl Glob {
     }
 }
 
+struct GlobMatchesIterator<'a> {
+    current: &'a str,
+    glob: &'a Glob,
+    match_partial: bool,
+    is_path_separator_equalivalent: bool,
+    stack: Vec<GlobPartMatchesIterator<'a>>,
+    index: usize,
+}
+
+impl<'a> Iterator for GlobMatchesIterator<'a> {
+    type Item = (&'a str, bool);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if let Some(part) = self.glob.expression.get(self.index) {
+                let iter = if let Some(iter) = self.stack.get_mut(self.index) {
+                    iter
+                } else {
+                    let iter = part.iter_matches(
+                        self.current,
+                        self.is_path_separator_equalivalent,
+                        self.match_partial,
+                    );
+                    self.stack.push(iter);
+                    self.stack.last_mut().unwrap()
+                };
+                if let Some((new_path, new_is_path_separator_equalivalent)) = iter.next() {
+                    self.current = new_path;
+                    self.is_path_separator_equalivalent = new_is_path_separator_equalivalent;
+
+                    self.index += 1;
+
+                    if self.match_partial && self.current.is_empty() {
+                        return Some(("", self.is_path_separator_equalivalent));
+                    }
+                } else {
+                    if self.index == 0 {
+                        // failed to match
+                        return None;
+                    }
+                    // backtrace
+                    self.stack.pop();
+                    self.index -= 1;
+                }
+            } else {
+                // end of expression, matched successfully
+
+                // backtrace for the next iteration
+                self.index -= 1;
+
+                return Some((self.current, self.is_path_separator_equalivalent));
+            }
+        }
+    }
+}
+
 impl GlobPart {
+    /// Iterates over all possible matches of this part with the provided path.
+    /// The least greedy match is returned first. This is usually used for
+    /// backtracking. The string slice returned is the remaining part or the
+    /// path. The boolean flag returned specifies if the matched part should
+    /// be considered as path-separator equalivalent.
     fn iter_matches<'a>(
         &'a self,
         path: &'a str,
         previous_part_is_path_separator_equalivalent: bool,
-    ) -> impl Iterator<Item = (&'a str, bool)> {
+        match_partial: bool,
+    ) -> GlobPartMatchesIterator<'a> {
         GlobPartMatchesIterator {
             path,
             part: self,
+            match_partial,
             previous_part_is_path_separator_equalivalent,
             index: 0,
+            glob_iterator: None,
         }
     }
 
@@ -130,7 +175,38 @@ impl GlobPart {
             ('?', _) => Ok((GlobPart::AnyFileChar, &input[1..])),
             ('[', Some('[')) => todo!("glob char classes are not implemented yet"),
             ('[', _) => todo!("glob char sequences are not implemented yet"),
-            ('{', _) => todo!("glob braces are not implemented yet"),
+            ('{', Some(_)) => {
+                let mut current = &input[1..];
+                let mut alternatives = Vec::new();
+                let mut expression = Vec::new();
+
+                loop {
+                    let (part, remainder) = GlobPart::parse(current, true)?;
+                    expression.push(part);
+                    current = remainder;
+                    match current.chars().next() {
+                        Some(',') => {
+                            alternatives.push(Glob {
+                                expression: take(&mut expression),
+                            });
+                            current = &current[1..];
+                        }
+                        Some('}') => {
+                            alternatives.push(Glob {
+                                expression: take(&mut expression),
+                            });
+                            current = &current[1..];
+                            break;
+                        }
+                        _ => bail!("Unterminated glob braces"),
+                    }
+                }
+
+                Ok((GlobPart::Alternatives(alternatives), current))
+            }
+            ('{', None) => {
+                bail!("Unterminated glob braces")
+            }
             _ => {
                 let mut is_escaped = false;
                 let mut literal = String::new();
@@ -144,6 +220,7 @@ impl GlobPart {
                         || c == '*'
                         || c == '?'
                         || c == '['
+                        || c == '{'
                         || (inside_of_braces && (c == ',' || c == '}'))
                     {
                         break;
@@ -160,8 +237,10 @@ impl GlobPart {
 struct GlobPartMatchesIterator<'a> {
     path: &'a str,
     part: &'a GlobPart,
+    match_partial: bool,
     previous_part_is_path_separator_equalivalent: bool,
     index: usize,
+    glob_iterator: Option<Box<GlobMatchesIterator<'a>>>,
 }
 
 impl<'a> Iterator for GlobPartMatchesIterator<'a> {
@@ -240,7 +319,26 @@ impl<'a> Iterator for GlobPartMatchesIterator<'a> {
                     None
                 }
             }
-            GlobPart::Alternatives(_) => todo!(),
+            GlobPart::Alternatives(alternatives) => loop {
+                if let Some(glob_iterator) = &mut self.glob_iterator {
+                    if let Some((path, is_path_separator_equalivalent)) = glob_iterator.next() {
+                        return Some((path, is_path_separator_equalivalent));
+                    } else {
+                        self.index += 1;
+                        self.glob_iterator = None;
+                    }
+                } else {
+                    if let Some(alternative) = alternatives.get(self.index) {
+                        self.glob_iterator = Some(Box::new(alternative.iter_matches(
+                            self.path,
+                            self.previous_part_is_path_separator_equalivalent,
+                            self.match_partial,
+                        )));
+                    } else {
+                        return None;
+                    }
+                }
+            },
         }
     }
 }
@@ -271,6 +369,9 @@ mod tests {
     #[case::file("file.js", "file.js")]
     #[case::dir_and_file("dir/file.js", "dir/file.js")]
     #[case::dir_and_file_partial("dir/file.js", "dir/")]
+    #[case::file_braces("file.{ts,js}", "file.js")]
+    #[case::dir_and_file_braces("dir/file.{ts,js}", "dir/file.js")]
+    #[case::dir_and_file_dir_braces("{dir,other}/file.{ts,js}", "dir/file.js")]
     #[case::star("*.js", "file.js")]
     #[case::dir_star("dir/*.js", "dir/file.js")]
     #[case::dir_star_partial("dir/*.js", "dir/")]

--- a/crates/turbopack-node/js/src/ipc/evaluate.ts
+++ b/crates/turbopack-node/js/src/ipc/evaluate.ts
@@ -1,4 +1,5 @@
-import { IPC, Ipc } from "./index";
+import { IPC } from "./index";
+import type { Ipc as GenericIpc } from "./index";
 
 type IpcIncomingMessage = {
   type: "evaluate";
@@ -11,25 +12,24 @@ type IpcOutgoingMessage =
       data: string;
     }
   | {
-      type: "file-dependency";
+      type: "fileDependency";
       path: string;
     }
   | {
-      type: "build-dependency";
+      type: "buildDependency";
       path: string;
     }
   | {
-      type: "dir-dependency";
+      type: "dirDependency";
       path: string;
+      glob: string;
     };
 
-const ipc = IPC as Ipc<IpcIncomingMessage, IpcOutgoingMessage>;
+export type Ipc = GenericIpc<IpcIncomingMessage, IpcOutgoingMessage>;
+const ipc = IPC as Ipc;
 
 export const run = async (
-  getValue: (
-    ipc: Ipc<IpcIncomingMessage, IpcOutgoingMessage>,
-    ...deserializedArgs: any[]
-  ) => any
+  getValue: (ipc: Ipc, ...deserializedArgs: any[]) => any
 ) => {
   while (true) {
     const msg = await ipc.recv();
@@ -54,3 +54,5 @@ export const run = async (
     }
   }
 };
+
+export type { IpcIncomingMessage, IpcOutgoingMessage };

--- a/crates/turbopack-node/js/src/ipc/evaluate.ts
+++ b/crates/turbopack-node/js/src/ipc/evaluate.ts
@@ -5,21 +5,39 @@ type IpcIncomingMessage = {
   args: string[];
 };
 
-type IpcOutgoingMessage = {
-  type: "jsonValue";
-  data: string;
-};
+type IpcOutgoingMessage =
+  | {
+      type: "jsonValue";
+      data: string;
+    }
+  | {
+      type: "file-dependency";
+      path: string;
+    }
+  | {
+      type: "build-dependency";
+      path: string;
+    }
+  | {
+      type: "dir-dependency";
+      path: string;
+    };
 
 const ipc = IPC as Ipc<IpcIncomingMessage, IpcOutgoingMessage>;
 
-export const run = async (getValue: (...deserializedArgs: any[]) => any) => {
+export const run = async (
+  getValue: (
+    ipc: Ipc<IpcIncomingMessage, IpcOutgoingMessage>,
+    ...deserializedArgs: any[]
+  ) => any
+) => {
   while (true) {
     const msg = await ipc.recv();
 
     switch (msg.type) {
       case "evaluate": {
         try {
-          const value = await getValue(...msg.args);
+          const value = await getValue(ipc, ...msg.args);
           await ipc.send({
             type: "jsonValue",
             data: JSON.stringify(value),

--- a/crates/turbopack-node/js/src/transforms/postcss.ts
+++ b/crates/turbopack-node/js/src/transforms/postcss.ts
@@ -1,9 +1,14 @@
+declare const __turbopack_external_require__: (id: string) => any;
+
+// @ts-ignore
 import postcss from "@vercel/turbopack/postcss";
+// @ts-ignore
 import importedConfig from "CONFIG";
 import { relative, isAbsolute, sep } from "path";
+import type { Ipc } from "../ipc/evaluate";
 
 const contextDir = process.cwd();
-const toPath = (file) => {
+const toPath = (file: string) => {
   const relPath = relative(contextDir, file);
   if (isAbsolute(relPath)) {
     throw new Error(
@@ -13,14 +18,14 @@ const toPath = (file) => {
   return sep !== "/" ? relPath.replaceAll(sep, "/") : relPath;
 };
 
-const transform = async (ipc, cssContent, name) => {
+const transform = async (ipc: Ipc, cssContent: string, name: string) => {
   let config = importedConfig;
   if (typeof config === "function") {
     config = await config({ env: "development" });
   }
-  let plugins = config.plugins;
-  if (Array.isArray(plugins)) {
-    plugins = plugins.map((plugin) => {
+  let plugins: any[];
+  if (Array.isArray(config.plugins)) {
+    plugins = config.plugins.map((plugin: [string, any] | string | any) => {
       if (Array.isArray(plugin)) {
         return plugin;
       } else if (typeof plugin === "string") {
@@ -29,8 +34,10 @@ const transform = async (ipc, cssContent, name) => {
         return plugin;
       }
     });
-  } else if (typeof plugins === "object") {
-    plugins = Object.entries(plugins).filter(([, options]) => options);
+  } else if (typeof config.plugins === "object") {
+    plugins = Object.entries(config.plugins).filter(([, options]) => options);
+  } else {
+    plugins = [];
   }
   const loadedPlugins = plugins.map((plugin) => {
     if (Array.isArray(plugin)) {
@@ -61,7 +68,6 @@ const transform = async (ipc, cssContent, name) => {
 
   const assets = [];
   for (const msg of messages) {
-    console.error(msg);
     switch (msg.type) {
       case "asset":
         assets.push({

--- a/crates/turbopack-node/src/evaluate.rs
+++ b/crates/turbopack-node/src/evaluate.rs
@@ -3,14 +3,16 @@ use std::{collections::HashMap, thread::available_parallelism};
 use anyhow::Result;
 use turbo_tasks::{
     primitives::{JsonValueVc, StringVc},
-    TryJoinIterExt, Value,
+    CompletionVc, TryJoinIterExt, Value, ValueToString,
 };
-use turbo_tasks_fs::{rope::Rope, to_sys_path, File, FileSystemPathVc};
+use turbo_tasks_fs::{
+    glob::GlobVc, rope::Rope, to_sys_path, DirectoryEntry, File, FileSystemPathVc, ReadGlobResultVc,
+};
 use turbopack_core::{
     asset::AssetVc,
     chunk::{dev::DevChunkingContextVc, ChunkGroupVc},
     context::AssetContextVc,
-    issue::{Issue, IssueVc},
+    issue::{Issue, IssueSeverity, IssueSeverityVc, IssueVc},
     source_asset::SourceAssetVc,
     virtual_asset::VirtualAssetVc,
 };
@@ -23,7 +25,7 @@ use crate::{
     bootstrap::NodeJsBootstrapAsset,
     embed_js::embed_file_path,
     emit,
-    pool::{NodeJsOperation, NodeJsPool, NodeJsPoolVc},
+    pool::{NodeJsPool, NodeJsPoolVc},
     EvalJavaScriptIncomingMessage, EvalJavaScriptOutgoingMessage, StructuredError,
 };
 
@@ -34,27 +36,6 @@ pub enum JavaScriptValue {
     Value(Rope),
     // TODO, support stream in the future
     Stream(#[turbo_tasks(trace_ignore)] Vec<u8>),
-}
-
-async fn eval_js_operation(
-    operation: &mut NodeJsOperation,
-    content: EvalJavaScriptOutgoingMessage<'_>,
-    context_path: FileSystemPathVc,
-) -> Result<JavaScriptValue> {
-    operation.send(content).await?;
-    Ok(match operation.recv().await? {
-        EvalJavaScriptIncomingMessage::Error(error) => {
-            EvaluationIssue {
-                error,
-                context_path,
-            }
-            .cell()
-            .as_issue()
-            .emit();
-            JavaScriptValue::Error
-        }
-        EvalJavaScriptIncomingMessage::JsonValue { data } => JavaScriptValue::Value(data.into()),
-    })
 }
 
 #[turbo_tasks::function]
@@ -133,6 +114,7 @@ pub async fn evaluate(
     context_path: FileSystemPathVc,
     module_asset: AssetVc,
     cwd: FileSystemPathVc,
+    context_path_for_issue: FileSystemPathVc,
     context: AssetContextVc,
     intermediate_output_path: FileSystemPathVc,
     runtime_entries: Option<EcmascriptChunkPlaceablesVc>,
@@ -149,14 +131,56 @@ pub async fn evaluate(
     .await?;
     let mut operation = pool.operation().await?;
     let args = args.into_iter().try_join().await?;
-    let output = eval_js_operation(
-        &mut operation,
-        EvalJavaScriptOutgoingMessage::Evaluate {
+    operation
+        .send(EvalJavaScriptOutgoingMessage::Evaluate {
             args: args.iter().map(|v| &**v).collect(),
-        },
-        context_path,
-    )
-    .await?;
+        })
+        .await?;
+    let mut file_dependencies = Vec::new();
+    let mut dir_dependencies = Vec::new();
+    let output = loop {
+        match operation.recv().await? {
+            EvalJavaScriptIncomingMessage::Error(error) => {
+                EvaluationIssue {
+                    error,
+                    context_path: context_path_for_issue,
+                }
+                .cell()
+                .as_issue()
+                .emit();
+                break JavaScriptValue::Error;
+            }
+            EvalJavaScriptIncomingMessage::JsonValue { data } => {
+                break JavaScriptValue::Value(data.into())
+            }
+            EvalJavaScriptIncomingMessage::FileDependency { path } => {
+                // TODO We might miss some changes that happened during execution
+                file_dependencies.push(cwd.join(&path).read());
+            }
+            EvalJavaScriptIncomingMessage::BuildDependency { path } => {
+                // TODO We might miss some changes that happened during execution
+                BuildDependencyIssue {
+                    context_path: context_path_for_issue,
+                    path: cwd.join(&path),
+                }
+                .cell()
+                .as_issue()
+                .emit();
+            }
+            EvalJavaScriptIncomingMessage::DirDependency { path, glob } => {
+                // TODO We might miss some changes that happened during execution
+                dir_dependencies.push(dir_dependency(
+                    cwd.join(&path).read_glob(GlobVc::new(&glob), false),
+                ));
+            }
+        }
+    };
+    for dep in file_dependencies {
+        dep.await?;
+    }
+    for dep in dir_dependencies {
+        dep.await?;
+    }
     if args.is_empty() {
         // Assume this is a one-off operation, so we can kill the process
         // TODO use a better way to decide that.
@@ -195,4 +219,81 @@ impl Issue for EvaluationIssue {
             self.error.print(Default::default(), None).await?,
         ))
     }
+}
+
+/// An issue that occurred while evaluating node code.
+#[turbo_tasks::value(shared)]
+pub struct BuildDependencyIssue {
+    pub context_path: FileSystemPathVc,
+    pub path: FileSystemPathVc,
+}
+
+#[turbo_tasks::value_impl]
+impl Issue for BuildDependencyIssue {
+    #[turbo_tasks::function]
+    fn severity(&self) -> IssueSeverityVc {
+        IssueSeverity::Warning.into()
+    }
+
+    #[turbo_tasks::function]
+    fn title(&self) -> StringVc {
+        StringVc::cell("Build dependencies are not yet supported".to_string())
+    }
+
+    #[turbo_tasks::function]
+    fn category(&self) -> StringVc {
+        StringVc::cell("build".to_string())
+    }
+
+    #[turbo_tasks::function]
+    fn context(&self) -> FileSystemPathVc {
+        self.context_path
+    }
+
+    #[turbo_tasks::function]
+    async fn description(&self) -> Result<StringVc> {
+        Ok(StringVc::cell(
+            format!("The file at {} is a build dependency, which is not yet implemented.
+Changing this file or any dependency will not be regonized and might requires restarting the server", self.path.to_string().await?)
+        ))
+    }
+}
+
+/// A hack to invalidate when any file in a directory changes. Need to be
+/// awaited before files are accessed.
+#[turbo_tasks::function]
+async fn dir_dependency(glob: ReadGlobResultVc) -> Result<CompletionVc> {
+    let shallow = dir_dependency_shallow(glob);
+    let glob = glob.await?;
+    glob.inner
+        .values()
+        .map(|&inner| dir_dependency(inner))
+        .try_join()
+        .await?;
+    shallow.await?;
+    Ok(CompletionVc::new())
+}
+
+#[turbo_tasks::function]
+async fn dir_dependency_shallow(glob: ReadGlobResultVc) -> Result<CompletionVc> {
+    let glob = glob.await?;
+    for item in glob.results.values() {
+        // Reading all files to add itself as dependency
+        match *item {
+            DirectoryEntry::File(file) => {
+                file.read().await?;
+            }
+            DirectoryEntry::Directory(dir) => {
+                dir_dependency(dir.read_glob(GlobVc::new("**"), false)).await?;
+            }
+            DirectoryEntry::Symlink(symlink) => {
+                symlink.read_link().await?;
+            }
+            DirectoryEntry::Other(other) => {
+                other.get_type().await?;
+            }
+            DirectoryEntry::Error => {}
+        }
+    }
+    Ok(CompletionVc::new())
 }

--- a/crates/turbopack-node/src/evaluate.rs
+++ b/crates/turbopack-node/src/evaluate.rs
@@ -175,6 +175,8 @@ pub async fn evaluate(
             }
         }
     };
+    // Read dependencies to make them a dependencies of this task. This task will
+    // execute again when they change.
     for dep in file_dependencies {
         dep.await?;
     }
@@ -254,7 +256,7 @@ impl Issue for BuildDependencyIssue {
     async fn description(&self) -> Result<StringVc> {
         Ok(StringVc::cell(
             format!("The file at {} is a build dependency, which is not yet implemented.
-Changing this file or any dependency will not be regonized and might requires restarting the server", self.path.to_string().await?)
+Changing this file or any dependency will not be recognized and might require restarting the server", self.path.to_string().await?)
         ))
     }
 }

--- a/crates/turbopack-node/src/lib.rs
+++ b/crates/turbopack-node/src/lib.rs
@@ -244,6 +244,9 @@ enum EvalJavaScriptOutgoingMessage<'a> {
 #[derive(Deserialize)]
 #[serde(tag = "type", rename_all = "camelCase")]
 enum EvalJavaScriptIncomingMessage {
+    FileDependency { path: String },
+    BuildDependency { path: String },
+    DirDependency { path: String, glob: String },
     JsonValue { data: String },
     Error(StructuredError),
 }

--- a/crates/turbopack-node/src/transforms/postcss.rs
+++ b/crates/turbopack-node/src/transforms/postcss.rs
@@ -219,7 +219,7 @@ impl PostCssTransformedAssetVc {
         )
         .await?;
         let JavaScriptValue::Value(val) = &*config_value else {
-            // An error happened, which has already converted into an issue.
+            // An error happened, which has already been converted into an issue.
             return Ok(ProcessPostCssResult {
                 content: AssetContent::File(FileContent::NotFound.cell()).cell(),
                 assets: Vec::new()

--- a/crates/turbopack-node/src/transforms/postcss.rs
+++ b/crates/turbopack-node/src/transforms/postcss.rs
@@ -18,8 +18,8 @@ use turbopack_core::{
     virtual_asset::VirtualAssetVc,
 };
 use turbopack_ecmascript::{
-    chunk::EcmascriptChunkPlaceablesVc, EcmascriptInputTransformsVc, EcmascriptModuleAssetType,
-    EcmascriptModuleAssetVc, InnerAssetsVc,
+    chunk::EcmascriptChunkPlaceablesVc, EcmascriptInputTransform, EcmascriptInputTransformsVc,
+    EcmascriptModuleAssetType, EcmascriptModuleAssetVc, InnerAssetsVc,
 };
 
 use crate::{
@@ -193,12 +193,12 @@ impl PostCssTransformedAssetVc {
         let postcss_executor = EcmascriptModuleAssetVc::new_with_inner_assets(
             VirtualAssetVc::new(
                 config_path.join("transform.js"),
-                AssetContent::File(embed_file("transforms/postcss.js")).cell(),
+                AssetContent::File(embed_file("transforms/postcss.ts")).cell(),
             )
             .into(),
             context,
-            Value::new(EcmascriptModuleAssetType::Ecmascript),
-            EcmascriptInputTransformsVc::cell(Default::default()),
+            Value::new(EcmascriptModuleAssetType::Typescript),
+            EcmascriptInputTransformsVc::cell(vec![EcmascriptInputTransform::TypeScript]),
             context.environment(),
             InnerAssetsVc::cell(HashMap::from([("CONFIG".to_string(), config_asset)])),
         );

--- a/crates/turbopack-node/src/transforms/postcss.rs
+++ b/crates/turbopack-node/src/transforms/postcss.rs
@@ -1,7 +1,8 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use anyhow::{bail, Context, Result};
 use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
 use turbo_tasks::{
     primitives::{JsonValueVc, StringsVc},
     TryJoinIterExt, Value,
@@ -27,12 +28,22 @@ use crate::{
     execution_context::{ExecutionContext, ExecutionContextVc},
 };
 
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+struct PostCssEmittedAsset {
+    file: String,
+    content: String,
+    source_map: Option<JsonValue>,
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 #[turbo_tasks::value(transparent, serialization = "custom")]
-struct ProcessedCSS {
+struct PostCssProcessingResult {
     css: String,
     map: Option<String>,
+    #[turbo_tasks(trace_ignore)]
+    assets: Option<Vec<PostCssEmittedAsset>>,
 }
 
 #[turbo_tasks::function]
@@ -110,25 +121,46 @@ impl Asset for PostCssTransformedAsset {
     }
 
     #[turbo_tasks::function]
-    async fn content(&self) -> Result<AssetContentVc> {
-        let find_config_result = find_context_file(self.source.path().parent(), postcss_configs());
+    async fn content(self_vc: PostCssTransformedAssetVc) -> Result<AssetContentVc> {
+        Ok(self_vc.process().await?.content)
+    }
+}
+
+#[turbo_tasks::value]
+struct ProcessPostCssResult {
+    content: AssetContentVc,
+    assets: Vec<VirtualAssetVc>,
+}
+
+#[turbo_tasks::value_impl]
+impl PostCssTransformedAssetVc {
+    #[turbo_tasks::function]
+    async fn process(self) -> Result<ProcessPostCssResultVc> {
+        let this = self.await?;
+        let find_config_result = find_context_file(this.source.path().parent(), postcss_configs());
         let FindContextFileResult::Found(config_path, _) = *find_config_result.await? else {
-            return Ok(self.source.content())
+            return Ok(ProcessPostCssResult {
+                content: this.source.content(),
+                assets: Vec::new()
+            }.cell())
         };
 
         let ExecutionContext {
             project_root,
             intermediate_output_path,
-        } = *self.execution_context.await?;
-        let source_content = self.source.content();
+        } = *this.execution_context.await?;
+        let source_content = this.source.content();
         let AssetContent::File(file) = *source_content.await? else {
             bail!("PostCSS transform only support transforming files");
         };
         let FileContent::Content(content) = &*file.await? else {
-            return Ok(AssetContent::File(FileContent::NotFound.cell()).cell());
+            return Ok(ProcessPostCssResult {
+                content: AssetContent::File(FileContent::NotFound.cell()).cell(),
+                assets: Vec::new()
+            }.cell());
         };
         let content = content.content().to_str()?;
-        let context = self.evaluate_context;
+        let context = this.evaluate_context;
         // TODO this is a hack to get these files watched.
         let config_paths = [config_path.parent().join("tailwind.config.js")];
         let configs = config_paths
@@ -170,12 +202,13 @@ impl Asset for PostCssTransformedAsset {
             context.environment(),
             InnerAssetsVc::cell(HashMap::from([("CONFIG".to_string(), config_asset)])),
         );
-        let css_fs_path = self.source.path().await?;
+        let css_fs_path = this.source.path().await?;
         let css_path = css_fs_path.path.as_str();
         let config_value = evaluate(
             project_root,
             postcss_executor.into(),
             project_root,
+            this.source.path(),
             context,
             intermediate_output_path,
             Some(EcmascriptChunkPlaceablesVc::cell(configs)),
@@ -186,12 +219,39 @@ impl Asset for PostCssTransformedAsset {
         )
         .await?;
         let JavaScriptValue::Value(val) = &*config_value else {
-            return Ok(source_content);
+            // An error happened, which has already converted into an issue.
+            return Ok(ProcessPostCssResult {
+                content: AssetContent::File(FileContent::NotFound.cell()).cell(),
+                assets: Vec::new()
+            }.cell());
         };
-        let processed_css: ProcessedCSS = serde_json::from_reader(val.read())
+        let processed_css: PostCssProcessingResult = serde_json::from_reader(val.read())
             .context("Unable to deserializate response from PostCSS transform operation")?;
         let file = File::from(processed_css.css);
         // TODO handle SourceMap
-        Ok(AssetContent::File(FileContent::Content(file).cell()).cell())
+        let assets = processed_css
+            .assets
+            .into_iter()
+            .flatten()
+            .map(
+                |PostCssEmittedAsset {
+                     file,
+                     content,
+                     source_map,
+                 }| (file, (content, source_map)),
+            )
+            // Sort it to make it determinstic
+            .collect::<BTreeMap<_, _>>()
+            .into_iter()
+            .map(|(file, (content, _source_map))| {
+                // TODO handle SourceMap
+                VirtualAssetVc::new(
+                    project_root.join(&file),
+                    AssetContent::File(FileContent::Content(File::from(content)).cell()).cell(),
+                )
+            })
+            .collect();
+        let content = AssetContent::File(FileContent::Content(file).cell()).cell();
+        Ok(ProcessPostCssResult { content, assets }.cell())
     }
 }


### PR DESCRIPTION
pass the dependencies reported by postcss to turbo-tasks-fs. We don't have a good mechanism to track dependencies back-timed, so we start watching some as soon we know about the dependencies (after postcss compilation)

tailwind reports dependencies as directory + glob, so our globbing need some improvements to handle these globs reported by tailwind.

e.g. tailwind will rerun when any file changed from the tailwind config `content` globs.

fixes WEB-356