### PR TITLE
docs: Document workaround for loaders with unserializable options

### DIFF
--- a/docs/pages/pack/docs/migrating-from-webpack.mdx
+++ b/docs/pages/pack/docs/migrating-from-webpack.mdx
@@ -17,14 +17,14 @@ Currently, Turbopack supports a subset of webpack's loader API and offers simila
 
 ## webpack loaders for Next.js
 
-Firstly, Turbopack for Next.js does not require loaders nor loader configuration for built-in functionality, just as they aren't required for Next.js. There's no need for `css-loader`, `postcss-loader`, or `babel-loader` if you're just using `@babel/preset-env`.
+Firstly, Turbopack for Next.js does not require loaders nor loader configuration for built-in functionality, just as they aren't required for Next.js. Turbopack has built-in support for css and compiling modern JavaScript, so there's no need for `css-loader`, `postcss-loader`, or `babel-loader` if you're just using `@babel/preset-env`.
 
-If you need loader support beyond what's built in, some webpack loaders, including [`@mdx-js/loader`](https://mdxjs.com/packages/loader/) already work with Turbopack! There are currently some limitations:
+If you need loader support beyond what's built in, many webpack loaders already work with Turbopack. There are currently some limitations:
 
 - At the moment, only a core subset of the webpack loader API is implemented. This is enough for some popular loaders, and we'll expand our support for this API in the future.
 - Options passed to webpack loaders must be plain JavaScript primitives, objects, and arrays. For example, it's not possible to pass `require()`d plugin modules as option values.
 
-Configuring webpack loaders is possible for Next.js apps through an experimental option in `next.config.js`. `turbo.loaders` can be set to a mapping of file extensions to a list of package names or `{loader, options}` pairs:
+As of Next 13.2, configuring webpack loaders is possible for Next.js apps through an experimental option in `next.config.js`. `turbo.loaders` can be set to a mapping of file extensions to a list of package names or `{loader, options}` pairs:
 
 ```js filename="next.config.js"
 module.exports = {
@@ -108,9 +108,12 @@ Turbopack also supports conditional aliasing through this field, similar to Node
 
 The following loaders have been tested to work with Turbopack's webpack loader implementation:
 
+- [`babel-loader`](https://www.npmjs.com/package/babel-loader)
 - [`@mdx-js/loader`](https://www.npmjs.com/package/@mdx-js/loader)
 - [`@svgr/webpack`](https://www.npmjs.com/package/@svgr/webpack)
+- [`svg-inline-loader`](https://www.npmjs.com/package/svg-inline-loader)
 - [`yaml-loader`](https://www.npmjs.com/package/yaml-loader)
+- [`string-replace-loader`](https://www.npmjs.com/package/string-replace-loader)
 - [`raw-loader`](https://www.npmjs.com/package/raw-loader)
 
 ### Will it be compatible with webpack's API?

--- a/docs/pages/pack/docs/migrating-from-webpack.mdx
+++ b/docs/pages/pack/docs/migrating-from-webpack.mdx
@@ -22,7 +22,7 @@ Firstly, Turbopack for Next.js does not require loaders nor loader configuration
 If you need loader support beyond what's built in, some webpack loaders, including [`@mdx-js/loader`](https://mdxjs.com/packages/loader/) already work with Turbopack! There are currently some limitations:
 
 - At the moment, only a core subset of the webpack loader API is implemented. This is enough for some popular loaders, and we'll expand our support for this API in the future.
-- Options passed to webpack loaders must be plain JavaScript primitives, objects, and arrays. For example, it's not possible to pass `require()`d plugin modules as option values. For an interim solution, check out
+- Options passed to webpack loaders must be plain JavaScript primitives, objects, and arrays. For example, it's not possible to pass `require()`d plugin modules as option values.
 
 Configuring webpack loaders is possible for Next.js apps through an experimental option in `next.config.js`. `turbo.loaders` can be set to a mapping of file extensions to a list of package names or `{loader, options}` pairs:
 

--- a/docs/pages/pack/docs/migrating-from-webpack.mdx
+++ b/docs/pages/pack/docs/migrating-from-webpack.mdx
@@ -22,9 +22,9 @@ Firstly, Turbopack for Next.js does not require loaders nor loader configuration
 If you need loader support beyond what's built in, some webpack loaders, including [`@mdx-js/loader`](https://mdxjs.com/packages/loader/) already work with Turbopack! There are currently some limitations:
 
 - At the moment, only a core subset of the webpack loader API is implemented. This is enough for some popular loaders, and we'll expand our support for this API in the future.
-- Options passed to webpack loaders must be plain JavaScript primitives, objects, and arrays. For example, it's not possible to pass `require()`d plugin modules as option values.
+- Options passed to webpack loaders must be plain JavaScript primitives, objects, and arrays. For example, it's not possible to pass `require()`d plugin modules as option values. For an interim solution, check out
 
-At the moment, configuring webpack loaders is possible for Next.js apps through an experimental option in `next.config.js`. `turbo.loaders` can be set to a mapping of file extensions to a list of package names or `{loader, options}` pairs:
+Configuring webpack loaders is possible for Next.js apps through an experimental option in `next.config.js`. `turbo.loaders` can be set to a mapping of file extensions to a list of package names or `{loader, options}` pairs:
 
 ```js filename="next.config.js"
 module.exports = {
@@ -42,6 +42,39 @@ module.exports = {
         ],
         // Option-less format
         '.mdx': '@mdx-js/loader',
+      },
+    },
+  },
+}
+```
+
+If you need to pass something like the result of importing an external package as a loader option, it's possible to wrap the webpack loader with your own, specifying options there. **This is an interim solution and should not be necessary in the future.** This loader wraps `@mdx-js/loader` and configures the `rehypePrism` rehype plugin:
+
+```js filename="my-mdx-loader.js"
+const mdxLoader = require('@mdx-js/loader');
+const rehypePrism = require('@mapbox/rehype-prism');
+
+module.exports = function (code) {
+	const prevGetOptions = this.getOptions.bind(this);
+	this.getOptions = function getOptions(...args) {
+		return {
+			...prevGetOptions(...args),
+			rehypePlugins: [rehypePrism]
+		}
+	}
+
+	mdxLoader.call(this, code);
+}
+```
+
+Then, configure Next.js to load the wrapper loader:
+
+```js filename="next.config.js"
+module.exports = {
+  experimental: {
+    turbo: {
+      loaders: {
+        '.mdx': './my-mdx-loader',
       },
     },
   },
@@ -75,7 +108,9 @@ Turbopack also supports conditional aliasing through this field, similar to Node
 
 The following loaders have been tested to work with Turbopack's webpack loader implementation:
 
-- [`@mdx-js/loader`](https://mdxjs.com/packages/loader/) — note that plugin modules passed to `rehypePlugins` and `remarkPlugins` are not currently supported.
+- [`@mdx-js/loader`](https://www.npmjs.com/package/@mdx-js/loader)
+- [`@svgr/webpack`](https://www.npmjs.com/package/@svgr/webpack)
+- [`yaml-loader`](https://www.npmjs.com/package/yaml-loader)
 - [`raw-loader`](https://www.npmjs.com/package/raw-loader)
 
 ### Will it be compatible with webpack's API?


### PR DESCRIPTION
This:
* Adds a section to the "Migrating from webpack" docs that includes a wrapper loader that configures these options itself, deferring loading them until Turbopack transforms.
* Adds to the list of loaders that have been confirmed to work with Turbopack's webpack loader implementation.
