### PR TITLE
Return a 404 status code when a data route is `.notFound`

### DIFF
--- a/crates/next-core/js/src/internal/page-server-handler.tsx
+++ b/crates/next-core/js/src/internal/page-server-handler.tsx
@@ -206,6 +206,8 @@ export default function startHandler({
       if (isDataReq) {
         return {
           type: "response",
+          // Returning a 404 status code is required for the client-side router
+          // to redirect to the error page.
           statusCode: 404,
           body: '{"notFound":true}',
           headers: [["Content-Type", MIME_APPLICATION_JAVASCRIPT]],

--- a/crates/next-core/js/src/internal/page-server-handler.tsx
+++ b/crates/next-core/js/src/internal/page-server-handler.tsx
@@ -206,7 +206,7 @@ export default function startHandler({
       if (isDataReq) {
         return {
           type: "response",
-          statusCode,
+          statusCode: 404,
           body: '{"notFound":true}',
           headers: [["Content-Type", MIME_APPLICATION_JAVASCRIPT]],
         };


### PR DESCRIPTION
Returning a 404 status code is required for the client-side router to redirect to the error page.