### PR TITLE
Reduce memory usage when writing files

### DIFF
--- a/crates/node-file-trace/src/lib.rs
+++ b/crates/node-file-trace/src/lib.rs
@@ -629,7 +629,7 @@ async fn create_module_asset(
     let env = EnvironmentVc::new(
         Value::new(ExecutionEnvironment::NodeJsLambda(
             NodeJsEnvironment {
-                cwd: OptionStringVc::cell(process_cwd.clone()),
+                cwd: OptionStringVc::cell(process_cwd),
                 ..Default::default()
             }
             .into(),

--- a/crates/turbo-tasks-fs/src/attach.rs
+++ b/crates/turbo-tasks-fs/src/attach.rs
@@ -141,6 +141,11 @@ impl FileSystem for AttachedFileSystem {
     }
 
     #[turbo_tasks::function]
+    fn track(self_vc: AttachedFileSystemVc, path: FileSystemPathVc) -> CompletionVc {
+        self_vc.get_inner_fs_path(path).track()
+    }
+
+    #[turbo_tasks::function]
     fn write(
         self_vc: AttachedFileSystemVc,
         path: FileSystemPathVc,

--- a/crates/turbo-tasks-fs/src/embed/fs.rs
+++ b/crates/turbo-tasks-fs/src/embed/fs.rs
@@ -74,6 +74,11 @@ impl FileSystem for EmbeddedFileSystem {
     }
 
     #[turbo_tasks::function]
+    fn track(&self, _path: FileSystemPathVc) -> CompletionVc {
+        CompletionVc::immutable()
+    }
+
+    #[turbo_tasks::function]
     fn write(&self, _path: FileSystemPathVc, _content: FileContentVc) -> Result<CompletionVc> {
         bail!("Writing is not possible to the embedded filesystem")
     }

--- a/crates/turbo-tasks-fs/src/lib.rs
+++ b/crates/turbo-tasks-fs/src/lib.rs
@@ -53,7 +53,7 @@ use turbo_tasks::{
     primitives::{BoolVc, StringReadRef, StringVc},
     spawn_thread,
     trace::TraceRawVcs,
-    CompletionVc, Invalidator, ValueToString, ValueToStringVc,
+    turbo_tasks, CompletionVc, Invalidator, RawVc, ValueToString, ValueToStringVc,
 };
 use turbo_tasks_hash::hash_xxh3_hash64;
 use util::{join_path, normalize_path, sys_to_unix, unix_to_sys};
@@ -474,8 +474,8 @@ impl FileSystem for DiskFileSystem {
     ) -> Result<CompletionVc> {
         let full_path = self.to_sys_path(fs_path).await?;
         let content = content.await?;
-        let old_content = fs_path
-            .read()
+        let old_content = RawVc::from(fs_path.read())
+            .into_read_untracked(&*turbo_tasks())
             .await
             .with_context(|| format!("reading old content of {}", full_path.display()))?;
 

--- a/crates/turbo-tasks-fs/src/lib.rs
+++ b/crates/turbo-tasks-fs/src/lib.rs
@@ -476,7 +476,7 @@ impl FileSystem for DiskFileSystem {
     #[turbo_tasks::function]
     async fn track(&self, fs_path: FileSystemPathVc) -> Result<CompletionVc> {
         let full_path = self.to_sys_path(fs_path).await?;
-        self.register_invalidator(&full_path, true);
+        self.register_invalidator(full_path, true);
         Ok(CompletionVc::new())
     }
 

--- a/crates/turbopack-core/src/server_fs.rs
+++ b/crates/turbopack-core/src/server_fs.rs
@@ -34,6 +34,11 @@ impl FileSystem for ServerFileSystem {
     }
 
     #[turbo_tasks::function]
+    fn track(&self, _fs_path: FileSystemPathVc) -> Result<CompletionVc> {
+        bail!("Tracking is not possible to the marker filesystem for the server")
+    }
+
+    #[turbo_tasks::function]
     fn write(&self, _fs_path: FileSystemPathVc, _content: FileContentVc) -> Result<CompletionVc> {
         bail!("Writing is not possible to the marker filesystem for the server")
     }

--- a/crates/turbopack-node/src/evaluate.rs
+++ b/crates/turbopack-node/src/evaluate.rs
@@ -390,7 +390,7 @@ async fn dir_dependency_shallow(glob: ReadGlobResultVc) -> Result<CompletionVc> 
         // Reading all files to add itself as dependency
         match *item {
             DirectoryEntry::File(file) => {
-                file.read().await?;
+                file.track().await?;
             }
             DirectoryEntry::Directory(dir) => {
                 dir_dependency(dir.read_glob(GlobVc::new("**"), false)).await?;


### PR DESCRIPTION
This PR reduces the our total memory usage (hopefully) for files that we write to disk.

When we write a file, we obviously have the input bytes (the bytes we want to write to disk). But we also read the file to see if the file needs to be written at all. This means we have _another_ copy of the bytes, the ones that came from the disk.

Worse, our write is strongly dependent on the read's `RopeVc`. Meaning we're stuck with that read memory until some indeterminate time. And any time we update the written contents, we're gonna get more bytes stuck in our Vc cache.

The goal here is to track the file, so that we can rewrite it if it's modified/deleted. Why not have an API specific to tracking, without actually reading any contents? This PR does exactly that. And now that we don't need to read contents to track, we can avoid using the `read()` API (and its `RopeVc`) in order to do our new-old contents comparison.

