### PR TITLE
Change error log line to debug, it's not an error

### DIFF
--- a/cli/internal/fs/fs_windows_test.go
+++ b/cli/internal/fs/fs_windows_test.go
@@ -13,6 +13,6 @@ func TestDifferentVolumes(t *testing.T) {
 		t.Errorf("DirContainsPath got error %v, want <nil>", err)
 	}
 	if contains {
-		t.Errof("DirContainsPath got true, want false")
+		t.Errorf("DirContainsPath got true, want false")
 	}
 }

--- a/cli/internal/fs/fs_windows_test.go
+++ b/cli/internal/fs/fs_windows_test.go
@@ -1,0 +1,18 @@
+//go:build windows
+// +build windows
+
+package fs
+
+import "testing"
+
+func TestDifferentVolumes(t *testing.T) {
+	p1 := "C:\\some\\path"
+	p2 := "D:\\other\\path"
+	contains, err := DirContainsPath(p1, p2)
+	if err != nil {
+		t.Errorf("DirContainsPath got error %v, want <nil>", err)
+	}
+	if contains {
+		t.Errof("DirContainsPath got true, want false")
+	}
+}

--- a/cli/internal/globwatcher/globwatcher.go
+++ b/cli/internal/globwatcher/globwatcher.go
@@ -135,7 +135,7 @@ func (g *GlobWatcher) OnFileWatchEvent(ev filewatcher.Event) {
 	absolutePath := ev.Path
 	repoRelativePath, err := g.repoRoot.RelativePathString(absolutePath.ToStringDuringMigration())
 	if err != nil {
-		g.logger.Error(fmt.Sprintf("could not get relative path from %v to %v: %v", g.repoRoot, absolutePath, err))
+		g.logger.Debug(fmt.Sprintf("could not get relative path from %v to %v: %v", g.repoRoot, absolutePath, err))
 		return
 	}
 	g.mu.Lock()


### PR DESCRIPTION
This can happen when a cookie file is written on Windows and the volume letters are different. It's not an error, it just means that the event is not relevant to the glob watcher.

Also update DirContainsPath to handle windows paths with different volumes. Similarly, it is not an error, we can detect that one path doesn't contain the other.