### PR TITLE
enable and fix backtracing for fatal errors in tasks

### DIFF
--- a/crates/next-dev/Cargo.toml
+++ b/crates/next-dev/Cargo.toml
@@ -39,7 +39,7 @@ native-tls = ["next-core/native-tls"]
 rustls-tls = ["next-core/rustls-tls"]
 
 [dependencies]
-anyhow = "1.0.47"
+anyhow = { version = "1.0.47", features = ["backtrace"] }
 clap = { version = "4.0.18", features = ["derive", "env"], optional = true }
 console-subscriber = { version = "0.1.8", optional = true }
 futures = "0.3.25"

--- a/crates/turbo-tasks/src/util.rs
+++ b/crates/turbo-tasks/src/util.rs
@@ -1,4 +1,5 @@
 use std::{
+    any::Provider,
     fmt::{Debug, Display},
     sync::Arc,
     time::Duration,
@@ -31,7 +32,7 @@ impl std::error::Error for SharedError {
     }
 
     fn provide<'a>(&'a self, req: &mut std::any::Demand<'a>) {
-        self.inner.provide(req);
+        Provider::provide(&*self.inner, req);
     }
 }
 


### PR DESCRIPTION
Enables the anyhow backtrace feature to capture backtraces for errors too when `RUST_BACKTRACE` is enabled.

When running in release mode compiling with `CARGO_PROFILE_RELEASE_DEBUG=1` is recommended to get debug info into the errors.