### PR TITLE
docs: add package.json and turbo.json to a pruned directory example

### DIFF
--- a/docs/pages/repo/docs/handbook/deploying-with-docker.mdx
+++ b/docs/pages/repo/docs/handbook/deploying-with-docker.mdx
@@ -87,14 +87,17 @@ First, we want to copy over only what we need to install the packages. When runn
 ```txt
 out
 ├── json
-│   └── apps
-│       └── docs
-│           └── package.json
+│   ├── apps
+│   │   └── docs
+│   │       └── package.json
+│   └── package.json
 ├── full
-│   └── apps
-│       └── docs
-│           ├── server.js
-│           └── package.json
+│   ├── apps
+│   │   └── docs
+│   │       ├── server.js
+│   │       └── package.json
+│   ├── package.json
+│   └── turbo.json
 └── package-lock.json
 ```
 
@@ -134,7 +137,6 @@ RUN yarn install
 
 # Build the project
 COPY --from=builder /app/out/full/ .
-COPY turbo.json turbo.json
 RUN yarn turbo run build --filter=web...
 
 FROM node:alpine AS runner


### PR DESCRIPTION
I fixed two mistakes.
- `./out/json` has `package.json` and `./out/full` has `package.json` and `turbo.json` in fact.
- You don't need to copy `turbo.json` manually in Dockerfile because `turbo.json` is already copied in [the previous line](https://github.com/vercel/turbo/compare/main...m-shaka:turbo:docs/fix-pruned-directory-structure?expand=1#diff-3d80bc97cc73148cf5956531eb631ce3e7f58860e778c4b52cf2e3499f4c4f05R139)