### PR TITLE
fix: use the correct value in termsize tuple

### DIFF
--- a/crates/turbo-updater/src/ui/mod.rs
+++ b/crates/turbo-updater/src/ui/mod.rs
@@ -1,4 +1,4 @@
-use console::{measure_text_width, strip_ansi_codes, Term};
+use console::{measure_text_width, Term};
 
 use crate::UpdateNotifierError;
 pub mod utils;

--- a/crates/turbo-updater/src/ui/mod.rs
+++ b/crates/turbo-updater/src/ui/mod.rs
@@ -1,4 +1,4 @@
-use console::{measure_text_width, Term};
+use console::{measure_text_width, strip_ansi_codes, Term};
 
 use crate::UpdateNotifierError;
 pub mod utils;
@@ -35,12 +35,12 @@ pub fn message(text: &str) -> Result<(), UpdateNotifierError> {
     };
 
     // render differently depending on viewport
-    if let Some((term_width, _)) = size {
+    if let Some((_, num_cols)) = size {
         // if possible, pad this value slightly
-        let term_width = if term_width > 2 {
-            usize::from(term_width) - 2
+        let term_width = if num_cols > 2 {
+            usize::from(num_cols) - 2
         } else {
-            term_width.into()
+            num_cols.into()
         };
 
         let can_fit_box = term_width >= full_message_width;


### PR DESCRIPTION
In #3371, I messed up and used the number of rows instead of the number of columns as the width of the terminal. We now don't require a very tall terminal to print out the full update message:
![Screen Shot 2023-01-24 at 11 51 54 AM](https://user-images.githubusercontent.com/4131117/214395125-2ef19b3c-92af-4688-a92a-1f07f8202a7c.png)
