### PR TITLE
fix: allow HMR to recover from hydration errors

### DIFF
--- a/crates/next-core/js/src/overlay/internal/ReactDevOverlay.tsx
+++ b/crates/next-core/js/src/overlay/internal/ReactDevOverlay.tsx
@@ -3,7 +3,6 @@ import * as React from "react";
 import type { Issue } from "@vercel/turbopack-runtime/types/protocol";
 
 import * as Bus from "./bus";
-import { TYPE_REACT_ERROR } from "./bus";
 import { ShadowPortal } from "./components/ShadowPortal";
 import { Errors, SupportedErrorEvent } from "./container/Errors";
 import { ErrorBoundary } from "./ErrorBoundary";
@@ -168,7 +167,7 @@ export default function ReactDevOverlay({
   const onComponentError = React.useCallback(
     (error: Error, componentStack: string | null) => {
       Bus.emit({
-        type: TYPE_REACT_ERROR,
+        type: Bus.TYPE_REACT_ERROR,
         error,
         componentStack,
       });

--- a/crates/next-core/js/src/overlay/internal/bus.ts
+++ b/crates/next-core/js/src/overlay/internal/bus.ts
@@ -8,6 +8,7 @@ export const TYPE_BEFORE_REFRESH = "before-fast-refresh";
 export const TYPE_REFRESH = "fast-refresh";
 export const TYPE_UNHANDLED_ERROR = "unhandled-error";
 export const TYPE_UNHANDLED_REJECTION = "unhandled-rejection";
+export const TYPE_REACT_ERROR = "react-error";
 
 export type BuildOk = { type: typeof TYPE_BUILD_OK };
 export type TurbopackIssues = {
@@ -26,13 +27,20 @@ export type UnhandledRejection = {
   reason: Error;
   frames: StackFrame[];
 };
+export type ReactError = {
+  type: typeof TYPE_REACT_ERROR;
+  error: Error;
+  componentStack: string | null;
+};
+
 export type BusEvent =
   | BuildOk
   | TurbopackIssues
   | BeforeFastRefresh
   | FastRefresh
   | UnhandledError
-  | UnhandledRejection;
+  | UnhandledRejection
+  | ReactError;
 
 export type BusEventHandler = (ev: BusEvent) => void;
 


### PR DESCRIPTION
We now store react errors in the error overlay (hydration errors) and if the error overlay receives the "build ok" message after that it will hard reload the page to recover