### PR TITLE
ci(workflow): adjust summary report, drain all logs correctly

### DIFF
--- a/.github/actions/next-integration-stat/index.js
+++ b/.github/actions/next-integration-stat/index.js
@@ -16005,10 +16005,11 @@
         })
         .map((logs) => {
           var _a, _b, _c, _d;
-          let failedSplitLogs = logs.split(`failed to pass within`);
+          const failedSplitLogs = logs.split(`failed to pass within`);
+          let logLine = failedSplitLogs.shift();
           const ret = [];
-          while (!!failedSplitLogs && failedSplitLogs.length >= 1) {
-            let failedTest = failedSplitLogs.shift();
+          while (logLine) {
+            let failedTest = logLine;
             // Look for the failed test file name
             failedTest = (
               failedTest === null || failedTest === void 0
@@ -16044,6 +16045,7 @@
                 name: failedTest,
                 data: JSON.parse(testData),
               });
+              logLine = failedSplitLogs.shift();
             } catch (_) {
               console.log(`Failed to parse test data`);
             }
@@ -16549,11 +16551,15 @@
       const newFailedTests = currentTestFailedNames.filter(
         (name) => !baseTestFailedNames.includes(name)
       );
-      if (fixedTests.length > 0) {
-        ret += `\n:white_check_mark: **Fixed tests:**\n\n${fixedTests
-          .map((t) => (t.length > 5 ? `\t- ${t}` : t))
-          .join(" \n")}`;
-      }
+      /*
+    //NOTE: upstream test can be flaky, so this can appear intermittently
+    //even if there aren't actual fix. To avoid confusion, do not display this
+    //for now.
+    if (fixedTests.length > 0) {
+      ret += `\n:white_check_mark: **Fixed tests:**\n\n${fixedTests
+        .map((t) => (t.length > 5 ? `\t- ${t}` : t))
+        .join(" \n")}`;
+    }*/
       if (newFailedTests.length > 0) {
         ret += `\n:x: **Newly failed tests:**\n\n${newFailedTests
           .map((t) => (t.length > 5 ? `\t- ${t}` : t))

--- a/.github/actions/next-integration-stat/index.js
+++ b/.github/actions/next-integration-stat/index.js
@@ -16674,6 +16674,7 @@
           shouldDiffWithMain
         );
         const postCommentAsync = createCommentPostAsync(octokit, prNumber);
+        const failedTestLists = [];
         // Consturct a comment body to post test report with summary & full details.
         const comments = failedJobResults.result.reduce((acc, value, idx) => {
           var _a, _b, _c;
@@ -16715,6 +16716,7 @@
             groupedFails[ancestorKey].push(fail);
           }
           commentValues.push(`\`${failedTest}\``);
+          failedTestLists.push(failedTest);
           for (const group of Object.keys(groupedFails).sort()) {
             const fails = groupedFails[group];
             commentValues.push(`\n`);
@@ -16778,6 +16780,11 @@
           if (!prNumber) {
             return;
           }
+          // Store the list of failed test paths to a file
+          fs.writeFileSync(
+            "./failed-test-path-list.json",
+            JSON.stringify(failedTestLists, null, 2)
+          );
           if (failedJobResults.result.length === 0) {
             console.log("No failed test results found :tada:");
             yield postCommentAsync(

--- a/.github/actions/next-integration-stat/src/index.ts
+++ b/.github/actions/next-integration-stat/src/index.ts
@@ -177,11 +177,12 @@ function collectFailedTestResults(
       return true;
     })
     .map((logs) => {
-      let failedSplitLogs = logs.split(`failed to pass within`);
+      const failedSplitLogs = logs.split(`failed to pass within`);
+      let logLine = failedSplitLogs.shift();
       const ret = [];
 
-      while (!!failedSplitLogs && failedSplitLogs.length >= 1) {
-        let failedTest = failedSplitLogs.shift();
+      while (logLine) {
+        let failedTest = logLine;
         // Look for the failed test file name
         failedTest = failedTest?.includes("test/")
           ? failedTest?.split("\n").pop()?.trim()
@@ -201,6 +202,7 @@ function collectFailedTestResults(
             name: failedTest,
             data: JSON.parse(testData),
           });
+          logLine = failedSplitLogs.shift();
         } catch (_) {
           console.log(`Failed to parse test data`);
         }
@@ -652,11 +654,15 @@ function getTestSummary(
     (name) => !baseTestFailedNames.includes(name)
   );
 
+  /*
+  //NOTE: upstream test can be flaky, so this can appear intermittently
+  //even if there aren't actual fix. To avoid confusion, do not display this
+  //for now.
   if (fixedTests.length > 0) {
     ret += `\n:white_check_mark: **Fixed tests:**\n\n${fixedTests
       .map((t) => (t.length > 5 ? `\t- ${t}` : t))
       .join(" \n")}`;
-  }
+  }*/
 
   if (newFailedTests.length > 0) {
     ret += `\n:x: **Newly failed tests:**\n\n${newFailedTests

--- a/.github/actions/next-integration-stat/src/index.ts
+++ b/.github/actions/next-integration-stat/src/index.ts
@@ -788,6 +788,8 @@ async function run() {
 
   const postCommentAsync = createCommentPostAsync(octokit, prNumber);
 
+  const failedTestLists = [];
+
   // Consturct a comment body to post test report with summary & full details.
   const comments = failedJobResults.result.reduce((acc, value, idx) => {
     const { name: failedTest, data: testData } = value;
@@ -812,6 +814,7 @@ async function run() {
     }
 
     commentValues.push(`\`${failedTest}\``);
+    failedTestLists.push(failedTest);
 
     for (const group of Object.keys(groupedFails).sort()) {
       const fails = groupedFails[group];
@@ -882,6 +885,12 @@ async function run() {
     if (!prNumber) {
       return;
     }
+
+    // Store the list of failed test paths to a file
+    fs.writeFileSync(
+      "./failed-test-path-list.json",
+      JSON.stringify(failedTestLists, null, 2)
+    );
 
     if (failedJobResults.result.length === 0) {
       console.log("No failed test results found :tada:");

--- a/.github/workflows/nextjs-integration-test.yml
+++ b/.github/workflows/nextjs-integration-test.yml
@@ -230,4 +230,5 @@ jobs:
           name: test-results
           path: |
             nextjs-test-results.json
+            failed-test-path-list.json
             slack-payload.json

--- a/.github/workflows/upload-nextjs-integration-test-results.yml
+++ b/.github/workflows/upload-nextjs-integration-test-results.yml
@@ -35,6 +35,7 @@ jobs:
         run: |
           ls -al ./test-results/main
           cat ./test-results/main/nextjs-test-results.json
+          cat ./test-results/main/failed-test-path-list.json
           echo "NEXTJS_VERSION=$(cat ./test-results/main/nextjs-test-results.json | jq .nextjsVersion | tr -d '"' | cut -d ' ' -f2)" >> $GITHUB_ENV
           echo "SHA_SHORT=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
           echo "RESULT_SUBPATH=$(if ${{ inputs.is_main_branch }}; then echo 'main'; else echo ${{ env.NEXTJS_VERSION }}; fi)" >> $GITHUB_ENV
@@ -46,6 +47,7 @@ jobs:
           echo "Configured test result subpath for ${{ env.RESULT_SUBPATH }} / ${{ env.NEXTJS_VERSION }} / ${{ env.SHA_SHORT }}"
           mkdir -p test-results/${{ env.RESULT_SUBPATH }}
           mv test-results/main/nextjs-test-results.json test-results/${{ env.RESULT_SUBPATH }}/$(date '+%Y%m%d%H%M')-${{ env.NEXTJS_VERSION }}-${{ env.SHA_SHORT }}.json
+          mv -f test-results/main/failed-test-path-list.json test-results/${{ env.RESULT_SUBPATH }}/failed-test-path-list.json
           ls -al ./test-results
           ls -al ./test-results/${{ env.RESULT_SUBPATH }}
 


### PR DESCRIPTION
Closes WEB-544.

PR fixes minor issue to drain logs correctly. 

Also PR adjusts summary to not to print fixed tests - upstream test sometimes flaky and displaying some test as `fixed` intermittently can cause some confusions. For now, disabling those summary. Still we display `new failed`, false negatives are relatively not occur frequently and we can try for a while to see.