### PR TITLE
Dedupe TurboJSON and PackageJSON reads

### DIFF
--- a/cli/internal/context/context.go
+++ b/cli/internal/context/context.go
@@ -144,7 +144,9 @@ func isWorkspaceReference(packageVersion string, dependencyVersion string, cwd s
 
 // SinglePackageGraph constructs a Context instance from a single package.
 func SinglePackageGraph(repoRoot turbopath.AbsoluteSystemPath, rootPackageJSON *fs.PackageJSON) (*Context, error) {
-	workspaceInfos := map[string]*fs.PackageJSON{util.RootPkgName: rootPackageJSON}
+	workspaceInfos := graph.WorkspaceInfos{
+		PackageJSONs: map[string]*fs.PackageJSON{util.RootPkgName: rootPackageJSON},
+	}
 	c := &Context{
 		WorkspaceInfos: workspaceInfos,
 		RootNode:       core.ROOT_NODE_NAME,
@@ -162,7 +164,10 @@ func SinglePackageGraph(repoRoot turbopath.AbsoluteSystemPath, rootPackageJSON *
 func BuildPackageGraph(repoRoot turbopath.AbsoluteSystemPath, rootPackageJSON *fs.PackageJSON) (*Context, error) {
 	c := &Context{}
 	rootpath := repoRoot.ToStringDuringMigration()
-	c.WorkspaceInfos = make(graph.WorkspaceInfos)
+	c.WorkspaceInfos = graph.WorkspaceInfos{
+		PackageJSONs: map[string]*fs.PackageJSON{},
+		TurboConfigs: map[string]*fs.TurboJSON{},
+	}
 	c.RootNode = core.ROOT_NODE_NAME
 
 	var warnings Warnings
@@ -207,7 +212,7 @@ func BuildPackageGraph(repoRoot turbopath.AbsoluteSystemPath, rootPackageJSON *f
 		return nil, err
 	}
 	populateGraphWaitGroup := &errgroup.Group{}
-	for _, pkg := range c.WorkspaceInfos {
+	for _, pkg := range c.WorkspaceInfos.PackageJSONs {
 		pkg := pkg
 		populateGraphWaitGroup.Go(func() error {
 			return c.populateWorkspaceGraphForPackageJSON(pkg, rootpath, pkg.Name, &warnings)
@@ -224,7 +229,7 @@ func BuildPackageGraph(repoRoot turbopath.AbsoluteSystemPath, rootPackageJSON *f
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve dependencies for root package: %v", err)
 	}
-	c.WorkspaceInfos[util.RootPkgName] = rootPackageJSON
+	c.WorkspaceInfos.PackageJSONs[util.RootPkgName] = rootPackageJSON
 
 	return c, warnings.errorOrNil()
 }
@@ -293,7 +298,7 @@ func (c *Context) populateWorkspaceGraphForPackageJSON(pkg *fs.PackageJSON, root
 
 	// split out internal vs. external deps
 	for depName, depVersion := range depMap {
-		if item, ok := c.WorkspaceInfos[depName]; ok && isWorkspaceReference(item.Version, depVersion, pkg.Dir.ToStringDuringMigration(), rootpath) {
+		if item, ok := c.WorkspaceInfos.PackageJSONs[depName]; ok && isWorkspaceReference(item.Version, depVersion, pkg.Dir.ToStringDuringMigration(), rootpath) {
 			internalDepsSet.Add(depName)
 			c.WorkspaceGraph.Connect(dag.BasicEdge(vertexName, depName))
 		} else {
@@ -363,11 +368,11 @@ func (c *Context) parsePackageJSON(repoRoot turbopath.AbsoluteSystemPath, pkgJSO
 		c.WorkspaceGraph.Add(pkg.Name)
 		pkg.PackageJSONPath = turbopath.AnchoredSystemPathFromUpstream(relativePkgJSONPath)
 		pkg.Dir = turbopath.AnchoredSystemPathFromUpstream(filepath.Dir(relativePkgJSONPath))
-		if c.WorkspaceInfos[pkg.Name] != nil {
-			existing := c.WorkspaceInfos[pkg.Name]
+		if c.WorkspaceInfos.PackageJSONs[pkg.Name] != nil {
+			existing := c.WorkspaceInfos.PackageJSONs[pkg.Name]
 			return fmt.Errorf("Failed to add workspace \"%s\" from %s, it already exists at %s", pkg.Name, pkg.Dir, existing.Dir)
 		}
-		c.WorkspaceInfos[pkg.Name] = pkg
+		c.WorkspaceInfos.PackageJSONs[pkg.Name] = pkg
 		c.WorkspaceNames = append(c.WorkspaceNames, pkg.Name)
 	}
 	return nil
@@ -481,12 +486,12 @@ func (c *Context) ChangedPackages(previousLockfile lockfile.Lockfile) ([]string,
 		return false
 	}
 
-	changedPkgs := make([]string, 0, len(c.WorkspaceInfos))
+	changedPkgs := make([]string, 0, len(c.WorkspaceInfos.PackageJSONs))
 
 	// check if prev and current have "global" changes e.g. lockfile bump
 	globalChange := c.Lockfile.GlobalChange(previousLockfile)
 
-	for pkgName, pkg := range c.WorkspaceInfos {
+	for pkgName, pkg := range c.WorkspaceInfos.PackageJSONs {
 		if globalChange {
 			break
 		}
@@ -500,8 +505,8 @@ func (c *Context) ChangedPackages(previousLockfile lockfile.Lockfile) ([]string,
 	}
 
 	if globalChange {
-		changedPkgs = make([]string, 0, len(c.WorkspaceInfos))
-		for pkgName := range c.WorkspaceInfos {
+		changedPkgs = make([]string, 0, len(c.WorkspaceInfos.PackageJSONs))
+		for pkgName := range c.WorkspaceInfos.PackageJSONs {
 			changedPkgs = append(changedPkgs, pkgName)
 		}
 		sort.Strings(changedPkgs)

--- a/cli/internal/context/context.go
+++ b/cli/internal/context/context.go
@@ -146,6 +146,7 @@ func isWorkspaceReference(packageVersion string, dependencyVersion string, cwd s
 func SinglePackageGraph(repoRoot turbopath.AbsoluteSystemPath, rootPackageJSON *fs.PackageJSON) (*Context, error) {
 	workspaceInfos := graph.WorkspaceInfos{
 		PackageJSONs: map[string]*fs.PackageJSON{util.RootPkgName: rootPackageJSON},
+		TurboConfigs: map[string]*fs.TurboJSON{},
 	}
 	c := &Context{
 		WorkspaceInfos: workspaceInfos,

--- a/cli/internal/core/engine.go
+++ b/cli/internal/core/engine.go
@@ -407,7 +407,9 @@ func (e *Engine) getTaskDefinitionChain(taskID string, taskName string) ([]fs.Bo
 
 	rootPipeline, err := e.completeGraph.GetPipelineFromWorkspace(util.RootPkgName, e.isSinglePackage)
 	if err != nil {
-		return nil, fmt.Errorf("OOPS")
+		// It should be very unlikely that we can't find a root pipeline. Even for single package repos
+		// the pipeline is synthesized from package.json, so there should be _something_ here.
+		return nil, err
 	}
 
 	// Look for the taskDefinition in the root pipeline.

--- a/cli/internal/core/engine.go
+++ b/cli/internal/core/engine.go
@@ -176,7 +176,7 @@ func (e *Engine) Prepare(options *EngineBuildingOptions) error {
 		if pkg == ROOT_NODE_NAME {
 			pkgDefinition = &fs.PackageJSON{}
 		} else {
-			pkgJSON, ok := e.completeGraph.WorkspaceInfos[pkg]
+			pkgJSON, ok := e.completeGraph.WorkspaceInfos.PackageJSONs[pkg]
 			if !ok {
 				// If we have a pkg it should be in WorkspaceInfos.
 				// If we're hitting this error something has gone wrong earlier when building WorkspaceInfos
@@ -380,7 +380,7 @@ func (e *Engine) ValidatePersistentDependencies(graph *graph.CompleteGraph) erro
 			}
 
 			// Get information about the package
-			pkg, pkgExists := graph.WorkspaceInfos[packageName]
+			pkg, pkgExists := graph.WorkspaceInfos.PackageJSONs[packageName]
 			if !pkgExists {
 				return fmt.Errorf("Cannot find package %v", packageName)
 			}
@@ -542,7 +542,7 @@ func (e *Engine) getTurboConfigFromWorkspace(workspaceName string) (*fs.TurboJSO
 
 	// Note: dir for the root workspace will be an empty string, and for
 	// other workspaces, it will be a relative path.
-	dir := e.completeGraph.WorkspaceInfos[workspaceName].Dir
+	dir := e.completeGraph.WorkspaceInfos.PackageJSONs[workspaceName].Dir
 	repoRoot := e.completeGraph.RepoRoot
 	dirAbsolutePath := dir.RestoreAnchor(repoRoot)
 
@@ -572,7 +572,7 @@ func (e *Engine) getPackageJSONFromWorkspace(workspaceName string) (*fs.PackageJ
 
 	// Note: dir for the root workspace will be an empty string, and for
 	// other workspaces, it will be a relative path.
-	dir := e.completeGraph.WorkspaceInfos[workspaceName].Dir
+	dir := e.completeGraph.WorkspaceInfos.PackageJSONs[workspaceName].Dir
 	repoRoot := e.completeGraph.RepoRoot
 	dirAbsolutePath := dir.RestoreAnchor(repoRoot)
 

--- a/cli/internal/fs/turbo_json.go
+++ b/cli/internal/fs/turbo_json.go
@@ -156,7 +156,6 @@ func (pc Pipeline) GetTask(taskID string, taskName string) (*BookkeepingTaskDefi
 
 // LoadTurboConfig loads, or optionally, synthesizes a TurboJSON instance
 func LoadTurboConfig(dir turbopath.AbsoluteSystemPath, rootPackageJSON *PackageJSON, includeSynthesizedFromRootPackageJSON bool) (*TurboJSON, error) {
-	// fmt.Printf("[debug] LoadturboConfig() from %#v\n", dir)
 	// If the root package.json stil has a `turbo` key, log a warning and remove it.
 	if rootPackageJSON.LegacyTurboConfig != nil {
 		log.Printf("[WARNING] \"turbo\" in package.json is no longer supported. Migrate to %s by running \"npx @turbo/codemod create-turbo-config\"\n", configFile)

--- a/cli/internal/fs/turbo_json.go
+++ b/cli/internal/fs/turbo_json.go
@@ -156,6 +156,7 @@ func (pc Pipeline) GetTask(taskID string, taskName string) (*BookkeepingTaskDefi
 
 // LoadTurboConfig loads, or optionally, synthesizes a TurboJSON instance
 func LoadTurboConfig(dir turbopath.AbsoluteSystemPath, rootPackageJSON *PackageJSON, includeSynthesizedFromRootPackageJSON bool) (*TurboJSON, error) {
+	// fmt.Printf("[debug] LoadturboConfig() from %#v\n", dir)
 	// If the root package.json stil has a `turbo` key, log a warning and remove it.
 	if rootPackageJSON.LegacyTurboConfig != nil {
 		log.Printf("[WARNING] \"turbo\" in package.json is no longer supported. Migrate to %s by running \"npx @turbo/codemod create-turbo-config\"\n", configFile)

--- a/cli/internal/graph/graph.go
+++ b/cli/internal/graph/graph.go
@@ -16,6 +16,7 @@ import (
 // WorkspaceInfos holds information about each workspace in the monorepo.
 type WorkspaceInfos struct {
 	PackageJSONs map[string]*fs.PackageJSON
+	TurboConfigs map[string]*fs.TurboJSON
 }
 
 // CompleteGraph represents the common state inferred from the filesystem and pipeline.

--- a/cli/internal/graph/graph.go
+++ b/cli/internal/graph/graph.go
@@ -14,7 +14,9 @@ import (
 )
 
 // WorkspaceInfos holds information about each workspace in the monorepo.
-type WorkspaceInfos map[string]*fs.PackageJSON
+type WorkspaceInfos struct {
+	PackageJSONs map[string]*fs.PackageJSON
+}
 
 // CompleteGraph represents the common state inferred from the filesystem and pipeline.
 // It is not intended to include information specific to a particular run.
@@ -44,7 +46,7 @@ type CompleteGraph struct {
 func (g *CompleteGraph) GetPackageTaskVisitor(ctx gocontext.Context, visitor func(ctx gocontext.Context, packageTask *nodes.PackageTask) error) func(taskID string) error {
 	return func(taskID string) error {
 		packageName, taskName := util.GetPackageTaskFromId(taskID)
-		pkg, ok := g.WorkspaceInfos[packageName]
+		pkg, ok := g.WorkspaceInfos.PackageJSONs[packageName]
 		if !ok {
 			return fmt.Errorf("cannot find package %v for task %v", packageName, taskID)
 		}

--- a/cli/internal/graph/graph.go
+++ b/cli/internal/graph/graph.go
@@ -104,11 +104,10 @@ func (g *CompleteGraph) GetTurboConfigFromWorkspace(workspaceName string, isSing
 		return &fs.TurboJSON{}, nil
 	}
 
-	dir := pkgJSON.Dir
-	repoRoot := g.RepoRoot
-	dirAbsolutePath := dir.RestoreAnchor(repoRoot)
+	workspaceAbsolutePath := pkgJSON.Dir.RestoreAnchor(g.RepoRoot)
+	turboConfig, err := fs.LoadTurboConfig(workspaceAbsolutePath, pkgJSON, isSinglePackage)
 
-	turboConfig, err := fs.LoadTurboConfig(dirAbsolutePath, pkgJSON, isSinglePackage)
+	// If we failed to load a TurboConfig, return the error
 	if err != nil {
 		return nil, err
 	}

--- a/cli/internal/run/dry_run.go
+++ b/cli/internal/run/dry_run.go
@@ -208,7 +208,7 @@ func displayDryTextRun(ui cli.Ui, summary *dryRunSummary, workspaceInfos graph.W
 		p := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', 0)
 		fmt.Fprintln(p, "Name\tPath\t")
 		for _, pkg := range summary.Packages {
-			fmt.Fprintf(p, "%s\t%s\t\n", pkg, workspaceInfos[pkg].Dir)
+			fmt.Fprintf(p, "%s\t%s\t\n", pkg, workspaceInfos.PackageJSONs[pkg].Dir)
 		}
 		if err := p.Flush(); err != nil {
 			return err

--- a/cli/internal/scope/filter/filter.go
+++ b/cli/internal/scope/filter/filter.go
@@ -269,7 +269,7 @@ func (r *Resolver) filterNodesWithSelector(selector *TargetSelector) (util.Set, 
 					} else if matches {
 						entryPackages.Add(pkgName)
 					}
-				} else if pkg, ok := r.WorkspaceInfos[pkgNameStr]; !ok {
+				} else if pkg, ok := r.WorkspaceInfos.PackageJSONs[pkgNameStr]; !ok {
 					return nil, fmt.Errorf("missing info for package %v", pkgName)
 				} else if matches, err := doublestar.PathMatch(r.Cwd.Join(parentDir).ToString(), pkg.Dir.RestoreAnchor(r.Cwd).ToString()); err != nil {
 					return nil, fmt.Errorf("failed to resolve directory relationship %v contains %v: %v", selector.parentDir, pkg.Dir, err)
@@ -287,7 +287,7 @@ func (r *Resolver) filterNodesWithSelector(selector *TargetSelector) (util.Set, 
 		if parentDir == "." {
 			entryPackages.Add(util.RootPkgName)
 		} else {
-			for name, pkg := range r.WorkspaceInfos {
+			for name, pkg := range r.WorkspaceInfos.PackageJSONs {
 				if matches, err := doublestar.PathMatch(r.Cwd.Join(parentDir).ToString(), pkg.Dir.RestoreAnchor(r.Cwd).ToString()); err != nil {
 					return nil, fmt.Errorf("failed to resolve directory relationship %v contains %v: %v", selector.parentDir, pkg.Dir, err)
 				} else if matches {
@@ -332,7 +332,7 @@ func (r *Resolver) filterSubtreesWithSelector(selector *TargetSelector) (util.Se
 
 	parentDir := selector.parentDir
 	entryPackages := make(util.Set)
-	for name, pkg := range r.WorkspaceInfos {
+	for name, pkg := range r.WorkspaceInfos.PackageJSONs {
 		if parentDir == "" {
 			entryPackages.Add(name)
 		} else if matches, err := doublestar.PathMatch(parentDir.ToString(), pkg.Dir.RestoreAnchor(r.Cwd).ToString()); err != nil {

--- a/cli/internal/scope/filter/filter_test.go
+++ b/cli/internal/scope/filter/filter_test.go
@@ -37,7 +37,10 @@ func Test_filter(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get working directory: %v", err)
 	}
-	packageJSONs := make(graph.WorkspaceInfos)
+	workspaceInfos := graph.WorkspaceInfos{
+		PackageJSONs: make(map[string]*fs.PackageJSON),
+	}
+	packageJSONs := workspaceInfos.PackageJSONs
 	graph := &dag.AcyclicGraph{}
 	graph.Add("project-0")
 	packageJSONs["project-0"] = &fs.PackageJSON{
@@ -291,7 +294,7 @@ func Test_filter(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			r := &Resolver{
 				Graph:          graph,
-				WorkspaceInfos: packageJSONs,
+				WorkspaceInfos: workspaceInfos,
 				Cwd:            root,
 				Inference:      tc.PackageInference,
 			}
@@ -306,7 +309,7 @@ func Test_filter(t *testing.T) {
 	t.Run("report unmatched filters", func(t *testing.T) {
 		r := &Resolver{
 			Graph:          graph,
-			WorkspaceInfos: packageJSONs,
+			WorkspaceInfos: workspaceInfos,
 			Cwd:            root,
 		}
 		pkgs, err := r.getFilteredPackages([]*TargetSelector{
@@ -338,7 +341,10 @@ func Test_matchScopedPackage(t *testing.T) {
 		t.Fatalf("failed to get working directory: %v", err)
 	}
 
-	packageJSONs := make(graph.WorkspaceInfos)
+	workspaceInfos := graph.WorkspaceInfos{
+		PackageJSONs: make(map[string]*fs.PackageJSON),
+	}
+	packageJSONs := workspaceInfos.PackageJSONs
 	graph := &dag.AcyclicGraph{}
 	graph.Add("@foo/bar")
 	packageJSONs["@foo/bar"] = &fs.PackageJSON{
@@ -347,7 +353,7 @@ func Test_matchScopedPackage(t *testing.T) {
 	}
 	r := &Resolver{
 		Graph:          graph,
-		WorkspaceInfos: packageJSONs,
+		WorkspaceInfos: workspaceInfos,
 		Cwd:            root,
 	}
 	pkgs, err := r.getFilteredPackages([]*TargetSelector{
@@ -371,7 +377,10 @@ func Test_matchExactPackages(t *testing.T) {
 		t.Fatalf("failed to get working directory: %v", err)
 	}
 
-	packageJSONs := make(graph.WorkspaceInfos)
+	workspaceInfos := graph.WorkspaceInfos{
+		PackageJSONs: make(map[string]*fs.PackageJSON),
+	}
+	packageJSONs := workspaceInfos.PackageJSONs
 	graph := &dag.AcyclicGraph{}
 	graph.Add("@foo/bar")
 	packageJSONs["@foo/bar"] = &fs.PackageJSON{
@@ -385,7 +394,7 @@ func Test_matchExactPackages(t *testing.T) {
 	}
 	r := &Resolver{
 		Graph:          graph,
-		WorkspaceInfos: packageJSONs,
+		WorkspaceInfos: workspaceInfos,
 		Cwd:            root,
 	}
 	pkgs, err := r.getFilteredPackages([]*TargetSelector{
@@ -409,7 +418,10 @@ func Test_matchMultipleScopedPackages(t *testing.T) {
 		t.Fatalf("failed to get working directory: %v", err)
 	}
 
-	packageJSONs := make(graph.WorkspaceInfos)
+	workspaceInfos := graph.WorkspaceInfos{
+		PackageJSONs: make(map[string]*fs.PackageJSON),
+	}
+	packageJSONs := workspaceInfos.PackageJSONs
 	graph := &dag.AcyclicGraph{}
 	graph.Add("@foo/bar")
 	packageJSONs["@foo/bar"] = &fs.PackageJSON{
@@ -423,7 +435,7 @@ func Test_matchMultipleScopedPackages(t *testing.T) {
 	}
 	r := &Resolver{
 		Graph:          graph,
-		WorkspaceInfos: packageJSONs,
+		WorkspaceInfos: workspaceInfos,
 		Cwd:            root,
 	}
 	pkgs, err := r.getFilteredPackages([]*TargetSelector{
@@ -452,7 +464,10 @@ func Test_SCM(t *testing.T) {
 	head1Changed.Add(util.RootPkgName)
 	head2Changed := make(util.Set)
 	head2Changed.Add("package-3")
-	packageJSONs := make(graph.WorkspaceInfos)
+	workspaceInfos := graph.WorkspaceInfos{
+		PackageJSONs: make(map[string]*fs.PackageJSON),
+	}
+	packageJSONs := workspaceInfos.PackageJSONs
 	graph := &dag.AcyclicGraph{}
 	graph.Add("package-1")
 	packageJSONs["package-1"] = &fs.PackageJSON{
@@ -479,7 +494,7 @@ func Test_SCM(t *testing.T) {
 
 	r := &Resolver{
 		Graph:          graph,
-		WorkspaceInfos: packageJSONs,
+		WorkspaceInfos: workspaceInfos,
 		Cwd:            root,
 		PackagesChangedInRange: func(fromRef string, toRef string) (util.Set, error) {
 			if fromRef == "HEAD~1" && toRef == "HEAD" {

--- a/cli/internal/scope/scope.go
+++ b/cli/internal/scope/scope.go
@@ -160,7 +160,7 @@ func calculateInference(repoRoot turbopath.AbsoluteSystemPath, rawPkgInferenceDi
 	}
 	logger.Debug(fmt.Sprintf("Using %v as a basis for selecting packages", pkgInferencePath))
 	fullInferencePath := repoRoot.Join(pkgInferencePath)
-	for _, pkgInfo := range packageInfos {
+	for _, pkgInfo := range packageInfos.PackageJSONs {
 		pkgPath := pkgInfo.Dir.RestoreAnchor(repoRoot)
 		inferredPathIsBelow, err := pkgPath.ContainsPath(fullInferencePath)
 		if err != nil {
@@ -208,7 +208,7 @@ func (o *Opts) getPackageChangeFunc(scm scm.SCM, cwd turbopath.AbsoluteSystemPat
 		}
 		makeAllPkgs := func() util.Set {
 			allPkgs := make(util.Set)
-			for pkg := range ctx.WorkspaceInfos {
+			for pkg := range ctx.WorkspaceInfos.PackageJSONs {
 				allPkgs.Add(pkg)
 			}
 			return allPkgs
@@ -350,7 +350,7 @@ func getChangedPackages(changedFiles []string, packageInfos graph.WorkspaceInfos
 	changedPackages := make(util.Set)
 	for _, changedFile := range changedFiles {
 		found := false
-		for pkgName, pkgInfo := range packageInfos {
+		for pkgName, pkgInfo := range packageInfos.PackageJSONs {
 			if pkgName != util.RootPkgName && fileInPackage(changedFile, pkgInfo.Dir.ToStringDuringMigration()) {
 				changedPackages.Add(pkgName)
 				found = true

--- a/cli/internal/scope/scope_test.go
+++ b/cli/internal/scope/scope_test.go
@@ -129,57 +129,59 @@ func TestResolvePackages(t *testing.T) {
 	graph.Connect(dag.BasicEdge("app2", "libC"))
 	graph.Connect(dag.BasicEdge("app2-a", "libC"))
 	workspaceInfos := internalGraph.WorkspaceInfos{
-		"//": {
-			Dir:                    turbopath.AnchoredSystemPath("").ToSystemPath(),
-			UnresolvedExternalDeps: map[string]string{"global": "2"},
-			TransitiveDeps:         []lockfile.Package{{Key: "global2", Version: "2", Found: true}},
-		},
-		"app0": {
-			Dir:                    turbopath.AnchoredUnixPath("app/app0").ToSystemPath(),
-			Name:                   "app0",
-			UnresolvedExternalDeps: map[string]string{"app0-dep": "2"},
-			TransitiveDeps: []lockfile.Package{
-				{Key: "app0-dep2", Version: "2", Found: true},
-				{Key: "app0-util2", Version: "2", Found: true},
+		PackageJSONs: map[string]*fs.PackageJSON{
+			"//": {
+				Dir:                    turbopath.AnchoredSystemPath("").ToSystemPath(),
+				UnresolvedExternalDeps: map[string]string{"global": "2"},
+				TransitiveDeps:         []lockfile.Package{{Key: "global2", Version: "2", Found: true}},
 			},
-		},
-		"app1": {
-			Dir:  turbopath.AnchoredUnixPath("app/app1").ToSystemPath(),
-			Name: "app1",
-		},
-		"app2": {
-			Dir:  turbopath.AnchoredUnixPath("app/app2").ToSystemPath(),
-			Name: "app2",
-		},
-		"app2-a": {
-			Dir:  turbopath.AnchoredUnixPath("app/app2-a").ToSystemPath(),
-			Name: "app2-a",
-		},
-		"libA": {
-			Dir:  turbopath.AnchoredUnixPath("libs/libA").ToSystemPath(),
-			Name: "libA",
-		},
-		"libB": {
-			Dir:                    turbopath.AnchoredUnixPath("libs/libB").ToSystemPath(),
-			Name:                   "libB",
-			UnresolvedExternalDeps: map[string]string{"external": "1"},
-			TransitiveDeps: []lockfile.Package{
-				{Key: "external-dep-a1", Version: "1", Found: true},
-				{Key: "external-dep-b1", Version: "1", Found: true},
-				{Key: "external1", Version: "1", Found: true},
+			"app0": {
+				Dir:                    turbopath.AnchoredUnixPath("app/app0").ToSystemPath(),
+				Name:                   "app0",
+				UnresolvedExternalDeps: map[string]string{"app0-dep": "2"},
+				TransitiveDeps: []lockfile.Package{
+					{Key: "app0-dep2", Version: "2", Found: true},
+					{Key: "app0-util2", Version: "2", Found: true},
+				},
 			},
-		},
-		"libC": {
-			Dir:  turbopath.AnchoredUnixPath("libs/libC").ToSystemPath(),
-			Name: "libC",
-		},
-		"libD": {
-			Dir:  turbopath.AnchoredUnixPath("libs/libD").ToSystemPath(),
-			Name: "libD",
+			"app1": {
+				Dir:  turbopath.AnchoredUnixPath("app/app1").ToSystemPath(),
+				Name: "app1",
+			},
+			"app2": {
+				Dir:  turbopath.AnchoredUnixPath("app/app2").ToSystemPath(),
+				Name: "app2",
+			},
+			"app2-a": {
+				Dir:  turbopath.AnchoredUnixPath("app/app2-a").ToSystemPath(),
+				Name: "app2-a",
+			},
+			"libA": {
+				Dir:  turbopath.AnchoredUnixPath("libs/libA").ToSystemPath(),
+				Name: "libA",
+			},
+			"libB": {
+				Dir:                    turbopath.AnchoredUnixPath("libs/libB").ToSystemPath(),
+				Name:                   "libB",
+				UnresolvedExternalDeps: map[string]string{"external": "1"},
+				TransitiveDeps: []lockfile.Package{
+					{Key: "external-dep-a1", Version: "1", Found: true},
+					{Key: "external-dep-b1", Version: "1", Found: true},
+					{Key: "external1", Version: "1", Found: true},
+				},
+			},
+			"libC": {
+				Dir:  turbopath.AnchoredUnixPath("libs/libC").ToSystemPath(),
+				Name: "libC",
+			},
+			"libD": {
+				Dir:  turbopath.AnchoredUnixPath("libs/libD").ToSystemPath(),
+				Name: "libD",
+			},
 		},
 	}
 	packageNames := []string{}
-	for name := range workspaceInfos {
+	for name := range workspaceInfos.PackageJSONs {
 		packageNames = append(packageNames, name)
 	}
 

--- a/cli/internal/taskhash/taskhash.go
+++ b/cli/internal/taskhash/taskhash.go
@@ -200,7 +200,7 @@ func (th *Tracker) CalculateFileHashes(
 	for i := 0; i < workerCount; i++ {
 		hashErrs.Go(func() error {
 			for packageFileSpec := range hashQueue {
-				pkg, ok := th.workspaceInfos[packageFileSpec.pkg]
+				pkg, ok := th.workspaceInfos.PackageJSONs[packageFileSpec.pkg]
 				if !ok {
 					return fmt.Errorf("cannot find package %v", packageFileSpec.pkg)
 				}


### PR DESCRIPTION
Cache reads of turbo.json and package.json in the `WorkspaceInfos` struct in CompleteGraph. PackageJSON were already cached there, so it's a natural place to expand the notion of known Workspaces.