### PR TITLE
fix inconsistent sys_path leading to watching issue on root dir

### DIFF
--- a/crates/turbo-tasks-fs/src/lib.rs
+++ b/crates/turbo-tasks-fs/src/lib.rs
@@ -265,10 +265,11 @@ impl DiskFileSystem {
 
     pub async fn to_sys_path(&self, fs_path: FileSystemPathVc) -> Result<PathBuf> {
         let path = Path::new(&self.root);
-        Ok(if fs_path.await?.path.is_empty() {
+        let fs_path = fs_path.await?;
+        Ok(if fs_path.path.is_empty() {
             path.to_path_buf()
         } else {
-            path.join(&*unix_to_sys(&fs_path.await?.path))
+            path.join(&*unix_to_sys(&fs_path.path))
         })
     }
 }

--- a/crates/turbo-tasks-fs/src/lib.rs
+++ b/crates/turbo-tasks-fs/src/lib.rs
@@ -264,8 +264,13 @@ impl DiskFileSystem {
     }
 
     pub async fn to_sys_path(&self, fs_path: FileSystemPathVc) -> Result<PathBuf> {
-        let path = Path::new(&self.root).join(&*unix_to_sys(&fs_path.await?.path));
-        Ok(path)
+        let path = Path::new(&self.root);
+        if fs_path.await?.path.is_empty() {
+            Ok(path.to_path_buf())
+        } else {
+            let path = path.join(&*unix_to_sys(&fs_path.await?.path));
+            Ok(path)
+        }
     }
 }
 

--- a/crates/turbo-tasks-fs/src/lib.rs
+++ b/crates/turbo-tasks-fs/src/lib.rs
@@ -265,12 +265,11 @@ impl DiskFileSystem {
 
     pub async fn to_sys_path(&self, fs_path: FileSystemPathVc) -> Result<PathBuf> {
         let path = Path::new(&self.root);
-        if fs_path.await?.path.is_empty() {
-            Ok(path.to_path_buf())
+        Ok(if fs_path.await?.path.is_empty() {
+            path.to_path_buf()
         } else {
-            let path = path.join(&*unix_to_sys(&fs_path.await?.path));
-            Ok(path)
-        }
+            path.join(&*unix_to_sys(&fs_path.await?.path))
+        })
     }
 }
 


### PR DESCRIPTION
It fixes the case when adding, removing or renaming files on root dir doesn't trigger an update.

maybe fixes #3215, but I can confirm as I can't really reproduce with the steps provided.
