### PR TITLE
Fix retrying when port already bound

### DIFF
--- a/crates/next-dev/src/lib.rs
+++ b/crates/next-dev/src/lib.rs
@@ -164,13 +164,9 @@ impl NextDevServerBuilder {
                         // `std::io::ErrorKind::AddrInUse`.
                         e.source()
                             .map(|e| {
-                                e.source()
-                                    .map(|e| {
-                                        e.downcast_ref::<std::io::Error>()
-                                            .map(|e| e.kind() == std::io::ErrorKind::AddrInUse)
-                                            == Some(true)
-                                    })
-                                    .unwrap_or_else(|| false)
+                                e.downcast_ref::<std::io::Error>()
+                                    .map(|e| e.kind() == std::io::ErrorKind::AddrInUse)
+                                    == Some(true)
                             })
                             .unwrap_or_else(|| false)
                     } else {

--- a/crates/turbopack-dev-server/src/lib.rs
+++ b/crates/turbopack-dev-server/src/lib.rs
@@ -65,7 +65,7 @@ where
     }
 }
 
-#[derive(TraceRawVcs)]
+#[derive(TraceRawVcs, Debug)]
 pub struct DevServerBuilder {
     #[turbo_tasks(trace_ignore)]
     pub addr: SocketAddr,


### PR DESCRIPTION
#3021 [removed](https://github.com/vercel/turbo/pull/3021/files#diff-c6405fb94033af4296b1f72626fb990aaf76f645b6ed0f7812c56fcad719cf0eL304-L306) 1 level of error wrapping, and the unwrapping code was not updated to match.