### PR TITLE
Use IndexSet in IntrospectableChildrenVc

### DIFF
--- a/crates/next-core/src/next_route_matcher/path_regex.rs
+++ b/crates/next-core/src/next_route_matcher/path_regex.rs
@@ -51,7 +51,7 @@ impl RouteMatcher for PathRegex {
                             NamedParamKind::Multi => Param::Multi(
                                 value
                                     .as_str()
-                                    .split("/")
+                                    .split('/')
                                     .map(|segment| segment.to_string())
                                     .collect(),
                             ),

--- a/crates/next-core/src/router_source.rs
+++ b/crates/next-core/src/router_source.rs
@@ -1,6 +1,5 @@
-use std::collections::HashSet;
-
 use anyhow::Result;
+use indexmap::IndexSet;
 use turbo_tasks::{primitives::StringVc, Value};
 use turbopack_core::{
     environment::ServerAddrVc,
@@ -148,7 +147,7 @@ impl Introspectable for NextRouterContentSource {
 
     #[turbo_tasks::function]
     async fn children(&self) -> Result<IntrospectableChildrenVc> {
-        let mut children = HashSet::new();
+        let mut children = IndexSet::new();
         if let Some(inner) = IntrospectableVc::resolve_from(self.inner).await? {
             children.insert((StringVc::cell("inner".to_string()), inner));
         }

--- a/crates/next-dev/src/lib.rs
+++ b/crates/next-dev/src/lib.rs
@@ -422,7 +422,7 @@ pub async fn start_server(options: &DevServerOptions) -> Result<()> {
     let dir = options
         .dir
         .as_ref()
-        .map(|dir| canonicalize(dir))
+        .map(canonicalize)
         .unwrap_or_else(current_dir)
         .context("project directory can't be found")?
         .to_str()

--- a/crates/turbopack-core/src/introspect/asset.rs
+++ b/crates/turbopack-core/src/introspect/asset.rs
@@ -1,6 +1,5 @@
-use std::collections::HashSet;
-
 use anyhow::Result;
+use indexmap::IndexSet;
 use turbo_tasks::{primitives::StringVc, ValueToString};
 use turbo_tasks_fs::FileContent;
 
@@ -81,7 +80,7 @@ pub async fn children_from_asset_references(
     references: AssetReferencesVc,
 ) -> Result<IntrospectableChildrenVc> {
     let key = reference_ty();
-    let mut children = HashSet::new();
+    let mut children = IndexSet::new();
     let references = references.await?;
     for reference in &*references {
         for result in reference.resolve_reference().await?.primary.iter() {

--- a/crates/turbopack-core/src/introspect/mod.rs
+++ b/crates/turbopack-core/src/introspect/mod.rs
@@ -1,11 +1,10 @@
 pub mod asset;
 
-use std::collections::HashSet;
-
+use indexmap::IndexSet;
 use turbo_tasks::primitives::StringVc;
 
 #[turbo_tasks::value(transparent)]
-pub struct IntrospectableChildren(HashSet<(StringVc, IntrospectableVc)>);
+pub struct IntrospectableChildren(IndexSet<(StringVc, IntrospectableVc)>);
 
 #[turbo_tasks::value_trait]
 pub trait Introspectable {
@@ -17,6 +16,6 @@ pub trait Introspectable {
         StringVc::empty()
     }
     fn children(&self) -> IntrospectableChildrenVc {
-        IntrospectableChildrenVc::cell(HashSet::new())
+        IntrospectableChildrenVc::cell(IndexSet::new())
     }
 }

--- a/crates/turbopack-dev-server/src/introspect/mod.rs
+++ b/crates/turbopack-dev-server/src/introspect/mod.rs
@@ -103,7 +103,7 @@ impl ContentSource for IntrospectionSource {
         let details = introspectable.details().await?;
         let children = introspectable.children().await?;
         let has_children = !children.is_empty();
-        let mut children = children
+        let children = children
             .iter()
             .map(|&(name, child)| async move {
                 let name = name.await?;
@@ -120,7 +120,6 @@ impl ContentSource for IntrospectionSource {
             })
             .try_join()
             .await?;
-        children.sort();
         let details = if details.is_empty() {
             String::new()
         } else if has_children {

--- a/crates/turbopack-dev-server/src/source/static_assets.rs
+++ b/crates/turbopack-dev-server/src/source/static_assets.rs
@@ -1,5 +1,3 @@
-use std::collections::HashSet;
-
 use anyhow::Result;
 use turbo_tasks::{primitives::StringVc, Value};
 use turbo_tasks_fs::{DirectoryContent, DirectoryEntry, FileSystemEntryType, FileSystemPathVc};
@@ -72,7 +70,7 @@ impl Introspectable for StaticAssetsContentSource {
     async fn children(&self) -> Result<IntrospectableChildrenVc> {
         let dir = self.dir.read_dir().await?;
         let children = match &*dir {
-            DirectoryContent::NotFound => HashSet::new(),
+            DirectoryContent::NotFound => Default::default(),
             DirectoryContent::Entries(entries) => entries
                 .iter()
                 .map(|(name, entry)| {

--- a/crates/turbopack-node/src/render/node_api_source.rs
+++ b/crates/turbopack-node/src/render/node_api_source.rs
@@ -1,6 +1,5 @@
-use std::collections::HashSet;
-
 use anyhow::{anyhow, Result};
+use indexmap::IndexSet;
 use turbo_tasks::{primitives::StringVc, Value};
 use turbo_tasks_fs::FileSystemPathVc;
 use turbopack_core::introspect::{
@@ -182,7 +181,7 @@ impl Introspectable for NodeApiContentSource {
 
     #[turbo_tasks::function]
     async fn children(&self) -> Result<IntrospectableChildrenVc> {
-        let mut set = HashSet::new();
+        let mut set = IndexSet::new();
         for &entry in self.entry.entries().await?.iter() {
             let entry = entry.await?;
             set.insert((

--- a/crates/turbopack-node/src/render/rendered_source.rs
+++ b/crates/turbopack-node/src/render/rendered_source.rs
@@ -1,5 +1,3 @@
-use std::collections::HashSet;
-
 use anyhow::{anyhow, Result};
 use indexmap::IndexSet;
 use turbo_tasks::{primitives::StringVc, Value};
@@ -259,7 +257,7 @@ impl Introspectable for NodeRenderContentSource {
 
     #[turbo_tasks::function]
     async fn children(&self) -> Result<IntrospectableChildrenVc> {
-        let mut set = HashSet::new();
+        let mut set = IndexSet::new();
         for &entry in self.entry.entries().await?.iter() {
             let entry = entry.await?;
             set.insert((


### PR DESCRIPTION
Another small cleanup stemming from the the `basePath` PR. Makes the introspection ordering consistent, which is a nice usability win.