### PR TITLE
set nextExport flag for page rendering

### DIFF
--- a/crates/next-core/js/src/internal/page-server-handler.tsx
+++ b/crates/next-core/js/src/internal/page-server-handler.tsx
@@ -159,6 +159,8 @@ export default function startHandler({
         previewModeSigningKey: "",
       },
       basePath: "",
+      // TODO(WEB-583) this isn't correct, instead it should set `dev: true`
+      nextExport: true,
       resolvedUrl: renderData.url,
       optimizeFonts: false,
       optimizeCss: false,


### PR DESCRIPTION
Otherwise `router.isReady` will never be true for pages without gSSP, gSP or gIP