### PR TITLE
fix: turborepo integration test glob

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -137,6 +137,7 @@ jobs:
         with:
           PATTERNS: |
             cli/**
+            crates/turborepo*
             crates/turborepo*/**
             crates/turbo-updater
             Cargo.lock

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -136,7 +136,8 @@ jobs:
         uses: technote-space/get-diff-action@v6
         with:
           PATTERNS: |
-            crates/turborepo*
+            cli/**
+            crates/turborepo*/**
             crates/turbo-updater
             Cargo.lock
 


### PR DESCRIPTION
Expanding the patterns to include any changes to the `cli` directory as well as changing `crates/turborepo*` to `creates/turborepo*/**` which seems to be what we want.

Testing:
Under the hood get-diff-action [uses minimatch](https://github.com/technote-space/get-diff-action#usage) for matching patterns against `git diff`. I quick wrote a test script to verify these patterns should get us what we want:
```
const { minimatch } = require("minimatch")

const paths = [
'crates/turborepo',
'crates/turborepo-ffi',
'crates/turborepo-lib/src/shim.rs',
'crates/turborepo/Cargo.toml',
]
for (const pat of ['crates/turborepo*', 'crates/turborepo*/**']) {
    for (const path of paths) {
        console.log(`${pat} matches ${path}: ${minimatch(path, pat)}`)
    }
}
```
Output:
```
"crates/turborepo* matches crates/turborepo: true"
"crates/turborepo* matches crates/turborepo-ffi: true"
"crates/turborepo* matches crates/turborepo-lib/src/shim.rs: false"
"crates/turborepo* matches crates/turborepo/Cargo.toml: false"
"crates/turborepo*/** matches crates/turborepo: false"
"crates/turborepo*/** matches crates/turborepo-ffi: false"
"crates/turborepo*/** matches crates/turborepo-lib/src/shim.rs: true"
"crates/turborepo*/** matches crates/turborepo/Cargo.toml: true"
```