### PR TITLE
nextest.toml update to next-dev-tests and add retries

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,12 +1,7 @@
-[profile.default]
+[[profile.default.overrides]]
+filter = "package(next-dev-tests)"
 # Default is 100ms. Extending this addresses false positives in the
 # next-dev integration tests.
-#
-# TODO: Move this to [[profile.default.overrides]] below
-# Currently, doing so makes leak-timeout no longer parse as a duration:
-# https://github.com/nextest-rs/nextest/issues/762
 leak-timeout = "500ms"
-
-[[profile.default.overrides]]
-filter = "package(next-dev)"
+retries = 2
 slow-timeout = "60s"


### PR DESCRIPTION
This updates nextest.toml to use the new package name for next-dev tests, `next-dev-tests` and adds up to 2 additional retries (for a total of 3 attempts) since these tests tend to be flakey.

**Note**: This requires `cargo-nextest` version 0.9.49, which includes a fix for https://github.com/nextest-rs/nextest/issues/762. Otherwise, you may receive an error when running nextest like:

```
error: failed to parse nextest config at `path/to/.config/nextest.toml`

Caused by:
  profile.default.overrides[0].leak-timeout: invalid type: string "500ms", expected struct Duration

Caused by:
  invalid type: string "500ms", expected struct Duration
```

Test Plan: Temporarily changed `slow-timeout` to `0s` and verified the override selected next-dev tests by marking them as slow.