### PR TITLE
fix: bring back tty into ci detection

### DIFF
--- a/cli/internal/ui/ui.go
+++ b/cli/internal/ui/ui.go
@@ -20,7 +20,7 @@ const ansiEscapeStr = "[\u001B\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[a-zA-
 var IsTTY = isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd())
 
 // IsCI is true when we appear to be running in a non-interactive context.
-var IsCI = ci.IsCi()
+var IsCI = !IsTTY || ci.IsCi()
 var gray = color.New(color.Faint)
 var bold = color.New(color.Bold)
 var ERROR_PREFIX = color.New(color.Bold, color.FgRed, color.ReverseVideo).Sprint(" ERROR ")


### PR DESCRIPTION
#3586 changed how we calculate `IsCI` and dropped the `!IsTTY` start to the calculation. This breaks our cmdutil tests as they require the `IsCI` flag to be true when the test is running.

We need `IsCI` to be true otherwise we won't look at `VERCEL_ARTIFACTS_TOKEN` as a possible token source.