### PR TITLE
don't run `cargo fmt --all` in pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,4 +2,3 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 pnpm exec lint-staged
-cargo fmt --all


### PR DESCRIPTION
This action started failing because `cargo fmt` was added to the pre-commit hook and the tool is not available without running Rust setup. Instead, we should just skip applying hooks when creating commits from this workflow.

~Since the create-pull-request doesn't have a way of disabling hooks, simply remove the file before husky installs it into place.~ Let `cargo fmt` run on individual files through lint-staged, but don't run it on everything on every precommit.

Test Plan: Manual workflow run on this branch which opened #3401