### PR TITLE
ci(workflow): run next.js integration test with new release

### DIFF
--- a/.github/workflows/on-nextjs-release-publish.yml
+++ b/.github/workflows/on-nextjs-release-publish.yml
@@ -8,14 +8,19 @@ on:
     types: [nextjs-release-published]
 
 jobs:
+  # Debug purpose, write down release version.
   check-release-tag:
+    name: Check latest release
     runs-on: ubuntu-latest
     steps:
-      - name: Display release tag
+      - name: Print release tag
         run: echo "Found a new release ${{ github.event.client_payload.version }}"
 
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          repository: vercel/next.js
-          ref: ${{ github.event.client_payload.version }}
+  # Trigger actual next.js integration tests.
+  next_js_integration:
+    name: Execute Next.js integration workflow
+    needs: [determine_jobs]
+    if: needs.determine_jobs.outputs.rust == 'true' && needs.determine_jobs.outputs.push == 'true'
+    uses: ./.github/workflows/nextjs-integration-test.yml
+    with:
+    version: ${{ github.event.client_payload.version }}


### PR DESCRIPTION
This PR actually triggers integration tests when there's a new Next.js release. Collecting stats / displaying it required some trial & error, probably comes after this PR.