### PR TITLE
fix(turborepo): Add `.npmrc` support to `turbo prune`

### DIFF
--- a/cli/internal/prune/prune.go
+++ b/cli/internal/prune/prune.go
@@ -190,6 +190,17 @@ func (p *prune) prune(opts *turbostate.PrunePayload) error {
 		}
 	}
 
+	if fs.FileExists(".npmrc") {
+		if err := fs.CopyFile(&fs.LstatCachedFile{Path: p.base.RepoRoot.UntypedJoin(".npmrc")}, fullDir.UntypedJoin(".npmrc").ToStringDuringMigration()); err != nil {
+			return errors.Wrap(err, "failed to copy root .npmrc")
+		}
+		if opts.Docker {
+			if err := fs.CopyFile(&fs.LstatCachedFile{Path: p.base.RepoRoot.UntypedJoin(".npmrc")}, outDir.UntypedJoin("json/.npmrc").ToStringDuringMigration()); err != nil {
+				return errors.Wrap(err, "failed to copy root .npmrc")
+			}
+		}
+	}
+
 	if fs.FileExists("turbo.json") {
 		if err := fs.CopyFile(&fs.LstatCachedFile{Path: p.base.RepoRoot.UntypedJoin("turbo.json")}, fullDir.UntypedJoin("turbo.json").ToStringDuringMigration()); err != nil {
 			return errors.Wrap(err, "failed to copy root turbo.json")


### PR DESCRIPTION
closes #2871 

Copying `.npmrc` file if it exists to keep packageManager settings the same during deploy/Docker builds.