### PR TITLE
always allow to close the error overlay

### DIFF
--- a/crates/next-core/js/src/overlay/internal/container/Errors.tsx
+++ b/crates/next-core/js/src/overlay/internal/container/Errors.tsx
@@ -182,7 +182,10 @@ export function Errors({ issues, errors }: ErrorsProps) {
   const hasServerError = readyErrors.some((err) =>
     ["server", "edge-server"].includes(getErrorSource(err.error) || "")
   );
-  const isClosable = !isLoading && !hasIssueWithError && !hasServerError;
+
+  // TODO for now it's already closable, but in future we might want to block users from using a broken app
+  // const isClosable = !isLoading && !hasIssueWithError && !hasServerError;
+  const isClosable = true;
 
   const defaultTab =
     hasIssueWithError || !hasErrors


### PR DESCRIPTION
It's difficult to test an app, if a single error blocks using the whole page.

Therefore, error overlay should always be closeable.