### PR TITLE
add basic webpack loader support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7296,6 +7296,7 @@ dependencies = [
  "criterion 0.3.6",
  "difference",
  "futures",
+ "indexmap",
  "lazy_static",
  "regex",
  "rstest",

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -127,6 +127,7 @@ pub async fn get_client_module_options_context(
             postcss_package: Some(get_postcss_package_mapping(project_path)),
             ..Default::default()
         }),
+        enable_webpack_loaders: next_config.webpack_loaders_options().await?.clone_if(),
         enable_typescript_transform: true,
         rules: vec![(
             foreign_code_context_condition(next_config).await?,

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -218,10 +218,7 @@ impl NextConfigVc {
     #[turbo_tasks::function]
     pub async fn webpack_loaders_options(self) -> Result<WebpackLoadersOptionsVc> {
         let this = self.await?;
-        let Some(experimental) = this.experimental.as_ref() else {
-            return Ok(WebpackLoadersOptionsVc::cell(WebpackLoadersOptions::default()));
-        };
-        let Some(turbopack_webpack_loaders) = experimental.turbopack_webpack_loaders.as_ref() else {
+        let Some(turbopack_webpack_loaders) = this.experimental.as_ref().and_then(|experimental| experimental.turbopack_webpack_loaders.as_ref()) else {
             return Ok(WebpackLoadersOptionsVc::cell(WebpackLoadersOptions::default()));
         };
         let mut extension_to_loaders = IndexMap::new();

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -1,13 +1,17 @@
 use std::collections::HashMap;
 
 use anyhow::Result;
+use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use turbo_tasks::{
     primitives::{BoolVc, StringsVc},
     trace::TraceRawVcs,
     Value,
 };
-use turbopack::evaluate_context::node_evaluate_asset_context;
+use turbopack::{
+    evaluate_context::node_evaluate_asset_context,
+    module_options::{WebpackLoadersOptions, WebpackLoadersOptionsVc},
+};
 use turbopack_core::{
     asset::Asset,
     reference_type::{EntryReferenceSubType, ReferenceType},
@@ -127,11 +131,12 @@ pub enum RemotePatternProtocal {
     Https,
 }
 
-#[derive(Clone, Debug, Ord, PartialOrd, PartialEq, Eq, Serialize, Deserialize, TraceRawVcs)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, TraceRawVcs)]
 #[serde(rename_all = "camelCase")]
 pub struct ExperimentalConfig {
     pub server_components_external_packages: Option<Vec<String>>,
     pub app_dir: Option<bool>,
+    pub turbopack_webpack_loaders: Option<IndexMap<String, Vec<String>>>,
 }
 
 #[derive(Clone, Debug, Ord, PartialOrd, PartialEq, Eq, Serialize, Deserialize, TraceRawVcs)]
@@ -208,6 +213,26 @@ impl NextConfigVc {
         Ok(StringsVc::cell(
             self.await?.transpile_packages.clone().unwrap_or_default(),
         ))
+    }
+
+    #[turbo_tasks::function]
+    pub async fn webpack_loaders_options(self) -> Result<WebpackLoadersOptionsVc> {
+        let this = self.await?;
+        let Some(experimental) = this.experimental.as_ref() else {
+            return Ok(WebpackLoadersOptionsVc::cell(WebpackLoadersOptions::default()));
+        };
+        let Some(turbopack_webpack_loaders) = experimental.turbopack_webpack_loaders.as_ref() else {
+            return Ok(WebpackLoadersOptionsVc::cell(WebpackLoadersOptions::default()));
+        };
+        let mut extension_to_loaders = IndexMap::new();
+        for (ext, loaders) in turbopack_webpack_loaders {
+            extension_to_loaders.insert(ext.clone(), StringsVc::cell(loaders.clone()));
+        }
+        Ok(WebpackLoadersOptions {
+            extension_to_loaders,
+            ..Default::default()
+        }
+        .cell())
     }
 }
 

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -118,6 +118,7 @@ pub async fn get_server_module_options_context(
                     postcss_package: Some(get_postcss_package_mapping(project_path)),
                     ..Default::default()
                 }),
+                enable_webpack_loaders: next_config.webpack_loaders_options().await?.clone_if(),
                 enable_typescript_transform: true,
                 rules: vec![(
                     foreign_code_context_condition(next_config).await?,
@@ -138,6 +139,7 @@ pub async fn get_server_module_options_context(
                     postcss_package: Some(get_postcss_package_mapping(project_path)),
                     ..Default::default()
                 }),
+                enable_webpack_loaders: next_config.webpack_loaders_options().await?.clone_if(),
                 enable_typescript_transform: true,
                 rules: vec![(
                     foreign_code_context_condition(next_config).await?,
@@ -160,6 +162,7 @@ pub async fn get_server_module_options_context(
                     postcss_package: Some(get_postcss_package_mapping(project_path)),
                     ..Default::default()
                 }),
+                enable_webpack_loaders: next_config.webpack_loaders_options().await?.clone_if(),
                 enable_typescript_transform: true,
                 rules: vec![(
                     foreign_code_context_condition(next_config).await?,

--- a/crates/next-dev/src/lib.rs
+++ b/crates/next-dev/src/lib.rs
@@ -35,9 +35,9 @@ use turbopack_core::{
     environment::ServerAddr,
     issue::IssueSeverity,
     resolve::{parse::RequestVc, pattern::QueryMapVc},
+    server_fs::ServerFileSystemVc,
 };
 use turbopack_dev_server::{
-    fs::DevServerFileSystemVc,
     introspect::IntrospectionSource,
     source::{
         combined::CombinedContentSourceVc, router::RouterContentSource,
@@ -279,7 +279,7 @@ async fn source(
     let output_root = output_fs.root().join(".next/server");
     let server_addr = ServerAddr::new(*server_addr).cell();
 
-    let dev_server_fs = DevServerFileSystemVc::new().as_file_system();
+    let dev_server_fs = ServerFileSystemVc::new().as_file_system();
     let dev_server_root = dev_server_fs.root();
     let entry_requests = entry_requests
         .iter()

--- a/crates/next-dev/tests/integration/turbopack/basic/webpack-loaders/hello.raw
+++ b/crates/next-dev/tests/integration/turbopack/basic/webpack-loaders/hello.raw
@@ -1,0 +1,1 @@
+Hello World

--- a/crates/next-dev/tests/integration/turbopack/basic/webpack-loaders/index.js
+++ b/crates/next-dev/tests/integration/turbopack/basic/webpack-loaders/index.js
@@ -1,0 +1,5 @@
+import source from "./hello.raw";
+
+it("runs a simple loader", () => {
+  expect(source).toBe("Hello World");
+});

--- a/crates/next-dev/tests/integration/turbopack/basic/webpack-loaders/next.config.js
+++ b/crates/next-dev/tests/integration/turbopack/basic/webpack-loaders/next.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  experimental: {
+    turbopackWebpackLoaders: {
+      ".raw": ["raw-loader"],
+    },
+  },
+};

--- a/crates/next-dev/tests/integration/turbopack/basic/webpack-loaders/node_modules/raw-loader/index.js
+++ b/crates/next-dev/tests/integration/turbopack/basic/webpack-loaders/node_modules/raw-loader/index.js
@@ -1,0 +1,3 @@
+module.exports = async (source) => {
+  return `export default ${JSON.stringify(source.trim())};`
+}

--- a/crates/next-dev/tests/package.json
+++ b/crates/next-dev/tests/package.json
@@ -4,11 +4,12 @@
   "devDependencies": {
     "@turbo/pack-test-harness": "*",
     "autoprefixer": "^10.4.13",
+    "loader-runner": "^4.3.0",
     "next": "13.0.8-canary.2",
     "postcss": "^8.4.20",
-    "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-test-renderer": "^18.2.0",
+    "react": "^18.2.0",
     "styled-jsx": "^5.1.0",
     "tailwindcss": "^3.2.4"
   }

--- a/crates/turbopack-core/src/lib.rs
+++ b/crates/turbopack-core/src/lib.rs
@@ -15,6 +15,7 @@ pub mod issue;
 pub mod reference;
 pub mod reference_type;
 pub mod resolve;
+pub mod server_fs;
 pub mod source_asset;
 pub mod source_map;
 pub mod source_pos;

--- a/crates/turbopack-core/src/server_fs.rs
+++ b/crates/turbopack-core/src/server_fs.rs
@@ -6,36 +6,36 @@ use turbo_tasks_fs::{
 };
 
 #[turbo_tasks::value]
-pub struct DevServerFileSystem {}
+pub struct ServerFileSystem {}
 
 #[turbo_tasks::value_impl]
-impl DevServerFileSystemVc {
+impl ServerFileSystemVc {
     #[turbo_tasks::function]
     pub fn new() -> Self {
-        Self::cell(DevServerFileSystem {})
+        Self::cell(ServerFileSystem {})
     }
 }
 
 #[turbo_tasks::value_impl]
-impl FileSystem for DevServerFileSystem {
+impl FileSystem for ServerFileSystem {
     #[turbo_tasks::function]
     fn read(&self, _fs_path: FileSystemPathVc) -> Result<FileContentVc> {
-        bail!("Reading is not possible from the virtual filesystem for the dev server")
+        bail!("Reading is not possible from the marker filesystem for the server")
     }
 
     #[turbo_tasks::function]
     fn read_link(&self, _fs_path: FileSystemPathVc) -> Result<LinkContentVc> {
-        bail!("Reading is not possible from the virtual filesystem for the dev server")
+        bail!("Reading is not possible from the marker filesystem for the server")
     }
 
     #[turbo_tasks::function]
     fn read_dir(&self, _fs_path: FileSystemPathVc) -> Result<DirectoryContentVc> {
-        bail!("Reading is not possible from the virtual filesystem for the dev server")
+        bail!("Reading is not possible from the marker filesystem for the server")
     }
 
     #[turbo_tasks::function]
     fn write(&self, _fs_path: FileSystemPathVc, _content: FileContentVc) -> Result<CompletionVc> {
-        bail!("Writing is not possible to the virtual filesystem for the dev server")
+        bail!("Writing is not possible to the marker filesystem for the server")
     }
 
     #[turbo_tasks::function]
@@ -44,19 +44,19 @@ impl FileSystem for DevServerFileSystem {
         _fs_path: FileSystemPathVc,
         _target: LinkContentVc,
     ) -> Result<CompletionVc> {
-        bail!("Writing is not possible to the virtual filesystem for the dev server")
+        bail!("Writing is not possible to the marker filesystem for the  server")
     }
 
     #[turbo_tasks::function]
     fn metadata(&self, _fs_path: FileSystemPathVc) -> Result<FileMetaVc> {
-        bail!("Reading is not possible from the virtual filesystem for the dev server")
+        bail!("Reading is not possible from the marker filesystem for the  server")
     }
 }
 
 #[turbo_tasks::value_impl]
-impl ValueToString for DevServerFileSystem {
+impl ValueToString for ServerFileSystem {
     #[turbo_tasks::function]
     fn to_string(&self) -> StringVc {
-        StringVc::cell("root of the dev server".to_string())
+        StringVc::cell("root of the server".to_string())
     }
 }

--- a/crates/turbopack-dev-server/src/lib.rs
+++ b/crates/turbopack-dev-server/src/lib.rs
@@ -2,7 +2,6 @@
 #![feature(trait_alias)]
 #![feature(array_chunks)]
 
-pub mod fs;
 pub mod html;
 pub mod introspect;
 pub mod source;

--- a/crates/turbopack-node/js/package.json
+++ b/crates/turbopack-node/js/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@vercel/turbopack-node",
+  "version": "0.0.0",
+  "description": "turbopack node runtime",
+  "license": "UNLICENSED",
+  "private": true,
+  "scripts": {
+    "check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "loader-runner": "^4.3.0"
+  },
+  "devDependencies": {
+    "@types/loader-runner": "^2.2.4",
+    "@types/node": "^18.11.11"
+  }
+}

--- a/crates/turbopack-node/js/src/transforms/webpack-loaders.ts
+++ b/crates/turbopack-node/js/src/transforms/webpack-loaders.ts
@@ -1,0 +1,70 @@
+declare const __turbopack_external_require__: (id: string) => any;
+
+import type { Ipc } from "../ipc/evaluate";
+import {
+  relative,
+  isAbsolute,
+  sep,
+  dirname,
+  resolve as pathResolve,
+} from "path";
+
+const { runLoaders } = __turbopack_external_require__(
+  "loader-runner"
+) as typeof import("loader-runner");
+
+const contextDir = process.cwd();
+const toPath = (file: string) => {
+  const relPath = relative(contextDir, file);
+  if (isAbsolute(relPath)) {
+    throw new Error(
+      `Cannot depend on path (${file}) outside of root directory (${contextDir})`
+    );
+  }
+  return sep !== "/" ? relPath.replaceAll(sep, "/") : relPath;
+};
+
+const transform = (ipc: Ipc, content: string, name: string, loaders: any[]) => {
+  return new Promise((resolve, reject) => {
+    const resource = pathResolve(contextDir, name);
+    const resourceDir = dirname(resource);
+    // TODO this should be handled in turbopack instead to ensure it's watched
+    loaders = loaders.map((loader: any) => {
+      return require.resolve(loader, { paths: [resourceDir] });
+    });
+    runLoaders(
+      {
+        resource,
+        context: {
+          rootContext: contextDir,
+        },
+        loaders,
+        readResource: (_filename, callback) => {
+          // TODO assuming the filename === resource, but loaders might change that
+          callback(null, Buffer.from(content, "utf-8"));
+        },
+      },
+      (err, result) => {
+        if (err) return reject(err);
+        for (const dep of result.contextDependencies) {
+          ipc.send({
+            type: "dirDependency",
+            path: toPath(dep),
+            glob: "**",
+          });
+        }
+        for (const dep of result.fileDependencies) {
+          ipc.send({
+            type: "fileDependency",
+            path: toPath(dep),
+          });
+        }
+        if (!result.result) return reject(new Error("No result from loaders"));
+        const [source, map] = result.result;
+        resolve({ source, map });
+      }
+    );
+  });
+};
+
+export { transform as default };

--- a/crates/turbopack-node/js/tsconfig.json
+++ b/crates/turbopack-node/js/tsconfig.json
@@ -1,0 +1,31 @@
+{
+  "compilerOptions": {
+    // type checking
+    "strict": true,
+    "noFallthroughCasesInSwitch": true,
+    "skipLibCheck": true,
+
+    // interop constraints
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+
+    // js support
+    "allowJs": true,
+    "checkJs": false,
+
+    // environment
+    "jsx": "react-jsx",
+    "lib": ["ESNext", "DOM"],
+    "target": "esnext",
+
+    // modules
+    "baseUrl": ".",
+    "module": "esnext",
+    "moduleResolution": "node",
+
+    // emit
+    "noEmit": true,
+    "stripInternal": true
+  },
+  "include": ["src", "types"]
+}

--- a/crates/turbopack-node/js/tsconfig.json
+++ b/crates/turbopack-node/js/tsconfig.json
@@ -14,8 +14,7 @@
     "checkJs": false,
 
     // environment
-    "jsx": "react-jsx",
-    "lib": ["ESNext", "DOM"],
+    "lib": ["ESNext"],
     "target": "esnext",
 
     // modules
@@ -27,5 +26,5 @@
     "noEmit": true,
     "stripInternal": true
   },
-  "include": ["src", "types"]
+  "include": ["src"]
 }

--- a/crates/turbopack-node/src/transforms/mod.rs
+++ b/crates/turbopack-node/src/transforms/mod.rs
@@ -1,1 +1,3 @@
 pub mod postcss;
+mod util;
+pub mod webpack;

--- a/crates/turbopack-node/src/transforms/util.rs
+++ b/crates/turbopack-node/src/transforms/util.rs
@@ -1,0 +1,40 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+use turbo_tasks_fs::{File, FileContent, FileSystem};
+use turbopack_core::{
+    asset::AssetContent, server_fs::ServerFileSystemVc, virtual_asset::VirtualAssetVc,
+};
+
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct EmittedAsset {
+    file: String,
+    content: String,
+    source_map: Option<JsonValue>,
+}
+
+pub fn emitted_assets_to_virtual_assets(assets: Option<Vec<EmittedAsset>>) -> Vec<VirtualAssetVc> {
+    assets
+        .into_iter()
+        .flatten()
+        .map(
+            |EmittedAsset {
+                 file,
+                 content,
+                 source_map,
+             }| (file, (content, source_map)),
+        )
+        // Sort it to make it determinstic
+        .collect::<BTreeMap<_, _>>()
+        .into_iter()
+        .map(|(file, (content, _source_map))| {
+            // TODO handle SourceMap
+            VirtualAssetVc::new(
+                ServerFileSystemVc::new().root().join(&file),
+                AssetContent::File(FileContent::Content(File::from(content)).cell()).cell(),
+            )
+        })
+        .collect()
+}

--- a/crates/turbopack-node/src/transforms/webpack.rs
+++ b/crates/turbopack-node/src/transforms/webpack.rs
@@ -61,7 +61,7 @@ impl WebpackLoadersVc {
 impl SourceTransform for WebpackLoaders {
     #[turbo_tasks::function]
     fn transform(&self, source: AssetVc) -> AssetVc {
-        WebpackLoadersedAsset {
+        WebpackLoadersProcessedAsset {
             evaluate_context: self.evaluate_context,
             execution_context: self.execution_context,
             loaders: self.loaders,
@@ -73,7 +73,7 @@ impl SourceTransform for WebpackLoaders {
 }
 
 #[turbo_tasks::value]
-struct WebpackLoadersedAsset {
+struct WebpackLoadersProcessedAsset {
     evaluate_context: AssetContextVc,
     execution_context: ExecutionContextVc,
     loaders: StringsVc,
@@ -81,14 +81,14 @@ struct WebpackLoadersedAsset {
 }
 
 #[turbo_tasks::value_impl]
-impl Asset for WebpackLoadersedAsset {
+impl Asset for WebpackLoadersProcessedAsset {
     #[turbo_tasks::function]
     fn path(&self) -> FileSystemPathVc {
         self.source.path()
     }
 
     #[turbo_tasks::function]
-    async fn content(self_vc: WebpackLoadersedAssetVc) -> Result<AssetContentVc> {
+    async fn content(self_vc: WebpackLoadersProcessedAssetVc) -> Result<AssetContentVc> {
         Ok(self_vc.process().await?.content)
     }
 }
@@ -116,7 +116,7 @@ fn webpack_loaders_executor(project_root: FileSystemPathVc, context: AssetContex
 }
 
 #[turbo_tasks::value_impl]
-impl WebpackLoadersedAssetVc {
+impl WebpackLoadersProcessedAssetVc {
     #[turbo_tasks::function]
     async fn process(self) -> Result<ProcessWebpackLoadersResultVc> {
         let this = self.await?;

--- a/crates/turbopack-node/src/transforms/webpack.rs
+++ b/crates/turbopack-node/src/transforms/webpack.rs
@@ -1,0 +1,175 @@
+use anyhow::{bail, Context, Result};
+use serde::{Deserialize, Serialize};
+use turbo_tasks::{
+    primitives::{JsonValueVc, StringsVc},
+    Value,
+};
+use turbo_tasks_fs::{File, FileContent, FileSystemPathVc};
+use turbopack_core::{
+    asset::{Asset, AssetContent, AssetContentVc, AssetVc},
+    context::AssetContextVc,
+    source_transform::{SourceTransform, SourceTransformVc},
+    virtual_asset::VirtualAssetVc,
+};
+use turbopack_ecmascript::{
+    EcmascriptInputTransform, EcmascriptInputTransformsVc, EcmascriptModuleAssetType,
+    EcmascriptModuleAssetVc,
+};
+
+use super::util::{emitted_assets_to_virtual_assets, EmittedAsset};
+use crate::{
+    embed_js::embed_file,
+    evaluate::{evaluate, JavaScriptValue},
+    execution_context::{ExecutionContext, ExecutionContextVc},
+};
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+#[turbo_tasks::value(transparent, serialization = "custom")]
+struct WebpackLoadersProcessingResult {
+    source: String,
+    map: Option<String>,
+    #[turbo_tasks(trace_ignore)]
+    assets: Option<Vec<EmittedAsset>>,
+}
+
+#[turbo_tasks::value]
+pub struct WebpackLoaders {
+    evaluate_context: AssetContextVc,
+    execution_context: ExecutionContextVc,
+    loaders: StringsVc,
+}
+
+#[turbo_tasks::value_impl]
+impl WebpackLoadersVc {
+    #[turbo_tasks::function]
+    pub fn new(
+        evaluate_context: AssetContextVc,
+        execution_context: ExecutionContextVc,
+        loaders: StringsVc,
+    ) -> Self {
+        WebpackLoaders {
+            evaluate_context,
+            execution_context,
+            loaders,
+        }
+        .cell()
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl SourceTransform for WebpackLoaders {
+    #[turbo_tasks::function]
+    fn transform(&self, source: AssetVc) -> AssetVc {
+        WebpackLoadersedAsset {
+            evaluate_context: self.evaluate_context,
+            execution_context: self.execution_context,
+            loaders: self.loaders,
+            source,
+        }
+        .cell()
+        .into()
+    }
+}
+
+#[turbo_tasks::value]
+struct WebpackLoadersedAsset {
+    evaluate_context: AssetContextVc,
+    execution_context: ExecutionContextVc,
+    loaders: StringsVc,
+    source: AssetVc,
+}
+
+#[turbo_tasks::value_impl]
+impl Asset for WebpackLoadersedAsset {
+    #[turbo_tasks::function]
+    fn path(&self) -> FileSystemPathVc {
+        self.source.path()
+    }
+
+    #[turbo_tasks::function]
+    async fn content(self_vc: WebpackLoadersedAssetVc) -> Result<AssetContentVc> {
+        Ok(self_vc.process().await?.content)
+    }
+}
+
+#[turbo_tasks::value]
+struct ProcessWebpackLoadersResult {
+    content: AssetContentVc,
+    assets: Vec<VirtualAssetVc>,
+}
+
+#[turbo_tasks::function]
+fn webpack_loaders_executor(project_root: FileSystemPathVc, context: AssetContextVc) -> AssetVc {
+    EcmascriptModuleAssetVc::new(
+        VirtualAssetVc::new(
+            project_root.join("__turbopack__/webpack-loaders-executor.ts"),
+            AssetContent::File(embed_file("transforms/webpack-loaders.ts")).cell(),
+        )
+        .into(),
+        context,
+        Value::new(EcmascriptModuleAssetType::Typescript),
+        EcmascriptInputTransformsVc::cell(vec![EcmascriptInputTransform::TypeScript]),
+        context.environment(),
+    )
+    .into()
+}
+
+#[turbo_tasks::value_impl]
+impl WebpackLoadersedAssetVc {
+    #[turbo_tasks::function]
+    async fn process(self) -> Result<ProcessWebpackLoadersResultVc> {
+        let this = self.await?;
+
+        let ExecutionContext {
+            project_root,
+            intermediate_output_path,
+        } = *this.execution_context.await?;
+        let source_content = this.source.content();
+        let AssetContent::File(file) = *source_content.await? else {
+            bail!("Webpack Loaders transform only support transforming files");
+        };
+        let FileContent::Content(content) = &*file.await? else {
+            return Ok(ProcessWebpackLoadersResult {
+                content: AssetContent::File(FileContent::NotFound.cell()).cell(),
+                assets: Vec::new()
+            }.cell());
+        };
+        let content = content.content().to_str()?;
+        let context = this.evaluate_context;
+
+        let webpack_loaders_executor = webpack_loaders_executor(project_root, context);
+        let resource_fs_path = this.source.path().await?;
+        let resource_path = resource_fs_path.path.as_str();
+        let loaders = this.loaders.await?;
+        let config_value = evaluate(
+            project_root,
+            webpack_loaders_executor,
+            project_root,
+            this.source.path(),
+            context,
+            intermediate_output_path,
+            None,
+            vec![
+                JsonValueVc::cell(content.into()),
+                JsonValueVc::cell(resource_path.into()),
+                JsonValueVc::cell(loaders.clone_value().into()),
+            ],
+        )
+        .await?;
+        let JavaScriptValue::Value(val) = &*config_value else {
+            // An error happened, which has already been converted into an issue.
+            return Ok(ProcessWebpackLoadersResult {
+                content: AssetContent::File(FileContent::NotFound.cell()).cell(),
+                assets: Vec::new()
+            }.cell());
+        };
+        let processed: WebpackLoadersProcessingResult = serde_json::from_reader(val.read())
+            .context("Unable to deserializate response from webpack loaders transform operation")?;
+        // TODO handle SourceMap
+        let file = File::from(processed.source);
+        let assets = emitted_assets_to_virtual_assets(processed.assets);
+        let content = AssetContent::File(FileContent::Content(file).cell()).cell();
+        Ok(ProcessWebpackLoadersResult { content, assets }.cell())
+    }
+}

--- a/crates/turbopack/Cargo.toml
+++ b/crates/turbopack/Cargo.toml
@@ -15,6 +15,7 @@ bench_against_node_nft = []
 
 [dependencies]
 anyhow = "1.0.47"
+indexmap = { workspace = true, features = ["serde"] }
 lazy_static = "1.4.0"
 regex = "1.5.4"
 serde = "1.0.136"

--- a/crates/turbopack/src/module_options/module_options_context.rs
+++ b/crates/turbopack/src/module_options/module_options_context.rs
@@ -1,5 +1,6 @@
+use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
-use turbo_tasks::trace::TraceRawVcs;
+use turbo_tasks::{primitives::StringsVc, trace::TraceRawVcs};
 use turbopack_core::{environment::EnvironmentVc, resolve::options::ImportMappingVc};
 use turbopack_ecmascript::EcmascriptInputTransform;
 use turbopack_node::execution_context::ExecutionContextVc;
@@ -14,6 +15,27 @@ pub struct PostCssTransformOptions {
 }
 
 #[turbo_tasks::value(shared)]
+#[derive(Default, Clone, Debug)]
+pub struct WebpackLoadersOptions {
+    pub extension_to_loaders: IndexMap<String, StringsVc>,
+    pub placeholder_for_future_extensions: (),
+}
+
+impl WebpackLoadersOptions {
+    pub fn is_empty(&self) -> bool {
+        self.extension_to_loaders.is_empty()
+    }
+
+    pub fn clone_if(&self) -> Option<WebpackLoadersOptions> {
+        if self.is_empty() {
+            None
+        } else {
+            Some(self.clone())
+        }
+    }
+}
+
+#[turbo_tasks::value(shared)]
 #[derive(Default, Clone)]
 pub struct ModuleOptionsContext {
     pub enable_jsx: bool,
@@ -22,6 +44,7 @@ pub struct ModuleOptionsContext {
     pub enable_styled_components: bool,
     pub enable_styled_jsx: bool,
     pub enable_postcss_transform: Option<PostCssTransformOptions>,
+    pub enable_webpack_loaders: Option<WebpackLoadersOptions>,
     pub enable_types: bool,
     pub enable_typescript_transform: bool,
     pub preset_env_versions: Option<EnvironmentVc>,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,6 +125,7 @@ importers:
     specifiers:
       '@turbo/pack-test-harness': '*'
       autoprefixer: ^10.4.13
+      loader-runner: ^4.3.0
       next: 13.0.8-canary.2
       postcss: ^8.4.20
       react: ^18.2.0
@@ -135,6 +136,7 @@ importers:
     devDependencies:
       '@turbo/pack-test-harness': link:../test-harness
       autoprefixer: 10.4.13_postcss@8.4.20
+      loader-runner: 4.3.0
       next: 13.0.8-canary.2_biqbaboplfbrettd7655fr4n2y
       postcss: 8.4.20
       react: 18.2.0
@@ -150,6 +152,17 @@ importers:
     dependencies:
       '@next/react-refresh-utils': 13.0.6_react-refresh@0.12.0
     devDependencies:
+      '@types/node': 18.11.11
+
+  crates/turbopack-node/js:
+    specifiers:
+      '@types/loader-runner': ^2.2.4
+      '@types/node': ^18.11.11
+      loader-runner: ^4.3.0
+    dependencies:
+      loader-runner: 4.3.0
+    devDependencies:
+      '@types/loader-runner': 2.2.4
       '@types/node': 18.11.11
 
   docs:
@@ -2331,6 +2344,12 @@ packages:
 
   /@types/json5/0.0.29:
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
+    dev: true
+
+  /@types/loader-runner/2.2.4:
+    resolution: {integrity: sha512-loD63p9KWQPgTvMBbhu9nD/2AeLqzP7ey/h1cWUK3wzLtilRO1kcCtlJvGrT/LEtOM7bjzaFSX1hxXaOdZdt8g==}
+    dependencies:
+      '@types/node': 18.11.11
     dev: true
 
   /@types/mdast/3.0.10:
@@ -7562,7 +7581,6 @@ packages:
   /loader-runner/4.3.0:
     resolution: {integrity: sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==}
     engines: {node: '>=6.11.5'}
-    dev: true
 
   /localforage/1.10.0:
     resolution: {integrity: sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==}


### PR DESCRIPTION
add the minimum to run a simple raw-loader (see test case)

* add `experimental.turbopackWebpackLoaders` to next.config.js
  * key is extension like `".mdx"`, value is an array of loaders like `["mdx-loader"]`
