### PR TITLE
docs: Increase sidebar text contrast in dark mode

### DIFF
--- a/docs/custom.css
+++ b/docs/custom.css
@@ -6,6 +6,15 @@ code {
   filter: invert(1) brightness(1.8);
 }
 
+/*
+ * Increase the contrast of this text (used in the left sidebar) in dark mode to be WCAG AA compliant.
+ * Nextra does not expose a way of customizing just this color without creating a new theme, so use custom
+ * css. Includes the class name in the selector twice to increase specificity without using `!important`.
+ */
+html[class~="dark"] .dark\:nx-text-neutral-500.dark\:nx-text-neutral-500 {
+  color: rgba(150, 150, 150, var(--tw-text-opacity));
+}
+
 @font-face {
   font-family: "Space Grotesk";
   font-style: normal;


### PR DESCRIPTION
This increases the contrast of the sidebar text against its dark background by slightly lightening it. It now passes WCAG AA guidelines.

Test Plan: https://webaim.org/resources/contrastchecker/
