### PR TITLE
docs: mentioned missing info regarding putting npm organization while…

### DIFF
--- a/docs/pages/repo/docs/handbook/workspaces.mdx
+++ b/docs/pages/repo/docs/handbook/workspaces.mdx
@@ -147,6 +147,43 @@ For instance, if we want `apps/docs` to import `packages/shared-utils`, we'd nee
   of our packages change.
 </Callout>
 
+However if `shared-utils` includes an npm organization or user space in its name, for instance if it is named `@mycompany/shared-utils` in its `package.json` as described in the previous section, then you'll import it as follows:
+
+<Tabs items={['npm', 'yarn', 'pnpm']} storageKey="selected-pkg-manager">
+  <Tab>
+
+```json filename="apps/docs/package.json"
+{
+  "dependencies": {
+    "@mycompany/shared-utils": "*"
+  }
+}
+```
+
+  </Tab>
+  <Tab>
+```json filename="apps/docs/package.json"
+{
+  "dependencies": {
+    "@mycompany/shared-utils": "*"
+  }
+}
+```
+
+  </Tab>
+
+  <Tab>
+```json filename="apps/docs/package.json"
+{
+  "dependencies": {
+    "@mycompany/shared-utils": "workspace:*"
+  }
+}
+```
+
+  </Tab>
+</Tabs>
+
 Just like a normal package, we'd need to run `install` from root afterwards. Once installed, we can use the workspace as if it were any other package from `node_modules`. See our [section on sharing code](/repo/docs/handbook/sharing-code) for more information.
 
 ## Managing workspaces


### PR DESCRIPTION
… importing workspace

For coherence on the page, I mentioned the missing information of adding the npm organization or user space as well if it is there in the imported workspace's `package.json` file as part of it's `name` during import of a workspace in another workspace.

For example, if it is `@mycompany/shared-utils` instead of `shared-utils`.

This case is not mentioned in the 'Workspaces which depend on each other' section.

Currently the 'Workspaces which depend on each other' section only explains the case where npm organization or user space is not part of the imported workspace's `name`