### PR TITLE
@next/font/google: support setting a css variable for fonts

### DIFF
--- a/crates/next-core/src/next_font_google/options.rs
+++ b/crates/next-core/src/next_font_google/options.rs
@@ -20,7 +20,7 @@ pub struct NextFontGoogleOptions {
     pub selected_variable_axes: Option<Vec<String>>,
     pub fallback: Option<Vec<String>>,
     pub adjust_font_fallback: bool,
-    pub variable: Option<Vec<String>>,
+    pub variable: Option<String>,
     pub subsets: Option<Vec<String>>,
 }
 

--- a/crates/next-core/src/next_font_google/request.rs
+++ b/crates/next-core/src/next_font_google/request.rs
@@ -24,7 +24,7 @@ pub struct NextFontRequestArguments {
     pub fallback: Option<Vec<String>>,
     #[serde(default)]
     pub adjust_font_fallback: bool,
-    pub variable: Option<Vec<String>>,
+    pub variable: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/next-dev-tests/tests/integration/next/font-google/basic/pages/index.js
+++ b/crates/next-dev-tests/tests/integration/next/font-google/basic/pages/index.js
@@ -2,6 +2,9 @@ import { useEffect } from "react";
 import { Inter } from "@next/font/google";
 
 const interNoArgs = Inter();
+const interWithVariableName = Inter({
+  variable: "--my-font",
+});
 
 export default function Home() {
   useEffect(() => {
@@ -25,27 +28,50 @@ function runTests() {
   });
 
   it("includes a rule styling the exported className", () => {
-    const selector = `.${CSS.escape(interNoArgs.className)}`;
-
-    let matchingRule;
-    for (const stylesheet of document.querySelectorAll(
-      "link[rel=stylesheet]"
-    )) {
-      const sheet = stylesheet.sheet;
-      if (sheet == null) {
-        continue;
-      }
-
-      for (const rule of sheet.cssRules) {
-        if (rule.selectorText === selector) {
-          matchingRule = rule;
-          break;
-        }
-      }
-    }
-
+    const matchingRule = getRuleMatchingClassName(interNoArgs.className);
     expect(matchingRule).toBeTruthy();
     expect(matchingRule.style.fontFamily).toEqual("__Inter_34ab8b4d");
     expect(matchingRule.style.fontStyle).toEqual("normal");
   });
+
+  it("supports declaring a css custom property (css variable)", () => {
+    expect(interWithVariableName).toEqual({
+      className:
+        "className◽[project-with-next]/crates/next-dev-tests/tests/integration/next/font-google/basic/[embedded_modules]/@vercel/turbopack-next/internal/font/google/inter_c6e282f1.module.css",
+      style: {
+        fontFamily: "'__Inter_c6e282f1'",
+        fontStyle: "normal",
+      },
+      variable:
+        "variable◽[project-with-next]/crates/next-dev-tests/tests/integration/next/font-google/basic/[embedded_modules]/@vercel/turbopack-next/internal/font/google/inter_c6e282f1.module.css",
+    });
+
+    const matchingRule = getRuleMatchingClassName(
+      interWithVariableName.variable
+    );
+    expect(matchingRule.styleMap.get("--my-font").toString().trim()).toBe(
+      '"__Inter_c6e282f1"'
+    );
+  });
+}
+
+function getRuleMatchingClassName(className) {
+  const selector = `.${CSS.escape(className)}`;
+
+  let matchingRule;
+  for (const stylesheet of document.querySelectorAll("link[rel=stylesheet]")) {
+    const sheet = stylesheet.sheet;
+    if (sheet == null) {
+      continue;
+    }
+
+    for (const rule of sheet.cssRules) {
+      if (rule.selectorText === selector) {
+        matchingRule = rule;
+        break;
+      }
+    }
+  }
+
+  return matchingRule;
 }


### PR DESCRIPTION
Fixes WEB-501

Fixes https://github.com/vercel/turbo/issues/3139

This adds proper support for the [`variable` property](https://nextjs.org/docs/api-reference/next/font#variable) when constructing fonts. This results in:

* defining a selector in the css module for a classname defining the css custom property (css variable), whose value is the font family
* adding a `variable` property to the resulting js object whose value is the classname used in the selector above

Test Plan: Added an integration test.