### PR TITLE
docs(repo/existing-monorepo.md): update not working command

### DIFF
--- a/docs/pages/repo/docs/getting-started/existing-monorepo.mdx
+++ b/docs/pages/repo/docs/getting-started/existing-monorepo.mdx
@@ -76,7 +76,7 @@ yarn add turbo -D
   </Tab>
   <Tab>
 ```bash
-pnpm add turbo -Dw
+pnpm add turbo -D
 ```
   </Tab>
 </Tabs>

--- a/docs/pages/repo/docs/getting-started/existing-monorepo.mdx
+++ b/docs/pages/repo/docs/getting-started/existing-monorepo.mdx
@@ -71,7 +71,7 @@ npm install turbo -D
   </Tab>
   <Tab>
 ```bash
-yarn add turbo -DW
+yarn add turbo -D
 ```
   </Tab>
   <Tab>


### PR DESCRIPTION
# Update not working command `yarn add turbo -DW`
During adopt turborepo in [my existing monorepo](https://github.com/suspensive/react), I met this error after using command `yarn add turbo -DW`

After I found what -W is, I understood why use it. but because document already lead us this command in root, so Isn't it enough only -D not -DW? In my case, I can't use -W. but If using -D, It's working in my case.

## Error image
<img width="1184" alt="image" src="https://user-images.githubusercontent.com/61593290/211194210-f26180cc-e95b-451c-b632-0c53bd21204d.png">
