### PR TITLE
Allow tuples as TaskInputs

### DIFF
--- a/crates/turbo-tasks/src/task_input.rs
+++ b/crates/turbo-tasks/src/task_input.rs
@@ -879,14 +879,10 @@ macro_rules! tuple_impls {
             fn try_from(value: &'a TaskInput) -> Result<Self, Self::Error> {
                 match value {
                     TaskInput::List(value) => {
-                        let mut i = 0;
+                        let mut iter = value.iter();
                         $(
-                            let $name = value.get(i).ok_or_else(|| anyhow!("missing tuple element"))?;
+                            let $name = iter.next().ok_or_else(|| anyhow!("missing tuple element"))?;
                             let $name = FromTaskInput::try_from($name)?;
-                            #[allow(unused_assignments)]
-                            {
-                                i += 1;
-                            }
                         )+
                         Ok(($($name,)+))
                     },


### PR DESCRIPTION
(I would have created a Linear issue for this specifically but Linear is down)

This PR allows the use of `(A, B, ...)` as `TaskInput`s. This means that the following are now valid `turbo_tasks::function` signatures:

```rust
fn do_the_thing(path: (FileSystemPathVc, BoolVc)) -> SomeVc;
fn parse_headers(headers: Vec<(StringVc, StringVc)>) -> HeadersVc;
```

