### PR TITLE
Install AsyncLocalStorage for appDir rendering

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -18,7 +18,6 @@ __generated__/
 crates/next-core/js/src/compiled
 crates/turbopack-node/js/src/compiled
 crates/turbopack/bench.json
-# This file has intentional trailing commas
-crates/turbopack/tests/node-file-trace/integration/ts-package/tsconfig.json
+crates/turbopack/tests
 crates/next-transform-strip-page-exports/tests
 crates/next-transform-dynamic/tests

--- a/crates/next-core/js/src/entry/app-renderer.tsx
+++ b/crates/next-core/js/src/entry/app-renderer.tsx
@@ -29,10 +29,12 @@ import type { RenderData } from "types/turbopack";
 
 import "next/dist/server/node-polyfill-fetch";
 import "next/dist/server/node-polyfill-web-streams";
+import "@vercel/turbopack-next/polyfill/async-local-storage";
 import { RenderOpts, renderToHTMLOrFlight } from "next/dist/server/app-render";
 import { PassThrough } from "stream";
 import { ServerResponseShim } from "@vercel/turbopack-next/internal/http";
 import { ParsedUrlQuery } from "node:querystring";
+import { AsyncLocalStorage } from "node:async_hooks";
 
 globalThis.__next_require__ = (data) => {
   const [, , ssr_id] = JSON.parse(data);

--- a/crates/next-core/js/src/entry/app-renderer.tsx
+++ b/crates/next-core/js/src/entry/app-renderer.tsx
@@ -34,7 +34,6 @@ import { RenderOpts, renderToHTMLOrFlight } from "next/dist/server/app-render";
 import { PassThrough } from "stream";
 import { ServerResponseShim } from "@vercel/turbopack-next/internal/http";
 import { ParsedUrlQuery } from "node:querystring";
-import { AsyncLocalStorage } from "node:async_hooks";
 
 globalThis.__next_require__ = (data) => {
   const [, , ssr_id] = JSON.parse(data);

--- a/crates/next-core/js/src/polyfill/async-local-storage.js
+++ b/crates/next-core/js/src/polyfill/async-local-storage.js
@@ -1,0 +1,6 @@
+// Next.js now creates an AsyncLocalStorage in the module scope, meaning we
+// need to:
+// 1. Install it (it's accessed as `globalthis.AsyncLocalStorage`)
+// 2. Do it in an import (import ordering is guaranteed)
+import { AsyncLocalStorage } from "node:async_hooks";
+globalThis.AsyncLocalStorage = AsyncLocalStorage;

--- a/crates/next-core/js/types/globals.d.ts
+++ b/crates/next-core/js/types/globals.d.ts
@@ -20,6 +20,15 @@ declare global {
     page: string,
     paths: string[]
   ): unknown;
+
+  var AsyncLocalStorage = class AsyncLocalStorage<T> {
+    getStore(): T | undefined;
+    run<R, TArgs extends any[]>(
+      store: T,
+      callback: (...args: TArgs) => R,
+      ...args: TArgs
+    ): R;
+  };
 }
 
 export {};


### PR DESCRIPTION
https://github.com/vercel/next.js/pull/44668 refactored Next's use of `AsyncLocalStorage`, and installs a "polyfill" of the API by patching the node import onto `globalThis.` Importantly, it's then used in the module scope during imports, so we need to install the polyfill early in the app rendering startup.

Fixes https://github.com/vercel/turbo/issues/3319