### PR TITLE
Error if none of the tasks passed to CLI were found

### DIFF
--- a/cli/integration_tests/basic_monorepo/dry_run.t
+++ b/cli/integration_tests/basic_monorepo/dry_run.t
@@ -104,10 +104,6 @@ Check my-app#build output
 
 $ Non-existent tasks don't throw an error
   $ ${TURBO} run doesnotexist --dry=json
-  {
-    "packages": [
-      "my-app",
-      "util"
-    ],
-    "tasks": []
-  }
+   ERROR  run failed: error preparing engine: Could not find "doesnotexist" in project
+  Turbo error: error preparing engine: Could not find "doesnotexist" in project
+  [1]

--- a/cli/integration_tests/basic_monorepo/dry_run.t
+++ b/cli/integration_tests/basic_monorepo/dry_run.t
@@ -102,8 +102,8 @@ Check my-app#build output
     }
   }
 
-$ Non-existent tasks don't throw an error
+Tasks that don't exist throw an error
   $ ${TURBO} run doesnotexist --dry=json
-   ERROR  run failed: error preparing engine: Could not find "doesnotexist" in project
-  Turbo error: error preparing engine: Could not find "doesnotexist" in project
+   ERROR  run failed: error preparing engine: Could not find the following tasks in project: doesnotexist
+  Turbo error: error preparing engine: Could not find the following tasks in project: doesnotexist
   [1]

--- a/cli/integration_tests/basic_monorepo/run.t
+++ b/cli/integration_tests/basic_monorepo/run.t
@@ -4,13 +4,11 @@ Setup
 
 $ running non-existent tasks works
   $ ${TURBO} run doesnotexist
-  \xe2\x80\xa2 Packages in scope: my-app, util (esc)
-  \xe2\x80\xa2 Running doesnotexist in 2 packages (esc)
-  \xe2\x80\xa2 Remote caching disabled (esc)
-  
-  No tasks were executed as part of this run.
-  
-   Tasks:    0 successful, 0 total
-  Cached:    0 cached, 0 total
-    Time:\s*[\.0-9]+m?s  (re)
-  
+   ERROR  run failed: error preparing engine: Could not find "doesnotexist" in project
+  Turbo error: error preparing engine: Could not find "doesnotexist" in project
+  [1]
+
+  $ ${TURBO} run doesnotexist alsono
+   ERROR  run failed: error preparing engine: Could not find the following tasks in project: doesnotexist, alsono
+  Turbo error: error preparing engine: Could not find the following tasks in project: doesnotexist, alsono
+  [1]

--- a/cli/integration_tests/basic_monorepo/run.t
+++ b/cli/integration_tests/basic_monorepo/run.t
@@ -10,12 +10,12 @@ Setup
 
 # Multiple non-existent tasks also error
   $ ${TURBO} run doesnotexist alsono
-   ERROR  run failed: error preparing engine: Could not find the following tasks in project: doesnotexist, alsono
-  Turbo error: error preparing engine: Could not find the following tasks in project: doesnotexist, alsono
+   ERROR  run failed: error preparing engine: Could not find the following tasks in project: alsono, doesnotexist
+  Turbo error: error preparing engine: Could not find the following tasks in project: alsono, doesnotexist
   [1]
 
 # One good and one bad task does not error
   $ ${TURBO} run build doesnotexist
-   ERROR  run failed: error preparing engine: Could not find the following tasks in project: doesnotexist
-  Turbo error: error preparing engine: Could not find the following tasks in project: doesnotexist
+   ERROR  run failed: error preparing engine: Could not find "doesnotexist" in project
+  Turbo error: error preparing engine: Could not find "doesnotexist" in project
   [1]

--- a/cli/integration_tests/basic_monorepo/run.t
+++ b/cli/integration_tests/basic_monorepo/run.t
@@ -4,8 +4,8 @@ Setup
 
 # Running non-existent tasks errors
   $ ${TURBO} run doesnotexist
-   ERROR  run failed: error preparing engine: Could not find "doesnotexist" in project
-  Turbo error: error preparing engine: Could not find "doesnotexist" in project
+   ERROR  run failed: error preparing engine: Could not find the following tasks in project: doesnotexist
+  Turbo error: error preparing engine: Could not find the following tasks in project: doesnotexist
   [1]
 
 # Multiple non-existent tasks also error
@@ -16,6 +16,6 @@ Setup
 
 # One good and one bad task does not error
   $ ${TURBO} run build doesnotexist
-   ERROR  run failed: error preparing engine: Could not find "doesnotexist" in project
-  Turbo error: error preparing engine: Could not find "doesnotexist" in project
+   ERROR  run failed: error preparing engine: Could not find the following tasks in project: doesnotexist
+  Turbo error: error preparing engine: Could not find the following tasks in project: doesnotexist
   [1]

--- a/cli/integration_tests/basic_monorepo/run.t
+++ b/cli/integration_tests/basic_monorepo/run.t
@@ -2,13 +2,20 @@ Setup
   $ . ${TESTDIR}/../setup.sh
   $ . ${TESTDIR}/setup.sh $(pwd)
 
-$ running non-existent tasks works
+# Running non-existent tasks errors
   $ ${TURBO} run doesnotexist
    ERROR  run failed: error preparing engine: Could not find "doesnotexist" in project
   Turbo error: error preparing engine: Could not find "doesnotexist" in project
   [1]
 
+# Multiple non-existent tasks also error
   $ ${TURBO} run doesnotexist alsono
    ERROR  run failed: error preparing engine: Could not find the following tasks in project: doesnotexist, alsono
   Turbo error: error preparing engine: Could not find the following tasks in project: doesnotexist, alsono
+  [1]
+
+# One good and one bad task does not error
+  $ ${TURBO} run build doesnotexist
+   ERROR  run failed: error preparing engine: Could not find the following tasks in project: doesnotexist
+  Turbo error: error preparing engine: Could not find the following tasks in project: doesnotexist
   [1]

--- a/cli/internal/core/engine.go
+++ b/cli/internal/core/engine.go
@@ -188,6 +188,13 @@ func (e *Engine) Prepare(options *EngineBuildingOptions) error {
 
 	visited := make(util.Set)
 
+	if len(traversalQueue) == 0 {
+		if len(taskNames) == 1 {
+			return fmt.Errorf("Could not find \"%s\" in project", taskNames[0])
+		}
+		return fmt.Errorf("Could not find the following tasks in project: %s", strings.Join(taskNames, ", "))
+	}
+
 	// Things get appended to traversalQueue inside this loop, so we use the len() check instead of range.
 	for len(traversalQueue) > 0 {
 		// pop off the first item from the traversalQueue


### PR DESCRIPTION
Previously, a `validate` method would assert that tasks passed to the CLI exist. After switching to Lazy Loading Tasks and changing how errors bubble, I had removed this validation behavior. This PR adds it back.