### PR TITLE
refactor content sources to avoid evaluating content before serving

### DIFF
--- a/crates/next-core/src/manifest.rs
+++ b/crates/next-core/src/manifest.rs
@@ -77,7 +77,9 @@ impl ContentSource for DevManifestContentSource {
         let file = File::from(manifest_content).with_content_type(APPLICATION_JSON);
 
         Ok(ContentSourceResultVc::exact(
-            ContentSourceContent::Static(AssetContentVc::from(file).into()).cell(),
+            ContentSourceContent::Static(AssetContentVc::from(file).into())
+                .cell()
+                .into(),
         ))
     }
 }

--- a/crates/next-core/src/next_image/mod.rs
+++ b/crates/next-core/src/next_image/mod.rs
@@ -1,12 +1,12 @@
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 
 use anyhow::Result;
 use turbo_tasks::{primitives::StringVc, Value};
 use turbopack_core::introspect::{Introspectable, IntrospectableVc};
 use turbopack_dev_server::source::{
     query::QueryValue, ContentSource, ContentSourceContent, ContentSourceData,
-    ContentSourceDataFilter, ContentSourceDataVary, ContentSourceResultVc, ContentSourceVc,
-    NeededData, ProxyResult,
+    ContentSourceDataFilter, ContentSourceDataVary, ContentSourceResult, ContentSourceResultVc,
+    ContentSourceVc, NeededData, ProxyResult,
 };
 
 /// Serves, resizes, optimizes, and re-encodes images to be used with
@@ -42,20 +42,17 @@ impl ContentSource for NextImageContentSource {
                 ]
                 .iter()
                 .cloned()
-                .collect::<HashSet<_>>();
+                .collect::<BTreeSet<_>>();
 
-                return Ok(ContentSourceResultVc::exact(
-                    ContentSourceContent::NeedData(NeededData {
-                        source: self_vc.into(),
-                        path: path.to_string(),
-                        vary: ContentSourceDataVary {
-                            url: true,
-                            query: Some(ContentSourceDataFilter::Subset(queries)),
-                            ..Default::default()
-                        },
-                    })
-                    .cell(),
-                ));
+                return Ok(ContentSourceResultVc::need_data(Value::new(NeededData {
+                    source: self_vc.into(),
+                    path: path.to_string(),
+                    vary: ContentSourceDataVary {
+                        url: true,
+                        query: Some(ContentSourceDataFilter::Subset(queries)),
+                        ..Default::default()
+                    },
+                })));
             }
             Some(query) => query,
         };
@@ -71,8 +68,13 @@ impl ContentSource for NextImageContentSource {
             let asset = this.asset_source.get(path, Default::default());
             // THERE'S A HUGE PERFORMANCE ISSUE IF THIS MISSES
             let inner = asset.await?;
-            if matches!(&*inner.content.await?, ContentSourceContent::Static(..)) {
-                return Ok(asset);
+            if let ContentSourceResult::Result { get_content, .. } = &*inner {
+                if matches!(
+                    &*get_content.get(Default::default()).await?,
+                    ContentSourceContent::Static(..)
+                ) {
+                    return Ok(asset);
+                }
             }
         }
 
@@ -86,7 +88,8 @@ impl ContentSource for NextImageContentSource {
                 }
                 .cell(),
             )
-            .cell(),
+            .cell()
+            .into(),
         ))
     }
 }

--- a/crates/next-core/src/next_image/mod.rs
+++ b/crates/next-core/src/next_image/mod.rs
@@ -66,15 +66,9 @@ impl ContentSource for NextImageContentSource {
         // formats.
         if let Some(path) = url.strip_prefix('/') {
             let asset = this.asset_source.get(path, Default::default());
-            // THERE'S A HUGE PERFORMANCE ISSUE IF THIS MISSES
             let inner = asset.await?;
-            if let ContentSourceResult::Result { get_content, .. } = &*inner {
-                if matches!(
-                    &*get_content.get(Default::default()).await?,
-                    ContentSourceContent::Static(..)
-                ) {
-                    return Ok(asset);
-                }
+            if let ContentSourceResult::Result { .. } = &*inner {
+                return Ok(asset);
             }
         }
 

--- a/crates/next-dev/src/turbo_tasks_viz.rs
+++ b/crates/next-dev/src/turbo_tasks_viz.rs
@@ -86,17 +86,14 @@ impl ContentSource for TurboTasksSource {
                     let table = viz::table::create_table(tree, tt.stats_type());
                     viz::table::wrap_html(&table)
                 } else {
-                    return Ok(ContentSourceResultVc::exact(
-                        ContentSourceContent::NeedData(NeededData {
-                            source: self_vc.into(),
-                            path: path.to_string(),
-                            vary: ContentSourceDataVary {
-                                query: Some(ContentSourceDataFilter::All),
-                                ..Default::default()
-                            },
-                        })
-                        .cell(),
-                    ));
+                    return Ok(ContentSourceResultVc::need_data(Value::new(NeededData {
+                        source: self_vc.into(),
+                        path: path.to_string(),
+                        vary: ContentSourceDataVary {
+                            query: Some(ContentSourceDataFilter::All),
+                            ..Default::default()
+                        },
+                    })));
                 }
             }
             "reset" => {
@@ -112,7 +109,8 @@ impl ContentSource for TurboTasksSource {
             ContentSourceContent::Static(
                 AssetContentVc::from(File::from(html).with_content_type(TEXT_HTML_UTF_8)).into(),
             )
-            .cell(),
+            .cell()
+            .into(),
         ))
     }
 }

--- a/crates/turbopack-dev-server/src/introspect/mod.rs
+++ b/crates/turbopack-dev-server/src/introspect/mod.rs
@@ -148,7 +148,8 @@ impl ContentSource for IntrospectionSource {
                 .cell()
                 .into(),
             )
-            .cell(),
+            .cell()
+            .into(),
         ))
     }
 }

--- a/crates/turbopack-dev-server/src/lib.rs
+++ b/crates/turbopack-dev-server/src/lib.rs
@@ -39,8 +39,8 @@ use turbopack_core::asset::AssetContent;
 
 use self::{
     source::{
-        query::Query, ContentSourceContent, ContentSourceDataVary, ContentSourceResultVc,
-        ContentSourceVc, ProxyResultReadRef,
+        query::Query, ContentSourceContent, ContentSourceDataVary, ContentSourceResult,
+        ContentSourceResultVc, ContentSourceVc, ProxyResultReadRef,
     },
     update::{protocol::ResourceIdentifier, UpdateServer},
 };
@@ -114,23 +114,41 @@ async fn get_from_source(
     source: ContentSourceVc,
     path: &str,
     data: Value<ContentSourceData>,
+    vary: Value<ContentSourceDataVary>,
 ) -> Result<GetFromSourceResultVc> {
-    let content = source.get(path, data).await?.content.await?;
-    Ok(match &*content {
-        ContentSourceContent::Static(content_vc) => {
-            if let AssetContent::File(file) = &*content_vc.content().await? {
-                GetFromSourceResult::Static(file.await?)
-            } else {
-                GetFromSourceResult::NotFound
-            }
-        }
-        ContentSourceContent::HttpProxy(proxy) => GetFromSourceResult::HttpProxy(proxy.await?),
-        ContentSourceContent::NeedData(data) => GetFromSourceResult::NeedData {
+    let result = source.get(path, data.clone()).await?;
+    Ok(match &*result {
+        ContentSourceResult::NotFound => GetFromSourceResult::NotFound,
+        ContentSourceResult::NeedData(data) => GetFromSourceResult::NeedData {
             source: data.source.resolve().await?,
             path: data.path.clone(),
             vary: data.vary.clone(),
         },
-        ContentSourceContent::NotFound => GetFromSourceResult::NotFound,
+        ContentSourceResult::Result { get_content, .. } => {
+            let content_vary = get_content.vary().await?;
+            if &*vary != &*content_vary {
+                GetFromSourceResult::NeedData {
+                    source: ContentSourceResultVc::exact(*get_content).into(),
+                    path: String::new(),
+                    vary: content_vary.clone_value(),
+                }
+            } else {
+                let content = get_content.get(data).await?;
+                match &*content {
+                    ContentSourceContent::NotFound => GetFromSourceResult::NotFound,
+                    ContentSourceContent::Static(content_vc) => {
+                        if let AssetContent::File(file) = &*content_vc.content().await? {
+                            GetFromSourceResult::Static(file.await?)
+                        } else {
+                            GetFromSourceResult::NotFound
+                        }
+                    }
+                    ContentSourceContent::HttpProxy(proxy) => {
+                        GetFromSourceResult::HttpProxy(proxy.await?)
+                    }
+                }
+            }
+        }
     }
     .cell())
 }
@@ -143,8 +161,14 @@ async fn process_request_with_content_source(
     console_ui: ConsoleUiVc,
 ) -> Result<Response<hyper::Body>> {
     let mut data = ContentSourceData::default();
+    let mut data_vary = ContentSourceDataVary::default();
     loop {
-        let content_source_result = get_from_source(resolved_source, &asset_path, Value::new(data));
+        let content_source_result = get_from_source(
+            resolved_source,
+            &asset_path,
+            Value::new(data),
+            Value::new(data_vary),
+        );
         handle_issues(
             content_source_result,
             path,
@@ -201,6 +225,7 @@ async fn process_request_with_content_source(
                 resolved_source = *source;
                 asset_path = Cow::Owned(path.to_string());
                 data = request_to_data(&mut request, vary).await?;
+                data_vary = vary.clone();
                 continue;
             }
             GetFromSourceResult::NotFound => {}

--- a/crates/turbopack-dev-server/src/lib.rs
+++ b/crates/turbopack-dev-server/src/lib.rs
@@ -126,7 +126,7 @@ async fn get_from_source(
         },
         ContentSourceResult::Result { get_content, .. } => {
             let content_vary = get_content.vary().await?;
-            if &*vary != &*content_vary {
+            if *vary != *content_vary {
                 GetFromSourceResult::NeedData {
                     source: ContentSourceResultVc::exact(*get_content).into(),
                     path: String::new(),

--- a/crates/turbopack-dev-server/src/source/asset_graph.rs
+++ b/crates/turbopack-dev-server/src/source/asset_graph.rs
@@ -149,7 +149,9 @@ impl ContentSource for AssetGraphContentSource {
                 }
             }
             return Ok(ContentSourceResultVc::exact(
-                ContentSourceContent::Static(asset.versioned_content()).cell(),
+                ContentSourceContent::Static(asset.versioned_content())
+                    .cell()
+                    .into(),
             ));
         }
         Ok(ContentSourceResultVc::not_found())

--- a/crates/turbopack-dev-server/src/source/conditional.rs
+++ b/crates/turbopack-dev-server/src/source/conditional.rs
@@ -1,11 +1,13 @@
 use anyhow::Result;
-use turbo_tasks::{primitives::StringVc, State};
+use turbo_tasks::{primitives::StringVc, State, Value};
 use turbopack_core::introspect::{Introspectable, IntrospectableChildrenVc, IntrospectableVc};
 
 use super::{
-    ContentSource, ContentSourceContent, ContentSourceData, ContentSourceResultVc, ContentSourceVc,
+    combined::CombinedContentSource, ContentSource, ContentSourceData, ContentSourceDataVaryVc,
+    ContentSourceResult, ContentSourceResultVc, ContentSourceVc, GetContentSourceContent,
+    GetContentSourceContentVc,
 };
-use crate::source::ContentSourcesVc;
+use crate::source::{ContentSourceContentVc, ContentSourcesVc};
 
 /// Combines two [ContentSource]s like the [CombinedContentSource], but only
 /// allows to serve from the second source when the first source has
@@ -41,25 +43,31 @@ impl ConditionalContentSourceVc {
 impl ContentSource for ConditionalContentSource {
     #[turbo_tasks::function]
     async fn get(
-        &self,
+        self_vc: ConditionalContentSourceVc,
         path: &str,
         data: turbo_tasks::Value<ContentSourceData>,
     ) -> Result<ContentSourceResultVc> {
-        let first = self.activator.get(path, data.clone());
-        if let ContentSourceContent::NotFound = &*first.await?.content.await? {
-            if !*self.activated.get() {
-                return Ok(first);
-            }
+        let this = self_vc.await?;
+        if !*this.activated.get() {
+            let first = this.activator.get(path, data.clone());
+            let first_value = first.await?;
+            return Ok(match &*first_value {
+                &ContentSourceResult::Result {
+                    get_content,
+                    specificity,
+                } => ContentSourceResult::Result {
+                    get_content: ActivateOnGetContentSource(this, get_content).cell().into(),
+                    specificity,
+                }
+                .cell(),
+                _ => first,
+            });
         }
-        self.activated.set(true);
-        let second = self.action.get(path, data);
-        let first_specificity = first.await?.specificity.await?;
-        let second_specificity = second.await?.specificity.await?;
-        if first_specificity >= second_specificity {
-            Ok(first)
-        } else {
-            Ok(second)
+        Ok(CombinedContentSource {
+            sources: vec![this.activator, this.action],
         }
+        .cell()
+        .get(path, data))
     }
 
     #[turbo_tasks::function]
@@ -114,5 +122,22 @@ impl Introspectable for ConditionalContentSource {
             .flatten()
             .collect(),
         ))
+    }
+}
+
+#[turbo_tasks::value(serialization = "none", eq = "manual", cell = "new")]
+struct ActivateOnGetContentSource(ConditionalContentSourceReadRef, GetContentSourceContentVc);
+
+#[turbo_tasks::value_impl]
+impl GetContentSourceContent for ActivateOnGetContentSource {
+    #[turbo_tasks::function]
+    fn vary(&self) -> ContentSourceDataVaryVc {
+        self.1.vary()
+    }
+
+    #[turbo_tasks::function]
+    fn get(&self, data: Value<ContentSourceData>) -> ContentSourceContentVc {
+        self.0.activated.set(true);
+        self.1.get(data)
     }
 }

--- a/crates/turbopack-dev-server/src/source/mod.rs
+++ b/crates/turbopack-dev-server/src/source/mod.rs
@@ -338,7 +338,7 @@ impl ContentSourceDataFilter {
                 (ContentSourceDataFilter::All, _) => true,
                 (_, ContentSourceDataFilter::All) => false,
                 (ContentSourceDataFilter::Subset(this), ContentSourceDataFilter::Subset(other)) => {
-                    other.iter().all(|key| this.contains(key))
+                    this.is_superset(&other)
                 }
             },
         }
@@ -382,16 +382,16 @@ impl ContentSourceDataVary {
         if other.url && !self.url {
             return false;
         }
-        if !ContentSourceDataFilter::fulfills(&self.query, &other.query) {
-            return false;
-        }
-        if !ContentSourceDataFilter::fulfills(&self.headers, &other.headers) {
-            return false;
-        }
         if other.body && !self.body {
             return false;
         }
         if other.cache_buster && !self.cache_buster {
+            return false;
+        }
+        if !ContentSourceDataFilter::fulfills(&self.query, &other.query) {
+            return false;
+        }
+        if !ContentSourceDataFilter::fulfills(&self.headers, &other.headers) {
             return false;
         }
         true

--- a/crates/turbopack-dev-server/src/source/mod.rs
+++ b/crates/turbopack-dev-server/src/source/mod.rs
@@ -338,7 +338,7 @@ impl ContentSourceDataFilter {
                 (ContentSourceDataFilter::All, _) => true,
                 (_, ContentSourceDataFilter::All) => false,
                 (ContentSourceDataFilter::Subset(this), ContentSourceDataFilter::Subset(other)) => {
-                    this.is_superset(&other)
+                    this.is_superset(other)
                 }
             },
         }

--- a/crates/turbopack-dev-server/src/source/specificity.rs
+++ b/crates/turbopack-dev-server/src/source/specificity.rs
@@ -96,6 +96,16 @@ impl Specificity {
     pub fn is_exact(&self) -> bool {
         self.elements.is_empty()
     }
+
+    /// The lowest possible specificity. Used when no match is found.
+    pub fn not_found() -> Self {
+        Specificity {
+            elements: vec![SpecificityElement {
+                position: 0,
+                ty: SpecificityElementType::NotFound,
+            }],
+        }
+    }
 }
 
 impl Display for Specificity {
@@ -126,13 +136,7 @@ impl SpecificityVc {
     /// The lowest possible specificity. Used when no match is found.
     #[turbo_tasks::function]
     pub fn not_found() -> Self {
-        Specificity {
-            elements: vec![SpecificityElement {
-                position: 0,
-                ty: SpecificityElementType::NotFound,
-            }],
-        }
-        .cell()
+        Specificity::not_found().cell()
     }
 
     /// The highest possible specificity. Used for exact matches.

--- a/crates/turbopack-dev-server/src/source/static_assets.rs
+++ b/crates/turbopack-dev-server/src/source/static_assets.rs
@@ -50,7 +50,7 @@ impl ContentSource for StaticAssetsContentSource {
                 ) {
                     let content = SourceAssetVc::new(path).as_asset().content();
                     return Ok(ContentSourceResultVc::exact(
-                        ContentSourceContent::Static(content.into()).cell(),
+                        ContentSourceContent::Static(content.into()).cell().into(),
                     ));
                 }
             }

--- a/crates/turbopack-dev-server/src/update/stream.rs
+++ b/crates/turbopack-dev-server/src/update/stream.rs
@@ -7,16 +7,15 @@ use tokio_stream::wrappers::ReceiverStream;
 use turbo_tasks::{CollectiblesSource, State, TransientInstance, Value};
 use turbopack_core::{
     issue::{IssueVc, PlainIssueReadRef},
-    version::{
-        NotFoundVersionVc, PartialUpdate, TotalUpdate, Update, UpdateReadRef, VersionVc,
-        VersionedContentVc,
-    },
+    version::{NotFoundVersionVc, PartialUpdate, TotalUpdate, Update, UpdateReadRef, VersionVc},
 };
 
 use super::protocol::ResourceIdentifier;
 use crate::{
     resource_to_data,
-    source::{ContentSourceContent, ContentSourceResultVc},
+    source::{
+        ContentSourceContent, ContentSourceContentVc, ContentSourceResult, ContentSourceResultVc,
+    },
 };
 
 type GetContentFn = Box<dyn Fn() -> ContentSourceResultVc + Send + Sync>;
@@ -41,28 +40,26 @@ fn extend_issues(issues: &mut Vec<PlainIssueReadRef>, new_issues: Vec<PlainIssue
 async fn get_content_wrapper(
     resource: Value<ResourceIdentifier>,
     get_content: TransientInstance<GetContentFn>,
-) -> Result<ContentSourceResultVc> {
-    let mut content = get_content();
-    while let ContentSourceContent::NeedData(data) = &*content.await?.content.await? {
-        content = data.source.get(
-            &data.path,
-            Value::new(resource_to_data(resource.clone().into_value(), &data.vary)),
-        );
+) -> Result<ContentSourceContentVc> {
+    let mut content = get_content().await?;
+    while let ContentSourceResult::NeedData(data) = &*content {
+        content = data
+            .source
+            .get(
+                &data.path,
+                Value::new(resource_to_data(resource.clone().into_value(), &data.vary)),
+            )
+            .await?;
     }
-    Ok(content)
-}
-
-async fn resolve_static_content(
-    content_source_result: ContentSourceResultVc,
-) -> Result<Option<VersionedContentVc>> {
-    Ok(match *content_source_result.await?.content.await? {
-        ContentSourceContent::NotFound => None,
-        ContentSourceContent::HttpProxy(_) => {
-            panic!("HTTP proxying is not supported in UpdateStream")
-        }
-        ContentSourceContent::Static(content) => Some(content),
-        ContentSourceContent::NeedData(_) => {
-            bail!("this might only happen temporary as get_content_wrapper resolves the data")
+    Ok(match &*content {
+        ContentSourceResult::NeedData(..) => unreachable!(),
+        ContentSourceResult::NotFound => ContentSourceContentVc::not_found(),
+        ContentSourceResult::Result { get_content, .. } => {
+            let vary = get_content.vary().await?;
+            get_content.get(Value::new(resource_to_data(
+                resource.clone().into_value(),
+                &vary,
+            )))
         }
     })
 }
@@ -75,8 +72,21 @@ async fn get_update_stream_item(
 ) -> Result<UpdateStreamItemVc> {
     let content = get_content_wrapper(resource, get_content);
 
-    match resolve_static_content(content).await? {
-        None => {
+    match &*content.await? {
+        ContentSourceContent::Static(resolved_content) => {
+            let from = from.get();
+            let update = resolved_content.update(from);
+
+            let mut plain_issues = peek_issues(update).await?;
+            extend_issues(&mut plain_issues, peek_issues(content).await?);
+
+            Ok(UpdateStreamItem {
+                update: update.await?,
+                issues: plain_issues,
+            }
+            .cell())
+        }
+        _ => {
             let plain_issues = peek_issues(content).await?;
 
             let update = if plain_issues.is_empty() {
@@ -91,19 +101,6 @@ async fn get_update_stream_item(
             } else {
                 Update::None.cell()
             };
-
-            Ok(UpdateStreamItem {
-                update: update.await?,
-                issues: plain_issues,
-            }
-            .cell())
-        }
-        Some(resolved_content) => {
-            let from = from.get();
-            let update = resolved_content.update(from);
-
-            let mut plain_issues = peek_issues(update).await?;
-            extend_issues(&mut plain_issues, peek_issues(content).await?);
 
             Ok(UpdateStreamItem {
                 update: update.await?,
@@ -175,9 +172,9 @@ impl UpdateStream {
         let content = get_content_wrapper(Value::new(resource.clone()), get_content.clone());
         // We can ignore issues reported in content here since [compute_update_stream]
         // will handle them
-        let version = match resolve_static_content(content).await? {
-            Some(content) => content.version(),
-            None => NotFoundVersionVc::new().into(),
+        let version = match &*content.await? {
+            ContentSourceContent::Static(content) => content.version(),
+            _ => NotFoundVersionVc::new().into(),
         };
         let version_state = VersionStateVc::new(version).await?;
 

--- a/crates/turbopack-node/src/source_map/content_source.rs
+++ b/crates/turbopack-node/src/source_map/content_source.rs
@@ -6,7 +6,7 @@ use turbopack_core::{
 };
 use turbopack_dev_server::source::{
     ContentSource, ContentSourceContent, ContentSourceData, ContentSourceDataVary,
-    ContentSourceResultVc, ContentSourceVc, ContentSourcesVc, NeededData,
+    ContentSourceResult, ContentSourceResultVc, ContentSourceVc, ContentSourcesVc, NeededData,
 };
 use url::Url;
 
@@ -37,17 +37,14 @@ impl ContentSource for NextSourceMapTraceContentSource {
     ) -> Result<ContentSourceResultVc> {
         let url = match &data.url {
             None => {
-                return Ok(ContentSourceResultVc::exact(
-                    ContentSourceContent::NeedData(NeededData {
-                        source: self_vc.into(),
-                        path: path.to_string(),
-                        vary: ContentSourceDataVary {
-                            url: true,
-                            ..Default::default()
-                        },
-                    })
-                    .cell(),
-                ));
+                return Ok(ContentSourceResultVc::need_data(Value::new(NeededData {
+                    source: self_vc.into(),
+                    path: path.to_string(),
+                    vary: ContentSourceDataVary {
+                        url: true,
+                        ..Default::default()
+                    },
+                })));
             }
             Some(query) => query,
         };
@@ -83,7 +80,13 @@ impl ContentSource for NextSourceMapTraceContentSource {
 
         let this = self_vc.await?;
         let result = this.asset_source.get(path, Default::default()).await?;
-        let file = match &*result.content.await? {
+        let content = match &*result {
+            ContentSourceResult::Result { get_content, .. } => {
+                get_content.get(Default::default()).await?
+            }
+            _ => return Ok(ContentSourceResultVc::not_found()),
+        };
+        let file = match &*content {
             ContentSourceContent::Static(f) => *f,
             _ => return Ok(ContentSourceResultVc::not_found()),
         };
@@ -105,7 +108,9 @@ impl ContentSource for NextSourceMapTraceContentSource {
 
         let traced = SourceMapTraceVc::new(sm, line, column, frame.name);
         Ok(ContentSourceResultVc::exact(
-            ContentSourceContent::Static(traced.content().into()).cell(),
+            ContentSourceContent::Static(traced.content().into())
+                .cell()
+                .into(),
         ))
     }
 


### PR DESCRIPTION
fixes WEB-141

This changes the ContentSource API.

Before a ContentSource returned a tuple of specificity and content.
Now it returns a tuple of specificity and a get_content function.

The old way made it very inefficient to combine multiple ContentSource.
All combined ContentSources were ask before, all returned specificity and content, and they are ordered after that. That required to compute all contents, even if it is not really used after ordering.

Now we order specificity and a get_content function and only compute the content (by calling get_content) with the final result.

It also changes how data needs are expressed in the `get_content` function. Instead of asking it over and over again with more data, it statically returns the needed data with `vary` and the `get` function is only called with that data. This is technically more limited than the old way, but one can workaround that if needed. But practically we probably never need that. On the other hand it improves the number of function calls, since the `vary` method is only called once and the `get` only once per request. Before data needs required at least 2 `get` calls per request.