### PR TITLE
fix: turbo login on Windows

### DIFF
--- a/cli/Makefile
+++ b/cli/Makefile
@@ -4,7 +4,7 @@ TURBO_TAG = $(shell cat ../version.txt | sed -n '2 p')
 EXT :=
 ifeq ($(OS),Windows_NT)
 	UNAME := Windows
-	EXT = ".exe"
+	EXT = .exe
 else
 	UNAME := $(shell uname -s)
 endif

--- a/crates/turborepo-lib/src/lib.rs
+++ b/crates/turborepo-lib/src/lib.rs
@@ -26,6 +26,8 @@ pub fn get_version() -> &'static str {
         .split_once('\n')
         .expect("Failed to read version from version.txt")
         .0
+        // On windows we still have a trailing \r
+        .trim_end()
 }
 
 pub fn main() -> Payload {


### PR DESCRIPTION
Fixes #3647

Issue was that we were constructing a header with an unescaped `\r` on Windows as the user agent.

CRLF is the gift that keeps on giving