### PR TITLE
Ignore non-JS chunks on the server

### DIFF
--- a/crates/turbopack-ecmascript/js/src/runtime.nodejs.js
+++ b/crates/turbopack-ecmascript/js/src/runtime.nodejs.js
@@ -4,6 +4,13 @@
 const BACKEND = {
   loadChunk(chunkPath, from) {
     return new Promise((resolve, reject) => {
+      if (!chunkPath.endsWith(".js")) {
+        // We only support loading JS chunks in Node.js.
+        // This branch can be hit when trying to load a CSS chunk.
+        resolve();
+        return;
+      }
+
       const fromPath = getFirstModuleChunk(from);
       if (fromPath == null) {
         reject(


### PR DESCRIPTION
I also considered not including invalid chunks for the current environment in the `ManifestChunkAsset`. This could use the result of the `EnvironmentVc::chunk_loading()` method. I'm partial to neither solution.