### PR TITLE
fix(docs): remove empty array instruction

### DIFF
--- a/docs/pages/repo/docs/core-concepts/caching.mdx
+++ b/docs/pages/repo/docs/core-concepts/caching.mdx
@@ -71,7 +71,7 @@ To override the default cache output behavior, pass an array of globs to a [`pip
 }
 ```
 
-If your task does not emit any files (e.g. unit tests with Jest), set `outputs` to an empty array (i.e. `[]`), and Turborepo will cache the logs for you.
+If your task does not emit any files (e.g. unit tests with Jest), Turborepo will automatically cache the logs for you.
 
 When you run `turbo run build test`, Turborepo will execute your build and test scripts,
 and cache their `output`s in `./node_modules/.cache/turbo`.

--- a/docs/pages/repo/docs/core-concepts/caching.mdx
+++ b/docs/pages/repo/docs/core-concepts/caching.mdx
@@ -71,7 +71,7 @@ To override the default cache output behavior, pass an array of globs to a [`pip
 }
 ```
 
-If your task does not emit any files (e.g. unit tests with Jest), Turborepo will automatically cache the logs for you.
+Turborepo automatically records and caches the logs of every task. You do not need to specify anything to get this behavior. If your task does not emit any files (e.g. unit tests with Jest) you can simply omit `outputs`.
 
 When you run `turbo run build test`, Turborepo will execute your build and test scripts,
 and cache their `output`s in `./node_modules/.cache/turbo`.

--- a/docs/pages/repo/docs/core-concepts/caching.mdx
+++ b/docs/pages/repo/docs/core-concepts/caching.mdx
@@ -71,7 +71,7 @@ To override the default cache output behavior, pass an array of globs to a [`pip
 }
 ```
 
-Turborepo automatically records and caches the logs of every task. You do not need to specify anything to get this behavior. If your task does not emit any files (e.g. unit tests with Jest) you can simply omit `outputs`.
+If your task does not emit any files (e.g. unit tests with Jest) you can omit `outputs`. Even without any file outputs, Turborepo automatically records and caches the logs of every task. If no inputs change (i.e. if there is a cache hit), subsequent runs will replay these logs.
 
 When you run `turbo run build test`, Turborepo will execute your build and test scripts,
 and cache their `output`s in `./node_modules/.cache/turbo`.


### PR DESCRIPTION
`outputs: []` is no longer required to cache logs, and can be omitted entirely. 