### PR TITLE
fix outstanding clippy lints

### DIFF
--- a/crates/turbopack-ecmascript/src/chunk/mod.rs
+++ b/crates/turbopack-ecmascript/src/chunk/mod.rs
@@ -512,11 +512,7 @@ impl EcmascriptChunkContentEntryVc {
                 issue.as_issue().emit();
                 let mut code = CodeBuilder::default();
                 code += "(() => {{\n\n";
-                write!(
-                    code,
-                    "throw new Error({error});\n",
-                    error = &js_error_message
-                )?;
+                writeln!(code, "throw new Error({error});", error = &js_error_message)?;
                 code += "\n}})";
                 code.build().cell()
             }

--- a/crates/turbopack-node/src/render/render_static.rs
+++ b/crates/turbopack-node/src/render/render_static.rs
@@ -125,7 +125,7 @@ async fn run_static_operation(
                 headers,
                 body,
             } => StaticResultVc::content(
-                FileContent::Content({ File::from(body) }.into()).into(),
+                FileContent::Content(File::from(body)).into(),
                 status_code,
                 HeaderListVc::cell(headers),
             ),


### PR DESCRIPTION
Two minor issues that clippy complains about.

```
cargo clippy
    Blocking waiting for file lock on package cache
warning: using `write!()` with a format string that ends in a single newline
   --> crates/turbopack-ecmascript/src/chunk/mod.rs:515:17
    |
515 | /                 write!(
516 | |                     code,
517 | |                     "throw new Error({error});\n",
518 | |                     error = &js_error_message
519 | |                 )?;
    | |_________________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#write_with_newline
    = note: `#[warn(clippy::write_with_newline)]` on by default
help: use `writeln!` instead
    |
515 ~                 writeln!(
516 |                     code,
517 ~                     "throw new Error({error});",
    |

warning: `turbopack-ecmascript` (lib) generated 1 warning
warning: useless conversion to the same type: `turbo_tasks_fs::File`
   --> crates/turbopack-node/src/render/render_static.rs:128:38
    |
128 |                 FileContent::Content({ File::from(body) }.into()).into(),
    |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `.into()`: `{ File::from(body) }`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_conversion
    = note: `#[warn(clippy::useless_conversion)]` on by default
```