### PR TITLE
Various Rope updates and fixes

### DIFF
--- a/crates/turbo-tasks-fs/src/rope.rs
+++ b/crates/turbo-tasks-fs/src/rope.rs
@@ -375,8 +375,8 @@ impl From<Box<[RopeElem]>> for InnerRope {
             // It's important that an InnerRope never contain an empty Bytes section.
             for el in els.iter() {
                 match el {
-                    RopeElem::Local(b) => debug_assert!(!b.is_empty(), "must not have empty Bytes"),
-                    RopeElem::Shared(s) => {
+                    Local(b) => debug_assert!(!b.is_empty(), "must not have empty Bytes"),
+                    Shared(s) => {
                         // We check whether the shared slice is empty, and not its elements. The
                         // only way to construct the Shared's InnerRope is
                         // in this mod, and we have already checked that


### PR DESCRIPTION
Updates and fixes a few items:
- Fix: Prevents a Rope from containing an empty `Bytes` section
- Perf: Use a `Box<[RopeElem]>` instead of a `Vec<RopeElem>`, reducing memory useage
- Perf: Implement fast path for `Rope::to_str()` when containing a single `Shared` element

The first one is the important change. The assumption while iterating (for streaming, equality checks, etc) is that the only time we can hit an empty `Bytes` section is when we reach the end of the entire Rope. If an empty section is hit in the middle of a rope, we can't tell if we've reached the end or we're in the middle without calling N more times (eg, what if an empty section followed an empty section, then we'd need to call 2 more times to see).