### PR TITLE
Import Next's CJS AsyncLocalStorage modules

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ default-members = [
   "crates/next-binding",
   "crates/next-core",
   "crates/next-dev",
+  "crates/next-dev-tests",
   "crates/next-transform-dynamic",
   "crates/next-transform-strip-page-exports",
   "crates/node-file-trace",

--- a/crates/next-core/js/src/entry/app-renderer.tsx
+++ b/crates/next-core/js/src/entry/app-renderer.tsx
@@ -238,7 +238,9 @@ async function runOperation(renderData: RenderData) {
     body = result.toUnchunkedString();
   }
   return {
-    headers: [["Content-Type", result.contentType() ?? MIME_TEXT_HTML_UTF8]],
+    headers: [
+      ["Content-Type", result.contentType() ?? MIME_TEXT_HTML_UTF8],
+    ] as [string, string][],
     body,
   };
 }

--- a/crates/next-core/js/src/entry/app/layout-entry.tsx
+++ b/crates/next-core/js/src/entry/app/layout-entry.tsx
@@ -2,9 +2,9 @@ export { default as AppRouter } from "next/dist/client/components/app-router.js"
 export { default as LayoutRouter } from "next/dist/client/components/layout-router.js";
 export { default as RenderFromTemplateContext } from "next/dist/client/components/render-from-template-context.js";
 export { default as GlobalError } from "next/dist/client/components/error-boundary.js";
-export { staticGenerationAsyncStorage } from "next/dist/esm/client/components/static-generation-async-storage.js";
-export { requestAsyncStorage } from "next/dist/esm/client/components/request-async-storage.js";
-import * as serverHooks from "next/dist/esm/client/components/hooks-server-context.js";
+export { staticGenerationAsyncStorage } from "next/dist/client/components/static-generation-async-storage.js";
+export { requestAsyncStorage } from "next/dist/client/components/request-async-storage.js";
+import * as serverHooks from "next/dist/client/components/hooks-server-context.js";
 export { serverHooks };
 export { renderToReadableStream } from "next/dist/compiled/react-server-dom-webpack/server.browser";
 

--- a/crates/next-core/js/src/entry/edge-bootstrap.ts
+++ b/crates/next-core/js/src/entry/edge-bootstrap.ts
@@ -1,6 +1,6 @@
 declare const PAGE: string;
 
-import { adapter, enhanceGlobals } from "next/dist/esm/server/web/adapter";
+import { adapter, enhanceGlobals } from "next/dist/server/web/adapter";
 
 enhanceGlobals();
 

--- a/crates/next-core/js/types/modules.d.ts
+++ b/crates/next-core/js/types/modules.d.ts
@@ -1,4 +1,4 @@
-declare module "next/dist/esm/client/components/static-generation-async-storage.js";
-declare module "next/dist/esm/client/components/request-async-storage.js";
-declare module "next/dist/esm/client/components/hooks-server-context.js";
+declare module "next/dist/client/components/static-generation-async-storage.js";
+declare module "next/dist/client/components/request-async-storage.js";
+declare module "next/dist/client/components/hooks-server-context.js";
 declare module "next/dist/compiled/react-server-dom-webpack/server.browser";

--- a/crates/next-dev-tests/tests/integration/next/app/async-local-storage/input/app/layout.tsx
+++ b/crates/next-dev-tests/tests/integration/next/app/async-local-storage/input/app/layout.tsx
@@ -1,0 +1,12 @@
+import { cookies } from "next/headers";
+
+export default function RootLayout({ children }: { children: any }) {
+  return (
+    <html>
+      <body>
+        {JSON.stringify(cookies(), null, 2)}
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/crates/next-dev-tests/tests/integration/next/app/async-local-storage/input/app/page.tsx
+++ b/crates/next-dev-tests/tests/integration/next/app/async-local-storage/input/app/page.tsx
@@ -1,0 +1,9 @@
+import Test from "./test";
+
+export default function Page() {
+  return (
+    <div>
+      <Test />
+    </div>
+  );
+}

--- a/crates/next-dev-tests/tests/integration/next/app/async-local-storage/input/app/test.tsx
+++ b/crates/next-dev-tests/tests/integration/next/app/async-local-storage/input/app/test.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { useEffect } from "react";
+
+export default function Test() {
+  useEffect(() => {
+    import("@turbo/pack-test-harness").then(() => {
+      it("should run", () => {});
+    });
+    return () => {};
+  }, []);
+}

--- a/crates/next-dev-tests/tests/integration/next/app/async-local-storage/input/next.config.js
+++ b/crates/next-dev-tests/tests/integration/next/app/async-local-storage/input/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  experimental: {
+    appDir: true,
+  },
+};


### PR DESCRIPTION
The node evaluation always renders with `type: "commonjs"` and `require()` calls, so we'll always import the CJS files. But here we're importing the ESM files. That means we have 2 distinct instances of `requestAsyncStorage` in our node instance, and they cannot properly communicate with the other.

Fixes WEB-543