### PR TITLE
ci(workflow): store plain text test summary

### DIFF
--- a/.github/actions/next-integration-stat/tsconfig.json
+++ b/.github/actions/next-integration-stat/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "target": "es2015",
+    "moduleResolution": "node"
+  }
+}

--- a/.github/workflows/nextjs-integration-test.yml
+++ b/.github/workflows/nextjs-integration-test.yml
@@ -190,4 +190,6 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: test-results
-          path: nextjs-test-results.json
+          path: |
+            nextjs-test-results.json
+            test-summary.md


### PR DESCRIPTION
Requires https://github.com/vercel/turbo/pull/3534

Partially progresses WEB-460

This PR creates a plain text summary, so subsequent workflow can download it via download-artifact then broadcast as needed. We'll use it to posting into Slack channel. Action will only generate text file when we supposed to report (currently, release-to-release) so if download-artifact does not contain text-summary.md, it can skip to broadcast into Slack channel.
