### PR TITLE
fix: Skip over repo root package for package inferrence

### DIFF
--- a/cli/internal/scope/scope.go
+++ b/cli/internal/scope/scope.go
@@ -165,7 +165,8 @@ func calculateInference(repoRoot turbopath.AbsoluteSystemPath, rawPkgInferenceDi
 		if err != nil {
 			return nil, err
 		}
-		if inferredPathIsBelow {
+		// We skip over the root package as the inferred path will always be below it
+		if inferredPathIsBelow && pkgPath != repoRoot {
 			// set both. The user might have set a parent directory filter,
 			// in which case we *should* fail to find any packages, but we should
 			// do so in a consistent manner

--- a/cli/internal/scope/scope_test.go
+++ b/cli/internal/scope/scope_test.go
@@ -80,6 +80,10 @@ func TestResolvePackages(t *testing.T) {
 	graph.Connect(dag.BasicEdge("app2", "libC"))
 	graph.Connect(dag.BasicEdge("app2-a", "libC"))
 	workspaceInfos := internalGraph.WorkspaceInfos{
+		"//": {
+			Dir:  turbopath.AnchoredSystemPath("").ToSystemPath(),
+			Name: "monorepo",
+		},
 		"app0": {
 			Dir:  turbopath.AnchoredUnixPath("app/app0").ToSystemPath(),
 			Name: "app0",
@@ -142,21 +146,21 @@ func TestResolvePackages(t *testing.T) {
 		{
 			name:                "Only turbo.json changed",
 			changed:             []string{"turbo.json"},
-			expected:            []string{"app0", "app1", "app2", "app2-a", "libA", "libB", "libC", "libD"},
+			expected:            []string{"//", "app0", "app1", "app2", "app2-a", "libA", "libB", "libC", "libD"},
 			since:               "dummy",
 			includeDependencies: true,
 		},
 		{
 			name:                "Only root package.json changed",
 			changed:             []string{"package.json"},
-			expected:            []string{"app0", "app1", "app2", "app2-a", "libA", "libB", "libC", "libD"},
+			expected:            []string{"//", "app0", "app1", "app2", "app2-a", "libA", "libB", "libC", "libD"},
 			since:               "dummy",
 			includeDependencies: true,
 		},
 		{
 			name:                "Only package-lock.json changed",
 			changed:             []string{"package-lock.json"},
-			expected:            []string{"app0", "app1", "app2", "app2-a", "libA", "libB", "libC", "libD"},
+			expected:            []string{"//", "app0", "app1", "app2", "app2-a", "libA", "libB", "libC", "libD"},
 			since:               "dummy",
 			includeDependencies: true,
 			lockfile:            "package-lock.json",
@@ -164,7 +168,7 @@ func TestResolvePackages(t *testing.T) {
 		{
 			name:                "Only yarn.lock changed",
 			changed:             []string{"yarn.lock"},
-			expected:            []string{"app0", "app1", "app2", "app2-a", "libA", "libB", "libC", "libD"},
+			expected:            []string{"//", "app0", "app1", "app2", "app2-a", "libA", "libB", "libC", "libD"},
 			since:               "dummy",
 			includeDependencies: true,
 			lockfile:            "yarn.lock",
@@ -172,7 +176,7 @@ func TestResolvePackages(t *testing.T) {
 		{
 			name:                "Only pnpm-lock.yaml changed",
 			changed:             []string{"pnpm-lock.yaml"},
-			expected:            []string{"app0", "app1", "app2", "app2-a", "libA", "libB", "libC", "libD"},
+			expected:            []string{"//", "app0", "app1", "app2", "app2-a", "libA", "libB", "libC", "libD"},
 			since:               "dummy",
 			includeDependencies: true,
 			lockfile:            "pnpm-lock.yaml",
@@ -234,7 +238,7 @@ func TestResolvePackages(t *testing.T) {
 		{
 			name:       "global dependency changed, even though it was ignored, forcing a build of everything",
 			changed:    []string{"libs/libB/src/index.ts"},
-			expected:   []string{"app0", "app1", "app2", "app2-a", "libA", "libB", "libC", "libD"},
+			expected:   []string{"//", "app0", "app1", "app2", "app2-a", "libA", "libB", "libC", "libD"},
 			since:      "dummy",
 			ignore:     "libs/libB/**/*.ts",
 			globalDeps: []string{"libs/**/*.ts"},
@@ -257,7 +261,7 @@ func TestResolvePackages(t *testing.T) {
 			// no changes, no base to compare against, defaults to everything
 			name:              "no changes or scope specified, build everything",
 			since:             "",
-			expected:          []string{"app0", "app1", "app2", "app2-a", "libA", "libB", "libC", "libD"},
+			expected:          []string{"//", "app0", "app1", "app2", "app2-a", "libA", "libB", "libC", "libD"},
 			expectAllPackages: true,
 		},
 		{


### PR DESCRIPTION
Once again map iteration is the culprit. The failure of `infer_pkg.t` is caused by package inference iterating over the root package before the correct candidate package. This results in `pkgPath == repoRoot` and since `fullInferencePath` is necessarily contained in the repo root, the root package will always be selected as the exact package. The fix is just skipping over the root package.

First commit adds a root package to the tests. The package inference cases will fail in a non-deterministic fashion since this bug depends on the repo root package being iterated over before the package that should be inferred. The next commit is a fix.