### PR TITLE
Implement `experimental.resolveAlias` map for next.config.js

### DIFF
--- a/crates/next-core/src/fallback.rs
+++ b/crates/next-core/src/fallback.rs
@@ -49,7 +49,12 @@ pub async fn get_fallback_page(
     let entries = get_client_runtime_entries(project_path, env, ty, next_config);
 
     let mut import_map = ImportMap::empty();
-    insert_next_shared_aliases(&mut import_map, project_path);
+    insert_next_shared_aliases(
+        &mut import_map,
+        project_path,
+        next_config.resolve_alias_options(),
+    )
+    .await?;
 
     let context: AssetContextVc = ModuleAssetContextVc::new(
         TransitionsByNameVc::cell(HashMap::new()),

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -70,7 +70,7 @@ pub async fn get_client_resolve_options_context(
     ty: Value<ClientContextType>,
     next_config: NextConfigVc,
 ) -> Result<ResolveOptionsContextVc> {
-    let next_client_import_map = get_next_client_import_map(project_path, ty);
+    let next_client_import_map = get_next_client_import_map(project_path, ty, next_config);
     let next_client_fallback_import_map = get_next_client_fallback_import_map(ty);
     let next_client_resolved_map = get_next_client_resolved_map(project_path, project_path);
     let module_options_context = ResolveOptionsContext {

--- a/crates/next-core/src/next_import_map.rs
+++ b/crates/next-core/src/next_import_map.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use turbo_tasks::Value;
 use turbo_tasks_fs::{glob::GlobVc, FileSystemPathVc};
+use turbopack::module_options::ResolveAliasOptionsVc;
 use turbopack_core::resolve::{
     options::{ImportMap, ImportMapVc, ImportMapping, ImportMappingVc, ResolvedMap, ResolvedMapVc},
     AliasPattern,
@@ -16,13 +17,19 @@ use crate::{
 
 /// Computes the Next-specific client import map.
 #[turbo_tasks::function]
-pub fn get_next_client_import_map(
+pub async fn get_next_client_import_map(
     project_path: FileSystemPathVc,
     ty: Value<ClientContextType>,
-) -> ImportMapVc {
+    next_config: NextConfigVc,
+) -> Result<ImportMapVc> {
     let mut import_map = ImportMap::empty();
 
-    insert_next_shared_aliases(&mut import_map, project_path);
+    insert_next_shared_aliases(
+        &mut import_map,
+        project_path,
+        next_config.resolve_alias_options(),
+    )
+    .await?;
 
     match ty.into_value() {
         ClientContextType::Pages { pages_dir } => {
@@ -83,7 +90,7 @@ pub fn get_next_client_import_map(
         ClientContextType::Other => {}
     }
 
-    import_map.cell()
+    Ok(import_map.cell())
 }
 
 /// Computes the Next-specific client import map.
@@ -139,7 +146,12 @@ pub async fn get_next_server_import_map(
 ) -> Result<ImportMapVc> {
     let mut import_map = ImportMap::empty();
 
-    insert_next_shared_aliases(&mut import_map, project_path);
+    insert_next_shared_aliases(
+        &mut import_map,
+        project_path,
+        next_config.resolve_alias_options(),
+    )
+    .await?;
 
     match ty.into_value() {
         ServerContextType::Pages { pages_dir } => {
@@ -251,7 +263,11 @@ static NEXT_ALIASES: [(&str, &str); 23] = [
     ("setImmediate", "next/dist/compiled/setimmediate"),
 ];
 
-pub fn insert_next_shared_aliases(import_map: &mut ImportMap, project_path: FileSystemPathVc) {
+pub async fn insert_next_shared_aliases(
+    import_map: &mut ImportMap,
+    project_path: FileSystemPathVc,
+    alias_options: ResolveAliasOptionsVc,
+) -> Result<()> {
     let package_root = attached_next_js_package_path(project_path);
 
     // we use the next.js hydration code, so we replace the error overlay with our
@@ -277,6 +293,22 @@ pub fn insert_next_shared_aliases(import_map: &mut ImportMap, project_path: File
         AliasPattern::exact("@vercel/turbopack-next/internal/font/google/cssmodule.module.css"),
         ImportMapping::Dynamic(NextFontGoogleCssModuleReplacerVc::new(project_path).into()).into(),
     );
+
+    for (alias, mappings_vc) in &alias_options.await?.alias_map {
+        let mappings = mappings_vc.await?;
+        import_map.insert_alias(
+            AliasPattern::exact(alias),
+            ImportMapping::Alternatives(
+                mappings
+                    .iter()
+                    .map(|m| ImportMapping::PrimaryAlternative(m.clone(), None).cell())
+                    .collect::<Vec<ImportMappingVc>>(),
+            )
+            .cell(),
+        );
+    }
+
+    Ok(())
 }
 
 /// Inserts an alias to an alternative of import mappings into an import map.

--- a/crates/next-dev/tests/integration/next/resolve-alias/basic/index.js
+++ b/crates/next-dev/tests/integration/next/resolve-alias/basic/index.js
@@ -1,0 +1,5 @@
+import foo from "foo";
+
+it("aliases foo to bar through the next.config.js experimental.resolveAlias property", () => {
+  expect(foo).toBe(42);
+});

--- a/crates/next-dev/tests/integration/next/resolve-alias/basic/next.config.js
+++ b/crates/next-dev/tests/integration/next/resolve-alias/basic/next.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  experimental: {
+    resolveAlias: {
+      foo: ["bar"],
+    },
+  },
+};

--- a/crates/next-dev/tests/integration/next/resolve-alias/basic/node_modules/bar/index.js
+++ b/crates/next-dev/tests/integration/next/resolve-alias/basic/node_modules/bar/index.js
@@ -1,0 +1,1 @@
+export default 42;

--- a/crates/turbopack/src/module_options/module_options_context.rs
+++ b/crates/turbopack/src/module_options/module_options_context.rs
@@ -21,6 +21,13 @@ pub struct WebpackLoadersOptions {
     pub placeholder_for_future_extensions: (),
 }
 
+#[turbo_tasks::value(shared)]
+#[derive(Default, Clone, Debug)]
+pub struct ResolveAliasOptions {
+    pub alias_map: IndexMap<String, StringsVc>,
+    pub placeholder_for_future_extensions: (),
+}
+
 impl WebpackLoadersOptions {
     pub fn is_empty(&self) -> bool {
         self.extension_to_loaders.is_empty()


### PR DESCRIPTION
Fixes WEB-416.

This implements loading an alias map set as `experimental.resolveAlias` in `next.config.js`.

Test Plan: Added an integration test.