### PR TITLE
docs: Restore webpack loader documentation under "Customizing Turbopack"

### DIFF
--- a/docs/pages/pack/docs/features/_meta.json
+++ b/docs/pages/pack/docs/features/_meta.json
@@ -6,5 +6,6 @@
   "dev-server": "Dev Server",
   "static-assets": "Static Assets",
   "imports": "Imports",
-  "environment-variables": "Environment Variables"
+  "environment-variables": "Environment Variables",
+  "customizing-turbopack": "Customizing Turbopack"
 }

--- a/docs/pages/pack/docs/features/customizing-turbopack.mdx
+++ b/docs/pages/pack/docs/features/customizing-turbopack.mdx
@@ -1,0 +1,111 @@
+---
+title: Customizing Turbopack
+description: Learn about how to customize Turbopack to your needs
+---
+
+import Callout from "../../../../components/Callout";
+
+# Customizing Turbopack
+
+Turbopack can be customized to transform different files and change how modules are resolved. It supports a subset of webpack's loader API and offers similar configuration aliasing module resolution.
+
+## webpack loaders for Next.js
+
+<Callout type="info">
+  Turbopack for Next.js does not require loaders nor loader configuration for built-in functionality, just as they aren't required for Next.js. Turbopack has built-in support for css and compiling modern JavaScript, so there's no need for `css-loader`, `postcss-loader`, or `babel-loader` if you're just using `@babel/preset-env`.
+</Callout>
+
+If you need loader support beyond what's built in, many webpack loaders already work with Turbopack. There are currently some limitations:
+
+- At the moment, only a core subset of the webpack loader API is implemented. This is enough for some popular loaders, and we'll expand our support for this API in the future.
+- Options passed to webpack loaders must be plain JavaScript primitives, objects, and arrays. For example, it's not possible to pass `require()`d plugin modules as option values.
+
+As of Next 13.2, configuring webpack loaders is possible for Next.js apps through an experimental option in `next.config.js`. `turbo.loaders` can be set as a mapping of file extensions to a list of package names or `{loader, options}` pairs:
+
+```js filename="next.config.js"
+module.exports = {
+  experimental: {
+    turbo: {
+      loaders: {
+        // Option format
+        '.md': [
+          {
+            loader: '@mdx-js/loader',
+            options: {
+              format: 'md',
+            },
+          },
+        ],
+        // Option-less format
+        '.mdx': '@mdx-js/loader',
+      },
+    },
+  },
+}
+```
+
+If you need to pass something like the result of importing an external package as a loader option, it's possible to wrap the webpack loader with your own, specifying options there. **This is an interim solution and should not be necessary in the future.** This loader wraps `@mdx-js/loader` and configures the `rehypePrism` rehype plugin:
+
+```js filename="my-mdx-loader.js"
+const mdxLoader = require('@mdx-js/loader');
+const rehypePrism = require('@mapbox/rehype-prism');
+
+module.exports = function (code) {
+	const prevGetOptions = this.getOptions.bind(this);
+	this.getOptions = function getOptions(...args) {
+		return {
+			...prevGetOptions(...args),
+			rehypePlugins: [rehypePrism]
+		}
+	}
+
+	mdxLoader.call(this, code);
+}
+```
+
+Then, configure Next.js to load the wrapper loader:
+
+```js filename="next.config.js"
+module.exports = {
+  experimental: {
+    turbo: {
+      loaders: {
+        '.mdx': './my-mdx-loader',
+      },
+    },
+  },
+}
+```
+
+### Supported loaders
+
+The following loaders have been tested to work with Turbopack's webpack loader implementation:
+
+- [`babel-loader`](https://www.npmjs.com/package/babel-loader)
+- [`@mdx-js/loader`](https://www.npmjs.com/package/@mdx-js/loader)
+- [`@svgr/webpack`](https://www.npmjs.com/package/@svgr/webpack)
+- [`svg-inline-loader`](https://www.npmjs.com/package/svg-inline-loader)
+- [`yaml-loader`](https://www.npmjs.com/package/yaml-loader)
+- [`string-replace-loader`](https://www.npmjs.com/package/string-replace-loader)
+- [`raw-loader`](https://www.npmjs.com/package/raw-loader)
+
+## Resolve aliases
+
+Turbopack can be configured to modify module resolution through aliases, similar to webpack's [`resolve.alias`](https://webpack.js.org/configuration/resolve/#resolvealias) configuration:
+
+```js filename="next.config.js"
+module.exports = {
+  experimental: {
+    turbo: {
+      resolveAlias: {
+        underscore: 'lodash',
+        mocha: { browser: 'mocha/browser-entry.js' },
+      },
+    },
+  },
+}
+```
+
+This aliases imports of the `underscore` package to the `lodash` package. In other words, `import underscore from 'underscore'` will load the `lodash` module instead of `underscore`.
+
+Turbopack also supports conditional aliasing through this field, similar to Node.js's [conditional exports](https://nodejs.org/docs/latest-v18.x/api/packages.html#conditional-exports). At the moment only the `browser` condition is supported. In the case above, imports of the `mocha` module will be aliased to `mocha/browser-entry.js` when Turbopack targets browser environments.

--- a/docs/pages/pack/docs/features/customizing-turbopack.mdx
+++ b/docs/pages/pack/docs/features/customizing-turbopack.mdx
@@ -17,7 +17,8 @@ Turbopack can be customized to transform different files and change how modules 
 
 If you need loader support beyond what's built in, many webpack loaders already work with Turbopack. There are currently some limitations:
 
-- At the moment, only a core subset of the webpack loader API is implemented. This is enough for some popular loaders, and we'll expand our support for this API in the future.
+- Only a core subset of the webpack loader API is implemented. This is enough for some popular loaders, and we'll expand our support for this API in the future.
+- Only loaders that return JavaScript code are supported. Loaders that transform files like stylesheets or images are not currently supported.
 - Options passed to webpack loaders must be plain JavaScript primitives, objects, and arrays. For example, it's not possible to pass `require()`d plugin modules as option values.
 
 As of Next 13.2, configuring webpack loaders is possible for Next.js apps through an experimental option in `next.config.js`. `turbo.loaders` can be set as a mapping of file extensions to a list of package names or `{loader, options}` pairs:

--- a/docs/pages/pack/docs/migrating-from-webpack.mdx
+++ b/docs/pages/pack/docs/migrating-from-webpack.mdx
@@ -3,22 +3,32 @@ title: Migrate from webpack to Turbopack
 description: Learn about how to migrate from webpack to its Rust-powered successor, Turbopack.
 ---
 
+import Callout from "../../../components/Callout";
+
 # Migrating from webpack to Turbopack
+
+<Callout type="info">
+  Turbopack now implements basic webpack loader support and configuration familiar to webpack users. Visit [Customizing Turbopack](features/customizing-turbopack) for how to configure Turbopack to use webpack loaders.
+</Callout>
 
 We're planning Turbopack as the successor to webpack. In the future, we plan to give Turbopack all the tools needed to support your webpack app.
 
-Currently, migrating to Turbopack from webpack is **not yet possible**. In the future, we're planning to offer a smooth migration path for all webpack users to join the Turbopack future.
+## webpack loaders and resolve aliases
 
-## Will it be compatible with webpack's API?
+For apps running Next.js 13.2 or later, Turbopack supports configuration familiar to webpack users, including support for webpack loaders and customizing resolution rules. Visit [Customizing Turbopack](features/customizing-turbopack) for how to configure Turbopack with these options. Note that using webpack-based Next.js plugins as-is from `next.config.js` is **not yet possible**.
+
+## FAQ
+
+### Will it be compatible with webpack's API?
 
 webpack has a huge API. It's extremely flexible and extensible, which is a big reason why it's so popular.
 
 We're planning on making Turbopack very flexible and extensible, but we're **not planning 1:1 compatibility with webpack**. This lets us make choices which improve on webpack's API, and lets us optimize for speed and efficiency.
 
-## Will we be able to use webpack plugins?
+### Will we be able to use webpack plugins?
 
 webpack plugins are a crucial part of webpack's ecosystem. They let you customize your toolchain, giving you low-level tools to maximize your productivity.
 
-Since we're not offering 1:1 API compatibility, most webpack plugins won't work out of the box with Turbopack.
+Unlike loaders, webpack plugins can be tightly integrated with webpack's internals.
 
-However, we're working on porting several of the most popular webpack plugins to Turbopack.
+Since we're not offering 1:1 API compatibility for plugins, most won't work out of the box with Turbopack. However, we're working on porting several of the most popular webpack plugins to Turbopack.


### PR DESCRIPTION
This restores documentation for webpack loaders and resolve aliases under a new page, "Customizing Turbopack". This page is now linked to under a new section in "Migrating from Webpack".

**Do not merge until Next 13.2 lands**
