### PR TITLE
Use mdxjs upstream at 0.1.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3181,8 +3181,9 @@ dependencies = [
 
 [[package]]
 name = "mdxjs"
-version = "0.1.4"
-source = "git+https://github.com/jridgewell/mdxjs-rs.git?rev=7bb794ebb6b7c0506aff42089055bcd1837d99df#7bb794ebb6b7c0506aff42089055bcd1837d99df"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68931216cc0e72f009bd674c5178cfd20aae01c68575fda61dead94d9bd4e702"
 dependencies = [
  "markdown",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ swc_emotion = { version = "0.29.0" }
 styled_jsx = { version = "0.30.0" }
 styled_components = { version = "0.53.0" }
 modularize_imports = { version = "0.26.0" }
-mdxjs = { git = "https://github.com/jridgewell/mdxjs-rs.git", rev = "7bb794ebb6b7c0506aff42089055bcd1837d99df" }
+mdxjs = { version = "0.1.5" }
 next-dev = { path = "crates/next-dev", version = "0.1.0" }
 node-file-trace = { path = "crates/node-file-trace", version = "0.1.0" }
 # Be careful when selecting tls backend, including change default tls backend.


### PR DESCRIPTION
This replaces our use of @jridgewell's fork as upstream has updated to `swc_core@0.56.0`. 