### PR TITLE
separate typescript with types from typescript transformed

### DIFF
--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -116,6 +116,7 @@ pub async fn get_client_module_options_context(
         // We don't need to resolve React Refresh for each module. Instead,
         // we try resolve it once at the root and pass down a context to all
         // the modules.
+        enable_jsx: true,
         enable_emotion: true,
         enable_react_refresh,
         enable_styled_components: true,

--- a/crates/next-core/src/next_server/mod.rs
+++ b/crates/next-core/src/next_server/mod.rs
@@ -110,6 +110,7 @@ pub fn get_server_module_options_context(
                 ..Default::default()
             };
             ModuleOptionsContext {
+                enable_jsx: true,
                 enable_styled_jsx: true,
                 enable_postcss_transform: Some(PostCssTransformOptions {
                     postcss_package: Some(get_postcss_package_mapping(project_path)),
@@ -129,6 +130,7 @@ pub fn get_server_module_options_context(
                 ..Default::default()
             };
             ModuleOptionsContext {
+                enable_jsx: true,
                 enable_styled_jsx: true,
                 enable_postcss_transform: Some(PostCssTransformOptions {
                     postcss_package: Some(get_postcss_package_mapping(project_path)),
@@ -151,6 +153,7 @@ pub fn get_server_module_options_context(
                 ..Default::default()
             };
             ModuleOptionsContext {
+                enable_jsx: true,
                 enable_postcss_transform: Some(PostCssTransformOptions {
                     postcss_package: Some(get_postcss_package_mapping(project_path)),
                     ..Default::default()

--- a/crates/node-file-trace/src/lib.rs
+++ b/crates/node-file-trace/src/lib.rs
@@ -32,7 +32,7 @@ use turbo_tasks_memory::{
     viz, MemoryBackend,
 };
 use turbopack::{
-    emit_asset, emit_with_completion, rebase::RebasedAssetVc,
+    emit_asset, emit_with_completion, module_options::ModuleOptionsContext, rebase::RebasedAssetVc,
     resolve_options_context::ResolveOptionsContext, transition::TransitionsByNameVc,
     ModuleAssetContextVc,
 };
@@ -257,7 +257,11 @@ async fn input_to_modules<'a>(
     let context: AssetContextVc = ModuleAssetContextVc::new(
         TransitionsByNameVc::cell(HashMap::new()),
         env,
-        Default::default(),
+        ModuleOptionsContext {
+            enable_types: true,
+            ..Default::default()
+        }
+        .cell(),
         ResolveOptionsContext {
             emulate_environment: Some(env),
             resolved_map: Some(

--- a/crates/turbopack-ecmascript/src/lib.rs
+++ b/crates/turbopack-ecmascript/src/lib.rs
@@ -71,7 +71,7 @@ pub enum EcmascriptModuleAssetType {
     Ecmascript,
     /// Module with TypeScript code without types
     Typescript,
-    /// Module with TypeScript code with types
+    /// Module with TypeScript code with references to imported types
     TypescriptWithTypes,
     /// Module with TypeScript declaration code
     TypescriptDeclaration,

--- a/crates/turbopack-ecmascript/src/lib.rs
+++ b/crates/turbopack-ecmascript/src/lib.rs
@@ -67,9 +67,13 @@ use crate::{
 #[turbo_tasks::value(serialization = "auto_for_input")]
 #[derive(PartialOrd, Ord, Hash, Debug, Copy, Clone)]
 pub enum EcmascriptModuleAssetType {
+    /// Module with EcmaScript code
     Ecmascript,
+    /// Module with TypeScript code without types
     Typescript,
-    TypescriptSource,
+    /// Module with TypeScript code with types
+    TypescriptWithTypes,
+    /// Module with TypeScript declaration code
     TypescriptDeclaration,
 }
 

--- a/crates/turbopack-ecmascript/src/lib.rs
+++ b/crates/turbopack-ecmascript/src/lib.rs
@@ -69,6 +69,7 @@ use crate::{
 pub enum EcmascriptModuleAssetType {
     Ecmascript,
     Typescript,
+    TypescriptSource,
     TypescriptDeclaration,
 }
 

--- a/crates/turbopack-ecmascript/src/parse.rs
+++ b/crates/turbopack-ecmascript/src/parse.rs
@@ -205,12 +205,15 @@ async fn parse_content(
                             allow_super_outside_method: true,
                             allow_return_outside_function: true,
                         }),
-                        EcmascriptModuleAssetType::Typescript => Syntax::Typescript(TsConfig {
-                            decorators: true,
-                            dts: false,
-                            no_early_errors: true,
-                            tsx: true,
-                        }),
+                        EcmascriptModuleAssetType::Typescript
+                        | EcmascriptModuleAssetType::TypescriptSource => {
+                            Syntax::Typescript(TsConfig {
+                                decorators: true,
+                                dts: false,
+                                no_early_errors: true,
+                                tsx: true,
+                            })
+                        }
                         EcmascriptModuleAssetType::TypescriptDeclaration => {
                             Syntax::Typescript(TsConfig {
                                 decorators: true,
@@ -252,6 +255,7 @@ async fn parse_content(
             let is_typescript = matches!(
                 ty,
                 EcmascriptModuleAssetType::Typescript
+                    | EcmascriptModuleAssetType::TypescriptSource
                     | EcmascriptModuleAssetType::TypescriptDeclaration
             );
             parsed_program.visit_mut_with(&mut resolver(

--- a/crates/turbopack-ecmascript/src/parse.rs
+++ b/crates/turbopack-ecmascript/src/parse.rs
@@ -206,7 +206,7 @@ async fn parse_content(
                             allow_return_outside_function: true,
                         }),
                         EcmascriptModuleAssetType::Typescript
-                        | EcmascriptModuleAssetType::TypescriptSource => {
+                        | EcmascriptModuleAssetType::TypescriptWithTypes => {
                             Syntax::Typescript(TsConfig {
                                 decorators: true,
                                 dts: false,
@@ -255,7 +255,7 @@ async fn parse_content(
             let is_typescript = matches!(
                 ty,
                 EcmascriptModuleAssetType::Typescript
-                    | EcmascriptModuleAssetType::TypescriptSource
+                    | EcmascriptModuleAssetType::TypescriptWithTypes
                     | EcmascriptModuleAssetType::TypescriptDeclaration
             );
             parsed_program.visit_mut_with(&mut resolver(

--- a/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/crates/turbopack-ecmascript/src/references/mod.rs
@@ -178,7 +178,7 @@ pub(crate) async fn analyze_ecmascript_module(
 
     // Is this a typescript file that requires analzying type references?
     let is_typescript = match &*ty {
-        EcmascriptModuleAssetType::TypescriptSource
+        EcmascriptModuleAssetType::TypescriptWithTypes
         | EcmascriptModuleAssetType::TypescriptDeclaration => true,
         EcmascriptModuleAssetType::Typescript | EcmascriptModuleAssetType::Ecmascript => false,
     };

--- a/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/crates/turbopack-ecmascript/src/references/mod.rs
@@ -177,7 +177,7 @@ pub(crate) async fn analyze_ecmascript_module(
     let path = source.path();
 
     // Is this a typescript file that requires analzying type references?
-    let is_typescript = match &*ty {
+    let analyze_types = match &*ty {
         EcmascriptModuleAssetType::TypescriptWithTypes
         | EcmascriptModuleAssetType::TypescriptDeclaration => true,
         EcmascriptModuleAssetType::Typescript | EcmascriptModuleAssetType::Ecmascript => false,
@@ -192,7 +192,7 @@ pub(crate) async fn analyze_ecmascript_module(
         FindContextFileResult::NotFound(_) => {}
     };
 
-    if is_typescript {
+    if analyze_types {
         match &*find_context_file(path.parent(), tsconfig()).await? {
             FindContextFileResult::Found(tsconfig, _) => {
                 analysis.add_reference(TsConfigReferenceVc::new(origin, *tsconfig));
@@ -216,7 +216,7 @@ pub(crate) async fn analyze_ecmascript_module(
             let mut import_references = Vec::new();
 
             let pos = program.span().lo;
-            if is_typescript {
+            if analyze_types {
                 if let Some(comments) = comments.leading.get(&pos) {
                     for comment in comments.iter() {
                         if let CommentKind::Line = comment.kind {
@@ -423,7 +423,7 @@ pub(crate) async fn analyze_ecmascript_module(
                 this: JsValue,
                 args: Vec<JsValue>,
                 link_value: &'a F,
-                is_typescript: bool,
+                analyze_types: bool,
                 analysis: &'a mut AnalyzeEcmascriptModuleResultBuilder,
                 environment: EnvironmentVc,
             ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>> {
@@ -437,7 +437,7 @@ pub(crate) async fn analyze_ecmascript_module(
                     this,
                     args,
                     link_value,
-                    is_typescript,
+                    analyze_types,
                     analysis,
                     environment,
                 ))
@@ -456,7 +456,7 @@ pub(crate) async fn analyze_ecmascript_module(
                 this: JsValue,
                 args: Vec<JsValue>,
                 link_value: &F,
-                is_typescript: bool,
+                analyze_types: bool,
                 analysis: &mut AnalyzeEcmascriptModuleResultBuilder,
                 environment: EnvironmentVc,
             ) -> Result<()> {
@@ -477,7 +477,7 @@ pub(crate) async fn analyze_ecmascript_module(
                                 this.clone(),
                                 args.clone(),
                                 link_value,
-                                is_typescript,
+                                analyze_types,
                                 analysis,
                                 environment,
                             )
@@ -503,7 +503,7 @@ pub(crate) async fn analyze_ecmascript_module(
                                             JsValue::Unknown(None, "no this provided"),
                                             args,
                                             link_value,
-                                            is_typescript,
+                                            analyze_types,
                                             analysis,
                                             environment,
                                         )
@@ -1104,7 +1104,7 @@ pub(crate) async fn analyze_ecmascript_module(
                             JsValue::Unknown(None, "no this provided"),
                             args,
                             &link_value,
-                            is_typescript,
+                            analyze_types,
                             &mut analysis,
                             environment,
                         )
@@ -1135,7 +1135,7 @@ pub(crate) async fn analyze_ecmascript_module(
                             obj,
                             args,
                             &link_value,
-                            is_typescript,
+                            analyze_types,
                             &mut analysis,
                             environment,
                         )

--- a/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/crates/turbopack-ecmascript/src/references/mod.rs
@@ -176,10 +176,11 @@ pub(crate) async fn analyze_ecmascript_module(
     let mut analysis = AnalyzeEcmascriptModuleResultBuilder::new();
     let path = source.path();
 
+    // Is this a typescript file that requires analzying type references?
     let is_typescript = match &*ty {
-        EcmascriptModuleAssetType::Typescript
+        EcmascriptModuleAssetType::TypescriptSource
         | EcmascriptModuleAssetType::TypescriptDeclaration => true,
-        EcmascriptModuleAssetType::Ecmascript => false,
+        EcmascriptModuleAssetType::Typescript | EcmascriptModuleAssetType::Ecmascript => false,
     };
 
     let parsed = parse(source, ty, transforms);

--- a/crates/turbopack-tests/tests/snapshot.rs
+++ b/crates/turbopack-tests/tests/snapshot.rs
@@ -160,9 +160,17 @@ async fn run_test(resource: String) -> Result<FileSystemPathVc> {
         TransitionsByNameVc::cell(HashMap::new()),
         env,
         ModuleOptionsContext {
+            enable_jsx: true,
             enable_emotion: true,
             enable_styled_components: true,
             preset_env_versions: Some(env),
+            rules: vec![(
+                ContextCondition::InDirectory("node_modules".to_string()),
+                ModuleOptionsContext {
+                    ..Default::default()
+                }
+                .cell(),
+            )],
             ..Default::default()
         }
         .into(),

--- a/crates/turbopack/benches/node_file_trace.rs
+++ b/crates/turbopack/benches/node_file_trace.rs
@@ -6,7 +6,7 @@ use turbo_tasks::{NothingVc, TurboTasks, Value};
 use turbo_tasks_fs::{DiskFileSystemVc, FileSystem, NullFileSystem, NullFileSystemVc};
 use turbo_tasks_memory::MemoryBackend;
 use turbopack::{
-    emit_with_completion, rebase::RebasedAssetVc, register,
+    emit_with_completion, module_options::ModuleOptionsContext, rebase::RebasedAssetVc, register,
     resolve_options_context::ResolveOptionsContext, transition::TransitionsByNameVc,
     ModuleAssetContextVc,
 };
@@ -87,7 +87,11 @@ fn bench_emit(b: &mut Bencher, bench_input: &BenchInput) {
                 let context = ModuleAssetContextVc::new(
                     TransitionsByNameVc::cell(HashMap::new()),
                     environment,
-                    Default::default(),
+                    ModuleOptionsContext {
+                        enable_types: true,
+                        ..Default::default()
+                    }
+                    .cell(),
                     ResolveOptionsContext {
                         emulate_environment: Some(environment),
                         ..Default::default()

--- a/crates/turbopack/src/lib.rs
+++ b/crates/turbopack/src/lib.rs
@@ -125,10 +125,10 @@ async fn apply_module_type(
             context.environment(),
         )
         .into(),
-        ModuleType::TypescriptSource(transforms) => EcmascriptModuleAssetVc::new(
+        ModuleType::TypescriptWithTypes(transforms) => EcmascriptModuleAssetVc::new(
             source,
             context.with_types_resolving_enabled().into(),
-            Value::new(EcmascriptModuleAssetType::TypescriptSource),
+            Value::new(EcmascriptModuleAssetType::TypescriptWithTypes),
             *transforms,
             context.environment(),
         )

--- a/crates/turbopack/src/lib.rs
+++ b/crates/turbopack/src/lib.rs
@@ -119,15 +119,23 @@ async fn apply_module_type(
         .into(),
         ModuleType::Typescript(transforms) => EcmascriptModuleAssetVc::new(
             source,
-            context.with_typescript_resolving_enabled().into(),
+            context.into(),
             Value::new(EcmascriptModuleAssetType::Typescript),
+            *transforms,
+            context.environment(),
+        )
+        .into(),
+        ModuleType::TypescriptSource(transforms) => EcmascriptModuleAssetVc::new(
+            source,
+            context.with_types_resolving_enabled().into(),
+            Value::new(EcmascriptModuleAssetType::TypescriptSource),
             *transforms,
             context.environment(),
         )
         .into(),
         ModuleType::TypescriptDeclaration(transforms) => EcmascriptModuleAssetVc::new(
             source,
-            context.with_typescript_resolving_enabled().into(),
+            context.with_types_resolving_enabled().into(),
             Value::new(EcmascriptModuleAssetType::TypescriptDeclaration),
             *transforms,
             context.environment(),
@@ -278,21 +286,21 @@ impl ModuleAssetContextVc {
     }
 
     #[turbo_tasks::function]
-    pub async fn is_typescript_resolving_enabled(self) -> Result<BoolVc> {
+    pub async fn is_types_resolving_enabled(self) -> Result<BoolVc> {
         Ok(BoolVc::cell(
-            self.await?.resolve_options_context.await?.enable_typescript,
+            self.await?.resolve_options_context.await?.enable_types,
         ))
     }
 
     #[turbo_tasks::function]
-    pub async fn with_typescript_resolving_enabled(self) -> Result<ModuleAssetContextVc> {
-        if *self.is_typescript_resolving_enabled().await? {
+    pub async fn with_types_resolving_enabled(self) -> Result<ModuleAssetContextVc> {
+        if *self.is_types_resolving_enabled().await? {
             return Ok(self);
         }
         let this = self.await?;
         let resolve_options_context = this
             .resolve_options_context
-            .with_typescript_enabled()
+            .with_types_enabled()
             .resolve()
             .await?;
         Ok(ModuleAssetContextVc::new(
@@ -339,7 +347,7 @@ impl AssetContext for ModuleAssetContext {
         let result = resolve(context_path, request, resolve_options);
         let result = self_vc.process_resolve_result(result, reference_type);
 
-        if *self_vc.is_typescript_resolving_enabled().await? {
+        if *self_vc.is_types_resolving_enabled().await? {
             let types_reference = TypescriptTypesAssetReferenceVc::new(
                 PlainResolveOriginVc::new(self_vc.into(), origin_path).into(),
                 request,

--- a/crates/turbopack/src/lib.rs
+++ b/crates/turbopack/src/lib.rs
@@ -191,6 +191,11 @@ async fn module(
                             Some(ModuleType::Typescript(transforms)) => Some(
                                 ModuleType::Typescript(transforms.extend(*additional_transforms)),
                             ),
+                            Some(ModuleType::TypescriptWithTypes(transforms)) => {
+                                Some(ModuleType::TypescriptWithTypes(
+                                    transforms.extend(*additional_transforms),
+                                ))
+                            }
                             Some(module_type) => {
                                 ModuleIssue {
                                     path,
@@ -287,8 +292,9 @@ impl ModuleAssetContextVc {
 
     #[turbo_tasks::function]
     pub async fn is_types_resolving_enabled(self) -> Result<BoolVc> {
+        let context = self.await?.resolve_options_context.await?;
         Ok(BoolVc::cell(
-            self.await?.resolve_options_context.await?.enable_types,
+            context.enable_types && context.enable_typescript,
         ))
     }
 

--- a/crates/turbopack/src/module_options/mod.rs
+++ b/crates/turbopack/src/module_options/mod.rs
@@ -31,6 +31,7 @@ impl ModuleOptionsVc {
         context: ModuleOptionsContextVc,
     ) -> Result<ModuleOptionsVc> {
         let ModuleOptionsContext {
+            enable_jsx,
             enable_emotion,
             enable_react_refresh,
             enable_styled_jsx,
@@ -68,9 +69,11 @@ impl ModuleOptionsVc {
         if enable_styled_components {
             transforms.push(EcmascriptInputTransform::StyledComponents)
         }
-        transforms.push(EcmascriptInputTransform::React {
-            refresh: enable_react_refresh,
-        });
+        if enable_jsx {
+            transforms.push(EcmascriptInputTransform::React {
+                refresh: enable_react_refresh,
+            });
+        }
 
         if let Some(env) = preset_env_versions {
             transforms.push(EcmascriptInputTransform::PresetEnv(env));

--- a/crates/turbopack/src/module_options/mod.rs
+++ b/crates/turbopack/src/module_options/mod.rs
@@ -35,6 +35,7 @@ impl ModuleOptionsVc {
             enable_react_refresh,
             enable_styled_jsx,
             enable_styled_components,
+            enable_types,
             enable_typescript_transform,
             ref enable_postcss_transform,
             preset_env_versions,
@@ -210,10 +211,10 @@ impl ModuleOptionsVc {
                     ModuleRuleCondition::ResourcePathEndsWith(".ts".to_string()),
                     ModuleRuleCondition::ResourcePathEndsWith(".tsx".to_string()),
                 ]),
-                vec![if enable_typescript_transform {
-                    ModuleRuleEffect::ModuleType(ModuleType::Typescript(ts_app_transforms))
+                vec![if enable_types {
+                    ModuleRuleEffect::ModuleType(ModuleType::TypescriptWithTypes(ts_app_transforms))
                 } else {
-                    ModuleRuleEffect::ModuleType(ModuleType::TypescriptSource(ts_app_transforms))
+                    ModuleRuleEffect::ModuleType(ModuleType::Typescript(ts_app_transforms))
                 }],
             ),
             ModuleRule::new(
@@ -221,10 +222,10 @@ impl ModuleOptionsVc {
                     ModuleRuleCondition::ResourcePathEndsWith(".ts".to_string()),
                     ModuleRuleCondition::ResourcePathInDirectory("node_modules".to_string()),
                 ]),
-                vec![if enable_typescript_transform {
-                    ModuleRuleEffect::ModuleType(ModuleType::Typescript(ts_transforms))
+                vec![if enable_types {
+                    ModuleRuleEffect::ModuleType(ModuleType::TypescriptWithTypes(ts_transforms))
                 } else {
-                    ModuleRuleEffect::ModuleType(ModuleType::TypescriptSource(ts_transforms))
+                    ModuleRuleEffect::ModuleType(ModuleType::Typescript(ts_transforms))
                 }],
             ),
             ModuleRule::new(

--- a/crates/turbopack/src/module_options/mod.rs
+++ b/crates/turbopack/src/module_options/mod.rs
@@ -210,18 +210,22 @@ impl ModuleOptionsVc {
                     ModuleRuleCondition::ResourcePathEndsWith(".ts".to_string()),
                     ModuleRuleCondition::ResourcePathEndsWith(".tsx".to_string()),
                 ]),
-                vec![ModuleRuleEffect::ModuleType(ModuleType::Typescript(
-                    ts_app_transforms,
-                ))],
+                vec![if enable_typescript_transform {
+                    ModuleRuleEffect::ModuleType(ModuleType::Typescript(ts_app_transforms))
+                } else {
+                    ModuleRuleEffect::ModuleType(ModuleType::TypescriptSource(ts_app_transforms))
+                }],
             ),
             ModuleRule::new(
                 ModuleRuleCondition::all(vec![
                     ModuleRuleCondition::ResourcePathEndsWith(".ts".to_string()),
                     ModuleRuleCondition::ResourcePathInDirectory("node_modules".to_string()),
                 ]),
-                vec![ModuleRuleEffect::ModuleType(ModuleType::Typescript(
-                    ts_transforms,
-                ))],
+                vec![if enable_typescript_transform {
+                    ModuleRuleEffect::ModuleType(ModuleType::Typescript(ts_transforms))
+                } else {
+                    ModuleRuleEffect::ModuleType(ModuleType::TypescriptSource(ts_transforms))
+                }],
             ),
             ModuleRule::new(
                 ModuleRuleCondition::ResourcePathEndsWith(".d.ts".to_string()),

--- a/crates/turbopack/src/module_options/mod.rs
+++ b/crates/turbopack/src/module_options/mod.rs
@@ -79,21 +79,18 @@ impl ModuleOptionsVc {
         let app_transforms = EcmascriptInputTransformsVc::cell(transforms);
         let vendor_transforms =
             EcmascriptInputTransformsVc::cell(custom_ecmascript_transforms.clone());
-        let (ts_app_transforms, ts_transforms) = if enable_typescript_transform {
+        let ts_app_transforms = if enable_typescript_transform {
             let mut base_transforms = vec![EcmascriptInputTransform::TypeScript];
             base_transforms.extend(custom_ecmascript_transforms.iter().cloned());
-            (
-                EcmascriptInputTransformsVc::cell(
-                    base_transforms
-                        .iter()
-                        .cloned()
-                        .chain(app_transforms.await?.iter().cloned())
-                        .collect(),
-                ),
-                EcmascriptInputTransformsVc::cell(base_transforms),
+            EcmascriptInputTransformsVc::cell(
+                base_transforms
+                    .iter()
+                    .cloned()
+                    .chain(app_transforms.await?.iter().cloned())
+                    .collect(),
             )
         } else {
-            (app_transforms, vendor_transforms)
+            app_transforms
         };
 
         let css_transforms = CssInputTransformsVc::cell(vec![CssInputTransform::Nested]);
@@ -168,42 +165,15 @@ impl ModuleOptionsVc {
                 ))],
             ),
             ModuleRule::new(
-                ModuleRuleCondition::all(vec![
-                    ModuleRuleCondition::ResourcePathEndsWith(".js".to_string()),
-                    ModuleRuleCondition::ResourcePathInDirectory("node_modules".to_string()),
-                ]),
-                vec![ModuleRuleEffect::ModuleType(ModuleType::Ecmascript(
-                    vendor_transforms,
-                ))],
-            ),
-            ModuleRule::new(
                 ModuleRuleCondition::ResourcePathEndsWith(".mjs".to_string()),
                 vec![ModuleRuleEffect::ModuleType(ModuleType::Ecmascript(
                     app_transforms,
                 ))],
             ),
             ModuleRule::new(
-                ModuleRuleCondition::all(vec![
-                    ModuleRuleCondition::ResourcePathEndsWith(".mjs".to_string()),
-                    ModuleRuleCondition::ResourcePathInDirectory("node_modules".to_string()),
-                ]),
-                vec![ModuleRuleEffect::ModuleType(ModuleType::Ecmascript(
-                    vendor_transforms,
-                ))],
-            ),
-            ModuleRule::new(
                 ModuleRuleCondition::ResourcePathEndsWith(".cjs".to_string()),
                 vec![ModuleRuleEffect::ModuleType(ModuleType::Ecmascript(
                     app_transforms,
-                ))],
-            ),
-            ModuleRule::new(
-                ModuleRuleCondition::all(vec![
-                    ModuleRuleCondition::ResourcePathEndsWith(".cjs".to_string()),
-                    ModuleRuleCondition::ResourcePathInDirectory("node_modules".to_string()),
-                ]),
-                vec![ModuleRuleEffect::ModuleType(ModuleType::Ecmascript(
-                    vendor_transforms,
                 ))],
             ),
             ModuleRule::new(
@@ -215,17 +185,6 @@ impl ModuleOptionsVc {
                     ModuleRuleEffect::ModuleType(ModuleType::TypescriptWithTypes(ts_app_transforms))
                 } else {
                     ModuleRuleEffect::ModuleType(ModuleType::Typescript(ts_app_transforms))
-                }],
-            ),
-            ModuleRule::new(
-                ModuleRuleCondition::all(vec![
-                    ModuleRuleCondition::ResourcePathEndsWith(".ts".to_string()),
-                    ModuleRuleCondition::ResourcePathInDirectory("node_modules".to_string()),
-                ]),
-                vec![if enable_types {
-                    ModuleRuleEffect::ModuleType(ModuleType::TypescriptWithTypes(ts_transforms))
-                } else {
-                    ModuleRuleEffect::ModuleType(ModuleType::Typescript(ts_transforms))
                 }],
             ),
             ModuleRule::new(

--- a/crates/turbopack/src/module_options/module_options_context.rs
+++ b/crates/turbopack/src/module_options/module_options_context.rs
@@ -21,6 +21,7 @@ pub struct ModuleOptionsContext {
     pub enable_styled_components: bool,
     pub enable_styled_jsx: bool,
     pub enable_postcss_transform: Option<PostCssTransformOptions>,
+    pub enable_types: bool,
     pub enable_typescript_transform: bool,
     pub preset_env_versions: Option<EnvironmentVc>,
     pub custom_ecmascript_app_transforms: Vec<EcmascriptInputTransform>,

--- a/crates/turbopack/src/module_options/module_options_context.rs
+++ b/crates/turbopack/src/module_options/module_options_context.rs
@@ -16,6 +16,7 @@ pub struct PostCssTransformOptions {
 #[turbo_tasks::value(shared)]
 #[derive(Default, Clone)]
 pub struct ModuleOptionsContext {
+    pub enable_jsx: bool,
     pub enable_emotion: bool,
     pub enable_react_refresh: bool,
     pub enable_styled_components: bool,

--- a/crates/turbopack/src/module_options/module_rule.rs
+++ b/crates/turbopack/src/module_options/module_rule.rs
@@ -42,6 +42,7 @@ pub enum ModuleRuleEffect {
 pub enum ModuleType {
     Ecmascript(EcmascriptInputTransformsVc),
     Typescript(EcmascriptInputTransformsVc),
+    TypescriptSource(EcmascriptInputTransformsVc),
     TypescriptDeclaration(EcmascriptInputTransformsVc),
     Json,
     Raw,

--- a/crates/turbopack/src/module_options/module_rule.rs
+++ b/crates/turbopack/src/module_options/module_rule.rs
@@ -42,7 +42,7 @@ pub enum ModuleRuleEffect {
 pub enum ModuleType {
     Ecmascript(EcmascriptInputTransformsVc),
     Typescript(EcmascriptInputTransformsVc),
-    TypescriptSource(EcmascriptInputTransformsVc),
+    TypescriptWithTypes(EcmascriptInputTransformsVc),
     TypescriptDeclaration(EcmascriptInputTransformsVc),
     Json,
     Raw,

--- a/crates/turbopack/src/resolve_options_context.rs
+++ b/crates/turbopack/src/resolve_options_context.rs
@@ -10,6 +10,7 @@ use crate::condition::ContextCondition;
 #[derive(Default, Clone)]
 pub struct ResolveOptionsContext {
     pub emulate_environment: Option<EnvironmentVc>,
+    pub enable_types: bool,
     pub enable_typescript: bool,
     pub enable_react: bool,
     pub enable_node_native_modules: bool,
@@ -50,8 +51,9 @@ impl ResolveOptionsContextVc {
     }
 
     #[turbo_tasks::function]
-    pub async fn with_typescript_enabled(self) -> Result<Self> {
+    pub async fn with_types_enabled(self) -> Result<Self> {
         let mut clone = self.await?.clone_value();
+        clone.enable_types = true;
         clone.enable_typescript = true;
         Ok(Self::cell(clone))
     }

--- a/crates/turbopack/tests/node-file-trace.rs
+++ b/crates/turbopack/tests/node-file-trace.rs
@@ -27,7 +27,7 @@ use turbo_tasks::{backend::Backend, TurboTasks, Value, ValueToString};
 use turbo_tasks_fs::{DiskFileSystemVc, FileSystem, FileSystemPathVc, FileSystemVc};
 use turbo_tasks_memory::MemoryBackend;
 use turbopack::{
-    emit_with_completion, rebase::RebasedAssetVc, register,
+    emit_with_completion, module_options::ModuleOptionsContext, rebase::RebasedAssetVc, register,
     resolve_options_context::ResolveOptionsContext, transition::TransitionsByNameVc,
     ModuleAssetContextVc,
 };
@@ -403,7 +403,11 @@ fn node_file_trace<B: Backend + 'static>(
                         )),
                         Value::new(EnvironmentIntention::ServerRendering),
                     ),
-                    Default::default(),
+                    ModuleOptionsContext {
+                        enable_types: true,
+                        ..Default::default()
+                    }
+                    .cell(),
                     ResolveOptionsContext {
                         enable_node_native_modules: true,
                         enable_node_modules: true,


### PR DESCRIPTION
fixes weird typescript errors caused by types being referenced by .ts files