### PR TITLE
ci(workflow): upload integration test resuls from main branch, next.j… …s release

### DIFF
--- a/.github/actions/next-integration-stat/src/index.js
+++ b/.github/actions/next-integration-stat/src/index.js
@@ -2,9 +2,52 @@ const { context, getOctokit } = require("@actions/github");
 const { info, getInput } = require("@actions/core");
 const { default: stripAnsi } = require("strip-ansi");
 const { default: fetch } = require("node-fetch");
+const fs = require("fs");
 
 // A comment marker to identify the comment created by this action.
 const BOT_COMMENT_MARKER = `<!-- __marker__ next.js integration stats __marker__ -->`;
+
+// Download logs for a job in a workflow run by reading redirect url from workflow log response.
+async function fetchJobLogsFromWorkflow(octokit, token, job) {
+  console.log("Checking test results for the job ", job.name);
+
+  // downloadJobLogsForWorkflowRun returns a redirect to the actual logs
+  const jobLogRedirectResponse =
+    await octokit.rest.actions.downloadJobLogsForWorkflowRun({
+      accept: "application/vnd.github+json",
+      ...context.repo,
+      job_id: job.id,
+    });
+
+  // fetch the actual logs
+  const jobLogsResponse = await fetch(jobLogRedirectResponse.url, {
+    headers: {
+      Authorization: `token ${token}`,
+    },
+  });
+
+  if (!jobLogsResponse.ok) {
+    throw new Error(
+      `Failed to get logsUrl, got status ${jobLogsResponse.status}`
+    );
+  }
+
+  // this should be the check_run's raw logs including each line
+  // prefixed with a timestamp in format 2020-03-02T18:42:30.8504261Z
+  const logText = await jobLogsResponse.text();
+  const dateTimeStripped = logText
+    .split("\n")
+    .map((line) => line.substr("2020-03-02T19:39:16.8832288Z ".length));
+
+  const nextjsVersion = dateTimeStripped
+    .find((x) => x.includes("RUNNING NEXTJS VERSION:") && !x.includes("$("))
+    ?.split("RUNNING NEXTJS VERSION:")
+    .pop()
+    ?.trim();
+  const logs = dateTimeStripped.join("\n");
+
+  return { nextjsVersion, logs };
+}
 
 // An action report failed next.js integration test with --turbo
 async function run() {
@@ -14,27 +57,29 @@ async function run() {
   const prNumber = context?.payload?.pull_request?.number;
   const prSha = context?.sha;
 
-  console.log("Trying to collect integration stats for PR", {
-    prNumber,
-    sha: prSha,
-  });
+  let comments = null;
+  let existingComment = null;
 
-  if (!prNumber) {
-    info("No PR number found in context, skipping action.");
-    return;
+  if (prNumber) {
+    console.log("Trying to collect integration stats for PR", {
+      prNumber,
+      sha: prSha,
+    });
+
+    comments = await octokit.rest.issues.listComments({
+      ...context.repo,
+      issue_number: prNumber,
+    });
+
+    // Get a comment from the bot if it exists
+    existingComment = comments?.data.find(
+      (comment) =>
+        comment?.user?.login === "github-actions[bot]" &&
+        comment?.body?.includes(BOT_COMMENT_MARKER)
+    );
+  } else {
+    info("No PR number found in context, will not try to post comment.");
   }
-
-  const comments = await octokit.rest.issues.listComments({
-    ...context.repo,
-    issue_number: prNumber,
-  });
-
-  // Get a comment from the bot if it exists
-  const existingComment = comments?.data.find(
-    (comment) =>
-      comment?.user?.login === "github-actions[bot]" &&
-      comment?.body?.includes(BOT_COMMENT_MARKER)
-  );
 
   // Iterate all the jobs in the current workflow run
   console.log("Trying to collect next.js integration test logs");
@@ -64,36 +109,11 @@ async function run() {
 
   let commentToPost = "";
   for (const job of integrationTestJobs) {
-    console.log("Checking test results for the job ", job.name);
-
-    // downloadJobLogsForWorkflowRun returns a redirect to the actual logs
-    const jobLogRedirectResponse =
-      await octokit.rest.actions.downloadJobLogsForWorkflowRun({
-        accept: "application/vnd.github+json",
-        ...context.repo,
-        job_id: job.id,
-      });
-
-    // fetch the actual logs
-    const jobLogsResponse = await fetch(jobLogRedirectResponse.url, {
-      headers: {
-        Authorization: `token ${token}`,
-      },
-    });
-
-    if (!jobLogsResponse.ok) {
-      throw new Error(
-        `Failed to get logsUrl, got status ${jobLogsResponse.status}`
-      );
-    }
-
-    // this should be the check_run's raw logs including each line
-    // prefixed with a timestamp in format 2020-03-02T18:42:30.8504261Z
-    const logText = await jobLogsResponse.text();
-    const logs = logText
-      .split("\n")
-      .map((line) => line.substr("2020-03-02T19:39:16.8832288Z ".length))
-      .join("\n");
+    const { logs, nextjsVersion } = await fetchJobLogsFromWorkflow(
+      octokit,
+      token,
+      job
+    );
 
     if (
       !logs.includes(`failed to pass within`) ||
@@ -107,6 +127,14 @@ async function run() {
     const splittedLogs = logs
       .split("NEXT_INTEGRATION_TEST: true")
       .filter((log) => log.includes("--test output start--"));
+
+    // Collect all test results into single manifest to store into file. This'll allow to upload / compare test results
+    // across different runs.
+    const testResultsManifest = {
+      nextjsVersion,
+      ref: prSha,
+      result: [],
+    };
 
     // Iterate each chunk of logs, find out test name and corresponding test data
     splittedLogs.forEach((logs) => {
@@ -138,6 +166,12 @@ async function run() {
             ?.trim();
 
           testData = JSON.parse(testData);
+
+          testResultsManifest.result.push({
+            job: job.name,
+            name: failedTest,
+            data: testData,
+          });
         } catch (_) {
           console.log(`Failed to parse test data`);
         }
@@ -186,6 +220,12 @@ async function run() {
         commentToPost += `\n</details>\n`;
       }
     });
+
+    // store collected test results into file for external usage.
+    fs.writeFileSync(
+      "./nextjs-test-results.json",
+      JSON.stringify(testResultsManifest, null, 2)
+    );
   }
 
   if (!commentToPost || commentToPost.length === 0) {
@@ -194,30 +234,31 @@ async function run() {
   }
 
   try {
+    if (!prNumber) {
+      return;
+    }
+
     if (!existingComment) {
       info("No existing comment found, creating a new one");
-      await octokit.rest.issues.createComment({
+      const result = await octokit.rest.issues.createComment({
         ...context.repo,
         issue_number: prNumber,
         body: commentToPost,
       });
-      return;
+
+      console.log("Created a new comment", result.data.html_url);
     } else {
       info("Existing comment found, updating it");
-      await octokit.rest.issues.updateComment({
+      const result = await octokit.rest.issues.updateComment({
         ...context.repo,
         comment_id: existingComment.id,
         body: commentToPost,
       });
-      return;
+
+      console.log("Updated existing comment", result.data.html_url);
     }
   } catch (error) {
-    if (error.status === 403) {
-      info(
-        "No permission to create a comment. This can happen if PR is created from a fork."
-      );
-      return;
-    }
+    console.error("Failed to post comment", error);
   }
 }
 

--- a/.github/workflows/nextjs-integration-test.yml
+++ b/.github/workflows/nextjs-integration-test.yml
@@ -129,6 +129,8 @@ jobs:
           corepack disable
           pnpm install
           pnpm run build
+          # This is being used in github action to collect test results. Do not change it, or should update ./.github/actions/next-integration-test to match.
+          echo "RUNNING NEXTJS VERSION: $(packages/next/dist/bin/next --version)"
 
       - run: |
           docker run --rm -v $(pwd):/work mcr.microsoft.com/playwright:v1.28.1-focal /bin/bash -c "cd /work && ls && curl https://install-node.vercel.app/v${{ matrix.node }} | FORCE=1 bash && node -v && npm i -g pnpm@${PNPM_VERSION} && /work/next-dev --display-version && __INTERNAL_CUSTOM_TURBOPACK_BINARY=${NEXT_DEV_BIN} __INTERNAL_NEXT_DEV_TEST_TURBO_GLOB_MATCH=${NEXT_DEV_TEST_GLOB} NEXT_TEST_JOB=1 NEXT_TEST_MODE=dev xvfb-run node run-tests.js --type development --timings -g ${{ matrix.group }}/4 >> /proc/1/fd/1"
@@ -168,3 +170,22 @@ jobs:
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.NEXT_TURBO_INTEGRATION_SLACK_WEBHOOK_URL }}
+
+  # Collect integration test results from execute_tests,
+  # Store it as github artifact for next step to consume.
+  collect_nextjs_integration_stat:
+    needs: [execute_tests]
+    name: Next.js integration test status report
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Collect integration test stat
+        uses: ./.github/actions/next-integration-stat
+
+      - name: Store artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-results
+          path: nextjs-test-results.json

--- a/.github/workflows/on-default-branch-update.yml
+++ b/.github/workflows/on-default-branch-update.yml
@@ -1,0 +1,20 @@
+# A workflow supposed to run when there is a new changes committed in default branch.
+name: On Default Branch Update
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  # Trigger actual next.js integration tests.
+  next_js_integration:
+    name: Execute Next.js integration workflow
+    uses: ./.github/workflows/nextjs-integration-test.yml
+
+  # Upload test results to branch.
+  upload_test_results:
+    name: Upload test results
+    needs: [next_js_integration]
+    uses: ./.github/workflows/upload-nextjs-integration-test-results.yml
+    with:
+      is_main_branch: true

--- a/.github/workflows/on-nextjs-release-publish.yml
+++ b/.github/workflows/on-nextjs-release-publish.yml
@@ -6,6 +6,7 @@ on:
   repository_dispatch:
     # This is the event type defined by next.js upstream's `repository_dispatch` workflow dispatches.
     types: [nextjs-release-published]
+  workflow_dispatch:
 
 jobs:
   # Debug purpose, write down release version.
@@ -19,8 +20,14 @@ jobs:
   # Trigger actual next.js integration tests.
   next_js_integration:
     name: Execute Next.js integration workflow
-    needs: [determine_jobs]
-    if: needs.determine_jobs.outputs.rust == 'true' && needs.determine_jobs.outputs.push == 'true'
     uses: ./.github/workflows/nextjs-integration-test.yml
     with:
     version: ${{ github.event.client_payload.version }}
+
+  # Upload test results to branch.
+  upload_test_results:
+    name: Upload test results
+    needs: [next_js_integration]
+    uses: ./.github/workflows/upload-nextjs-integration-test-results.yml
+    with:
+      is_main_branch: false

--- a/.github/workflows/upload-nextjs-integration-test-results.yml
+++ b/.github/workflows/upload-nextjs-integration-test-results.yml
@@ -1,0 +1,59 @@
+# Reusable workflow to upload next.js integration test result to specific branch `nextjs-integration-test-data`
+# This workflow assumes `next-integration-test` workflow has been executed and test results are stored in `test-results/main` directory.
+name: Update next.js integration test results
+
+on:
+  workflow_call:
+    inputs:
+      # Boolean flag to indicate if this workflow is triggered by default branch update.
+      # If this flag is set to true, then the workflow will upload test results to subpath `/main`.
+      # Otherwise, the workflow will upload test results to subpath `/${nextjs-version}`.
+      is_main_branch:
+        required: true
+        type: boolean
+  workflow_dispatch:
+
+jobs:
+  upload_test_results:
+    name: Upload test results
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: nextjs-integration-test-data
+
+      # First, grab test results into `test-results/main` directory from artifact stored by `next-integration-test`.
+      - name: Grab test results
+        uses: actions/download-artifact@v3
+        with:
+          name: test-results
+          path: test-results/main
+
+      # Read next.js version from test results, set necessary environment variables.
+      - name: Print test results
+        run: |
+          ls -al ./test-results/main
+          cat ./test-results/main/nextjs-test-results.json
+          echo "NEXTJS_VERSION=$(cat ./test-results/${{ inputs.path }}}/nextjs-test-results.json | jq .nextjsVersion | cut -d ' ' -f2)" >> $GITHUB_ENV
+          echo "SHA_SHORT=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+          echo "RESULT_SUBPATH=$(if ${{ inputs.is_main_branch }}; then echo 'main'; else echo ${{ env.NEXTJS_VERSION }}; fi)" >> $GITHUB_ENV
+
+      # If workflow is not coming from main branch update, then we need to move test results to subpath `/${nextjs-version}`.
+      - name: Congifure subpath
+        run: |
+          echo "Configured test result subpath for ${{ env.RESULT_SUBPATH }} / ${{ env.NEXTJS_VERSION }} / ${{ env.SHA_SHORT }}"
+          mkdir -p test-results/${{ env.RESULT_SUBPATH }}
+          mv test-results/main/nextjs-test-results.json test-results/${{ env.RESULT_SUBPATH }}/$(date '+%Y%m%d%H%M')-${{ env.NEXTJS_VERSION }}-${{ env.SHA_SHORT }}.json
+          ls -al ./test-results
+          ls -al ./test-results/${{ env.RESULT_SUBPATH }}
+
+      - name: Git pull
+        run: |
+          git pull --depth=1 --no-tags origin nextjs-integration-test-data
+
+      - name: Push data to branch
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          file_pattern: test-results/**
+          commit_message: "test(integration): Integration test results for ${{ env.NEXTJS_VERSION }} (${{ env.SHA_SHORT }})"


### PR DESCRIPTION
Closes WEB-487.

This PR amends existing workflow for next-integration test to store its aggregated test results into github artifacts, then corresponding events for the running test (main branch update / new next.js release) to upload it into specific github branch `nextjs-integration-test-data`. 