### PR TITLE
Share rust config ownership between web-tooling and turbo-oss

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,11 +17,6 @@
 
 # Turbopack-specific things
 
-/Cargo.lock @vercel/web-tooling
-/Cargo.toml @vercel/web-tooling
-/rust-toolchain @vercel/web-tooling
-.rustfmt.toml @vercel/web-tooling
-.taplo.toml @vercel/web-tooling
 /docs/pages/pack @vercel/web-tooling
 /xtask @vercel/web-tooling
 


### PR DESCRIPTION
Both teams have an interest in top-level configuration, and we shouldn't block merges on changes to, e.g. `Cargo.lock`.