### PR TITLE
fix(turborepo): fix create branch workflow

### DIFF
--- a/.github/workflows/turborepo-release-step-3.yml
+++ b/.github/workflows/turborepo-release-step-3.yml
@@ -161,10 +161,19 @@ jobs:
         with:
           name: turbo-combined
           path: cli/dist
-
-      - name: Open Pull Request for release branch
-        uses: peter-evans/create-pull-request@v4
+  create-release-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@1.0.0
         with:
-          title: "feat(turborepo): release"
-          branch: "${{ inputs.release_branch }}"
+          ref: ${{ inputs.release_branch }}
+      - name: Get version
+        id: getVersion
+        run: echo ::set-output name=version::$(head -n 1 version.txt)
+      - name: Create pull request
+        uses: thomaseizinger/create-pull-request@master
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          head: ${{ inputs.release_branch }}
           base: main
+          title: "release(turborepo): ${{ steps.getVersion.outputs.version }}"


### PR DESCRIPTION
Swapping workflow since we don't need one that commits and creates it's own branch, we just need to open a PR from an existing branch. This is tested on my private fork