### PR TITLE
publish 1.7.0-canary.6 to registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ todos.md
 cli/libturbo.a
 cli/libturbo.h
 
+go-artifacts
+rust-artifacts

--- a/cli/cmd/turbo/version.go
+++ b/cli/cmd/turbo/version.go
@@ -1,3 +1,3 @@
 package main
 
-const turboVersion = "1.7.0-canary.5"
+const turboVersion = "1.7.0-canary.6"

--- a/packages/create-turbo/package.json
+++ b/packages/create-turbo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-turbo",
-  "version": "1.7.0-canary.5",
+  "version": "1.7.0-canary.6",
   "description": "Create a new Turborepo",
   "homepage": "https://turbo.build/repo",
   "license": "MPL-2.0",

--- a/packages/turbo-codemod/package.json
+++ b/packages/turbo-codemod/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/codemod",
-  "version": "1.7.0-canary.5",
+  "version": "1.7.0-canary.6",
   "description": "Provides Codemod transformations to help upgrade your Turborepo codebase when a feature is deprecated.",
   "homepage": "https://turbo.build/repo",
   "license": "MPL-2.0",

--- a/packages/turbo/package.json
+++ b/packages/turbo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbo",
-  "version": "1.7.0-canary.5",
+  "version": "1.7.0-canary.6",
   "description": "Turborepo is a high-performance build system for JavaScript and TypeScript codebases.",
   "repository": "https://github.com/vercel/turbo",
   "bugs": "https://github.com/vercel/turbo/issues",
@@ -19,11 +19,11 @@
     "install.js"
   ],
   "optionalDependencies": {
-    "turbo-darwin-64": "1.7.0-canary.5",
-    "turbo-darwin-arm64": "1.7.0-canary.5",
-    "turbo-linux-64": "1.7.0-canary.5",
-    "turbo-linux-arm64": "1.7.0-canary.5",
-    "turbo-windows-64": "1.7.0-canary.5",
-    "turbo-windows-arm64": "1.7.0-canary.5"
+    "turbo-darwin-64": "1.7.0-canary.6",
+    "turbo-darwin-arm64": "1.7.0-canary.6",
+    "turbo-linux-64": "1.7.0-canary.6",
+    "turbo-linux-arm64": "1.7.0-canary.6",
+    "turbo-windows-64": "1.7.0-canary.6",
+    "turbo-windows-arm64": "1.7.0-canary.6"
   }
 }

--- a/version.txt
+++ b/version.txt
@@ -1,2 +1,2 @@
-1.7.0-canary.5
+1.7.0-canary.6
 canary


### PR DESCRIPTION
Deployed, merging version bumps back into `main`.