### PR TITLE
Fix routing cases

### DIFF
--- a/crates/next-core/js/src/entry/router.ts
+++ b/crates/next-core/js/src/entry/router.ts
@@ -156,17 +156,18 @@ async function handleClientResponse(
     const data = JSON.parse(buffer) as RouteResult;
 
     switch (data.type) {
+      case "none":
+        return {
+          type: "none",
+        };
       case "rewrite":
+      default:
         return {
           type: "rewrite",
           data: {
             url: data.url,
             headers: Object.entries(data.headers).flat(),
           },
-        };
-      case "none":
-        return {
-          type: "none",
         };
     }
   }

--- a/crates/turbopack-ecmascript/src/lib.rs
+++ b/crates/turbopack-ecmascript/src/lib.rs
@@ -99,6 +99,10 @@ pub struct EcmascriptModuleAsset {
     pub inner_assets: Option<InnerAssetsVc>,
 }
 
+/// An optional [EcmascriptModuleAsset]
+#[turbo_tasks::value(transparent)]
+pub struct OptionEcmascriptModuleAsset(Option<EcmascriptModuleAssetVc>);
+
 #[turbo_tasks::value_impl]
 impl EcmascriptModuleAssetVc {
     #[turbo_tasks::function]


### PR DESCRIPTION
This fixes 2 bugs that I've found:
1. If the `middleware.ts` file doesn't exist, then we get an unhelpful `unable to resolve relative "."` error during `next-edge` transition processing
   - This is fixed by not processing the `VirtualAssetVc` with the edge transition
2. If you're using an older Next version, then the router doesn't have a `type` field
   - Because the `type` field is empty, we hit neither the `rewrite` nor `none` cases and fall through to the middleware case, returning an empty response with no body.
   - This is fixed by treating `{ url: string, headers: … }` as `{ type: 'rewrite', url: string, headers: … }`