### PR TITLE
Allow manual workflow dispatch and send a basic message through Slack

### DIFF
--- a/.github/workflows/nextjs-integration-test.yml
+++ b/.github/workflows/nextjs-integration-test.yml
@@ -13,6 +13,7 @@ on:
       version:
         required: false
         type: string
+  workflow_dispatch:
 
 jobs:
   # Build debug build of next-dev to use in integration test.
@@ -156,3 +157,14 @@ jobs:
         env:
           RECORD_REPLAY_METADATA_TEST_RUN_TITLE: testIntegration / Group ${{ matrix.group }}
           NEXT_INTEGRATION_TEST: true
+
+      - name: Send test data to Slack workflow
+        id: slack
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          payload: |
+            {
+              "text": "Hello from Next.js+Turbo integration tests!"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.NEXT_TURBO_INTEGRATION_SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
This:

* adds `workflow_dispatch` to `on` for the integration test workflow
* adds a basic Slack message that's sent when integration tests complete

It seems like we have to land this change before manual workflow runs become available in the GitHub UI.