### PR TITLE
Share request resolving logic between http and update servers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,9 +318,9 @@ checksum = "7a40729d2133846d9ed0ea60a8b9541bccddab49cd30f0715a1da672fe9a2524"
 
 [[package]]
 name = "async-trait"
-version = "0.1.63"
+version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff18d764974428cf3a9328e23fc5c986f5fbed46e6cd4cdf42544df5d297ec1"
+checksum = "1cd7fce9ba8c3c042128ce72d8b2ddbf3a05747efb67ea0313c635e10bda47a2"
 dependencies = [
  "proc-macro2 1.0.50",
  "quote 1.0.23",

--- a/crates/next-core/js/src/internal/page-server-handler.tsx
+++ b/crates/next-core/js/src/internal/page-server-handler.tsx
@@ -218,7 +218,7 @@ export default function startHandler({
         type: "rewrite",
         // _next/404 is a Turbopack-internal route that will always redirect to
         // the 404 page.
-        path: "_next/404",
+        path: "/_next/404",
       };
     }
 

--- a/crates/turbopack-dev-server/src/http.rs
+++ b/crates/turbopack-dev-server/src/http.rs
@@ -1,0 +1,153 @@
+use anyhow::Result;
+use futures::{StreamExt, TryStreamExt};
+use hyper::{header::HeaderName, Request, Response};
+use mime_guess::mime;
+use turbo_tasks::TransientInstance;
+use turbo_tasks_fs::{FileContent, FileContentReadRef};
+use turbopack_cli_utils::issue::ConsoleUiVc;
+use turbopack_core::asset::AssetContent;
+
+use crate::source::{
+    request::SourceRequest,
+    resolve::{resolve_source_request, ResolveSourceRequestResult},
+    Body, Bytes, ContentSourceVc, HeaderListReadRef, ProxyResultReadRef,
+};
+
+#[turbo_tasks::value(serialization = "none")]
+enum GetFromSourceResult {
+    Static {
+        content: FileContentReadRef,
+        status_code: u16,
+        headers: HeaderListReadRef,
+    },
+    HttpProxy(ProxyResultReadRef),
+    NotFound,
+}
+
+/// Resolves a [SourceRequest] within a [super::ContentSource], returning the
+/// corresponding content as a
+#[turbo_tasks::function]
+async fn get_from_source(
+    source: ContentSourceVc,
+    request: TransientInstance<SourceRequest>,
+    console_ui: ConsoleUiVc,
+) -> Result<GetFromSourceResultVc> {
+    Ok(
+        match &*resolve_source_request(source, request, console_ui).await? {
+            ResolveSourceRequestResult::Static(static_content_vc) => {
+                let static_content = static_content_vc.await?;
+                if let AssetContent::File(file) = &*static_content.content.content().await? {
+                    GetFromSourceResult::Static {
+                        content: file.await?,
+                        status_code: static_content.status_code,
+                        headers: static_content.headers.await?,
+                    }
+                } else {
+                    GetFromSourceResult::NotFound
+                }
+            }
+            ResolveSourceRequestResult::HttpProxy(proxy) => {
+                GetFromSourceResult::HttpProxy(proxy.await?)
+            }
+            ResolveSourceRequestResult::NotFound => GetFromSourceResult::NotFound,
+        }
+        .cell(),
+    )
+}
+
+/// Processes an HTTP request within a given content source and returns the
+/// response.
+pub async fn process_request_with_content_source(
+    source: ContentSourceVc,
+    request: Request<hyper::Body>,
+    console_ui: ConsoleUiVc,
+) -> Result<Response<hyper::Body>> {
+    let original_path = request.uri().path().to_string();
+    let request = http_request_to_source_request(request).await?;
+    let result = get_from_source(source, TransientInstance::new(request), console_ui);
+    match &*result.strongly_consistent().await? {
+        GetFromSourceResult::Static {
+            content,
+            status_code,
+            headers,
+        } => {
+            if let FileContent::Content(file) = &**content {
+                let mut response = Response::builder().status(*status_code);
+
+                let header_map = response.headers_mut().expect("headers must be defined");
+
+                for (header_name, header_value) in &*headers {
+                    header_map.append(
+                        HeaderName::try_from(header_name.clone())?,
+                        hyper::header::HeaderValue::try_from(header_value.as_str())?,
+                    );
+                }
+
+                if let Some(content_type) = file.content_type() {
+                    header_map.append(
+                        "content-type",
+                        hyper::header::HeaderValue::try_from(content_type.to_string())?,
+                    );
+                } else if let hyper::header::Entry::Vacant(entry) = header_map.entry("content-type")
+                {
+                    let guess = mime_guess::from_path(&original_path).first_or_octet_stream();
+                    // If a text type, application/javascript, or application/json was
+                    // guessed, use a utf-8 charset as  we most likely generated it as
+                    // such.
+                    entry.insert(hyper::header::HeaderValue::try_from(
+                        if (guess.type_() == mime::TEXT
+                            || guess.subtype() == mime::JAVASCRIPT
+                            || guess.subtype() == mime::JSON)
+                            && guess.get_param("charset").is_none()
+                        {
+                            guess.to_string() + "; charset=utf-8"
+                        } else {
+                            guess.to_string()
+                        },
+                    )?);
+                }
+
+                let content = file.content();
+                header_map.insert(
+                    "Content-Length",
+                    hyper::header::HeaderValue::try_from(content.len().to_string())?,
+                );
+
+                let bytes = content.read();
+                return Ok(response.body(hyper::Body::wrap_stream(bytes))?);
+            }
+        }
+        GetFromSourceResult::HttpProxy(proxy_result) => {
+            let mut response = Response::builder().status(proxy_result.status);
+            let headers = response.headers_mut().expect("headers must be defined");
+
+            for [name, value] in proxy_result.headers.array_chunks() {
+                headers.append(
+                    HeaderName::from_bytes(name.as_bytes())?,
+                    hyper::header::HeaderValue::from_str(value)?,
+                );
+            }
+
+            return Ok(response.body(hyper::Body::wrap_stream(proxy_result.body.read()))?);
+        }
+        _ => {}
+    }
+
+    Ok(Response::builder().status(404).body(hyper::Body::empty())?)
+}
+
+async fn http_request_to_source_request(request: Request<hyper::Body>) -> Result<SourceRequest> {
+    let (parts, body) = request.into_parts();
+
+    let bytes: Vec<_> = body
+        .map(|bytes| bytes.map(Bytes::from))
+        .try_collect::<Vec<_>>()
+        .await?;
+
+    Ok(SourceRequest {
+        method: parts.method.to_string(),
+        uri: parts.uri,
+        headers: parts.headers,
+        body: Body::new(bytes),
+    })
+}

--- a/crates/turbopack-dev-server/src/source/request.rs
+++ b/crates/turbopack-dev-server/src/source/request.rs
@@ -1,0 +1,16 @@
+use hyper::{HeaderMap, Uri};
+
+use super::Body;
+
+/// A request to a content source.
+#[derive(Debug, Clone)]
+pub struct SourceRequest {
+    /// The HTTP method to use.
+    pub method: String,
+    /// The URI to request.
+    pub uri: Uri,
+    /// The headers to send.
+    pub headers: HeaderMap<hyper::header::HeaderValue>,
+    /// The body to send.
+    pub body: Body,
+}

--- a/crates/turbopack-dev-server/src/source/resolve.rs
+++ b/crates/turbopack-dev-server/src/source/resolve.rs
@@ -1,0 +1,152 @@
+use std::{
+    collections::btree_map::Entry,
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+use anyhow::{bail, Result};
+use hyper::Uri;
+use turbo_tasks::{TransientInstance, Value};
+use turbopack_cli_utils::issue::ConsoleUiVc;
+
+use super::{
+    headers::{HeaderValue, Headers},
+    query::Query,
+    request::SourceRequest,
+    ContentSourceContent, ContentSourceDataVary, ContentSourceResult, ContentSourceVc,
+    ProxyResultVc, StaticContentVc,
+};
+use crate::{handle_issues, source::ContentSourceData};
+
+/// The result of [`resolve_source_request`]. Similar to a
+/// `ContentSourceContent`, but without the `Rewrite` variant as this is taken
+/// care in the function.
+#[turbo_tasks::value(serialization = "none")]
+pub enum ResolveSourceRequestResult {
+    NotFound,
+    Static(StaticContentVc),
+    HttpProxy(ProxyResultVc),
+}
+
+/// Resolves a [SourceRequest] within a [super::ContentSource], returning the
+/// corresponding content.
+#[turbo_tasks::function]
+pub async fn resolve_source_request(
+    source: ContentSourceVc,
+    request: TransientInstance<SourceRequest>,
+    console_ui: ConsoleUiVc,
+) -> Result<ResolveSourceRequestResultVc> {
+    let mut data = ContentSourceData::default();
+    let mut current_source = source;
+    // Remove leading slash.
+    let original_path = request.uri.path().to_string();
+    let mut current_asset_path = urlencoding::decode(&original_path[1..])?.into_owned();
+    let mut request_overwrites = (*request).clone();
+    loop {
+        let result = current_source.get(&current_asset_path, Value::new(data));
+        handle_issues(
+            result,
+            &original_path,
+            "get content from source",
+            console_ui,
+        )
+        .await?;
+
+        match &*result.strongly_consistent().await? {
+            ContentSourceResult::NotFound => break Ok(ResolveSourceRequestResult::NotFound.cell()),
+            ContentSourceResult::NeedData(needed) => {
+                current_source = needed.source.resolve().await?;
+                current_asset_path = needed.path.clone();
+                data = request_to_data(&mut request_overwrites, &needed.vary).await?;
+            }
+            ContentSourceResult::Result { get_content, .. } => {
+                let content_vary = get_content.vary().await?;
+                let content_data = request_to_data(&mut request_overwrites, &content_vary).await?;
+                let content = get_content.get(Value::new(content_data));
+                match &*content.await? {
+                    ContentSourceContent::Rewrite(rewrite) => {
+                        let rewrite = rewrite.await?;
+                        // If a source isn't specified, we restart at the top.
+                        let new_source = rewrite.source.unwrap_or(source);
+                        let new_uri = Uri::try_from(&rewrite.path_and_query)?;
+                        if new_source == current_source && new_uri == request_overwrites.uri {
+                            bail!("rewrite loop detected: {}", new_uri);
+                        }
+                        let new_asset_path =
+                            urlencoding::decode(&new_uri.path()[1..])?.into_owned();
+
+                        current_source = new_source;
+                        request_overwrites.uri = new_uri;
+                        current_asset_path = new_asset_path;
+                        data = ContentSourceData::default();
+                    } // _ => ,
+                    ContentSourceContent::NotFound => {
+                        break Ok(ResolveSourceRequestResult::NotFound.cell())
+                    }
+                    ContentSourceContent::Static(static_content) => {
+                        break Ok(ResolveSourceRequestResult::Static(*static_content).cell())
+                    }
+                    ContentSourceContent::HttpProxy(proxy_result) => {
+                        break Ok(ResolveSourceRequestResult::HttpProxy(*proxy_result).cell())
+                    }
+                }
+            }
+        }
+    }
+}
+
+static CACHE_BUSTER: AtomicU64 = AtomicU64::new(0);
+
+async fn request_to_data(
+    request: &SourceRequest,
+    vary: &ContentSourceDataVary,
+) -> Result<ContentSourceData> {
+    let mut data = ContentSourceData::default();
+    if vary.method {
+        data.method = Some(request.method.clone());
+    }
+    if vary.url {
+        data.url = Some(request.uri.to_string());
+    }
+    if vary.body {
+        data.body = Some(request.body.clone().into());
+    }
+    if let Some(filter) = vary.query.as_ref() {
+        if let Some(query) = request.uri.query() {
+            let mut query: Query = serde_qs::from_str(query)?;
+            query.filter_with(filter);
+            data.query = Some(query);
+        } else {
+            data.query = Some(Query::default())
+        }
+    }
+    if let Some(filter) = vary.headers.as_ref() {
+        let mut headers = Headers::default();
+        for (header_name, header_value) in request.headers.iter() {
+            if !filter.contains(header_name.as_str()) {
+                continue;
+            }
+            match headers.entry(header_name.to_string()) {
+                Entry::Vacant(e) => {
+                    if let Ok(s) = header_value.to_str() {
+                        e.insert(HeaderValue::SingleString(s.to_string()));
+                    } else {
+                        e.insert(HeaderValue::SingleBytes(header_value.as_bytes().to_vec()));
+                    }
+                }
+                Entry::Occupied(mut e) => {
+                    if let Ok(s) = header_value.to_str() {
+                        e.get_mut().extend_with_string(s.to_string());
+                    } else {
+                        e.get_mut()
+                            .extend_with_bytes(header_value.as_bytes().to_vec());
+                    }
+                }
+            }
+        }
+        data.headers = Some(headers);
+    }
+    if vary.cache_buster {
+        data.cache_buster = CACHE_BUSTER.fetch_add(1, Ordering::SeqCst);
+    }
+    Ok(data)
+}

--- a/crates/turbopack-dev-server/src/source/source_maps.rs
+++ b/crates/turbopack-dev-server/src/source/source_maps.rs
@@ -78,7 +78,7 @@ impl ContentSource for SourceMapContentSource {
             _ => return Ok(ContentSourceResultVc::not_found()),
         };
         let file = match &*content {
-            ContentSourceContent::Static { content: f, .. } => *f,
+            ContentSourceContent::Static(static_content) => static_content.await?.content,
             _ => return Ok(ContentSourceResultVc::not_found()),
         };
 

--- a/crates/turbopack-node/src/render/render_static.rs
+++ b/crates/turbopack-node/src/render/render_static.rs
@@ -118,14 +118,14 @@ async fn run_static_operation(
             .context("receiving from node.js process")?
         {
             RenderStaticIncomingMessage::Rewrite { path } => {
-                StaticResultVc::rewrite(RewriteVc::new(path))
+                StaticResultVc::rewrite(RewriteVc::new_path_query(path))
             }
             RenderStaticIncomingMessage::Response {
                 status_code,
                 headers,
                 body,
             } => StaticResultVc::content(
-                FileContent::Content({ File::from(body) }.into()).into(),
+                FileContent::Content(File::from(body)).into(),
                 status_code,
                 HeaderListVc::cell(headers),
             ),

--- a/crates/turbopack-node/src/source_map/content_source.rs
+++ b/crates/turbopack-node/src/source_map/content_source.rs
@@ -88,7 +88,7 @@ impl ContentSource for NextSourceMapTraceContentSource {
             _ => return Ok(ContentSourceResultVc::not_found()),
         };
         let file = match &*content {
-            ContentSourceContent::Static { content: f, .. } => *f,
+            ContentSourceContent::Static(static_content) => static_content.await?.content,
             _ => return Ok(ContentSourceResultVc::not_found()),
         };
 


### PR DESCRIPTION
With the addition of the Next.js routing layer at the root of our content sources, we need the update server to also be able to follow Next.js rewrites, like the HTTP server.

This requires the following:
* Rewrites need to be able to indicate a source where to "resume" after rewriting. Otherwise, we would enter an infinite loop of the Next.js layer rewriting to the Next.js layer.
* The resolving logic from `process_request_with_content_source` needs to be extracted into its own function, so it may be called both from the HTTP server (which expects fully resolved `ReadRef`s) and the update server (which needs a `VersionedContentVc`): this is where `resolve_source_request` comes in.