### PR TITLE
Automate nightly Turbopack release tagging

### DIFF
--- a/.github/workflows/turbopack-nightly-release.yml
+++ b/.github/workflows/turbopack-nightly-release.yml
@@ -29,6 +29,10 @@ jobs:
           # commits from Turborepo, but that'd require a custom
           # action.
           custom_release_rules: ""
+          # Ensure we generate prerelease versions, not stables.
+          release_branches: ""
+          pre_release_branches: "main"
+          append_to_pre_release_tag: "alpha"
 
       - name: Create GitHub release
         uses: ncipollo/release-action@v1

--- a/.github/workflows/turbopack-nightly-release.yml
+++ b/.github/workflows/turbopack-nightly-release.yml
@@ -23,6 +23,12 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           commit_sha: ${{ steps.green_commit.outputs.result }}
           tag_prefix: "turbopack-"
+          # Override the default conventional commit messages
+          # so that we always generate patch releases.
+          # This would be easier if we could filter Turbopack
+          # commits from Turborepo, but that'd require a custom
+          # action.
+          custom_release_rules: ""
 
       - name: Create GitHub release
         uses: ncipollo/release-action@v1

--- a/.github/workflows/turbopack-nightly-release.yml
+++ b/.github/workflows/turbopack-nightly-release.yml
@@ -32,11 +32,11 @@ jobs:
           # Ensure we generate prerelease versions, not stables.
           release_branches: ""
           pre_release_branches: "main"
-          append_to_pre_release_tag: "alpha"
+          append_to_pre_release_tag: "nightly"
 
       - name: Create GitHub release
         uses: ncipollo/release-action@v1
         with:
           tag: ${{ steps.tag_version.outputs.new_tag }}
           name: Turbopack Release ${{ steps.tag_version.outputs.new_tag }}
-          body: ${{ steps.tag_version.outputs.changelog }}
+          omitBody: true

--- a/.github/workflows/turbopack-nightly-release.yml
+++ b/.github/workflows/turbopack-nightly-release.yml
@@ -1,0 +1,32 @@
+name: Turobpack Nightly Release
+
+on:
+  schedule:
+    - cron: "15 8 * * *" # Run every day at 00:15 PST
+  workflow_dispatch:
+
+jobs:
+  turbopack_nightly:
+    name: Cut nightly Turbopack release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout latest commit that passes CI
+        uses: talentpair/last-green-commit-action@d95cfa8
+        id: green_commit
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Tag nightly
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v6.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          commit_sha: ${{ steps.green_commit.outputs.result }}
+          tag_prefix: "turbopack-"
+
+      - name: Create GitHub release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ steps.tag_version.outputs.new_tag }}
+          name: Turbopack Release ${{ steps.tag_version.outputs.new_tag }}
+          body: ${{ steps.tag_version.outputs.changelog }}


### PR DESCRIPTION
This adds a new workflow which automatically releases nightly versions of turbopack. Coupled with https://github.com/vercel/next.js/pull/45506, we'll be able to fully automate our release process into Next.js.

1. The process kicks of with cron every midnight-ish PST.
2. We find the latest commit that passes CI
3. We bump the latest tag version (more on this in a bit)
4. We generate a new GH release with this version

The automated tagging version will break with our current `turbopack-YYMMDD.XYZ` release process just a bit. The tag action that I'm using can't generate a date-like tag, it can only handle semver (with optional prefix). So I've set it up to generate `turbopack-MAJOR.MINOR.PATCH-nightly.XYZ` tags. The `turbopack-` here differentiates us from Turborepo, and the `nightly` tag denotes this a non-release software.

I hope that I've configured this correctly to always bump patches, but I'm not 100% confident until it runs.

Fixes WEB-502
