### PR TITLE
Snapshot issues in next-dev-tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3754,7 +3754,6 @@ dependencies = [
  "mime",
  "next-core",
  "next-dev",
- "once_cell",
  "owo-colors",
  "parking_lot",
  "rand",
@@ -3774,6 +3773,7 @@ dependencies = [
  "turbopack-core",
  "turbopack-dev-server",
  "turbopack-node",
+ "turbopack-test-utils",
  "url",
  "webbrowser 0.7.1",
 ]
@@ -7929,6 +7929,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "turbopack-test-utils"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "once_cell",
+ "similar",
+ "turbo-tasks",
+ "turbo-tasks-build",
+ "turbo-tasks-fs",
+ "turbo-tasks-hash",
+ "turbopack-core",
+]
+
+[[package]]
 name = "turbopack-tests"
 version = "0.1.0"
 dependencies = [
@@ -7937,18 +7951,17 @@ dependencies = [
  "once_cell",
  "serde",
  "serde_json",
- "similar",
  "test-generator",
  "tokio",
  "turbo-tasks",
  "turbo-tasks-build",
  "turbo-tasks-env",
  "turbo-tasks-fs",
- "turbo-tasks-hash",
  "turbo-tasks-memory",
  "turbopack",
  "turbopack-core",
  "turbopack-env",
+ "turbopack-test-utils",
 ]
 
 [[package]]

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -527,7 +527,7 @@ impl NextConfigVc {
     }
 }
 
-fn next_configs() -> StringsVc {
+pub fn next_configs() -> StringsVc {
     StringsVc::cell(
         ["next.config.mjs", "next.config.js"]
             .into_iter()

--- a/crates/next-dev-tests/Cargo.toml
+++ b/crates/next-dev-tests/Cargo.toml
@@ -30,7 +30,6 @@ lazy_static = "1.4.0"
 mime = "0.3.16"
 next-core = { path = "../next-core" }
 next-dev = { path = "../next-dev" }
-once_cell = "1.13.0"
 owo-colors = "3"
 parking_lot = "0.12.1"
 rand = "0.8.5"
@@ -53,6 +52,7 @@ turbopack-cli-utils = { path = "../turbopack-cli-utils" }
 turbopack-core = { path = "../turbopack-core" }
 turbopack-dev-server = { path = "../turbopack-dev-server" }
 turbopack-node = { path = "../turbopack-node" }
+turbopack-test-utils = { path = "../turbopack-test-utils" }
 url = "2.2.2"
 webbrowser = "0.7.1"
 

--- a/crates/next-dev-tests/build.rs
+++ b/crates/next-dev-tests/build.rs
@@ -1,6 +1,7 @@
-use turbo_tasks_build::rerun_if_glob;
+use turbo_tasks_build::{generate_register, rerun_if_glob};
 
 fn main() {
+    generate_register();
     // The test/integration crate need to be rebuilt if any test input is changed.
     // Unfortunately, we can't have the build.rs file operate differently on
     // each file, so the entire next-dev crate needs to be rebuilt.

--- a/crates/next-dev-tests/tests/integration.rs
+++ b/crates/next-dev-tests/tests/integration.rs
@@ -1,3 +1,4 @@
+#![feature(min_specialization)]
 #![cfg(test)]
 extern crate test_generator;
 
@@ -25,16 +26,31 @@ use chromiumoxide::{
 };
 use futures::StreamExt;
 use lazy_static::lazy_static;
-use next_dev::{register, EntryRequest, NextDevServerBuilder};
+use next_dev::{EntryRequest, NextDevServerBuilder};
 use owo_colors::OwoColorize;
 use serde::Deserialize;
 use test_generator::test_resources;
-use tokio::{net::TcpSocket, task::JoinSet};
+use tokio::{
+    net::TcpSocket,
+    sync::mpsc::{channel, Sender},
+    task::{JoinHandle, JoinSet},
+};
 use tungstenite::{error::ProtocolError::ResetWithoutClosingHandshake, Error::Protocol};
-use turbo_tasks::TurboTasks;
-use turbo_tasks_fs::util::sys_to_unix;
+use turbo_tasks::{
+    NothingVc, RawVc, ReadRef, State, TransientInstance, TransientValue, TurboTasks,
+};
+use turbo_tasks_fs::{util::sys_to_unix, DiskFileSystemVc, FileSystem};
 use turbo_tasks_memory::MemoryBackend;
 use turbo_tasks_testing::retry::retry_async;
+use turbopack_core::issue::{
+    CapturedIssues, Issue, IssueReporter, IssueReporterVc, PlainIssueReadRef,
+};
+use turbopack_test_utils::snapshot::snapshot_issues;
+
+fn register() {
+    next_dev::register();
+    include!(concat!(env!("OUT_DIR"), "/register_test_integration.rs"));
+}
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -155,16 +171,25 @@ async fn run_test(resource: &str) -> JestRunResult {
     );
 
     let package_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let workspace_root = package_root.parent().unwrap().parent().unwrap();
-    let project_dir = workspace_root.join(resource).join("input");
+    let workspace_root = package_root
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf();
+    let test_dir = workspace_root.join(resource);
+    let project_dir = test_dir.join("input");
     let requested_addr = get_free_local_addr().unwrap();
 
     let mock_dir = path.join("__httpmock__");
     let mock_server_future = get_mock_server_future(&mock_dir);
 
-    let turbo_tasks = TurboTasks::new(MemoryBackend::default());
+    let (issue_tx, mut issue_rx) = channel(u16::MAX as usize);
+    let issue_tx = TransientInstance::new(issue_tx);
+
+    let tt = TurboTasks::new(MemoryBackend::default());
     let server = NextDevServerBuilder::new(
-        turbo_tasks,
+        tt.clone(),
         sys_to_unix(&project_dir.to_string_lossy()).to_string(),
         sys_to_unix(&workspace_root.to_string_lossy()).to_string(),
     )
@@ -178,6 +203,9 @@ async fn run_test(resource: &str) -> JestRunResult {
     .port(requested_addr.port())
     .log_level(turbopack_core::issue::IssueSeverity::Warning)
     .log_detail(true)
+    .issue_reporter(Box::new(move || {
+        TestIssueReporterVc::new(issue_tx.clone()).into()
+    }))
     .show_all(true)
     .build()
     .await
@@ -197,6 +225,29 @@ async fn run_test(resource: &str) -> JestRunResult {
     };
 
     env::remove_var("TURBOPACK_TEST_ONLY_MOCK_SERVER");
+
+    let task = tt.spawn_once_task(async move {
+        let issues_fs = DiskFileSystemVc::new(
+            "issues".to_string(),
+            test_dir.join("issues").to_string_lossy().to_string(),
+        )
+        .as_file_system();
+
+        let mut issues = vec![];
+        while let Ok(issue) = issue_rx.try_recv() {
+            issues.push(issue);
+        }
+
+        snapshot_issues(
+            issues.iter().cloned(),
+            issues_fs.root(),
+            &workspace_root.to_string_lossy(),
+        )
+        .await?;
+
+        Ok(NothingVc::new().into())
+    });
+    tt.wait_task_completion(task, true).await.unwrap();
 
     result
 }
@@ -412,5 +463,39 @@ async fn get_mock_server_future(mock_dir: &Path) -> Result<(), String> {
         .await
     } else {
         std::future::pending::<Result<(), String>>().await
+    }
+}
+
+#[turbo_tasks::value(shared)]
+struct TestIssueReporter {
+    #[turbo_tasks(trace_ignore, debug_ignore)]
+    pub issue_tx: State<Sender<PlainIssueReadRef>>,
+}
+
+#[turbo_tasks::value_impl]
+impl TestIssueReporterVc {
+    #[turbo_tasks::function]
+    fn new(issue_tx: TransientInstance<Sender<PlainIssueReadRef>>) -> Self {
+        TestIssueReporter {
+            issue_tx: State::new((*issue_tx).clone()),
+        }
+        .cell()
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl IssueReporter for TestIssueReporter {
+    #[turbo_tasks::function]
+    async fn report_issues(
+        &self,
+        captured_issues: TransientInstance<ReadRef<CapturedIssues>>,
+        _source: TransientValue<RawVc>,
+    ) -> Result<()> {
+        let issue_tx = self.issue_tx.lock().clone();
+        for issue in captured_issues.iter() {
+            issue_tx.send(issue.into_plain().await?).await?;
+        }
+
+        Ok(())
     }
 }

--- a/crates/turbo-tasks/src/state.rs
+++ b/crates/turbo-tasks/src/state.rs
@@ -1,4 +1,8 @@
-use std::{fmt::Debug, mem::take};
+use std::{
+    fmt::Debug,
+    mem::take,
+    ops::{Deref, DerefMut},
+};
 
 use auto_hash_map::AutoSet;
 use parking_lot::{Mutex, MutexGuard};
@@ -17,6 +21,11 @@ struct StateInner<T> {
 
 pub struct StateRef<'a, T> {
     inner: MutexGuard<'a, StateInner<T>>,
+}
+
+pub struct StateRefMut<'a, T> {
+    inner: MutexGuard<'a, StateInner<T>>,
+    mutated: bool,
 }
 
 impl<T: Debug> Debug for State<T> {
@@ -47,7 +56,7 @@ impl<T> PartialEq for State<T> {
 }
 impl<T> Eq for State<T> {}
 
-impl<T: Serialize> Serialize for State<T> {
+impl<T> Serialize for State<T> {
     fn serialize<S: serde::Serializer>(&self, _serializer: S) -> Result<S::Ok, S::Error> {
         // For this to work at all we need to do more. Changing the the state need to
         // invalidate the serialization of the task that contains the state. So we
@@ -57,7 +66,7 @@ impl<T: Serialize> Serialize for State<T> {
     }
 }
 
-impl<'de, T: Deserialize<'de>> Deserialize<'de> for State<T> {
+impl<'de, T> Deserialize<'de> for State<T> {
     fn deserialize<D: Deserializer<'de>>(_deserializer: D) -> Result<Self, D::Error> {
         panic!("State serialization is not implemented yet");
     }
@@ -93,6 +102,12 @@ impl<T> State<T> {
         StateRef { inner }
     }
 
+    /// Gets the current value of the state. Untracked.
+    pub fn get_untracked(&self) -> StateRef<'_, T> {
+        let inner = self.inner.lock();
+        StateRef { inner }
+    }
+
     /// Sets the current state without comparing it with the old value. This
     /// should only be used if one is sure that the value has changed.
     pub fn set_unconditionally(&self, value: T) {
@@ -116,6 +131,13 @@ impl<T> State<T> {
             invalidator.invalidate();
         }
     }
+
+    pub fn lock(&self) -> StateRefMut<'_, T> {
+        StateRefMut {
+            inner: self.inner.lock(),
+            mutated: false,
+        }
+    }
 }
 
 impl<T: PartialEq> State<T> {
@@ -133,10 +155,35 @@ impl<T: PartialEq> State<T> {
     }
 }
 
-impl<'a, T> std::ops::Deref for StateRef<'a, T> {
+impl<'a, T> Deref for StateRef<'a, T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
         &self.inner.value
+    }
+}
+
+impl<'a, T> Deref for StateRefMut<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner.value
+    }
+}
+
+impl<'a, T> DerefMut for StateRefMut<'a, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.mutated = true;
+        &mut self.inner.value
+    }
+}
+
+impl<'a, T> Drop for StateRefMut<'a, T> {
+    fn drop(&mut self) {
+        if self.mutated {
+            for invalidator in take(&mut self.inner.invalidators) {
+                invalidator.invalidate();
+            }
+        }
     }
 }

--- a/crates/turbopack-core/src/issue/mod.rs
+++ b/crates/turbopack-core/src/issue/mod.rs
@@ -362,6 +362,19 @@ impl CapturedIssuesVc {
     pub async fn is_empty(self) -> Result<BoolVc> {
         Ok(BoolVc::cell(self.await?.is_empty()))
     }
+
+    #[turbo_tasks::function]
+    pub async fn has_fatal(self) -> Result<BoolVc> {
+        let mut has_fatal = false;
+        for issue in self.await?.iter() {
+            let severity = *issue.severity().await?;
+            if severity == IssueSeverity::Fatal {
+                has_fatal = true;
+                break;
+            }
+        }
+        Ok(BoolVc::cell(has_fatal))
+    }
 }
 
 impl CapturedIssues {
@@ -471,24 +484,18 @@ pub struct PlainIssue {
     pub sub_issues: Vec<PlainIssueReadRef>,
 }
 
-#[turbo_tasks::value_impl]
-impl PlainIssueVc {
-    /// We need deduplicate issues that can come from unique paths, but
-    /// represent the same underlying problem. Eg, a parse error for a file
-    /// that is compiled in both client and server contexts.
-    #[turbo_tasks::function]
-    pub async fn internal_hash(self) -> Result<U64Vc> {
-        let this = self.await?;
+impl PlainIssue {
+    pub fn internal_hash(&self) -> u64 {
         let mut hasher = Xxh3Hash64Hasher::new();
-        hasher.write_ref(&this.severity);
-        hasher.write_ref(&this.context);
-        hasher.write_ref(&this.category);
-        hasher.write_ref(&this.title);
-        hasher.write_ref(&this.description);
-        hasher.write_ref(&this.detail);
-        hasher.write_ref(&this.documentation_link);
+        hasher.write_ref(&self.severity);
+        hasher.write_ref(&self.context);
+        hasher.write_ref(&self.category);
+        hasher.write_ref(&self.title);
+        hasher.write_ref(&self.description);
+        hasher.write_ref(&self.detail);
+        hasher.write_ref(&self.documentation_link);
 
-        if let Some(source) = &this.source {
+        if let Some(source) = &self.source {
             hasher.write_value(1_u8);
             // I'm assuming we don't need to hash the contents. Not 100% correct, but
             // probably 99%.
@@ -498,7 +505,18 @@ impl PlainIssueVc {
             hasher.write_value(0_u8);
         }
 
-        Ok(U64Vc::cell(hasher.finish()))
+        hasher.finish()
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl PlainIssueVc {
+    /// We need deduplicate issues that can come from unique paths, but
+    /// represent the same underlying problem. Eg, a parse error for a file
+    /// that is compiled in both client and server contexts.
+    #[turbo_tasks::function]
+    pub async fn internal_hash(self) -> Result<U64Vc> {
+        Ok(U64Vc::cell(self.await?.internal_hash()))
     }
 }
 

--- a/crates/turbopack-test-utils/Cargo.toml
+++ b/crates/turbopack-test-utils/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "turbopack-test-utils"
+version = "0.1.0"
+description = "TBD"
+license = "MPL-2.0"
+edition = "2021"
+autobenches = false
+
+[lib]
+bench = false
+
+[dependencies]
+anyhow = "1.0.47"
+once_cell = "1.13.0"
+similar = "2.2.0"
+turbo-tasks = { path = "../turbo-tasks" }
+turbo-tasks-fs = { path = "../turbo-tasks-fs" }
+turbo-tasks-hash = { path = "../turbo-tasks-hash" }
+turbopack-core = { path = "../turbopack-core" }
+
+[build-dependencies]
+turbo-tasks-build = { path = "../turbo-tasks-build" }

--- a/crates/turbopack-test-utils/build.rs
+++ b/crates/turbopack-test-utils/build.rs
@@ -1,0 +1,5 @@
+use turbo_tasks_build::generate_register;
+
+fn main() {
+    generate_register();
+}

--- a/crates/turbopack-test-utils/src/lib.rs
+++ b/crates/turbopack-test-utils/src/lib.rs
@@ -1,0 +1,4 @@
+#![feature(min_specialization)]
+#![feature(str_split_as_str)]
+
+pub mod snapshot;

--- a/crates/turbopack-test-utils/src/snapshot.rs
+++ b/crates/turbopack-test-utils/src/snapshot.rs
@@ -1,0 +1,178 @@
+use std::{
+    collections::{HashMap, HashSet},
+    env, fs,
+};
+
+use anyhow::{anyhow, bail, Context, Result};
+use once_cell::sync::Lazy;
+use similar::TextDiff;
+use turbo_tasks::{TryJoinIterExt, ValueToString};
+use turbo_tasks_fs::{
+    DirectoryContent, DirectoryEntry, DiskFileSystemVc, File, FileContent, FileSystemEntryType,
+    FileSystemPathVc,
+};
+use turbo_tasks_hash::encode_hex;
+use turbopack_core::{
+    asset::{AssetContent, AssetContentVc},
+    issue::PlainIssueReadRef,
+};
+
+// Updates the existing snapshot outputs with the actual outputs of this run.
+// e.g. `UPDATE=1 cargo test -p turbopack-tests -- test_my_pattern`
+static UPDATE: Lazy<bool> = Lazy::new(|| env::var("UPDATE").unwrap_or_default() == "1");
+
+pub async fn snapshot_issues<I: IntoIterator<Item = PlainIssueReadRef>>(
+    captured_issues: I,
+    issues_path: FileSystemPathVc,
+    workspace_root: &str,
+) -> Result<()> {
+    let expected_issues = expected(issues_path).await?;
+    let mut seen = HashSet::new();
+    for plain_issue in captured_issues.into_iter() {
+        let hash = encode_hex(plain_issue.internal_hash());
+
+        // We replace "*" because it's not allowed for filename on Windows.
+        let path = issues_path.join(&format!(
+            "{}-{}.txt",
+            plain_issue.title.replace('*', "__star__"),
+            &hash[0..6]
+        ));
+        seen.insert(path);
+
+        // Annoyingly, the PlainIssue.source -> PlainIssueSource.asset ->
+        // PlainAsset.path -> FileSystemPath.fs -> DiskFileSystem.root changes
+        // for everyone.
+        let content = format!("{:#?}", plain_issue).replace(workspace_root, "WORKSPACE_ROOT");
+        let asset = File::from(content).into();
+
+        diff(path, asset).await?;
+    }
+
+    matches_expected(expected_issues, seen).await
+}
+
+pub async fn expected(dir: FileSystemPathVc) -> Result<HashSet<FileSystemPathVc>> {
+    let mut expected = HashSet::new();
+    let entries = dir.read_dir().await?;
+    if let DirectoryContent::Entries(entries) = &*entries {
+        for (file, entry) in entries {
+            match entry {
+                DirectoryEntry::File(file) => {
+                    expected.insert(*file);
+                }
+                _ => bail!(
+                    "expected file at {}, found {:?}",
+                    file,
+                    FileSystemEntryType::from(entry)
+                ),
+            }
+        }
+    }
+    Ok(expected)
+}
+
+pub async fn matches_expected(
+    expected: HashSet<FileSystemPathVc>,
+    seen: HashSet<FileSystemPathVc>,
+) -> Result<()> {
+    for path in diff_paths(&expected, &seen).await? {
+        let p = &path.await?.path;
+        if *UPDATE {
+            remove_file(path).await?;
+            println!("removed file {}", p);
+        } else {
+            bail!("expected file {}, but it was not emitted", p);
+        }
+    }
+    Ok(())
+}
+
+pub async fn diff(path: FileSystemPathVc, actual: AssetContentVc) -> Result<()> {
+    let path_str = &path.await?.path;
+    let expected = path.read().into();
+
+    let actual = match get_contents(actual, path).await? {
+        Some(s) => s,
+        None => bail!("could not generate {} contents", path_str),
+    };
+    let expected = get_contents(expected, path).await?;
+
+    if Some(&actual) != expected.as_ref() {
+        if *UPDATE {
+            let content = File::from(actual).into();
+            path.write(content).await?;
+            println!("updated contents of {}", path_str);
+        } else {
+            if expected.is_none() {
+                eprintln!("new file {path_str} detected:");
+            } else {
+                eprintln!("contents of {path_str} did not match:");
+            }
+            let expected = expected.unwrap_or_default();
+            let diff = TextDiff::from_lines(&expected, &actual);
+            eprintln!(
+                "{}",
+                diff.unified_diff()
+                    .context_radius(3)
+                    .header("expected", "actual")
+            );
+            bail!("contents of {path_str} did not match");
+        }
+    }
+
+    Ok(())
+}
+
+async fn get_contents(file: AssetContentVc, path: FileSystemPathVc) -> Result<Option<String>> {
+    Ok(
+        match &*file.await.context(format!(
+            "Unable to read AssetContent of {}",
+            path.to_string().await?
+        ))? {
+            AssetContent::File(file) => match &*file.await.context(format!(
+                "Unable to read FileContent of {}",
+                path.to_string().await?
+            ))? {
+                FileContent::NotFound => None,
+                FileContent::Content(expected) => {
+                    Some(expected.content().to_str()?.trim().to_string())
+                }
+            },
+            AssetContent::Redirect { target, link_type } => Some(format!(
+                "Redirect {{ target: {target}, link_type: {:?} }}",
+                link_type
+            )),
+        },
+    )
+}
+
+async fn remove_file(path: FileSystemPathVc) -> Result<()> {
+    let fs = DiskFileSystemVc::resolve_from(path.fs())
+        .await?
+        .context(anyhow!("unexpected fs type"))?
+        .await?;
+    let sys_path = fs.to_sys_path(path).await?;
+    fs::remove_file(&sys_path).context(format!("remove file {} error", sys_path.display()))?;
+    Ok(())
+}
+
+/// Values in left that are not in right.
+/// FileSystemPathVc hashes as a Vc, not as the file path, so we need to get the
+/// path to properly diff.
+async fn diff_paths(
+    left: &HashSet<FileSystemPathVc>,
+    right: &HashSet<FileSystemPathVc>,
+) -> Result<HashSet<FileSystemPathVc>> {
+    let mut map = left
+        .iter()
+        .map(|p| async move { Ok((p.await?.path.clone(), *p)) })
+        .try_join()
+        .await?
+        .iter()
+        .cloned()
+        .collect::<HashMap<_, _>>();
+    for p in right {
+        map.remove(&p.await?.path);
+    }
+    Ok(map.values().copied().collect())
+}

--- a/crates/turbopack-tests/Cargo.toml
+++ b/crates/turbopack-tests/Cargo.toml
@@ -18,16 +18,15 @@ next-core = { path = "../next-core", features = ['native-tls'] }
 once_cell = "1.13.0"
 serde = "1.0.136"
 serde_json = "1.0.85"
-similar = "2.2.0"
 test-generator = "0.3.0"
 tokio = "1.21.2"
 turbo-tasks = { path = "../turbo-tasks" }
 turbo-tasks-env = { path = "../turbo-tasks-env" }
 turbo-tasks-fs = { path = "../turbo-tasks-fs" }
-turbo-tasks-hash = { path = "../turbo-tasks-hash" }
 turbo-tasks-memory = { path = "../turbo-tasks-memory" }
 turbopack-core = { path = "../turbopack-core" }
 turbopack-env = { path = "../turbopack-env" }
+turbopack-test-utils = { path = "../turbopack-test-utils" }
 
 [build-dependencies]
 turbo-tasks-build = { path = "../turbo-tasks-build" }

--- a/crates/turbopack-tests/tests/snapshot.rs
+++ b/crates/turbopack-tests/tests/snapshot.rs
@@ -6,19 +6,16 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{anyhow, Context, Result};
 use once_cell::sync::Lazy;
 use serde::Deserialize;
-use similar::TextDiff;
 use test_generator::test_resources;
-use turbo_tasks::{debug::ValueDebug, NothingVc, TryJoinIterExt, TurboTasks, Value, ValueToString};
+use turbo_tasks::{NothingVc, TryJoinIterExt, TurboTasks, Value, ValueToString};
 use turbo_tasks_env::DotenvProcessEnvVc;
 use turbo_tasks_fs::{
-    json::parse_json_with_source_context, util::sys_to_unix, DirectoryContent, DirectoryEntry,
-    DiskFileSystemVc, File, FileContent, FileSystem, FileSystemEntryType, FileSystemPathVc,
-    FileSystemVc,
+    json::parse_json_with_source_context, util::sys_to_unix, DiskFileSystemVc, FileSystem,
+    FileSystemPathVc, FileSystemVc,
 };
-use turbo_tasks_hash::encode_hex;
 use turbo_tasks_memory::MemoryBackend;
 use turbopack::{
     condition::ContextCondition,
@@ -29,7 +26,7 @@ use turbopack::{
     ModuleAssetContextVc,
 };
 use turbopack_core::{
-    asset::{Asset, AssetContent, AssetContentVc, AssetVc},
+    asset::{Asset, AssetVc},
     chunk::{dev::DevChunkingContextVc, ChunkableAsset, ChunkableAssetVc},
     context::{AssetContext, AssetContextVc},
     environment::{BrowserEnvironment, EnvironmentIntention, EnvironmentVc, ExecutionEnvironment},
@@ -39,15 +36,12 @@ use turbopack_core::{
     source_asset::SourceAssetVc,
 };
 use turbopack_env::ProcessEnvAssetVc;
+use turbopack_test_utils::snapshot::{diff, expected, matches_expected, snapshot_issues};
 
 fn register() {
     turbopack::register();
     include!(concat!(env!("OUT_DIR"), "/register_test_snapshot.rs"));
 }
-
-// Updates the existing snapshot outputs with the actual outputs of this run.
-// `UPDATE=1 cargo test -p turbopack -- test_my_pattern`
-static UPDATE: Lazy<bool> = Lazy::new(|| env::var("UPDATE").unwrap_or_default() == "1");
 
 static WORKSPACE_ROOT: Lazy<String> = Lazy::new(|| {
     let package_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -102,16 +96,30 @@ async fn run(resource: &'static str) -> Result<()> {
     let tt = TurboTasks::new(MemoryBackend::default());
     let task = tt.spawn_once_task(async move {
         let out = run_test(resource.to_string());
-        handle_issues(out)
-            .await
-            .context("Unable to handle issues")?;
+        let captured_issues = IssueVc::peek_issues_with_path(out)
+            .await?
+            .strongly_consistent()
+            .await?;
+
+        let plain_issues = captured_issues
+            .iter()
+            .map(|issue_vc| async move { issue_vc.into_plain().await })
+            .try_join()
+            .await?;
+
+        snapshot_issues(
+            plain_issues.into_iter(),
+            out.join("issues"),
+            &WORKSPACE_ROOT,
+        )
+        .await
+        .context("Unable to handle issues")?;
         Ok(NothingVc::new().into())
     });
     tt.wait_task_completion(task, true).await?;
 
     Ok(())
 }
-
 #[turbo_tasks::function]
 async fn run_test(resource: String) -> Result<FileSystemPathVc> {
     let test_path = Path::new(&resource)
@@ -256,16 +264,6 @@ async fn run_test(resource: String) -> Result<FileSystemPathVc> {
     Ok(path)
 }
 
-async fn remove_file(path: FileSystemPathVc) -> Result<()> {
-    let fs = DiskFileSystemVc::resolve_from(path.fs())
-        .await?
-        .context(anyhow!("unexpected fs type"))?
-        .await?;
-    let sys_path = fs.to_sys_path(path).await?;
-    fs::remove_file(&sys_path).context(format!("remove file {} error", sys_path.display()))?;
-    Ok(())
-}
-
 async fn walk_asset(
     asset: AssetVc,
     seen: &mut HashSet<FileSystemPathVc>,
@@ -279,65 +277,6 @@ async fn walk_asset(
 
     diff(path, asset.content()).await?;
     queue.extend(&*all_referenced_assets(asset).await?);
-
-    Ok(())
-}
-
-async fn get_contents(file: AssetContentVc, path: FileSystemPathVc) -> Result<Option<String>> {
-    Ok(
-        match &*file.await.context(format!(
-            "Unable to read AssetContent of {}",
-            path.to_string().await?
-        ))? {
-            AssetContent::File(file) => match &*file.await.context(format!(
-                "Unable to read FileContent of {}",
-                path.to_string().await?
-            ))? {
-                FileContent::NotFound => None,
-                FileContent::Content(expected) => {
-                    Some(expected.content().to_str()?.trim().to_string())
-                }
-            },
-            AssetContent::Redirect { target, link_type } => Some(format!(
-                "Redirect {{ target: {target}, link_type: {:?} }}",
-                link_type
-            )),
-        },
-    )
-}
-
-async fn diff(path: FileSystemPathVc, actual: AssetContentVc) -> Result<()> {
-    let path_str = &path.await?.path;
-    let expected = path.read().into();
-
-    let actual = match get_contents(actual, path).await? {
-        Some(s) => s,
-        None => bail!("could not generate {} contents", path_str),
-    };
-    let expected = get_contents(expected, path).await?;
-
-    if Some(&actual) != expected.as_ref() {
-        if *UPDATE {
-            let content = File::from(actual).into();
-            path.write(content).await?;
-            println!("updated contents of {}", path_str);
-        } else {
-            if expected.is_none() {
-                eprintln!("new file {path_str} detected:");
-            } else {
-                eprintln!("contents of {path_str} did not match:");
-            }
-            let expected = expected.unwrap_or_default();
-            let diff = TextDiff::from_lines(&expected, &actual);
-            eprintln!(
-                "{}",
-                diff.unified_diff()
-                    .context_radius(3)
-                    .header("expected", "actual")
-            );
-            bail!("contents of {path_str} did not match");
-        }
-    }
 
     Ok(())
 }
@@ -359,96 +298,4 @@ async fn maybe_load_env(
     Ok(Some(EcmascriptChunkPlaceablesVc::cell(vec![
         asset.as_ecmascript_chunk_placeable()
     ])))
-}
-
-async fn expected(dir: FileSystemPathVc) -> Result<HashSet<FileSystemPathVc>> {
-    let mut expected = HashSet::new();
-    let entries = dir.read_dir().await?;
-    if let DirectoryContent::Entries(entries) = &*entries {
-        for (file, entry) in entries {
-            match entry {
-                DirectoryEntry::File(file) => {
-                    expected.insert(*file);
-                }
-                _ => bail!(
-                    "expected file at {}, found {:?}",
-                    file,
-                    FileSystemEntryType::from(entry)
-                ),
-            }
-        }
-    }
-    Ok(expected)
-}
-
-/// Values in left that are not in right.
-/// FileSystemPathVc hashes as a Vc, not as the file path, so we need to get the
-/// path to properly diff.
-async fn diff_paths(
-    left: &HashSet<FileSystemPathVc>,
-    right: &HashSet<FileSystemPathVc>,
-) -> Result<HashSet<FileSystemPathVc>> {
-    let mut map = left
-        .iter()
-        .map(|p| async move { Ok((p.await?.path.clone(), *p)) })
-        .try_join()
-        .await?
-        .iter()
-        .cloned()
-        .collect::<HashMap<_, _>>();
-    for p in right {
-        map.remove(&p.await?.path);
-    }
-    Ok(map.values().copied().collect())
-}
-
-async fn matches_expected(
-    expected: HashSet<FileSystemPathVc>,
-    seen: HashSet<FileSystemPathVc>,
-) -> Result<()> {
-    for path in diff_paths(&expected, &seen).await? {
-        let p = &path.await?.path;
-        if *UPDATE {
-            remove_file(path).await?;
-            println!("removed file {}", p);
-        } else {
-            bail!("expected file {}, but it was not emitted", p);
-        }
-    }
-    Ok(())
-}
-
-async fn handle_issues(source: FileSystemPathVc) -> Result<()> {
-    let issues_path = source.join("issues");
-    let expected_issues = expected(issues_path).await?;
-
-    let mut seen = HashSet::new();
-    let issues = IssueVc::peek_issues_with_path(source)
-        .await?
-        .strongly_consistent()
-        .await?;
-
-    for issue in issues.iter() {
-        let plain_issue = issue.into_plain();
-        let hash = encode_hex(*plain_issue.internal_hash().await?);
-
-        // We replace "*" because it's not allowed for filename on Windows.
-        let path = issues_path.join(&format!(
-            "{}-{}.txt",
-            plain_issue.await?.title.replace('*', "__star__"),
-            &hash[0..6]
-        ));
-        seen.insert(path);
-
-        // Annoyingly, the PlainIssue.source -> PlainIssueSource.asset ->
-        // PlainAsset.path -> FileSystemPath.fs -> DiskFileSystem.root changes
-        // for everyone.
-        let content =
-            format!("{}", plain_issue.dbg().await?).replace(&*WORKSPACE_ROOT, "WORKSPACE_ROOT");
-        let asset = File::from(content).into();
-
-        diff(path, asset).await?;
-    }
-
-    matches_expected(expected_issues, seen).await
 }


### PR DESCRIPTION
This:
* Adds issue snapshot support to next-dev-tests. This will allow us to assert that certain issues are raised in tests that require next-dev.
* Extracts common snapshot code into a new crates, `turbopack-test-utils`, which is shared between snapshot tests and next-dev-tests.
* Implements an issue reporter that emits issues in a channel to the the integration test code, where they are snapshotted.
* Fixes an issue where next-dev tests that were not Next.js apps would emit non-fatal issues for a missing `pages/` directory.

Co-authored-by: Justin Ridgewell <justin@ridgewell.name>
