### PR TITLE
chore: add local and global versions in debug

### DIFF
--- a/crates/turborepo-lib/src/shim.rs
+++ b/crates/turborepo-lib/src/shim.rs
@@ -211,6 +211,7 @@ impl LocalTurboState {
         let package_json: PackageJson =
             serde_json::from_reader(File::open(local_turbo_package_path).ok()?).ok()?;
 
+        debug!("Local turbo version: {}", package_json.version);
         Some(Self {
             bin_path: local_turbo_path,
             version: package_json.version,
@@ -510,6 +511,7 @@ pub fn run() -> Result<Payload> {
     let args = ShimArgs::parse()?;
 
     init_env_logger(args.verbosity);
+    debug!("Global turbo version: {}", get_version());
 
     // If skip_infer is passed, we're probably running local turbo with
     // global turbo having handled the inference. We can run without any


### PR DESCRIPTION
Adds some additional debug logs in the shim about the global/local versions:
```
olszewski@chriss-mbp sushiswap % turbo_dev -vv --version
2023-02-06T13:38:47.876-0800 [DEBUG] turborepo_lib::shim: Global turbo version: 1.7.3
2023-02-06T13:38:47.880-0800 [DEBUG] turborepo_lib::shim: Local turbo version: 1.7.2
2023-02-06T13:38:47.880-0800 [DEBUG] turborepo_lib::shim: Running local turbo binary in /private/tmp/sushiswap/node_modules/.bin/turbo

2023-02-06T13:38:47.880-0800 [DEBUG] turborepo_lib::shim: supports_skip_infer_and_single_package true
1.7.2
```

a future PR will add this to the github issues template once this gets released