### PR TITLE
Fix server generation of 404 pages

### DIFF
--- a/crates/next-core/src/server_rendered_source.rs
+++ b/crates/next-core/src/server_rendered_source.rs
@@ -318,7 +318,7 @@ async fn create_server_rendered_source_for_directory(
                                         )
                                     } else if basename == "404" {
                                         (
-                                            server_path.join("[...]"),
+                                            server_path.join("[...].html"),
                                             intermediate_output_path.join(basename),
                                             specificity.with_fallback(position),
                                         )


### PR DESCRIPTION
Any `404.js` page would inject a `[...]` path into the server generation. The problem comes from the `pathname_for_path` function, which will extract the extension from that path. In this case, it leads to a basename of `[...` and an extension of `]`, breaking the `regular_expression_for_path` dynamic route parser.

Unfortunately, our integration tests timeout when I try to write a basic test case for this, so it's not possible to test at the moment. I've manually verified.

Fixes WEB-214