### PR TITLE
Do not submit a default --output-logs argument from Rust 

### DIFF
--- a/cli/integration_tests/no_args.t
+++ b/cli/integration_tests/no_args.t
@@ -51,7 +51,7 @@ Make sure exit code is 2 when no args are passed
         --no-cache                       Avoid saving task results to the cache. Useful for development/watch tasks
         --no-daemon                      Run without using turbo's daemon process
         --no-deps                        Exclude dependent task consumers from execution
-        --output-logs <OUTPUT_LOGS>      Set type of process output logging. Use "full" to show all output. Use "hash-only" to show only turbo-computed task hashes. Use "new-only" to show only new output with only hashes for cached tasks. Use "none" to hide process output. (default full) [default: full] [possible values: full, none, hash-only, new-only, errors-only]
+        --output-logs <OUTPUT_LOGS>      Set type of process output logging. Use "full" to show all output. Use "hash-only" to show only turbo-computed task hashes. Use "new-only" to show only new output with only hashes for cached tasks. Use "none" to hide process output. (default full) [possible values: full, none, hash-only, new-only, errors-only]
         --parallel                       Execute all tasks in parallel
         --profile <PROFILE>              File to write turbo's performance profile output into. You can load the file up in chrome://tracing to see which parts of your build were slow
         --remote-only                    Ignore the local filesystem cache for all tasks. Only allow reading and caching artifacts using the remote cache

--- a/cli/integration_tests/turbo_help.t
+++ b/cli/integration_tests/turbo_help.t
@@ -51,7 +51,7 @@ Test help flag
         --no-cache                       Avoid saving task results to the cache. Useful for development/watch tasks
         --no-daemon                      Run without using turbo's daemon process
         --no-deps                        Exclude dependent task consumers from execution
-        --output-logs <OUTPUT_LOGS>      Set type of process output logging. Use "full" to show all output. Use "hash-only" to show only turbo-computed task hashes. Use "new-only" to show only new output with only hashes for cached tasks. Use "none" to hide process output. (default full) [default: full] [possible values: full, none, hash-only, new-only, errors-only]
+        --output-logs <OUTPUT_LOGS>      Set type of process output logging. Use "full" to show all output. Use "hash-only" to show only turbo-computed task hashes. Use "new-only" to show only new output with only hashes for cached tasks. Use "none" to hide process output. (default full) [possible values: full, none, hash-only, new-only, errors-only]
         --parallel                       Execute all tasks in parallel
         --profile <PROFILE>              File to write turbo's performance profile output into. You can load the file up in chrome://tracing to see which parts of your build were slow
         --remote-only                    Ignore the local filesystem cache for all tasks. Only allow reading and caching artifacts using the remote cache
@@ -112,7 +112,7 @@ Test help flag
         --no-cache                       Avoid saving task results to the cache. Useful for development/watch tasks
         --no-daemon                      Run without using turbo's daemon process
         --no-deps                        Exclude dependent task consumers from execution
-        --output-logs <OUTPUT_LOGS>      Set type of process output logging. Use "full" to show all output. Use "hash-only" to show only turbo-computed task hashes. Use "new-only" to show only new output with only hashes for cached tasks. Use "none" to hide process output. (default full) [default: full] [possible values: full, none, hash-only, new-only, errors-only]
+        --output-logs <OUTPUT_LOGS>      Set type of process output logging. Use "full" to show all output. Use "hash-only" to show only turbo-computed task hashes. Use "new-only" to show only new output with only hashes for cached tasks. Use "none" to hide process output. (default full) [possible values: full, none, hash-only, new-only, errors-only]
         --parallel                       Execute all tasks in parallel
         --profile <PROFILE>              File to write turbo's performance profile output into. You can load the file up in chrome://tracing to see which parts of your build were slow
         --remote-only                    Ignore the local filesystem cache for all tasks. Only allow reading and caching artifacts using the remote cache

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -81,9 +81,11 @@ func optsFromArgs(args *turbostate.ParsedArgsFromRust) (*Opts, error) {
 	opts.runcacheOpts.SkipReads = runPayload.Force
 	opts.runcacheOpts.SkipWrites = runPayload.NoCache
 
-	err := opts.runcacheOpts.SetTaskOutputMode(runPayload.OutputLogs)
-	if err != nil {
-		return nil, err
+	if runPayload.OutputLogs != "" {
+		err := opts.runcacheOpts.SetTaskOutputMode(runPayload.OutputLogs)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Run flags

--- a/crates/turborepo-lib/src/cli.rs
+++ b/crates/turborepo-lib/src/cli.rs
@@ -415,6 +415,7 @@ mod test {
     fn get_default_run_args() -> RunArgs {
         RunArgs {
             cache_workers: 10,
+            output_logs: None,
             ..RunArgs::default()
         }
     }

--- a/crates/turborepo-lib/src/cli.rs
+++ b/crates/turborepo-lib/src/cli.rs
@@ -452,10 +452,12 @@ mod test {
         }
     }
 
+    use anyhow::Result;
+
     use crate::cli::{Args, Command, DryRunMode, OutputLogsMode, RunArgs, Verbosity};
 
     #[test]
-    fn test_parse_run() {
+    fn test_parse_run() -> Result<()> {
         assert_eq!(
             Args::try_parse_from(["turbo", "run", "build"]).unwrap(),
             Args {
@@ -715,6 +717,13 @@ mod test {
             }
         );
 
+        // Test that ouput-logs is not serialized by default
+        assert_eq!(
+            serde_json::to_string(&Args::try_parse_from(["turbo", "run", "build"]).unwrap())?
+                .contains("\"output_logs\":null"),
+            true
+        );
+
         assert_eq!(
             Args::try_parse_from(["turbo", "run", "build", "--output-logs", "full"]).unwrap(),
             Args {
@@ -833,6 +842,8 @@ mod test {
                 ..Args::default()
             }
         );
+
+        Ok(())
     }
 
     #[test]

--- a/crates/turborepo-lib/src/cli.rs
+++ b/crates/turborepo-lib/src/cli.rs
@@ -719,7 +719,7 @@ mod test {
             Args {
                 command: Some(Command::Run(Box::new(RunArgs {
                     tasks: vec!["build".to_string()],
-                    output_logs: OutputLogsMode::Full,
+                    output_logs: Some(OutputLogsMode::Full),
                     ..get_default_run_args()
                 }))),
                 ..Args::default()
@@ -731,7 +731,7 @@ mod test {
             Args {
                 command: Some(Command::Run(Box::new(RunArgs {
                     tasks: vec!["build".to_string()],
-                    output_logs: OutputLogsMode::None,
+                    output_logs: Some(OutputLogsMode::None),
                     ..get_default_run_args()
                 }))),
                 ..Args::default()
@@ -743,7 +743,7 @@ mod test {
             Args {
                 command: Some(Command::Run(Box::new(RunArgs {
                     tasks: vec!["build".to_string()],
-                    output_logs: OutputLogsMode::HashOnly,
+                    output_logs: Some(OutputLogsMode::HashOnly),
                     ..get_default_run_args()
                 }))),
                 ..Args::default()

--- a/crates/turborepo-lib/src/cli.rs
+++ b/crates/turborepo-lib/src/cli.rs
@@ -314,8 +314,8 @@ pub struct RunArgs {
     /// task hashes. Use "new-only" to show only new output with
     /// only hashes for cached tasks. Use "none" to hide process
     /// output. (default full)
-    #[clap(long, value_enum)]
-    pub output_logs: Option<OutputLogsMode>,
+    #[clap(long, value_enum, default_value_t = OutputLogsMode::Full)]
+    pub output_logs: OutputLogsMode,
     #[clap(long, hide = true)]
     pub only: bool,
     /// Execute all tasks in parallel.

--- a/crates/turborepo-lib/src/cli.rs
+++ b/crates/turborepo-lib/src/cli.rs
@@ -314,8 +314,8 @@ pub struct RunArgs {
     /// task hashes. Use "new-only" to show only new output with
     /// only hashes for cached tasks. Use "none" to hide process
     /// output. (default full)
-    #[clap(long, value_enum, default_value_t = OutputLogsMode::Full)]
-    pub output_logs: OutputLogsMode,
+    #[clap(long, value_enum)]
+    pub output_logs: Option<OutputLogsMode>,
     #[clap(long, hide = true)]
     pub only: bool,
     /// Execute all tasks in parallel.


### PR DESCRIPTION
Specifying the CLI arg overrides outputMode from Task Definitions,
so we want to ensure that the user explicitly passes it, and not provide a default.

Fixes https://github.com/vercel/turbo/issues/3272