### PR TITLE
Nightly releases: generate basic release body

### DIFF
--- a/.github/actions/turbopack-bump/action.yml
+++ b/.github/actions/turbopack-bump/action.yml
@@ -16,3 +16,5 @@ inputs:
 outputs:
   new_tag:
     description: "The newly generated tag's name"
+  changelog:
+    description: "A changelog of commits since the last tag"

--- a/.github/actions/turbopack-bump/src/index.ts
+++ b/.github/actions/turbopack-bump/src/index.ts
@@ -51,6 +51,12 @@ async function run() {
 
   core.setOutput("new_tag", nextTag);
   await createTag(octokit, nextTag, commitSha);
+
+  // TODO: generate real release notes
+  core.setOutput(
+    "changelog",
+    `See the commit diff at https://github.com/vercel/turbo/compare/${lastTag.name}...${nextTag}`
+  );
 }
 
 /**

--- a/.github/workflows/turbopack-nightly-release.yml
+++ b/.github/workflows/turbopack-nightly-release.yml
@@ -31,5 +31,5 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           tag: ${{ steps.tag_version.outputs.new_tag }}
-          name: Turbopack Release ${{ steps.tag_version.outputs.new_tag }}
-          omitBody: true
+          name: Turbopack Nightly Release ${{ steps.tag_version.outputs.new_tag }}
+          body: ${{ steps.tag_version.outputs.changelog }}


### PR DESCRIPTION
The nightly releases are using the last commit message for the release body, which is a bit weird. This generates a "compare at https://github.com/vercel/turbo/compare/turbopack-230214.2...turbopack-230215.1" listing the commits between the last and new tag.