### PR TITLE
Remove TIMING=1 from eslint command in examples and create-turbo starter

### DIFF
--- a/examples/basic/packages/ui/package.json
+++ b/examples/basic/packages/ui/package.json
@@ -5,7 +5,7 @@
   "types": "./index.tsx",
   "license": "MIT",
   "scripts": {
-    "lint": "TIMING=1 eslint \"**/*.ts*\""
+    "lint": "eslint \"**/*.ts*\""
   },
   "devDependencies": {
     "@types/react": "^17.0.37",

--- a/examples/design-system/packages/acme-core/package.json
+++ b/examples/design-system/packages/acme-core/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "tsup src/index.tsx --format esm,cjs --dts --external react",
     "dev": "tsup src/index.tsx --format esm,cjs --watch --dts --external react",
-    "lint": "TIMING=1 eslint \"src/**/*.ts*\"",
+    "lint": "eslint \"src/**/*.ts*\"",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist"
   },
   "devDependencies": {

--- a/examples/design-system/packages/acme-utils/package.json
+++ b/examples/design-system/packages/acme-utils/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "tsup src/index.tsx --format esm,cjs --dts --external react",
     "dev": "tsup src/index.tsx --format esm,cjs --watch --dts --external react",
-    "lint": "TIMING=1 eslint \"src/**/*.ts*\"",
+    "lint": "eslint \"src/**/*.ts*\"",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist"
   },
   "devDependencies": {

--- a/examples/kitchen-sink/apps/admin/package.json
+++ b/examples/kitchen-sink/apps/admin/package.json
@@ -7,7 +7,7 @@
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",
     "deploy": "vercel deploy dist --team=turborepo --confirm",
     "dev": "vite --host 0.0.0.0 --port 3001 --clearScreen false",
-    "lint": "tsc --noEmit && TIMING=1 eslint \"src/**/*.ts*\""
+    "lint": "tsc --noEmit && eslint \"src/**/*.ts*\""
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/examples/kitchen-sink/apps/api/package.json
+++ b/examples/kitchen-sink/apps/api/package.json
@@ -6,7 +6,7 @@
     "build": "tsup src/index.ts --format cjs",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",
     "dev": "tsup src/index.ts --format cjs --watch --onSuccess \"node dist/index.js\"",
-    "lint": "tsc --noEmit && TIMING=1 eslint \"src/**/*.ts*\"",
+    "lint": "tsc --noEmit && eslint \"src/**/*.ts*\"",
     "start": "node dist/index.js",
     "test": "jest --detectOpenHandles"
   },

--- a/examples/kitchen-sink/apps/storefront/package.json
+++ b/examples/kitchen-sink/apps/storefront/package.json
@@ -6,7 +6,7 @@
     "build": "next build",
     "clean": "rm -rf .next",
     "dev": "next dev -p 3002",
-    "lint": "TIMING=1 next lint",
+    "lint": "next lint",
     "start": "next start "
   },
   "dependencies": {

--- a/examples/kitchen-sink/packages/logger/package.json
+++ b/examples/kitchen-sink/packages/logger/package.json
@@ -12,7 +12,7 @@
     "build": "tsc",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",
     "dev": "tsc -w",
-    "lint": "TIMING=1 eslint \"src/**/*.ts*\"",
+    "lint": "eslint \"src/**/*.ts*\"",
     "test": "jest"
   },
   "jest": {

--- a/examples/kitchen-sink/packages/ui/package.json
+++ b/examples/kitchen-sink/packages/ui/package.json
@@ -14,7 +14,7 @@
     "build": "tsup src/index.tsx --format esm,cjs --dts --external react",
     "clean": "rm -rf dist",
     "dev": "tsup src/index.tsx --format esm,cjs --watch --dts --external react",
-    "lint": "TIMING=1 eslint \"src/**/*.ts*\"",
+    "lint": "eslint \"src/**/*.ts*\"",
     "test": "jest"
   },
   "jest": {

--- a/examples/with-changesets/apps/docs/package.json
+++ b/examples/with-changesets/apps/docs/package.json
@@ -6,7 +6,7 @@
     "build": "next build",
     "start": "next start ",
     "dev": "next dev -p 3002",
-    "lint": "TIMING=1 next lint",
+    "lint": "next lint",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf .next"
   },
   "dependencies": {

--- a/examples/with-changesets/packages/acme-core/package.json
+++ b/examples/with-changesets/packages/acme-core/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "tsup src/index.tsx --format esm,cjs --dts --external react",
     "dev": "tsup src/index.tsx --format esm,cjs --watch --dts --external react",
-    "lint": "TIMING=1 eslint \"src/**/*.ts*\"",
+    "lint": "eslint \"src/**/*.ts*\"",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist"
   },
   "devDependencies": {

--- a/examples/with-changesets/packages/acme-utils/package.json
+++ b/examples/with-changesets/packages/acme-utils/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "tsup src/index.tsx --format esm,cjs --dts --external react",
     "dev": "tsup src/index.tsx --format esm,cjs --watch --dts --external react",
-    "lint": "TIMING=1 eslint \"src/**/*.ts*\"",
+    "lint": "eslint \"src/**/*.ts*\"",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist"
   },
   "devDependencies": {

--- a/examples/with-create-react-app/apps/docs/package.json
+++ b/examples/with-create-react-app/apps/docs/package.json
@@ -8,7 +8,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "lint": "TIMING=1 eslint \"src/**/*.ts*\"",
+    "lint": "eslint \"src/**/*.ts*\"",
     "clean": "rm -rf build"
   },
   "dependencies": {

--- a/examples/with-create-react-app/apps/web/package.json
+++ b/examples/with-create-react-app/apps/web/package.json
@@ -8,7 +8,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "lint": "TIMING=1 eslint \"src/**/*.ts*\"",
+    "lint": "eslint \"src/**/*.ts*\"",
     "clean": "rm -rf build"
   },
   "dependencies": {

--- a/examples/with-create-react-app/packages/ui/package.json
+++ b/examples/with-create-react-app/packages/ui/package.json
@@ -10,7 +10,7 @@
     "build": "tsup src/index.tsx --format cjs --dts --external react",
     "clean": "rm -rf dist",
     "dev": "tsup src/index.tsx --format cjs --watch --dts --external react",
-    "lint": "TIMING=1 eslint \"src/**/*.ts*\""
+    "lint": "eslint \"src/**/*.ts*\""
   },
   "devDependencies": {
     "@types/react": "^17.0.13",

--- a/examples/with-docker/apps/api/package.json
+++ b/examples/with-docker/apps/api/package.json
@@ -6,7 +6,7 @@
     "build": "tsc",
     "clean": "rm -rf dist",
     "dev": "nodemon --exec \"node -r esbuild-register ./src/index.ts\" -e .ts",
-    "lint": "tsc --noEmit && TIMING=1 eslint \"src/**/*.ts*\"",
+    "lint": "tsc --noEmit && eslint \"src/**/*.ts*\"",
     "start": "node -r esbuild-register ./src/index.ts",
     "test": "jest --detectOpenHandles"
   },

--- a/examples/with-docker/packages/logger/package.json
+++ b/examples/with-docker/packages/logger/package.json
@@ -12,7 +12,7 @@
     "build": "tsc",
     "clean": "rm -rf dist",
     "dev": "tsc -w",
-    "lint": "TIMING=1 eslint \"src/**/*.ts*\"",
+    "lint": "eslint \"src/**/*.ts*\"",
     "test": "jest"
   },
   "jest": {

--- a/examples/with-docker/packages/ui/package.json
+++ b/examples/with-docker/packages/ui/package.json
@@ -5,7 +5,7 @@
   "main": "./index.tsx",
   "types": "./index.tsx",
   "scripts": {
-    "lint": "TIMING=1 eslint \"**/*.ts*\""
+    "lint": "eslint \"**/*.ts*\""
   },
   "devDependencies": {
     "@types/react": "^17.0.37",

--- a/examples/with-npm/packages/ui/package.json
+++ b/examples/with-npm/packages/ui/package.json
@@ -5,7 +5,7 @@
   "types": "./index.tsx",
   "license": "MIT",
   "scripts": {
-    "lint": "TIMING=1 eslint \"**/*.ts*\""
+    "lint": "eslint \"**/*.ts*\""
   },
   "devDependencies": {
     "@types/react": "^17.0.37",

--- a/examples/with-prisma/packages/database/package.json
+++ b/examples/with-prisma/packages/database/package.json
@@ -18,7 +18,7 @@
     "dev": "tsup --watch",
     "format": "prisma format",
     "generate": "prisma generate",
-    "lint": "TIMING=1 eslint \"src/**/*.ts\"",
+    "lint": "eslint \"src/**/*.ts\"",
     "prebuild": "npm run generate",
     "predev": "npm run generate",
     "studio": "prisma studio"

--- a/examples/with-svelte/apps/docs/package.json
+++ b/examples/with-svelte/apps/docs/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview",
     "check": "svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-check --tsconfig ./tsconfig.json --watch",
-    "lint": "prettier --check --ignore-path=../../.prettierignore . && TIMING=1 eslint \"src\"",
+    "lint": "prettier --check --ignore-path=../../.prettierignore . && eslint \"src\"",
     "format": "prettier --write --ignore-path=../../.prettierignore ."
   },
   "dependencies": {

--- a/examples/with-svelte/apps/web/package.json
+++ b/examples/with-svelte/apps/web/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview",
     "check": "svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-check --tsconfig ./tsconfig.json --watch",
-    "lint": "prettier --check --ignore-path=../../.prettierignore . && TIMING=1 eslint \"src\"",
+    "lint": "prettier --check --ignore-path=../../.prettierignore . && eslint \"src\"",
     "format": "prettier --write --ignore-path=../../.prettierignore ."
   },
   "dependencies": {

--- a/examples/with-vite/apps/docs/package.json
+++ b/examples/with-vite/apps/docs/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "lint": "TIMING=1 eslint \"src/**/*.ts\""
+    "lint": "eslint \"src/**/*.ts\""
   },
   "dependencies": {
     "ui": "workspace:*"

--- a/examples/with-vite/apps/web/package.json
+++ b/examples/with-vite/apps/web/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "lint": "TIMING=1 eslint \"src/**/*.ts\""
+    "lint": "eslint \"src/**/*.ts\""
   },
   "dependencies": {
     "ui": "workspace:*"

--- a/examples/with-vite/packages/ui/package.json
+++ b/examples/with-vite/packages/ui/package.json
@@ -5,7 +5,7 @@
   "types": "./index.ts",
   "license": "MIT",
   "scripts": {
-    "lint": "TIMING=1 eslint \"**/*.ts\""
+    "lint": "eslint \"**/*.ts\""
   },
   "devDependencies": {
     "eslint": "^7.32.0",

--- a/examples/with-yarn/packages/ui/package.json
+++ b/examples/with-yarn/packages/ui/package.json
@@ -5,7 +5,7 @@
   "types": "./index.tsx",
   "license": "MIT",
   "scripts": {
-    "lint": "TIMING=1 eslint \"**/*.ts*\""
+    "lint": "eslint \"**/*.ts*\""
   },
   "devDependencies": {
     "@types/react": "^17.0.37",

--- a/packages/create-turbo/templates/_shared_ts/packages/ui/package.json
+++ b/packages/create-turbo/templates/_shared_ts/packages/ui/package.json
@@ -5,7 +5,7 @@
   "types": "./index.tsx",
   "license": "MIT",
   "scripts": {
-    "lint": "TIMING=1 eslint \"**/*.ts*\""
+    "lint": "eslint \"**/*.ts*\""
   },
   "devDependencies": {
     "@types/react": "^17.0.37",


### PR DESCRIPTION
This is not a cross-platform compatible way to set an environment variable, and it is not critical to have this as part of the examples and starter template.

Fixes https://github.com/vercel/turbo/issues/3797