### PR TITLE
publish 1.7.1-canary.3 to registry

### DIFF
--- a/cli/Makefile
+++ b/cli/Makefile
@@ -88,9 +88,9 @@ cmd/turbo/version.go: ../version.txt
 	mv cmd/turbo/version.go.txt cmd/turbo/version.go
 
 build: install
-	# cd $(CLI_DIR)/../packages/turbo-ignore && pnpm install --filter=turbo-ignore && npm run build
-	cd $(CLI_DIR)/../packages/create-turbo && pnpm install --filter=create-turbo && npm run build
-	cd $(CLI_DIR)/../packages/turbo-codemod && pnpm install --filter=@turbo/codemod && npm run build
+	# cd $(CLI_DIR)/../packages/turbo-ignore && pnpm install --filter=turbo-ignore && pnpm run build
+	cd $(CLI_DIR)/../packages/create-turbo && pnpm install --filter=create-turbo && pnpm run build
+	cd $(CLI_DIR)/../packages/turbo-codemod && pnpm install --filter=@turbo/codemod && pnpm run build
 
 .PHONY: prepublish
 prepublish: compile-protos cmd/turbo/version.go
@@ -152,10 +152,10 @@ stage-release: cmd/turbo/version.go
 	@test "" != "`git diff -- $(CLI_DIR)/cmd/turbo/version.go`" || (echo "Refusing to publish with unupdated version.go" && false)
 
 	# Prepare the packages.
-	cd $(CLI_DIR)/../packages/turbo && npm version "$(TURBO_VERSION)" --allow-same-version
-	# cd $(CLI_DIR)/../packages/turbo-ignore && npm version "$(TURBO_VERSION)" --allow-same-version
-	cd $(CLI_DIR)/../packages/create-turbo && npm version "$(TURBO_VERSION)" --allow-same-version
-	cd $(CLI_DIR)/../packages/turbo-codemod && npm version "$(TURBO_VERSION)" --allow-same-version
+	cd $(CLI_DIR)/../packages/turbo && pnpm version "$(TURBO_VERSION)" --allow-same-version
+	# cd $(CLI_DIR)/../packages/turbo-ignore && pnpm version "$(TURBO_VERSION)" --allow-same-version
+	cd $(CLI_DIR)/../packages/create-turbo && pnpm version "$(TURBO_VERSION)" --allow-same-version
+	cd $(CLI_DIR)/../packages/turbo-codemod && pnpm version "$(TURBO_VERSION)" --allow-same-version
 
 	git checkout -b staging-$(TURBO_VERSION)
 	git commit -anm "publish $(TURBO_VERSION) to registry"
@@ -172,15 +172,14 @@ publish: clean build
 
 	npm config set --location=project "//registry.npmjs.org/:_authToken" $(NPM_TOKEN)
 
-
 	# Publishes the native npm modules.
 	goreleaser release --rm-dist -f combined-release.yml
 
-	# Split packing from the publish step so that npm locates the correct .npmrc file.
-	npm pack $(CLI_DIR)/../packages/turbo --pack-destination=$(CLI_DIR)/../
-	npm pack $(CLI_DIR)/../packages/turbo-ignore --pack-destination=$(CLI_DIR)/../
-	npm pack $(CLI_DIR)/../packages/create-turbo --pack-destination=$(CLI_DIR)/../
-	npm pack $(CLI_DIR)/../packages/turbo-codemod --pack-destination=$(CLI_DIR)/../
+	# Split packing from the publish step so that pnpm locates the correct .npmrc file.
+	cd $(CLI_DIR)/../packages/turbo && pnpm pack --pack-destination=$(CLI_DIR)/../
+	cd $(CLI_DIR)/../packages/turbo-ignore && pnpm pack --pack-destination=$(CLI_DIR)/../
+	cd $(CLI_DIR)/../packages/create-turbo && pnpm pack --pack-destination=$(CLI_DIR)/../
+	cd $(CLI_DIR)/../packages/turbo-codemod && pnpm pack --pack-destination=$(CLI_DIR)/../
 
 	# Publish the remaining JS packages in order to avoid race conditions.
 	cd $(CLI_DIR)/../
@@ -203,10 +202,10 @@ snapshot-turbo:
 	goreleaser release --rm-dist -f combined-shim.yml --snapshot
 
 	# Split packing from the publish step so that npm locates the correct .npmrc file.
-	npm pack $(CLI_DIR)/../packages/turbo --pack-destination=$(CLI_DIR)/dist/
-	npm pack $(CLI_DIR)/../packages/turbo-ignore --pack-destination=$(CLI_DIR)/dist/
-	npm pack $(CLI_DIR)/../packages/create-turbo --pack-destination=$(CLI_DIR)/dist/
-	npm pack $(CLI_DIR)/../packages/turbo-codemod --pack-destination=$(CLI_DIR)/dist/
+	cd $(CLI_DIR)/../packages/turbo && pnpm pack --pack-destination=$(CLI_DIR)/dist/
+	cd $(CLI_DIR)/../packages/turbo-ignore && pnpm pack --pack-destination=$(CLI_DIR)/dist/
+	cd $(CLI_DIR)/../packages/create-turbo && pnpm pack --pack-destination=$(CLI_DIR)/dist/
+	cd $(CLI_DIR)/../packages/turbo-codemod && pnpm pack --pack-destination=$(CLI_DIR)/dist/
 
 
 .PHONY: publish-turbo
@@ -223,9 +222,9 @@ publish-turbo: clean build
 	goreleaser release --rm-dist -f combined-shim.yml
 
 	# Split packing from the publish step so that npm locates the correct .npmrc file.
-	npm pack $(CLI_DIR)/../packages/turbo --pack-destination=$(CLI_DIR)/../
-	npm pack $(CLI_DIR)/../packages/create-turbo --pack-destination=$(CLI_DIR)/../
-	npm pack $(CLI_DIR)/../packages/turbo-codemod --pack-destination=$(CLI_DIR)/../
+	cd $(CLI_DIR)/../packages/turbo && pnpm pack --pack-destination=$(CLI_DIR)/../
+	cd $(CLI_DIR)/../packages/create-turbo && pnpm pack --pack-destination=$(CLI_DIR)/../
+	cd $(CLI_DIR)/../packages/turbo-codemod && pnpm pack --pack-destination=$(CLI_DIR)/../
 
 	# Publish the remaining JS packages in order to avoid race conditions.
 	cd $(CLI_DIR)/../

--- a/cli/cmd/turbo/version.go
+++ b/cli/cmd/turbo/version.go
@@ -1,3 +1,3 @@
 package main
 
-const turboVersion = "1.7.1-canary.2"
+const turboVersion = "1.7.1-canary.3"

--- a/packages/create-turbo/package.json
+++ b/packages/create-turbo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-turbo",
-  "version": "1.7.1-canary.2",
+  "version": "1.7.1-canary.3",
   "description": "Create a new Turborepo",
   "homepage": "https://turbo.build/repo",
   "license": "MPL-2.0",

--- a/packages/turbo-codemod/package.json
+++ b/packages/turbo-codemod/package.json
@@ -12,7 +12,7 @@
   "bugs": {
     "url": "https://github.com/vercel/turbo/issues"
   },
-  "bin": "dist/index.js",
+  "bin": "dist/cli.js",
   "scripts": {
     "build": "tsup",
     "test": "jest",
@@ -33,7 +33,6 @@
     "is-git-clean": "^1.1.0",
     "ora": "4.1.1",
     "semver": "^7.3.7",
-    "turbo-utils": "workspace:*",
     "update-check": "^1.5.4"
   },
   "devDependencies": {

--- a/packages/turbo-codemod/package.json
+++ b/packages/turbo-codemod/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/codemod",
-  "version": "1.7.1-canary.2",
+  "version": "1.7.1-canary.3",
   "description": "Provides Codemod transformations to help upgrade your Turborepo codebase when a feature is deprecated.",
   "homepage": "https://turbo.build/repo",
   "license": "MPL-2.0",

--- a/packages/turbo-codemod/tsup.config.ts
+++ b/packages/turbo-codemod/tsup.config.ts
@@ -4,5 +4,6 @@ export default defineConfig((options: Options) => ({
   entry: ["src/cli.ts", "src/transforms/*.ts"],
   format: ["cjs"],
   clean: true,
+  minify: true,
   ...options,
 }));

--- a/packages/turbo/package.json
+++ b/packages/turbo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbo",
-  "version": "1.7.1-canary.2",
+  "version": "1.7.1-canary.3",
   "description": "Turborepo is a high-performance build system for JavaScript and TypeScript codebases.",
   "repository": "https://github.com/vercel/turbo",
   "bugs": "https://github.com/vercel/turbo/issues",
@@ -19,11 +19,11 @@
     "install.js"
   ],
   "optionalDependencies": {
-    "turbo-darwin-64": "1.7.1-canary.2",
-    "turbo-darwin-arm64": "1.7.1-canary.2",
-    "turbo-linux-64": "1.7.1-canary.2",
-    "turbo-linux-arm64": "1.7.1-canary.2",
-    "turbo-windows-64": "1.7.1-canary.2",
-    "turbo-windows-arm64": "1.7.1-canary.2"
+    "turbo-darwin-64": "1.7.1-canary.3",
+    "turbo-darwin-arm64": "1.7.1-canary.3",
+    "turbo-linux-64": "1.7.1-canary.3",
+    "turbo-linux-arm64": "1.7.1-canary.3",
+    "turbo-windows-64": "1.7.1-canary.3",
+    "turbo-windows-arm64": "1.7.1-canary.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -379,7 +379,6 @@ importers:
       tsconfig: workspace:*
       tsup: ^5.10.3
       turbo-types: workspace:*
-      turbo-utils: workspace:*
       typescript: ^4.5.5
       update-check: ^1.5.4
       uuid: ^9.0.0
@@ -396,7 +395,6 @@ importers:
       is-git-clean: 1.1.0
       ora: 4.1.1
       semver: 7.3.8
-      turbo-utils: link:../turbo-utils
       update-check: 1.5.4
     devDependencies:
       '@types/chalk-animation': 1.6.1

--- a/version.txt
+++ b/version.txt
@@ -1,2 +1,2 @@
-1.7.1-canary.2
+1.7.1-canary.3
 canary


### PR DESCRIPTION
This includes release flow changes to pack with pnpm instead of npm to ensure we convert workspace references correctly. 

This branch has already released, which is why I'm including them here. 