### PR TITLE
fix export * warning for client pages

### DIFF
--- a/crates/next-core/js/src/entry/app-renderer.tsx
+++ b/crates/next-core/js/src/entry/app-renderer.tsx
@@ -117,7 +117,11 @@ async function runOperation(renderData: RenderData) {
   const layoutInfoChunks: Record<string, string[]> = {};
   const pageItem = LAYOUT_INFO[LAYOUT_INFO.length - 1];
   const pageModule = pageItem.page!.module;
-  let tree: LoaderTree = ["", {}, { page: [() => pageModule, "page.js"] }];
+  let tree: LoaderTree = [
+    "",
+    {},
+    { page: [() => pageModule.module, "page.js"] },
+  ];
   layoutInfoChunks["page"] = pageItem.page!.chunks;
   for (let i = LAYOUT_INFO.length - 2; i >= 0; i--) {
     const info = LAYOUT_INFO[i];
@@ -127,7 +131,7 @@ async function runOperation(renderData: RenderData) {
         continue;
       }
       const k = key as FileType;
-      components[k] = [() => info[k]!.module, `${k}${i}.js`];
+      components[k] = [() => info[k]!.module.module, `${k}${i}.js`];
       layoutInfoChunks[`${k}${i}`] = info[k]!.chunks;
     }
     tree = [info.segment, { children: tree }, components];

--- a/crates/next-core/js/src/entry/app/layout-entry.tsx
+++ b/crates/next-core/js/src/entry/app/layout-entry.tsx
@@ -8,5 +8,5 @@ import * as serverHooks from "next/dist/client/components/hooks-server-context.j
 export { serverHooks };
 export { renderToReadableStream } from "next/dist/compiled/react-server-dom-webpack/server.browser";
 
-export { default } from ".";
-export * from ".";
+import * as module from ".";
+export { module };

--- a/crates/turbopack-ecmascript/src/references/esm/export.rs
+++ b/crates/turbopack-ecmascript/src/references/esm/export.rs
@@ -167,7 +167,7 @@ impl CodeGenerateable for EsmExports {
                     let ident = ReferencedAsset::get_ident_from_placeable(asset).await?;
 
                     cjs_exports.push(quote_expr!(
-                        "__turbopack__cjs__($arg)",
+                        "__turbopack_cjs__($arg)",
                         arg: Expr = Ident::new(ident.into(), DUMMY_SP).into()
                     ));
                 }

--- a/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/crates/turbopack-ecmascript/src/references/mod.rs
@@ -2139,7 +2139,22 @@ fn has_cjs_export(p: &Program) -> bool {
 
     if let Program::Module(m) = p {
         // Check for imports/exports
-        if m.body.iter().any(ModuleItem::is_module_decl) {
+        if m.body.iter().any(|item| {
+            item.as_module_decl().map_or(false, |module_decl| {
+                module_decl
+                    .as_import()
+                    .and_then(|import| import.asserts.as_ref())
+                    .map_or(true, |asserts| {
+                        asserts.props.iter().any(|assert| {
+                            assert
+                                .as_prop()
+                                .and_then(|prop| prop.as_key_value())
+                                .and_then(|kv| kv.key.as_ident())
+                                .map_or(true, |ident| &*ident.sym != "turbopackHelper")
+                        })
+                    })
+            })
+        }) {
             return false;
         }
     }
@@ -2152,7 +2167,10 @@ fn has_cjs_export(p: &Program) -> bool {
         visit_obj_and_computed!();
 
         fn visit_ident(&mut self, i: &Ident) {
-            if &*i.sym == "module" || &*i.sym == "exports" {
+            if &*i.sym == "module"
+                || &*i.sym == "exports"
+                || &*i.sym == "__turbopack_export_value__"
+            {
                 self.found = true;
             }
         }

--- a/crates/turbopack-ecmascript/src/transform/server_to_client_proxy.rs
+++ b/crates/turbopack-ecmascript/src/transform/server_to_client_proxy.rs
@@ -11,6 +11,8 @@ use swc_core::{
     quote,
 };
 
+use crate::references::TURBOPACK_HELPER;
+
 macro_rules! has_client_directive {
     ($stmts:expr) => {
         $stmts
@@ -56,7 +58,7 @@ pub fn create_proxy_module(transition_name: &str, target_import: &str) -> Progra
                 asserts: Some(box ObjectLit {
                     span: DUMMY_SP,
                     props: vec![PropOrSpread::Prop(box Prop::KeyValue(KeyValueProp {
-                        key: PropName::Ident(Ident::new("turbopackHelper".into(), DUMMY_SP)),
+                        key: PropName::Ident(Ident::new(TURBOPACK_HELPER.into(), DUMMY_SP)),
                         value: box Expr::Lit(true.into()),
                     }))],
                 }),

--- a/crates/turbopack-ecmascript/src/transform/server_to_client_proxy.rs
+++ b/crates/turbopack-ecmascript/src/transform/server_to_client_proxy.rs
@@ -2,8 +2,9 @@ use swc_core::{
     common::DUMMY_SP,
     ecma::{
         ast::{
-            Expr, ExprStmt, ImportDecl, ImportDefaultSpecifier, ImportSpecifier, Lit, Module,
-            ModuleDecl, ModuleItem, Program, Stmt, Str,
+            Expr, ExprStmt, Ident, ImportDecl, ImportDefaultSpecifier, ImportSpecifier,
+            KeyValueProp, Lit, Module, ModuleDecl, ModuleItem, ObjectLit, Program, Prop, PropName,
+            PropOrSpread, Stmt, Str,
         },
         utils::private_ident,
     },
@@ -52,7 +53,13 @@ pub fn create_proxy_module(transition_name: &str, target_import: &str) -> Progra
                 })],
                 src: box target_import.into(),
                 type_only: false,
-                asserts: None,
+                asserts: Some(box ObjectLit {
+                    span: DUMMY_SP,
+                    props: vec![PropOrSpread::Prop(box Prop::KeyValue(KeyValueProp {
+                        key: PropName::Ident(Ident::new("turbopackHelper".into(), DUMMY_SP)),
+                        value: box Expr::Lit(true.into()),
+                    }))],
+                }),
                 span: DUMMY_SP,
             })),
             ModuleItem::Stmt(quote!(

--- a/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/output/crates_turbopack-tests_tests_snapshot_export-alls_cjs-2_input_index_0ea679.js
+++ b/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/output/crates_turbopack-tests_tests_snapshot_export-alls_cjs-2_input_index_0ea679.js
@@ -12,7 +12,7 @@ console.log(__TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$
 
 __turbopack_esm__({});
 var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$export$2d$alls$2f$cjs$2d$2$2f$input$2f$c$2e$js__ = __turbopack_import__("[project]/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/input/c.js (ecmascript)");
-__turbopack__cjs__(__TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$export$2d$alls$2f$cjs$2d$2$2f$input$2f$c$2e$js__);
+__turbopack_cjs__(__TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$export$2d$alls$2f$cjs$2d$2$2f$input$2f$c$2e$js__);
 "__TURBOPACK__ecmascript__hoisting__location__";
 ;
 
@@ -21,7 +21,7 @@ __turbopack__cjs__(__TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$tur
 
 __turbopack_esm__({});
 var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$export$2d$alls$2f$cjs$2d$2$2f$input$2f$commonjs$2e$js__ = __turbopack_import__("[project]/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/input/commonjs.js (ecmascript)");
-__turbopack__cjs__(__TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$export$2d$alls$2f$cjs$2d$2$2f$input$2f$commonjs$2e$js__);
+__turbopack_cjs__(__TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$export$2d$alls$2f$cjs$2d$2$2f$input$2f$commonjs$2e$js__);
 "__TURBOPACK__ecmascript__hoisting__location__";
 ;
 

--- a/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/output/crates_turbopack-tests_tests_snapshot_export-alls_cjs-script_input_index_1cb91d.js
+++ b/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/output/crates_turbopack-tests_tests_snapshot_export-alls_cjs-script_input_index_1cb91d.js
@@ -12,7 +12,7 @@ console.log(__TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$
 
 __turbopack_esm__({});
 var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$export$2d$alls$2f$cjs$2d$script$2f$input$2f$exported$2e$cjs__ = __turbopack_import__("[project]/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/input/exported.cjs (ecmascript)");
-__turbopack__cjs__(__TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$export$2d$alls$2f$cjs$2d$script$2f$input$2f$exported$2e$cjs__);
+__turbopack_cjs__(__TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$export$2d$alls$2f$cjs$2d$script$2f$input$2f$exported$2e$cjs__);
 "__TURBOPACK__ecmascript__hoisting__location__";
 ;
 console.log('Hoist test');


### PR DESCRIPTION
This gets rid of this warning when using a client component as page:

```
warning - [analyze] [project-with-next]/src/app/client/page.jsx  unexpected export *
  export * used with module [project-with-next]/src/app/client/page.jsx which has no exports
  Typescript only: Did you want to export only types with `export type { ... } from "..."`?
```

* fix export * warning for client pages
* Detect `__turbopack_export_value__` as CJS style exports
* fix `__turbopack_cjs__` name
* flag turbopackHelper in client proxy