### PR TITLE
Fix eslint missing next config error

### DIFF
--- a/examples/design-system/packages/eslint-config-acme/index.js
+++ b/examples/design-system/packages/eslint-config-acme/index.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: ["next", "turbo", "prettier"],
+  extends: ["turbo", "prettier"],
   rules: {
     "@next/next/no-html-link-for-pages": "off",
     "react/jsx-key": "off",


### PR DESCRIPTION
The eslint config is trying to load a next eslint config that is missing and that we don't need : 
```
Error: Failed to load parser './parser.js' declared in '.eslintrc.js » eslint-config-acme » eslint-config-next': Cannot find module 'next/dist/compiled/babel/eslint-parser'
```