### PR TITLE
Add snapshot workflow for Turborepo releases

### DIFF
--- a/.github/workflows/build_rust_snapshot.yml
+++ b/.github/workflows/build_rust_snapshot.yml
@@ -1,0 +1,168 @@
+name: Snapshot Turborepo
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_branch:
+        description: "Staging branch to run snapshot from"
+
+env:
+  RELEASE_TURBO_CLI: true
+
+jobs:
+  build-native:
+    name: "Build Native"
+    strategy:
+      fail-fast: false
+      matrix:
+        settings:
+          - host: macos-latest
+            target: "x86_64-apple-darwin"
+            container-options: "--rm"
+          - host: macos-latest
+            target: "aarch64-apple-darwin"
+            container-options: "--rm"
+          - host: ubuntu-latest
+            container: ubuntu:xenial
+            container-options: "--platform=linux/amd64 --rm"
+            container-setup: "apt-get update && apt-get install -y curl musl-tools"
+            target: "x86_64-unknown-linux-musl"
+            setup: "apt-get install -y build-essential clang-5.0 lldb-5.0 llvm-5.0-dev libclang-5.0-dev"
+          - host: ubuntu-latest
+            container-options: "--rm"
+            target: "aarch64-unknown-linux-musl"
+            rustflags: 'CC_aarch64_unknown_linux_musl=clang AR_aarch64_unknown_linux_musl=llvm-ar RUSTFLAGS="-Clink-self-contained=yes -Clinker=rust-lld"'
+            setup: "sudo apt-get install -y build-essential musl-tools clang llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu"
+          - host: windows-latest
+            target: x86_64-pc-windows-gnu
+            setup: "rustup set default-host x86_64-pc-windows-gnu"
+            container-options: "--rm"
+    runs-on: ${{ matrix.settings.host }}
+    container:
+      image: ${{ matrix.settings.container }}
+      options: ${{ matrix.settings.container-options }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: "${{ inputs.release_branch }}"
+
+      - name: Setup Container
+        if: ${{ matrix.settings.container-setup }}
+        run: ${{ matrix.settings.container-setup }}
+
+      - name: Install
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          override: true
+          target: ${{ matrix.settings.target }}
+
+      # - name: Cache cargo registry
+      #   uses: actions/cache@v3
+      #   with:
+      #     path: ~/.cargo/registry
+      #     key: ${{ matrix.settings.target }}-cargo-registry
+
+      # - name: Cache cargo index
+      #   uses: actions/cache@v3
+      #   with:
+      #     path: ~/.cargo/git
+      #     key: ${{ matrix.settings.target }}-cargo-index
+
+      - name: Build Setup
+        shell: bash
+        if: ${{ matrix.settings.setup }}
+        run: ${{ matrix.settings.setup }}
+
+      - name: Build
+        run: ${{ matrix.settings.rustflags }} cargo build --release -p turbo --target ${{ matrix.settings.target }}
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: turbo-${{ matrix.settings.target }}
+          path: target/${{ matrix.settings.target }}/release/turbo*
+
+  final-publish:
+    name: "Publish To NPM"
+    runs-on: ubuntu-latest
+    needs: [build-native]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: "${{ inputs.release_branch }}"
+      - run: git fetch origin --tags
+      - uses: ./.github/actions/setup-node
+        with:
+          enable-corepack: false
+      - uses: ./.github/actions/setup-go
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Configure git
+        run: |
+          git config --global user.name 'Turbobot'
+          git config --global user.email 'turbobot@vercel.com'
+
+      - name: Install GoReleaser
+        uses: goreleaser/goreleaser-action@v3
+        with:
+          distribution: goreleaser-pro
+          version: latest
+          install-only: true
+        env:
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+
+      - name: Download Rust artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: rust-artifacts
+
+      - name: Move Rust artifacts into place
+        run: |
+          mv rust-artifacts/turbo-aarch64-apple-darwin cli/dist-darwin-arm64
+          mv rust-artifacts/turbo-aarch64-unknown-linux-musl cli/dist-linux-arm64
+          cp -r rust-artifacts/turbo-x86_64-pc-windows-gnu cli/dist-windows-arm64
+          mv rust-artifacts/turbo-x86_64-unknown-linux-musl cli/dist-linux-amd64
+          mv rust-artifacts/turbo-x86_64-apple-darwin cli/dist-darwin-amd64
+          mv rust-artifacts/turbo-x86_64-pc-windows-gnu cli/dist-windows-amd64
+
+      - name: Download Go artifacts
+        id: download-artifact
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          github_token: ${{secrets.TURBOBOT}}
+          workflow: build_go_binary.yml
+          workflow_conclusion: success
+          branch: ${{ inputs.release_branch }}
+          path: go-artifacts
+          skip_unpack: false
+          if_no_artifact_found: fail
+
+      - name: Move Go artifacts into place
+        run: |
+          mv go-artifacts/turbo-go-cross-${{ inputs.release_branch }}/turbo_linux_amd64_v1/bin/* cli/dist-linux-amd64
+          chmod a+x cli/dist-linux-amd64/bin/*
+          mv go-artifacts/turbo-go-cross-${{ inputs.release_branch }}/turbo_linux_arm64/bin/* cli/dist-linux-arm64
+          chmod a+x cli/dist-linux-arm64/bin/*
+          mv go-artifacts/turbo-go-cross-${{ inputs.release_branch }}/turbo_windows_amd64_v1/bin/* cli/dist-windows-amd64
+          chmod a+x cli/dist-windows-amd64/bin/*
+          mv go-artifacts/turbo-go-cross-${{ inputs.release_branch }}/turbo_windows_arm64/bin/* cli/dist-windows-arm64
+          chmod a+x cli/dist-windows-arm64/bin/*
+          mv go-artifacts/turbo-go-darwin-${{ inputs.release_branch }}/turbo_darwin_amd64_v1/bin/* cli/dist-darwin-amd64
+          chmod a+x cli/dist-darwin-amd64/bin/*
+          mv go-artifacts/turbo-go-darwin-${{ inputs.release_branch }}/turbo_darwin_arm64/bin/* cli/dist-darwin-arm64
+          chmod a+x cli/dist-darwin-arm64/bin/*
+
+      - name: Perform Release
+        run: cd cli && make snapshot-turbo
+        env:
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # TODO: probably don't need to upload this once we've verified the snapshots
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: turbo-combined
+          path: cli/dist


### PR DESCRIPTION
Rather than running `publish`, this workflow performs all of the same steps but generates and saves a snapshot for QA purposes.