### PR TITLE
use consistent actions/checkout version in examples

### DIFF
--- a/docs/pages/repo/docs/ci/github-actions.mdx
+++ b/docs/pages/repo/docs/ci/github-actions.mdx
@@ -223,7 +223,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 2
     # ...


### PR DESCRIPTION
The other example on this page uses `actions/checkout@v3` 