### PR TITLE
Expose `process.turbopack` to js run from turbopack-node

### DIFF
--- a/crates/turbopack-node/js/src/globals.ts
+++ b/crates/turbopack-node/js/src/globals.ts
@@ -1,0 +1,2 @@
+// @ts-ignore
+process.turbopack = {};

--- a/crates/turbopack-node/src/evaluate.rs
+++ b/crates/turbopack-node/src/evaluate.rs
@@ -92,6 +92,27 @@ pub async fn get_evaluate_pool(
     let (Some(cwd), Some(entrypoint)) = (to_sys_path(cwd).await?, to_sys_path(path).await?) else {
         panic!("can only evaluate from a disk filesystem");
     };
+
+    let runtime_entries = {
+        let globals_module = EcmascriptModuleAssetVc::new(
+            SourceAssetVc::new(embed_file_path("globals.ts")).into(),
+            context,
+            Value::new(EcmascriptModuleAssetType::Typescript),
+            EcmascriptInputTransformsVc::cell(vec![EcmascriptInputTransform::TypeScript]),
+            context.environment(),
+        )
+        .as_ecmascript_chunk_placeable();
+
+        let mut entries = vec![globals_module];
+        if let Some(other_entries) = runtime_entries {
+            for entry in &*other_entries.await? {
+                entries.push(*entry)
+            }
+        };
+
+        Some(EcmascriptChunkPlaceablesVc::cell(entries))
+    };
+
     let bootstrap = NodeJsBootstrapAsset {
         path,
         chunk_group: ChunkGroupVc::from_chunk(


### PR DESCRIPTION
For now, this can allow `next.config.js` to understand where it's been run and apply different options. We should probably have better compatibility in the future, which would make this unnecessary for this usecase.

Test Plan: Modified a `next.config.js` to change its behavior based on the presence of this option. Verified non-turbo case doesn't have this exposed.