### PR TITLE
Improve error bubbling

### DIFF
--- a/cli/integration_tests/basic_monorepo/dry_run.t
+++ b/cli/integration_tests/basic_monorepo/dry_run.t
@@ -101,3 +101,13 @@ Check my-app#build output
       "persistent": false
     }
   }
+
+$ Non-existent tasks don't throw an error
+  $ ${TURBO} run doesnotexist --dry=json
+  {
+    "packages": [
+      "my-app",
+      "util"
+    ],
+    "tasks": []
+  }

--- a/cli/integration_tests/basic_monorepo/run.t
+++ b/cli/integration_tests/basic_monorepo/run.t
@@ -1,0 +1,16 @@
+Setup
+  $ . ${TESTDIR}/../setup.sh
+  $ . ${TESTDIR}/setup.sh $(pwd)
+
+$ running non-existent tasks works
+  $ ${TURBO} run doesnotexist
+  \xe2\x80\xa2 Packages in scope: my-app, util (esc)
+  \xe2\x80\xa2 Running doesnotexist in 2 packages (esc)
+  \xe2\x80\xa2 Remote caching disabled (esc)
+  
+  No tasks were executed as part of this run.
+  
+   Tasks:    0 successful, 0 total
+  Cached:    0 cached, 0 total
+    Time:\s*[\.0-9]+m?s  (re)
+  

--- a/cli/integration_tests/composable_config/composing-bad-json.t
+++ b/cli/integration_tests/composable_config/composing-bad-json.t
@@ -1,0 +1,14 @@
+Setup
+  $ . ${TESTDIR}/../setup.sh
+  $ . ${TESTDIR}/setup.sh $(pwd) ./monorepo
+
+# Put some bad JSON into the turbo.json in this app
+  $ echo '{"pipeline": {"trailing-comma": {},}}' > "$TARGET_DIR/apps/bad-json/turbo.json"
+# The test is greping from a logfile because the list of errors can appear in any order
+
+# Errors are shown if we run across a malformed turbo.json
+  $ ${TURBO} run trailing-comma --filter=bad-json > tmp.log 2>&1
+  [1]
+  $ cat tmp.log
+   ERROR  run failed: error preparing engine: turbo.json: invalid character '}' looking for beginning of object key string
+  Turbo error: error preparing engine: turbo.json: invalid character '}' looking for beginning of object key string

--- a/cli/integration_tests/composable_config/monorepo/apps/bad-json/package.json
+++ b/cli/integration_tests/composable_config/monorepo/apps/bad-json/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "bad-json",
+  "scripts": {
+    "trailing-comma": "echo 'trailing-comma'"
+  }
+}

--- a/cli/internal/fs/turbo_json.go
+++ b/cli/internal/fs/turbo_json.go
@@ -168,7 +168,8 @@ func LoadTurboConfig(dir turbopath.AbsoluteSystemPath, rootPackageJSON *PackageJ
 	if !includeSynthesizedFromRootPackageJSON && err != nil {
 		// If the file didn't exist, throw a custom error here instead of propagating
 		if errors.Is(err, os.ErrNotExist) {
-			return nil, fmt.Errorf("Could not find %s. Follow directions at https://turbo.build/repo/docs to create one: file does not exist", configFile)
+			return nil, errors.Wrap(err, fmt.Sprintf("Could not find %s. Follow directions at https://turbo.build/repo/docs to create one", configFile))
+
 		}
 
 		// There was an error, and we don't have any chance of recovering
@@ -262,7 +263,7 @@ func ReadTurboConfig(turboJSONPath turbopath.AbsoluteSystemPath) (*TurboJSON, er
 	}
 
 	// If there's no turbo.json, return an error.
-	return nil, errors.Wrapf(os.ErrNotExist, "Could not find %s", configFile)
+	return nil, os.ErrNotExist
 }
 
 // readTurboJSON reads the configFile in to a struct


### PR DESCRIPTION
Only allow the error where workspace config is missing, since
this config is not required. Throw other errors, including
when the contents of the workspace config are malformed.
This allows us to provide better error messaging to the end user