### PR TITLE
Misc ContentSource changes

### DIFF
--- a/crates/next-core/src/next_image/mod.rs
+++ b/crates/next-core/src/next_image/mod.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use anyhow::Result;
 use turbo_tasks::{primitives::StringVc, Value};
-use turbopack_core::introspect::{Introspectable, IntrospectableChildrenVc, IntrospectableVc};
+use turbopack_core::introspect::{Introspectable, IntrospectableVc};
 use turbopack_dev_server::source::{
     query::QueryValue, ContentSource, ContentSourceContent, ContentSourceData,
     ContentSourceDataFilter, ContentSourceDataVary, ContentSourceResultVc, ContentSourceVc,
@@ -101,10 +101,5 @@ impl Introspectable for NextImageContentSource {
     #[turbo_tasks::function]
     fn details(&self) -> StringVc {
         StringVc::cell("suports dynamic serving of any statically imported image".to_string())
-    }
-
-    #[turbo_tasks::function]
-    async fn children(&self) -> Result<IntrospectableChildrenVc> {
-        Ok(IntrospectableChildrenVc::cell(HashSet::new()))
     }
 }

--- a/crates/turbopack-core/src/introspect/mod.rs
+++ b/crates/turbopack-core/src/introspect/mod.rs
@@ -16,5 +16,7 @@ pub trait Introspectable {
     fn details(&self) -> StringVc {
         StringVc::empty()
     }
-    fn children(&self) -> IntrospectableChildrenVc;
+    fn children(&self) -> IntrospectableChildrenVc {
+        IntrospectableChildrenVc::cell(HashSet::new())
+    }
 }

--- a/crates/turbopack-dev-server/src/source/source_maps.rs
+++ b/crates/turbopack-dev-server/src/source/source_maps.rs
@@ -1,11 +1,11 @@
-use std::collections::HashSet;
+
 
 use anyhow::Result;
 use turbo_tasks::{primitives::StringVc, Value};
 use turbo_tasks_fs::File;
 use turbopack_core::{
     asset::AssetContentVc,
-    introspect::{Introspectable, IntrospectableChildrenVc, IntrospectableVc},
+    introspect::{Introspectable, IntrospectableVc},
     source_map::GenerateSourceMapVc,
 };
 
@@ -110,11 +110,11 @@ impl ContentSource for SourceMapContentSource {
 impl Introspectable for SourceMapContentSource {
     #[turbo_tasks::function]
     fn ty(&self) -> StringVc {
-        StringVc::cell("static assets directory content source".to_string())
+        StringVc::cell("source map content source".to_string())
     }
 
     #[turbo_tasks::function]
-    fn children(&self) -> IntrospectableChildrenVc {
-        IntrospectableChildrenVc::cell(HashSet::new())
+    fn details(&self) -> StringVc {
+        StringVc::cell("serves chunk and chunk item source maps".to_string())
     }
 }

--- a/crates/turbopack-dev-server/src/source/source_maps.rs
+++ b/crates/turbopack-dev-server/src/source/source_maps.rs
@@ -1,5 +1,3 @@
-
-
 use anyhow::Result;
 use turbo_tasks::{primitives::StringVc, Value};
 use turbo_tasks_fs::File;

--- a/crates/turbopack-node/src/source_map/content_source.rs
+++ b/crates/turbopack-node/src/source_map/content_source.rs
@@ -1,9 +1,7 @@
-use std::collections::HashSet;
-
 use anyhow::Result;
 use turbo_tasks::{primitives::StringVc, Value};
 use turbopack_core::{
-    introspect::{Introspectable, IntrospectableChildrenVc, IntrospectableVc},
+    introspect::{Introspectable, IntrospectableVc},
     source_map::GenerateSourceMapVc,
 };
 use turbopack_dev_server::source::{
@@ -132,10 +130,5 @@ impl Introspectable for NextSourceMapTraceContentSource {
         StringVc::cell(
             "supports tracing an error stack frame to its original source location".to_string(),
         )
-    }
-
-    #[turbo_tasks::function]
-    async fn children(&self) -> Result<IntrospectableChildrenVc> {
-        Ok(IntrospectableChildrenVc::cell(HashSet::new()))
     }
 }

--- a/crates/turbopack-node/src/source_map/trace.rs
+++ b/crates/turbopack-node/src/source_map/trace.rs
@@ -1,7 +1,7 @@
 use std::fmt::Display;
 
 use anyhow::Result;
-use mime::APPLICATION_JAVASCRIPT_UTF_8;
+use mime::APPLICATION_JSON;
 use serde_json::json;
 use turbo_tasks_fs::File;
 use turbopack_core::{
@@ -133,7 +133,7 @@ impl SourceMapTraceVc {
             })
             .to_string(),
         };
-        let file = File::from(result).with_content_type(APPLICATION_JAVASCRIPT_UTF_8);
+        let file = File::from(result).with_content_type(APPLICATION_JSON);
         Ok(file.into())
     }
 }


### PR DESCRIPTION
- Adds `details` to `SourceMapContentSource`
- Fixes `ty` of `SourceMapContentSource`
- Adds default `children` trait method that returns empty children