### PR TITLE
fix: Support pnpm lockfile keys in dependencies

### DIFF
--- a/cli/internal/lockfile/pnpm_lockfile.go
+++ b/cli/internal/lockfile/pnpm_lockfile.go
@@ -202,6 +202,11 @@ func DecodePnpmLockfile(contents []byte) (Lockfile, error) {
 
 // ResolvePackage Given a package and version returns the key, resolved version, and if it was found
 func (p *PnpmLockfile) ResolvePackage(workspacePath turbopath.AnchoredUnixPath, name string, version string) (Package, error) {
+	// Check if version is a key
+	if _, ok := p.Packages[version]; ok {
+		return Package{Key: version, Version: getVersionFromKey(version), Found: true}, nil
+	}
+
 	resolvedVersion, ok, err := p.resolveSpecifier(workspacePath, name, version)
 	if !ok || err != nil {
 		return Package{}, err
@@ -222,6 +227,11 @@ func (p *PnpmLockfile) ResolvePackage(workspacePath turbopath.AnchoredUnixPath, 
 
 // ResolvePackage Given a package and version returns the key, resolved version, and if it was found
 func (p *PnpmLockfileV6) ResolvePackage(workspacePath turbopath.AnchoredUnixPath, name string, version string) (Package, error) {
+	// Check if version is a key
+	if _, ok := p.Packages[version]; ok {
+		return Package{Key: version, Version: getVersionFromKeyV6(version), Found: true}, nil
+	}
+
 	resolvedVersion, ok, err := p.resolveSpecifier(workspacePath, name, version)
 	if !ok || err != nil {
 		return Package{}, err
@@ -585,4 +595,20 @@ func formatPnpmKey(name string, version string) string {
 
 func formatPnpmKeyV6(name string, version string) string {
 	return fmt.Sprintf("/%s@%s", name, version)
+}
+
+func getVersionFromKey(key string) string {
+	atIndex := strings.LastIndex(key, "/")
+	if atIndex == -1 || len(key) == atIndex+1 {
+		return ""
+	}
+	return key[atIndex+1:]
+}
+
+func getVersionFromKeyV6(key string) string {
+	atIndex := strings.LastIndex(key, "@")
+	if atIndex == -1 || len(key) == atIndex+1 {
+		return ""
+	}
+	return key[atIndex+1:]
 }

--- a/cli/internal/lockfile/pnpm_lockfile_test.go
+++ b/cli/internal/lockfile/pnpm_lockfile_test.go
@@ -216,15 +216,25 @@ func Test_PnpmPrunePatchesV6(t *testing.T) {
 }
 
 func Test_PnpmAbsoluteDependency(t *testing.T) {
-	contents, err := getFixture(t, "pnpm-absolute.yaml")
-	assert.NilError(t, err)
+	type testCase struct {
+		fixture string
+		key     string
+	}
+	testcases := []testCase{
+		{"pnpm-absolute.yaml", "/@scope/child/1.0.0"},
+		{"pnpm-absolute-v6.yaml", "/@scope/child@1.0.0"},
+	}
+	for _, tc := range testcases {
+		contents, err := getFixture(t, tc.fixture)
+		assert.NilError(t, err, tc.fixture)
 
-	lockfile, err := DecodePnpmLockfile(contents)
-	assert.NilError(t, err)
+		lockfile, err := DecodePnpmLockfile(contents)
+		assert.NilError(t, err, tc.fixture)
 
-	pkg, err := lockfile.ResolvePackage(turbopath.AnchoredUnixPath("packages/a"), "child", "/@scope/child/1.0.0")
-	assert.NilError(t, err, "resolve")
-	assert.Assert(t, pkg.Found)
-	assert.DeepEqual(t, pkg.Key, "/@scope/child/1.0.0")
-	assert.DeepEqual(t, pkg.Version, "1.0.0")
+		pkg, err := lockfile.ResolvePackage(turbopath.AnchoredUnixPath("packages/a"), "child", tc.key)
+		assert.NilError(t, err, "resolve")
+		assert.Assert(t, pkg.Found, tc.fixture)
+		assert.DeepEqual(t, pkg.Key, tc.key)
+		assert.DeepEqual(t, pkg.Version, "1.0.0")
+	}
 }

--- a/cli/internal/lockfile/pnpm_lockfile_test.go
+++ b/cli/internal/lockfile/pnpm_lockfile_test.go
@@ -214,3 +214,17 @@ func Test_PnpmPrunePatchesV6(t *testing.T) {
 
 	assert.Equal(t, len(prunedLockfile.Patches()), 1)
 }
+
+func Test_PnpmAbsoluteDependency(t *testing.T) {
+	contents, err := getFixture(t, "pnpm-absolute.yaml")
+	assert.NilError(t, err)
+
+	lockfile, err := DecodePnpmLockfile(contents)
+	assert.NilError(t, err)
+
+	pkg, err := lockfile.ResolvePackage(turbopath.AnchoredUnixPath("packages/a"), "child", "/@scope/child/1.0.0")
+	assert.NilError(t, err, "resolve")
+	assert.Assert(t, pkg.Found)
+	assert.DeepEqual(t, pkg.Key, "/@scope/child/1.0.0")
+	assert.DeepEqual(t, pkg.Version, "1.0.0")
+}

--- a/cli/internal/lockfile/testdata/pnpm-absolute-v6.yaml
+++ b/cli/internal/lockfile/testdata/pnpm-absolute-v6.yaml
@@ -1,0 +1,18 @@
+lockfileVersion: "6.0"
+importers:
+  packages/a:
+    dependencies:
+      "@scope/parent":
+        specifier: ^1.0.0
+        version: 1.0.0
+
+packages:
+  /@scope/parent@1.0.0:
+    resolution: { integrity: junk }
+    dependencies:
+      child: /@scope/child@1.0.0
+    dev: false
+
+  /@scope/child@1.0.0:
+    resolution: { integrity: junk }
+    dev: false

--- a/cli/internal/lockfile/testdata/pnpm-absolute.yaml
+++ b/cli/internal/lockfile/testdata/pnpm-absolute.yaml
@@ -1,0 +1,17 @@
+lockfileVersion: 5.4
+importers:
+  packages/a:
+    specifiers:
+      "@scope/parent": ^1.0.0
+    dependencies:
+      somepackage: 1.0.0
+packages:
+  /@scope/parent/1.0.0:
+    resolution: { integrity: junk }
+    dependencies:
+      child: /@scope/child/1.0.0
+    dev: false
+
+  /@scope/child/1.0.0:
+    resolution: { integrity: junk }
+    dev: false


### PR DESCRIPTION
Fixes #3382

This PR adds support for when pnpm encodes a dependency version as a lockfile key instead of just a version. We already have similar logic in the npm lockfile implementation.

Thanks to @omarahm3 for the reproduction!