### PR TITLE
fix(docs): use correct enterprise link in footer

### DIFF
--- a/docs/components/Footer.tsx
+++ b/docs/components/Footer.tsx
@@ -4,6 +4,7 @@ import { useState, ReactNode, ReactElement } from "react";
 import cn from "classnames";
 import { ThemeSwitch } from "nextra-theme-docs";
 import VercelLogo from "./logos/Vercel";
+import { useTurboSite, TurboSite } from "./SiteSwitcher";
 
 function FooterLink({ href, children }: { href: string; children: ReactNode }) {
   const classes =
@@ -53,7 +54,7 @@ const navigation = {
       href: "https://turbo.build/discord",
     },
   ],
-  company: [
+  company: (site: TurboSite) => [
     { name: "Vercel", href: "https://vercel.com" },
     {
       name: "Open Source Software",
@@ -61,7 +62,9 @@ const navigation = {
     },
     {
       name: "Contact Sales",
-      href: "https://vercel.com/contact/turborepo?utm_source=turbo.build&utm_medium=referral&utm_campaign=footer-enterpriseLink",
+      href: `https://vercel.com/${
+        site === "repo" ? "solutions" : "contact"
+      }/turborepo?utm_source=turbo.build&utm_medium=referral&utm_campaign=footer-enterpriseLink`,
     },
     { name: "Twitter", href: "https://twitter.com/vercel" },
   ],
@@ -72,6 +75,7 @@ const navigation = {
 };
 
 export function FooterContent() {
+  const site = useTurboSite();
   return (
     <div className="w-full" aria-labelledby="footer-heading">
       <h2 id="footer-heading" className="sr-only">
@@ -114,7 +118,7 @@ export function FooterContent() {
               <div className="mt-12 md:!mt-0">
                 <FooterHeader>Company</FooterHeader>
                 <ul role="list" className="mt-4 space-y-1.5 list-none ml-0">
-                  {navigation.company.map((item) => (
+                  {navigation.company(site).map((item) => (
                     <li key={item.name}>
                       <FooterLink href={item.href}>{item.name}</FooterLink>
                     </li>

--- a/docs/components/SiteSwitcher.tsx
+++ b/docs/components/SiteSwitcher.tsx
@@ -2,7 +2,9 @@ import cn from "classnames";
 import { useRouter } from "next/router";
 import Link from "next/link";
 
-export function useTurboSite(): "pack" | "repo" | undefined {
+export type TurboSite = "pack" | "repo";
+
+export function useTurboSite(): TurboSite | undefined {
   const { pathname } = useRouter();
 
   if (pathname.startsWith("/repo")) {


### PR DESCRIPTION
The footer sales link should match the behavior of the header enterprise link.