### PR TITLE
Handle empty pageData during HMR

### DIFF
--- a/crates/next-core/js/src/internal/page-server-handler.tsx
+++ b/crates/next-core/js/src/internal/page-server-handler.tsx
@@ -59,11 +59,12 @@ export default function startHandler({
         }
       }
 
-      const res = await runOperation(renderData);
+      let res = await runOperation(renderData);
 
       if (isDataReq) {
         if (res === undefined) {
-          throw new Error("no data result returned");
+          // Page data is only returned if the page had getXxyProps.
+          res = {};
         }
         ipc.send({
           type: "result",


### PR DESCRIPTION
Our `pageData` HMR process treated an undefined response as an error condition, but if the page doesn't have a `getXyzProps` exported method, then this is the default response. This prevented us from having any pages without page props.

The new code just sends down an empty object, which seems to work for establishing the connection. HMR updates are sent down (and seem to trigger restarts, at least from what I tested with `getStaticProps`).

Fixes WEB-445