### PR TITLE
fix: add info message when using global turbo in repo

### DIFF
--- a/cli/integration_tests/basic_monorepo/profile.t
+++ b/cli/integration_tests/basic_monorepo/profile.t
@@ -5,5 +5,7 @@ Setup
 Run build and record a trace
 Ignore output since we want to focus on testing the generated profile
   $ ${TURBO} build --profile=build.trace > turbo.log
+  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
+  Running command as global turbo
 Make sure the resulting trace is valid JSON
   $ node -e "require('./build.trace')"

--- a/cli/integration_tests/basic_monorepo/verbosity.t
+++ b/cli/integration_tests/basic_monorepo/verbosity.t
@@ -4,6 +4,8 @@ Setup
 
 Verbosity level 1
   $ ${TURBO} build -v --filter=util --force
+  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
+  Running command as global turbo
   [-0-9:.TWZ+]+ \[INFO]  turbo: skipping turbod since we appear to be in a non-interactive context (re)
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
@@ -20,6 +22,8 @@ Verbosity level 1
     Time:\s*[\.0-9]+m?s  (re)
   
   $ ${TURBO} build --verbosity=1 --filter=util --force
+  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
+  Running command as global turbo
   [-0-9:.TWZ+]+ \[INFO]  turbo: skipping turbod since we appear to be in a non-interactive context (re)
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
@@ -38,6 +42,8 @@ Verbosity level 1
 
 Verbosity level 2
   $ ${TURBO} build -vv --filter=util --force
+  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
+  Running command as global turbo
   [-0-9:.TWZ+]+ \[INFO]  turbo: skipping turbod since we appear to be in a non-interactive context (re)
   [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash env vars: vars=\["VERCEL_ANALYTICS_ID"] (re)
   [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash: value=c1fb8f74a026cdb8 (re)
@@ -62,6 +68,8 @@ Verbosity level 2
     Time:\s*[\.0-9]+m?s  (re)
   
   $ ${TURBO} build --verbosity=2 --filter=util --force
+  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
+  Running command as global turbo
   [-0-9:.TWZ+]+ \[INFO]  turbo: skipping turbod since we appear to be in a non-interactive context (re)
   [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash env vars: vars=\["VERCEL_ANALYTICS_ID"] (re)
   [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash: value=c1fb8f74a026cdb8 (re)
@@ -90,6 +98,8 @@ Verbosity level 2
 
 Make sure users can only use one verbosity flag
   $ ${TURBO} build -v --verbosity=1
+  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
+  Running command as global turbo
   error: The argument '-v...' cannot be used with '--verbosity <COUNT>'
   
   Usage: turbo [OPTIONS] [COMMAND]

--- a/cli/integration_tests/find_correct_turbo.t
+++ b/cli/integration_tests/find_correct_turbo.t
@@ -2,4 +2,6 @@
 
 Make sure exit code is 2 when no args are passed
   $ CURR=$(${TURBO} --cwd ${TESTDIR}/../.. bin)
+  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
+  Running command as global turbo
   $ diff <(readlink -f ${TURBO}) <(readlink -f ${CURR})

--- a/cli/integration_tests/lockfile_aware_caching/berry.t
+++ b/cli/integration_tests/lockfile_aware_caching/berry.t
@@ -4,6 +4,8 @@ Setup
 
 Populate cache
   $ ${TURBO} build --filter=a
+  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
+  Running command as global turbo
   \xe2\x80\xa2 Packages in scope: a (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
@@ -15,6 +17,8 @@ Populate cache
     Time:\s*[\.0-9]+m?s  (re)
   
   $ ${TURBO} build --filter=b
+  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
+  Running command as global turbo
   \xe2\x80\xa2 Packages in scope: b (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
@@ -31,6 +35,8 @@ Only b should have a cache miss
   $ patch yarn.lock yarn-lock.patch
   patching file yarn.lock
   $ ${TURBO} build  --filter=a
+  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
+  Running command as global turbo
   \xe2\x80\xa2 Packages in scope: a (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
@@ -43,6 +49,8 @@ Only b should have a cache miss
   
 
   $ ${TURBO} build  --filter=b
+  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
+  Running command as global turbo
   \xe2\x80\xa2 Packages in scope: b (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
@@ -58,6 +66,8 @@ Bump of root workspace invalidates all packages
   $ patch yarn.lock turbo-bump.patch
   patching file yarn.lock
   $ ${TURBO} build  --filter=a
+  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
+  Running command as global turbo
   \xe2\x80\xa2 Packages in scope: a (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
@@ -69,6 +79,8 @@ Bump of root workspace invalidates all packages
     Time:\s*[\.0-9]+m?s  (re)
   
   $ ${TURBO} build  --filter=b
+  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
+  Running command as global turbo
   \xe2\x80\xa2 Packages in scope: b (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)

--- a/cli/integration_tests/lockfile_aware_caching/npm.t
+++ b/cli/integration_tests/lockfile_aware_caching/npm.t
@@ -4,6 +4,8 @@ Setup
 
 Populate cache
   $ ${TURBO} build --filter=a
+  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
+  Running command as global turbo
   \xe2\x80\xa2 Packages in scope: a (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
@@ -19,6 +21,8 @@ Populate cache
     Time:\s*[\.0-9]+m?s  (re)
   
   $ ${TURBO} build --filter=b
+  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
+  Running command as global turbo
   \xe2\x80\xa2 Packages in scope: b (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
@@ -39,6 +43,8 @@ Only b should have a cache miss
   $ patch package-lock.json package-lock.patch
   patching file package-lock.json
   $ ${TURBO} build  --filter=a
+  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
+  Running command as global turbo
   \xe2\x80\xa2 Packages in scope: a (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
@@ -55,6 +61,8 @@ Only b should have a cache miss
   
 
   $ ${TURBO} build  --filter=b
+  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
+  Running command as global turbo
   \xe2\x80\xa2 Packages in scope: b (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
@@ -74,6 +82,8 @@ Bump of root workspace invalidates all packages
   $ patch package-lock.json turbo-bump.patch
   patching file package-lock.json
   $ ${TURBO} build  --filter=a
+  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
+  Running command as global turbo
   \xe2\x80\xa2 Packages in scope: a (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
@@ -89,6 +99,8 @@ Bump of root workspace invalidates all packages
     Time:\s*[\.0-9]+m?s  (re)
   
   $ ${TURBO} build  --filter=b
+  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
+  Running command as global turbo
   \xe2\x80\xa2 Packages in scope: b (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)

--- a/cli/integration_tests/lockfile_aware_caching/pnpm.t
+++ b/cli/integration_tests/lockfile_aware_caching/pnpm.t
@@ -4,6 +4,8 @@ Setup
 
 Populate cache
   $ ${TURBO} build --filter=a
+  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
+  Running command as global turbo
   \xe2\x80\xa2 Packages in scope: a (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
@@ -19,6 +21,8 @@ Populate cache
     Time:\s*[\.0-9]+m?s  (re)
   
   $ ${TURBO} build --filter=b
+  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
+  Running command as global turbo
   \xe2\x80\xa2 Packages in scope: b (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
@@ -39,6 +43,8 @@ Only b should have a cache miss
   $ patch pnpm-lock.yaml pnpm-lock.patch
   patching file pnpm-lock.yaml
   $ ${TURBO} build  --filter=a
+  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
+  Running command as global turbo
   \xe2\x80\xa2 Packages in scope: a (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
@@ -55,6 +61,8 @@ Only b should have a cache miss
   
 
   $ ${TURBO} build  --filter=b
+  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
+  Running command as global turbo
   \xe2\x80\xa2 Packages in scope: b (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
@@ -74,6 +82,8 @@ Bump of root workspace invalidates all packages
   $ patch pnpm-lock.yaml turbo-bump.patch
   patching file pnpm-lock.yaml
   $ ${TURBO} build  --filter=a
+  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
+  Running command as global turbo
   \xe2\x80\xa2 Packages in scope: a (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
@@ -89,6 +99,8 @@ Bump of root workspace invalidates all packages
     Time:\s*[\.0-9]+m?s  (re)
   
   $ ${TURBO} build  --filter=b
+  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
+  Running command as global turbo
   \xe2\x80\xa2 Packages in scope: b (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)

--- a/cli/integration_tests/lockfile_aware_caching/yarn.t
+++ b/cli/integration_tests/lockfile_aware_caching/yarn.t
@@ -4,6 +4,8 @@ Setup
 
 Populate cache
   $ ${TURBO} build --filter=a
+  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
+  Running command as global turbo
   \xe2\x80\xa2 Packages in scope: a (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
@@ -19,6 +21,8 @@ Populate cache
     Time:\s*[\.0-9]+m?s  (re)
   
   $ ${TURBO} build --filter=b
+  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
+  Running command as global turbo
   \xe2\x80\xa2 Packages in scope: b (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
@@ -39,6 +43,8 @@ Only b should have a cache miss
   $ patch yarn.lock yarn-lock.patch
   patching file yarn.lock
   $ ${TURBO} build  --filter=a
+  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
+  Running command as global turbo
   \xe2\x80\xa2 Packages in scope: a (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
@@ -55,6 +61,8 @@ Only b should have a cache miss
   
 
   $ ${TURBO} build  --filter=b
+  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
+  Running command as global turbo
   \xe2\x80\xa2 Packages in scope: b (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
@@ -74,6 +82,8 @@ Bump of root workspace invalidates all packages
   $ patch yarn.lock turbo-bump.patch
   patching file yarn.lock
   $ ${TURBO} build  --filter=a
+  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
+  Running command as global turbo
   \xe2\x80\xa2 Packages in scope: a (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
@@ -89,6 +99,8 @@ Bump of root workspace invalidates all packages
     Time:\s*[\.0-9]+m?s  (re)
   
   $ ${TURBO} build  --filter=b
+  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
+  Running command as global turbo
   \xe2\x80\xa2 Packages in scope: b (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)

--- a/cli/integration_tests/monorepo_one_script_error/run.t
+++ b/cli/integration_tests/monorepo_one_script_error/run.t
@@ -5,6 +5,8 @@ Setup
 Check error is properly reported
 Note that npm reports any failed script as exit code 1, even though we "exit 2"
   $ ${TURBO} error
+  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
+  Running command as global turbo
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running error in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
@@ -36,6 +38,8 @@ Note that npm reports any failed script as exit code 1, even though we "exit 2"
 
 Make sure error isn't cached
   $ ${TURBO} error
+  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
+  Running command as global turbo
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running error in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
@@ -67,6 +71,8 @@ Make sure error isn't cached
 
 Running with --output-mode=errors-only gives error output only
   $ ${TURBO} --output-logs=errors-only error
+  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
+  Running command as global turbo
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running error in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)

--- a/cli/integration_tests/single_package/dry-run.t
+++ b/cli/integration_tests/single_package/dry-run.t
@@ -4,6 +4,8 @@ Setup
 
 Check
   $ ${TURBO} run build --dry --single-package
+  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
+  Running command as global turbo
   
   Tasks to Run
   build
@@ -18,6 +20,8 @@ Check
     Dependendents   =                        
 
   $ ${TURBO} run build --dry=json --single-package
+  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
+  Running command as global turbo
   {
     "tasks": [
       {

--- a/cli/integration_tests/single_package/graph.t
+++ b/cli/integration_tests/single_package/graph.t
@@ -4,6 +4,8 @@ Setup
 
 Graph
   $ ${TURBO} run build --single-package --graph
+  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
+  Running command as global turbo
   
   digraph {
   \tcompound = "true" (esc)

--- a/cli/integration_tests/single_package/run.t
+++ b/cli/integration_tests/single_package/run.t
@@ -4,6 +4,8 @@ Setup
 
 Check
   $ ${TURBO} run build --single-package
+  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
+  Running command as global turbo
   \xe2\x80\xa2 Running build (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
   build: cache miss, executing 7bf32e1dedb04a5d
@@ -18,6 +20,8 @@ Check
   
 Run a second time, verify caching works because there is a config
   $ ${TURBO} run build --single-package
+  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
+  Running command as global turbo
   \xe2\x80\xa2 Running build (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
   build: cache hit, replaying output 7bf32e1dedb04a5d

--- a/cli/integration_tests/single_package_deps/dry-run.t
+++ b/cli/integration_tests/single_package_deps/dry-run.t
@@ -4,6 +4,8 @@ Setup
 
 Check
   $ ${TURBO} run test --dry --single-package
+  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
+  Running command as global turbo
   
   Tasks to Run
   build
@@ -28,6 +30,8 @@ Check
     Dependendents   =                                              
 
   $ ${TURBO} run test --dry=json --single-package
+  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
+  Running command as global turbo
   {
     "tasks": [
       {

--- a/cli/integration_tests/single_package_deps/graph.t
+++ b/cli/integration_tests/single_package_deps/graph.t
@@ -4,6 +4,8 @@ Setup
 
 Graph
   $ ${TURBO} run test --single-package --graph
+  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
+  Running command as global turbo
   
   digraph {
   \tcompound = "true" (esc)

--- a/cli/integration_tests/single_package_deps/run.t
+++ b/cli/integration_tests/single_package_deps/run.t
@@ -4,6 +4,8 @@ Setup
 
 Check
   $ ${TURBO} run test --single-package
+  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
+  Running command as global turbo
   \xe2\x80\xa2 Running test (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
   build: cache miss, executing 8fc80cfff3b64237
@@ -23,6 +25,8 @@ Check
   
 Run a second time, verify caching works because there is a config
   $ ${TURBO} run test --single-package
+  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
+  Running command as global turbo
   \xe2\x80\xa2 Running test (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
   build: cache hit, replaying output 8fc80cfff3b64237
@@ -42,6 +46,8 @@ Run a second time, verify caching works because there is a config
   
 Run with --output-logs=hash-only
   $ ${TURBO} run test --single-package --output-logs=hash-only
+  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
+  Running command as global turbo
   \xe2\x80\xa2 Running test (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
   build: cache hit, suppressing output 8fc80cfff3b64237
@@ -53,6 +59,8 @@ Run with --output-logs=hash-only
   
 Run with --output-logs=errors-only
   $ ${TURBO} run test --single-package --output-logs=errors-only
+  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
+  Running command as global turbo
   \xe2\x80\xa2 Running test (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
   
@@ -62,6 +70,8 @@ Run with --output-logs=errors-only
   
 Run with --output-logs=none
   $ ${TURBO} run test --single-package --output-logs=none
+  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
+  Running command as global turbo
   \xe2\x80\xa2 Running test (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
   

--- a/cli/integration_tests/single_package_no_config/dry-run.t
+++ b/cli/integration_tests/single_package_no_config/dry-run.t
@@ -4,6 +4,8 @@ Setup
 
 Check
   $ ${TURBO} run build --dry --single-package
+  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
+  Running command as global turbo
   
   Tasks to Run
   build
@@ -18,6 +20,8 @@ Check
     Dependendents   =                        
 
   $ ${TURBO} run build --dry=json --single-package
+  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
+  Running command as global turbo
   {
     "tasks": [
       {

--- a/cli/integration_tests/single_package_no_config/graph.t
+++ b/cli/integration_tests/single_package_no_config/graph.t
@@ -4,6 +4,8 @@ Setup
 
 Graph
   $ ${TURBO} run build --single-package --graph
+  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
+  Running command as global turbo
   
   digraph {
   \tcompound = "true" (esc)

--- a/cli/integration_tests/single_package_no_config/run.t
+++ b/cli/integration_tests/single_package_no_config/run.t
@@ -4,6 +4,8 @@ Setup
 
 Check
   $ ${TURBO} run build --single-package
+  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
+  Running command as global turbo
   \xe2\x80\xa2 Running build (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
   build: cache bypass, force executing c7223f212c321d3b
@@ -19,6 +21,8 @@ Check
   
 Run a second time, verify no caching because there is no config
   $ ${TURBO} run build --single-package
+  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
+  Running command as global turbo
   \xe2\x80\xa2 Running build (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
   build: cache bypass, force executing c7223f212c321d3b

--- a/cli/scripts/e2e/e2e.ts
+++ b/cli/scripts/e2e/e2e.ts
@@ -694,7 +694,7 @@ function getImmutableInstallForPackageManager(ws: PackageManager): string[] {
 function getCommandOutputAsArray(
   results: execa.ExecaSyncReturnValue<string>
 ): string[] {
-  return (results.stdout + results.stderr)
+  return (results.stdout + "\n" + results.stderr)
     .split("\n")
     .map((line) => line.replace("\r", ""));
 }

--- a/crates/turborepo-lib/src/shim.rs
+++ b/crates/turborepo-lib/src/shim.rs
@@ -259,6 +259,11 @@ impl RepoState {
                 self.spawn_local_turbo(&canonical_local_turbo, shim_args),
             ))
         } else {
+            eprintln!(
+                "No local turbo binary found at: {}",
+                local_turbo_path.display()
+            );
+            eprintln!("Running command as global turbo");
             cli::run(Some(self))
         }
     }


### PR DESCRIPTION
Adds an info message if the turbo shim detects it's being run in a Turborepo project, but there's no local turbo binary to invoke e.g. the Turborepo project itself