### PR TITLE
Show an error if no tasks are supplied to run

### DIFF
--- a/cli/integration_tests/no_args.t
+++ b/cli/integration_tests/no_args.t
@@ -58,3 +58,6 @@ Make sure exit code is 2 when no args are passed
         --scope <SCOPE>                  Specify package(s) to act as entry points for task execution. Supports globs
         --since <SINCE>                  Limit/Set scope to changed packages since a mergebase. This uses the git diff ${target_branch}... mechanism to identify which packages have changed
   [1]
+  $ ${TURBO} run
+  Turbo error: at least one task must be specified
+  [1]

--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -97,6 +97,7 @@ func RunWithArgs(args turbostate.ParsedArgsFromRust, turboVersion string) int {
 		if errors.As(execErr, &exitErr) {
 			return exitErr.ExitCode
 		} else if execErr != nil {
+			fmt.Printf("Turbo error: %v\n", execErr)
 			return 1
 		}
 		return 0


### PR DESCRIPTION
Top-level Go errors currently get swallowed, this PR sends them to `stderr`. 

Includes an integration test to ensure that the error is visible