### PR TITLE
Check for mid-run input mutation.

### DIFF
--- a/cli/internal/run/dry_run.go
+++ b/cli/internal/run/dry_run.go
@@ -85,7 +85,7 @@ func executeDryRun(ctx gocontext.Context, engine *core.Engine, g *graph.Complete
 	dryRunExecFunc := func(ctx gocontext.Context, packageTask *nodes.PackageTask) error {
 		deps := engine.TaskGraph.DownEdges(packageTask.TaskID)
 		passThroughArgs := rs.ArgsForTask(packageTask.Task)
-		hash, err := taskHashes.CalculateTaskHash(packageTask, deps, base.Logger, passThroughArgs)
+		hash, err := taskHashes.CalculateTaskHash(packageTask, deps, base.RepoRoot, base.Logger, passThroughArgs)
 		if err != nil {
 			return err
 		}

--- a/cli/internal/run/real_run.go
+++ b/cli/internal/run/real_run.go
@@ -89,11 +89,6 @@ func RealRun(
 	}
 
 	execFunc := func(ctx gocontext.Context, packageTask *nodes.PackageTask) error {
-		err := hashes.CalculateFileHashes(packageTask.TaskID, 1, base.RepoRoot)
-		if err != nil {
-			return err
-		}
-
 		deps := engine.TaskGraph.DownEdges(packageTask.TaskID)
 		// deps here are passed in to calculate the task hash
 		return ec.exec(ctx, packageTask, deps)
@@ -166,7 +161,7 @@ func (ec *execContext) exec(ctx gocontext.Context, packageTask *nodes.PackageTas
 	tracer := ec.runState.Run(packageTask.TaskID)
 
 	passThroughArgs := ec.rs.ArgsForTask(packageTask.Task)
-	hash, err := ec.taskHashes.CalculateTaskHash(packageTask, deps, ec.logger, passThroughArgs)
+	hash, err := ec.taskHashes.CalculateTaskHash(packageTask, deps, ec.repoRoot, ec.logger, passThroughArgs)
 	ec.logger.Debug("task hash", "value", hash)
 	if err != nil {
 		ec.ui.Error(fmt.Sprintf("Hashing error: %v", err))

--- a/cli/internal/run/real_run.go
+++ b/cli/internal/run/real_run.go
@@ -89,6 +89,11 @@ func RealRun(
 	}
 
 	execFunc := func(ctx gocontext.Context, packageTask *nodes.PackageTask) error {
+		err := hashes.CalculateFileHashes(packageTask.TaskID, 1, base.RepoRoot)
+		if err != nil {
+			return err
+		}
+
 		deps := engine.TaskGraph.DownEdges(packageTask.TaskID)
 		// deps here are passed in to calculate the task hash
 		return ec.exec(ctx, packageTask, deps)

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -270,10 +270,6 @@ func (r *run) run(ctx gocontext.Context, targets []string) error {
 		return errors.Wrap(err, "error preparing engine")
 	}
 	tracker := taskhash.NewTracker(g.RootNode, g.GlobalHash, g.Pipeline, g.WorkspaceInfos)
-	err = tracker.CalculateFileHashes(engine.TaskGraph.Vertices(), rs.Opts.runOpts.concurrency, r.base.RepoRoot)
-	if err != nil {
-		return errors.Wrap(err, "error hashing package files")
-	}
 
 	// If we are running in parallel, then we remove all the edges in the graph
 	// except for the root. Rebuild the task graph for backwards compatibility.

--- a/cli/internal/taskhash/taskhash.go
+++ b/cli/internal/taskhash/taskhash.go
@@ -231,12 +231,9 @@ func (th *Tracker) calculateDependencyHashes(dependencySet dag.Set) ([]string, e
 // that it has previously been called on its task-graph dependencies. File hashes must be calculated
 // first.
 func (th *Tracker) CalculateTaskHash(packageTask *nodes.PackageTask, dependencySet dag.Set, repoRoot turbopath.AbsoluteSystemPath, logger hclog.Logger, args []string) (string, error) {
-	pfs := specFromPackageTask(packageTask)
-	pkgFileHashKey := pfs.ToKey()
-
 	hashOfFiles, err := th.CalculateFileHashes(packageTask.TaskID, repoRoot)
 	if err != nil {
-		return "", fmt.Errorf("cannot find package-file hash for %v", pkgFileHashKey)
+		return "", err
 	}
 
 	var envPrefixes []string


### PR DESCRIPTION
If, by consequence of executing a parent task, the inputs to a child task are changed (and consequently its hash changes mid-run) then the side effects created by the _unknown_ parent task are almost guaranteed to _not_ be recreated on cache restoration.

This can be seen in this test case:
https://github.com/nathanhammond/dynamic-all-the-way-down

The consequences of this issue are that:
- Dry-run is not an accurate picture of the world.
- Parallel tasks can surprisingly mutate the inputs of non-dependent tasks.
- We get "nested" cache results. In the scenario of a single task with side effects, consumed by a single downstream task, it takes two runs to reach FULL TURBO because the side-effect inducing task needs to hit cache before any consumers of the side effect are able to do so.
- The cache artifact stored is stored at the "wrong" address and can be (dangerously!) restored.

***

This PR:
- makes task hash calculation point-in-time, primarily by reworking file hashing behavior.
- enables us to detect when a previous (or parallel) step has mutated the inputs of a following step.
- ensures that the state of the inputs at execution time are accurately reflected in the hash. (Race conditions can still occur but this will in theory eventually trigger on those race conditions.)
- removes a lot of brittle async and stateful behavior.