### PR TITLE
`changesets` action: `yarn` -> `pnpm`

### DIFF
--- a/examples/with-changesets/.github/workflows/release.yml
+++ b/examples/with-changesets/.github/workflows/release.yml
@@ -21,14 +21,14 @@ jobs:
           node-version: 16.x
 
       - name: Install Dependencies
-        run: yarn
+        run: pnpm i
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1
         with:
           # This expects you to have a script called release which does a build for your packages and calls changeset publish
-          publish: yarn release
+          publish: pnpm publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/examples/with-changesets/.github/workflows/release.yml
+++ b/examples/with-changesets/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         uses: changesets/action@v1
         with:
           # This expects you to have a script called release which does a build for your packages and calls changeset publish
-          publish: pnpm publish
+          publish: pnpm release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Looks like we missed the action here when we moved our examples from yarn to pnpm.

Thanks, @colbyfayock for letting us know!