### PR TITLE
fix(examples) tailwind - ignore ui dist/

### DIFF
--- a/examples/with-tailwind/.gitignore
+++ b/examples/with-tailwind/.gitignore
@@ -31,3 +31,6 @@ yarn-error.log*
 
 # turbo
 .turbo
+
+# ui
+dist/


### PR DESCRIPTION
The `dist` folder containing distributable component-library and tailwind compiled script should be ignored by git. It will grow bigger if someone didn't realize about it.