### PR TITLE
ci(workflow): setup a new workflow for next.js repo_dispatch

### DIFF
--- a/.github/workflows/on-nextjs-release-publish.yml
+++ b/.github/workflows/on-nextjs-release-publish.yml
@@ -1,0 +1,21 @@
+# A workflow supposed to run when there is a new release of Next.js.
+# This relies on next.js upstream's `repository_dispatch` workflow.
+name: Next.js Release Publish
+
+on:
+  repository_dispatch:
+    # This is the event type defined by next.js upstream's `repository_dispatch` workflow dispatches.
+    types: [nextjs-release-published]
+
+jobs:
+  check-release-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Display release tag
+        run: echo "Found a new release ${{ github.event.client_payload.version }}"
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          repository: vercel/next.js
+          ref: ${{ github.event.client_payload.version }}


### PR DESCRIPTION
Partially progresses WEB-457.

This PR sets up new workflow to subscribe into repository_dispatch event. The event is supposed to be dispatched from next.js upstream when there is a new release.

Currently this is for the access scope (token) verification, so it doesn't do any actual work other than payload correctly delivers ref to the release.
