### PR TITLE
Make `chunk_content_internal` parallel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7731,6 +7731,7 @@ dependencies = [
  "futures",
  "indexmap",
  "lazy_static",
+ "parking_lot",
  "patricia_tree",
  "qstring",
  "regex",

--- a/crates/next-core/src/manifest.rs
+++ b/crates/next-core/src/manifest.rs
@@ -3,7 +3,7 @@ use indexmap::IndexMap;
 use mime::{APPLICATION_JAVASCRIPT_UTF_8, APPLICATION_JSON};
 use serde::Serialize;
 use turbo_tasks::{
-    graph::{GraphTraversal, NonDeterministic},
+    graph::{GraphTraversal, GraphTraversalResult, NonDeterministic},
     primitives::{StringVc, StringsVc},
     TryJoinIterExt,
 };
@@ -65,7 +65,8 @@ impl DevManifestContentSourceVc {
             this.page_roots.iter().copied(),
             get_content_source_children,
         )
-        .await?
+        .await
+        .completed()?
         .into_iter()
         .map(content_source_to_pathname)
         .try_join()

--- a/crates/turbo-tasks/src/graph/get_children.rs
+++ b/crates/turbo-tasks/src/graph/get_children.rs
@@ -2,12 +2,14 @@ use std::{collections::HashSet, future::Future};
 
 use anyhow::Result;
 
+use super::GraphTraversalControlFlow;
+
 /// A trait that allows a graph traversal to get the children of a node.
-pub trait GetChildren<T, A = ()> {
+pub trait GetChildren<T, A = !, Impl = ()> {
     type Children: IntoIterator<Item = T>;
     type Future: Future<Output = Result<Self::Children>>;
 
-    fn get_children(&mut self, item: &T) -> Option<Self::Future>;
+    fn get_children(&mut self, item: &T) -> GraphTraversalControlFlow<Self::Future, A>;
 }
 
 // The different `Impl*` here are necessary in order to avoid the `Conflicting
@@ -17,7 +19,7 @@ pub trait GetChildren<T, A = ()> {
 
 pub struct ImplRef;
 
-impl<T, C, F, CI> GetChildren<T, ImplRef> for C
+impl<T, C, F, CI> GetChildren<T, !, ImplRef> for C
 where
     C: FnMut(&T) -> F,
     F: Future<Output = Result<CI>>,
@@ -26,14 +28,14 @@ where
     type Children = CI;
     type Future = F;
 
-    fn get_children(&mut self, item: &T) -> Option<Self::Future> {
-        Some((self)(item))
+    fn get_children(&mut self, item: &T) -> GraphTraversalControlFlow<Self::Future> {
+        GraphTraversalControlFlow::Continue((self)(item))
     }
 }
 
 pub struct ImplRefOption;
 
-impl<T, C, F, CI> GetChildren<T, ImplRefOption> for C
+impl<T, C, F, CI> GetChildren<T, !, ImplRefOption> for C
 where
     C: FnMut(&T) -> Option<F>,
     F: Future<Output = Result<CI>>,
@@ -42,16 +44,36 @@ where
     type Children = CI;
     type Future = F;
 
-    fn get_children(&mut self, item: &T) -> Option<Self::Future> {
+    fn get_children(&mut self, item: &T) -> GraphTraversalControlFlow<Self::Future> {
+        match (self)(item) {
+            Some(future) => GraphTraversalControlFlow::Continue(future),
+            None => GraphTraversalControlFlow::Skip,
+        }
+    }
+}
+
+pub struct ImplRefControlFlow;
+
+impl<T, C, F, CI, A> GetChildren<T, A, ImplRefControlFlow> for C
+where
+    T: Clone,
+    C: FnMut(&T) -> GraphTraversalControlFlow<F, A>,
+    F: Future<Output = Result<CI>>,
+    CI: IntoIterator<Item = T>,
+{
+    type Children = CI;
+    type Future = F;
+
+    fn get_children(&mut self, item: &T) -> GraphTraversalControlFlow<Self::Future, A> {
         (self)(item)
     }
 }
 
 pub struct ImplValue;
 
-impl<T, C, F, CI> GetChildren<T, ImplValue> for C
+impl<T, C, F, CI> GetChildren<T, !, ImplValue> for C
 where
-    T: Copy,
+    T: Clone,
     C: FnMut(T) -> F,
     F: Future<Output = Result<CI>>,
     CI: IntoIterator<Item = T>,
@@ -59,16 +81,16 @@ where
     type Children = CI;
     type Future = F;
 
-    fn get_children(&mut self, item: &T) -> Option<Self::Future> {
-        Some((self)(*item))
+    fn get_children(&mut self, item: &T) -> GraphTraversalControlFlow<Self::Future> {
+        GraphTraversalControlFlow::Continue((self)(item.clone()))
     }
 }
 
 pub struct ImplValueOption;
 
-impl<T, C, F, CI> GetChildren<T, ImplValueOption> for C
+impl<T, C, F, CI> GetChildren<T, !, ImplValueOption> for C
 where
-    T: Copy,
+    T: Clone,
     C: FnMut(T) -> Option<F>,
     F: Future<Output = Result<CI>>,
     CI: IntoIterator<Item = T>,
@@ -76,8 +98,28 @@ where
     type Children = CI;
     type Future = F;
 
-    fn get_children(&mut self, item: &T) -> Option<Self::Future> {
-        (self)(*item)
+    fn get_children(&mut self, item: &T) -> GraphTraversalControlFlow<Self::Future> {
+        match (self)(item.clone()) {
+            Some(future) => GraphTraversalControlFlow::Continue(future),
+            None => GraphTraversalControlFlow::Skip,
+        }
+    }
+}
+
+pub struct ImplValueControlFlow;
+
+impl<T, C, F, CI, A> GetChildren<T, A, ImplValueControlFlow> for C
+where
+    T: Clone,
+    C: FnMut(T) -> GraphTraversalControlFlow<F, A>,
+    F: Future<Output = Result<CI>>,
+    CI: IntoIterator<Item = T>,
+{
+    type Children = CI;
+    type Future = F;
+
+    fn get_children(&mut self, item: &T) -> GraphTraversalControlFlow<Self::Future, A> {
+        (self)(item.clone())
     }
 }
 
@@ -85,37 +127,39 @@ where
 /// visited. This is necessary to avoid repeated work when traversing non-tree
 /// graphs (i.e. where a child can have more than one parent).
 #[derive(Debug)]
-pub struct SkipDuplicates<T, C, A> {
+pub struct SkipDuplicates<T, C, A, Impl> {
     get_children: C,
     visited: HashSet<T>,
-    _phantom: std::marker::PhantomData<A>,
+    _a: std::marker::PhantomData<A>,
+    _impl: std::marker::PhantomData<Impl>,
 }
 
-impl<T, C, A> SkipDuplicates<T, C, A> {
+impl<T, C, A, Impl> SkipDuplicates<T, C, A, Impl> {
     /// Create a new [`SkipDuplicates`] that wraps the given [`GetChildren`].
     pub fn new(get_children: C) -> Self {
         Self {
             get_children,
             visited: HashSet::new(),
-            _phantom: std::marker::PhantomData,
+            _a: std::marker::PhantomData,
+            _impl: std::marker::PhantomData,
         }
     }
 }
 
-impl<T, C, A> GetChildren<T> for SkipDuplicates<T, C, A>
+impl<T, C, A, Impl> GetChildren<T, A, Impl> for SkipDuplicates<T, C, A, Impl>
 where
     T: Eq + std::hash::Hash + Clone,
-    C: GetChildren<T, A>,
+    C: GetChildren<T, A, Impl>,
 {
     type Children = C::Children;
     type Future = C::Future;
 
-    fn get_children(&mut self, item: &T) -> Option<Self::Future> {
+    fn get_children(&mut self, item: &T) -> GraphTraversalControlFlow<Self::Future, A> {
         if !self.visited.contains(item) {
             self.visited.insert(item.clone());
             self.get_children.get_children(item)
         } else {
-            None
+            GraphTraversalControlFlow::Skip
         }
     }
 }

--- a/crates/turbo-tasks/src/graph/mod.rs
+++ b/crates/turbo-tasks/src/graph/mod.rs
@@ -5,6 +5,6 @@ mod non_deterministic;
 mod reverse_topological;
 
 pub use get_children::{GetChildren, SkipDuplicates};
-pub use graph_traversal::GraphTraversal;
+pub use graph_traversal::{GraphTraversal, GraphTraversalControlFlow, GraphTraversalResult};
 pub use non_deterministic::NonDeterministic;
 pub use reverse_topological::ReverseTopological;

--- a/crates/turbo-tasks/src/join_iter_ext.rs
+++ b/crates/turbo-tasks/src/join_iter_ext.rs
@@ -5,33 +5,35 @@ use futures::{
     future::{join_all, JoinAll},
     FutureExt,
 };
+use pin_project_lite::pin_project;
 
-/// Future for the [JoinIterExt::join] method.
-pub struct Join<F>
-where
-    F: Future,
-{
-    inner: JoinAll<F>,
+pin_project! {
+    /// Future for the [JoinIterExt::join] method.
+    pub struct Join<F>
+    where
+        F: Future,
+    {
+        #[pin]
+        inner: JoinAll<F>,
+    }
 }
 
 impl<T, F> Future for Join<F>
 where
-    T: Unpin,
     F: Future<Output = T>,
 {
     type Output = Vec<T>;
 
     fn poll(
-        mut self: std::pin::Pin<&mut Self>,
+        self: std::pin::Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Self::Output> {
-        self.inner.poll_unpin(cx)
+        self.project().inner.poll(cx)
     }
 }
 
 pub trait JoinIterExt<T, F>: Iterator
 where
-    T: Unpin,
     F: Future<Output = T>,
 {
     /// Returns a future that resolves to a vector of the outputs of the futures
@@ -39,26 +41,28 @@ where
     fn join(self) -> Join<F>;
 }
 
-/// Future for the [TryJoinIterExt::try_join] method.
-pub struct TryJoin<F>
-where
-    F: Future,
-{
-    inner: JoinAll<F>,
+pin_project! {
+    /// Future for the [TryJoinIterExt::try_join] method.
+    pub struct TryJoin<F>
+    where
+        F: Future,
+    {
+        #[pin]
+        inner: JoinAll<F>,
+    }
 }
 
 impl<T, F> Future for TryJoin<F>
 where
-    T: Unpin,
     F: Future<Output = Result<T>>,
 {
     type Output = Result<Vec<T>>;
 
     fn poll(
-        mut self: std::pin::Pin<&mut Self>,
+        self: std::pin::Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Self::Output> {
-        match self.inner.poll_unpin(cx) {
+        match self.project().inner.poll_unpin(cx) {
             std::task::Poll::Ready(res) => {
                 std::task::Poll::Ready(res.into_iter().collect::<Result<Vec<_>>>())
             }
@@ -69,7 +73,6 @@ where
 
 pub trait TryJoinIterExt<T, F>: Iterator
 where
-    T: Unpin,
     F: Future<Output = Result<T>>,
 {
     /// Returns a future that resolves to a vector of the outputs of the futures
@@ -82,7 +85,6 @@ where
 
 impl<T, F, IF, It> JoinIterExt<T, F> for It
 where
-    T: Unpin,
     F: Future<Output = T>,
     IF: IntoFuture<Output = T, IntoFuture = F>,
     It: Iterator<Item = IF>,
@@ -96,7 +98,6 @@ where
 
 impl<T, F, IF, It> TryJoinIterExt<T, F> for It
 where
-    T: Unpin,
     F: Future<Output = Result<T>>,
     IF: IntoFuture<Output = Result<T>, IntoFuture = F>,
     It: Iterator<Item = IF>,

--- a/crates/turbo-tasks/src/lib.rs
+++ b/crates/turbo-tasks/src/lib.rs
@@ -32,6 +32,7 @@
 #![feature(error_generic_member_access)]
 #![feature(provide_any)]
 #![feature(new_uninit)]
+#![feature(never_type)]
 
 pub mod backend;
 mod collectibles;

--- a/crates/turbopack-core/Cargo.toml
+++ b/crates/turbopack-core/Cargo.toml
@@ -17,6 +17,7 @@ browserslist-rs = { workspace = true }
 futures = "0.3.25"
 indexmap = { workspace = true }
 lazy_static = "1.4.0"
+parking_lot = "0.12.1"
 patricia_tree = "0.3.1"
 qstring = "0.7.2"
 regex = "1.5.4"

--- a/crates/turbopack-core/src/chunk/mod.rs
+++ b/crates/turbopack-core/src/chunk/mod.rs
@@ -3,16 +3,20 @@ pub mod dev;
 pub mod optimize;
 
 use std::{
-    collections::VecDeque,
+    collections::HashSet,
     fmt::{Debug, Display},
+    sync::Arc,
 };
 
 use anyhow::{anyhow, Result};
-use indexmap::IndexSet;
+use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use turbo_tasks::{
     debug::ValueDebugFormat,
-    graph::{GraphTraversal, ReverseTopological, SkipDuplicates},
+    graph::{
+        GraphTraversal, GraphTraversalControlFlow, GraphTraversalResult, ReverseTopological,
+        SkipDuplicates,
+    },
     primitives::{BoolVc, StringVc},
     trace::TraceRawVcs,
     TryJoinIterExt, ValueToString, ValueToStringVc,
@@ -130,7 +134,8 @@ impl ChunkGroupVc {
             [self.await?.entry],
             SkipDuplicates::new(get_chunk_children),
         )
-        .await?
+        .await
+        .completed()?
         .into_iter()
         .collect();
 
@@ -362,190 +367,301 @@ pub trait FromChunkableAsset: ChunkItem + Sized + Debug {
     ) -> Result<Option<(Self, ChunkableAssetVc)>>;
 }
 
-pub async fn chunk_content_split<I: FromChunkableAsset>(
+pub async fn chunk_content_split<I>(
     context: ChunkingContextVc,
     entry: AssetVc,
     additional_entries: Option<AssetsVc>,
-) -> Result<ChunkContentResult<I>> {
-    chunk_content_internal(context, entry, additional_entries, true)
+) -> Result<ChunkContentResult<I>>
+where
+    I: FromChunkableAsset + Eq + std::hash::Hash + Clone,
+{
+    chunk_content_internal_parallel(context, entry, additional_entries, true)
         .await
         .map(|o| o.unwrap())
 }
 
-pub async fn chunk_content<I: FromChunkableAsset>(
+pub async fn chunk_content<I>(
     context: ChunkingContextVc,
     entry: AssetVc,
     additional_entries: Option<AssetsVc>,
-) -> Result<Option<ChunkContentResult<I>>> {
-    chunk_content_internal(context, entry, additional_entries, false).await
+) -> Result<Option<ChunkContentResult<I>>>
+where
+    I: FromChunkableAsset + Eq + std::hash::Hash + Clone,
+{
+    chunk_content_internal_parallel(context, entry, additional_entries, false).await
 }
 
-enum ChunkContentWorkItem {
-    AssetReferences(AssetReferencesVc),
-    ResolveResult {
-        result: ResolveResultVc,
-        reference: AssetReferenceVc,
-        chunking_type: ChunkingType,
-    },
+#[derive(Eq, PartialEq, Clone, Hash)]
+enum ChunkContentGraphNode<I> {
+    // Chunk items that are placed into the current chunk
+    ChunkItem(I),
+    // Chunks that are loaded in parallel to the current chunk
+    Chunk(ChunkVc),
+    // Chunk groups that are referenced from the current chunk, but
+    // not loaded in parallel
+    AsyncChunkGroup(ChunkGroupVc),
+    ExternalAssetReference(AssetReferenceVc),
 }
 
-async fn chunk_content_internal<I: FromChunkableAsset>(
-    context: ChunkingContextVc,
+#[derive(Clone, Copy)]
+struct ChunkContentContext {
+    chunking_context: ChunkingContextVc,
     entry: AssetVc,
-    additional_entries: Option<AssetsVc>,
     split: bool,
-) -> Result<Option<ChunkContentResult<I>>> {
-    let mut chunk_items = Vec::new();
-    let mut processed_assets = IndexSet::new();
-    let mut chunks = Vec::new();
-    let mut async_chunk_groups = Vec::new();
-    let mut external_asset_references = Vec::new();
-    let mut queue = VecDeque::with_capacity(32);
+}
 
-    let chunk_item = I::from_asset(context, entry).await?.unwrap();
-    queue.push_back(ChunkContentWorkItem::AssetReferences(
-        chunk_item.references(),
-    ));
-    chunk_items.push(chunk_item);
-    processed_assets.insert((ChunkingType::Placed, entry));
+struct ChunkContentState {
+    processed_assets: HashSet<(ChunkingType, AssetVc)>,
+    chunk_items_count: usize,
+}
 
-    if let Some(additional_entries) = additional_entries {
-        for entry in &*additional_entries.await? {
-            let chunk_item = I::from_asset(context, *entry).await?.unwrap();
-            queue.push_back(ChunkContentWorkItem::AssetReferences(
-                chunk_item.references(),
-            ));
-            chunk_items.push(chunk_item);
-            processed_assets.insert((ChunkingType::Placed, *entry));
+async fn reference_to_graph_nodes<I>(
+    context: ChunkContentContext,
+    state: Arc<Mutex<ChunkContentState>>,
+    reference: AssetReferenceVc,
+) -> Result<Vec<ChunkContentGraphNode<I>>>
+where
+    I: FromChunkableAsset + Eq + std::hash::Hash + Clone,
+{
+    let Some(chunkable_asset_reference) = ChunkableAssetReferenceVc::resolve_from(reference).await? else {
+        return Ok(vec![ChunkContentGraphNode::ExternalAssetReference(reference)]);
+    };
+
+    let Some(chunking_type) = *chunkable_asset_reference.chunking_type(context.chunking_context).await? else {
+        return Ok(vec![ChunkContentGraphNode::ExternalAssetReference(reference)]);
+    };
+
+    let mut new_processed_assets: HashSet<(ChunkingType, AssetVc)> = HashSet::default();
+
+    let result = reference.resolve_reference().await?;
+
+    // We can't keep the assets as an iterator because that would preserve the lock
+    // on the state across await points, which would make the future !Send.
+    let assets: Vec<_> = result
+        .primary
+        .iter()
+        .filter_map({
+            let new_processed_assets = &mut new_processed_assets;
+            let state = state.lock();
+
+            move |result| {
+                if let PrimaryResolveResult::Asset(asset) = *result {
+                    if !state.processed_assets.contains(&(chunking_type, asset))
+                        && new_processed_assets.insert((chunking_type, asset))
+                    {
+                        return Some(asset);
+                    }
+                }
+                None
+            }
+        })
+        .collect();
+
+    if assets.len() == 0 {
+        return Ok(vec![]);
+    }
+
+    let mut graph_nodes = vec![];
+    let mut new_chunk_items_count = 0;
+
+    for asset in assets {
+        let chunkable_asset = match ChunkableAssetVc::resolve_from(asset).await? {
+            Some(chunkable_asset) => chunkable_asset,
+            _ => {
+                return Ok(vec![ChunkContentGraphNode::ExternalAssetReference(
+                    reference,
+                )]);
+            }
+        };
+
+        match chunking_type {
+            ChunkingType::Placed => {
+                if let Some(chunk_item) = I::from_asset(context.chunking_context, asset).await? {
+                    new_chunk_items_count += 1;
+                    graph_nodes.push(ChunkContentGraphNode::ChunkItem(chunk_item));
+                } else {
+                    return Err(anyhow!(
+                        "Asset {} was requested to be placed into the  same chunk, but this \
+                         wasn't possible",
+                        asset.path().to_string().await?
+                    ));
+                }
+            }
+            ChunkingType::Parallel => {
+                let chunk = chunkable_asset.as_chunk(context.chunking_context);
+                graph_nodes.push(ChunkContentGraphNode::Chunk(chunk));
+            }
+            ChunkingType::PlacedOrParallel => {
+                // heuristic for being in the same chunk
+                if !context.split
+                    && *context
+                        .chunking_context
+                        .can_be_in_same_chunk(context.entry, asset)
+                        .await?
+                {
+                    // chunk item, chunk or other asset?
+                    if let Some(chunk_item) = I::from_asset(context.chunking_context, asset).await?
+                    {
+                        new_chunk_items_count += 1;
+
+                        graph_nodes.push(ChunkContentGraphNode::ChunkItem(chunk_item));
+                        continue;
+                    }
+                }
+
+                let chunk = chunkable_asset.as_chunk(context.chunking_context);
+                graph_nodes.push(ChunkContentGraphNode::Chunk(chunk));
+            }
+            ChunkingType::Separate => {
+                graph_nodes.push(ChunkContentGraphNode::AsyncChunkGroup(
+                    ChunkGroupVc::from_asset(chunkable_asset, context.chunking_context),
+                ));
+            }
+            ChunkingType::SeparateAsync => {
+                if let Some((manifest_loader_item, manifest_chunk)) =
+                    I::from_async_asset(context.chunking_context, chunkable_asset).await?
+                {
+                    new_chunk_items_count += 1;
+
+                    graph_nodes.push(ChunkContentGraphNode::ChunkItem(manifest_loader_item));
+                    graph_nodes.push(ChunkContentGraphNode::AsyncChunkGroup(
+                        ChunkGroupVc::from_asset(manifest_chunk, context.chunking_context),
+                    ));
+                } else {
+                    return Ok(vec![ChunkContentGraphNode::ExternalAssetReference(
+                        reference,
+                    )]);
+                }
+            }
         }
     }
 
-    'outer: while let Some(item) = queue.pop_front() {
-        match item {
-            ChunkContentWorkItem::AssetReferences(item) => {
-                for r in item.await?.iter() {
-                    if let Some(pc) = ChunkableAssetReferenceVc::resolve_from(r).await? {
-                        if let Some(chunking_type) = *pc.chunking_type(context).await? {
-                            queue.push_back(ChunkContentWorkItem::ResolveResult {
-                                result: r.resolve_reference(),
-                                reference: *r,
-                                chunking_type,
-                            });
-                            continue;
-                        }
-                    }
-                    external_asset_references.push(*r);
-                }
+    if new_processed_assets.len() > 0 && new_chunk_items_count > 0 {
+        let mut state = state.lock();
+        state.processed_assets.extend(new_processed_assets);
+        state.chunk_items_count += new_chunk_items_count;
+    }
+
+    Ok(graph_nodes)
+}
+
+async fn chunk_item_to_graph_nodes<I>(
+    context: ChunkContentContext,
+    state: Arc<Mutex<ChunkContentState>>,
+    chunk_item: I,
+) -> Result<impl Iterator<Item = ChunkContentGraphNode<I>>>
+where
+    I: FromChunkableAsset + Eq + std::hash::Hash + Clone,
+{
+    Ok(chunk_item
+        .references()
+        .await?
+        .into_iter()
+        .map(|reference| reference_to_graph_nodes::<I>(context, Arc::clone(&state), *reference))
+        .try_join()
+        .await?
+        .into_iter()
+        .flatten())
+}
+
+/// The maximum number of chunk items that can be in a chunk before we split it
+/// into multiple chunks.
+const MAX_CHUNK_ITEMS_COUNT: usize = 5000;
+
+async fn chunk_content_internal_parallel<I>(
+    chunking_context: ChunkingContextVc,
+    entry: AssetVc,
+    additional_entries: Option<AssetsVc>,
+    split: bool,
+) -> Result<Option<ChunkContentResult<I>>>
+where
+    I: FromChunkableAsset + Eq + std::hash::Hash + Clone,
+{
+    let mut processed_assets: HashSet<(ChunkingType, AssetVc)> = HashSet::default();
+
+    // TODO(alexkirsz) We shouldn't need a clone here.
+    let additional_entries = if let Some(additional_entries) = additional_entries {
+        additional_entries.await?.clone_value().into_iter()
+    } else {
+        vec![].into_iter()
+    };
+
+    let entries = [entry].into_iter().chain(additional_entries);
+
+    // TODO(alexkirsz) We shouldn't need a clone here.
+    for entry in entries.clone() {
+        processed_assets.insert((ChunkingType::Placed, entry));
+    }
+
+    let root_graph_nodes = entries
+        .map(|entry| async move {
+            Ok(ChunkContentGraphNode::ChunkItem(
+                I::from_asset(chunking_context, entry).await?.unwrap(),
+            ))
+        })
+        .try_join()
+        .await?;
+
+    processed_assets.insert((ChunkingType::Placed, entry));
+
+    let context = ChunkContentContext {
+        chunking_context,
+        entry,
+        split,
+    };
+    let state = Arc::new(Mutex::new(ChunkContentState {
+        processed_assets,
+        chunk_items_count: 0,
+    }));
+
+    let get_children = move |node| {
+        {
+            let state = state.lock();
+            if !context.split && state.chunk_items_count >= MAX_CHUNK_ITEMS_COUNT {
+                return GraphTraversalControlFlow::Abort(());
             }
-            ChunkContentWorkItem::ResolveResult {
-                result,
-                reference,
-                chunking_type,
-            } => {
-                // It's important to temporary store these results in these variables
-                // so that we can cancel to complete list of assets by that references together
-                // and fallback to an external reference completely
-                // The cancellation is at these "continue 'outer;" lines
+        }
 
-                // Chunk items that are placed into the current chunk
-                let mut inner_chunk_items = Vec::new();
+        // TODO(alexkirsz) Right now the output type of the traversal is the same as the
+        // input type. If we can have them be separate types, we wouldn't need
+        // to call `get_children` on graph nodes that we know not to have any children
+        // (i.e. anything that's not a chunk item).
+        let ChunkContentGraphNode::ChunkItem(chunk_item) = node else {
+            return GraphTraversalControlFlow::Skip;
+        };
 
-                // Chunks that are loaded in parallel to the current chunk
-                let mut inner_chunks = Vec::new();
+        GraphTraversalControlFlow::Continue(chunk_item_to_graph_nodes::<I>(
+            context,
+            Arc::clone(&state),
+            chunk_item,
+        ))
+    };
 
-                // Chunk groups that are referenced from the current chunk, but
-                // not loaded in parallel
-                let mut inner_chunk_groups = Vec::new();
+    let GraphTraversalResult::Completed(traversal_result) =
+        GraphTraversal::<ReverseTopological<_>>::visit(root_graph_nodes, get_children).await else {
+            return Ok(None);
+        };
 
-                let result = result.await?;
-                let assets = result.primary.iter().filter_map(|result| {
-                    if let PrimaryResolveResult::Asset(asset) = *result {
-                        if processed_assets.insert((chunking_type, asset)) {
-                            return Some(asset);
-                        }
-                    }
-                    None
-                });
-                for asset in assets {
-                    let chunkable_asset = match ChunkableAssetVc::resolve_from(asset).await? {
-                        Some(chunkable_asset) => chunkable_asset,
-                        _ => {
-                            external_asset_references.push(reference);
-                            continue 'outer;
-                        }
-                    };
+    let graph_nodes: Vec<_> = traversal_result?.into_iter().collect();
 
-                    match chunking_type {
-                        ChunkingType::Placed => {
-                            if let Some(chunk_item) = I::from_asset(context, asset).await? {
-                                inner_chunk_items.push(chunk_item);
-                            } else {
-                                return Err(anyhow!(
-                                    "Asset {} was requested to be placed into the same chunk, but \
-                                     this wasn't possible",
-                                    asset.path().to_string().await?
-                                ));
-                            }
-                        }
-                        ChunkingType::Parallel => {
-                            let chunk = chunkable_asset.as_chunk(context);
-                            inner_chunks.push(chunk);
-                        }
-                        ChunkingType::PlacedOrParallel => {
-                            // heuristic for being in the same chunk
-                            if !split && *context.can_be_in_same_chunk(entry, asset).await? {
-                                // chunk item, chunk or other asset?
-                                if let Some(chunk_item) = I::from_asset(context, asset).await? {
-                                    inner_chunk_items.push(chunk_item);
-                                    continue;
-                                }
-                            }
+    let mut chunk_items = Vec::new();
+    let mut chunks = Vec::new();
+    let mut async_chunk_groups = Vec::new();
+    let mut external_asset_references = Vec::new();
 
-                            let chunk = chunkable_asset.as_chunk(context);
-                            inner_chunks.push(chunk);
-                        }
-                        ChunkingType::Separate => {
-                            inner_chunk_groups
-                                .push(ChunkGroupVc::from_asset(chunkable_asset, context));
-                        }
-                        ChunkingType::SeparateAsync => {
-                            if let Some((manifest_loader_item, manifest_chunk)) =
-                                I::from_async_asset(context, chunkable_asset).await?
-                            {
-                                inner_chunk_items.push(manifest_loader_item);
-                                inner_chunk_groups
-                                    .push(ChunkGroupVc::from_asset(manifest_chunk, context));
-                            } else {
-                                external_asset_references.push(reference);
-                                continue 'outer;
-                            }
-                        }
-                    }
-                }
-
-                let prev_chunk_items = chunk_items.len();
-
-                for chunk_item in inner_chunk_items {
-                    queue.push_back(ChunkContentWorkItem::AssetReferences(
-                        chunk_item.references(),
-                    ));
-                    chunk_items.push(chunk_item);
-                }
-                chunks.extend(inner_chunks);
-                async_chunk_groups.extend(inner_chunk_groups);
-
-                // Make sure the chunk doesn't become too large.
-                // This will hurt performance in many aspects.
-                let chunk_items_count = chunk_items.len();
-                if !split
-                    && prev_chunk_items != chunk_items_count
-                    && chunk_items_count > 5000
-                    && prev_chunk_items > 1
-                {
-                    // Chunk is too large, cancel this algorithm and
-                    // restart with splitting from the start
-                    return Ok(None);
-                }
+    for graph_node in graph_nodes {
+        match graph_node {
+            ChunkContentGraphNode::ChunkItem(chunk_item) => {
+                chunk_items.push(chunk_item);
+            }
+            ChunkContentGraphNode::Chunk(chunk) => {
+                chunks.push(chunk);
+            }
+            ChunkContentGraphNode::AsyncChunkGroup(async_chunk_group) => {
+                async_chunk_groups.push(async_chunk_group);
+            }
+            ChunkContentGraphNode::ExternalAssetReference(reference) => {
+                external_asset_references.push(reference);
             }
         }
     }


### PR DESCRIPTION
This switches the `chunk_content_internal` function from a sequential BFS to a parallel BFS (+ reverse topological sort at the end).

I expected this to make some difference in performance, as traversing references in parallel can lead to better CPU usage (see #3771), but in practice our benchmarks show no significant difference.

Real apps might be a different story, but I didn't notice any particular performance improvement on vercel.com either.

This implementation is not perfect (we're making more calls to `get_children` than strictly necessary), but I think it's enough to measure a potential performance improvement.

Marking this as a draft for now as it's more complicated than the current implementation and there's no clear win to adopting this.