### PR TITLE
docs: add quotes to directory filter with glob

### DIFF
--- a/docs/pages/repo/docs/core-concepts/monorepos/filtering.mdx
+++ b/docs/pages/repo/docs/core-concepts/monorepos/filtering.mdx
@@ -105,11 +105,11 @@ turbo run build --filter=my-app^...
 Useful for when you want to target a specific directory, not a workspace name. It supports:
 
 - Exact matches: `--filter=./apps/docs`
-- Globs: `--filter=./apps/*`
+- Globs: `--filter='./apps/*'`
 
 ```sh
 # Build all of the workspaces in the 'apps' directory
-turbo run build --filter=./apps/*
+turbo run build --filter='./apps/*'
 ```
 
 #### Combining with other syntaxes


### PR DESCRIPTION
As reported in #3480 pnpm seems to intercept filter syntax before it reaches turbo if a package script uses `--filter=./dir/*` without quotes.

Since quotes are also required to use a directory with a glob via ZSH it seems to make sense to add them to our docs.