### PR TITLE
ci(workflow): reusable next.js integration test

### DIFF
--- a/.github/workflows/nextjs-integration-test.yml
+++ b/.github/workflows/nextjs-integration-test.yml
@@ -1,0 +1,158 @@
+# Reusable workflow to execute certain version of Next.js integration tests
+# with turbopack.
+#
+# Refer test.yml for how this workflow is being initialized
+# - Workflow can specify `inputs.version` to specify which version of next.js to use, otherwise will use latest release version.
+name: Turbopack Next.js integration test
+
+on:
+  workflow_call:
+    inputs:
+      # Allow to specify Next.js version to run integration test against.
+      # If not specified, will use latest release version including canary.
+      version:
+        required: false
+        type: string
+
+jobs:
+  # Build debug build of next-dev to use in integration test.
+  rust_build_dev:
+    strategy:
+      fail-fast: false
+    runs-on: ubuntu-latest-16-core-oss
+    name: Rust building debug next-dev for next.js integration test
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+        with:
+          targets: x86_64-unknown-linux-musl
+          cache-key: dev-x86_64-unknown-linux-musl
+          save-cache: true
+
+      - name: Install musl tools
+        run: |
+          wget https://github.com/napi-rs/napi-rs/releases/download/linux-musl-cross%4011.2.1/x86_64-linux-musl-native.tgz -O musl.tgz
+          tar -xvzf musl.tgz
+          sudo mv x86_64-linux-musl-native /usr/x86_64-linux-musl
+          sudo ln -sf /usr/x86_64-linux-musl/bin/x86_64-linux-musl-cc /usr/bin/musl-gcc
+          sudo ln -sf /usr/x86_64-linux-musl/bin/x86_64-linux-musl-g++ /usr/bin/musl-g++
+
+      - name: Build debug next-dev (rustls-tls)
+        run: |
+          cargo build -p next-dev --target x86_64-unknown-linux-musl --no-default-features --features cli,custom_allocator,rustls-tls
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: debug-next-dev-linux-musl
+          path: |
+            target/x86_64-unknown-linux-musl/debug/next-dev
+
+  # Run actual next.js integration test
+  execute_tests:
+    needs: [rust_build_dev]
+    # This job name is being used in github action to collect test results. Do not change it, or should update
+    # ./.github/actions/next-integration-test to match the new name.
+    name: Next.js integration test
+    runs-on: ubuntu-latest-8-core-oss
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [16, 18]
+        group: [1, 2]
+
+    env:
+      # Enabling backtrace will makes snapshot tests fail
+      RUST_BACKTRACE: 0
+      NEXT_TELEMETRY_DISABLED: 1
+      # Path to the next-dev binary located in **docker container** image.
+      NEXT_DEV_BIN: /work/next-dev
+      # Glob pattern to run specific tests with --turbo.
+      NEXT_DEV_TEST_GLOB: "*"
+      # pnpm version should match to what upstream next.js uses
+      PNPM_VERSION: 7.24.3
+
+    steps:
+      - name: Find Next.js latest release version
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Grab the latest release version from next.js repo, including prelease. `/releases/latest` will only return latest stable release.
+          echo NEXJS_LATEST_VERSION=$(gh release --repo vercel/next.js --limit 1 list | sed -n 1p | awk '{print $1}') >> $GITHUB_ENV
+      - name: Set Next.js release version
+        run: |
+          echo "NEXTJS_VERSION=${{ inputs.version != '' && inputs.version || env.NEXJS_LATEST_VERSION }}" >> $GITHUB_ENV
+          echo "Checking out Next.js ${{ env.NEXTJS_VERSION }}"
+
+      # https://github.com/actions/virtual-environments/issues/1187
+      - name: tune linux network
+        run: sudo ethtool -K eth0 tx off rx off
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          repository: vercel/next.js
+          ref: ${{ env.NEXTJS_VERSION }}
+
+      - uses: actions/cache@v3
+        id: restore-build
+        with:
+          path: ./*
+          key: ${{ github.sha }}-${{ github.run_number }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2.2.4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: pnpm
+
+      - name: Download binary
+        uses: actions/download-artifact@v3
+        with:
+          path: artifacts
+
+      - name: Validate next-dev binary
+        run: |
+          ls -r ${{ github.workspace }}/artifacts
+          chmod +x ${{ github.workspace }}/artifacts/debug-next-dev-linux-musl/next-dev
+          cp ${{ github.workspace }}/artifacts/debug-next-dev-linux-musl/next-dev .
+          ./next-dev --display-version
+
+      - name: Install dependencies
+        run: |
+          corepack disable
+          pnpm install
+          pnpm run build
+
+      - run: |
+          docker run --rm -v $(pwd):/work mcr.microsoft.com/playwright:v1.28.1-focal /bin/bash -c "cd /work && ls && curl https://install-node.vercel.app/v${{ matrix.node }} | FORCE=1 bash && node -v && npm i -g pnpm@${PNPM_VERSION} && /work/next-dev --display-version && __INTERNAL_CUSTOM_TURBOPACK_BINARY=${NEXT_DEV_BIN} __INTERNAL_NEXT_DEV_TEST_TURBO_GLOB_MATCH=${NEXT_DEV_TEST_GLOB} NEXT_TEST_JOB=1 NEXT_TEST_MODE=dev xvfb-run node run-tests.js --type development --timings -g ${{ matrix.group }}/4 >> /proc/1/fd/1"
+        name: Run test/development
+        # It is currently expected to fail some of next.js integration test, do not fail CI check.
+        continue-on-error: true
+        env:
+          RECORD_REPLAY_METADATA_TEST_RUN_TITLE: testDev / Group ${{ matrix.group }}
+          # marker to parse log output, do not delete / change.
+          NEXT_INTEGRATION_TEST: true
+
+      - run: |
+          docker run --rm -v $(pwd):/work mcr.microsoft.com/playwright:v1.28.1-focal /bin/bash -c "cd /work && ls && curl https://install-node.vercel.app/v${{ matrix.node }} | FORCE=1 bash && node -v && npm i -g pnpm@${PNPM_VERSION} && __INTERNAL_CUSTOM_TURBOPACK_BINARY=${NEXT_DEV_BIN} __INTERNAL_NEXT_DEV_TEST_TURBO_GLOB_MATCH=${NEXT_DEV_TEST_GLOB} NEXT_TEST_JOB=1 NEXT_TEST_MODE=dev xvfb-run node run-tests.js --type e2e --timings -g ${{ matrix.group }}/7 >> /proc/1/fd/1"
+        name: Run test/e2e (dev)
+        continue-on-error: true
+        env:
+          RECORD_REPLAY_METADATA_TEST_RUN_TITLE: testDevE2E / Group ${{ matrix.group }} / Node ${{ matrix.node }}
+          NEXT_TEST_MODE: dev
+          RECORD_REPLAY_TEST_METRICS: 1
+          NEXT_INTEGRATION_TEST: true
+
+      - run: |
+          docker run --rm -v $(pwd):/work mcr.microsoft.com/playwright:v1.28.1-focal /bin/bash -c "cd /work && ls && curl https://install-node.vercel.app/v16 | FORCE=1 bash && node -v && npm i -g pnpm@${PNPM_VERSION} && __INTERNAL_CUSTOM_TURBOPACK_BINARY=${NEXT_DEV_BIN} __INTERNAL_NEXT_DEV_TEST_TURBO_GLOB_MATCH=${NEXT_DEV_TEST_GLOB} NEXT_TEST_JOB=1 xvfb-run node run-tests.js --timings -g ${{ matrix.group }}/25 >> /proc/1/fd/1"
+        name: Test Integration
+        continue-on-error: true
+        env:
+          RECORD_REPLAY_METADATA_TEST_RUN_TITLE: testIntegration / Group ${{ matrix.group }}
+          NEXT_INTEGRATION_TEST: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -647,42 +647,6 @@ jobs:
             target/${{ matrix.os.target }}/release/next-dev
             target/${{ matrix.os.target }}/release/next-dev.exe
 
-  rust_build_dev:
-    needs: [determine_jobs]
-    if: needs.determine_jobs.outputs.rust == 'true' && needs.determine_jobs.outputs.push == 'true'
-    strategy:
-      fail-fast: false
-    runs-on: ubuntu-latest-16-core-oss
-    name: Rust building debug next-dev for next.js integration test
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Setup Rust
-        uses: ./.github/actions/setup-rust
-        with:
-          targets: x86_64-unknown-linux-musl
-          cache-key: dev-x86_64-unknown-linux-musl
-          save-cache: true
-
-      - name: Install musl tools
-        run: |
-          wget https://github.com/napi-rs/napi-rs/releases/download/linux-musl-cross%4011.2.1/x86_64-linux-musl-native.tgz -O musl.tgz
-          tar -xvzf musl.tgz
-          sudo mv x86_64-linux-musl-native /usr/x86_64-linux-musl
-          sudo ln -sf /usr/x86_64-linux-musl/bin/x86_64-linux-musl-cc /usr/bin/musl-gcc
-          sudo ln -sf /usr/x86_64-linux-musl/bin/x86_64-linux-musl-g++ /usr/bin/musl-g++
-
-      - name: Build debug next-dev (rustls-tls)
-        run: |
-          cargo build -p next-dev --target x86_64-unknown-linux-musl --no-default-features --features cli,custom_allocator,rustls-tls
-
-      - uses: actions/upload-artifact@v3
-        with:
-          name: debug-next-dev-linux-musl
-          path: |
-            target/x86_64-unknown-linux-musl/debug/next-dev
-
   rust_bench_pr:
     needs: [determine_jobs, rust_prepare]
     if: needs.determine_jobs.outputs.rust == 'true' && github.event_name == 'pull_request'
@@ -856,103 +820,16 @@ jobs:
           commit_message: Benchmark result for ${{ steps.date.outputs.pretty }} (${{ github.sha }})
 
   next_js_integration:
-    needs: [rust_build_dev]
-    if: needs.determine_jobs.outputs.rust == 'true'
-    # This job name is being used in github action to collect test results. Do not change it, or should update
-    # ./.github/actions/next-integration-test to match the new name.
-    name: Next.js integration test
-    runs-on: ubuntu-latest-8-core-oss
-    strategy:
-      fail-fast: false
-      matrix:
-        node: [16, 18]
-        group: [1, 2]
-    env:
-      # Enabling backtrace will makes snapshot tests fail
-      RUST_BACKTRACE: 0
-      NEXT_TELEMETRY_DISABLED: 1
-      # Path to the next-dev binary located in **docker container** image.
-      NEXT_DEV_BIN: /work/next-dev
-      # Glob pattern to run specific tests with --turbo.
-      NEXT_DEV_TEST_GLOB: "*"
-      # pnpm version should match to what upstream next.js uses
-      PNPM_VERSION: 7.24.3
-
-    steps:
-      # https://github.com/actions/virtual-environments/issues/1187
-      - name: tune linux network
-        run: sudo ethtool -K eth0 tx off rx off
-
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          repository: vercel/next.js
-          ref: v13.1.2-canary.8
-
-      - uses: actions/cache@v3
-        id: restore-build
-        with:
-          path: ./*
-          key: ${{ github.sha }}-${{ github.run_number }}
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v2.2.4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16
-          cache: pnpm
-
-      - name: Download binary
-        uses: actions/download-artifact@v3
-        with:
-          path: artifacts
-
-      - name: Validate next-dev binary
-        run: |
-          ls -r ${{ github.workspace }}/artifacts
-          chmod +x ${{ github.workspace }}/artifacts/debug-next-dev-linux-musl/next-dev
-          cp ${{ github.workspace }}/artifacts/debug-next-dev-linux-musl/next-dev .
-          ./next-dev --display-version
-
-      - name: Install dependencies
-        run: |
-          corepack disable
-          pnpm install
-          pnpm run build
-
-      - run: |
-          docker run --rm -v $(pwd):/work mcr.microsoft.com/playwright:v1.28.1-focal /bin/bash -c "cd /work && ls && curl https://install-node.vercel.app/v${{ matrix.node }} | FORCE=1 bash && node -v && npm i -g pnpm@${PNPM_VERSION} && /work/next-dev --display-version && __INTERNAL_CUSTOM_TURBOPACK_BINARY=${NEXT_DEV_BIN} __INTERNAL_NEXT_DEV_TEST_TURBO_GLOB_MATCH=${NEXT_DEV_TEST_GLOB} NEXT_TEST_JOB=1 NEXT_TEST_MODE=dev xvfb-run node run-tests.js --type development --timings -g ${{ matrix.group }}/4 >> /proc/1/fd/1"
-        name: Run test/development
-        # It is currently expected to fail some of next.js integration test, do not fail CI check.
-        continue-on-error: true
-        env:
-          RECORD_REPLAY_METADATA_TEST_RUN_TITLE: testDev / Group ${{ matrix.group }}
-          # marker to parse log output, do not delete / change.
-          NEXT_INTEGRATION_TEST: true
-
-      - run: |
-          docker run --rm -v $(pwd):/work mcr.microsoft.com/playwright:v1.28.1-focal /bin/bash -c "cd /work && ls && curl https://install-node.vercel.app/v${{ matrix.node }} | FORCE=1 bash && node -v && npm i -g pnpm@${PNPM_VERSION} && __INTERNAL_CUSTOM_TURBOPACK_BINARY=${NEXT_DEV_BIN} __INTERNAL_NEXT_DEV_TEST_TURBO_GLOB_MATCH=${NEXT_DEV_TEST_GLOB} NEXT_TEST_JOB=1 NEXT_TEST_MODE=dev xvfb-run node run-tests.js --type e2e --timings -g ${{ matrix.group }}/7 >> /proc/1/fd/1"
-        name: Run test/e2e (dev)
-        continue-on-error: true
-        env:
-          RECORD_REPLAY_METADATA_TEST_RUN_TITLE: testDevE2E / Group ${{ matrix.group }} / Node ${{ matrix.node }}
-          NEXT_TEST_MODE: dev
-          RECORD_REPLAY_TEST_METRICS: 1
-          NEXT_INTEGRATION_TEST: true
-
-      - run: |
-          docker run --rm -v $(pwd):/work mcr.microsoft.com/playwright:v1.28.1-focal /bin/bash -c "cd /work && ls && curl https://install-node.vercel.app/v16 | FORCE=1 bash && node -v && npm i -g pnpm@${PNPM_VERSION} && __INTERNAL_CUSTOM_TURBOPACK_BINARY=${NEXT_DEV_BIN} __INTERNAL_NEXT_DEV_TEST_TURBO_GLOB_MATCH=${NEXT_DEV_TEST_GLOB} NEXT_TEST_JOB=1 xvfb-run node run-tests.js --timings -g ${{ matrix.group }}/25 >> /proc/1/fd/1"
-        name: Test Integration
-        continue-on-error: true
-        env:
-          RECORD_REPLAY_METADATA_TEST_RUN_TITLE: testIntegration / Group ${{ matrix.group }}
-          NEXT_INTEGRATION_TEST: true
+    name: Execute Next.js integration workflow
+    needs: [determine_jobs]
+    if: needs.determine_jobs.outputs.rust == 'true' && needs.determine_jobs.outputs.push == 'true'
+    uses: ./.github/workflows/nextjs-integration-test.yml
+    # Uncomment to test against a specific version of Next.js
+    # with:
+    # version: v13.1.6-canary.0
 
   collect_nextjs_integration_stat:
     needs: [next_js_integration]
-    if: needs.determine_jobs.outputs.rust == 'true'
     name: Next.js integration test status report
     permissions:
       pull-requests: write


### PR DESCRIPTION
We'll need to run next.js test in multiple place (PR, new next.js release..). This PR makes running next.js integration test reusable without duplicating same logics.


Also this PR changes default behavior of next.js integration test to **always pull latest version of next.js**.