### PR TITLE
fix(docs): remove old image link

### DIFF
--- a/docs/pages/repo/docs/ci/circleci.mdx
+++ b/docs/pages/repo/docs/ci/circleci.mdx
@@ -126,7 +126,6 @@ To use Vercel Remote Caching, you can get the value of these variables in a few 
 
 1. Create a Scoped Access Token to your account in the [Vercel Dashboard](https://vercel.com/account/tokens)
 
-![Vercel Access Tokens](/images/docs/vercel-tokens.png)
 ![Vercel Access Tokens](/images/docs/vercel-create-token.png)
 
 Copy the value to a safe place. You'll need it in a moment.

--- a/docs/pages/repo/docs/ci/gitlabci.mdx
+++ b/docs/pages/repo/docs/ci/gitlabci.mdx
@@ -119,7 +119,6 @@ To use Vercel Remote Caching, you can get the value of these variables in a few 
 
 1. Create a Scoped Access Token to your account in the [Vercel Dashboard](https://vercel.com/account/tokens)
 
-![Vercel Access Tokens](/images/docs/vercel-tokens.png)
 ![Vercel Access Tokens](/images/docs/vercel-create-token.png)
 
 Copy the value to a safe place. You'll need it in a moment.

--- a/docs/pages/repo/docs/ci/travisci.mdx
+++ b/docs/pages/repo/docs/ci/travisci.mdx
@@ -104,7 +104,6 @@ To use Vercel Remote Caching, you can get the value of these variables in a few 
 
 1. Create a Scoped Access Token to your account in the [Vercel Dashboard](https://vercel.com/account/tokens)
 
-![Vercel Access Tokens](/images/docs/vercel-tokens.png)
 ![Vercel Access Tokens](/images/docs/vercel-create-token.png)
 
 Copy the value to a safe place. You'll need it in a moment.


### PR DESCRIPTION
Images were updated as part of https://github.com/vercel/turbo/pull/3274, but some were missed. This removes the rest.