### PR TITLE
Restore Issue Reporters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7779,6 +7779,7 @@ dependencies = [
  "indexmap",
  "mime",
  "mime_guess",
+ "once_cell",
  "parking_lot",
  "pin-project-lite",
  "serde",

--- a/crates/node-file-trace/src/lib.rs
+++ b/crates/node-file-trace/src/lib.rs
@@ -492,12 +492,6 @@ async fn run<B: Backend + 'static, F: Future<Output = ()>>(
         let args = args.clone();
         let sender = sender.clone();
         Box::pin(async move {
-            let console_ui = ConsoleUiVc::new(TransientInstance::new(LogOptions {
-                current_dir: dir.clone(),
-                show_all,
-                log_detail,
-                log_level: log_level.map_or_else(|| IssueSeverity::Error, |l| l.0),
-            }));
             let output = main_operation(TransientValue::new(dir.clone()), args.clone().into());
 
             let source = TransientValue::new(output.into());
@@ -505,6 +499,13 @@ async fn run<B: Backend + 'static, F: Future<Output = ()>>(
                 .await?
                 .strongly_consistent()
                 .await?;
+
+            let console_ui = ConsoleUiVc::new(TransientInstance::new(LogOptions {
+                current_dir: dir.clone(),
+                show_all,
+                log_detail,
+                log_level: log_level.map_or_else(|| IssueSeverity::Error, |l| l.0),
+            }));
             console_ui
                 .as_issue_reporter()
                 .report_issues(TransientInstance::new(issues), source);

--- a/crates/node-file-trace/src/lib.rs
+++ b/crates/node-file-trace/src/lib.rs
@@ -488,16 +488,16 @@ async fn run<B: Backend + 'static, F: Future<Output = ()>>(
     let dir = current_dir().unwrap();
     let tt = create_tt();
     let task = tt.spawn_root_task(move || {
-        let console_ui = ConsoleUiVc::new(TransientInstance::new(LogOptions {
-            current_dir: dir.clone(),
-            show_all,
-            log_detail,
-            log_level: log_level.map_or_else(|| IssueSeverity::Error, |l| l.0),
-        }));
         let dir = dir.clone();
         let args = args.clone();
         let sender = sender.clone();
         Box::pin(async move {
+            let console_ui = ConsoleUiVc::new(TransientInstance::new(LogOptions {
+                current_dir: dir.clone(),
+                show_all,
+                log_detail,
+                log_level: log_level.map_or_else(|| IssueSeverity::Error, |l| l.0),
+            }));
             let output = main_operation(TransientValue::new(dir.clone()), args.clone().into());
 
             let source = TransientValue::new(output.into());

--- a/crates/turbopack-core/src/issue/mod.rs
+++ b/crates/turbopack-core/src/issue/mod.rs
@@ -17,7 +17,8 @@ use futures::FutureExt;
 use turbo_tasks::{
     emit,
     primitives::{BoolVc, StringVc, U64Vc},
-    CollectiblesSource, ReadRef, TryJoinIterExt, ValueToString, ValueToStringVc,
+    CollectiblesSource, RawVc, ReadRef, TransientInstance, TransientValue, TryJoinIterExt,
+    ValueToString, ValueToStringVc,
 };
 use turbo_tasks_fs::{
     FileContent, FileContentReadRef, FileLine, FileLinesContent, FileSystemPathReadRef,
@@ -340,6 +341,21 @@ pub struct CapturedIssues {
     processing_path: ItemIssueProcessingPathVc,
 }
 
+impl CapturedIssues {
+    pub async fn has_fatal(&self) -> Result<bool> {
+        let mut has_fatal = false;
+
+        for issue in self.issues.iter() {
+            let severity = *issue.severity().await?;
+            if severity == IssueSeverity::Fatal {
+                has_fatal = true;
+                break;
+            }
+        }
+        Ok(has_fatal)
+    }
+}
+
 #[turbo_tasks::value_impl]
 impl CapturedIssuesVc {
     #[turbo_tasks::function]
@@ -567,4 +583,13 @@ impl PlainAssetVc {
         }
         .cell())
     }
+}
+
+#[turbo_tasks::value_trait]
+pub trait IssueReporter {
+    fn report_issues(
+        &self,
+        issues: TransientInstance<ReadRef<CapturedIssues>>,
+        source: TransientValue<RawVc>,
+    );
 }

--- a/crates/turbopack-dev-server/Cargo.toml
+++ b/crates/turbopack-dev-server/Cargo.toml
@@ -17,6 +17,7 @@ hyper-tungstenite = "0.8.1"
 indexmap = { workspace = true, features = ["serde"] }
 mime = "0.3.16"
 mime_guess = "2.0.4"
+once_cell = "1.13.0"
 parking_lot = "0.12.1"
 pin-project-lite = "0.2.9"
 serde = "1.0.136"

--- a/crates/turbopack-dev-server/src/http.rs
+++ b/crates/turbopack-dev-server/src/http.rs
@@ -4,8 +4,7 @@ use hyper::{header::HeaderName, Request, Response};
 use mime_guess::mime;
 use turbo_tasks::TransientInstance;
 use turbo_tasks_fs::{FileContent, FileContentReadRef};
-use turbopack_cli_utils::issue::ConsoleUiVc;
-use turbopack_core::{asset::AssetContent, version::VersionedContent};
+use turbopack_core::{asset::AssetContent, issue::IssueReporterVc, version::VersionedContent};
 
 use crate::source::{
     request::SourceRequest,
@@ -30,10 +29,10 @@ enum GetFromSourceResult {
 async fn get_from_source(
     source: ContentSourceVc,
     request: TransientInstance<SourceRequest>,
-    console_ui: ConsoleUiVc,
+    issue_repoter: IssueReporterVc,
 ) -> Result<GetFromSourceResultVc> {
     Ok(
-        match &*resolve_source_request(source, request, console_ui).await? {
+        match &*resolve_source_request(source, request, issue_repoter).await? {
             ResolveSourceRequestResult::Static(static_content_vc) => {
                 let static_content = static_content_vc.await?;
                 if let AssetContent::File(file) = &*static_content.content.content().await? {
@@ -60,11 +59,11 @@ async fn get_from_source(
 pub async fn process_request_with_content_source(
     source: ContentSourceVc,
     request: Request<hyper::Body>,
-    console_ui: ConsoleUiVc,
+    issue_reporter: IssueReporterVc,
 ) -> Result<Response<hyper::Body>> {
     let original_path = request.uri().path().to_string();
     let request = http_request_to_source_request(request).await?;
-    let result = get_from_source(source, TransientInstance::new(request), console_ui);
+    let result = get_from_source(source, TransientInstance::new(request), issue_reporter);
     match &*result.strongly_consistent().await? {
         GetFromSourceResult::Static {
             content,

--- a/crates/turbopack-dev-server/src/lib.rs
+++ b/crates/turbopack-dev-server/src/lib.rs
@@ -16,16 +16,17 @@ use std::{
     time::{Duration, Instant},
 };
 
-use anyhow::{bail, Context, Result};
+use anyhow::{anyhow, Context, Result};
 use hyper::{
     server::{conn::AddrIncoming, Builder},
     service::{make_service_fn, service_fn},
     Request, Response, Server,
 };
 use turbo_tasks::{
-    run_once, trace::TraceRawVcs, util::FormatDuration, RawVc, TransientValue, TurboTasksApi,
+    run_once, trace::TraceRawVcs, util::FormatDuration, CollectiblesSource, RawVc,
+    TransientInstance, TransientValue, TurboTasksApi,
 };
-use turbopack_cli_utils::issue::{ConsoleUi, ConsoleUiVc};
+use turbopack_core::issue::{IssueReporter, IssueReporterVc, IssueVc};
 
 use self::{
     source::{ContentSourceResultVc, ContentSourceVc},
@@ -66,21 +67,27 @@ pub struct DevServer {
     pub future: Pin<Box<dyn Future<Output = Result<()>> + Send + 'static>>,
 }
 
-// Just print issues to console for now...
-async fn handle_issues<T: Into<RawVc>>(
+async fn handle_issues<T: Into<RawVc> + CollectiblesSource + Copy>(
     source: T,
     path: &str,
     operation: &str,
-    console_ui: ConsoleUiVc,
+    issue_reporter: IssueReporterVc,
 ) -> Result<()> {
-    let state = console_ui
-        .group_and_display_issues(TransientValue::new(source.into()))
+    let issues = IssueVc::peek_issues_with_path(source)
+        .await?
+        .strongly_consistent()
         .await?;
-    if state.has_fatal {
-        bail!("Fatal issue(s) occurred in {path} ({operation}")
-    }
 
-    Ok(())
+    issue_reporter.report_issues(
+        TransientInstance::new(issues.clone()),
+        TransientValue::new(source.into()),
+    );
+
+    if issues.has_fatal().await? {
+        Err(anyhow!("Fatal issue(s) occurred in {path} ({operation})"))
+    } else {
+        Ok(())
+    }
 }
 
 impl DevServer {
@@ -106,21 +113,21 @@ impl DevServerBuilder {
         self,
         turbo_tasks: Arc<dyn TurboTasksApi>,
         source_provider: impl SourceProvider + Clone + Send + Sync,
-        console_ui: Arc<ConsoleUi>,
+        get_issue_reporter: Arc<dyn Fn() -> IssueReporterVc + Send + Sync>,
     ) -> DevServer {
         let make_svc = make_service_fn(move |_| {
             let tt = turbo_tasks.clone();
             let source_provider = source_provider.clone();
-            let console_ui = console_ui.clone();
+            let get_issue_reporter = get_issue_reporter.clone();
             async move {
                 let handler = move |request: Request<hyper::Body>| {
-                    let console_ui = console_ui.clone();
                     let start = Instant::now();
                     let tt = tt.clone();
+                    let get_issue_reporter = get_issue_reporter.clone();
                     let source_provider = source_provider.clone();
                     let future = async move {
                         run_once(tt.clone(), async move {
-                            let console_ui = (*console_ui).clone().cell();
+                            let issue_reporter = get_issue_reporter();
 
                             if hyper_tungstenite::is_upgrade_request(&request) {
                                 let uri = request.uri();
@@ -130,7 +137,7 @@ impl DevServerBuilder {
                                     let (response, websocket) =
                                         hyper_tungstenite::upgrade(request, None)?;
                                     let update_server =
-                                        UpdateServer::new(source_provider, console_ui);
+                                        UpdateServer::new(source_provider, issue_reporter);
                                     update_server.run(&*tt, websocket);
                                     return Ok(response);
                                 }
@@ -158,12 +165,12 @@ impl DevServerBuilder {
                             let uri = request.uri();
                             let path = uri.path().to_string();
                             let source = source_provider.get_source();
-                            handle_issues(source, &path, "get source", console_ui).await?;
+                            handle_issues(source, &path, "get source", issue_reporter).await?;
                             let resolved_source = source.resolve_strongly_consistent().await?;
                             let response = http::process_request_with_content_source(
                                 resolved_source,
                                 request,
-                                console_ui,
+                                issue_reporter,
                             )
                             .await?;
                             let status = response.status().as_u16();

--- a/crates/turbopack-dev-server/src/source/resolve.rs
+++ b/crates/turbopack-dev-server/src/source/resolve.rs
@@ -6,7 +6,7 @@ use std::{
 use anyhow::{bail, Result};
 use hyper::Uri;
 use turbo_tasks::{TransientInstance, Value};
-use turbopack_cli_utils::issue::ConsoleUiVc;
+use turbopack_core::issue::IssueReporterVc;
 
 use super::{
     headers::{HeaderValue, Headers},
@@ -36,7 +36,7 @@ pub enum ResolveSourceRequestResult {
 pub async fn resolve_source_request(
     source: ContentSourceVc,
     request: TransientInstance<SourceRequest>,
-    console_ui: ConsoleUiVc,
+    issue_reporter: IssueReporterVc,
 ) -> Result<ResolveSourceRequestResultVc> {
     let mut data = ContentSourceData::default();
     let mut current_source = source;
@@ -50,7 +50,7 @@ pub async fn resolve_source_request(
             result,
             &original_path,
             "get content from source",
-            console_ui,
+            issue_reporter,
         )
         .await?;
 

--- a/crates/turbopack-dev-server/src/update/server.rs
+++ b/crates/turbopack-dev-server/src/update/server.rs
@@ -12,8 +12,7 @@ use tokio::select;
 use tokio_stream::StreamMap;
 use turbo_tasks::{TransientInstance, TurboTasksApi};
 use turbo_tasks_fs::json::parse_json_with_source_context;
-use turbopack_cli_utils::issue::ConsoleUiVc;
-use turbopack_core::version::Update;
+use turbopack_core::{issue::IssueReporterVc, version::Update};
 
 use super::{
     protocol::{ClientMessage, ClientUpdateInstruction, Issue, ResourceIdentifier},
@@ -28,15 +27,15 @@ use crate::{
 /// A server that listens for updates and sends them to connected clients.
 pub(crate) struct UpdateServer<P: SourceProvider> {
     source_provider: P,
-    console_ui: ConsoleUiVc,
+    issue_reporter: IssueReporterVc,
 }
 
 impl<P: SourceProvider + Clone + Send + Sync> UpdateServer<P> {
     /// Create a new update server with the given websocket and content source.
-    pub fn new(source_provider: P, console_ui: ConsoleUiVc) -> Self {
+    pub fn new(source_provider: P, issue_reporter: IssueReporterVc) -> Self {
         Self {
             source_provider,
-            console_ui,
+            issue_reporter,
         }
     }
 
@@ -69,7 +68,7 @@ impl<P: SourceProvider + Clone + Send + Sync> UpdateServer<P> {
                                     resolve_source_request(
                                         source,
                                         TransientInstance::new(request),
-                                        self.console_ui
+                                        self.issue_reporter
                                     )
                                 }
                             };


### PR DESCRIPTION
This restores issue reporters, addressing a bug that prevented turbo-trace from completing. This moves `ConsoleUiVc::new` into an async block to prevent it from stalling.

Test Plan: Verify `cargo run --bin node-file-trace -- print path/to/my/app` no longer stalls.
