### PR TITLE
ci(workflow): move integration test to daily

### DIFF
--- a/.github/workflows/daily-nextjs-integration-test.yml
+++ b/.github/workflows/daily-nextjs-integration-test.yml
@@ -1,0 +1,18 @@
+# A workflow to run next.js integration test with turbopack for each day.
+# This runs against main branch with latest Next.js release.
+name: Daily Next.js integration test with turbopack
+
+on:
+  schedule:
+    - cron: "0 8 * * *"
+  workflow_dispatch:
+
+jobs:
+  # Trigger actual next.js integration tests.
+  next_js_integration:
+    name: Execute Next.js integration workflow
+    permissions:
+      pull-requests: write
+    uses: ./.github/workflows/nextjs-integration-test.yml
+    with:
+      force_post_to_slack: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1032,17 +1032,6 @@ jobs:
           file_pattern: data/**
           commit_message: Benchmark result for ${{ steps.date.outputs.pretty }} (${{ github.sha }})
 
-  next_js_integration:
-    name: Execute Next.js integration workflow
-    needs: [determine_jobs]
-    permissions:
-      pull-requests: write
-    if: needs.determine_jobs.outputs.rust == 'true' && needs.determine_jobs.outputs.push == 'true'
-    uses: ./.github/workflows/nextjs-integration-test.yml
-    # Uncomment to test against a specific version of Next.js
-    # with:
-    # version: v13.1.6-canary.0
-
   format_lint:
     name: Formatting
     runs-on: ubuntu-latest

--- a/.github/workflows/upload-nextjs-integration-test-results.yml
+++ b/.github/workflows/upload-nextjs-integration-test-results.yml
@@ -33,6 +33,7 @@ jobs:
       # Read next.js version from test results, set necessary environment variables.
       - name: Print test results
         run: |
+          rm -rf ./test-results/main/slack-payload.json
           ls -al ./test-results/main
           echo "Print failed test path list:"
           cat ./test-results/main/failed-test-path-list.json


### PR DESCRIPTION
This PR attempts to move next.js integration workflow to the daily cron job, and then post it to the slack since we don't write comment to the PR.