### PR TITLE
feat(shim): add logger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1824,6 +1824,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "erased-serde"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7598,10 +7611,13 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "chrono",
  "clap 4.0.29",
  "clap_complete",
  "dunce",
+ "env_logger",
  "itertools",
+ "log",
  "predicates",
  "pretty_assertions",
  "semver 1.0.14",

--- a/cli/integration_tests/bad_flag.t
+++ b/cli/integration_tests/bad_flag.t
@@ -3,8 +3,6 @@ Setup
 
 Bad flag should print misuse text
   $ ${TURBO} --bad-flag
-  Repository inference failed: Unable to find `turbo.json` or `package.json` in current path
-  Running command as global turbo
   error: Found argument '--bad-flag' which wasn't expected, or isn't valid in this context
   
     If you tried to supply '--bad-flag' as a value rather than a flag, use '-- --bad-flag'
@@ -16,8 +14,6 @@ Bad flag should print misuse text
 
 Bad flag with an implied run command should display run flags
   $ ${TURBO} build --bad-flag
-  Repository inference failed: Unable to find `turbo.json` or `package.json` in current path
-  Running command as global turbo
   error: Found argument '--bad-flag' which wasn't expected, or isn't valid in this context
   
     If you tried to supply '--bad-flag' as a value rather than a flag, use '-- --bad-flag'

--- a/cli/integration_tests/basic_monorepo/profile.t
+++ b/cli/integration_tests/basic_monorepo/profile.t
@@ -5,7 +5,5 @@ Setup
 Run build and record a trace
 Ignore output since we want to focus on testing the generated profile
   $ ${TURBO} build --profile=build.trace > turbo.log
-  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
-  Running command as global turbo
 Make sure the resulting trace is valid JSON
   $ node -e "require('./build.trace')"

--- a/cli/integration_tests/basic_monorepo/verbosity.t
+++ b/cli/integration_tests/basic_monorepo/verbosity.t
@@ -4,8 +4,6 @@ Setup
 
 Verbosity level 1
   $ ${TURBO} build -v --filter=util --force
-  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
-  Running command as global turbo
   [-0-9:.TWZ+]+ \[INFO]  turbo: skipping turbod since we appear to be in a non-interactive context (re)
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
@@ -22,8 +20,6 @@ Verbosity level 1
     Time:\s*[\.0-9]+m?s  (re)
   
   $ ${TURBO} build --verbosity=1 --filter=util --force
-  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
-  Running command as global turbo
   [-0-9:.TWZ+]+ \[INFO]  turbo: skipping turbod since we appear to be in a non-interactive context (re)
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
@@ -42,8 +38,8 @@ Verbosity level 1
 
 Verbosity level 2
   $ ${TURBO} build -vv --filter=util --force
-  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
-  Running command as global turbo
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .+node_modules/\.bin/turbo (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running command as global turbo (re)
   [-0-9:.TWZ+]+ \[INFO]  turbo: skipping turbod since we appear to be in a non-interactive context (re)
   [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash env vars: vars=\["VERCEL_ANALYTICS_ID"] (re)
   [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash: value=c1fb8f74a026cdb8 (re)
@@ -68,8 +64,8 @@ Verbosity level 2
     Time:\s*[\.0-9]+m?s  (re)
   
   $ ${TURBO} build --verbosity=2 --filter=util --force
-  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
-  Running command as global turbo
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .+node_modules/\.bin/turbo (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running command as global turbo (re)
   [-0-9:.TWZ+]+ \[INFO]  turbo: skipping turbod since we appear to be in a non-interactive context (re)
   [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash env vars: vars=\["VERCEL_ANALYTICS_ID"] (re)
   [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash: value=c1fb8f74a026cdb8 (re)
@@ -98,8 +94,6 @@ Verbosity level 2
 
 Make sure users can only use one verbosity flag
   $ ${TURBO} build -v --verbosity=1
-  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
-  Running command as global turbo
   error: The argument '-v...' cannot be used with '--verbosity <COUNT>'
   
   Usage: turbo [OPTIONS] [COMMAND]

--- a/cli/integration_tests/find_correct_turbo.t
+++ b/cli/integration_tests/find_correct_turbo.t
@@ -2,6 +2,4 @@
 
 Make sure exit code is 2 when no args are passed
   $ CURR=$(${TURBO} --cwd ${TESTDIR}/../.. bin)
-  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
-  Running command as global turbo
   $ diff <(readlink -f ${TURBO}) <(readlink -f ${CURR})

--- a/cli/integration_tests/global_turbo/uses_local.t
+++ b/cli/integration_tests/global_turbo/uses_local.t
@@ -4,34 +4,24 @@ Setup
 Make sure we use local and don't pass --skip-infer to old binary
   $ . ${TESTDIR}/setup.sh 1.2.3
   $ ${TURBO} build --filter foo
-  Running local turbo binary in .*node_modules/.bin/turbo (re)
-  
   build --filter foo --
 
 Make sure we use local and pass --skip-infer to newer binary
   $ . ${TESTDIR}/setup.sh 1.8.9
   $ ${TURBO} build --filter foo
-  Running local turbo binary in .*node_modules/.bin/turbo (re)
-  
   --skip-infer build --filter foo --single-package --
 
 It finds repo root and uses correct version
   $ cd subdir
   $ ${TURBO} build --filter foo
-  Running local turbo binary in .*node_modules/.bin/turbo (re)
-  
   --skip-infer build --filter foo --single-package --
   $ cd ..
 
 It respects cwd
   $ ROOT=$(pwd); cd ..
   $ ${TURBO} build --filter foo --cwd ${ROOT}
-  Running local turbo binary in .*node_modules/.bin/turbo (re)
-  
   --skip-infer build --filter foo --single-package --
 
 It respects cwd and finds repo root
   $ ${TURBO} build --filter foo --cwd ${ROOT}/subdir
-  Running local turbo binary in .*node_modules/.bin/turbo (re)
-  
   --skip-infer build --filter foo --single-package --

--- a/cli/integration_tests/link.t
+++ b/cli/integration_tests/link.t
@@ -3,6 +3,4 @@ Setup
 
 Link Test Run
   $ ${TURBO} link --__test-run
-  Repository inference failed: Unable to find `turbo.json` or `package.json` in current path
-  Running command as global turbo
   Link test run successful

--- a/cli/integration_tests/lockfile_aware_caching/berry.t
+++ b/cli/integration_tests/lockfile_aware_caching/berry.t
@@ -4,8 +4,6 @@ Setup
 
 Populate cache
   $ ${TURBO} build --filter=a
-  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
-  Running command as global turbo
   \xe2\x80\xa2 Packages in scope: a (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
@@ -17,8 +15,6 @@ Populate cache
     Time:\s*[\.0-9]+m?s  (re)
   
   $ ${TURBO} build --filter=b
-  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
-  Running command as global turbo
   \xe2\x80\xa2 Packages in scope: b (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
@@ -35,8 +31,6 @@ Only b should have a cache miss
   $ patch yarn.lock yarn-lock.patch
   patching file yarn.lock
   $ ${TURBO} build  --filter=a
-  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
-  Running command as global turbo
   \xe2\x80\xa2 Packages in scope: a (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
@@ -49,8 +43,6 @@ Only b should have a cache miss
   
 
   $ ${TURBO} build  --filter=b
-  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
-  Running command as global turbo
   \xe2\x80\xa2 Packages in scope: b (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
@@ -66,8 +58,6 @@ Bump of root workspace invalidates all packages
   $ patch yarn.lock turbo-bump.patch
   patching file yarn.lock
   $ ${TURBO} build  --filter=a
-  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
-  Running command as global turbo
   \xe2\x80\xa2 Packages in scope: a (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
@@ -79,8 +69,6 @@ Bump of root workspace invalidates all packages
     Time:\s*[\.0-9]+m?s  (re)
   
   $ ${TURBO} build  --filter=b
-  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
-  Running command as global turbo
   \xe2\x80\xa2 Packages in scope: b (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)

--- a/cli/integration_tests/lockfile_aware_caching/npm.t
+++ b/cli/integration_tests/lockfile_aware_caching/npm.t
@@ -4,8 +4,6 @@ Setup
 
 Populate cache
   $ ${TURBO} build --filter=a
-  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
-  Running command as global turbo
   \xe2\x80\xa2 Packages in scope: a (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
@@ -21,8 +19,6 @@ Populate cache
     Time:\s*[\.0-9]+m?s  (re)
   
   $ ${TURBO} build --filter=b
-  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
-  Running command as global turbo
   \xe2\x80\xa2 Packages in scope: b (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
@@ -43,8 +39,6 @@ Only b should have a cache miss
   $ patch package-lock.json package-lock.patch
   patching file package-lock.json
   $ ${TURBO} build  --filter=a
-  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
-  Running command as global turbo
   \xe2\x80\xa2 Packages in scope: a (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
@@ -61,8 +55,6 @@ Only b should have a cache miss
   
 
   $ ${TURBO} build  --filter=b
-  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
-  Running command as global turbo
   \xe2\x80\xa2 Packages in scope: b (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
@@ -82,8 +74,6 @@ Bump of root workspace invalidates all packages
   $ patch package-lock.json turbo-bump.patch
   patching file package-lock.json
   $ ${TURBO} build  --filter=a
-  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
-  Running command as global turbo
   \xe2\x80\xa2 Packages in scope: a (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
@@ -99,8 +89,6 @@ Bump of root workspace invalidates all packages
     Time:\s*[\.0-9]+m?s  (re)
   
   $ ${TURBO} build  --filter=b
-  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
-  Running command as global turbo
   \xe2\x80\xa2 Packages in scope: b (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)

--- a/cli/integration_tests/lockfile_aware_caching/pnpm.t
+++ b/cli/integration_tests/lockfile_aware_caching/pnpm.t
@@ -4,8 +4,6 @@ Setup
 
 Populate cache
   $ ${TURBO} build --filter=a
-  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
-  Running command as global turbo
   \xe2\x80\xa2 Packages in scope: a (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
@@ -21,8 +19,6 @@ Populate cache
     Time:\s*[\.0-9]+m?s  (re)
   
   $ ${TURBO} build --filter=b
-  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
-  Running command as global turbo
   \xe2\x80\xa2 Packages in scope: b (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
@@ -43,8 +39,6 @@ Only b should have a cache miss
   $ patch pnpm-lock.yaml pnpm-lock.patch
   patching file pnpm-lock.yaml
   $ ${TURBO} build  --filter=a
-  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
-  Running command as global turbo
   \xe2\x80\xa2 Packages in scope: a (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
@@ -61,8 +55,6 @@ Only b should have a cache miss
   
 
   $ ${TURBO} build  --filter=b
-  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
-  Running command as global turbo
   \xe2\x80\xa2 Packages in scope: b (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
@@ -82,8 +74,6 @@ Bump of root workspace invalidates all packages
   $ patch pnpm-lock.yaml turbo-bump.patch
   patching file pnpm-lock.yaml
   $ ${TURBO} build  --filter=a
-  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
-  Running command as global turbo
   \xe2\x80\xa2 Packages in scope: a (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
@@ -99,8 +89,6 @@ Bump of root workspace invalidates all packages
     Time:\s*[\.0-9]+m?s  (re)
   
   $ ${TURBO} build  --filter=b
-  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
-  Running command as global turbo
   \xe2\x80\xa2 Packages in scope: b (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)

--- a/cli/integration_tests/lockfile_aware_caching/yarn.t
+++ b/cli/integration_tests/lockfile_aware_caching/yarn.t
@@ -4,8 +4,6 @@ Setup
 
 Populate cache
   $ ${TURBO} build --filter=a
-  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
-  Running command as global turbo
   \xe2\x80\xa2 Packages in scope: a (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
@@ -21,8 +19,6 @@ Populate cache
     Time:\s*[\.0-9]+m?s  (re)
   
   $ ${TURBO} build --filter=b
-  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
-  Running command as global turbo
   \xe2\x80\xa2 Packages in scope: b (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
@@ -43,8 +39,6 @@ Only b should have a cache miss
   $ patch yarn.lock yarn-lock.patch
   patching file yarn.lock
   $ ${TURBO} build  --filter=a
-  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
-  Running command as global turbo
   \xe2\x80\xa2 Packages in scope: a (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
@@ -61,8 +55,6 @@ Only b should have a cache miss
   
 
   $ ${TURBO} build  --filter=b
-  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
-  Running command as global turbo
   \xe2\x80\xa2 Packages in scope: b (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
@@ -82,8 +74,6 @@ Bump of root workspace invalidates all packages
   $ patch yarn.lock turbo-bump.patch
   patching file yarn.lock
   $ ${TURBO} build  --filter=a
-  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
-  Running command as global turbo
   \xe2\x80\xa2 Packages in scope: a (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
@@ -99,8 +89,6 @@ Bump of root workspace invalidates all packages
     Time:\s*[\.0-9]+m?s  (re)
   
   $ ${TURBO} build  --filter=b
-  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
-  Running command as global turbo
   \xe2\x80\xa2 Packages in scope: b (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)

--- a/cli/integration_tests/login.t
+++ b/cli/integration_tests/login.t
@@ -3,6 +3,4 @@ Setup
 
 Login Test Run
   $ ${TURBO} login --__test-run
-  Repository inference failed: Unable to find `turbo.json` or `package.json` in current path
-  Running command as global turbo
   Login test run successful

--- a/cli/integration_tests/logout.t
+++ b/cli/integration_tests/logout.t
@@ -4,13 +4,9 @@ Setup
 
 Logout while logged in
   $ ${TURBO} logout
-  Repository inference failed: Unable to find `turbo.json` or `package.json` in current path
-  Running command as global turbo
   >>> Logged out
 
 Logout while logged out
   $ ${TURBO} logout
-  Repository inference failed: Unable to find `turbo.json` or `package.json` in current path
-  Running command as global turbo
   >>> Logged out
 

--- a/cli/integration_tests/monorepo_one_script_error/run.t
+++ b/cli/integration_tests/monorepo_one_script_error/run.t
@@ -5,8 +5,6 @@ Setup
 Check error is properly reported
 Note that npm reports any failed script as exit code 1, even though we "exit 2"
   $ ${TURBO} error
-  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
-  Running command as global turbo
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running error in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
@@ -38,8 +36,6 @@ Note that npm reports any failed script as exit code 1, even though we "exit 2"
 
 Make sure error isn't cached
   $ ${TURBO} error
-  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
-  Running command as global turbo
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running error in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
@@ -71,8 +67,6 @@ Make sure error isn't cached
 
 Running with --output-mode=errors-only gives error output only
   $ ${TURBO} --output-logs=errors-only error
-  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
-  Running command as global turbo
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running error in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)

--- a/cli/integration_tests/no_args.t
+++ b/cli/integration_tests/no_args.t
@@ -3,8 +3,6 @@ Setup
 
 Make sure exit code is 2 when no args are passed
   $ ${TURBO}
-  Repository inference failed: Unable to find `turbo.json` or `package.json` in current path
-  Running command as global turbo
   The build system that makes ship happen
   
   Usage: turbo [OPTIONS] [COMMAND]

--- a/cli/integration_tests/single_package/dry-run.t
+++ b/cli/integration_tests/single_package/dry-run.t
@@ -4,8 +4,6 @@ Setup
 
 Check
   $ ${TURBO} run build --dry --single-package
-  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
-  Running command as global turbo
   
   Tasks to Run
   build
@@ -20,8 +18,6 @@ Check
     Dependendents   =                        
 
   $ ${TURBO} run build --dry=json --single-package
-  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
-  Running command as global turbo
   {
     "tasks": [
       {

--- a/cli/integration_tests/single_package/graph.t
+++ b/cli/integration_tests/single_package/graph.t
@@ -4,8 +4,6 @@ Setup
 
 Graph
   $ ${TURBO} run build --single-package --graph
-  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
-  Running command as global turbo
   
   digraph {
   \tcompound = "true" (esc)

--- a/cli/integration_tests/single_package/run.t
+++ b/cli/integration_tests/single_package/run.t
@@ -4,8 +4,6 @@ Setup
 
 Check
   $ ${TURBO} run build --single-package
-  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
-  Running command as global turbo
   \xe2\x80\xa2 Running build (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
   build: cache miss, executing 7bf32e1dedb04a5d
@@ -20,8 +18,6 @@ Check
   
 Run a second time, verify caching works because there is a config
   $ ${TURBO} run build --single-package
-  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
-  Running command as global turbo
   \xe2\x80\xa2 Running build (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
   build: cache hit, replaying output 7bf32e1dedb04a5d

--- a/cli/integration_tests/single_package_deps/dry-run.t
+++ b/cli/integration_tests/single_package_deps/dry-run.t
@@ -4,8 +4,6 @@ Setup
 
 Check
   $ ${TURBO} run test --dry --single-package
-  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
-  Running command as global turbo
   
   Tasks to Run
   build
@@ -30,8 +28,6 @@ Check
     Dependendents   =                                              
 
   $ ${TURBO} run test --dry=json --single-package
-  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
-  Running command as global turbo
   {
     "tasks": [
       {

--- a/cli/integration_tests/single_package_deps/graph.t
+++ b/cli/integration_tests/single_package_deps/graph.t
@@ -4,8 +4,6 @@ Setup
 
 Graph
   $ ${TURBO} run test --single-package --graph
-  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
-  Running command as global turbo
   
   digraph {
   \tcompound = "true" (esc)

--- a/cli/integration_tests/single_package_deps/run.t
+++ b/cli/integration_tests/single_package_deps/run.t
@@ -4,8 +4,6 @@ Setup
 
 Check
   $ ${TURBO} run test --single-package
-  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
-  Running command as global turbo
   \xe2\x80\xa2 Running test (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
   build: cache miss, executing 8fc80cfff3b64237
@@ -25,8 +23,6 @@ Check
   
 Run a second time, verify caching works because there is a config
   $ ${TURBO} run test --single-package
-  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
-  Running command as global turbo
   \xe2\x80\xa2 Running test (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
   build: cache hit, replaying output 8fc80cfff3b64237
@@ -46,8 +42,6 @@ Run a second time, verify caching works because there is a config
   
 Run with --output-logs=hash-only
   $ ${TURBO} run test --single-package --output-logs=hash-only
-  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
-  Running command as global turbo
   \xe2\x80\xa2 Running test (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
   build: cache hit, suppressing output 8fc80cfff3b64237
@@ -59,8 +53,6 @@ Run with --output-logs=hash-only
   
 Run with --output-logs=errors-only
   $ ${TURBO} run test --single-package --output-logs=errors-only
-  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
-  Running command as global turbo
   \xe2\x80\xa2 Running test (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
   
@@ -70,8 +62,6 @@ Run with --output-logs=errors-only
   
 Run with --output-logs=none
   $ ${TURBO} run test --single-package --output-logs=none
-  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
-  Running command as global turbo
   \xe2\x80\xa2 Running test (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
   

--- a/cli/integration_tests/single_package_no_config/dry-run.t
+++ b/cli/integration_tests/single_package_no_config/dry-run.t
@@ -4,8 +4,6 @@ Setup
 
 Check
   $ ${TURBO} run build --dry --single-package
-  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
-  Running command as global turbo
   
   Tasks to Run
   build
@@ -20,8 +18,6 @@ Check
     Dependendents   =                        
 
   $ ${TURBO} run build --dry=json --single-package
-  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
-  Running command as global turbo
   {
     "tasks": [
       {

--- a/cli/integration_tests/single_package_no_config/graph.t
+++ b/cli/integration_tests/single_package_no_config/graph.t
@@ -4,8 +4,6 @@ Setup
 
 Graph
   $ ${TURBO} run build --single-package --graph
-  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
-  Running command as global turbo
   
   digraph {
   \tcompound = "true" (esc)

--- a/cli/integration_tests/single_package_no_config/run.t
+++ b/cli/integration_tests/single_package_no_config/run.t
@@ -4,8 +4,6 @@ Setup
 
 Check
   $ ${TURBO} run build --single-package
-  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
-  Running command as global turbo
   \xe2\x80\xa2 Running build (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
   build: cache bypass, force executing c7223f212c321d3b
@@ -21,8 +19,6 @@ Check
   
 Run a second time, verify no caching because there is no config
   $ ${TURBO} run build --single-package
-  No local turbo binary found at: .+node_modules/\.bin/turbo (re)
-  Running command as global turbo
   \xe2\x80\xa2 Running build (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
   build: cache bypass, force executing c7223f212c321d3b

--- a/cli/integration_tests/turbo_help.t
+++ b/cli/integration_tests/turbo_help.t
@@ -3,8 +3,6 @@ Setup
 
 Test help flag
   $ ${TURBO} -h
-  Repository inference failed: Unable to find `turbo.json` or `package.json` in current path
-  Running command as global turbo
   The build system that makes ship happen
   
   Usage: turbo [OPTIONS] [COMMAND]
@@ -66,8 +64,6 @@ Test help flag
 
 
   $ ${TURBO} --help
-  Repository inference failed: Unable to find `turbo.json` or `package.json` in current path
-  Running command as global turbo
   The build system that makes ship happen
   
   Usage: turbo [OPTIONS] [COMMAND]
@@ -125,8 +121,6 @@ Test help flag
 
 Test help flag for link command
   $ ${TURBO} link -h
-  Repository inference failed: Unable to find `turbo.json` or `package.json` in current path
-  Running command as global turbo
   Link your local directory to a Vercel organization and enable remote caching
   
   Usage: turbo link [OPTIONS]
@@ -154,8 +148,6 @@ Test help flag for link command
 
 Test help flag for unlink command
   $ ${TURBO} unlink -h
-  Repository inference failed: Unable to find `turbo.json` or `package.json` in current path
-  Running command as global turbo
   Unlink the current directory from your Vercel organization and disable Remote Caching
   
   Usage: turbo unlink [OPTIONS]
@@ -182,8 +174,6 @@ Test help flag for unlink command
 
 Test help flag for login command
   $ ${TURBO} login -h
-  Repository inference failed: Unable to find `turbo.json` or `package.json` in current path
-  Running command as global turbo
   Login to your Vercel account
   
   Usage: turbo login [OPTIONS]
@@ -211,8 +201,6 @@ Test help flag for login command
 
 Test help flag for logout command
   $ ${TURBO} logout -h
-  Repository inference failed: Unable to find `turbo.json` or `package.json` in current path
-  Running command as global turbo
   Logout to your Vercel account
   
   Usage: turbo logout [OPTIONS]

--- a/cli/integration_tests/turbo_version.t
+++ b/cli/integration_tests/turbo_version.t
@@ -3,8 +3,6 @@ Setup
 
 Test version matches that of version.txt
   $ diff <(head -n 1 ${VERSION}) <(${TURBO} --version)
-  Repository inference failed: Unable to find `turbo.json` or `package.json` in current path
-  Running command as global turbo
 
 TODO: resolve ambiguity
 $ ${TURBO} -v

--- a/cli/integration_tests/unlink.t
+++ b/cli/integration_tests/unlink.t
@@ -3,6 +3,4 @@ Setup
 
 Unlink Test Run
   $ ${TURBO} unlink --__test-run
-  Repository inference failed: Unable to find `turbo.json` or `package.json` in current path
-  Running command as global turbo
   Unlink test run successful

--- a/crates/turborepo-lib/Cargo.toml
+++ b/crates/turborepo-lib/Cargo.toml
@@ -12,9 +12,12 @@ pretty_assertions = "1.3.0"
 
 [dependencies]
 anyhow = { version = "1.0.65", features = ["backtrace"] }
+chrono = "0.4.23"
 clap = { version = "4.0.22", features = ["derive"] }
 clap_complete = "4.0.6"
 dunce = "1.0"
+env_logger = "0.10.0"
+log = "0.4.17"
 predicates = "2.1.1"
 semver = "1.0"
 serde = { version = "1.0.145", features = ["derive"] }

--- a/crates/turborepo-lib/src/shim.rs
+++ b/crates/turborepo-lib/src/shim.rs
@@ -77,17 +77,15 @@ impl ShimArgs {
             } else if arg == "--verbosity" {
                 // If we see `--verbosity` we expect the next arg to be a number.
                 found_verbosity_flag = true
-            } else if found_verbosity_flag {
-                verbosity = match arg.parse::<usize>() {
-                    Ok(level) => level,
-                    Err(_) => 0,
+            } else if arg.starts_with("--verbosity=") || found_verbosity_flag {
+                let verbosity_count = if found_verbosity_flag {
+                    found_verbosity_flag = false;
+                    &arg
+                } else {
+                    arg.strip_prefix("--verbosity=").unwrap_or("0")
                 };
-                found_verbosity_flag = false;
-            } else if let Some(verbosity_level) = arg.strip_prefix("--verbosity=") {
-                verbosity = match verbosity_level.parse::<usize>() {
-                    Ok(level) => level,
-                    Err(_) => 0,
-                }
+
+                verbosity = verbosity_count.parse::<usize>().unwrap_or(0);
             } else if arg == "-v" || arg.starts_with("-vv") {
                 verbosity = arg[1..].len();
             } else if found_cwd_flag {

--- a/crates/turborepo-lib/src/shim.rs
+++ b/crates/turborepo-lib/src/shim.rs
@@ -4,6 +4,7 @@ use std::{
     env,
     env::current_dir,
     fs::{self, File},
+    io::Write,
     path::{Path, PathBuf},
     process,
     process::Stdio,
@@ -12,8 +13,11 @@ use std::{
 };
 
 use anyhow::{anyhow, Result};
+use chrono::offset::Local;
 #[cfg(windows)]
 use dunce::canonicalize as fs_canonicalize;
+use env_logger::{fmt::Color, Builder, Env, WriteStyle};
+use log::{debug, Level, LevelFilter};
 use semver::{Version, VersionReq};
 use serde::{Deserialize, Serialize};
 use tiny_gradient::{GradientStr, RGB};
@@ -41,6 +45,7 @@ static SUPPORTS_SKIP_INFER_SEMVER: &str = ">=1.7.0-canary.0";
 struct ShimArgs {
     cwd: PathBuf,
     skip_infer: bool,
+    verbosity: usize,
     force_update_check: bool,
     remaining_turbo_args: Vec<String>,
     forwarded_args: Vec<String>,
@@ -51,6 +56,7 @@ impl ShimArgs {
         let mut found_cwd_flag = false;
         let mut cwd: Option<PathBuf> = None;
         let mut skip_infer = false;
+        let mut verbosity = 0;
         let mut force_update_check = false;
         let mut remaining_turbo_args = Vec::new();
         let mut forwarded_args = Vec::new();
@@ -67,6 +73,20 @@ impl ShimArgs {
             } else if arg == "--" {
                 // If we've hit `--` we've reached the args forwarded to tasks.
                 is_forwarded_args = true;
+            // parse verbosity
+            } else if let Some(verbosity_level) = arg.strip_prefix("--verbosity=") {
+                verbosity = match verbosity_level.parse::<usize>() {
+                    Ok(level) => {
+                        if level <= 3 {
+                            level
+                        } else {
+                            0
+                        }
+                    }
+                    Err(_) => 0,
+                }
+            } else if arg == "-v" || arg == "-vv" || arg == "-vvv" {
+                verbosity = arg[1..].len();
             } else if found_cwd_flag {
                 // We've seen a `--cwd` and therefore set the cwd to this arg.
                 cwd = Some(arg.into());
@@ -101,6 +121,7 @@ impl ShimArgs {
             Ok(ShimArgs {
                 cwd,
                 skip_infer,
+                verbosity,
                 force_update_check,
                 remaining_turbo_args,
                 forwarded_args,
@@ -259,11 +280,11 @@ impl RepoState {
                 self.spawn_local_turbo(&canonical_local_turbo, shim_args),
             ))
         } else {
-            eprintln!(
+            debug!(
                 "No local turbo binary found at: {}",
                 local_turbo_path.display()
             );
-            eprintln!("Running command as global turbo");
+            debug!("Running command as global turbo");
             cli::run(Some(self))
         }
     }
@@ -282,7 +303,7 @@ impl RepoState {
     }
 
     fn spawn_local_turbo(&self, local_turbo_path: &Path, mut shim_args: ShimArgs) -> Result<i32> {
-        println!(
+        debug!(
             "Running local turbo binary in {}\n",
             local_turbo_path.display()
         );
@@ -338,9 +359,76 @@ fn is_turbo_binary_path_set() -> bool {
     env::var("TURBO_BINARY_PATH").is_ok()
 }
 
+fn init_env_logger(verbosity: usize) {
+    // configure logger
+    let level = match verbosity {
+        1 => LevelFilter::Info,
+        2 => LevelFilter::Debug,
+        3 => LevelFilter::Trace,
+        _ => LevelFilter::Warn,
+    };
+
+    let mut builder = Builder::new();
+    let env = Env::new().filter("TURBO_LOG_VERBOSITY");
+
+    builder
+        // set defaults
+        .filter_level(level)
+        .write_style(WriteStyle::Auto)
+        // override from env (if available)
+        .parse_env(env);
+
+    builder.format(|buf, record| match record.level() {
+        Level::Error => {
+            let mut level_style = buf.style();
+            let mut log_style = buf.style();
+            level_style.set_bg(Color::Red).set_color(Color::Black);
+            log_style.set_color(Color::Red);
+
+            writeln!(
+                buf,
+                "{} {}",
+                level_style.value(record.level()),
+                log_style.value(record.args())
+            )
+        }
+        Level::Warn => {
+            let mut level_style = buf.style();
+            let mut log_style = buf.style();
+            level_style.set_bg(Color::Yellow).set_color(Color::Black);
+            log_style.set_color(Color::Yellow);
+
+            writeln!(
+                buf,
+                "{} {}",
+                level_style.value(record.level()),
+                log_style.value(record.args())
+            )
+        }
+        Level::Info => writeln!(buf, "{}", record.args()),
+        // trace and debug use the same style
+        _ => {
+            let now = Local::now();
+            writeln!(
+                buf,
+                "{} [{}] {}: {}",
+                // build our own timestamp to match the hashicorp/go-hclog format used by the go
+                // binary
+                now.format("%Y-%m-%dT%H:%M:%S.%3f%z"),
+                record.level(),
+                record.target(),
+                record.args()
+            )
+        }
+    });
+
+    builder.init();
+}
+
 pub fn run() -> Result<Payload> {
     let args = ShimArgs::parse()?;
 
+    init_env_logger(args.verbosity);
     if args.should_check_for_update() {
         // custom footer for update message
         let footer = format!(
@@ -388,8 +476,8 @@ pub fn run() -> Result<Payload> {
         Err(err) => {
             // If we cannot infer, we still run global turbo. This allows for global
             // commands like login/logout/link/unlink to still work
-            eprintln!("Repository inference failed: {}", err);
-            eprintln!("Running command as global turbo");
+            debug!("Repository inference failed: {}", err);
+            debug!("Running command as global turbo");
             cli::run(None)
         }
     }


### PR DESCRIPTION
This parses verbosity in the shim, and then configures a shim logger that matches the format of the go logger. 

This also moves all messages about detecting local vs global and inference to DEBUG (hidden by default)