### PR TITLE
Add `outputs` to all examples

### DIFF
--- a/docs/pages/repo/docs/ci/circleci.mdx
+++ b/docs/pages/repo/docs/ci/circleci.mdx
@@ -31,6 +31,7 @@ And a `turbo.json`:
   "$schema": "https://turbo.build/schema.json",
   "pipeline": {
     "build": {
+      "outputs": [".next/**", ".svelte-kit/**"],
       "dependsOn": ["^build"]
     },
     "test": {

--- a/docs/pages/repo/docs/ci/github-actions.mdx
+++ b/docs/pages/repo/docs/ci/github-actions.mdx
@@ -31,6 +31,7 @@ And a `turbo.json`:
   "$schema": "https://turbo.build/schema.json",
   "pipeline": {
     "build": {
+      "outputs": [".next/**", ".svelte-kit/**"],
       "dependsOn": ["^build"]
     },
     "test": {

--- a/docs/pages/repo/docs/ci/gitlabci.mdx
+++ b/docs/pages/repo/docs/ci/gitlabci.mdx
@@ -31,6 +31,7 @@ And a `turbo.json`:
   "$schema": "https://turbo.build/schema.json",
   "pipeline": {
     "build": {
+      "outputs": [".next/**", ".svelte-kit/**"],
       "dependsOn": ["^build"]
     },
     "test": {

--- a/docs/pages/repo/docs/ci/travisci.mdx
+++ b/docs/pages/repo/docs/ci/travisci.mdx
@@ -31,6 +31,7 @@ And a `turbo.json`:
   "$schema": "https://turbo.build/schema.json",
   "pipeline": {
     "build": {
+      "outputs": [".next/**", ".svelte-kit/**"],
       "dependsOn": ["^build"]
     },
     "test": {

--- a/docs/pages/repo/docs/core-concepts/caching.mdx
+++ b/docs/pages/repo/docs/core-concepts/caching.mdx
@@ -315,6 +315,7 @@ For example, consider a monorepo with three workspaces: a Next.js project, a Cre
 {
   "pipeline": {
     "build": {
+      "outputs": [".next/**", "dist/**"],
       "dependsOn": ["^build"]
     }
   }

--- a/docs/pages/repo/docs/core-concepts/monorepos/running-tasks.mdx
+++ b/docs/pages/repo/docs/core-concepts/monorepos/running-tasks.mdx
@@ -45,6 +45,7 @@ First, we declare our tasks inside `turbo.json`:
     "build": {
       // ^build means build must be run in dependencies
       // before it can be run in this workspace
+      "outputs": [".svelte/**"],
       "dependsOn": ["^build"]
     },
     "test": {},
@@ -83,7 +84,8 @@ The `pipeline` configuration declares which tasks depend on each other in your m
       // topological dependencies' and devDependencies'
       // `build` tasks  being completed first. The `^` symbol
       // indicates an upstream dependency.
-      "dependsOn": ["^build"]
+      "dependsOn": ["^build"],
+      "outputs": [".next/**", ".svelte-kit/**"]
     },
     "test": {
       // A workspace's `test` task depends on that workspace's
@@ -120,7 +122,10 @@ If both tasks are in the same workspace, you can specify the relationship like t
 {
   "$schema": "https://turbo.build/schema.json",
   "pipeline": {
-    "build": {},
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": [".next/**", ".svelte-kit/**"]
+    },
     "deploy": {
       // A workspace's `deploy` task depends on the `build`,
       // task of the same workspace being completed.
@@ -145,7 +150,8 @@ The `^` symbol explicitly declares that the task has a dependency on a task in a
     "build": {
       // "A workspace's `build` command depends on its dependencies'
       // and devDependencies' `build` commands being completed first"
-      "dependsOn": ["^build"]
+      "dependsOn": ["^build"],
+      "outputs": [".next/**", ".svelte-kit/**"]
     }
   }
 }
@@ -179,7 +185,8 @@ The example below describes the `deploy` script of a `frontend` application that
   "pipeline": {
     // Standard configuration
     "build": {
-      "dependsOn": ["^build"]
+      "dependsOn": ["^build"],
+      "outputs": [".next/**", ".svelte-kit/**"]
     },
     "test": {
       "dependsOn": ["^build"]
@@ -224,7 +231,8 @@ A sample pipeline that defines the root task `format` and opts the root into `te
   "$schema": "https://turbo.build/schema.json",
   "pipeline": {
     "build": {
-      "dependsOn": ["^build"]
+      "dependsOn": ["^build"],
+      "outputs": [".next/**", ".svelte-kit/**"]
     },
     "test": {
       "dependsOn": ["^build"],

--- a/docs/pages/repo/docs/reference/configuration.mdx
+++ b/docs/pages/repo/docs/reference/configuration.mdx
@@ -109,6 +109,7 @@ Items in `dependsOn` without `^` prefix, express the relationships between tasks
     "build": {
       // "A workspace's `build` command depends on its dependencies'
       // or devDependencies' `build` command being completed first"
+      "outputs": ["dist/**", ".next/**"],
       "dependsOn": ["^build"]
     },
     "test": {
@@ -230,6 +231,7 @@ Defaults to `true`. Whether or not to cache the task [`outputs`](#outputs). Sett
   "$schema": "https://turbo.build/schema.json",
   "pipeline": {
     "build": {
+      "outputs": ["dist/**", ".svelte-kit/**"],
       "dependsOn": ["^build"]
     },
     "test": {
@@ -269,7 +271,7 @@ Specifying `[]` will cause the task to be rerun when any file in the workspace c
       // A workspace's `test` task depends on that workspace's
       // own `build` task being completed first.
       "dependsOn": ["build"],
-      "outputs": [""],
+      "outputs": ["dist/**", ".next/**"],
       // A workspace's `test` task should only be rerun when
       // either a `.tsx` or `.ts` file has changed.
       "inputs": ["src/**/*.tsx", "src/**/*.ts", "test/**/*.ts"]
@@ -299,6 +301,7 @@ Set type of output logging.
   "pipeline": {
     "build": {
       "dependsOn": ["^build"],
+      "outputs": ["dist/**", ".svelte-kit/**"],
       "outputMode": "new-only"
     },
     "test": {


### PR DESCRIPTION
As of 1.7, you're required to specify your outputs.

The docs weren't caught up yet, though, leaving a lot of the old implicit cache behavior.

In the interest of always educating with "the happy path", I've added output arrays to our examples with various combinations of `.next/**`, `.svelte-kit`, and `dist/**`.