### PR TITLE
fix: Turbo updater feature

### DIFF
--- a/crates/turborepo-lib/Cargo.toml
+++ b/crates/turborepo-lib/Cargo.toml
@@ -44,5 +44,8 @@ serde_json = "1.0.86"
 serde_yaml = "0.8.26"
 tiny-gradient = "0.1"
 tokio = { version = "1.24.2", features = ["full"] }
-turbo-updater = { path = "../turbo-updater" }
+# turbo-updater is optional because it uses ureq which in turn uses ring
+# which doesn't compile on Windows with ARM currently:
+# https://github.com/briansmith/ring/issues/1514
+turbo-updater = { path = "../turbo-updater", optional = true }
 webbrowser = "0.8.4"

--- a/crates/turborepo-lib/src/lib.rs
+++ b/crates/turborepo-lib/src/lib.rs
@@ -6,6 +6,8 @@ mod package_manager;
 mod retry;
 mod shim;
 mod ui;
+#[cfg(feature = "turbo-updater")]
+mod updater;
 
 use anyhow::Result;
 use log::error;

--- a/crates/turborepo-lib/src/shim.rs
+++ b/crates/turborepo-lib/src/shim.rs
@@ -17,8 +17,10 @@ use semver::Version;
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "turbo-updater")]
+use crate::get_version;
+#[cfg(feature = "turbo-updater")]
 use crate::updater::try_check_for_updates;
-use crate::{cli, get_version, PackageManager, Payload};
+use crate::{cli, PackageManager, Payload};
 
 static TURBO_JSON: &str = "turbo.json";
 

--- a/crates/turborepo-lib/src/updater.rs
+++ b/crates/turborepo-lib/src/updater.rs
@@ -1,0 +1,78 @@
+use std::time::Duration;
+
+use tiny_gradient::{GradientStr, RGB};
+use turbo_updater::check_for_updates;
+
+use crate::shim::ShimArgs;
+
+static TURBO_SKIP_NOTIFIER_ARGS: [&str; 4] = ["--help", "--h", "--version", "--v"];
+
+// all arguments that result in a stdout that much be directly parsable and
+// should not be paired with additional output (from the update notifier for
+// example)
+static TURBO_PURE_OUTPUT_ARGS: [&str; 6] = [
+    "--json",
+    "--dry",
+    "--dry-run",
+    "--dry=json",
+    "--graph",
+    "--dry-run=json",
+];
+
+pub(crate) fn try_check_for_updates(args: &ShimArgs, current_version: &str, is_global_turbo: bool) {
+    if args.should_check_for_update() {
+        // custom footer for update message
+        let footer = format!(
+            "Follow {username} for updates: {url}",
+            username = "@turborepo".gradient([RGB::new(0, 153, 247), RGB::new(241, 23, 18)]),
+            url = "https://twitter.com/turborepo"
+        );
+
+        let interval = if args.force_update_check {
+            // force update check
+            Some(Duration::ZERO)
+        } else {
+            // use default (24 hours)
+            None
+        };
+        // check for updates
+        let _ = check_for_updates(
+            "turbo",
+            "https://github.com/vercel/turbo",
+            Some(&footer),
+            current_version,
+            // use default for timeout (800ms)
+            None,
+            interval,
+            is_global_turbo,
+        );
+    }
+}
+
+impl ShimArgs {
+    // returns true if any flags result in pure json output to stdout
+    fn has_json_flags(&self) -> bool {
+        self.remaining_turbo_args
+            .iter()
+            .any(|arg| TURBO_PURE_OUTPUT_ARGS.contains(&arg.as_str()))
+    }
+
+    // returns true if any flags should bypass the update notifier
+    fn has_notifier_skip_flags(&self) -> bool {
+        self.remaining_turbo_args
+            .iter()
+            .any(|arg| TURBO_SKIP_NOTIFIER_ARGS.contains(&arg.as_str()))
+    }
+
+    pub fn should_check_for_update(&self) -> bool {
+        if self.force_update_check {
+            return true;
+        }
+
+        if self.has_notifier_skip_flags() || self.has_json_flags() {
+            return false;
+        }
+
+        true
+    }
+}

--- a/crates/turborepo/Cargo.toml
+++ b/crates/turborepo/Cargo.toml
@@ -7,6 +7,8 @@ license = "MPL-2.0"
 [features]
 native-tls = ["turborepo-lib/native-tls"]
 rustls-tls = ["turborepo-lib/rustls-tls"]
+turbo-updater = ["turborepo-lib/turbo-updater"]
+default = ["turbo-updater"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [build-dependencies]


### PR DESCRIPTION
Gate turbo-updater behind a feature because it uses `ureq` which in turn uses `rustls-tls` which uses `ring` which [doesn't build on Windows ARM](https://github.com/briansmith/ring/issues/1514) (at least until 0.17 is released).