### PR TITLE
Make stringify_str and stringify_module_id use Serialize

### DIFF
--- a/crates/next-core/src/app_source.rs
+++ b/crates/next-core/src/app_source.rs
@@ -34,7 +34,7 @@ use turbopack_dev_server::{
     },
 };
 use turbopack_ecmascript::{
-    chunk::EcmascriptChunkPlaceablesVc, magic_identifier, utils::stringify_str,
+    chunk::EcmascriptChunkPlaceablesVc, magic_identifier, utils::stringify_js,
     EcmascriptInputTransformsVc, EcmascriptModuleAssetType, EcmascriptModuleAssetVc,
 };
 use turbopack_env::ProcessEnvAssetVc;
@@ -572,7 +572,7 @@ impl AppRendererVc {
                                     ));
                                 }
                             }
-                            Ok((stringify_str(segment_path), imports))
+                            Ok((stringify_js(segment_path), imports))
                         });
                         futures
                     })
@@ -597,7 +597,7 @@ impl AppRendererVc {
                     "import {}, {{ chunks as {} }} from {};\n",
                     identifier,
                     chunks_identifier,
-                    stringify_str(p)
+                    stringify_js(p)
                 )?
             }
         }
@@ -607,7 +607,7 @@ impl AppRendererVc {
                 r#"("TURBOPACK {{ transition: next-client }}");
 import BOOTSTRAP from {};
 "#,
-                stringify_str(&page)
+                stringify_js(&page)
             )?;
         }
 
@@ -618,7 +618,7 @@ import BOOTSTRAP from {};
                 writeln!(
                     result,
                     "    {key}: {{ module: {identifier}, chunks: {chunks_identifier} }},",
-                    key = stringify_str(key),
+                    key = stringify_js(key),
                 )?;
             }
             result += "  },";

--- a/crates/next-core/src/next_client_chunks/with_chunks.rs
+++ b/crates/next-core/src/next_client_chunks/with_chunks.rs
@@ -8,7 +8,7 @@ use turbopack::ecmascript::{
         EcmascriptChunkItemVc, EcmascriptChunkPlaceable, EcmascriptChunkPlaceableVc,
         EcmascriptChunkVc, EcmascriptExports, EcmascriptExportsVc,
     },
-    utils::stringify_module_id,
+    utils::stringify_js,
 };
 use turbopack_core::{
     asset::{Asset, AssetContentVc, AssetVc},
@@ -122,8 +122,7 @@ impl EcmascriptChunkItem for WithChunksChunkItem {
                 client_chunks.push(Value::String(path.to_string()));
             }
         }
-        let module_id =
-            stringify_module_id(&*inner.asset.as_chunk_item(self.inner_context).id().await?);
+        let module_id = stringify_js(&*inner.asset.as_chunk_item(self.inner_context).id().await?);
         Ok(EcmascriptChunkItemContent {
             inner_code: format!(
                 "__turbopack_esm__({{

--- a/crates/next-core/src/next_client_component/with_client_chunks.rs
+++ b/crates/next-core/src/next_client_component/with_client_chunks.rs
@@ -8,7 +8,7 @@ use turbopack::ecmascript::{
         EcmascriptChunkItemVc, EcmascriptChunkPlaceable, EcmascriptChunkPlaceableVc,
         EcmascriptChunkVc, EcmascriptExports, EcmascriptExportsVc,
     },
-    utils::stringify_module_id,
+    utils::stringify_js,
 };
 use turbopack_core::{
     asset::{Asset, AssetContentVc, AssetVc},
@@ -130,7 +130,7 @@ impl EcmascriptChunkItem for WithClientChunksChunkItem {
                 }
             }
         }
-        let module_id = stringify_module_id(&*inner.asset.as_chunk_item(self.context).id().await?);
+        let module_id = stringify_js(&*inner.asset.as_chunk_item(self.context).id().await?);
         Ok(EcmascriptChunkItemContent {
             inner_code: format!(
                 "__turbopack_esm__({{

--- a/crates/next-core/src/next_edge/transition.rs
+++ b/crates/next-core/src/next_edge/transition.rs
@@ -13,7 +13,7 @@ use turbopack_core::{
     environment::EnvironmentVc,
     virtual_asset::VirtualAssetVc,
 };
-use turbopack_ecmascript::{chunk_group_files_asset::ChunkGroupFilesAsset, utils::stringify_str};
+use turbopack_ecmascript::{chunk_group_files_asset::ChunkGroupFilesAsset, utils::stringify_js};
 
 use crate::embed_js::next_js_file;
 
@@ -36,7 +36,7 @@ impl Transition for NextEdgeTransition {
         let mut new_content = RopeBuilder::from(
             format!(
                 "const PAGE = {};\n",
-                stringify_str(
+                stringify_js(
                     self.base_path
                         .await?
                         .get_path_to(&*asset.path().await?)

--- a/crates/next-core/src/page_loader.rs
+++ b/crates/next-core/src/page_loader.rs
@@ -13,7 +13,7 @@ use turbopack_core::{
 };
 use turbopack_dev_server::source::{asset_graph::AssetGraphContentSourceVc, ContentSourceVc};
 use turbopack_ecmascript::{
-    utils::stringify_str, EcmascriptInputTransform, EcmascriptInputTransformsVc,
+    utils::stringify_js, EcmascriptInputTransform, EcmascriptInputTransformsVc,
     EcmascriptModuleAssetType, EcmascriptModuleAssetVc,
 };
 
@@ -58,7 +58,7 @@ impl PageLoaderAssetVc {
         writeln!(
             result,
             "const PAGE_PATH = {};\n",
-            stringify_str(&format!("/{}", &*this.pathname.await?))
+            stringify_js(&format!("/{}", &*this.pathname.await?))
         )?;
 
         let base_code = next_js_file("entry/page-loader.ts");
@@ -118,7 +118,7 @@ impl Asset for PageLoaderAsset {
 
         let content = format!(
             "__turbopack_load_page_chunks__({}, {})\n",
-            stringify_str(&this.pathname.await?),
+            stringify_js(&this.pathname.await?),
             Value::Array(data)
         );
 

--- a/crates/turbopack-core/src/chunk/mod.rs
+++ b/crates/turbopack-core/src/chunk/mod.rs
@@ -8,7 +8,7 @@ use std::{
 
 use anyhow::{anyhow, Result};
 use indexmap::IndexSet;
-use serde::{Deserialize, Serialize};
+use serde::{de::Visitor, Deserialize, Serialize};
 use turbo_tasks::{
     debug::ValueDebugFormat,
     primitives::{BoolVc, StringVc},
@@ -27,9 +27,8 @@ use crate::{
 };
 
 /// A module id, which can be a number or string
-#[turbo_tasks::value(shared)]
+#[turbo_tasks::value(shared, serialization = "custom")]
 #[derive(Debug, Clone, Hash, DeterministicHash)]
-#[serde(untagged)]
 pub enum ModuleId {
     Number(u32),
     String(String),
@@ -41,6 +40,51 @@ impl Display for ModuleId {
             ModuleId::Number(i) => write!(f, "{}", i),
             ModuleId::String(s) => write!(f, "{}", s),
         }
+    }
+}
+
+impl Serialize for ModuleId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            ModuleId::Number(i) => serializer.serialize_u32(*i),
+            ModuleId::String(s) => serializer.serialize_str(s),
+        }
+    }
+}
+
+struct ModuleIdVisitor;
+
+impl<'de> Visitor<'de> for ModuleIdVisitor {
+    type Value = ModuleId;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        formatter.write_str("a string or number module id")
+    }
+
+    fn visit_u32<E>(self, value: u32) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        Ok(ModuleId::Number(u32::from(value)))
+    }
+
+    fn visit_string<E>(self, v: String) -> std::result::Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        Ok(ModuleId::String(v))
+    }
+}
+
+impl<'de> Deserialize<'de> for ModuleId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(ModuleIdVisitor)
     }
 }
 

--- a/crates/turbopack-css/src/chunk/mod.rs
+++ b/crates/turbopack-css/src/chunk/mod.rs
@@ -28,7 +28,7 @@ use self::{optimize::CssChunkOptimizerVc, source_map::CssChunkSourceMapAssetRefe
 use crate::{
     embed::{CssEmbed, CssEmbeddable, CssEmbeddableVc},
     parse::ParseResultSourceMapVc,
-    util::stringify_str,
+    util::stringify_js,
     ImportAssetReferenceVc,
 };
 
@@ -134,7 +134,7 @@ impl CssChunkContentVc {
         let mut code = CodeBuilder::default();
         writeln!(code, "/* chunk {} */", chunk_name.await?)?;
         for external_import in external_imports {
-            writeln!(code, "@import {};", stringify_str(&external_import))?;
+            writeln!(code, "@import {};", stringify_js(&external_import))?;
         }
 
         code.push_code(&body.build());

--- a/crates/turbopack-css/src/module_asset.rs
+++ b/crates/turbopack-css/src/module_asset.rs
@@ -27,7 +27,7 @@ use turbopack_ecmascript::{
         EcmascriptChunkItemVc, EcmascriptChunkPlaceable, EcmascriptChunkPlaceableVc,
         EcmascriptChunkVc, EcmascriptExports, EcmascriptExportsVc,
     },
-    utils::stringify_str,
+    utils::stringify_js,
     ParseResultSourceMap, ParseResultSourceMapVc,
 };
 
@@ -193,12 +193,7 @@ impl EcmascriptChunkItem for ModuleChunkItem {
                         })
                         .collect::<Vec<_>>()
                         .join(" ");
-                    writeln!(
-                        code,
-                        "  {}: {},",
-                        stringify_str(key),
-                        stringify_str(&content)
-                    )?;
+                    writeln!(code, "  {}: {},", stringify_js(key), stringify_js(&content))?;
                 }
                 code += "});\n";
                 EcmascriptChunkItemContent {

--- a/crates/turbopack-css/src/util.rs
+++ b/crates/turbopack-css/src/util.rs
@@ -1,4 +1,4 @@
-pub fn stringify_str(str: &str) -> String {
+pub fn stringify_js(str: &str) -> String {
     let mut escaped = String::with_capacity(str.len());
     for char in str.chars() {
         match char {
@@ -22,32 +22,32 @@ pub fn stringify_str(str: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use crate::util::stringify_str;
+    use crate::util::stringify_js;
 
     #[test]
     fn surrounds_with_double_quotes() {
-        assert_eq!(stringify_str("foo"), r#""foo""#);
+        assert_eq!(stringify_js("foo"), r#""foo""#);
     }
 
     #[test]
     fn escapes_double_quotes() {
-        assert_eq!(stringify_str(r#""""#), r#""\"\"""#);
+        assert_eq!(stringify_js(r#""""#), r#""\"\"""#);
     }
 
     #[test]
     fn escapes_backslash() {
-        assert_eq!(stringify_str(r#"\"#), r#""\\""#);
-        assert_eq!(stringify_str(r#"\\"#), r#""\\\\""#);
-        assert_eq!(stringify_str(r#"\n"#), r#""\\n""#);
+        assert_eq!(stringify_js(r#"\"#), r#""\\""#);
+        assert_eq!(stringify_js(r#"\\"#), r#""\\\\""#);
+        assert_eq!(stringify_js(r#"\n"#), r#""\\n""#);
     }
 
     #[test]
     fn escapes_newlines() {
-        assert_eq!(stringify_str("\n"), r#""\n""#);
+        assert_eq!(stringify_js("\n"), r#""\n""#);
     }
 
     #[test]
     fn escapes_mixed() {
-        assert_eq!(stringify_str("\n\r\u{0c}"), r#""\n\r\f""#);
+        assert_eq!(stringify_js("\n\r\u{0c}"), r#""\n\r\f""#);
     }
 }

--- a/crates/turbopack-ecmascript/src/chunk/loader.rs
+++ b/crates/turbopack-ecmascript/src/chunk/loader.rs
@@ -19,7 +19,7 @@ use crate::{
         EcmascriptChunkItemVc, EcmascriptChunkPlaceable, EcmascriptChunkPlaceableVc,
         EcmascriptChunkVc, EcmascriptExports, EcmascriptExportsVc,
     },
-    utils::{stringify_module_id, stringify_str},
+    utils::stringify_js,
 };
 
 /// The manifest loader item is shipped in the same chunk that uses the dynamic
@@ -125,9 +125,9 @@ __turbopack_export_value__((__turbopack_import__) => {{
         return __turbopack_require__({item_id});
     }}).then(() => __turbopack_import__({dynamic_id}));
 }});",
-            chunk_server_path = stringify_str(chunk_server_path),
-            item_id = stringify_module_id(item_id),
-            dynamic_id = stringify_module_id(dynamic_id),
+            chunk_server_path = stringify_js(chunk_server_path),
+            item_id = stringify_js(item_id),
+            dynamic_id = stringify_js(dynamic_id),
         )?;
 
         Ok(EcmascriptChunkItemContent {
@@ -274,7 +274,7 @@ impl EcmascriptChunkItem for ManifestChunkItem {
 
         let mut code = b"const chunks = [\n".to_vec();
         for pathname in chunk_server_paths {
-            writeln!(code, "    {},", stringify_str(&pathname))?;
+            writeln!(code, "    {},", stringify_js(&pathname))?;
         }
         writeln!(code, "];")?;
 

--- a/crates/turbopack-ecmascript/src/chunk/mod.rs
+++ b/crates/turbopack-ecmascript/src/chunk/mod.rs
@@ -49,7 +49,7 @@ use self::{
 use crate::{
     parse::ParseResultSourceMapVc,
     references::esm::EsmExportsVc,
-    utils::{stringify_module_id, stringify_str, FormatIter},
+    utils::{stringify_js, FormatIter},
 };
 
 #[turbo_tasks::value]
@@ -613,9 +613,9 @@ impl EcmascriptChunkContentVc {
         let mut code = CodeBuilder::default();
         code += "(self.TURBOPACK = self.TURBOPACK || []).push([";
 
-        writeln!(code, "{}, {{", stringify_str(chunk_server_path))?;
+        writeln!(code, "{}, {{", stringify_js(chunk_server_path))?;
         for entry in &this.module_factories {
-            write!(code, "\n{}: ", &stringify_module_id(entry.id()))?;
+            write!(code, "\n{}: ", &stringify_js(entry.id()))?;
             code.push_code(entry.code());
             code += ",";
         }
@@ -627,7 +627,7 @@ impl EcmascriptChunkContentVc {
                 .chunks_server_paths
                 .await?
                 .iter()
-                .map(|path| format!(" && loadedChunks.has({})", stringify_str(path)))
+                .map(|path| format!(" && loadedChunks.has({})", stringify_js(path)))
                 .collect::<Vec<_>>()
                 .join("");
             let entries_ids = &*evaluate.entry_modules_ids.await?;
@@ -635,7 +635,7 @@ impl EcmascriptChunkContentVc {
                 .iter()
                 .map(|id| async move {
                     let id = id.await?;
-                    let id = stringify_module_id(&id);
+                    let id = stringify_js(&id);
                     Ok(format!(r#"instantiateRuntimeModule({id});"#)) as Result<_>
                 })
                 .try_join()

--- a/crates/turbopack-ecmascript/src/utils.rs
+++ b/crates/turbopack-ecmascript/src/utils.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use pin_project_lite::pin_project;
+use serde::Serialize;
 use swc_core::{
     common::DUMMY_SP,
     ecma::ast::{Expr, Lit, Str},
@@ -64,19 +65,12 @@ pub fn module_id_to_lit(module_id: &ModuleId) -> Expr {
     })
 }
 
-pub fn stringify_module_id(id: &ModuleId) -> String {
-    match id {
-        ModuleId::Number(n) => stringify_number(*n),
-        ModuleId::String(s) => stringify_str(s),
-    }
-}
-
-pub fn stringify_str(s: &str) -> String {
+/// Converts a serializable value into a valid JavaScript expression.
+pub fn stringify_js<T>(s: &T) -> String
+where
+    T: Serialize + ?Sized,
+{
     serde_json::to_string(s).unwrap()
-}
-
-pub fn stringify_number(s: u32) -> String {
-    s.to_string()
 }
 
 pub struct FormatIter<T: Iterator, F: Fn() -> T>(pub F);

--- a/crates/turbopack-env/src/asset.rs
+++ b/crates/turbopack-env/src/asset.rs
@@ -15,7 +15,7 @@ use turbopack_ecmascript::{
         EcmascriptChunkItemVc, EcmascriptChunkPlaceable, EcmascriptChunkPlaceableVc,
         EcmascriptChunkVc, EcmascriptExports, EcmascriptExportsVc,
     },
-    utils::stringify_str,
+    utils::stringify_js,
 };
 
 /// The `process.env` asset, responsible for initializing the env (shared by all
@@ -134,7 +134,7 @@ impl EcmascriptChunkItem for ProcessEnvChunkItem {
             // env can be used to inject live code into the output.
             // TODO this is not completely correct as env vars need to ignore casing
             // So `process.env.path === process.env.PATH === process.env.PaTh`
-            writeln!(code, "env[{}] = {};", stringify_str(name), val)?;
+            writeln!(code, "env[{}] = {};", stringify_js(name), val)?;
         }
 
         Ok(EcmascriptChunkItemContent {

--- a/crates/turbopack-env/src/embeddable.rs
+++ b/crates/turbopack-env/src/embeddable.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use turbo_tasks::primitives::OptionStringVc;
 use turbo_tasks_env::{EnvMapVc, ProcessEnv, ProcessEnvVc};
-use turbopack_ecmascript::utils::stringify_str;
+use turbopack_ecmascript::utils::stringify_js;
 
 /// Encodes values as JS strings so that they can be safely injected into a JS
 /// output.
@@ -26,7 +26,7 @@ impl ProcessEnv for EmbeddableProcessEnv {
 
         let encoded = prior
             .iter()
-            .map(|(k, v)| (k.clone(), stringify_str(v)))
+            .map(|(k, v)| (k.clone(), stringify_js(v)))
             .collect();
 
         Ok(EnvMapVc::cell(encoded))
@@ -35,7 +35,7 @@ impl ProcessEnv for EmbeddableProcessEnv {
     #[turbo_tasks::function]
     async fn read(&self, name: &str) -> Result<OptionStringVc> {
         let prior = self.prior.read(name).await?;
-        let encoded = prior.as_deref().map(stringify_str);
+        let encoded = prior.as_deref().map(stringify_js);
         Ok(OptionStringVc::cell(encoded))
     }
 }

--- a/crates/turbopack-node/src/bootstrap.rs
+++ b/crates/turbopack-node/src/bootstrap.rs
@@ -7,7 +7,7 @@ use turbopack_core::{
     chunk::{ChunkGroupVc, ChunkReferenceVc},
     reference::AssetReferencesVc,
 };
-use turbopack_ecmascript::utils::stringify_str;
+use turbopack_ecmascript::utils::stringify_js;
 
 #[turbo_tasks::value(shared)]
 pub(super) struct NodeJsBootstrapAsset {
@@ -34,7 +34,7 @@ impl Asset for NodeJsBootstrapAsset {
             let path = &*chunk.path().await?;
             if let Some(p) = context_path.get_relative_path_to(path) {
                 if p.ends_with(".js") {
-                    writeln!(&mut output, "require({});", stringify_str(&p))?;
+                    writeln!(&mut output, "require({});", stringify_js(&p))?;
                 }
             }
         }

--- a/crates/turbopack-static/src/lib.rs
+++ b/crates/turbopack-static/src/lib.rs
@@ -29,7 +29,7 @@ use turbopack_ecmascript::{
         EcmascriptChunkItemVc, EcmascriptChunkPlaceable, EcmascriptChunkPlaceableVc,
         EcmascriptChunkVc, EcmascriptExports, EcmascriptExportsVc,
     },
-    utils::stringify_str,
+    utils::stringify_js,
 };
 
 #[turbo_tasks::value]
@@ -193,7 +193,7 @@ impl EcmascriptChunkItem for ModuleChunkItem {
         Ok(EcmascriptChunkItemContent {
             inner_code: format!(
                 "__turbopack_export_value__({path});",
-                path = stringify_str(&format!("/{}", &*self.static_asset.path().await?))
+                path = stringify_js(&format!("/{}", &*self.static_asset.path().await?))
             )
             .into(),
             ..Default::default()


### PR DESCRIPTION
Both `stringify_str` and `stringify_module_id` are now simply `stringify_js`. We could skip this and go directly to `serde_json`, but this hides the dependency behind turbopack-ecmascript.