### PR TITLE
Reuse TurboTasks cross turbotrace runs

### DIFF
--- a/crates/node-file-trace/src/lib.rs
+++ b/crates/node-file-trace/src/lib.rs
@@ -343,7 +343,10 @@ fn process_input(dir: &Path, context: &str, input: &[String]) -> Result<Vec<Stri
         .collect()
 }
 
-pub async fn start(args: Arc<Args>) -> Result<Vec<String>> {
+pub async fn start(
+    args: Arc<Args>,
+    turbo_tasks: Option<&Arc<TurboTasks<MemoryBackend>>>,
+) -> Result<Vec<String>> {
     register();
     let &CommonArgs {
         visualize_graph,
@@ -406,7 +409,11 @@ pub async fn start(args: Arc<Args>) -> Result<Vec<String>> {
 
     run(
         args.clone(),
-        || TurboTasks::new(MemoryBackend::new(memory_limit.unwrap_or(usize::MAX))),
+        || {
+            turbo_tasks.cloned().unwrap_or_else(|| {
+                TurboTasks::new(MemoryBackend::new(memory_limit.unwrap_or(usize::MAX)))
+            })
+        },
         |tt, root_task, _| async move {
             if visualize_graph {
                 let mut stats = Stats::new();

--- a/crates/node-file-trace/src/main.rs
+++ b/crates/node-file-trace/src/main.rs
@@ -15,7 +15,7 @@ async fn main() -> Result<()> {
     console_subscriber::init();
     let args = Arc::new(Args::parse());
     let should_print = matches!(&*args, Args::Print { .. });
-    let result = start(args).await?;
+    let result = start(args, None).await?;
     if should_print {
         for file in result.iter() {
             println!("{}", file);


### PR DESCRIPTION
Allow reusing `TurboTasks` cross multiple `turbotrace` runs, can create `TurboTasks` in the next.js side and pass it back to reuse it.

Partially Close WEB-562