### PR TITLE
fix: use prerelease update-informer to cut ureq

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7635,7 +7635,6 @@ dependencies = [
  "serde",
  "thiserror",
  "update-informer",
- "ureq",
 ]
 
 [[package]]
@@ -8086,32 +8085,13 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 [[package]]
 name = "update-informer"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "152ff185ca29f7f487c51ca785b0f1d85970c4581f4cdd12ed499227890200f5"
+source = "git+https://github.com/mgrachev/update-informer?rev=b7a415ac2276e857167b9fe8282044f93155878a#b7a415ac2276e857167b9fe8282044f93155878a"
 dependencies = [
  "directories",
+ "reqwest",
  "semver 1.0.16",
  "serde",
  "serde_json",
- "ureq",
-]
-
-[[package]]
-name = "ureq"
-version = "2.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "338b31dd1314f68f3aabf3ed57ab922df95ffcd902476ca7ba3c4ce7b908c46d"
-dependencies = [
- "base64 0.13.1",
- "flate2",
- "log",
- "once_cell",
- "rustls",
- "serde",
- "serde_json",
- "url",
- "webpki",
- "webpki-roots",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7631,6 +7631,7 @@ version = "0.1.0"
 dependencies = [
  "atty",
  "console",
+ "reqwest",
  "semver 1.0.16",
  "serde",
  "thiserror",
@@ -8088,7 +8089,6 @@ version = "0.6.0"
 source = "git+https://github.com/mgrachev/update-informer?rev=b7a415ac2276e857167b9fe8282044f93155878a#b7a415ac2276e857167b9fe8282044f93155878a"
 dependencies = [
  "directories",
- "reqwest",
  "semver 1.0.16",
  "serde",
  "serde_json",

--- a/crates/turbo-updater/Cargo.toml
+++ b/crates/turbo-updater/Cargo.toml
@@ -12,5 +12,6 @@ console = "0.15.5"
 semver = "1.0"
 serde = { version = "1.0.126", features = ["derive"] }
 thiserror = "1.0"
-update-informer = "0.6.0"
-ureq = { version = "2.3.0" }
+update-informer = { git = "https://github.com/mgrachev/update-informer", rev = "b7a415ac2276e857167b9fe8282044f93155878a", default_features = false, features = [
+  "reqwest",
+] }

--- a/crates/turbo-updater/Cargo.toml
+++ b/crates/turbo-updater/Cargo.toml
@@ -6,12 +6,20 @@ description = "Minimal wrapper around update-informer to provide npm registry su
 license = "MPL-2.0"
 publish = false
 
+[features]
+# Allows configuring a specific tls backend for reqwest.
+# See top level Cargo.toml for more details.
+native-tls = ["reqwest/native-tls"]
+rustls-tls = ["reqwest/rustls-tls"]
+
 [dependencies]
 atty = "0.2"
 console = "0.15.5"
+reqwest = { version = "0.11.14", default_features = false, features = [
+  "json",
+  "blocking",
+] }
 semver = "1.0"
 serde = { version = "1.0.126", features = ["derive"] }
 thiserror = "1.0"
-update-informer = { git = "https://github.com/mgrachev/update-informer", rev = "b7a415ac2276e857167b9fe8282044f93155878a", default_features = false, features = [
-  "reqwest",
-] }
+update-informer = { git = "https://github.com/mgrachev/update-informer", rev = "b7a415ac2276e857167b9fe8282044f93155878a", default_features = false }

--- a/crates/turborepo-lib/Cargo.toml
+++ b/crates/turborepo-lib/Cargo.toml
@@ -7,8 +7,8 @@ license = "MPL-2.0"
 [features]
 # Allows configuring a specific tls backend for reqwest.
 # See top level Cargo.toml for more details.
-native-tls = ["reqwest/native-tls"]
-rustls-tls = ["reqwest/rustls-tls"]
+native-tls = ["reqwest/native-tls", "turbo-updater/native-tls"]
+rustls-tls = ["reqwest/rustls-tls", "turbo-updater/rustls-tls"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dev-dependencies]


### PR DESCRIPTION
`update-informer` has some good stuff in the pipeline that allows us to specify the http client we use. This is a quick and dirty add support for the updater on Windows ARM. If we don't want to use a non-release version of `update-informer` than #3722 should be merged instead of this.

I expect a new release of `update-informer` might take a little bit as this is a breaking change due to the updated `Registry` trait definition. 
![Screen Shot 2023-02-09 at 11 48 37 AM](https://user-images.githubusercontent.com/4131117/217921725-f8fd3651-aac7-4d43-aba1-74da9234165c.png)
