### PR TITLE
fix: remove quotes around extension in makefile

### DIFF
--- a/cli/Makefile
+++ b/cli/Makefile
@@ -4,7 +4,7 @@ TURBO_TAG = $(shell cat ../version.txt | sed -n '2 p')
 EXT :=
 ifeq ($(OS),Windows_NT)
 	UNAME := Windows
-	EXT = ".exe"
+	EXT = .exe
 else
 	UNAME := $(shell uname -s)
 endif


### PR DESCRIPTION
There was an issue with building the go binary on windows. 

Before this PR:
```
make -p
...
go-turbo".exe": internal/turbodprotocol/turbod.pb.go internal/turbodprotocol/turbod_grpc.pb.go go.mod turborepo-ffi-install
...
```

Now dropping the quotes we get the desired build target:
```
make -p
...
go-turbo.exe: internal/turbodprotocol/turbod.pb.go internal/turbodprotocol/turbod_grpc.pb.go go.mod turborepo-ffi-install
...
```
and `make go-turbo.exe` works.