### PR TITLE
Align ids and data attributes with Next.js's redbox

### DIFF
--- a/crates/next-core/js/src/dev/hmr-client.ts
+++ b/crates/next-core/js/src/dev/hmr-client.ts
@@ -266,6 +266,14 @@ function handleSocketMessage(msg: ServerMessage) {
   }
 
   if (runHooks) onBuildOk();
+
+  // This is used by the Next.js integration test suite to notify it when HMR
+  // updates have been completed.
+  // TODO: Only run this in test environments (gate by `process.env.__NEXT_TEST_MODE`)
+  if (globalThis.__NEXT_HMR_CB) {
+    globalThis.__NEXT_HMR_CB();
+    globalThis.__NEXT_HMR_CB = null;
+  }
 }
 
 export function subscribeToChunkUpdate(

--- a/crates/next-core/js/src/overlay/internal/components/CodeFrame/CodeFrame.tsx
+++ b/crates/next-core/js/src/overlay/internal/components/CodeFrame/CodeFrame.tsx
@@ -64,7 +64,7 @@ export function CodeFrame({ stackFrame, codeFrame }: CodeFrameProps) {
 
   // TODO: make the caret absolute
   return (
-    <div className="codeframe">
+    <div data-nextjs-codeframe className="codeframe">
       <div>
         <p
           role="link"

--- a/crates/next-core/js/src/overlay/internal/components/Dialog/DialogHeader.tsx
+++ b/crates/next-core/js/src/overlay/internal/components/Dialog/DialogHeader.tsx
@@ -54,7 +54,7 @@ export function DialogHeader({
   }, [close, buttonClose]);
 
   return (
-    <div className={clsx("dialog-header", className)}>
+    <div data-nextjs-dialog-header className={clsx("dialog-header", className)}>
       {children}
       <div className="filler">&nbsp;</div>
       {close ? (

--- a/crates/next-core/js/src/overlay/internal/components/Terminal/Terminal.tsx
+++ b/crates/next-core/js/src/overlay/internal/components/Terminal/Terminal.tsx
@@ -13,7 +13,7 @@ export function Terminal({ content }: TerminalProps) {
   }, [content]);
 
   return (
-    <div className="terminal">
+    <div data-nextjs-terminal className="terminal">
       <pre>
         {decoded.map((entry, index) => (
           <span

--- a/crates/next-core/js/src/overlay/internal/components/Toast/Toast.tsx
+++ b/crates/next-core/js/src/overlay/internal/components/Toast/Toast.tsx
@@ -8,8 +8,14 @@ export type ToastProps = React.PropsWithChildren & {
 
 export function Toast({ onClick, children, className }: ToastProps) {
   return (
-    <div onClick={onClick} className={clsx("toast", className)}>
-      <div className="toast-wrapper">{children}</div>
+    <div
+      data-nextjs-toast
+      onClick={onClick}
+      className={clsx("toast", className)}
+    >
+      <div data-nextjs-toast-wrapper className="toast-wrapper">
+        {children}
+      </div>
     </div>
   );
 }

--- a/crates/next-core/js/src/overlay/internal/container/Errors.tsx
+++ b/crates/next-core/js/src/overlay/internal/container/Errors.tsx
@@ -203,8 +203,8 @@ export function Errors({ issues, errors }: ErrorsProps) {
 
   return (
     <ErrorsDialog
-      aria-labelledby="errors_label"
-      aria-describedby="errors_desc"
+      aria-labelledby="nextjs__container_errors_label"
+      aria-describedby="nextjs__container_errors_desc"
       onClose={isClosable ? minimize : undefined}
     >
       <Tabs

--- a/crates/next-core/js/src/overlay/internal/container/RuntimeError.tsx
+++ b/crates/next-core/js/src/overlay/internal/container/RuntimeError.tsx
@@ -210,7 +210,7 @@ export function RuntimeErrorsDialogBody({
         data-hidden={hidden}
         className={clsx("runtime-errors", className)}
       >
-        <h1 id="errors_label">Resolving Source Maps...</h1>
+        <h1 id="nextjs__container_errors_label">Resolving Source Maps...</h1>
       </DialogBody>
     );
   }
@@ -236,7 +236,7 @@ export function RuntimeErrorsDialogBody({
       className={clsx("runtime-errors", className)}
     >
       <div className="title-pagination">
-        <h1 id="errors_label">
+        <h1 id="nextjs__container_errors_label">
           {isServerError ? "Server Error" : "Unhandled Runtime Error"}
         </h1>
         <LeftRightDialogHeader
@@ -250,7 +250,7 @@ export function RuntimeErrorsDialogBody({
           </small>
         </LeftRightDialogHeader>
       </div>
-      <h2 id="errors_desc" data-severity="error">
+      <h2 id="nextjs__container_errors_desc" data-severity="error">
         {activeError.error.name}:{" "}
         <HotlinkedText
           text={decodeMagicIdentifiers(activeError.error.message)}

--- a/crates/next-core/js/src/overlay/internal/container/TurbopackIssue.tsx
+++ b/crates/next-core/js/src/overlay/internal/container/TurbopackIssue.tsx
@@ -40,7 +40,7 @@ export function TurbopackIssuesDialogBody({
       className={clsx("issues-body", className)}
     >
       <div className="title-pagination">
-        <h1 id="errors_label">
+        <h1 id="nextjs__container_errors_label">
           {hasIssueWithError
             ? "Turbopack failed to compile"
             : "Turbopack compiled with warnings"}
@@ -58,7 +58,7 @@ export function TurbopackIssuesDialogBody({
       </div>
 
       <h2
-        id="errors_desc"
+        id="nextjs__container_errors_desc"
         data-severity={activeIssueIsError ? "error" : "warning"}
       >
         {activeIssue.title}

--- a/crates/turbopack-ecmascript/js/types/index.d.ts
+++ b/crates/turbopack-ecmascript/js/types/index.d.ts
@@ -87,6 +87,9 @@ export type ChunkUpdateProvider = {
 };
 
 export interface TurbopackGlobals {
+  // This is used by the Next.js integration test suite to notify it when HMR
+  // updates have been completed.
+  __NEXT_HMR_CB?: null | (() => void);
   TURBOPACK?: ChunkRegistration[];
   TURBOPACK_CHUNK_UPDATE_LISTENERS?:
     | ChunkUpdateProvider


### PR DESCRIPTION
Next.js's integration test suite depends on these ids and data attributes to select against items in running test pages. This gets us passing some of those tests.