### PR TITLE
Allow controlling depth of Vc debugging

### DIFF
--- a/crates/turbo-tasks-build/src/lib.rs
+++ b/crates/turbo-tasks-build/src/lib.rs
@@ -397,23 +397,27 @@ impl<'a> RegisterContext<'a> {
 
     /// Declares the default derive of the `ValueDebug` trait.
     fn register_debug_impl(&mut self, ident: &Ident, dbg_ty: DebugType) -> std::fmt::Result {
-        let fn_ident = Ident::new("dbg", ident.span());
+        for fn_name in ["dbg", "dbg_depth"] {
+            let fn_ident = Ident::new(fn_name, ident.span());
 
-        let (impl_fn_ident, global_name) = match dbg_ty {
-            DebugType::Value => {
-                let trait_ident = Ident::new("ValueDebug", ident.span());
-                (
-                    get_trait_impl_function_ident(ident, &trait_ident, &fn_ident),
-                    self.get_global_name(&[ident, &trait_ident, &fn_ident]),
-                )
-            }
-            DebugType::Trait => (
-                get_impl_function_ident(ident, &fn_ident),
-                self.get_global_name(&[ident, &fn_ident]),
-            ),
-        };
+            let (impl_fn_ident, global_name) = match dbg_ty {
+                DebugType::Value => {
+                    let trait_ident = Ident::new("ValueDebug", ident.span());
+                    (
+                        get_trait_impl_function_ident(ident, &trait_ident, &fn_ident),
+                        self.get_global_name(&[ident, &trait_ident, &fn_ident]),
+                    )
+                }
+                DebugType::Trait => (
+                    get_impl_function_ident(ident, &fn_ident),
+                    self.get_global_name(&[ident, &fn_ident]),
+                ),
+            };
 
-        self.register(impl_fn_ident, global_name)
+            self.register(impl_fn_ident, global_name)?;
+        }
+
+        Ok(())
     }
 }
 

--- a/crates/turbo-tasks-macros/src/derive/value_debug_macro.rs
+++ b/crates/turbo-tasks-macros/src/derive/value_debug_macro.rs
@@ -17,7 +17,12 @@ pub fn derive_value_debug(input: TokenStream) -> TokenStream {
         impl turbo_tasks::debug::ValueDebug for #ident {
             #[turbo_tasks::function]
             async fn dbg(&self) -> anyhow::Result<turbo_tasks::debug::ValueDebugStringVc> {
-                self.#value_debug_format_ident().await
+                self.#value_debug_format_ident(usize::MAX).await
+            }
+
+            #[turbo_tasks::function]
+            async fn dbg_depth(&self, depth: usize) -> anyhow::Result<turbo_tasks::debug::ValueDebugStringVc> {
+                self.#value_debug_format_ident(depth).await
             }
         }
     }

--- a/crates/turbo-tasks-macros/src/value_trait_macro.rs
+++ b/crates/turbo-tasks-macros/src/value_trait_macro.rs
@@ -149,7 +149,13 @@ pub fn value_trait(args: TokenStream, input: TokenStream) -> TokenStream {
                 #[turbo_tasks::function]
                 pub async fn dbg(self) -> anyhow::Result<turbo_tasks::debug::ValueDebugStringVc> {
                     use turbo_tasks::debug::ValueDebugFormat;
-                    self.value_debug_format().try_to_value_debug_string().await
+                    self.value_debug_format(usize::MAX).try_to_value_debug_string().await
+                }
+
+                #[turbo_tasks::function]
+                pub async fn dbg_depth(self, depth: usize) -> anyhow::Result<turbo_tasks::debug::ValueDebugStringVc> {
+                    use turbo_tasks::debug::ValueDebugFormat;
+                    self.value_debug_format(depth).try_to_value_debug_string().await
                 }
             }
         }
@@ -159,10 +165,10 @@ pub fn value_trait(args: TokenStream, input: TokenStream) -> TokenStream {
 
     let value_debug_format_impl = quote! {
         impl turbo_tasks::debug::ValueDebugFormat for #ref_ident {
-            fn value_debug_format(&self) -> turbo_tasks::debug::ValueDebugFormatString {
+            fn value_debug_format(&self, depth: usize) -> turbo_tasks::debug::ValueDebugFormatString {
                 turbo_tasks::debug::ValueDebugFormatString::Async(Box::pin(async move {
                     Ok(if let Some(value_debug) = turbo_tasks::debug::ValueDebugVc::resolve_from(self).await? {
-                        format!(concat!(stringify!(#ident), "({})"), value_debug.dbg().await?.as_str())
+                        format!(concat!(stringify!(#ident), "({})"), value_debug.dbg_depth(depth).await?.as_str())
                     } else {
                         // This case means the `Vc` pointed to by this `Vc` does not implement `ValueDebug`.
                         // This could happen if we provide a way to opt-out of the default `ValueDebug` derive,

--- a/crates/turbo-tasks/src/debug/mod.rs
+++ b/crates/turbo-tasks/src/debug/mod.rs
@@ -54,13 +54,15 @@ impl ValueDebugStringVc {
 #[turbo_tasks::value_trait(no_debug)]
 pub trait ValueDebug {
     fn dbg(&self) -> ValueDebugStringVc;
+
+    fn dbg_depth(&self, depth: usize) -> ValueDebugStringVc;
 }
 
 /// Use [autoref specialization] to implement `ValueDebug` for `T: Debug`.
 ///
 /// [autoref specialization] https://github.com/dtolnay/case-studies/blob/master/autoref-specialization/README.md
 pub trait ValueDebugFormat {
-    fn value_debug_format(&self) -> ValueDebugFormatString;
+    fn value_debug_format(&self, depth: usize) -> ValueDebugFormatString;
 }
 
 // Use autoref specialization [1] to implement `ValueDebugFormat` for `T:
@@ -72,7 +74,11 @@ impl<T> ValueDebugFormat for &T
 where
     T: Debug,
 {
-    fn value_debug_format(&self) -> ValueDebugFormatString {
+    fn value_debug_format(&self, depth: usize) -> ValueDebugFormatString {
+        if depth == 0 {
+            return ValueDebugFormatString::Sync(std::any::type_name::<Self>().to_string());
+        }
+
         ValueDebugFormatString::Sync(format!("{:#?}", self))
     }
 }
@@ -81,10 +87,14 @@ impl<T> ValueDebugFormat for Option<T>
 where
     T: ValueDebugFormat,
 {
-    fn value_debug_format(&self) -> ValueDebugFormatString {
+    fn value_debug_format(&self, depth: usize) -> ValueDebugFormatString {
+        if depth == 0 {
+            return ValueDebugFormatString::Sync(std::any::type_name::<Self>().to_string());
+        }
+
         match self {
             None => ValueDebugFormatString::Sync(format!("{:#?}", Option::<()>::None)),
-            Some(value) => match value.value_debug_format() {
+            Some(value) => match value.value_debug_format(depth.saturating_sub(1)) {
                 ValueDebugFormatString::Sync(string) => ValueDebugFormatString::Sync(format!(
                     "{:#?}",
                     Some(PassthroughDebug::new_string(string))
@@ -104,10 +114,14 @@ impl<T> ValueDebugFormat for Vec<T>
 where
     T: ValueDebugFormat,
 {
-    fn value_debug_format(&self) -> ValueDebugFormatString {
+    fn value_debug_format(&self, depth: usize) -> ValueDebugFormatString {
+        if depth == 0 {
+            return ValueDebugFormatString::Sync(std::any::type_name::<Self>().to_string());
+        }
+
         let values = self
             .iter()
-            .map(|value| value.value_debug_format())
+            .map(|value| value.value_debug_format(depth.saturating_sub(1)))
             .collect::<Vec<_>>();
 
         ValueDebugFormatString::Async(Box::pin(async move {
@@ -131,10 +145,14 @@ impl<K> ValueDebugFormat for AutoSet<K>
 where
     K: ValueDebugFormat,
 {
-    fn value_debug_format(&self) -> ValueDebugFormatString {
+    fn value_debug_format(&self, depth: usize) -> ValueDebugFormatString {
+        if depth == 0 {
+            return ValueDebugFormatString::Sync(std::any::type_name::<Self>().to_string());
+        }
+
         let values = self
             .iter()
-            .map(|item| item.value_debug_format())
+            .map(|item| item.value_debug_format(depth.saturating_sub(1)))
             .collect::<Vec<_>>();
 
         ValueDebugFormatString::Async(Box::pin(async move {
@@ -159,10 +177,19 @@ where
     K: Debug,
     V: ValueDebugFormat,
 {
-    fn value_debug_format(&self) -> ValueDebugFormatString {
+    fn value_debug_format(&self, depth: usize) -> ValueDebugFormatString {
+        if depth == 0 {
+            return ValueDebugFormatString::Sync(std::any::type_name::<Self>().to_string());
+        }
+
         let values = self
             .iter()
-            .map(|(key, value)| (format!("{:#?}", key), value.value_debug_format()))
+            .map(|(key, value)| {
+                (
+                    format!("{:#?}", key),
+                    value.value_debug_format(depth.saturating_sub(1)),
+                )
+            })
             .collect::<Vec<_>>();
 
         ValueDebugFormatString::Async(Box::pin(async move {
@@ -187,10 +214,19 @@ where
     K: Debug,
     V: ValueDebugFormat,
 {
-    fn value_debug_format(&self) -> ValueDebugFormatString {
+    fn value_debug_format(&self, depth: usize) -> ValueDebugFormatString {
+        if depth == 0 {
+            return ValueDebugFormatString::Sync(std::any::type_name::<Self>().to_string());
+        }
+
         let values = self
             .iter()
-            .map(|(key, value)| (format!("{:#?}", key), value.value_debug_format()))
+            .map(|(key, value)| {
+                (
+                    format!("{:#?}", key),
+                    value.value_debug_format(depth.saturating_sub(1)),
+                )
+            })
             .collect::<Vec<_>>();
 
         ValueDebugFormatString::Async(Box::pin(async move {
@@ -215,9 +251,13 @@ macro_rules! tuple_impls {
         impl<$($name: ValueDebugFormat),+> ValueDebugFormat for ($($name,)+)
         {
             #[allow(non_snake_case)]
-            fn value_debug_format(&self) -> ValueDebugFormatString {
+            fn value_debug_format(&self, depth: usize) -> ValueDebugFormatString {
+                if depth == 0 {
+                    return ValueDebugFormatString::Sync(std::any::type_name::<Self>().to_string());
+                }
+
                 let ($($name,)+) = self;
-                let ($($name,)+) = ($($name.value_debug_format(),)+);
+                let ($($name,)+) = ($($name.value_debug_format(depth.saturating_sub(1)),)+);
 
                 ValueDebugFormatString::Async(Box::pin(async move {
                     let values = ($(PassthroughDebug::new_string($name.try_to_string().await?),)+);

--- a/crates/turbo-tasks/src/debug/mod.rs
+++ b/crates/turbo-tasks/src/debug/mod.rs
@@ -55,6 +55,7 @@ impl ValueDebugStringVc {
 pub trait ValueDebug {
     fn dbg(&self) -> ValueDebugStringVc;
 
+    /// Like `dbg`, but with a depth limit.
     fn dbg_depth(&self, depth: usize) -> ValueDebugStringVc;
 }
 

--- a/crates/turbo-tasks/src/read_ref.rs
+++ b/crates/turbo-tasks/src/read_ref.rs
@@ -53,9 +53,9 @@ impl<T, U: TraceRawVcs> TraceRawVcs for ReadRef<T, U> {
 }
 
 impl<T, U: ValueDebugFormat + 'static> ValueDebugFormat for ReadRef<T, U> {
-    fn value_debug_format(&self) -> ValueDebugFormatString {
+    fn value_debug_format(&self, depth: usize) -> ValueDebugFormatString {
         let value = &**self;
-        value.value_debug_format()
+        value.value_debug_format(depth)
     }
 }
 


### PR DESCRIPTION
Adds a mechanism for controlling the depth of `Vc` debugging, to avoid printing out huge structs when we're only interested in some superficial overview of it.

This will only affect `Vc`s: if a `Vc` contains a non-`Vc`, very deep struct, the struct will be fully printed out. This is because you can't control the printing depth of the default Rust `Debug` trait.

Marking this as a draft for now as I intend to change the name and arguments of `dbg_depth`.

```rust
eprintln!("{:?}", some_vc.dbg_depth(2).await?) // will now only print up to a depth of 2
```

