### PR TITLE
Add print_task_invalidation feature

### DIFF
--- a/crates/auto-hash-map/src/set.rs
+++ b/crates/auto-hash-map/src/set.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::hash_map::RandomState,
-    fmt::Debug,
+    fmt::{Debug, Display},
     hash::{BuildHasher, Hash},
     marker::PhantomData,
 };
@@ -18,6 +18,20 @@ impl<K, H> Default for AutoSet<K, H> {
     fn default() -> Self {
         Self {
             map: Default::default(),
+        }
+    }
+}
+
+impl<K: Display, H> Display for AutoSet<K, H> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.is_empty() {
+            write!(f, "{{}}")
+        } else {
+            write!(f, "{{ ")?;
+            for i in self.iter() {
+                Display::fmt(i, f)?;
+            }
+            write!(f, " }}")
         }
     }
 }

--- a/crates/auto-hash-map/src/set.rs
+++ b/crates/auto-hash-map/src/set.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::hash_map::RandomState,
-    fmt::{Debug, Display},
+    fmt::Debug,
     hash::{BuildHasher, Hash},
     marker::PhantomData,
 };
@@ -18,20 +18,6 @@ impl<K, H> Default for AutoSet<K, H> {
     fn default() -> Self {
         Self {
             map: Default::default(),
-        }
-    }
-}
-
-impl<K: Display, H> Display for AutoSet<K, H> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if self.is_empty() {
-            write!(f, "{{}}")
-        } else {
-            write!(f, "{{ ")?;
-            for i in self.iter() {
-                Display::fmt(i, f)?;
-            }
-            write!(f, " }}")
         }
     }
 }

--- a/crates/turbo-tasks-memory/Cargo.toml
+++ b/crates/turbo-tasks-memory/Cargo.toml
@@ -43,6 +43,7 @@ log_activate_tasks = []
 log_connect_tasks = []
 report_expensive = []
 print_scope_updates = []
+print_task_invalidation = []
 
 [[bench]]
 name = "mod"

--- a/crates/turbo-tasks-memory/src/memory_backend.rs
+++ b/crates/turbo-tasks-memory/src/memory_backend.rs
@@ -316,7 +316,7 @@ impl Backend for MemoryBackend {
         turbo_tasks: &dyn TurboTasksBackendApi,
     ) {
         self.with_task(task, |task| {
-            task.execution_result(result, turbo_tasks);
+            task.execution_result(result, self, turbo_tasks);
         })
     }
 

--- a/crates/turbo-tasks/src/backend.rs
+++ b/crates/turbo-tasks/src/backend.rs
@@ -1,6 +1,7 @@
 use std::{
     any::Any,
     borrow::Cow,
+    fmt,
     fmt::{Debug, Display},
     future::Future,
     pin::Pin,
@@ -73,6 +74,19 @@ pub enum PersistentTaskType {
     /// The method call will do a cache lookup and might resolve arguments
     /// before.
     ResolveTrait(TraitTypeId, Cow<'static, str>, Vec<TaskInput>),
+}
+
+impl Display for PersistentTaskType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Native(fid, _) | Self::ResolveNative(fid, _) => {
+                Display::fmt(&registry::get_function(*fid).name, f)
+            }
+            Self::ResolveTrait(tid, n, _) => {
+                write!(f, "{}::{n}", registry::get_trait(*tid).name)
+            }
+        }
+    }
 }
 
 impl PersistentTaskType {


### PR DESCRIPTION
I used this to track down the infinite looping behavior #3525 and #3526. Running `cargo run --features print_task_invalidation --bin next-dev` will print something similar to:

```
invalidated Task { id: 16875, name: ConditionalContentSource::get }
Task { id: 16875, name: ConditionalContentSource::get } invalidates:
	Task { id: 16873, name: CombinedContentSource::get }
	Task { id: 16832, name: CombinedContentSource::get }
	Task { id: 16815, name: CombinedContentSource::get }
	Task { id: 16807, name: CombinedContentSource::get }
	Task { id: 15384, name: get_from_source }
invalidated Task { id: 16873, name: CombinedContentSource::get }
invalidated Task { id: 16832, name: CombinedContentSource::get }
invalidated Task { id: 16815, name: CombinedContentSource::get }
invalidated Task { id: 16807, name: CombinedContentSource::get }
invalidated Task { id: 15384, name: get_from_source }
invalidated Task { id: 71537, name: DiskFileSystem::read }
invalidated Task { id: 71517, name: DiskFileSystem::write }
invalidated Task { id: 72217, name: DiskFileSystem::read }
invalidated Task { id: 72214, name: DiskFileSystem::write }