### PR TITLE
Apply `hygiene` pass before `fixer`

### DIFF
--- a/crates/turbopack-ecmascript/src/lib.rs
+++ b/crates/turbopack-ecmascript/src/lib.rs
@@ -318,6 +318,7 @@ impl EcmascriptChunkItem for ModuleChunkItem {
                 for visitor in root_visitors {
                     program.visit_mut_with(&mut visitor.create());
                 }
+                program.visit_mut_with(&mut swc_core::ecma::transforms::base::hygiene::hygiene());
                 program.visit_mut_with(&mut swc_core::ecma::transforms::base::fixer::fixer(None));
             });
 


### PR DESCRIPTION
`hygiene` pass is required to prevent duplicate variable names.

fixes WEB-393

x-ref: https://vercel.slack.com/archives/C02HY34AKME/p1673451065749759