### PR TITLE
test(turborepo): Login

### DIFF
--- a/crates/turborepo-lib/src/cli.rs
+++ b/crates/turborepo-lib/src/cli.rs
@@ -454,9 +454,9 @@ pub async fn run(repo_state: Option<RepoState>) -> Result<Payload> {
                 return Ok(Payload::Go(Box::new(clap_args)));
             }
 
-            let base = CommandBase::new(clap_args, repo_root)?;
+            let mut base = CommandBase::new(clap_args, repo_root)?;
 
-            login::login(base).await?;
+            login::login(&mut base).await?;
 
             Ok(Payload::Rust(Ok(0)))
         }

--- a/crates/turborepo-lib/src/client.rs
+++ b/crates/turborepo-lib/src/client.rs
@@ -106,9 +106,10 @@ impl UserClient for APIClient {
     async fn get_user(&self) -> Result<UserResponse> {
         let response = self
             .make_retryable_request(|| {
+                let url = self.make_url("/v2/user");
                 let request_builder = self
                     .client
-                    .get(self.make_url("/v2/user"))
+                    .get(url)
                     .header("User-Agent", USER_AGENT.clone())
                     .header("Authorization", format!("Bearer {}", self.token))
                     .header("Content-Type", "application/json");

--- a/crates/turborepo-lib/src/commands/link.rs
+++ b/crates/turborepo-lib/src/commands/link.rs
@@ -290,10 +290,9 @@ mod test {
 
         link::link(&mut base, false).await.unwrap();
 
+        handle.abort();
         let team_id = base.repo_config().unwrap().team_id();
         assert!(team_id == Some(TEAM_ID) || team_id == Some(USER_ID));
-
-        handle.abort();
     }
 
     async fn start_test_server() -> Result<()> {

--- a/crates/turborepo-lib/src/commands/link.rs
+++ b/crates/turborepo-lib/src/commands/link.rs
@@ -268,7 +268,7 @@ mod test {
         )
         .unwrap();
 
-        tokio::spawn(start_test_server());
+        let handle = tokio::spawn(start_test_server());
         let mut base = CommandBase {
             repo_root: Default::default(),
             ui: UI::new(false),
@@ -291,7 +291,9 @@ mod test {
         link::link(&mut base, false).await.unwrap();
 
         let team_id = base.repo_config().unwrap().team_id();
-        assert!(team_id == Some(TEAM_ID) || team_id == Some(USER_ID))
+        assert!(team_id == Some(TEAM_ID) || team_id == Some(USER_ID));
+
+        handle.abort();
     }
 
     async fn start_test_server() -> Result<()> {

--- a/crates/turborepo-lib/src/commands/login.rs
+++ b/crates/turborepo-lib/src/commands/login.rs
@@ -169,12 +169,12 @@ mod test {
 
         login::login(&mut base).await.unwrap();
 
+        handle.abort();
+
         assert_eq!(
             base.user_config().unwrap().token().unwrap(),
             EXPECTED_TOKEN_TEST
         );
-
-        handle.abort();
     }
 
     #[derive(Debug, Clone, Deserialize)]

--- a/crates/turborepo-lib/src/commands/login.rs
+++ b/crates/turborepo-lib/src/commands/login.rs
@@ -183,6 +183,8 @@ mod test {
         redirect_uri: String,
     }
 
+    /// NOTE: Each test server should be on its own port to avoid any
+    /// concurrency bugs.
     async fn start_test_server() -> Result<()> {
         let app = Router::new()
             // `GET /` goes to `root`

--- a/crates/turborepo-lib/src/commands/login.rs
+++ b/crates/turborepo-lib/src/commands/login.rs
@@ -2,7 +2,7 @@ use std::{net::SocketAddr, sync::Arc};
 
 use anyhow::{anyhow, Result};
 use axum::{extract::Query, response::Redirect, routing::get, Router};
-use log::{debug, warn};
+use log::debug;
 use serde::Deserialize;
 use tokio::sync::OnceCell;
 
@@ -16,7 +16,7 @@ use crate::{
 const DEFAULT_HOST_NAME: &str = "127.0.0.1";
 const DEFAULT_PORT: u16 = 9789;
 
-pub async fn login(mut base: CommandBase) -> Result<()> {
+pub async fn login(base: &mut CommandBase) -> Result<()> {
     let repo_config = base.repo_config()?;
     let login_url_base = repo_config.login_url();
     debug!("turbo v{}", get_version());
@@ -26,9 +26,8 @@ pub async fn login(mut base: CommandBase) -> Result<()> {
     let redirect_url = format!("http://{DEFAULT_HOST_NAME}:{DEFAULT_PORT}");
     let login_url = format!("{login_url_base}/turborepo/token?redirect_uri={redirect_url}");
     println!(">>> Opening browser to {login_url}");
+    direct_user_to_url(&login_url).await;
     let spinner = start_spinner("Waiting for your authorization...");
-    direct_user_to_url(&login_url);
-
     let token_cell = Arc::new(OnceCell::new());
     new_one_shot_server(
         DEFAULT_PORT,
@@ -36,6 +35,7 @@ pub async fn login(mut base: CommandBase) -> Result<()> {
         token_cell.clone(),
     )
     .await?;
+
     spinner.finish_and_clear();
     let token = token_cell
         .get()
@@ -46,7 +46,7 @@ pub async fn login(mut base: CommandBase) -> Result<()> {
     let client = base.api_client()?.unwrap();
     let user_response = client.get_user().await?;
 
-    let ui = base.ui;
+    let ui = &base.ui;
 
     println!(
         "
@@ -67,6 +67,9 @@ pub async fn login(mut base: CommandBase) -> Result<()> {
     Ok(())
 }
 
+#[cfg(test)]
+async fn direct_user_to_url(url: &str) {}
+#[cfg(not(test))]
 fn direct_user_to_url(url: &str) {
     if webbrowser::open(url).is_err() {
         warn!("Failed to open browser. Please visit {url} in your browser.");
@@ -78,6 +81,13 @@ struct LoginPayload {
     token: String,
 }
 
+#[cfg(test)]
+async fn new_one_shot_server(_: u16, _: String, login_token: Arc<OnceCell<String>>) -> Result<()> {
+    login_token.set("test-token".to_string()).unwrap();
+    Ok(())
+}
+
+#[cfg(not(test))]
 async fn new_one_shot_server(
     port: u16,
     login_url_base: String,
@@ -101,4 +111,115 @@ async fn new_one_shot_server(
         .handle(handle)
         .serve(app.into_make_service())
         .await?)
+}
+
+#[cfg(test)]
+mod test {
+    use std::{fs, net::SocketAddr};
+
+    use anyhow::Result;
+    use axum::{extract::Query, routing::get, Json, Router};
+    use serde::Deserialize;
+    use tempfile::NamedTempFile;
+    use tokio::sync::OnceCell;
+
+    use crate::{
+        client::{
+            CachingStatus, CachingStatusResponse, Membership, Role, Team, TeamsResponse, User,
+            UserResponse,
+        },
+        commands::{login, CommandBase},
+        config::{RepoConfigLoader, UserConfigLoader},
+        ui::UI,
+        Args,
+    };
+
+    #[tokio::test]
+    async fn test_login() {
+        let user_config_file = NamedTempFile::new().unwrap();
+        fs::write(user_config_file.path(), r#"{ "token": "hello" }"#).unwrap();
+        let repo_config_file = NamedTempFile::new().unwrap();
+        fs::write(
+            repo_config_file.path(),
+            r#"{ "apiurl": "http://localhost:3000" }"#,
+        )
+        .unwrap();
+
+        tokio::spawn(start_test_server());
+        let mut base = CommandBase {
+            repo_root: Default::default(),
+            ui: UI::new(false),
+            user_config: OnceCell::from(
+                UserConfigLoader::new(user_config_file.path().to_path_buf())
+                    .load()
+                    .unwrap(),
+            ),
+            repo_config: OnceCell::from(
+                RepoConfigLoader::new(repo_config_file.path().to_path_buf())
+                    .with_api(Some("http://localhost:3000".to_string()))
+                    .with_login(Some("http://localhost:3000".to_string()))
+                    .load()
+                    .unwrap(),
+            ),
+            args: Args::default(),
+        };
+
+        login::login(&mut base).await.unwrap();
+
+        assert_eq!(base.user_config().unwrap().token().unwrap(), "test-token");
+    }
+
+    #[derive(Debug, Clone, Deserialize)]
+    struct TokenRequest {
+        redirect_uri: String,
+    }
+
+    const EXPECTED_TOKEN: &str = "expected_token";
+
+    async fn start_test_server() -> Result<()> {
+        let app = Router::new()
+            // `GET /` goes to `root`
+            .route(
+                "/v2/teams",
+                get(|| async move {
+                    Json(TeamsResponse {
+                        teams: vec![Team {
+                            id: "vercel".to_string(),
+                            slug: "vercel".to_string(),
+                            name: "vercel".to_string(),
+                            created_at: 0,
+                            created: Default::default(),
+                            membership: Membership::new(Role::Owner),
+                        }],
+                    })
+                }),
+            )
+            .route(
+                "/v2/user",
+                get(|| async move {
+                    Json(UserResponse {
+                        user: User {
+                            id: "my_user_id".to_string(),
+                            username: "my_username".to_string(),
+                            email: "my_email".to_string(),
+                            name: None,
+                            created_at: 0,
+                        },
+                    })
+                }),
+            )
+            .route(
+                "/v8/artifacts/status",
+                get(|| async {
+                    Json(CachingStatusResponse {
+                        status: CachingStatus::Enabled,
+                    })
+                }),
+            );
+        let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
+
+        Ok(axum_server::bind(addr)
+            .serve(app.into_make_service())
+            .await?)
+    }
 }


### PR DESCRIPTION
Adds a test for login. A little messy with the `cfgs`. Perhaps at some point we can abstract out the `dialoguer` terminal interactions into a module, then stub it more cleanly.

