### PR TITLE
Add basic test for next/dynamic

### DIFF
--- a/crates/next-dev/tests/integration/next/dynamic/no-ssr/pages/_dynamic.js
+++ b/crates/next-dev/tests/integration/next/dynamic/no-ssr/pages/_dynamic.js
@@ -1,0 +1,3 @@
+export default function Dynamic() {
+  return <>dynamic</>;
+}

--- a/crates/next-dev/tests/integration/next/dynamic/no-ssr/pages/index.js
+++ b/crates/next-dev/tests/integration/next/dynamic/no-ssr/pages/index.js
@@ -1,0 +1,34 @@
+import { useEffect } from "react";
+import dynamic from "next/dynamic";
+import { Deferred } from "@turbo/pack-test-harness/deferred";
+
+const Dynamic = dynamic(() => import("./_dynamic"), {
+  ssr: false,
+});
+
+const testResult = new Deferred();
+
+let ssr = false;
+if (typeof document !== "undefined") {
+  ssr = document.getElementById("__next").innerText === "dynamic";
+}
+
+export default function Home() {
+  useEffect(() => {
+    import("@turbo/pack-test-harness").then(runClientSideTests);
+  }, []);
+
+  return <Dynamic />;
+}
+
+globalThis.waitForTests = function () {
+  return testResult.promise;
+};
+
+function runClientSideTests() {
+  it("should not render the dynamic component on the server-side when ssr: false", () => {
+    expect(ssr).toBe(false);
+  });
+
+  testResult.resolve(__jest__.run());
+}

--- a/crates/next-dev/tests/integration/next/dynamic/ssr/pages/_dynamic.js
+++ b/crates/next-dev/tests/integration/next/dynamic/ssr/pages/_dynamic.js
@@ -1,0 +1,3 @@
+export default function Dynamic() {
+  return <>dynamic</>;
+}

--- a/crates/next-dev/tests/integration/next/dynamic/ssr/pages/index.js
+++ b/crates/next-dev/tests/integration/next/dynamic/ssr/pages/index.js
@@ -1,0 +1,32 @@
+import { useEffect } from "react";
+import dynamic from "next/dynamic";
+import { Deferred } from "@turbo/pack-test-harness/deferred";
+
+const Dynamic = dynamic(() => import("./_dynamic"));
+
+const testResult = new Deferred();
+
+let ssr = false;
+if (typeof document !== "undefined") {
+  ssr = document.getElementById("__next").innerText === "dynamic";
+}
+
+export default function Home() {
+  useEffect(() => {
+    import("@turbo/pack-test-harness").then(runClientSideTests);
+  }, []);
+
+  return <Dynamic />;
+}
+
+globalThis.waitForTests = function () {
+  return testResult.promise;
+};
+
+function runClientSideTests() {
+  it("should render the dynamic component on the server-side", () => {
+    expect(ssr).toBe(true);
+  });
+
+  testResult.resolve(__jest__.run());
+}


### PR DESCRIPTION
This adds two basic tests for next/dynamic:
* one ensures that SSR supports dynamic components;
* the other ensures that SSR doesn't run when `ssr: false`.