### PR TITLE
Add req.cookies to API requests

### DIFF
--- a/crates/next-core/js/src/entry/router.ts
+++ b/crates/next-core/js/src/entry/router.ts
@@ -12,8 +12,8 @@ type RouterRequest = {
   method: string;
   pathname: string;
   // TODO: not passed to request
-  headers: Record<string, string>;
-  query: Record<string, string>;
+  rawHeaders: Array<[string, string]>;
+  rawQuery: string;
 };
 
 type RouteResult = {
@@ -88,8 +88,8 @@ export default async function route(
       server,
       routerRequest.method,
       routerRequest.pathname,
-      routerRequest.query,
-      routerRequest.headers
+      routerRequest.rawQuery,
+      routerRequest.rawHeaders
     );
 
     // Send the clientRequest, so the server parses everything. We can then pass

--- a/crates/next-core/js/src/entry/server-api.tsx
+++ b/crates/next-core/js/src/entry/server-api.tsx
@@ -6,12 +6,24 @@ import "next/dist/server/node-polyfill-fetch.js";
 
 import * as allExports from ".";
 import { apiResolver } from "next/dist/server/api-utils/node";
+import { IncomingMessage, ServerResponse } from "node:http";
+import {
+  NodeNextRequest,
+  NodeNextResponse,
+} from "next/dist/server/base-http/node";
+import { parse } from "node:querystring";
 
 startHandler(({ request, response, query, params, path }) => {
-  const mergedQuery = { ...query, ...params };
+  const parsedQuery = parse(query);
+
+  const mergedQuery = { ...parsedQuery, ...params };
+
+  const req = new NodeNextRequest(request);
+  const res = new NodeNextResponse(response);
+
   return apiResolver(
-    request,
-    response,
+    req.originalRequest,
+    res.originalResponse,
     mergedQuery,
     allExports,
     {

--- a/crates/next-core/js/src/entry/server-api.tsx
+++ b/crates/next-core/js/src/entry/server-api.tsx
@@ -18,6 +18,7 @@ startHandler(({ request, response, query, params, path }) => {
 
   const mergedQuery = { ...parsedQuery, ...params };
 
+  // This enables `req.cookies` in API routes.
   const req = new NodeNextRequest(request);
   const res = new NodeNextResponse(response);
 

--- a/crates/next-core/js/src/entry/server-edge-api.tsx
+++ b/crates/next-core/js/src/entry/server-edge-api.tsx
@@ -17,7 +17,7 @@ import {
   NodeNextRequest,
   NodeNextResponse,
 } from "next/dist/server/base-http/node";
-import type { ParsedUrlQuery } from "querystring";
+import { parse, ParsedUrlQuery } from "querystring";
 import type { Params } from "next/dist/shared/lib/router/utils/route-matcher";
 import { FetchEventResult } from "next/dist/server/web/types";
 import { getClonableBody } from "next/dist/server/body-streams";
@@ -45,7 +45,7 @@ async function runEdgeFunction({
 }: {
   req: BaseNextRequest | NodeNextRequest;
   res: BaseNextResponse | NodeNextResponse;
-  query: ParsedUrlQuery;
+  query: string;
   path: string;
   params: Params | undefined;
   onWarning?: (warning: Error) => void;
@@ -60,9 +60,10 @@ async function runEdgeFunction({
 
   // For edge to "fetch" we must always provide an absolute URL
   const initialUrl = new URL(path, "http://n");
+  const parsedQuery = parse(query);
   const queryString = urlQueryToSearchParams({
     ...Object.fromEntries(initialUrl.searchParams),
-    ...query,
+    ...parsedQuery,
   }).toString();
 
   initialUrl.search = queryString;

--- a/crates/next-core/js/src/internal/page-server-handler.tsx
+++ b/crates/next-core/js/src/internal/page-server-handler.tsx
@@ -15,9 +15,11 @@ import type { BuildManifest } from "next/dist/server/get-page-files";
 import type { ReactLoadableManifest } from "next/dist/server/load-components";
 
 import { ServerResponseShim } from "@vercel/turbopack-next/internal/http";
+import { headersFromEntries } from "@vercel/turbopack-next/internal/utils";
 import type { Ipc } from "@vercel/turbopack-next/ipc/index";
 import type { RenderData } from "types/turbopack";
 import type { ChunkGroup } from "types/next";
+import { parse } from "node:querystring";
 
 const ipc = IPC as Ipc<IpcIncomingMessage, IpcOutgoingMessage>;
 
@@ -195,7 +197,7 @@ export default function startHandler({
     const req: IncomingMessage = {
       url: renderData.url,
       method: "GET",
-      headers: renderData.headers,
+      headers: headersFromEntries(renderData.rawHeaders),
     } as any;
     const res: ServerResponse = new ServerResponseShim(req) as any;
 
@@ -211,7 +213,8 @@ export default function startHandler({
     // `Error.getInitialProps` to detect the status code.
     res.statusCode = statusCode;
 
-    const query = { ...renderData.query, ...renderData.params };
+    const parsedQuery = parse(renderData.rawQuery);
+    const query = { ...parsedQuery, ...renderData.params };
 
     const renderResult = await renderToHTML(
       /* req: IncomingMessage */

--- a/crates/next-core/js/src/internal/utils.ts
+++ b/crates/next-core/js/src/internal/utils.ts
@@ -1,0 +1,21 @@
+/**
+ * Converts an array of raw header entries to a map of header names to values.
+ */
+export function headersFromEntries(
+  entries: Array<[string, string]>
+): Record<string, string | string[]> {
+  const headers: Record<string, string | string[]> = Object.create(null);
+  for (const [key, value] of entries) {
+    if (key in headers) {
+      const prevValue = headers[key];
+      if (typeof prevValue === "string") {
+        headers[key] = [prevValue, value];
+      } else {
+        prevValue.push(value);
+      }
+    } else {
+      headers[key] = value;
+    }
+  }
+  return headers;
+}

--- a/crates/next-core/js/src/ipc/server.ts
+++ b/crates/next-core/js/src/ipc/server.ts
@@ -1,7 +1,7 @@
 import type { ClientRequest, IncomingMessage, Server } from "node:http";
 import type { AddressInfo } from "node:net";
 import http, { ServerResponse } from "node:http";
-import qs from "node:querystring";
+import { headersFromEntries } from "@vercel/turbopack-next/internal/utils";
 
 /**
  * Creates a server that listens a random port.
@@ -23,8 +23,8 @@ export function makeRequest(
   server: Server,
   method: string,
   path: string,
-  query?: Record<string, string>,
-  headers?: Record<string, string>
+  rawQuery?: string,
+  rawHeaders?: Array<[string, string]>
 ): Promise<{
   clientRequest: ClientRequest;
   clientResponsePromise: Promise<IncomingMessage>;
@@ -106,11 +106,10 @@ export function makeRequest(
       port: address.port,
       method,
       path:
-        query && Object.keys(query).length > 0
-          ? `${path}?${qs.stringify(query)}`
-          : path,
-      headers,
+        rawQuery != null && rawQuery.length > 0 ? `${path}?${rawQuery}` : path,
+      headers: rawHeaders != null ? headersFromEntries(rawHeaders) : undefined,
     });
+
     // Otherwise Node.js waits for the first chunk of data to be written before sending the request.
     clientRequest.flushHeaders();
 

--- a/crates/next-core/js/types/turbopack.d.ts
+++ b/crates/next-core/js/types/turbopack.d.ts
@@ -5,6 +5,6 @@ export type RenderData = {
   method: string;
   url: string;
   path: string;
-  query: NextParsedUrlQuery;
-  headers: Record<string, HeaderValue>;
+  rawQuery: string;
+  rawHeaders: Array<[string, string]>;
 };

--- a/crates/next-core/src/router.rs
+++ b/crates/next-core/src/router.rs
@@ -12,7 +12,6 @@ use turbopack_core::{
     resolve::{find_context_file, FindContextFileResult},
     source_asset::SourceAssetVc,
 };
-use turbopack_dev_server::source::{headers::Headers, query::Query};
 use turbopack_ecmascript::{
     chunk::EcmascriptChunkPlaceablesVc, EcmascriptInputTransform, EcmascriptInputTransformsVc,
     EcmascriptModuleAssetType, EcmascriptModuleAssetVc,
@@ -43,8 +42,8 @@ fn next_configs() -> StringsVc {
 pub struct RouterRequest {
     pub method: String,
     pub pathname: String,
-    pub query: Query,
-    pub headers: Headers,
+    pub raw_query: String,
+    pub raw_headers: Vec<(String, String)>,
 }
 
 #[turbo_tasks::value(shared)]

--- a/crates/next-core/src/router_source.rs
+++ b/crates/next-core/src/router_source.rs
@@ -4,9 +4,8 @@ use anyhow::Result;
 use turbo_tasks::{primitives::StringVc, Value};
 use turbopack_core::introspect::{Introspectable, IntrospectableChildrenVc, IntrospectableVc};
 use turbopack_dev_server::source::{
-    ContentSource, ContentSourceContent, ContentSourceData, ContentSourceDataFilter,
-    ContentSourceDataVary, ContentSourceResultVc, ContentSourceVc, NeededData, ProxyResult,
-    RewriteVc,
+    ContentSource, ContentSourceContent, ContentSourceData, ContentSourceDataVary,
+    ContentSourceResultVc, ContentSourceVc, NeededData, ProxyResult, RewriteVc,
 };
 use turbopack_node::execution_context::ExecutionContextVc;
 
@@ -42,8 +41,8 @@ fn need_data(source: ContentSourceVc, path: &str) -> ContentSourceResultVc {
             path: path.to_string(),
             vary: ContentSourceDataVary {
                 method: true,
-                headers: Some(ContentSourceDataFilter::All),
-                query: Some(ContentSourceDataFilter::All),
+                raw_headers: true,
+                raw_query: true,
                 ..Default::default()
             },
         }
@@ -63,8 +62,8 @@ impl ContentSource for NextRouterContentSource {
 
         let ContentSourceData {
             method: Some(method),
-            headers: Some(headers),
-            query: Some(query),
+            raw_headers: Some(raw_headers),
+            raw_query: Some(raw_query),
             ..
         } = &*data else {
             return Ok(need_data(self_vc.into(), path))
@@ -73,8 +72,8 @@ impl ContentSource for NextRouterContentSource {
         let request = RouterRequest {
             pathname: format!("/{path}"),
             method: method.clone(),
-            headers: headers.clone(),
-            query: query.clone(),
+            raw_headers: raw_headers.clone(),
+            raw_query: raw_query.clone(),
         }
         .cell();
 

--- a/crates/turbopack-dev-server/src/source/mod.rs
+++ b/crates/turbopack-dev-server/src/source/mod.rs
@@ -207,23 +207,23 @@ impl From<VersionedContentVc> for ContentSourceContentVc {
 #[turbo_tasks::value(serialization = "auto_for_input")]
 #[derive(Clone, Debug, PartialOrd, Ord, Hash, Default)]
 pub struct ContentSourceData {
-    /// http method, if requested
+    /// HTTP method, if requested.
     pub method: Option<String>,
-    /// The full url (including query string), if requested
+    /// The full url (including query string), if requested.
     pub url: Option<String>,
-    /// query string items, if requested
+    /// Query string items, if requested.
     pub query: Option<Query>,
-    /// raw query string, if requested
+    /// raw query string, if requested. Does not include the `?`.
     pub raw_query: Option<String>,
-    /// http headers, might contain multiple headers with the same name, if
-    /// requested
+    /// HTTP headers, might contain multiple headers with the same name, if
+    /// requested.
     pub headers: Option<Headers>,
-    /// raw HTTP headers, might contain multiple headers with the same name, if
-    /// requested
+    /// Raw HTTP headers, might contain multiple headers with the same name, if
+    /// requested.
     pub raw_headers: Option<Vec<(String, String)>>,
-    /// request body, if requested
+    /// Request body, if requested.
     pub body: Option<BodyVc>,
-    /// see [ContentSourceDataVary::cache_buster]
+    /// See [ContentSourceDataVary::cache_buster].
     pub cache_buster: u64,
 }
 

--- a/crates/turbopack-dev-server/src/source/mod.rs
+++ b/crates/turbopack-dev-server/src/source/mod.rs
@@ -213,9 +213,14 @@ pub struct ContentSourceData {
     pub url: Option<String>,
     /// query string items, if requested
     pub query: Option<Query>,
+    /// raw query string, if requested
+    pub raw_query: Option<String>,
     /// http headers, might contain multiple headers with the same name, if
     /// requested
     pub headers: Option<Headers>,
+    /// raw HTTP headers, might contain multiple headers with the same name, if
+    /// requested
+    pub raw_headers: Option<Vec<(String, String)>>,
     /// request body, if requested
     pub body: Option<BodyVc>,
     /// see [ContentSourceDataVary::cache_buster]
@@ -354,7 +359,9 @@ pub struct ContentSourceDataVary {
     pub method: bool,
     pub url: bool,
     pub query: Option<ContentSourceDataFilter>,
+    pub raw_query: bool,
     pub headers: Option<ContentSourceDataFilter>,
+    pub raw_headers: bool,
     pub body: bool,
     /// When true, a `cache_buster` value is added to the [ContentSourceData].
     /// This value will be different on every request, which ensures the
@@ -367,12 +374,25 @@ impl ContentSourceDataVary {
     /// Merges two vary specification to create a combination of both that cover
     /// all information requested by either one
     pub fn extend(&mut self, other: &ContentSourceDataVary) {
-        self.method = self.method || other.method;
-        self.url = self.url || other.url;
-        self.body = self.body || other.body;
-        self.cache_buster = self.cache_buster || other.cache_buster;
-        ContentSourceDataFilter::extend_options(&mut self.query, &other.query);
-        ContentSourceDataFilter::extend_options(&mut self.headers, &other.headers);
+        let ContentSourceDataVary {
+            method,
+            url,
+            query,
+            raw_query,
+            headers,
+            raw_headers,
+            body,
+            cache_buster,
+            placeholder_for_future_extensions: _,
+        } = self;
+        *method = *method || other.method;
+        *url = *url || other.url;
+        *body = *body || other.body;
+        *cache_buster = *cache_buster || other.cache_buster;
+        *raw_query = *raw_query || other.raw_query;
+        *raw_headers = *raw_headers || other.raw_headers;
+        ContentSourceDataFilter::extend_options(query, &other.query);
+        ContentSourceDataFilter::extend_options(headers, &other.headers);
     }
 
     /// Returns true if `self` at least contains all values that the
@@ -383,7 +403,9 @@ impl ContentSourceDataVary {
             method,
             url,
             query,
+            raw_query,
             headers,
+            raw_headers,
             body,
             cache_buster,
             placeholder_for_future_extensions: _,
@@ -395,6 +417,12 @@ impl ContentSourceDataVary {
             return false;
         }
         if other.body && !body {
+            return false;
+        }
+        if other.raw_query && !raw_query {
+            return false;
+        }
+        if other.raw_headers && !raw_headers {
             return false;
         }
         if other.cache_buster && !cache_buster {

--- a/crates/turbopack-dev-server/src/source/resolve.rs
+++ b/crates/turbopack-dev-server/src/source/resolve.rs
@@ -113,6 +113,18 @@ async fn request_to_data(
     if vary.body {
         data.body = Some(request.body.clone().into());
     }
+    if vary.raw_query {
+        data.raw_query = Some(request.uri.query().unwrap_or("").to_string());
+    }
+    if vary.raw_headers {
+        data.raw_headers = Some(
+            request
+                .headers
+                .iter()
+                .map(|(name, value)| Ok((name.to_string(), value.to_str()?.to_string())))
+                .collect::<Result<Vec<_>>>()?,
+        );
+    }
     if let Some(filter) = vary.query.as_ref() {
         if let Some(query) = request.uri.query() {
             let mut query: Query = serde_qs::from_str(query)?;

--- a/crates/turbopack-node/src/render/mod.rs
+++ b/crates/turbopack-node/src/render/mod.rs
@@ -1,6 +1,5 @@
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
-use turbopack_dev_server::source::{headers::Headers, query::Query};
 
 use crate::{ResponseHeaders, StructuredError};
 
@@ -11,12 +10,13 @@ pub mod render_static;
 pub mod rendered_source;
 
 #[turbo_tasks::value(shared)]
+#[serde(rename_all = "camelCase")]
 pub struct RenderData {
     params: IndexMap<String, String>,
     method: String,
     url: String,
-    query: Query,
-    headers: Headers,
+    raw_query: String,
+    raw_headers: Vec<(String, String)>,
     path: String,
 }
 

--- a/crates/turbopack-node/src/render/node_api_source.rs
+++ b/crates/turbopack-node/src/render/node_api_source.rs
@@ -8,9 +8,8 @@ use turbopack_core::introspect::{
 };
 use turbopack_dev_server::source::{
     specificity::SpecificityVc, ContentSource, ContentSourceContent, ContentSourceContentVc,
-    ContentSourceData, ContentSourceDataFilter, ContentSourceDataVary, ContentSourceDataVaryVc,
-    ContentSourceResult, ContentSourceResultVc, ContentSourceVc, GetContentSourceContent,
-    GetContentSourceContentVc,
+    ContentSourceData, ContentSourceDataVary, ContentSourceDataVaryVc, ContentSourceResult,
+    ContentSourceResultVc, ContentSourceVc, GetContentSourceContent, GetContentSourceContentVc,
 };
 use turbopack_ecmascript::chunk::EcmascriptChunkPlaceablesVc;
 
@@ -105,8 +104,8 @@ impl GetContentSourceContent for NodeApiGetContentResult {
         ContentSourceDataVary {
             method: true,
             url: true,
-            headers: Some(ContentSourceDataFilter::All),
-            query: Some(ContentSourceDataFilter::All),
+            raw_headers: true,
+            raw_query: true,
             body: true,
             cache_buster: true,
             ..Default::default()
@@ -122,8 +121,8 @@ impl GetContentSourceContent for NodeApiGetContentResult {
         let ContentSourceData {
             method: Some(method),
             url: Some(url),
-            headers: Some(headers),
-            query: Some(query),
+            raw_headers: Some(raw_headers),
+            raw_query: Some(raw_query),
             body: Some(body),
             ..
         } = &*data else {
@@ -141,8 +140,8 @@ impl GetContentSourceContent for NodeApiGetContentResult {
                 params: params.clone(),
                 method: method.clone(),
                 url: url.clone(),
-                query: query.clone(),
-                headers: headers.clone(),
+                raw_query: raw_query.clone(),
+                raw_headers: raw_headers.clone(),
                 path: format!("/{}", self.path),
             }
             .cell(),

--- a/crates/turbopack-node/src/render/rendered_source.rs
+++ b/crates/turbopack-node/src/render/rendered_source.rs
@@ -20,9 +20,8 @@ use turbopack_dev_server::{
         lazy_instantiated::{GetContentSource, GetContentSourceVc, LazyInstantiatedContentSource},
         specificity::SpecificityVc,
         ContentSource, ContentSourceContent, ContentSourceContentVc, ContentSourceData,
-        ContentSourceDataFilter, ContentSourceDataVary, ContentSourceDataVaryVc,
-        ContentSourceResult, ContentSourceResultVc, ContentSourceVc, GetContentSourceContent,
-        GetContentSourceContentVc,
+        ContentSourceDataVary, ContentSourceDataVaryVc, ContentSourceResult, ContentSourceResultVc,
+        ContentSourceVc, GetContentSourceContent, GetContentSourceContentVc,
     },
 };
 use turbopack_ecmascript::chunk::EcmascriptChunkPlaceablesVc;
@@ -177,8 +176,8 @@ impl GetContentSourceContent for NodeRenderGetContentResult {
         ContentSourceDataVary {
             method: true,
             url: true,
-            headers: Some(ContentSourceDataFilter::All),
-            query: Some(ContentSourceDataFilter::All),
+            raw_headers: true,
+            raw_query: true,
             ..Default::default()
         }
         .cell()
@@ -193,8 +192,8 @@ impl GetContentSourceContent for NodeRenderGetContentResult {
         let ContentSourceData {
             method: Some(method),
             url: Some(url),
-            headers: Some(headers),
-            query: Some(query),
+            raw_headers: Some(raw_headers),
+            raw_query: Some(raw_query),
             ..
         } = &*data else {
             return Err(anyhow!("Missing request data"));
@@ -212,8 +211,8 @@ impl GetContentSourceContent for NodeRenderGetContentResult {
                 params: params.clone(),
                 method: method.clone(),
                 url: url.clone(),
-                query: query.clone(),
-                headers: headers.clone(),
+                raw_query: raw_query.clone(),
+                raw_headers: raw_headers.clone(),
                 path: format!("/{}", this.pathname.await?),
             }
             .cell(),

--- a/crates/turbopack-node/src/source_map/content_source.rs
+++ b/crates/turbopack-node/src/source_map/content_source.rs
@@ -36,13 +36,13 @@ impl ContentSource for NextSourceMapTraceContentSource {
         path: &str,
         data: Value<ContentSourceData>,
     ) -> Result<ContentSourceResultVc> {
-        let url = match &data.url {
+        let raw_query = match &data.raw_query {
             None => {
                 return Ok(ContentSourceResultVc::need_data(Value::new(NeededData {
                     source: self_vc.into(),
                     path: path.to_string(),
                     vary: ContentSourceDataVary {
-                        url: true,
+                        raw_query: true,
                         ..Default::default()
                     },
                 })));
@@ -50,13 +50,7 @@ impl ContentSource for NextSourceMapTraceContentSource {
             Some(query) => query,
         };
 
-        // TODO: It'd be nice if the data.query value contained the unparsed query, so I
-        // could convert it into my struct.
-        let query_idx = match url.find('?') {
-            Some(i) => i,
-            _ => return Ok(ContentSourceResultVc::not_found()),
-        };
-        let frame: StackFrame = match serde_qs::from_str(&url[query_idx + 1..]) {
+        let frame: StackFrame = match serde_qs::from_str(raw_query) {
             Ok(f) => f,
             _ => return Ok(ContentSourceResultVc::not_found()),
         };


### PR DESCRIPTION
This PR does a little bit more than what it says on the box. Before, we were parsing URL queries and request headers, only to serialize them some other way afterwards. The reason why we were parsing headers and queries is because we sometimes need to filter them. However, we don't need that for router/page SSR/page API. This PR makes it so we avoid parsing on Turbopack's side through `rawHeaders` and `rawQuery`.