### PR TITLE
feat(cli): disable package.json config support

### DIFF
--- a/cli/internal/fs/turbo_json.go
+++ b/cli/internal/fs/turbo_json.go
@@ -169,7 +169,6 @@ func ReadTurboConfig(rootPath turbopath.AbsoluteSystemPath, rootPackageJSON *Pac
 		}
 
 		// If pkg.Turbo exists, log a warning and delete it from the representation
-		// TODO: turn off this warning eventually
 		if hasLegacyConfig {
 			log.Printf("[WARNING] Ignoring \"turbo\" key in package.json, using %s instead.", configFile)
 			rootPackageJSON.LegacyTurboConfig = nil
@@ -178,11 +177,9 @@ func ReadTurboConfig(rootPath turbopath.AbsoluteSystemPath, rootPackageJSON *Pac
 		return turboJSON, nil
 	}
 
-	// Use pkg.Turbo if the configFile doesn't exist and we want the fallback feature
-	// TODO: turn this fallback off eventually
+	// If the configFile doesn't exist, but a legacy config does, log that it's deprecated and return an error
 	if hasLegacyConfig {
 		log.Printf("[DEPRECATED] \"turbo\" in package.json is deprecated. Migrate to %s by running \"npx @turbo/codemod create-turbo-config\"\n", configFile)
-		return rootPackageJSON.LegacyTurboConfig, nil
 	}
 
 	// If there's no turbo.json and no turbo key in package.json, return an error.

--- a/cli/internal/fs/turbo_json_test.go
+++ b/cli/internal/fs/turbo_json_test.go
@@ -95,25 +95,10 @@ func Test_ReadTurboConfig_Legacy(t *testing.T) {
 		t.Fatalf("invalid parse: %#v", pkgJSONReadErr)
 	}
 
-	turboJSON, turboJSONReadErr := ReadTurboConfig(testDir, rootPackageJSON)
+	_, turboJSONReadErr := ReadTurboConfig(testDir, rootPackageJSON)
 
-	if turboJSONReadErr != nil {
-		t.Fatalf("invalid parse: %#v", turboJSONReadErr)
-	}
-
-	pipelineExpected := map[string]TaskDefinition{
-		"build": {
-			Outputs:                 TaskOutputs{},
-			TopologicalDependencies: []string{},
-			EnvVarDependencies:      []string{},
-			TaskDependencies:        []string{},
-			ShouldCache:             true,
-			OutputMode:              util.FullTaskOutput,
-		},
-	}
-
-	validateOutput(t, turboJSON, pipelineExpected)
-	assert.Empty(t, turboJSON.RemoteCacheOptions)
+	expectedErrorMsg := "Could not find turbo.json. Follow directions at https://turbo.build/repo/docs to create one: file does not exist"
+	assert.EqualErrorf(t, turboJSONReadErr, expectedErrorMsg, "Error should be: %v, got: %v", expectedErrorMsg, turboJSONReadErr)
 }
 
 func Test_ReadTurboConfig_BothCorrectAndLegacy(t *testing.T) {


### PR DESCRIPTION
Deprecate package.json configs. We've had a warning and migration path (codemod) in place for close to a year.