### PR TITLE
fix: update cargo lockfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -892,9 +892,9 @@ checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2 1.0.47",
- "quote 1.0.21",
- "syn 1.0.105",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]


### PR DESCRIPTION
`Cargo.lock` on main appears to be [out of date](https://github.com/vercel/turbo/actions/runs/3963061842/jobs/6790483844#step:9:276), these are the results of `cargo check`