### PR TITLE
no longer build arm64 go builds

### DIFF
--- a/.github/workflows/turborepo-release-step-3.yml
+++ b/.github/workflows/turborepo-release-step-3.yml
@@ -141,12 +141,17 @@ jobs:
           mv go-artifacts/turbo-go-cross-${{ inputs.release_branch }}/turbo_linux_arm64/bin/* cli/dist-linux-arm64
           chmod a+x cli/dist-linux-arm64/turbo
           chmod a+x cli/dist-linux-arm64/go-turbo
+
+          # rust doesn't have a toolchain for arm + windows + gnu, so we just use the exe from the amd64 build
+          # and rely on windows' arm JITer to do the work for us. this is because the go exe cannot be build w/ msvc
+          cp -r go-artifacts/turbo-go-cross-${{ inputs.release_branch }}/turbo_windows_amd64_v1/bin/* cli/dist-windows-arm64
+          chmod a+x cli/dist-windows-arm64/turbo.exe
+          chmod a+x cli/dist-windows-arm64/go-turbo.exe
+
           mv go-artifacts/turbo-go-cross-${{ inputs.release_branch }}/turbo_windows_amd64_v1/bin/* cli/dist-windows-amd64
           chmod a+x cli/dist-windows-amd64/turbo.exe
           chmod a+x cli/dist-windows-amd64/go-turbo.exe
-          mv go-artifacts/turbo-go-cross-${{ inputs.release_branch }}/turbo_windows_arm64/bin/* cli/dist-windows-arm64
-          chmod a+x cli/dist-windows-arm64/turbo.exe
-          chmod a+x cli/dist-windows-arm64/go-turbo.exe
+
           mv go-artifacts/turbo-go-darwin-${{ inputs.release_branch }}/turbo_darwin_amd64_v1/bin/* cli/dist-darwin-amd64
           chmod a+x cli/dist-darwin-amd64/turbo
           chmod a+x cli/dist-darwin-amd64/go-turbo

--- a/cli/cross-release.yml
+++ b/cli/cross-release.yml
@@ -22,7 +22,6 @@ builds:
     targets:
       - linux_arm64
       - linux_amd64
-      - windows_arm64
       - windows_amd64
     overrides:
       - goos: linux


### PR DESCRIPTION
> 🚨 note: I am assuming here that npm is intelligent enough to offer up the x86 package automatically, but there may be more we need to do here..

Rust's only toolchain on windows arm is msvc, which complicates linking now that we have the rust sandwich, as go uses gnu. Rather than attempt to get go building with msvc, we can instead just rely on windows' x86 emulation and publish one set of binaries for that platform until go is removed from our toolchain altogether.

