### PR TITLE
Prevent `tsconfig.json` loading inside `node_modules`

### DIFF
--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -224,7 +224,7 @@ pub async fn load_next_config(execution_context: ExecutionContextVc) -> Result<N
     import_map.insert_wildcard_alias("next/", ImportMapping::External(None).into());
 
     let context = node_evaluate_asset_context(Some(import_map.cell()));
-    let find_config_result = find_context_file(project_root, next_configs());
+    let find_config_result = find_context_file(project_root, next_configs(), false);
     let config_asset = match &*find_config_result.await? {
         FindContextFileResult::Found(config_path, _) => Some(SourceAssetVc::new(*config_path)),
         FindContextFileResult::NotFound(_) => None,

--- a/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/crates/turbopack-ecmascript/src/references/mod.rs
@@ -184,7 +184,7 @@ pub(crate) async fn analyze_ecmascript_module(
 
     let parsed = parse(source, ty, transforms);
 
-    match &*find_context_file(path.parent(), package_json()).await? {
+    match &*find_context_file(path.parent(), package_json(), true).await? {
         FindContextFileResult::Found(package_json, _) => {
             analysis.add_reference(PackageJsonReferenceVc::new(*package_json));
         }
@@ -192,7 +192,7 @@ pub(crate) async fn analyze_ecmascript_module(
     };
 
     if is_typescript {
-        match &*find_context_file(path.parent(), tsconfig()).await? {
+        match &*find_context_file(path.parent(), tsconfig(), false).await? {
             FindContextFileResult::Found(tsconfig, _) => {
                 analysis.add_reference(TsConfigReferenceVc::new(origin, *tsconfig));
             }

--- a/crates/turbopack-node/src/transforms/postcss.rs
+++ b/crates/turbopack-node/src/transforms/postcss.rs
@@ -137,7 +137,8 @@ impl PostCssTransformedAssetVc {
     #[turbo_tasks::function]
     async fn process(self) -> Result<ProcessPostCssResultVc> {
         let this = self.await?;
-        let find_config_result = find_context_file(this.source.path().parent(), postcss_configs());
+        let find_config_result =
+            find_context_file(this.source.path().parent(), postcss_configs(), false);
         let FindContextFileResult::Found(config_path, _) = *find_config_result.await? else {
             return Ok(ProcessPostCssResult {
                 content: this.source.content(),

--- a/crates/turbopack/src/resolve.rs
+++ b/crates/turbopack/src/resolve.rs
@@ -235,7 +235,7 @@ pub async fn resolve_options(
 
     let options_context = options_context.await?;
     let resolve_options = if options_context.enable_typescript {
-        let tsconfig = find_context_file(context, tsconfig()).await?;
+        let tsconfig = find_context_file(context, tsconfig(), false).await?;
         let cjs_resolve_options = apply_cjs_specific_options(resolve_options);
         match *tsconfig {
             FindContextFileResult::Found(path, _) => apply_tsconfig_resolve_options(


### PR DESCRIPTION
Node modules often accidentally include their `tsconfig.json` files, and loading that file very frequently breaks the app (eg, if it uses `paths` or `baseUrl`). This excludes the loading of the following files inside `node_modules`:
- `tsconfig.json`
- `next.config.js` (and the like)
- `postcss.config.js` (and the like)

Fixes WEB-43