### PR TITLE
fix: Use go implementation when no build tags present

### DIFF
--- a/cli/internal/fs/get_turbo_data_dir_go.go
+++ b/cli/internal/fs/get_turbo_data_dir_go.go
@@ -1,5 +1,5 @@
-//go:build go
-// +build go
+//go:build go || !rust
+// +build go !rust
 
 package fs
 


### PR DESCRIPTION
Currently our release process is broken as we aren't passing any tags: https://github.com/vercel/turbo/actions/runs/4117196602/jobs/7108350138#step:6:35

Currently the default `go` tag is applied in the makefile which doesn't get picked up by goreleaser. We now default to a go implementation if the `rust` tag isn't present (or if the `go` tag is present). I did this instead of setting default tags in all of our `.yml` files to avoid needing to remember to keep in in sync with the makefile default.