### PR TITLE
ci(workflow): fix integration job log detection

### DIFF
--- a/.github/actions/next-integration-stat/index.js
+++ b/.github/actions/next-integration-stat/index.js
@@ -12531,8 +12531,10 @@
 
       // Filter out next.js integration test jobs
       const integrationTestJobs = jobs?.filter((job) =>
-        job?.name?.startsWith("Next.js integration test (")
+        /Next\.js integration test \([^)]*\)$/.test(job.name)
       );
+      console.log(jobs?.map((j) => j.name));
+
       console.log(
         `Logs found for ${integrationTestJobs.length} jobs`,
         integrationTestJobs.map((job) => job.name)

--- a/.github/actions/next-integration-stat/src/index.js
+++ b/.github/actions/next-integration-stat/src/index.js
@@ -49,8 +49,10 @@ async function run() {
 
   // Filter out next.js integration test jobs
   const integrationTestJobs = jobs?.filter((job) =>
-    job?.name?.startsWith("Next.js integration test (")
+    /Next\.js integration test \([^)]*\)$/.test(job.name)
   );
+  console.log(jobs?.map((j) => j.name));
+
   console.log(
     `Logs found for ${integrationTestJobs.length} jobs`,
     integrationTestJobs.map((job) => job.name)


### PR DESCRIPTION
Fixes integration test stat report in PR, due to changing workflow group with reusable one. One day we may need better than this, but changing detection more generic for now.