### PR TITLE
Use non-high intensity yellow for warnings for readability on white background

### DIFF
--- a/cli/internal/ui/ui.go
+++ b/cli/internal/ui/ui.go
@@ -115,7 +115,7 @@ func BuildColoredUi(colorMode ColorMode) *cli.ColoredUi {
 		},
 		OutputColor: cli.UiColorNone,
 		InfoColor:   cli.UiColorNone,
-		WarnColor:   cli.UiColorYellow,
+		WarnColor:   cli.UiColor{Code: int(color.FgYellow), Bold: false},
 		ErrorColor:  cli.UiColorRed,
 	}
 }


### PR DESCRIPTION
Closes #3799. 

| bg | before | after |
| --- | --- | --- |
| dark | <img width="312" alt="CleanShot 2023-02-14 at 16 07 13@2x" src="https://user-images.githubusercontent.com/490968/218891495-7e3abf32-1c82-486b-a534-acebf24c2d5c.png"> | <img width="313" alt="CleanShot 2023-02-14 at 16 07 09@2x" src="https://user-images.githubusercontent.com/490968/218891498-7605c95d-5dbf-4250-8069-4e6d02f84f61.png"> |
| light | <img width="311" alt="CleanShot 2023-02-14 at 16 06 59@2x" src="https://user-images.githubusercontent.com/490968/218891503-06066dcd-603e-4146-a397-e28ee13d355e.png"> | <img width="311" alt="CleanShot 2023-02-14 at 16 06 56@2x" src="https://user-images.githubusercontent.com/490968/218891507-b65ecc8e-ddbb-451f-9714-b1705a73eb34.png"> |

the new color is a bit more dull, but it is also more visible. There are a few other options we can pick from without spending too much more time on this: https://github.com/fatih/color/blob/3d5097c6b003cf3a784e670ddb79710cf46e9a07/color.go#L68-L90


