### PR TITLE
Check for root tasks when needed, rather than from a cache

### DIFF
--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -409,11 +409,6 @@ func buildTaskGraphEngine(
 ) (*core.Engine, error) {
 	engine := core.NewEngine(g, isSinglePackage)
 
-	// Note: g.Pipeline is a map, but this for loop only cares about the keys
-	for taskName := range g.Pipeline {
-		engine.AddTask(taskName)
-	}
-
 	if err := engine.Prepare(&core.EngineBuildingOptions{
 		Packages:  rs.FilteredPkgs.UnsafeListOfStrings(),
 		TaskNames: rs.Targets,


### PR DESCRIPTION
This operation is just checking a string, so it should be fairly fast and we don't need a cache for it. The benefit of making this change is that we can drop one more usage of the global Pipeline from the root turbo config, and evaluate this more lazily