### PR TITLE
ci(workflow): expand integration test groups

### DIFF
--- a/.github/actions/next-integration-stat/action.yml
+++ b/.github/actions/next-integration-stat/action.yml
@@ -11,6 +11,12 @@ inputs:
   diff_base:
     default: "main"
 
+  # Include full test failure message in the report.
+  # This is currently disabled as we have too many failed test cases, causes
+  # too many report comment generated.
+  expand_full_result_message:
+    default: "false"
+
 runs:
   using: node16
   main: index.js

--- a/.github/actions/next-integration-stat/index.js
+++ b/.github/actions/next-integration-stat/index.js
@@ -15906,11 +15906,10 @@
     const BOT_COMMENT_MARKER = `<!-- __marker__ next.js integration stats __marker__ -->`;
     // Header for the test report.
     const commentTitlePre = `## Failing next.js integration test suites`;
-    // Download logs for a job in a workflow run by reading redirect url from workflow log response.
-    function fetchJobLogsFromWorkflow(octokit, token, job) {
+    function findNextJsVersionFromBuildLogs(octokit, token, job) {
       var _a, _b;
       return __awaiter(this, void 0, void 0, function* () {
-        console.log("Checking test results for the job ", job.name);
+        console.log("Checking logs for the job ", job.name);
         // downloadJobLogsForWorkflowRun returns a redirect to the actual logs
         const jobLogRedirectResponse =
           yield octokit.rest.actions.downloadJobLogsForWorkflowRun(
@@ -15949,8 +15948,44 @@
           _b === void 0
             ? void 0
             : _b.trim();
+        console.log("Found Next.js version: ", nextjsVersion);
+        return nextjsVersion;
+      });
+    }
+    // Download logs for a job in a workflow run by reading redirect url from workflow log response.
+    function fetchJobLogsFromWorkflow(octokit, token, job) {
+      return __awaiter(this, void 0, void 0, function* () {
+        console.log("Checking test results for the job ", job.name);
+        // downloadJobLogsForWorkflowRun returns a redirect to the actual logs
+        const jobLogRedirectResponse =
+          yield octokit.rest.actions.downloadJobLogsForWorkflowRun(
+            Object.assign(
+              Object.assign(
+                { accept: "application/vnd.github+json" },
+                _actions_github__WEBPACK_IMPORTED_MODULE_0__.context.repo
+              ),
+              { job_id: job.id }
+            )
+          );
+        // fetch the actual logs
+        const jobLogsResponse = yield nodeFetch(jobLogRedirectResponse.url, {
+          headers: {
+            Authorization: `token ${token}`,
+          },
+        });
+        if (!jobLogsResponse.ok) {
+          throw new Error(
+            `Failed to get logsUrl, got status ${jobLogsResponse.status}`
+          );
+        }
+        // this should be the check_run's raw logs including each line
+        // prefixed with a timestamp in format 2020-03-02T18:42:30.8504261Z
+        const logText = yield jobLogsResponse.text();
+        const dateTimeStripped = logText
+          .split("\n")
+          .map((line) => line.substr("2020-03-02T19:39:16.8832288Z ".length));
         const logs = dateTimeStripped.join("\n");
-        return { nextjsVersion, logs, job };
+        return { logs, job };
       });
     }
     // Filter out logs that does not contain failed tests, then parse test results into json
@@ -16070,11 +16105,13 @@
               { issue_number: prNumber }
             )
           );
-          // Get a comment from the bot if it exists
-          existingComment =
+          // Get a comment from the bot if it exists, delete all of them.
+          // Due to test report can exceed single comment size limit, it can be multiple comments and sync those is not trivial.
+          // Instead, we just delete all of them and post a new one.
+          const existingComments =
             comments === null || comments === void 0
               ? void 0
-              : comments.data.find((comment) => {
+              : comments.data.filter((comment) => {
                   var _a, _b;
                   return (
                     ((_a =
@@ -16091,6 +16128,24 @@
                       : _b.includes(BOT_COMMENT_MARKER))
                   );
                 });
+          if (
+            existingComments === null || existingComments === void 0
+              ? void 0
+              : existingComments.length
+          ) {
+            console.log("Found existing comments, deleting them");
+            for (const comment of existingComments) {
+              yield octokit.rest.issues.deleteComment(
+                Object.assign(
+                  Object.assign(
+                    {},
+                    _actions_github__WEBPACK_IMPORTED_MODULE_0__.context.repo
+                  ),
+                  { comment_id: comment.id }
+                )
+              );
+            }
+          }
         } else {
           (0, _actions_core__WEBPACK_IMPORTED_MODULE_1__.info)(
             "No PR number found in context, will not try to post comment."
@@ -16114,7 +16169,6 @@
           octokit,
           prNumber,
           sha,
-          existingComment,
         };
       });
     }
@@ -16139,12 +16193,27 @@
             }
           )
         );
+        // Filter out next.js build setup jobs
+        const nextjsBuildSetupJob =
+          jobs === null || jobs === void 0
+            ? void 0
+            : jobs.find((job) =>
+                /Build Next.js for the turbopack integration test$/.test(
+                  job.name
+                )
+              );
+        // Next.js build setup jobs includes the version of next.js that is being tested, try to read it.
+        const nextjsVersion = yield findNextJsVersionFromBuildLogs(
+          octokit,
+          token,
+          nextjsBuildSetupJob
+        );
         // Filter out next.js integration test jobs
         const integrationTestJobs =
           jobs === null || jobs === void 0
             ? void 0
             : jobs.filter((job) =>
-                /Next\.js integration test \([^)]*\)$/.test(job.name)
+                /Next\.js integration test \([^)]*\) \([^)]*\)$/.test(job.name)
               );
         console.log(
           jobs === null || jobs === void 0 ? void 0 : jobs.map((j) => j.name)
@@ -16160,6 +16229,7 @@
           )
         );
         const testResultManifest = {
+          nextjsVersion,
           ref: sha,
         };
         const failedJobResults = fullJobLogsFromWorkflow
@@ -16176,8 +16246,7 @@
             }
             return true;
           })
-          .reduce((acc, { logs, nextjsVersion, job }) => {
-            testResultManifest.nextjsVersion = nextjsVersion;
+          .reduce((acc, { logs, job }) => {
             // Split logs per each test suites, exclude if it's arbitrary log does not contain test data
             const splittedLogs = logs
               .split("NEXT_INTEGRATION_TEST: true")
@@ -16507,17 +16576,44 @@
       }
       return ret;
     }
+    // Create a markdown formatted comment body for the PR
+    // with marker prefix to look for existing comment for the subsequent runs.
+    const createFormattedComment = (comment) => {
+      var _a;
+      return (
+        [
+          `${commentTitlePre} ${BOT_COMMENT_MARKER}`,
+          ...((_a = comment.header) !== null && _a !== void 0 ? _a : []),
+        ].join(`\n`) +
+        `\n\n` +
+        comment.contents.join(`\n`)
+      );
+    };
+    // Higher order fn to create a function that creates a comment on a PR
+    const createCommentPostAsync = (octokit, prNumber) => (body) =>
+      __awaiter(void 0, void 0, void 0, function* () {
+        if (!prNumber) {
+          console.log(
+            "This workflow run doesn't seem to be triggered via PR, there's no corresponding PR number. Skipping creating a comment."
+          );
+          return;
+        }
+        const result = yield octokit.rest.issues.createComment(
+          Object.assign(
+            Object.assign(
+              {},
+              _actions_github__WEBPACK_IMPORTED_MODULE_0__.context.repo
+            ),
+            { issue_number: prNumber, body }
+          )
+        );
+        console.log("Created a new comment", result.data.html_url);
+      });
     // An action report failed next.js integration test with --turbo
     function run() {
       return __awaiter(this, void 0, void 0, function* () {
-        const {
-          token,
-          octokit,
-          shouldDiffWithMain,
-          prNumber,
-          sha,
-          existingComment,
-        } = yield getInputs();
+        const { token, octokit, shouldDiffWithMain, prNumber, sha } =
+          yield getInputs();
         // determine if we want to report summary into slack channel.
         // As a first step, we'll only report summary when the test is run against release-to-release. (no main branch regressions yet)
         const shouldReportSlack =
@@ -16530,132 +16626,137 @@
           octokit,
           shouldDiffWithMain
         );
-        let fullCommentBody = "";
-        if (failedJobResults.result.length === 0) {
-          console.log("No failed test results found :tada:");
-          fullCommentBody =
-            `### Next.js test passes :green_circle: ${BOT_COMMENT_MARKER}` +
-            `\nCommit: ${sha}\n`;
-          return;
-        } else {
-          // Comment body to post test report with summary & full details.
-          fullCommentBody =
-            // Put the header title with marer comment to identify the comment for subsequent runs.
-            `${commentTitlePre} ${BOT_COMMENT_MARKER}` + `\nCommit: ${sha}\n`;
-          fullCommentBody += getTestSummary(
-            sha,
-            shouldDiffWithMain,
-            baseResults,
-            failedJobResults,
-            shouldReportSlack
+        const postCommentAsync = createCommentPostAsync(octokit, prNumber);
+        // Consturct a comment body to post test report with summary & full details.
+        const comments = failedJobResults.result.reduce((acc, value, idx) => {
+          var _a, _b, _c;
+          const { name: failedTest, data: testData } = value;
+          const commentValues = [];
+          // each job have nested array of test results
+          // Fill in each individual test suite failures
+          const groupedFails = {};
+          const testResult =
+            (_a = testData.testResults) === null || _a === void 0
+              ? void 0
+              : _a[0];
+          const resultMessage = stripAnsi(
+            testResult === null || testResult === void 0
+              ? void 0
+              : testResult.message
           );
-          // Append full test report to the comment body, with collapsed <details>
-          fullCommentBody += `\n<details>\n<summary>Full test report</summary>\n`;
-          // Iterate over job results to construct full test report
-          failedJobResults.result.forEach(
-            ({ job, name: failedTest, data: testData }) => {
-              var _a, _b, _c, _d, _e;
-              // each job have nested array of test results
-              // Fill in each individual test suite failures
-              const groupedFails = {};
-              const testResult =
-                (_a = testData.testResults) === null || _a === void 0
+          const failedAssertions =
+            (_b =
+              testResult === null || testResult === void 0
+                ? void 0
+                : testResult.assertionResults) === null || _b === void 0
+              ? void 0
+              : _b.filter((res) => res.status === "failed");
+          for (const fail of failedAssertions !== null &&
+          failedAssertions !== void 0
+            ? failedAssertions
+            : []) {
+            const ancestorKey =
+              (_c =
+                fail === null || fail === void 0
                   ? void 0
-                  : _a[0];
-              const resultMessage = stripAnsi(
-                testResult === null || testResult === void 0
-                  ? void 0
-                  : testResult.message
-              );
-              const failedAssertions =
-                (_b =
-                  testResult === null || testResult === void 0
-                    ? void 0
-                    : testResult.assertionResults) === null || _b === void 0
-                  ? void 0
-                  : _b.filter((res) => res.status === "failed");
-              for (const fail of failedAssertions !== null &&
-              failedAssertions !== void 0
-                ? failedAssertions
-                : []) {
-                const ancestorKey =
-                  (_c =
-                    fail === null || fail === void 0
-                      ? void 0
-                      : fail.ancestorTitles) === null || _c === void 0
-                    ? void 0
-                    : _c.join(" > ");
-                if (!groupedFails[ancestorKey]) {
-                  groupedFails[ancestorKey] = [];
-                }
-                groupedFails[ancestorKey].push(fail);
-              }
-              if (
-                (_d =
-                  existingComment === null || existingComment === void 0
-                    ? void 0
-                    : existingComment.body) === null || _d === void 0
-                  ? void 0
-                  : _d.includes(sha)
-              ) {
-                if (
-                  failedTest &&
-                  ((_e = existingComment.body) === null || _e === void 0
-                    ? void 0
-                    : _e.includes(failedTest))
-                ) {
-                  console.log(
-                    `Suite is already included in current comment on ${prNumber}`
-                  );
-                  // the check_suite comment already says this test failed
-                  return;
-                }
-                fullCommentBody = existingComment.body;
-              }
-              fullCommentBody += `\n\`${failedTest}\` `;
-              for (const group of Object.keys(groupedFails).sort()) {
-                const fails = groupedFails[group];
-                fullCommentBody +=
-                  `\n- ` +
-                  fails.map((fail) => `${group} > ${fail.title}`).join("\n- ");
-              }
-              fullCommentBody += `\n\n<details>`;
-              fullCommentBody += `\n<summary>Expand output</summary>`;
-              fullCommentBody += `\n\n${resultMessage}`;
-              fullCommentBody += `\n</details>\n`;
+                  : fail.ancestorTitles) === null || _c === void 0
+                ? void 0
+                : _c.join(" > ");
+            if (!groupedFails[ancestorKey]) {
+              groupedFails[ancestorKey] = [];
             }
-          );
-          // Close </details>
-          fullCommentBody += `</details>\n`;
-        }
+            groupedFails[ancestorKey].push(fail);
+          }
+          commentValues.push(`\`${failedTest}\``);
+          for (const group of Object.keys(groupedFails).sort()) {
+            const fails = groupedFails[group];
+            commentValues.push(`\n`);
+            fails.forEach((fail) => {
+              commentValues.push(`- ${group} > ${fail.title}`);
+            });
+          }
+          const strippedResultMessage =
+            resultMessage.length >= 50000
+              ? resultMessage.substring(0, 50000) +
+                `...\n(Test result messages are too long, cannot post full message in comment. See the action logs for the full message.)`
+              : resultMessage;
+          if (resultMessage.length >= 50000) {
+            console.log(
+              "Test result messages are too long, comment will post stripped. Here is the full message:\n",
+              resultMessage
+            );
+          }
+          commentValues.push(`\n`);
+          commentValues.push(`<details>`);
+          commentValues.push(`<summary>Expand output</summary>`);
+          commentValues.push(strippedResultMessage);
+          commentValues.push(`</details>`);
+          commentValues.push(`\n`);
+          // Check last comment body's length, append or either create new comment depends on the length of the text.
+          const commentIdxToUpdate = acc.length - 1;
+          if (
+            acc.length === 0 ||
+            commentValues.join(`\n`).length +
+              acc[commentIdxToUpdate].contents.join(`\n`).length >
+              60000
+          ) {
+            acc.push({
+              header: [`Commit: ${sha}`],
+              contents: commentValues,
+            });
+          } else {
+            acc[commentIdxToUpdate].contents.push(...commentValues);
+          }
+          return acc;
+        }, []);
+        const commentsWithSummary = [
+          // First comment is always a summary
+          {
+            header: [`Commit: ${sha}`],
+            contents: [
+              getTestSummary(
+                sha,
+                shouldDiffWithMain,
+                baseResults,
+                failedJobResults,
+                shouldReportSlack
+              ),
+            ],
+          },
+          ...comments,
+        ];
+        const isMultipleComments = comments.length > 1;
         try {
           if (!prNumber) {
             return;
           }
-          if (!existingComment) {
-            console.log("No existing comment found, creating a new one");
-            const result = yield octokit.rest.issues.createComment(
-              Object.assign(
-                Object.assign(
-                  {},
-                  _actions_github__WEBPACK_IMPORTED_MODULE_0__.context.repo
-                ),
-                { issue_number: prNumber, body: fullCommentBody }
-              )
+          if (failedJobResults.result.length === 0) {
+            console.log("No failed test results found :tada:");
+            yield postCommentAsync(
+              `### Next.js test passes :green_circle: ${BOT_COMMENT_MARKER}` +
+                `\nCommit: ${sha}\n`
             );
-            console.log("Created a new comment", result.data.html_url);
-          } else {
-            console.log("Existing comment found, updating it");
-            const result = yield octokit.rest.issues.updateComment(
-              Object.assign(
-                Object.assign(
-                  {},
-                  _actions_github__WEBPACK_IMPORTED_MODULE_0__.context.repo
-                ),
-                { comment_id: existingComment.id, body: fullCommentBody }
-              )
-            );
-            console.log("Updated existing comment", result.data.html_url);
+            return;
+          }
+          for (const [idx, comment] of commentsWithSummary.entries()) {
+            const value = Object.assign({}, comment);
+            if (isMultipleComments) {
+              value.header.push(
+                `**(Report ${idx + 1}/${commentsWithSummary.length})**`
+              );
+            }
+            // Add collapsible details for full test report
+            if (idx > 0) {
+              value.contents = [
+                `<details>`,
+                `<summary>Expand full test reports</summary>`,
+                `\n`,
+                ...value.contents,
+                `</details>`,
+              ];
+            }
+            const commentBodyText = createFormattedComment(value);
+            yield postCommentAsync(commentBodyText);
           }
         } catch (error) {
           console.error("Failed to post comment", error);

--- a/.github/actions/next-integration-stat/index.js
+++ b/.github/actions/next-integration-stat/index.js
@@ -15990,7 +15990,7 @@
     }
     // Filter out logs that does not contain failed tests, then parse test results into json
     function collectFailedTestResults(splittedLogs, job) {
-      return splittedLogs
+      const ret = splittedLogs
         .filter((logs) => {
           if (
             !logs.includes(`failed to pass within`) ||
@@ -16005,48 +16005,58 @@
         })
         .map((logs) => {
           var _a, _b, _c, _d;
-          let failedTest = logs.split(`failed to pass within`).shift();
-          // Look for the failed test file name
-          failedTest = (
-            failedTest === null || failedTest === void 0
-              ? void 0
-              : failedTest.includes("test/")
-          )
-            ? (_a =
-                failedTest === null || failedTest === void 0
-                  ? void 0
-                  : failedTest.split("\n").pop()) === null || _a === void 0
-              ? void 0
-              : _a.trim()
-            : "";
-          console.log("Failed test: ", { job: job.name, failedTest });
-          // Parse JSON-stringified test output between marker
-          try {
-            const testData =
-              (_d =
-                (_c =
-                  (_b =
-                    logs === null || logs === void 0
-                      ? void 0
-                      : logs.split("--test output start--").pop()) === null ||
-                  _b === void 0
-                    ? void 0
-                    : _b.split("--test output end--")) === null || _c === void 0
-                  ? void 0
-                  : _c.shift()) === null || _d === void 0
+          let failedSplitLogs = logs.split(`failed to pass within`);
+          const ret = [];
+          while (!!failedSplitLogs && failedSplitLogs.length >= 1) {
+            let failedTest = failedSplitLogs.shift();
+            // Look for the failed test file name
+            failedTest = (
+              failedTest === null || failedTest === void 0
                 ? void 0
-                : _d.trim();
-            return {
-              job: job.name,
-              name: failedTest,
-              data: JSON.parse(testData),
-            };
-          } catch (_) {
-            console.log(`Failed to parse test data`);
-            return null;
+                : failedTest.includes("test/")
+            )
+              ? (_a =
+                  failedTest === null || failedTest === void 0
+                    ? void 0
+                    : failedTest.split("\n").pop()) === null || _a === void 0
+                ? void 0
+                : _a.trim()
+              : "";
+            // Parse JSON-stringified test output between marker
+            try {
+              const testData =
+                (_d =
+                  (_c =
+                    (_b =
+                      logs === null || logs === void 0
+                        ? void 0
+                        : logs.split("--test output start--").pop()) === null ||
+                    _b === void 0
+                      ? void 0
+                      : _b.split("--test output end--")) === null ||
+                  _c === void 0
+                    ? void 0
+                    : _c.shift()) === null || _d === void 0
+                  ? void 0
+                  : _d.trim();
+              ret.push({
+                job: job.name,
+                name: failedTest,
+                data: JSON.parse(testData),
+              });
+            } catch (_) {
+              console.log(`Failed to parse test data`);
+            }
           }
+          return ret;
         })
+        .flatMap((x) => x)
         .filter(Boolean);
+      console.log(`Found failed test results from job`, {
+        job: job.name,
+        failedTests: ret.map((x) => x.name),
+      });
+      return ret;
     }
     // Collect necessary inputs to run actions,
     function getInputs() {

--- a/.github/workflows/nextjs-integration-test.yml
+++ b/.github/workflows/nextjs-integration-test.yml
@@ -20,54 +20,98 @@ on:
         type: boolean
 
 jobs:
-  # Build next-dev binary to use in integration test.
-  rust_build_dev:
-    strategy:
-      fail-fast: false
-    runs-on: ubuntu-latest-16-core-oss
-    name: Building next-dev for next.js integration test
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+  # First, build next-dev and Next.js both to execute across tests.
+  setup_nextjs:
+    name: Setup Next.js build
+    uses: ./.github/workflows/setup-nextjs-build.yml
+    with:
+      version: ${{ inputs.version }}
 
-      - name: Setup Rust
-        uses: ./.github/actions/setup-rust
-        with:
-          targets: x86_64-unknown-linux-musl
-          cache-key: dev-x86_64-unknown-linux-musl
-          save-cache: true
-
-      - name: Install musl tools
-        run: |
-          wget https://github.com/napi-rs/napi-rs/releases/download/linux-musl-cross%4011.2.1/x86_64-linux-musl-native.tgz -O musl.tgz
-          tar -xvzf musl.tgz
-          sudo mv x86_64-linux-musl-native /usr/x86_64-linux-musl
-          sudo ln -sf /usr/x86_64-linux-musl/bin/x86_64-linux-musl-cc /usr/bin/musl-gcc
-          sudo ln -sf /usr/x86_64-linux-musl/bin/x86_64-linux-musl-g++ /usr/bin/musl-g++
-
-      - name: Build next-dev (rustls-tls)
-        run: |
-          cargo build --release -p next-dev --target x86_64-unknown-linux-musl --no-default-features --features cli,custom_allocator,rustls-tls
-
-      - uses: actions/upload-artifact@v3
-        with:
-          name: release-next-dev-linux-musl
-          path: |
-            target/x86_64-unknown-linux-musl/release/next-dev
-
-  # Run actual next.js integration test
-  execute_tests:
-    needs: [rust_build_dev]
+  # Actual test scheduling. These jobs mimic the same jobs in Next.js repo,
+  # which we do allow some of duplications to make it easier to update if upstream changes.
+  # Refer build_test_deploy.yml in the Next.js repo for more details.
+  test_dev:
     # This job name is being used in github action to collect test results. Do not change it, or should update
-    # ./.github/actions/next-integration-test to match the new name.
-    name: Next.js integration test
-    runs-on: ubuntu-latest-8-core-oss
+    # ./.github/actions/next-integration-stat to match the new name.
+    name: Next.js integration test (Development)
+    runs-on: ubuntu-latest
+    needs: [setup_nextjs]
+    env:
+      # Enabling backtrace will makes snapshot tests fail
+      RUST_BACKTRACE: 0
+      NEXT_TELEMETRY_DISABLED: 1
+      # Path to the next-dev binary located in **docker container** image.
+      NEXT_DEV_BIN: /work/next-dev
+      # Glob pattern to run specific tests with --turbo.
+      NEXT_DEV_TEST_GLOB: "*"
+      # pnpm version should match to what upstream next.js uses
+      PNPM_VERSION: 7.24.3
     strategy:
-      fail-fast: false
       matrix:
         node: [16, 18]
-        group: [1, 2]
+        group: [1, 2, 3, 4]
 
+    steps:
+      - uses: actions/cache@v3
+        id: restore-build
+        with:
+          path: ./*
+          key: ${{ github.sha }}-${{ github.run_number }}
+
+      - run: |
+          docker run --rm -v $(pwd):/work mcr.microsoft.com/playwright:v1.28.1-focal /bin/bash -c "cd /work && ls && curl https://install-node.vercel.app/v${{ matrix.node }} | FORCE=1 bash && node -v && npm i -g pnpm@${PNPM_VERSION} && /work/next-dev --display-version && __INTERNAL_CUSTOM_TURBOPACK_BINARY=${NEXT_DEV_BIN} __INTERNAL_NEXT_DEV_TEST_TURBO_GLOB_MATCH=${NEXT_DEV_TEST_GLOB} NEXT_TEST_CONTINUE_ON_ERROR=TRUE NEXT_TEST_JOB=1 NEXT_TEST_MODE=dev xvfb-run node run-tests.js --type development -g ${{ matrix.group }}/4 >> /proc/1/fd/1"
+        name: Run test/development
+        # It is currently expected to fail some of next.js integration test, do not fail CI check.
+        continue-on-error: true
+        env:
+          RECORD_REPLAY_METADATA_TEST_RUN_TITLE: testDev / Group ${{ matrix.group }}
+          # marker to parse log output, do not delete / change.
+          NEXT_INTEGRATION_TEST: true
+
+  test_dev_e2e:
+    # This job name is being used in github action to collect test results. Do not change it, or should update
+    # ./.github/actions/next-integration-stat to match the new name.
+    name: Next.js integration test (e2e/Development)
+    runs-on: ubuntu-latest
+    needs: [setup_nextjs]
+    env:
+      # Enabling backtrace will makes snapshot tests fail
+      RUST_BACKTRACE: 0
+      NEXT_TELEMETRY_DISABLED: 1
+      # Path to the next-dev binary located in **docker container** image.
+      NEXT_DEV_BIN: /work/next-dev
+      # Glob pattern to run specific tests with --turbo.
+      NEXT_DEV_TEST_GLOB: "*"
+      # pnpm version should match to what upstream next.js uses
+      PNPM_VERSION: 7.24.3
+    strategy:
+      matrix:
+        node: [16, 18]
+        group: [1, 2, 3, 4, 5, 6, 7]
+
+    steps:
+      - uses: actions/cache@v3
+        id: restore-build
+        with:
+          path: ./*
+          key: ${{ github.sha }}-${{ github.run_number }}
+
+      - run: |
+          docker run --rm -v $(pwd):/work mcr.microsoft.com/playwright:v1.28.1-focal /bin/bash -c "cd /work && ls && curl https://install-node.vercel.app/v${{ matrix.node }} | FORCE=1 bash && node -v && npm i -g pnpm@${PNPM_VERSION} && __INTERNAL_CUSTOM_TURBOPACK_BINARY=${NEXT_DEV_BIN} __INTERNAL_NEXT_DEV_TEST_TURBO_GLOB_MATCH=${NEXT_DEV_TEST_GLOB} NEXT_TEST_CONTINUE_ON_ERROR=TRUE NEXT_TEST_JOB=1 NEXT_TEST_MODE=dev xvfb-run node run-tests.js --type e2e -g ${{ matrix.group }}/7 >> /proc/1/fd/1"
+        name: Run test/e2e (dev)
+        continue-on-error: true
+        env:
+          RECORD_REPLAY_METADATA_TEST_RUN_TITLE: testDevE2E / Group ${{ matrix.group }} / Node ${{ matrix.node }}
+          NEXT_TEST_MODE: dev
+          RECORD_REPLAY_TEST_METRICS: 1
+          NEXT_INTEGRATION_TEST: true
+
+  test_cna:
+    # This job name is being used in github action to collect test results. Do not change it, or should update
+    # ./.github/actions/next-integration-stat to match the new name.
+    name: Next.js integration test (Create Next App) (No group)
+    runs-on: ubuntu-latest
+    needs: [setup_nextjs]
     env:
       # Enabling backtrace will makes snapshot tests fail
       RUST_BACKTRACE: 0
@@ -80,84 +124,81 @@ jobs:
       PNPM_VERSION: 7.24.3
 
     steps:
-      - name: Find Next.js latest release version
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          # Grab the latest release version from next.js repo, including prelease. `/releases/latest` will only return latest stable release.
-          echo NEXJS_LATEST_VERSION=$(gh release --repo vercel/next.js --limit 1 list | sed -n 1p | awk '{print $1}') >> $GITHUB_ENV
-      - name: Set Next.js release version
-        run: |
-          echo "NEXTJS_VERSION=${{ inputs.version != '' && inputs.version || env.NEXJS_LATEST_VERSION }}" >> $GITHUB_ENV
-          echo "Checking out Next.js ${{ env.NEXTJS_VERSION }}"
-
-      # https://github.com/actions/virtual-environments/issues/1187
-      - name: tune linux network
-        run: sudo ethtool -K eth0 tx off rx off
-
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          repository: vercel/next.js
-          ref: ${{ env.NEXTJS_VERSION }}
-
       - uses: actions/cache@v3
         id: restore-build
         with:
           path: ./*
           key: ${{ github.sha }}-${{ github.run_number }}
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v2.2.4
+      # TODO: This test currently seems to load wasm/swc and does not load the next-dev binary.
+      # Temporary disabled until figure out details.
+      #- run: |
+      #    docker run --rm -v $(pwd):/work mcr.microsoft.com/playwright:v1.28.1-focal /bin/bash -c "cd /work && curl -s https://install-node.vercel.app/v16 | FORCE=1 bash && npm i -g pnpm@${PNPM_VERSION} > /dev/null && __INTERNAL_CUSTOM_TURBOPACK_BINARY=${NEXT_DEV_BIN} __INTERNAL_NEXT_DEV_TEST_TURBO_GLOB_MATCH=${NEXT_DEV_TEST_GLOB} NEXT_TEST_CONTINUE_ON_ERROR=TRUE NEXT_TEST_JOB=1 NEXT_TEST_CNA=1 xvfb-run node run-tests.js test/integration/create-next-app/index.test.ts test/integration/create-next-app/templates.test.ts >> /proc/1/fd/1"
+      #  name: Run test/e2e (create-next-app)
+      #  continue-on-error: true
+      #  env:
+      #    RECORD_REPLAY_METADATA_TEST_RUN_TITLE: testDevE2E / Group ${{ matrix.group }} / Node ${{ matrix.node }}
+      #    NEXT_TEST_MODE: dev
+      #    RECORD_REPLAY_TEST_METRICS: 1
+      #    NEXT_INTEGRATION_TEST: true
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
+  test_integration:
+    # This job name is being used in github action to collect test results. Do not change it, or should update
+    # ./.github/actions/next-integration-stat to match the new name.
+    name: Next.js integration test (integration)
+    runs-on: ubuntu-latest
+    needs: [setup_nextjs]
+    env:
+      # Enabling backtrace will makes snapshot tests fail
+      RUST_BACKTRACE: 0
+      NEXT_TELEMETRY_DISABLED: 1
+      # Path to the next-dev binary located in **docker container** image.
+      NEXT_DEV_BIN: /work/next-dev
+      # Glob pattern to run specific tests with --turbo.
+      NEXT_DEV_TEST_GLOB: "*"
+      # pnpm version should match to what upstream next.js uses
+      PNPM_VERSION: 7.24.3
+    strategy:
+      fail-fast: false
+      matrix:
+        group:
+          [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            22,
+            23,
+            24,
+            25,
+          ]
+
+    steps:
+      - uses: actions/cache@v3
+        id: restore-build
         with:
-          node-version: 16
-          cache: pnpm
-
-      - name: Download binary
-        uses: actions/download-artifact@v3
-        with:
-          path: artifacts
-
-      - name: Validate next-dev binary
-        run: |
-          ls -r ${{ github.workspace }}/artifacts
-          chmod +x ${{ github.workspace }}/artifacts/release-next-dev-linux-musl/next-dev
-          cp ${{ github.workspace }}/artifacts/release-next-dev-linux-musl/next-dev .
-          ./next-dev --display-version
-
-      - name: Install dependencies
-        run: |
-          corepack disable
-          pnpm install
-          pnpm run build
-          # This is being used in github action to collect test results. Do not change it, or should update ./.github/actions/next-integration-test to match.
-          echo "RUNNING NEXTJS VERSION: $(packages/next/dist/bin/next --version)"
+          path: ./*
+          key: ${{ github.sha }}-${{ github.run_number }}
 
       - run: |
-          docker run --rm -v $(pwd):/work mcr.microsoft.com/playwright:v1.28.1-focal /bin/bash -c "cd /work && ls && curl https://install-node.vercel.app/v${{ matrix.node }} | FORCE=1 bash && node -v && npm i -g pnpm@${PNPM_VERSION} && /work/next-dev --display-version && __INTERNAL_CUSTOM_TURBOPACK_BINARY=${NEXT_DEV_BIN} __INTERNAL_NEXT_DEV_TEST_TURBO_GLOB_MATCH=${NEXT_DEV_TEST_GLOB} NEXT_TEST_CONTINUE_ON_ERROR=TRUE NEXT_TEST_JOB=1 NEXT_TEST_MODE=dev xvfb-run node run-tests.js --type development --timings -g ${{ matrix.group }}/4 >> /proc/1/fd/1"
-        name: Run test/development
-        # It is currently expected to fail some of next.js integration test, do not fail CI check.
-        continue-on-error: true
-        env:
-          RECORD_REPLAY_METADATA_TEST_RUN_TITLE: testDev / Group ${{ matrix.group }}
-          # marker to parse log output, do not delete / change.
-          NEXT_INTEGRATION_TEST: true
-
-      - run: |
-          docker run --rm -v $(pwd):/work mcr.microsoft.com/playwright:v1.28.1-focal /bin/bash -c "cd /work && ls && curl https://install-node.vercel.app/v${{ matrix.node }} | FORCE=1 bash && node -v && npm i -g pnpm@${PNPM_VERSION} && __INTERNAL_CUSTOM_TURBOPACK_BINARY=${NEXT_DEV_BIN} __INTERNAL_NEXT_DEV_TEST_TURBO_GLOB_MATCH=${NEXT_DEV_TEST_GLOB} NEXT_TEST_CONTINUE_ON_ERROR=TRUE NEXT_TEST_JOB=1 NEXT_TEST_MODE=dev xvfb-run node run-tests.js --type e2e --timings -g ${{ matrix.group }}/7 >> /proc/1/fd/1"
-        name: Run test/e2e (dev)
-        continue-on-error: true
-        env:
-          RECORD_REPLAY_METADATA_TEST_RUN_TITLE: testDevE2E / Group ${{ matrix.group }} / Node ${{ matrix.node }}
-          NEXT_TEST_MODE: dev
-          RECORD_REPLAY_TEST_METRICS: 1
-          NEXT_INTEGRATION_TEST: true
-
-      - run: |
-          docker run --rm -v $(pwd):/work mcr.microsoft.com/playwright:v1.28.1-focal /bin/bash -c "cd /work && ls && curl https://install-node.vercel.app/v16 | FORCE=1 bash && node -v && npm i -g pnpm@${PNPM_VERSION} && __INTERNAL_CUSTOM_TURBOPACK_BINARY=${NEXT_DEV_BIN} __INTERNAL_NEXT_DEV_TEST_TURBO_GLOB_MATCH=${NEXT_DEV_TEST_GLOB} NEXT_TEST_CONTINUE_ON_ERROR=TRUE NEXT_TEST_JOB=1 xvfb-run node run-tests.js --timings -g ${{ matrix.group }}/25 >> /proc/1/fd/1"
+          docker run --rm -v $(pwd):/work mcr.microsoft.com/playwright:v1.28.1-focal /bin/bash -c "cd /work && ls && curl https://install-node.vercel.app/v16 | FORCE=1 bash && node -v && npm i -g pnpm@${PNPM_VERSION} && __INTERNAL_CUSTOM_TURBOPACK_BINARY=${NEXT_DEV_BIN} __INTERNAL_NEXT_DEV_TEST_TURBO_GLOB_MATCH=${NEXT_DEV_TEST_GLOB} NEXT_TEST_CONTINUE_ON_ERROR=TRUE NEXT_TEST_JOB=1 xvfb-run node run-tests.js -g ${{ matrix.group }}/25 >> /proc/1/fd/1"
         name: Test Integration
         continue-on-error: true
         env:
@@ -167,7 +208,7 @@ jobs:
   # Collect integration test results from execute_tests,
   # Store it as github artifact for next step to consume.
   collect_nextjs_integration_stat:
-    needs: [execute_tests]
+    needs: [test_dev, test_dev_e2e, test_cna, test_integration]
     name: Next.js integration test status report
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/setup-nextjs-build.yml
+++ b/.github/workflows/setup-nextjs-build.yml
@@ -1,0 +1,125 @@
+# Reusable workflow to setup next.js integration test environment.
+name: Setup Next.js
+
+on:
+  workflow_call:
+    inputs:
+      # Allow to specify Next.js version to run integration test against.
+      # If not specified, will use latest release version including canary.
+      version:
+        type: string
+
+jobs:
+  # Build next-dev binary to use in integration test.
+  build_next_dev:
+    name: Building next-dev for next.js integration test
+    runs-on: ubuntu-latest-16-core-oss
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+        with:
+          targets: x86_64-unknown-linux-musl
+          cache-key: dev-x86_64-unknown-linux-musl
+          save-cache: true
+
+      - name: Install musl tools
+        run: |
+          wget https://github.com/napi-rs/napi-rs/releases/download/linux-musl-cross%4011.2.1/x86_64-linux-musl-native.tgz -O musl.tgz
+          tar -xvzf musl.tgz
+          sudo mv x86_64-linux-musl-native /usr/x86_64-linux-musl
+          sudo ln -sf /usr/x86_64-linux-musl/bin/x86_64-linux-musl-cc /usr/bin/musl-gcc
+          sudo ln -sf /usr/x86_64-linux-musl/bin/x86_64-linux-musl-g++ /usr/bin/musl-g++
+
+      - name: Build next-dev (rustls-tls)
+        run: |
+          cargo build --release -p next-dev --target x86_64-unknown-linux-musl --no-default-features --features cli,custom_allocator,rustls-tls
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: release-next-dev-linux-musl
+          path: |
+            target/x86_64-unknown-linux-musl/release/next-dev
+
+  build_nextjs:
+    name: Build Next.js for the turbopack integration test
+    runs-on: ubuntu-latest
+    needs: [build_next_dev]
+    env:
+      # pnpm version should match to what upstream next.js uses
+      PNPM_VERSION: 7.24.3
+    steps:
+      - name: Find Next.js latest release version
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Grab the latest release version from next.js repo, including prelease. `/releases/latest` will only return latest stable release.
+          echo NEXJS_LATEST_VERSION=$(gh release --repo vercel/next.js --limit 1 list | sed -n 1p | awk '{print $1}') >> $GITHUB_ENV
+      - name: Set Next.js release version
+        run: |
+          echo "NEXTJS_VERSION=${{ inputs.version != '' && inputs.version || env.NEXJS_LATEST_VERSION }}" >> $GITHUB_ENV
+          echo "Checking out Next.js ${{ env.NEXTJS_VERSION }}"
+
+      # https://github.com/actions/virtual-environments/issues/1187
+      - name: tune linux network
+        run: sudo ethtool -K eth0 tx off rx off
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          repository: vercel/next.js
+          ref: ${{ env.NEXTJS_VERSION }}
+
+      - uses: actions/cache@v3
+        id: restore-build
+        with:
+          path: ./*
+          key: ${{ github.sha }}-${{ github.run_number }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2.2.4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: pnpm
+
+      - name: Download binary
+        uses: actions/download-artifact@v3
+        with:
+          path: artifacts
+
+      - name: Validate next-dev binary
+        run: |
+          ls -r ${{ github.workspace }}/artifacts
+          chmod +x ${{ github.workspace }}/artifacts/release-next-dev-linux-musl/next-dev
+          cp ${{ github.workspace }}/artifacts/release-next-dev-linux-musl/next-dev .
+          ./next-dev --display-version
+
+      - name: Install dependencies
+        run: |
+          corepack disable
+          pnpm install
+          pnpm run build
+
+      - name: Check Next.js build version
+        run: |
+          ./next-dev --version
+          # This is being used in github action to collect test results. Do not change it, or should update ./.github/actions/next-integration-test to match.
+          echo "RUNNING NEXTJS VERSION: $(packages/next/dist/bin/next --version)"
+
+      # Once build completes, creates a cache of the build output
+      # so subsequent job to actually execute tests can reuse it.
+      # Note that we do not use upload / download artifacts for this -
+      # it is too heavyweight for the purpose since we do not need to persist
+      # the cache across multiple runs.
+      - name: Store next.js build cache with next-dev binary
+        uses: actions/cache@v3
+        timeout-minutes: 2
+        id: cache-build
+        with:
+          path: ./*
+          key: ${{ github.sha }}-${{ github.run_number }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,6 +56,9 @@ jobs:
           PATTERNS: |
             .github/actions/**
             .github/workflows/test.yml
+            .github/workflows/setup-nextjs-build.yml
+            .github/workflows/nextjs-integration-test-results.yml
+            .github/workflows/upload-nextjs-integration-test-results.yml
 
       - name: Root cargo related changes
         id: cargo


### PR DESCRIPTION
closes WEB-545, WEB-571.

This PR mimic upstream next.js test group config to expand turbopack's integration integration to match with it. To reduce some of duplication, this PR also sets up reusable workflow to setup  / build next.js and share its build artifact via github cache. Since those build artifacts are one-off usage per each test, it doesn't use upload/download artifact which is too slow & heavyweight for those purpose.