### PR TITLE
split tests into two steps, report ok and done separately

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1081,7 +1081,7 @@ jobs:
             local name=$2
             if [ "$result" = "cancelled" ]; then
               cancelled=true
-            elif [ "$result" != "success" && "$result" != "skipped" ]; then
+            elif [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
               echo "- $name" >> failures.md
               failure=true
             fi
@@ -1198,7 +1198,7 @@ jobs:
             local name=$2
             if [ "$result" = "cancelled" ]; then
               cancelled=true
-            elif [ "$result" != "success" && "$result" != "skipped" ]; then
+            elif [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
               echo "- $name" >> failures.md
               failure=true
             fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1086,19 +1086,19 @@ jobs:
               failure=true
             fi
           }
-          subjob needs.determine_jobs.result "Determining jobs"
-          subjob needs.go_lint.result "Go lints"
-          subjob needs.go_unit.result "Go unit tests"
-          subjob needs.go_examples.result "Go examples"
-          subjob needs.go_e2e.result "Go e2e tests"
-          subjob needs.go_integration.result "Go integration tests"
-          subjob needs.rust_prepare.result "Rust prepare"
-          subjob needs.rust_lint.result "Rust lints"
-          subjob needs.rust_check.result "Rust checks"
-          subjob needs.turbopack_rust_test1.result "Turbopack Rust tests (linux)"
-          subjob needs.turborepo_rust_test.result "TurboRepo Rust tests"
-          subjob needs.turbopack_rust_test_bench1.result "Turbopack Rust benchmark tests (linux)"
-          subjob needs.format_lint.result "Formatting"
+          subjob ${{needs.determine_jobs.result}} "Determining jobs"
+          subjob ${{needs.go_lint.result}} "Go lints"
+          subjob ${{needs.go_unit.result}} "Go unit tests"
+          subjob ${{needs.go_examples.result}} "Go examples"
+          subjob ${{needs.go_e2e.result}} "Go e2e tests"
+          subjob ${{needs.go_integration.result}} "Go integration tests"
+          subjob ${{needs.rust_prepare.result}} "Rust prepare"
+          subjob ${{needs.rust_lint.result}} "Rust lints"
+          subjob ${{needs.rust_check.result}} "Rust checks"
+          subjob ${{needs.turbopack_rust_test1.result}} "Turbopack Rust tests (linux)"
+          subjob ${{needs.turborepo_rust_test.result}} "TurboRepo Rust tests"
+          subjob ${{needs.turbopack_rust_test_bench1.result}} "Turbopack Rust benchmark tests (linux)"
+          subjob ${{needs.format_lint.result}} "Formatting"
           if [ "$cancelled" = "true" ]; then
              echo "cancelled=true" >> $GITHUB_OUTPUT
           elif [ "$failure" = "true" ]; then
@@ -1196,6 +1196,7 @@ jobs:
           subjob () {
             local result=$1
             local name=$2
+            echo "$name: $result"
             if [ "$result" = "cancelled" ]; then
               cancelled=true
             elif [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
@@ -1203,25 +1204,25 @@ jobs:
               failure=true
             fi
           }
-          subjob needs.determine_jobs.result "Determining jobs"
-          subjob needs.go_lint.result "Go lints"
-          subjob needs.go_unit.result "Go unit tests"
-          subjob needs.go_examples.result "Go examples"
-          subjob needs.go_e2e.result "Go e2e tests"
-          subjob needs.go_integration.result "Go integration tests"
-          subjob needs.rust_prepare.result "Rust prepare"
-          subjob needs.rust_lint.result "Rust lints"
-          subjob needs.rust_check.result "Rust checks"
-          subjob needs.turbopack_rust_test1.result "Turbopack Rust tests (linux)"
-          subjob needs.turbopack_rust_test2.result "Turbopack Rust tests (mac/win, non-blocking)"
-          subjob needs.turborepo_rust_test.result "TurboRepo Rust tests"
-          subjob needs.turbopack_rust_test_bench1.result "Turbopack Rust benchmark tests (linux)"
-          subjob needs.turbopack_rust_test_bench2.result "Turbopack Rust benchmark tests (mac/win, non-blocking)"
-          subjob needs.format_lint.result "Formatting"
-          subjob needs.rust_build_release.result "Rust release build (non-blocking)"
-          subjob needs.rust_bench.result "Turbopack Rust benchmarks (non-blocking)"
-          subjob needs.rust_bench_pr.result "Turbopack Rust PR benchmarks (non-blocking)"
-          subjob needs.next_js_integration.result "Next.js Integration tests (non-blocking)"
+          subjob ${{needs.determine_jobs.result}} "Determining jobs"
+          subjob ${{needs.go_lint.result}} "Go lints"
+          subjob ${{needs.go_unit.result}} "Go unit tests"
+          subjob ${{needs.go_examples.result}} "Go examples"
+          subjob ${{needs.go_e2e.result}} "Go e2e tests"
+          subjob ${{needs.go_integration.result}} "Go integration tests"
+          subjob ${{needs.rust_prepare.result}} "Rust prepare"
+          subjob ${{needs.rust_lint.result}} "Rust lints"
+          subjob ${{needs.rust_check.result}} "Rust checks"
+          subjob ${{needs.turbopack_rust_test1.result}} "Turbopack Rust tests (linux)"
+          subjob ${{needs.turbopack_rust_test2.result}} "Turbopack Rust tests (mac/win, non-blocking)"
+          subjob ${{needs.turborepo_rust_test.result}} "TurboRepo Rust tests"
+          subjob ${{needs.turbopack_rust_test_bench1.result}} "Turbopack Rust benchmark tests (linux)"
+          subjob ${{needs.turbopack_rust_test_bench2.result}} "Turbopack Rust benchmark tests (mac/win, non-blocking)"
+          subjob ${{needs.format_lint.result}} "Formatting"
+          subjob ${{needs.rust_build_release.result}} "Rust release build (non-blocking)"
+          subjob ${{needs.rust_bench.result}} "Turbopack Rust benchmarks (non-blocking)"
+          subjob ${{needs.rust_bench_pr.result}} "Turbopack Rust PR benchmarks (non-blocking)"
+          subjob ${{needs.next_js_integration.result}} "Next.js Integration tests (non-blocking)"
           if [ "$cancelled" = "true" ]; then
              echo "cancelled=true" >> $GITHUB_OUTPUT
           elif [ "$failure" = "true" ]; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1175,7 +1175,7 @@ jobs:
       - turbopack_rust_test2
       - turborepo_rust_test
       - turbopack_rust_test_bench1
-      - turbopack_rust_test_bench1
+      - turbopack_rust_test_bench2
       - rust_build_release
       - rust_bench
       - rust_bench_pr

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1062,7 +1062,7 @@ jobs:
       - rust_check
       - turbopack_rust_test1
       - turborepo_rust_test
-      - turbopack_rust_test1_bench
+      - turbopack_rust_test_bench1
       - format_lint
     if: always()
     permissions:
@@ -1174,8 +1174,8 @@ jobs:
       - turbopack_rust_test1
       - turbopack_rust_test2
       - turborepo_rust_test
-      - turbopack_rust_test1_bench
-      - turbopack_rust_test2_bench
+      - turbopack_rust_test_bench1
+      - turbopack_rust_test_bench1
       - rust_build_release
       - rust_bench
       - rust_bench_pr

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -996,108 +996,47 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - name: Check cancellation
-        id: cancelled
-        if: needs.rust_prepare.result == 'cancelled' || needs.rust_lint.result == 'cancelled' || needs.rust_check.result == 'cancelled' || needs.turbopack_rust_test.result == 'cancelled' || needs.turborepo_rust_test.result == 'cancelled' || needs.turbopack_rust_test_bench.result == 'cancelled' || needs.rust_build_release.result == 'cancelled' || needs.format_lint.result == 'cancelled' || needs.rust_bench.result == 'cancelled'
-        run: echo "cancelled=true" >> $GITHUB_OUTPUT
-
-      - name: Start summary
+      - name: Compute info
+        id: info
+        if: always()
         run: |
-          echo "The following steps have failed in CI" > comment.md
-          echo >> comment.md
-
-      - name: Determine Jobs failed
-        if: always() && needs.determine_jobs.result != 'success' && needs.determine_jobs.result != 'skipped'
-        run: |
-          echo "- Determining jobs" >> failures.md
-          exit 1
-
-      - name: Go Linting failed
-        if: always() && needs.go_lint.result != 'success' && needs.go_lint.result != 'skipped'
-        run: |
-          echo "- Go lints" >> failures.md
-          exit 1
-
-      - name: Go Unit Tests failed
-        if: always() && needs.go_unit.result != 'success' && needs.go_unit.result != 'skipped'
-        run: |
-          echo "- Go Unit Tests" >> failures.md
-          exit 1
-
-      - name: Go Integration Tests failed
-        if: always() && needs.go_integration.result != 'success' && needs.go_integration.result != 'skipped'
-        run: |
-          echo "- Go Integration Tests" >> failures.md
-          exit 1
-
-      - name: Go Examples failed
-        if: always() && needs.go_examples.result != 'success' && needs.go_examples.result != 'skipped'
-        run: |
-          echo "- Go Examples" >> failures.md
-          exit 1
-
-      - name: Go E2E failed
-        if: always() && needs.go_e2e.result != 'success' && needs.go_e2e.result != 'skipped'
-        run: |
-          echo "- Go E2E" >> failures.md
-          exit 1
-
-      - name: Rust Compilation failed
-        if: always() && needs.rust_prepare.result != 'success' && needs.rust_prepare.result != 'skipped'
-        run: |
-          echo "- Rust compilation" >> failures.md
-          exit 1
-
-      - name: Rust Linting failed
-        if: always() && needs.rust_lint.result != 'success' && needs.rust_lint.result != 'skipped'
-        run: |
-          echo "- Rust lints" >> failures.md
-          exit 1
-
-      - name: Rust Checking failed
-        if: always() && needs.rust_check.result != 'success' && needs.rust_check.result != 'skipped'
-        run: |
-          echo "- Rust checks / clippy" >> failures.md
-          exit 1
-
-      - name: Turbopack Rust Testing failed
-        if: always() && needs.turbopack_rust_test.result != 'success' && needs.turbopack_rust_test.result != 'skipped'
-        run: |
-          echo "- Turbopack Rust tests" >> failures.md
-          exit 1
-
-      - name: Turborepo Rust Testing failed
-        if: always() && needs.turborepo_rust_test.result != 'success' && needs.turborepo_rust_test.result != 'skipped'
-        run: |
-          echo "- Turborepo Rust tests" >> failures.md
-          exit 1
-
-      - name: Rust Benchmark Testing failed
-        if: always() && needs.turbopack_rust_test_bench.result != 'success' && needs.turbopack_rust_test_bench.result != 'skipped'
-        run: |
-          echo "- Rust benchmark tests" >> failures.md
-          exit 1
-
-      - name: Rust Release Build failed
-        if: always() && needs.rust_build_release.result != 'success' && needs.rust_build_release.result != 'skipped'
-        run: |
-          echo "- Rust release build" >> failures.md
-          exit 1
-
-      - name: Rust benchmarks
-        if: always() && needs.rust_bench.result != 'success' && needs.rust_bench.result != 'skipped'
-        run: |
-          echo "- Rust benchmarks" >> failures.md
-          exit 1
-
-      - name: Formatting failed
-        if: always() && needs.format_lint.result != 'success' && needs.format_lint.result != 'skipped'
-        run: |
-          echo "- Formatting" >> failures.md
-          exit 1
+          cancelled=false
+          failure=false
+          subjob () {
+            local result=$1
+            local name=$2
+            if [ "$result" = "cancelled" ]; then
+              cancelled=true
+            elif [ "$result" != "success" && "$result" != "skipped" ]; then
+              echo "- $name" >> failures.md
+              failure=true
+            fi
+          }
+          subjob needs.determine_jobs.result "Determining jobs"
+          subjob needs.go_lint.result "Go lints"
+          subjob needs.go_unit.result "Go unit tests"
+          subjob needs.go_examples.result "Go examples"
+          subjob needs.go_e2e.result "Go e2e tests"
+          subjob needs.go_integration.result "Go integration tests"
+          subjob needs.rust_prepare.result "Rust prepare"
+          subjob needs.rust_lint.result "Rust lints"
+          subjob needs.rust_check.result "Rust checks"
+          subjob needs.turbopack_rust_test.result "TurboPack Rust tests"
+          subjob needs.turborepo_rust_test.result "TurboRepo Rust tests"
+          subjob needs.turbopack_rust_test_bench.result "TurboPack Rust benchmarks"
+          subjob needs.rust_build_release.result "Rust release build"
+          subjob needs.format_lint.result "Formatting"
+          subjob needs.rust_bench.result "Rust benchmarks"
+          if [ "$cancelled" = "true" ]; then
+             echo "cancelled=true" >> $GITHUB_OUTPUT
+          elif [ "$failure" = "true" ]; then
+            echo "failure=true" >> $GITHUB_OUTPUT
+          else
+            echo "success=true" >> $GITHUB_OUTPUT
+          fi
 
       - name: Add failure prose text
-        if: failure()
+        if: steps.info.outputs.failure == 'true'
         run: |
           echo "## :warning: CI failed :warning:" > comment.md
           echo >> comment.md
@@ -1110,7 +1049,7 @@ jobs:
           echo "<!-- CI COMMENT -->" >> comment.md
 
       - name: Add success prose text
-        if: success()
+        if: steps.info.outputs.success == 'true'
         run: |
           echo "## :green_circle: CI successful :green_circle:" > comment.md
           echo >> comment.md
@@ -1120,7 +1059,7 @@ jobs:
 
       - name: Find PR Comment
         id: comment
-        if: always() && github.event_name == 'pull_request' && steps.cancelled.outputs.cancelled != 'true'
+        if: always() && github.event_name == 'pull_request' && steps.info.outputs.cancelled != 'true'
         uses: peter-evans/find-comment@v2
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -1128,7 +1067,7 @@ jobs:
           body-includes: "<!-- CI COMMENT -->"
 
       - name: Create or update PR comment
-        if: always() && github.event_name == 'pull_request' && steps.cancelled.outputs.cancelled != 'true'
+        if: always() && github.event_name == 'pull_request' && steps.info.outputs.cancelled != 'true'
         uses: peter-evans/create-or-update-comment@v2
         continue-on-error: true
         with:
@@ -1138,11 +1077,11 @@ jobs:
           edit-mode: replace
 
       - name: It's not fine
-        if: failure() && steps.cancelled.outputs.cancelled != 'true'
+        if: steps.info.outputs.failure == 'true'
         run: exit 1
 
       - name: It's fine
-        if: success() && steps.cancelled.outputs.cancelled != 'true'
+        if: steps.info.outputs.success == 'true'
         run: echo Ok
 
   cleanup:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -563,22 +563,57 @@ jobs:
         run: |
           cargo test -p turborepo-lib
 
-  turbopack_rust_test:
+  turbopack_rust_test1:
+    needs: [determine_jobs, rust_prepare]
+    if: needs.determine_jobs.outputs.turbopack == 'true' || needs.determine_jobs.outputs.cargo_on_main == 'true'
+    runs-on: ubuntu-latest-16-core-oss
+    name: Turbopack Rust testing on ubuntu
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+        with:
+          save-cache: true
+
+      - name: Setup Node.js
+        uses: ./.github/actions/setup-node
+
+      - name: Install tests dependencies
+        working-directory: crates/turbopack/tests/node-file-trace
+        run: pnpm install -r --side-effects-cache false
+
+      - name: Install tests dependencies in examples/with-yarn
+        working-directory: examples/with-yarn
+        run: npm install
+
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Build nextest
+        timeout-minutes: 120
+        # We exclude turbo as it requires linking Go and all logic resides in turborepo-lib
+        run: |
+          cargo nextest run --no-run --workspace --release --exclude turbo
+
+      - name: Run nextest
+        timeout-minutes: 120
+        # We exclude turbo as it requires linking Go and all logic resides in turborepo-lib
+        run: |
+          cargo nextest run --workspace --release --no-fail-fast --exclude turbo
+
+  turbopack_rust_test2:
     needs: [determine_jobs, rust_prepare]
     if: needs.determine_jobs.outputs.turbopack == 'true' || needs.determine_jobs.outputs.cargo_on_main == 'true'
     strategy:
       fail-fast: false
       matrix:
         os:
-          - name: ubuntu
-            runner: ubuntu-latest-16-core-oss
-            nextest: linux
           - name: macos
             runner: macos-latest
-            nextest: mac
           - name: windows
             runner: windows-latest
-            nextest: windows-tar
     runs-on: ${{ matrix.os.runner }}
     name: Turbopack Rust testing on ${{ matrix.os.name }}
     steps:
@@ -628,23 +663,66 @@ jobs:
         run: |
           cargo nextest run --workspace --release --no-fail-fast --exclude turbo
 
-  turbopack_rust_test_bench:
+  turbopack_rust_test_bench1:
+    needs: [determine_jobs, rust_prepare]
+    if: needs.determine_jobs.outputs.turbopack == 'true' || needs.determine_jobs.outputs.cargo_on_main == 'true'
+    runs-on: ubuntu-latest-16-core-oss
+    name: Turbopack Rust testing benchmarks on ubuntu
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+        with:
+          save-cache: true
+
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Setup Node.js
+        uses: ./.github/actions/setup-node
+        with:
+          node-version: 16
+
+      - name: Build benchmarks for tests
+        timeout-minutes: 120
+        run: |
+          cargo test --benches --release --no-run
+
+      - name: Run cargo test on benchmarks
+        timeout-minutes: 120
+        env:
+          TURBOPACK_BENCH_COUNTS: "100"
+          TURBOPACK_BENCH_PROGRESS: "1"
+        run: |
+          cargo test --benches --release
+
+      - name: Run cargo test on benchmarks for other bundlers
+        if: needs.determine_jobs.outputs.rust_bench == 'true'
+        timeout-minutes: 120
+        env:
+          TURBOPACK_BENCH_COUNTS: "100"
+          TURBOPACK_BENCH_PROGRESS: "1"
+          TURBOPACK_BENCH_BUNDLERS: "others"
+        run: |
+          cargo test --benches --release
+
+  turbopack_rust_test_bench2:
     needs: [determine_jobs, rust_prepare]
     if: needs.determine_jobs.outputs.turbopack == 'true' || needs.determine_jobs.outputs.cargo_on_main == 'true'
     strategy:
       fail-fast: false
       matrix:
         os:
-          - name: ubuntu
-            runner: ubuntu-latest-16-core-oss
-            nextest: linux
           - name: macos
             runner: macos-latest
-            nextest: mac
           # Temporarily disable windows bench due to consistent timeouts
           # - name: windows
           #   runner: windows-2019
-          #   nextest: windows-tar
     runs-on: ${{ matrix.os.runner }}
     name: Turbopack Rust testing benchmarks on ${{ matrix.os.name }}
 
@@ -982,14 +1060,10 @@ jobs:
       - rust_prepare
       - rust_lint
       - rust_check
-      - turbopack_rust_test
+      - turbopack_rust_test1
       - turborepo_rust_test
-      - turbopack_rust_test_bench
-      - rust_build_release
-      - rust_bench
+      - turbopack_rust_test1_bench
       - format_lint
-      # rust_bench_pr is not included
-      # since we don't want block the result on that
     if: always()
     permissions:
       contents: read
@@ -1021,12 +1095,133 @@ jobs:
           subjob needs.rust_prepare.result "Rust prepare"
           subjob needs.rust_lint.result "Rust lints"
           subjob needs.rust_check.result "Rust checks"
-          subjob needs.turbopack_rust_test.result "TurboPack Rust tests"
+          subjob needs.turbopack_rust_test1.result "Turbopack Rust tests (linux)"
           subjob needs.turborepo_rust_test.result "TurboRepo Rust tests"
-          subjob needs.turbopack_rust_test_bench.result "TurboPack Rust benchmarks"
-          subjob needs.rust_build_release.result "Rust release build"
+          subjob needs.turbopack_rust_test_bench1.result "Turbopack Rust benchmark tests (linux)"
           subjob needs.format_lint.result "Formatting"
-          subjob needs.rust_bench.result "Rust benchmarks"
+          if [ "$cancelled" = "true" ]; then
+             echo "cancelled=true" >> $GITHUB_OUTPUT
+          elif [ "$failure" = "true" ]; then
+            echo "failure=true" >> $GITHUB_OUTPUT
+          else
+            echo "success=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Add failure prose text
+        if: steps.info.outputs.failure == 'true'
+        run: |
+          echo "## :warning: CI failed :warning:" > comment.md
+          echo >> comment.md
+          echo "The following steps have failed in CI:" >> comment.md
+          echo >> comment.md
+          cat failures.md >> comment.md
+          echo >> comment.md
+          echo "See [workflow summary](https://github.com/vercel/turbo/actions/runs/${{ github.run_id }}) for details">> comment.md
+          echo >> comment.md
+          echo "<!-- CI COMMENT -->" >> comment.md
+
+      - name: Add success prose text
+        if: steps.info.outputs.success == 'true'
+        run: |
+          echo "## :green_circle: CI likely successful :green_circle:" > comment.md
+          echo >> comment.md
+          echo "A few longer running steps are still running, but they should not be considered as blocking." >> comment.md
+          echo >> comment.md
+          echo "See [workflow summary](https://github.com/vercel/turbo/actions/runs/${{ github.run_id }}) for details">> comment.md
+          echo >> comment.md
+          echo "<!-- CI COMMENT -->" >> comment.md
+
+      - name: Find PR Comment
+        id: comment
+        if: always() && github.event_name == 'pull_request' && steps.info.outputs.cancelled != 'true'
+        uses: peter-evans/find-comment@v2
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: "github-actions[bot]"
+          body-includes: "<!-- CI COMMENT -->"
+
+      - name: Create or update PR comment
+        if: always() && github.event_name == 'pull_request' && steps.info.outputs.cancelled != 'true'
+        uses: peter-evans/create-or-update-comment@v2
+        continue-on-error: true
+        with:
+          comment-id: ${{ steps.comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body-file: "comment.md"
+          edit-mode: replace
+
+      - name: It's not fine
+        if: steps.info.outputs.failure == 'true'
+        run: exit 1
+
+      - name: It's fine
+        if: steps.info.outputs.success == 'true'
+        run: echo Ok
+
+  done:
+    name: Done
+    needs:
+      - final
+      - determine_jobs
+      - go_lint
+      - go_unit
+      - go_examples
+      - go_e2e
+      - go_integration
+      - rust_prepare
+      - rust_lint
+      - rust_check
+      - turbopack_rust_test1
+      - turbopack_rust_test2
+      - turborepo_rust_test
+      - turbopack_rust_test1_bench
+      - turbopack_rust_test2_bench
+      - rust_build_release
+      - rust_bench
+      - rust_bench_pr
+      - next_js_integration
+      - format_lint
+    if: always()
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Compute info
+        id: info
+        if: always()
+        run: |
+          cancelled=false
+          failure=false
+          subjob () {
+            local result=$1
+            local name=$2
+            if [ "$result" = "cancelled" ]; then
+              cancelled=true
+            elif [ "$result" != "success" && "$result" != "skipped" ]; then
+              echo "- $name" >> failures.md
+              failure=true
+            fi
+          }
+          subjob needs.determine_jobs.result "Determining jobs"
+          subjob needs.go_lint.result "Go lints"
+          subjob needs.go_unit.result "Go unit tests"
+          subjob needs.go_examples.result "Go examples"
+          subjob needs.go_e2e.result "Go e2e tests"
+          subjob needs.go_integration.result "Go integration tests"
+          subjob needs.rust_prepare.result "Rust prepare"
+          subjob needs.rust_lint.result "Rust lints"
+          subjob needs.rust_check.result "Rust checks"
+          subjob needs.turbopack_rust_test1.result "Turbopack Rust tests (linux)"
+          subjob needs.turbopack_rust_test2.result "Turbopack Rust tests (mac/win, non-blocking)"
+          subjob needs.turborepo_rust_test.result "TurboRepo Rust tests"
+          subjob needs.turbopack_rust_test_bench1.result "Turbopack Rust benchmark tests (linux)"
+          subjob needs.turbopack_rust_test_bench2.result "Turbopack Rust benchmark tests (mac/win, non-blocking)"
+          subjob needs.format_lint.result "Formatting"
+          subjob needs.rust_build_release.result "Rust release build (non-blocking)"
+          subjob needs.rust_bench.result "Turbopack Rust benchmarks (non-blocking)"
+          subjob needs.rust_bench_pr.result "Turbopack Rust PR benchmarks (non-blocking)"
+          subjob needs.next_js_integration.result "Next.js Integration tests (non-blocking)"
           if [ "$cancelled" = "true" ]; then
              echo "cancelled=true" >> $GITHUB_OUTPUT
           elif [ "$failure" = "true" ]; then
@@ -1086,7 +1281,7 @@ jobs:
 
   cleanup:
     name: Cleanup
-    needs: [final]
+    needs: [done]
     if: always()
     uses: ./.github/workflows/pr-clean-caches.yml
     secrets: inherit


### PR DESCRIPTION
This removes some long running tests (mac and windows) from the required PR checks.

Now the CI workflow is split into two parts, `Ok` (required) for the required checks and `Done` (non-blocking) for all checks.

The PR comment will show

🟢 CI likely successful 🟢
A few longer running steps are still running, but they should not be considered as blocking.

See workflow summary for details

after the required checks are done.

Once all checks are done, it will be updated to 🟢 CI successful 🟢 or to ⚠️ CI failed ⚠️ depending on the full result