### PR TITLE
Run the Test workflow on all PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
When using stacked PRs with Graphite, PRs up the stack will not target `main`. This means that, with the current filter, the Test workflow will not apply to them.