### PR TITLE
Support for getStaticPaths.fallback = false

### DIFF
--- a/crates/next-core/js/src/internal/page-server-handler.tsx
+++ b/crates/next-core/js/src/internal/page-server-handler.tsx
@@ -92,10 +92,13 @@ export default function startHandler({
         configFileName: "next.config.js",
       });
 
+      // We provide a dummy base URL to the URL constructor so that it doesn't
+      // throw when we pass a relative URL.
+      const resolvedPath = new URL(renderData.url, "next://").pathname;
       if (
         prerenderFallback === false &&
         // TODO(alexkirsz) Strip basePath.
-        !prerenderRoutes.includes(renderData.url)
+        !prerenderRoutes.includes(resolvedPath)
       ) {
         return createNotFoundResponse(isDataReq);
       }


### PR DESCRIPTION
Adds support for `getStaticPaths` returning `{ fallback: false }` by building out all static paths and checking whether the resolved path is included in that list.

`buildStaticPaths` requires the `next.config.js` path, as well as other config options such as locale. I created WEB-546 to track being able to pass them to the handlers.