### PR TITLE
fix: support prune without turbo.json

### DIFF
--- a/cli/internal/fs/turbo_json.go
+++ b/cli/internal/fs/turbo_json.go
@@ -126,7 +126,7 @@ func LoadTurboConfig(rootPath turbopath.AbsoluteSystemPath, rootPackageJSON *Pac
 	if !includeSynthesizedFromRootPackageJSON && err != nil {
 		// If the file didn't exist, throw a custom error here instead of propagating
 		if errors.Is(err, os.ErrNotExist) {
-			return nil, fmt.Errorf("Could not find %s. Follow directions at https://turbo.build/repo/docs to create one: file does not exist", configFile)
+			return nil, errors.Wrapf(err, "Could not find %s. Follow directions at https://turbo.build/repo/docs to create one", configFile)
 		}
 
 		// There was an error, and we don't have any chance of recovering

--- a/cli/internal/prune/prune.go
+++ b/cli/internal/prune/prune.go
@@ -3,6 +3,7 @@ package prune
 import (
 	"bufio"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/vercel/turbo/cli/internal/cmdutil"
@@ -209,7 +210,7 @@ func (p *prune) prune(opts *turbostate.PrunePayload) error {
 	}
 
 	turboJSON, err := fs.LoadTurboConfig(p.base.RepoRoot, rootPackageJSON, false)
-	if err != nil {
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return errors.Wrap(err, "failed to read turbo.json")
 	}
 	if turboJSON != nil {


### PR DESCRIPTION
Fixes #3645
Before #3216 we would ignore if `turbo.json` wasn't present. This PR restores that behavior by ignoring "not exists" errors.

Note: this is a slight UI change as we're now wrapping the not found error so we can match against it:
Previous:
` ERROR  failed to read turbo.json: Could not find turbo.json. Follow directions at https://turbo.build/repo/docs to create one: file does not exist`
New:
` ERROR  failed to read turbo.json: Could not find turbo.json. Follow directions at https://turbo.build/repo/docs to create one: Could not find turbo.json: file does not exist`