### PR TITLE
ci(workflow): store failed test path list

### DIFF
--- a/.github/actions/next-integration-stat/index.js
+++ b/.github/actions/next-integration-stat/index.js
@@ -16572,6 +16572,11 @@
           .map((t) => (t.length > 5 ? `\t- ${t}` : t))
           .join(" \n")}`;
       }
+      console.log(
+        "Newly failed tests",
+        JSON.stringify(newFailedTests, null, 2)
+      );
+      console.log("Fixed tests", JSON.stringify(fixedTests, null, 2));
       // Store a json payload to share via slackapi/slack-github-action into Slack channel
       if (shouldShareTestSummaryToSlack) {
         let resultsSummary = "";
@@ -16777,14 +16782,18 @@
         ];
         const isMultipleComments = comments.length > 1;
         try {
-          if (!prNumber) {
-            return;
-          }
           // Store the list of failed test paths to a file
           fs.writeFileSync(
             "./failed-test-path-list.json",
-            JSON.stringify(failedTestLists, null, 2)
+            JSON.stringify(
+              failedTestLists.filter((x) => x.length > 5),
+              null,
+              2
+            )
           );
+          if (!prNumber) {
+            return;
+          }
           if (failedJobResults.result.length === 0) {
             console.log("No failed test results found :tada:");
             yield postCommentAsync(

--- a/.github/actions/next-integration-stat/src/index.ts
+++ b/.github/actions/next-integration-stat/src/index.ts
@@ -679,6 +679,9 @@ function getTestSummary(
       .join(" \n")}`;
   }
 
+  console.log("Newly failed tests", JSON.stringify(newFailedTests, null, 2));
+  console.log("Fixed tests", JSON.stringify(fixedTests, null, 2));
+
   // Store a json payload to share via slackapi/slack-github-action into Slack channel
   if (shouldShareTestSummaryToSlack) {
     let resultsSummary = "";
@@ -882,15 +885,19 @@ async function run() {
   const isMultipleComments = comments.length > 1;
 
   try {
-    if (!prNumber) {
-      return;
-    }
-
     // Store the list of failed test paths to a file
     fs.writeFileSync(
       "./failed-test-path-list.json",
-      JSON.stringify(failedTestLists, null, 2)
+      JSON.stringify(
+        failedTestLists.filter((x) => x.length > 5),
+        null,
+        2
+      )
     );
+
+    if (!prNumber) {
+      return;
+    }
 
     if (failedJobResults.result.length === 0) {
       console.log("No failed test results found :tada:");

--- a/.github/workflows/upload-nextjs-integration-test-results.yml
+++ b/.github/workflows/upload-nextjs-integration-test-results.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Print test results
         run: |
           ls -al ./test-results/main
-          cat ./test-results/main/nextjs-test-results.json
+          echo "Print failed test path list:"
           cat ./test-results/main/failed-test-path-list.json
           echo "NEXTJS_VERSION=$(cat ./test-results/main/nextjs-test-results.json | jq .nextjsVersion | tr -d '"' | cut -d ' ' -f2)" >> $GITHUB_ENV
           echo "SHA_SHORT=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
@@ -46,8 +46,8 @@ jobs:
         run: |
           echo "Configured test result subpath for ${{ env.RESULT_SUBPATH }} / ${{ env.NEXTJS_VERSION }} / ${{ env.SHA_SHORT }}"
           mkdir -p test-results/${{ env.RESULT_SUBPATH }}
-          mv test-results/main/nextjs-test-results.json test-results/${{ env.RESULT_SUBPATH }}/$(date '+%Y%m%d%H%M')-${{ env.NEXTJS_VERSION }}-${{ env.SHA_SHORT }}.json
-          mv -f test-results/main/failed-test-path-list.json test-results/${{ env.RESULT_SUBPATH }}/failed-test-path-list.json
+          mv -v test-results/main/nextjs-test-results.json test-results/${{ env.RESULT_SUBPATH }}/$(date '+%Y%m%d%H%M')-${{ env.NEXTJS_VERSION }}-${{ env.SHA_SHORT }}.json
+          mv -fvn test-results/main/failed-test-path-list.json test-results/${{ env.RESULT_SUBPATH }}/failed-test-path-list.json
           ls -al ./test-results
           ls -al ./test-results/${{ env.RESULT_SUBPATH }}
 


### PR DESCRIPTION
Trying to close WEB-589: along with full test results, stores latest test failure list to skip retrying for the known failures.