### PR TITLE
Enable HMR updates even when critical issues occur

### DIFF
--- a/crates/next-core/js/src/dev/hmr-client.ts
+++ b/crates/next-core/js/src/dev/hmr-client.ts
@@ -284,8 +284,6 @@ function handleSocketMessage(msg: ServerMessage) {
   const hasCriticalIssues = handleIssues(msg);
   const aggregatedMsg = aggregateUpdates(msg, hasCriticalIssues);
 
-  if (hasCriticalIssues) return;
-
   const runHooks = chunksWithUpdates.size === 0;
 
   if (aggregatedMsg.type !== "issues") {


### PR DESCRIPTION
This enables HMR updates, even when the update message also contains critical issues.

There were some inconsistencies with the logic previously, so I'm not sure whether this fix is fully correct. More on that in PR comments.