### PR TITLE
Include workspace turbo.json in inputs

### DIFF
--- a/cli/integration_tests/composable_config/composing-add-keys.t
+++ b/cli/integration_tests/composable_config/composing-add-keys.t
@@ -15,13 +15,13 @@ Setup
   \xe2\x80\xa2 Packages in scope: add-keys (esc)
   \xe2\x80\xa2 Running add-keys-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  add-keys:add-keys-underlying-task: cache miss, executing 11b8af0d5b4ec46f
+  add-keys:add-keys-underlying-task: cache miss, executing a33d34272db64281
   add-keys:add-keys-underlying-task: 
   add-keys:add-keys-underlying-task: > add-keys-underlying-task
   add-keys:add-keys-underlying-task: > echo "running add-keys-underlying-task"
   add-keys:add-keys-underlying-task: 
   add-keys:add-keys-underlying-task: running add-keys-underlying-task
-  add-keys:add-keys-task: cache miss, executing d0092c043ad245ce
+  add-keys:add-keys-task: cache miss, executing f4bbaa26e53aac6f
   add-keys:add-keys-task: 
   add-keys:add-keys-task: > add-keys-task
   add-keys:add-keys-task: > echo "running add-keys-task" > out/foo.min.txt
@@ -43,13 +43,13 @@ Setup
   \xe2\x80\xa2 Packages in scope: add-keys (esc)
   \xe2\x80\xa2 Running add-keys-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  add-keys:add-keys-underlying-task: cache hit, replaying output 11b8af0d5b4ec46f
+  add-keys:add-keys-underlying-task: cache hit, replaying output a33d34272db64281
   add-keys:add-keys-underlying-task: 
   add-keys:add-keys-underlying-task: > add-keys-underlying-task
   add-keys:add-keys-underlying-task: > echo "running add-keys-underlying-task"
   add-keys:add-keys-underlying-task: 
   add-keys:add-keys-underlying-task: running add-keys-underlying-task
-  add-keys:add-keys-task: cache hit, suppressing output d0092c043ad245ce
+  add-keys:add-keys-task: cache hit, suppressing output f4bbaa26e53aac6f
   
    Tasks:    2 successful, 2 total
   Cached:    2 cached, 2 total
@@ -61,13 +61,13 @@ Setup
   \xe2\x80\xa2 Packages in scope: add-keys (esc)
   \xe2\x80\xa2 Running add-keys-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  add-keys:add-keys-underlying-task: cache miss, executing b7390d43fae5a180
+  add-keys:add-keys-underlying-task: cache miss, executing dfc32b367b1c6a9a
   add-keys:add-keys-underlying-task: 
   add-keys:add-keys-underlying-task: > add-keys-underlying-task
   add-keys:add-keys-underlying-task: > echo "running add-keys-underlying-task"
   add-keys:add-keys-underlying-task: 
   add-keys:add-keys-underlying-task: running add-keys-underlying-task
-  add-keys:add-keys-task: cache miss, executing b256f31e3957fee3
+  add-keys:add-keys-task: cache miss, executing e0596a25ab3888ea
   add-keys:add-keys-task: 
   add-keys:add-keys-task: > add-keys-task
   add-keys:add-keys-task: > echo "running add-keys-task" > out/foo.min.txt
@@ -82,13 +82,13 @@ Setup
   \xe2\x80\xa2 Packages in scope: add-keys (esc)
   \xe2\x80\xa2 Running add-keys-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  add-keys:add-keys-underlying-task: cache hit, replaying output b7390d43fae5a180
+  add-keys:add-keys-underlying-task: cache hit, replaying output dfc32b367b1c6a9a
   add-keys:add-keys-underlying-task: 
   add-keys:add-keys-underlying-task: > add-keys-underlying-task
   add-keys:add-keys-underlying-task: > echo "running add-keys-underlying-task"
   add-keys:add-keys-underlying-task: 
   add-keys:add-keys-underlying-task: running add-keys-underlying-task
-  add-keys:add-keys-task: cache miss, executing 8e76bee49319e00e
+  add-keys:add-keys-task: cache miss, executing 2ff6e32f88af5a65
   add-keys:add-keys-task: 
   add-keys:add-keys-task: > add-keys-task
   add-keys:add-keys-task: > echo "running add-keys-task" > out/foo.min.txt

--- a/cli/integration_tests/composable_config/composing-add-tasks.t
+++ b/cli/integration_tests/composable_config/composing-add-tasks.t
@@ -6,7 +6,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: add-tasks (esc)
   \xe2\x80\xa2 Running added-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  add-tasks:added-task: cache miss, executing 49e39f2b39207531
+  add-tasks:added-task: cache miss, executing 8f82d0bc5ced2f1c
   add-tasks:added-task: 
   add-tasks:added-task: > added-task
   add-tasks:added-task: > echo "running added-task" > out/foo.min.txt

--- a/cli/integration_tests/composable_config/composing-cache.t
+++ b/cli/integration_tests/composable_config/composing-cache.t
@@ -14,7 +14,7 @@ This test covers:
   \xe2\x80\xa2 Packages in scope: cached (esc)
   \xe2\x80\xa2 Running cached-task-1 in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  cached:cached-task-1: cache miss, executing a6607ea0e6633b06
+  cached:cached-task-1: cache miss, executing e74036fd7badaaf6
   cached:cached-task-1: 
   cached:cached-task-1: > cached-task-1
   cached:cached-task-1: > echo 'cached-task-1' > out/foo.min.txt
@@ -39,7 +39,7 @@ This test covers:
   \xe2\x80\xa2 Packages in scope: cached (esc)
   \xe2\x80\xa2 Running cached-task-2 in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  cached:cached-task-2: cache bypass, force executing b62581e51e1924b1
+  cached:cached-task-2: cache bypass, force executing a98a2c287f1d2763
   cached:cached-task-2: 
   cached:cached-task-2: > cached-task-2
   cached:cached-task-2: > echo 'cached-task-2' > out/foo.min.txt
@@ -61,7 +61,7 @@ no `cache` config in root, cache:false in workspace
   \xe2\x80\xa2 Packages in scope: cached (esc)
   \xe2\x80\xa2 Running cached-task-3 in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  cached:cached-task-3: cache bypass, force executing deea66a9c4a5a2b6
+  cached:cached-task-3: cache bypass, force executing 8a426151da6db286
   cached:cached-task-3: 
   cached:cached-task-3: > cached-task-3
   cached:cached-task-3: > echo 'cached-task-3' > out/foo.min.txt
@@ -85,7 +85,7 @@ we already have a workspace that doesn't have a config
   \xe2\x80\xa2 Packages in scope: missing-workspace-config (esc)
   \xe2\x80\xa2 Running cached-task-4 in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  missing-workspace-config:cached-task-4: cache bypass, force executing 2e1ed564d0007d66
+  missing-workspace-config:cached-task-4: cache bypass, force executing ecbdd1ee8d9f34a5
   missing-workspace-config:cached-task-4: 
   missing-workspace-config:cached-task-4: > cached-task-4
   missing-workspace-config:cached-task-4: > echo 'cached-task-4' > out/foo.min.txt

--- a/cli/integration_tests/composable_config/composing-config-change.t
+++ b/cli/integration_tests/composable_config/composing-config-change.t
@@ -2,18 +2,15 @@ Setup
   $ . ${TESTDIR}/../setup.sh
   $ . ${TESTDIR}/setup.sh $(pwd) ./monorepo
 
-# The override-values-task task in the root turbo.json has ALL the config. The workspace config
-# defines the task and overrides all the keys. The tests below use `override-values-task` to assert that:
-# - `outputs`, `inputs`, `env`, and `outputMode` are overriden from the root config.
-
-# 1. First run, assert cache miss
+# 1. First run, check the hash
   $ ${TURBO} run config-change-task --filter=config-change --dry=json | jq .tasks[0].hash
-  "29e0c6e610c3d010"
+  "b17ced7629048d97"
 
-2. Run again and assert cache hit, and that full output is displayed
+2. Run again and assert task hash stays the same
   $ ${TURBO} run config-change-task --filter=config-change --dry=json | jq .tasks[0].hash
-  "29e0c6e610c3d010"
-3. Change turbo.json and assert cache miss
+  "b17ced7629048d97"
+
+3. Change turbo.json and assert that hash changes
   $ cp $TARGET_DIR/apps/config-change/turbo-changed.json $TARGET_DIR/apps/config-change/turbo.json
   $ ${TURBO} run config-change-task --filter=config-change --dry=json | jq .tasks[0].hash
-  "something-else"
+  "6c56b35e06abb856"

--- a/cli/integration_tests/composable_config/composing-config-change.t
+++ b/cli/integration_tests/composable_config/composing-config-change.t
@@ -1,0 +1,19 @@
+Setup
+  $ . ${TESTDIR}/../setup.sh
+  $ . ${TESTDIR}/setup.sh $(pwd) ./monorepo
+
+# The override-values-task task in the root turbo.json has ALL the config. The workspace config
+# defines the task and overrides all the keys. The tests below use `override-values-task` to assert that:
+# - `outputs`, `inputs`, `env`, and `outputMode` are overriden from the root config.
+
+# 1. First run, assert cache miss
+  $ ${TURBO} run config-change-task --filter=config-change --dry=json | jq .tasks[0].hash
+  "29e0c6e610c3d010"
+
+2. Run again and assert cache hit, and that full output is displayed
+  $ ${TURBO} run config-change-task --filter=config-change --dry=json | jq .tasks[0].hash
+  "29e0c6e610c3d010"
+3. Change turbo.json and assert cache miss
+  $ cp $TARGET_DIR/apps/config-change/turbo-changed.json $TARGET_DIR/apps/config-change/turbo.json
+  $ ${TURBO} run config-change-task --filter=config-change --dry=json | jq .tasks[0].hash
+  "something-else"

--- a/cli/integration_tests/composable_config/composing-missing-workspace-config-deps.t
+++ b/cli/integration_tests/composable_config/composing-missing-workspace-config-deps.t
@@ -16,14 +16,14 @@ Setup
   \xe2\x80\xa2 Remote caching disabled (esc)
 
   $ cat tmp.log | grep "missing-workspace-config:missing-workspace-config-task-with-deps"
-  missing-workspace-config:missing-workspace-config-task-with-deps: cache miss, executing 90f569a4d233900b
+  missing-workspace-config:missing-workspace-config-task-with-deps: cache miss, executing 68582686ba468bdb
   missing-workspace-config:missing-workspace-config-task-with-deps: 
   missing-workspace-config:missing-workspace-config-task-with-deps: > missing-workspace-config-task-with-deps
   missing-workspace-config:missing-workspace-config-task-with-deps: > echo "running missing-workspace-config-task-with-deps" > out/foo.min.txt
   missing-workspace-config:missing-workspace-config-task-with-deps: 
 
   $ cat tmp.log | grep "missing-workspace-config:missing-workspace-config-underlying-task"
-  missing-workspace-config:missing-workspace-config-underlying-task: cache miss, executing 4f3b4521c6ff4ae7
+  missing-workspace-config:missing-workspace-config-underlying-task: cache miss, executing 73dd0ecdcdc4a3f4
   missing-workspace-config:missing-workspace-config-underlying-task: 
   missing-workspace-config:missing-workspace-config-underlying-task: > missing-workspace-config-underlying-task
   missing-workspace-config:missing-workspace-config-underlying-task: > echo "running missing-workspace-config-underlying-task"
@@ -31,7 +31,7 @@ Setup
   missing-workspace-config:missing-workspace-config-underlying-task: running missing-workspace-config-underlying-task
 
   $ cat tmp.log | grep "blank-pkg:missing-workspace-config-underlying-topo-task"
-  blank-pkg:missing-workspace-config-underlying-topo-task: cache miss, executing 94978ec88d0432da
+  blank-pkg:missing-workspace-config-underlying-topo-task: cache miss, executing 7f25337c32f440a0
   blank-pkg:missing-workspace-config-underlying-topo-task: 
   blank-pkg:missing-workspace-config-underlying-topo-task: > missing-workspace-config-underlying-topo-task
   blank-pkg:missing-workspace-config-underlying-topo-task: > echo "missing-workspace-config-underlying-topo-task from blank-pkg"

--- a/cli/integration_tests/composable_config/composing-missing-workspace-config.t
+++ b/cli/integration_tests/composable_config/composing-missing-workspace-config.t
@@ -12,7 +12,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: missing-workspace-config (esc)
   \xe2\x80\xa2 Running missing-workspace-config-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  missing-workspace-config:missing-workspace-config-task: cache miss, executing 79a54a30e54f2dfd
+  missing-workspace-config:missing-workspace-config-task: cache miss, executing b4851e92e758d2a8
   missing-workspace-config:missing-workspace-config-task: 
   missing-workspace-config:missing-workspace-config-task: > missing-workspace-config-task
   missing-workspace-config:missing-workspace-config-task: > echo "running missing-workspace-config-task" > out/foo.min.txt
@@ -34,7 +34,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: missing-workspace-config (esc)
   \xe2\x80\xa2 Running missing-workspace-config-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  missing-workspace-config:missing-workspace-config-task: cache hit, suppressing output 79a54a30e54f2dfd
+  missing-workspace-config:missing-workspace-config-task: cache hit, suppressing output b4851e92e758d2a8
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total
@@ -46,7 +46,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: missing-workspace-config (esc)
   \xe2\x80\xa2 Running missing-workspace-config-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  missing-workspace-config:missing-workspace-config-task: cache miss, executing c0bada87846f1bfb
+  missing-workspace-config:missing-workspace-config-task: cache miss, executing 1ca45c09eccb3931
   missing-workspace-config:missing-workspace-config-task: 
   missing-workspace-config:missing-workspace-config-task: > missing-workspace-config-task
   missing-workspace-config:missing-workspace-config-task: > echo "running missing-workspace-config-task" > out/foo.min.txt
@@ -63,7 +63,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: missing-workspace-config (esc)
   \xe2\x80\xa2 Running missing-workspace-config-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  missing-workspace-config:missing-workspace-config-task: cache hit, suppressing output c0bada87846f1bfb
+  missing-workspace-config:missing-workspace-config-task: cache hit, suppressing output 1ca45c09eccb3931
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total
@@ -74,7 +74,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: missing-workspace-config (esc)
   \xe2\x80\xa2 Running missing-workspace-config-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  missing-workspace-config:missing-workspace-config-task: cache miss, executing 54d7193f1944a600
+  missing-workspace-config:missing-workspace-config-task: cache miss, executing 06fd150c6e5e8a1b
   missing-workspace-config:missing-workspace-config-task: 
   missing-workspace-config:missing-workspace-config-task: > missing-workspace-config-task
   missing-workspace-config:missing-workspace-config-task: > echo "running missing-workspace-config-task" > out/foo.min.txt
@@ -90,7 +90,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: missing-workspace-config (esc)
   \xe2\x80\xa2 Running cached-task-4 in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  missing-workspace-config:cached-task-4: cache bypass, force executing c7af8921ec1b664a
+  missing-workspace-config:cached-task-4: cache bypass, force executing aaa8d1d189163b4c
   missing-workspace-config:cached-task-4: 
   missing-workspace-config:cached-task-4: > cached-task-4
   missing-workspace-config:cached-task-4: > echo 'cached-task-4' > out/foo.min.txt

--- a/cli/integration_tests/composable_config/composing-omit-keys-deps.t
+++ b/cli/integration_tests/composable_config/composing-omit-keys-deps.t
@@ -16,14 +16,14 @@ Setup
   \xe2\x80\xa2 Running omit-keys-task-with-deps in 1 packages (esc)
 
   $ cat tmp.log | grep "omit-keys:omit-keys-task-with-deps"
-  omit-keys:omit-keys-task-with-deps: cache miss, executing 821d445c5223ff3c
+  omit-keys:omit-keys-task-with-deps: cache miss, executing c12b0d1d341419fd
   omit-keys:omit-keys-task-with-deps: 
   omit-keys:omit-keys-task-with-deps: > omit-keys-task-with-deps
   omit-keys:omit-keys-task-with-deps: > echo "running omit-keys-task-with-deps" > out/foo.min.txt
   omit-keys:omit-keys-task-with-deps: 
 
   $ cat tmp.log | grep "omit-keys:omit-keys-underlying-task"
-  omit-keys:omit-keys-underlying-task: cache miss, executing 48b5b3b2215253ae
+  omit-keys:omit-keys-underlying-task: cache miss, executing a16948b5c74ccef9
   omit-keys:omit-keys-underlying-task: 
   omit-keys:omit-keys-underlying-task: > omit-keys-underlying-task
   omit-keys:omit-keys-underlying-task: > echo "running omit-keys-underlying-task"
@@ -31,7 +31,7 @@ Setup
   omit-keys:omit-keys-underlying-task: running omit-keys-underlying-task
 
   $ cat tmp.log | grep "blank-pkg:omit-keys-underlying-topo-task"
-  blank-pkg:omit-keys-underlying-topo-task: cache miss, executing 08faed7a20ede252
+  blank-pkg:omit-keys-underlying-topo-task: cache miss, executing 5b3c524f8ead8679
   blank-pkg:omit-keys-underlying-topo-task: 
   blank-pkg:omit-keys-underlying-topo-task: > omit-keys-underlying-topo-task
   blank-pkg:omit-keys-underlying-topo-task: > echo "omit-keys-underlying-topo-task from blank-pkg"

--- a/cli/integration_tests/composable_config/composing-omit-keys.t
+++ b/cli/integration_tests/composable_config/composing-omit-keys.t
@@ -15,7 +15,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: omit-keys (esc)
   \xe2\x80\xa2 Running omit-keys-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  omit-keys:omit-keys-task: cache miss, executing a1711cdb6b04d805
+  omit-keys:omit-keys-task: cache miss, executing a2c5f2a3a6b20d6e
   omit-keys:omit-keys-task: 
   omit-keys:omit-keys-task: > omit-keys-task
   omit-keys:omit-keys-task: > echo "running omit-keys-task" > out/foo.min.txt
@@ -37,7 +37,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: omit-keys (esc)
   \xe2\x80\xa2 Running omit-keys-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  omit-keys:omit-keys-task: cache hit, suppressing output a1711cdb6b04d805
+  omit-keys:omit-keys-task: cache hit, suppressing output a2c5f2a3a6b20d6e
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total
@@ -49,7 +49,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: omit-keys (esc)
   \xe2\x80\xa2 Running omit-keys-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  omit-keys:omit-keys-task: cache miss, executing 8bd4867ef67efcf8
+  omit-keys:omit-keys-task: cache miss, executing b8b6909ecb130e0f
   omit-keys:omit-keys-task: 
   omit-keys:omit-keys-task: > omit-keys-task
   omit-keys:omit-keys-task: > echo "running omit-keys-task" > out/foo.min.txt
@@ -66,7 +66,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: omit-keys (esc)
   \xe2\x80\xa2 Running omit-keys-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  omit-keys:omit-keys-task: cache hit, suppressing output 8bd4867ef67efcf8
+  omit-keys:omit-keys-task: cache hit, suppressing output b8b6909ecb130e0f
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total
@@ -77,7 +77,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: omit-keys (esc)
   \xe2\x80\xa2 Running omit-keys-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  omit-keys:omit-keys-task: cache miss, executing 1fcdb11297866c94
+  omit-keys:omit-keys-task: cache miss, executing bb73a08ebe0a4ed6
   omit-keys:omit-keys-task: 
   omit-keys:omit-keys-task: > omit-keys-task
   omit-keys:omit-keys-task: > echo "running omit-keys-task" > out/foo.min.txt

--- a/cli/integration_tests/composable_config/composing-override-values-deps.t
+++ b/cli/integration_tests/composable_config/composing-override-values-deps.t
@@ -16,14 +16,14 @@ Setup
   \xe2\x80\xa2 Remote caching disabled (esc)
 
   $ cat tmp.log | grep "override-values:override-values-task-with-deps"
-  override-values:override-values-task-with-deps: cache miss, executing 3d2372c2f2000cd6
+  override-values:override-values-task-with-deps: cache miss, executing cf35abb7b46ffad7
   override-values:override-values-task-with-deps: 
   override-values:override-values-task-with-deps: > override-values-task-with-deps
   override-values:override-values-task-with-deps: > echo "running override-values-task-with-deps" > out/foo.min.txt
   override-values:override-values-task-with-deps: 
 
   $ cat tmp.log | grep "override-values:override-values-underlying-task"
-  override-values:override-values-underlying-task: cache miss, executing 3a0c61b37b07c844
+  override-values:override-values-underlying-task: cache miss, executing 783a94e433071496
   override-values:override-values-underlying-task: 
   override-values:override-values-underlying-task: > override-values-underlying-task
   override-values:override-values-underlying-task: > echo "running override-values-underlying-task"
@@ -31,7 +31,7 @@ Setup
   override-values:override-values-underlying-task: running override-values-underlying-task
 
   $ cat tmp.log | grep "blank-pkg:override-values-underlying-topo-task"
-  blank-pkg:override-values-underlying-topo-task: cache miss, executing a20f51570cf3ca37
+  blank-pkg:override-values-underlying-topo-task: cache miss, executing 0e2630802fda80c3
   blank-pkg:override-values-underlying-topo-task: 
   blank-pkg:override-values-underlying-topo-task: > override-values-underlying-topo-task
   blank-pkg:override-values-underlying-topo-task: > echo "override-values-underlying-topo-task from blank-pkg"

--- a/cli/integration_tests/composable_config/composing-override-values.t
+++ b/cli/integration_tests/composable_config/composing-override-values.t
@@ -12,7 +12,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: override-values (esc)
   \xe2\x80\xa2 Running override-values-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  override-values:override-values-task: cache miss, executing ac45efe67ee8d1f3
+  override-values:override-values-task: cache miss, executing 51d1d668d9adffe5
   override-values:override-values-task: 
   override-values:override-values-task: > override-values-task
   override-values:override-values-task: > echo "running override-values-task" > lib/bar.min.txt
@@ -34,7 +34,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: override-values (esc)
   \xe2\x80\xa2 Running override-values-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  override-values:override-values-task: cache hit, replaying output ac45efe67ee8d1f3
+  override-values:override-values-task: cache hit, replaying output 51d1d668d9adffe5
   override-values:override-values-task: 
   override-values:override-values-task: > override-values-task
   override-values:override-values-task: > echo "running override-values-task" > lib/bar.min.txt
@@ -50,7 +50,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: override-values (esc)
   \xe2\x80\xa2 Running override-values-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  override-values:override-values-task: cache miss, executing 950ae666cb260d4d
+  override-values:override-values-task: cache miss, executing 8f07b7ef52189a94
   override-values:override-values-task: 
   override-values:override-values-task: > override-values-task
   override-values:override-values-task: > echo "running override-values-task" > lib/bar.min.txt
@@ -66,7 +66,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: override-values (esc)
   \xe2\x80\xa2 Running override-values-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  override-values:override-values-task: cache hit, replaying output 950ae666cb260d4d
+  override-values:override-values-task: cache hit, replaying output 8f07b7ef52189a94
   override-values:override-values-task: 
   override-values:override-values-task: > override-values-task
   override-values:override-values-task: > echo "running override-values-task" > lib/bar.min.txt
@@ -81,7 +81,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: override-values (esc)
   \xe2\x80\xa2 Running override-values-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  override-values:override-values-task: cache miss, executing 13d19ccfe25b65d4
+  override-values:override-values-task: cache miss, executing 7106c9435e784aaf
   override-values:override-values-task: 
   override-values:override-values-task: > override-values-task
   override-values:override-values-task: > echo "running override-values-task" > lib/bar.min.txt
@@ -96,7 +96,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: override-values (esc)
   \xe2\x80\xa2 Running override-values-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  override-values:override-values-task: cache hit, replaying output 13d19ccfe25b65d4
+  override-values:override-values-task: cache hit, replaying output 7106c9435e784aaf
   override-values:override-values-task: 
   override-values:override-values-task: > override-values-task
   override-values:override-values-task: > echo "running override-values-task" > lib/bar.min.txt

--- a/cli/integration_tests/composable_config/composing-persistent.t
+++ b/cli/integration_tests/composable_config/composing-persistent.t
@@ -23,13 +23,13 @@ This test covers:
   \xe2\x80\xa2 Packages in scope: persistent (esc)
   \xe2\x80\xa2 Running persistent-task-2-parent in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  persistent:persistent-task-2: cache miss, executing 23dbaa659bf45d29
+  persistent:persistent-task-2: cache miss, executing 5b8a1c3719e1add7
   persistent:persistent-task-2: 
   persistent:persistent-task-2: > persistent-task-2
   persistent:persistent-task-2: > echo 'persistent-task-2'
   persistent:persistent-task-2: 
   persistent:persistent-task-2: persistent-task-2
-  persistent:persistent-task-2-parent: cache miss, executing db90399020f2bdd3
+  persistent:persistent-task-2-parent: cache miss, executing e352678c40ca2536
   persistent:persistent-task-2-parent: 
   persistent:persistent-task-2-parent: > persistent-task-2-parent
   persistent:persistent-task-2-parent: > echo 'persistent-task-2-parent'

--- a/cli/integration_tests/composable_config/monorepo/apps/config-change/package.json
+++ b/cli/integration_tests/composable_config/monorepo/apps/config-change/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "config-change",
+  "scripts": {
+    "config-change-task": "echo 'config-change-task'"
+  }
+}

--- a/cli/integration_tests/composable_config/monorepo/apps/config-change/src/foo.txt
+++ b/cli/integration_tests/composable_config/monorepo/apps/config-change/src/foo.txt
@@ -1,0 +1,1 @@
+contents

--- a/cli/integration_tests/composable_config/monorepo/apps/config-change/turbo-changed.json
+++ b/cli/integration_tests/composable_config/monorepo/apps/config-change/turbo-changed.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["//"],
+  "pipeline": {
+    "config-change-task": {},
+    "other-task": {
+      "env": ["ARBITRARY_CHANGE"]
+    }
+  }
+}

--- a/cli/integration_tests/composable_config/monorepo/apps/config-change/turbo.json
+++ b/cli/integration_tests/composable_config/monorepo/apps/config-change/turbo.json
@@ -1,0 +1,7 @@
+{
+  "extends": ["//"],
+  "pipeline": {
+    "config-change-task": {},
+    "other-task": {}
+  }
+}

--- a/cli/integration_tests/composable_config/monorepo/turbo.json
+++ b/cli/integration_tests/composable_config/monorepo/turbo.json
@@ -90,6 +90,10 @@
     "cached-task-4": {
       "cache": false,
       "outputs": ["out/**"]
+    },
+
+    "config-change-task": {
+      "inputs": ["src/foo.txt"]
     }
   }
 }

--- a/cli/internal/hashing/package_deps_hash.go
+++ b/cli/internal/hashing/package_deps_hash.go
@@ -43,12 +43,16 @@ func GetPackageDeps(rootPath turbopath.AbsoluteSystemPath, p *PackageDepsOptions
 		}
 		result = gitLsTreeOutput
 	} else {
-
-		// Add in package.json to input patterns because if the `scripts` in
-		// the package.json change (i.e. the tasks that turbo executes), we want
-		// a cache miss, since any existing cache could be invalid.
-		// Note this package.json will be resolved relative to the pkgPath.
+		// Add in package.json and turbo.json to input patterns. Both file paths are relative to pkgPath
+		//
+		// - package.json is an input because if the `scripts` in
+		// 		the package.json change (i.e. the tasks that turbo executes), we want
+		// 		a cache miss, since any existing cache could be invalid.
+		// - turbo.json because it's the definition of the tasks themselves. The root turbo.json
+		// 		is similarly included in the global hash. This file may not exist in the workspace, but
+		// 		that is ok, because it will get ignored downstream.
 		calculatedInputs = append(calculatedInputs, "package.json")
+		calculatedInputs = append(calculatedInputs, "turbo.json")
 
 		// The input patterns are relative to the package.
 		// However, we need to change the globbing to be relative to the repo root.


### PR DESCRIPTION
When `inputs` is configured for a task, we want to ensure that changes to the `turbo.json` in that workspace cause a cache miss. This is similar to how we treat the `package.json` in the workspace, and also how we treat the root `turbo.json` for the global hash.