### PR TITLE
filter out invalid Pipelines from TurboJSON when running turbo prune

### DIFF
--- a/cli/internal/fs/turbo_json.go
+++ b/cli/internal/fs/turbo_json.go
@@ -28,7 +28,7 @@ type rawTurboJSON struct {
 	GlobalEnv []string `json:"globalEnv,omitempty"`
 	// Pipeline is a map of Turbo pipeline entries which define the task graph
 	// and cache behavior on a per task or per package-task basis.
-	Pipeline Pipeline
+	Pipeline Pipeline `json:"pipeline"`
 	// Configuration options when interfacing with the remote cache
 	RemoteCacheOptions RemoteCacheOptions `json:"remoteCache,omitempty"`
 }
@@ -408,4 +408,16 @@ func (c *TurboJSON) UnmarshalJSON(data []byte) error {
 	c.RemoteCacheOptions = raw.RemoteCacheOptions
 
 	return nil
+}
+
+// MarshalJSON converts a TurboJSON into the equivalent json object in bytes
+// note: we go via rawTurboJSON so that the output format is correct
+func (c *TurboJSON) MarshalJSON() ([]byte, error) {
+	raw := rawTurboJSON{}
+	raw.GlobalDependencies = c.GlobalDeps
+	raw.GlobalEnv = c.GlobalEnv
+	raw.Pipeline = c.Pipeline
+	raw.RemoteCacheOptions = c.RemoteCacheOptions
+
+	return json.Marshal(&raw)
 }

--- a/cli/internal/prune/prune.go
+++ b/cli/internal/prune/prune.go
@@ -11,6 +11,7 @@ import (
 	"github.com/vercel/turbo/cli/internal/turbopath"
 	"github.com/vercel/turbo/cli/internal/turbostate"
 	"github.com/vercel/turbo/cli/internal/ui"
+	"github.com/vercel/turbo/cli/internal/util"
 
 	"github.com/fatih/color"
 	"github.com/hashicorp/go-hclog"
@@ -201,9 +202,36 @@ func (p *prune) prune(opts *turbostate.PrunePayload) error {
 		}
 	}
 
-	if fs.FileExists("turbo.json") {
-		if err := fs.CopyFile(&fs.LstatCachedFile{Path: p.base.RepoRoot.UntypedJoin("turbo.json")}, fullDir.UntypedJoin("turbo.json").ToStringDuringMigration()); err != nil {
-			return errors.Wrap(err, "failed to copy root turbo.json")
+	turboJSON, err := fs.LoadTurboConfig(p.base.RepoRoot, rootPackageJSON, false)
+	if err != nil {
+		return errors.Wrap(err, "failed to read turbo.json")
+	}
+	if turboJSON != nil {
+		// when executing a prune, it is not enough to simply copy the file, as
+		// tasks may refer to scopes that no longer exist. to remedy this, we need
+		// to remove from the Pipeline the TaskDefinitions that no longer apply
+		for pipelineTask := range turboJSON.Pipeline {
+			includeTask := false
+			for _, includedPackage := range targets {
+				if util.IsTaskInPackage(pipelineTask, includedPackage) {
+					includeTask = true
+					break
+				}
+			}
+
+			if !includeTask {
+				delete(turboJSON.Pipeline, pipelineTask)
+			}
+		}
+
+		bytes, err := turboJSON.MarshalJSON()
+
+		if err != nil {
+			return errors.Wrap(err, "failed to write turbo.json")
+		}
+
+		if err := fullDir.UntypedJoin("turbo.json").WriteFile(bytes, 0644); err != nil {
+			return errors.Wrap(err, "failed to prune workspace tasks from turbo.json")
 		}
 	}
 

--- a/cli/internal/util/task_id.go
+++ b/cli/internal/util/task_id.go
@@ -36,9 +36,23 @@ func RootTaskTaskName(taskID string) string {
 	return strings.TrimPrefix(taskID, RootPkgName+TaskDelimiter)
 }
 
-// IsPackageTask returns true if a is a package-specific task (e.g. myapp#build)
+// IsPackageTask returns true if input is a package-specific task
+// whose name has a length greater than 0.
+//
+// Accepted: myapp#build
+// Rejected: #build, build
 func IsPackageTask(task string) bool {
-	return strings.Contains(task, TaskDelimiter)
+	return strings.Index(task, TaskDelimiter) > 0
+}
+
+// IsTaskInPackage returns true if the task does not belong to a different package
+// note that this means unscoped tasks will always return true
+func IsTaskInPackage(task string, packageName string) bool {
+	if !IsPackageTask(task) {
+		return true
+	}
+	packageNameExpected, _ := GetPackageTaskFromId(task)
+	return packageNameExpected == packageName
 }
 
 // StripPackageName removes the package portion of a taskID if it


### PR DESCRIPTION
Closes #1161

This is based on top of https://github.com/vercel/turbo/pull/3213

Open questions:

- do we want to include root-scoped tasks in the output?
- what should the permissions be on the new turbo file created? we could read the permissions from the old one, or set it manually (I currently do 0664)