### PR TITLE
Update profiling instructions for macOS

### DIFF
--- a/docs/pages/pack/docs/advanced/profiling.mdx
+++ b/docs/pages/pack/docs/advanced/profiling.mdx
@@ -11,12 +11,8 @@ import { ThemedImageFigure } from '../../../../components/image/ThemedImageFigur
 
 ### Install [`cargo-instruments`]
 
-[`cargo-instruments`] version 0.4.7 is incompatible with our workspace setup, so to install it you'll need to clone it and install it from an updated branch:
-
 ```sh
-git clone https://github.com/cmyr/cargo-instruments.git
-git checkout update-deps
-cargo install --path .
+cargo install cargo-instruments
 ```
 
 Make sure you have all the [prerequisites](https://github.com/cmyr/cargo-instruments#pre-requisites) for running cargo-instruments.


### PR DESCRIPTION
`cargo-instruments` 0.4.8 has since been released with an updated cargo dependency. 