### PR TITLE
Combine next.config.js Turbopack options into a nested object

### DIFF
--- a/crates/next-core/js/src/entry/config/next.js
+++ b/crates/next-core/js/src/entry/config/next.js
@@ -17,9 +17,9 @@ const loadNextConfig = async (silent) => {
   nextConfig.exportPathMap = nextConfig.exportPathMap && {};
   nextConfig.webpack = nextConfig.webpack && {};
 
-  if (nextConfig.experimental?.turbopackLoaders) {
+  if (nextConfig.experimental?.turbopack?.loaders) {
     ensureLoadersHaveSerializableOptions(
-      nextConfig.experimental.turbopackLoaders
+      nextConfig.experimental.turbopack.loaders
     );
   }
 

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -243,7 +243,7 @@ pub enum RemotePatternProtocal {
 
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize, TraceRawVcs)]
 #[serde(rename_all = "camelCase")]
-pub struct ExperimentalTurbopackConfig {
+pub struct ExperimentalTurboConfig {
     pub loaders: Option<IndexMap<String, WebpackLoaderConfigs>>,
     pub resolve_alias: Option<IndexMap<String, JsonValue>>,
 }
@@ -253,7 +253,7 @@ pub struct ExperimentalTurbopackConfig {
 pub struct ExperimentalConfig {
     pub app_dir: Option<bool>,
     pub server_components_external_packages: Option<Vec<String>>,
-    pub turbopack: Option<ExperimentalTurbopackConfig>,
+    pub turbo: Option<ExperimentalTurboConfig>,
 
     // unsupported
     adjust_font_fallbacks: Option<bool>,
@@ -405,11 +405,11 @@ impl NextConfigVc {
     #[turbo_tasks::function]
     pub async fn webpack_loaders_options(self) -> Result<WebpackLoadersOptionsVc> {
         let this = self.await?;
-        let Some(turbopack_loaders) = this.experimental.turbopack.as_ref().and_then(|t| t.loaders.as_ref()) else {
+        let Some(turbo_loaders) = this.experimental.turbo.as_ref().and_then(|t| t.loaders.as_ref()) else {
             return Ok(WebpackLoadersOptionsVc::cell(WebpackLoadersOptions::default()));
         };
         let mut extension_to_loaders = IndexMap::new();
-        for (ext, loaders) in turbopack_loaders {
+        for (ext, loaders) in turbo_loaders {
             extension_to_loaders.insert(ext.clone(), WebpackLoaderConfigsVc::cell(loaders.clone()));
         }
         Ok(WebpackLoadersOptions {
@@ -422,7 +422,7 @@ impl NextConfigVc {
     #[turbo_tasks::function]
     pub async fn resolve_alias_options(self) -> Result<ResolveAliasMapVc> {
         let this = self.await?;
-        let Some(resolve_alias) = this.experimental.turbopack.as_ref().and_then(|t| t.resolve_alias.as_ref()) else {
+        let Some(resolve_alias) = this.experimental.turbo.as_ref().and_then(|t| t.resolve_alias.as_ref()) else {
             return Ok(ResolveAliasMapVc::cell(ResolveAliasMap::default()));
         };
         let alias_map: ResolveAliasMap = resolve_alias.try_into()?;

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -243,11 +243,17 @@ pub enum RemotePatternProtocal {
 
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize, TraceRawVcs)]
 #[serde(rename_all = "camelCase")]
+pub struct ExperimentalTurbopackConfig {
+    pub loaders: Option<IndexMap<String, WebpackLoaderConfigs>>,
+    pub resolve_alias: Option<IndexMap<String, JsonValue>>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize, TraceRawVcs)]
+#[serde(rename_all = "camelCase")]
 pub struct ExperimentalConfig {
     pub app_dir: Option<bool>,
     pub server_components_external_packages: Option<Vec<String>>,
-    pub turbopack_loaders: Option<IndexMap<String, WebpackLoaderConfigs>>,
-    pub turbopack_resolve_alias: Option<IndexMap<String, JsonValue>>,
+    pub turbopack: Option<ExperimentalTurbopackConfig>,
 
     // unsupported
     adjust_font_fallbacks: Option<bool>,
@@ -398,7 +404,8 @@ impl NextConfigVc {
 
     #[turbo_tasks::function]
     pub async fn webpack_loaders_options(self) -> Result<WebpackLoadersOptionsVc> {
-        let Some(ref turbopack_loaders) = self.await?.experimental.turbopack_loaders else {
+        let this = self.await?;
+        let Some(turbopack_loaders) = this.experimental.turbopack.as_ref().and_then(|t| t.loaders.as_ref()) else {
             return Ok(WebpackLoadersOptionsVc::cell(WebpackLoadersOptions::default()));
         };
         let mut extension_to_loaders = IndexMap::new();
@@ -415,7 +422,7 @@ impl NextConfigVc {
     #[turbo_tasks::function]
     pub async fn resolve_alias_options(self) -> Result<ResolveAliasMapVc> {
         let this = self.await?;
-        let Some(resolve_alias) = this.experimental.turbopack_resolve_alias.as_ref() else {
+        let Some(resolve_alias) = this.experimental.turbopack.as_ref().and_then(|t| t.resolve_alias.as_ref()) else {
             return Ok(ResolveAliasMapVc::cell(ResolveAliasMap::default()));
         };
         let alias_map: ResolveAliasMap = resolve_alias.try_into()?;

--- a/crates/next-dev-tests/tests/integration/next/resolve-alias/basic/input/index.js
+++ b/crates/next-dev-tests/tests/integration/next/resolve-alias/basic/input/index.js
@@ -1,10 +1,10 @@
 import foo from "foo";
 import foo2 from "foo2";
 
-it("aliases foo to bar through the next.config.js experimental.turbopackResolveAlias property", () => {
+it("aliases foo to bar through the next.config.js experimental.turbopack.resolveAlias property", () => {
   expect(foo).toBe(42);
 });
 
-it("aliases foo2 to bar through the next.config.js experimental.turbopackResolveAlias property with export condition", () => {
+it("aliases foo2 to bar through the next.config.js experimental.turbopack.resolveAlias property with export condition", () => {
   expect(foo2).toBe(42);
 });

--- a/crates/next-dev-tests/tests/integration/next/resolve-alias/basic/input/next.config.js
+++ b/crates/next-dev-tests/tests/integration/next/resolve-alias/basic/input/next.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   experimental: {
-    turbopack: {
+    turbo: {
       resolveAlias: {
         foo: ["bar"],
         foo2: { browser: "bar" },

--- a/crates/next-dev-tests/tests/integration/next/resolve-alias/basic/input/next.config.js
+++ b/crates/next-dev-tests/tests/integration/next/resolve-alias/basic/input/next.config.js
@@ -1,8 +1,10 @@
 module.exports = {
   experimental: {
-    turbopackResolveAlias: {
-      foo: ["bar"],
-      foo2: { browser: "bar" },
+    turbopack: {
+      resolveAlias: {
+        foo: ["bar"],
+        foo2: { browser: "bar" },
+      },
     },
   },
 };

--- a/crates/next-dev-tests/tests/integration/next/webpack-loaders/basic-options/input/next.config.js
+++ b/crates/next-dev-tests/tests/integration/next/webpack-loaders/basic-options/input/next.config.js
@@ -1,7 +1,11 @@
 module.exports = {
   experimental: {
-    turbopackLoaders: {
-      ".replace": [{ loader: "replace-loader", options: { defaultExport: 3 } }],
+    turbopack: {
+      loaders: {
+        ".replace": [
+          { loader: "replace-loader", options: { defaultExport: 3 } },
+        ],
+      },
     },
   },
 };

--- a/crates/next-dev-tests/tests/integration/next/webpack-loaders/basic-options/input/next.config.js
+++ b/crates/next-dev-tests/tests/integration/next/webpack-loaders/basic-options/input/next.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   experimental: {
-    turbopack: {
+    turbo: {
       loaders: {
         ".replace": [
           { loader: "replace-loader", options: { defaultExport: 3 } },

--- a/crates/next-dev-tests/tests/integration/next/webpack-loaders/no-options/input/next.config.js
+++ b/crates/next-dev-tests/tests/integration/next/webpack-loaders/no-options/input/next.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   experimental: {
-    turbopack: {
+    turbo: {
       loaders: {
         ".raw": ["raw-loader"],
       },

--- a/crates/next-dev-tests/tests/integration/next/webpack-loaders/no-options/input/next.config.js
+++ b/crates/next-dev-tests/tests/integration/next/webpack-loaders/no-options/input/next.config.js
@@ -1,7 +1,9 @@
 module.exports = {
   experimental: {
-    turbopackLoaders: {
-      ".raw": ["raw-loader"],
+    turbopack: {
+      loaders: {
+        ".raw": ["raw-loader"],
+      },
     },
   },
 };

--- a/docs/pages/pack/docs/migrating-from-webpack.mdx
+++ b/docs/pages/pack/docs/migrating-from-webpack.mdx
@@ -29,7 +29,7 @@ At the moment, configuring webpack loaders is possible for Next.js apps through 
 ```js filename="next.config.js"
 module.exports = {
   experimental: {
-    turbopack: {
+    turbo: {
       loaders: {
         // Option format
         '.md': [
@@ -55,7 +55,7 @@ Turbopack can be configured to modify module resolution through aliases, similar
 ```js filename="next.config.js"
 module.exports = {
   experimental: {
-    turbopack: {
+    turbo: {
       resolveAlias: {
         underscore: 'lodash',
         mocha: { browser: 'mocha/browser-entry.js' },

--- a/docs/pages/pack/docs/migrating-from-webpack.mdx
+++ b/docs/pages/pack/docs/migrating-from-webpack.mdx
@@ -24,23 +24,25 @@ If you need loader support beyond what's built in, some webpack loaders, includi
 - At the moment, only a core subset of the webpack loader API is implemented. This is enough for some popular loaders, and we'll expand our support for this API in the future.
 - Options passed to webpack loaders must be plain JavaScript primitives, objects, and arrays. For example, it's not possible to pass `require()`d plugin modules as option values.
 
-At the moment, configuring webpack loaders is possible for Next.js apps through an experimental option in `next.config.js`. `turbopackLoaders` can be set to a mapping of file extensions to a list of package names or `{loader, options}` pairs:
+At the moment, configuring webpack loaders is possible for Next.js apps through an experimental option in `next.config.js`. `turbopack.loaders` can be set to a mapping of file extensions to a list of package names or `{loader, options}` pairs:
 
 ```js filename="next.config.js"
 module.exports = {
   experimental: {
-    turbopackLoaders: {
-      // Option format
-      '.md': [
-        {
-          loader: '@mdx-js/loader',
-          options: {
-            format: 'md',
+    turbopack: {
+      loaders: {
+        // Option format
+        '.md': [
+          {
+            loader: '@mdx-js/loader',
+            options: {
+              format: 'md',
+            },
           },
-        },
-      ],
-      // Option-less format
-      '.mdx': '@mdx-js/loader',
+        ],
+        // Option-less format
+        '.mdx': '@mdx-js/loader',
+      },
     },
   },
 }
@@ -53,9 +55,11 @@ Turbopack can be configured to modify module resolution through aliases, similar
 ```js filename="next.config.js"
 module.exports = {
   experimental: {
-    turbopackResolveAlias: {
-      underscore: 'lodash',
-      mocha: { browser: 'mocha/browser-entry.js' },
+    turbopack: {
+      resolveAlias: {
+        underscore: 'lodash',
+        mocha: { browser: 'mocha/browser-entry.js' },
+      },
     },
   },
 }


### PR DESCRIPTION
This combines Turbopack-specific options into a nested object `experimental.turbopack`, exposing `loaders` and `resolveAlias` properties.

x-ref: https://github.com/vercel/next.js/pull/45560/files/631b637f42757e20aabe84dc933527dc66b55173#r1098123643

Test Plan: Integration tests for loaders and resolveAlias.
