### PR TITLE
ci: allow opting-in to a dry run for stage 3 of release

### DIFF
--- a/.github/workflows/turborepo-release-step-1.yml
+++ b/.github/workflows/turborepo-release-step-1.yml
@@ -1,3 +1,23 @@
+# Turborepo Release Pipeline
+#
+# This release consists of 3 steps. The first, is this one.
+#
+# 1. Kick off the release flow with a manual workflow_dispatch
+#    which increments the version and creates a new branch,
+#    with a commit incrementing version.go as well as version.txt.
+#    For more detail, see stage-release in cli/Makefile
+# 2. Stage two takes the newly-created staging branch and compiles
+#    a production go build, the artifacts for which are stored
+#    in the build cache
+# 3. Stage three, if it has not successfully run before, builds
+#    the rust binaries, and then finally loads both of them
+#    into a new container where the final npm package assembly
+#    is performed. If opting-in to a dry run, the tarballs will
+#    be uploaded and the build will terminate. If it is _not_ a
+#    dry run, it will first check for previously-built artifacts
+#    to avoid re-building. That way you can test the exact tar-
+#    balls that will be used in the final release.
+
 name: 1. Turborepo Release (release branch)
 
 # TODO: Once we have confidence with the release process, add an

--- a/.github/workflows/turborepo-release-step-3.yml
+++ b/.github/workflows/turborepo-release-step-3.yml
@@ -5,6 +5,9 @@ on:
     inputs:
       release_branch:
         description: "Staging branch to run release from"
+      dry_run:
+        description: "Do a dry run, skipping the final publish step. The outputs of a previous dry-run will be reused when uploading properly, but you can delete the old ones to force a re-build."
+        type: boolean
 
 env:
   RELEASE_TURBO_CLI: true
@@ -47,11 +50,22 @@ jobs:
         with:
           ref: "${{ inputs.release_branch }}"
 
+      - name: Attempt to download release artifacts
+        uses: dawidd6/action-download-artifact@v2
+        id: cached-release
+        with:
+          name: turbo-${{ matrix.settings.target }}
+          path: target/${{ matrix.settings.target }}/release/turbo*
+          github_token: ${{secrets.TURBOBOT}}
+          branch: ${{ inputs.release_branch }}
+          if_no_artifact_found: ignore
+
       - name: Setup Container
-        if: ${{ matrix.settings.container-setup }}
+        if: ${{ !steps.cached-release.outputs.found_artifact && matrix.settings.container-setup }}
         run: ${{ matrix.settings.container-setup }}
 
       - name: Rust Setup
+        if: ${{ !steps.cached-release.outputs.found_artifact }}
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -60,10 +74,11 @@ jobs:
 
       - name: Build Setup
         shell: bash
-        if: ${{ matrix.settings.setup }}
+        if: ${{ !steps.cached-release.outputs.found_artifact && matrix.settings.setup }}
         run: ${{ matrix.settings.setup }}
 
       - name: Build
+        if: ${{ !steps.cached-release.outputs.found_artifact }}
         run: ${{ matrix.settings.rust-build-env }} cargo build --release -p turbo --features rustls-tls --target ${{ matrix.settings.target }}
 
       - name: Upload Artifacts
@@ -93,6 +108,16 @@ jobs:
           git config --global user.name 'Turbobot'
           git config --global user.email 'turbobot@vercel.com'
 
+      - name: Attempt to download release artifacts
+        uses: dawidd6/action-download-artifact@v2
+        id: cached-release
+        with:
+          name: turbo-combined
+          path: cli/dist
+          github_token: ${{secrets.TURBOBOT}}
+          branch: ${{ inputs.release_branch }}
+          if_no_artifact_found: ignore
+
       - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@v3
         with:
@@ -103,11 +128,13 @@ jobs:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
 
       - name: Download Rust artifacts
+        if: ${{ steps.cached-release.outputs.found_artifact }}
         uses: actions/download-artifact@v3
         with:
           path: rust-artifacts
 
       - name: Move Rust artifacts into place
+        if: ${{ steps.cached-release.outputs.found_artifact }}
         run: |
           mv rust-artifacts/turbo-aarch64-apple-darwin cli/dist-darwin-arm64
           mv rust-artifacts/turbo-aarch64-unknown-linux-musl cli/dist-linux-arm64
@@ -117,7 +144,7 @@ jobs:
           mv rust-artifacts/turbo-x86_64-pc-windows-gnu cli/dist-windows-amd64
 
       - name: Download Go artifacts
-        id: download-artifact
+        if: ${{ steps.cached-release.outputs.found_artifact }}
         uses: dawidd6/action-download-artifact@v2
         with:
           github_token: ${{secrets.TURBOBOT}}
@@ -125,10 +152,9 @@ jobs:
           workflow_conclusion: success
           branch: ${{ inputs.release_branch }}
           path: go-artifacts
-          skip_unpack: false
-          if_no_artifact_found: fail
 
       - name: Move Go artifacts into place
+        if: ${{ steps.cached-release.outputs.found_artifact }}
         run: |
           mv go-artifacts/turbo-go-cross-${{ inputs.release_branch }}/turbo_linux_amd64_v1/bin/* cli/dist-linux-amd64
           chmod a+x cli/dist-linux-amd64/turbo
@@ -150,7 +176,7 @@ jobs:
           chmod a+x cli/dist-darwin-arm64/go-turbo
 
       - name: Perform Release
-        run: cd cli && make publish-turbo
+        run: cd cli && make publish-turbo SKIP_PUBLISH=${{ inputs.dry_run && '--skip-publish' || '' }}
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -174,6 +200,7 @@ jobs:
         run: echo ::set-output name=version::$(head -n 1 version.txt)
       - name: Create pull request
         uses: thomaseizinger/create-pull-request@master
+        if: ${{ !inputs.dry_run }}
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           head: ${{ inputs.release_branch }}

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -190,7 +190,7 @@ publish-turbo: clean build
 	npm config set --location=project "//registry.npmjs.org/:_authToken" $(NPM_TOKEN)
 
 	# Publishes the native npm modules.
-	goreleaser release --rm-dist -f combined-shim.yml
+	goreleaser release --rm-dist -f combined-shim.yml $(SKIP_PUBLISH)
 
 	# Split packing from the publish step so that npm locates the correct .npmrc file.
 	cd $(CLI_DIR)/../packages/turbo && pnpm pack --pack-destination=$(CLI_DIR)/../
@@ -198,12 +198,14 @@ publish-turbo: clean build
 	cd $(CLI_DIR)/../packages/turbo-codemod && pnpm pack --pack-destination=$(CLI_DIR)/../
 	cd $(CLI_DIR)/../packages/turbo-ignore && pnpm pack --pack-destination=$(CLI_DIR)/../
 
+ifneq ($(SKIP_PUBLISH),--skip-publish)
 	# Publish the remaining JS packages in order to avoid race conditions.
 	cd $(CLI_DIR)/../
 	npm publish -ddd --tag $(TURBO_TAG) $(CLI_DIR)/../turbo-$(TURBO_VERSION).tgz
 	npm publish -ddd --tag $(TURBO_TAG) $(CLI_DIR)/../create-turbo-$(TURBO_VERSION).tgz
 	npm publish -ddd --tag $(TURBO_TAG) $(CLI_DIR)/../turbo-codemod-$(TURBO_VERSION).tgz
 	npm publish -ddd --tag $(TURBO_TAG) $(CLI_DIR)/../turbo-ignore-$(TURBO_VERSION).tgz
+endif
 
 demo/lage: install
 	node $(CLI_DIR)/scripts/generate.mjs lage


### PR DESCRIPTION
This adds an additional flag into the workflow that allows you to run a dry run of the release process, skipping the final publish step. The artifacts can be downloaded and tested, and a subsequent run on the same branch will download those prebuilt binaries rather than starting from scratch. For an example, see:

1. https://github.com/arlyon/turbo/actions/runs/4026998158 (dry run)