### PR TITLE
fix: remove turborepo binary dependency on ffi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7421,7 +7421,6 @@ dependencies = [
  "serde_json",
  "serde_yaml 0.8.26",
  "tiny-gradient",
- "turborepo-ffi",
  "turborepo-lib",
 ]
 

--- a/crates/turborepo/Cargo.toml
+++ b/crates/turborepo/Cargo.toml
@@ -12,10 +12,6 @@ rustls-tls = ["turborepo-lib/rustls-tls"]
 [build-dependencies]
 build-target = "0.4.0"
 
-# we do not actually depend on this, but need
-# to build it before our build.rs script is run
-turborepo-ffi = { path = "../turborepo-ffi" }
-
 [dev-dependencies]
 assert_cmd = "2.0.7"
 itertools = "0.10.5"


### PR DESCRIPTION
Currently our release process is broken due to `protoc` not being setup on the machine: https://github.com/vercel/turbo/actions/runs/4118079447/jobs/7110161689#step:6:363

We shouldn't need protoc when building the top level Rust binary as it's only used when building `turborepo-ffi` which is used by `go-turbo` to call Rust code. `turborepo-ffi` is already built if one runs `make go-turbo` which happens as part of our Rust binary's build script (when not creating a release build). During a release build we don't build `go-turbo` since it is built in an earlier step and is only needed when we package up the two binaries.

We could instead setup `protoc` in the Rust build process, but that adds time to the release process.