### PR TITLE
Remove feature that runs all known tasks when none are specified

### DIFF
--- a/cli/internal/core/engine.go
+++ b/cli/internal/core/engine.go
@@ -61,12 +61,6 @@ type EngineBuildingOptions struct {
 func (e *Engine) Prepare(options *EngineBuildingOptions) error {
 	pkgs := options.Packages
 	tasks := options.TaskNames
-	if len(tasks) == 0 {
-		// TODO(gsoltis): Is this behavior used?
-		for key := range e.Tasks {
-			tasks = append(tasks, key)
-		}
-	}
 
 	if err := e.generateTaskGraph(pkgs, tasks, options.TasksOnly); err != nil {
 		return err

--- a/cli/internal/fs/package_json.go
+++ b/cli/internal/fs/package_json.go
@@ -64,7 +64,13 @@ func ReadPackageJSON(path turbopath.AbsoluteSystemPath) (*PackageJSON, error) {
 	if err != nil {
 		return nil, err
 	}
-	return UnmarshalPackageJSON(b)
+	pkg, err := UnmarshalPackageJSON(b)
+
+	if err != nil {
+		return nil, err
+	}
+	pkg.Dir = turbopath.AnchoredSystemPath(path.Dir())
+	return pkg, nil
 }
 
 // UnmarshalPackageJSON decodes a byte slice into a PackageJSON struct


### PR DESCRIPTION
This condition is never hit, because at least one task is required by turbo run