### PR TITLE
Add turboVersion key to turbo.json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4463,6 +4463,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_jsonc"
+version = "1.0.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b605afc6c4fc0589e7f740b4f06c46f63b1be86b16e55b3661a5ce2b79e9d0f1"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_path_to_error"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6859,7 +6870,7 @@ dependencies = [
  "rustc_version_runtime",
  "semver 1.0.16",
  "serde",
- "serde_json",
+ "serde_jsonc",
  "serde_yaml",
  "tempfile",
  "tiny-gradient",

--- a/crates/turborepo-lib/Cargo.toml
+++ b/crates/turborepo-lib/Cargo.toml
@@ -42,7 +42,7 @@ reqwest = { workspace = true, default_features = false, features = ["json"] }
 rustc_version_runtime = "0.2.1"
 semver = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
-serde_json = { workspace = true }
+serde_json = { version = "1.0.94", package = "serde_jsonc" }
 serde_yaml = { workspace = true }
 tiny-gradient = { workspace = true }
 tokio = { workspace = true, features = ["full"] }

--- a/crates/turborepo-lib/src/files/README.md
+++ b/crates/turborepo-lib/src/files/README.md
@@ -1,0 +1,19 @@
+# Special File Types
+
+There are a few files that we'll need to read regularly, so we combine their interfaces here.
+
+## Default Values
+
+Each of these structs implements per-field defaults without `Option<>` as long as we do not need to distinguish between "set" and "unset". For example, these two `package.json` files are materially different per business logic, and as such are implemented as `Option<Workspaces>` instead of just defaulting to an empty `Workspaces::TopLevel(vec![])`.
+
+```json
+{
+  "workspaces": []
+}
+```
+
+```json
+{}
+```
+
+Note that "enabling serialized output to be only of user-supplied values" _is_ a need to distinguish between "set" and "unset".

--- a/crates/turborepo-lib/src/files/mod.rs
+++ b/crates/turborepo-lib/src/files/mod.rs
@@ -1,0 +1,4 @@
+pub(crate) mod package_json;
+pub(crate) mod pnpm_workspace;
+pub(crate) mod turbo_json;
+pub(crate) mod yarn_rc;

--- a/crates/turborepo-lib/src/files/package_json.rs
+++ b/crates/turborepo-lib/src/files/package_json.rs
@@ -1,0 +1,68 @@
+use std::{fs, path::PathBuf};
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PackageJson {
+    pub version: Option<String>,
+    pub workspaces: Option<Workspaces>,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[serde(untagged)]
+pub enum Workspaces {
+    TopLevel(Vec<String>),
+
+    // This only works in old npm.
+    Nested { packages: Vec<String> },
+}
+
+impl AsRef<[String]> for Workspaces {
+    fn as_ref(&self) -> &[String] {
+        match self {
+            Workspaces::TopLevel(packages) => packages.as_slice(),
+            Workspaces::Nested { packages } => packages.as_slice(),
+        }
+    }
+}
+
+impl From<Workspaces> for Vec<String> {
+    fn from(value: Workspaces) -> Self {
+        match value {
+            Workspaces::TopLevel(packages) => packages,
+            Workspaces::Nested { packages } => packages,
+        }
+    }
+}
+
+impl Default for PackageJson {
+    fn default() -> Self {
+        Self {
+            version: None,
+            workspaces: Some(Workspaces::TopLevel(vec![])),
+        }
+    }
+}
+
+pub fn read(path: PathBuf) -> Result<PackageJson> {
+    let package_json_string = fs::read_to_string(path)?;
+    let package_json = serde_json::from_str(&package_json_string)?;
+
+    Ok(package_json)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_nested_workspace_globs() -> Result<()> {
+        let top_level: PackageJson = serde_json::from_str("{ \"workspaces\": [\"packages/**\"]}")?;
+        assert_eq!(top_level.workspaces.unwrap().as_ref(), vec!["packages/**"]);
+        let nested: PackageJson =
+            serde_json::from_str("{ \"workspaces\": {\"packages\": [\"packages/**\"]}}")?;
+        assert_eq!(nested.workspaces.unwrap().as_ref(), vec!["packages/**"]);
+        Ok(())
+    }
+}

--- a/crates/turborepo-lib/src/files/package_json.rs
+++ b/crates/turborepo-lib/src/files/package_json.rs
@@ -45,7 +45,7 @@ impl Default for PackageJson {
     }
 }
 
-pub fn read(path: PathBuf) -> Result<PackageJson> {
+pub fn read(path: &PathBuf) -> Result<PackageJson> {
     let package_json_string = fs::read_to_string(path)?;
     let package_json = serde_json::from_str(&package_json_string)?;
 

--- a/crates/turborepo-lib/src/files/pnpm_workspace.rs
+++ b/crates/turborepo-lib/src/files/pnpm_workspace.rs
@@ -1,0 +1,16 @@
+use std::{fs, path::PathBuf};
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct PnpmWorkspace {
+    pub packages: Option<Vec<String>>,
+}
+
+pub fn read(path: PathBuf) -> Result<PnpmWorkspace> {
+    let pnpm_workspace_string = fs::read_to_string(path)?;
+    let pnpm_workspace = serde_yaml::from_str(&pnpm_workspace_string)?;
+
+    Ok(pnpm_workspace)
+}

--- a/crates/turborepo-lib/src/files/pnpm_workspace.rs
+++ b/crates/turborepo-lib/src/files/pnpm_workspace.rs
@@ -8,7 +8,7 @@ pub struct PnpmWorkspace {
     pub packages: Option<Vec<String>>,
 }
 
-pub fn read(path: PathBuf) -> Result<PnpmWorkspace> {
+pub fn read(path: &PathBuf) -> Result<PnpmWorkspace> {
     let pnpm_workspace_string = fs::read_to_string(path)?;
     let pnpm_workspace = serde_yaml::from_str(&pnpm_workspace_string)?;
 

--- a/crates/turborepo-lib/src/files/turbo_json.rs
+++ b/crates/turborepo-lib/src/files/turbo_json.rs
@@ -1,0 +1,37 @@
+use std::{fs, path::PathBuf};
+
+use anyhow::Result;
+use semver::{Version, VersionReq};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(default, rename_all = "camelCase")]
+pub struct TurboJson {
+    pub turbo_version: String,
+}
+
+impl TurboJson {
+    #[allow(dead_code)]
+    pub fn check_version(&self, version: &str) -> Result<bool> {
+        let version = Version::parse(version)?;
+
+        let version_request = VersionReq::parse(&self.turbo_version)?;
+        Ok(version_request.matches(&version))
+    }
+}
+
+impl Default for TurboJson {
+    fn default() -> Self {
+        Self {
+            turbo_version: "*".to_string(),
+        }
+    }
+}
+
+#[allow(dead_code)]
+pub fn read(path: PathBuf) -> Result<TurboJson> {
+    let turbo_json_string = fs::read_to_string(path)?;
+    let turbo_json = serde_json::from_str(&turbo_json_string)?;
+
+    Ok(turbo_json)
+}

--- a/crates/turborepo-lib/src/files/turbo_json.rs
+++ b/crates/turborepo-lib/src/files/turbo_json.rs
@@ -27,7 +27,7 @@ impl Default for TurboJson {
     }
 }
 
-pub fn read(path: PathBuf) -> Result<TurboJson> {
+pub fn read(path: &PathBuf) -> Result<TurboJson> {
     let turbo_json_string = fs::read_to_string(path)?;
     let turbo_json = serde_json::from_str(&turbo_json_string)?;
 

--- a/crates/turborepo-lib/src/files/turbo_json.rs
+++ b/crates/turborepo-lib/src/files/turbo_json.rs
@@ -11,7 +11,6 @@ pub struct TurboJson {
 }
 
 impl TurboJson {
-    #[allow(dead_code)]
     pub fn check_version(&self, version: &str) -> Result<bool> {
         let version = Version::parse(version)?;
 
@@ -28,7 +27,6 @@ impl Default for TurboJson {
     }
 }
 
-#[allow(dead_code)]
 pub fn read(path: PathBuf) -> Result<TurboJson> {
     let turbo_json_string = fs::read_to_string(path)?;
     let turbo_json = serde_json::from_str(&turbo_json_string)?;

--- a/crates/turborepo-lib/src/files/yarn_rc.rs
+++ b/crates/turborepo-lib/src/files/yarn_rc.rs
@@ -17,7 +17,7 @@ impl Default for YarnRc {
     }
 }
 
-pub fn read(path: PathBuf) -> Result<YarnRc> {
+pub fn read(path: &PathBuf) -> Result<YarnRc> {
     let yarn_rc_string = fs::read_to_string(path)?;
     let yarn_rc = serde_yaml::from_str(&yarn_rc_string)?;
 

--- a/crates/turborepo-lib/src/files/yarn_rc.rs
+++ b/crates/turborepo-lib/src/files/yarn_rc.rs
@@ -1,0 +1,25 @@
+use std::{fs, path::PathBuf};
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+pub struct YarnRc {
+    pub pnp_unplugged_folder: PathBuf,
+}
+
+impl Default for YarnRc {
+    fn default() -> Self {
+        Self {
+            pnp_unplugged_folder: [".yarn", "unplugged"].iter().collect(),
+        }
+    }
+}
+
+pub fn read(path: PathBuf) -> Result<YarnRc> {
+    let yarn_rc_string = fs::read_to_string(path)?;
+    let yarn_rc = serde_yaml::from_str(&yarn_rc_string)?;
+
+    Ok(yarn_rc)
+}

--- a/crates/turborepo-lib/src/lib.rs
+++ b/crates/turborepo-lib/src/lib.rs
@@ -2,6 +2,7 @@ mod cli;
 mod client;
 mod commands;
 mod config;
+mod files;
 mod package_manager;
 mod retry;
 mod shim;

--- a/crates/turborepo-lib/src/package_manager.rs
+++ b/crates/turborepo-lib/src/package_manager.rs
@@ -61,7 +61,7 @@ impl PackageManager {
     pub fn get_workspace_globs(&self, root_path: &Path) -> Result<Option<Globs>> {
         let globs = match self {
             PackageManager::Pnpm | PackageManager::Pnpm6 => {
-                let pnpm_workspace = pnpm_workspace::read(root_path.join("pnpm-workspace.yaml"))?;
+                let pnpm_workspace = pnpm_workspace::read(&root_path.join("pnpm-workspace.yaml"))?;
 
                 match pnpm_workspace.packages {
                     Some(packages) => packages,
@@ -69,7 +69,7 @@ impl PackageManager {
                 }
             }
             PackageManager::Berry | PackageManager::Npm | PackageManager::Yarn => {
-                let package_json = package_json::read(root_path.join("package.json"))?;
+                let package_json = package_json::read(&root_path.join("package.json"))?;
 
                 match package_json.workspaces {
                     Some(workspaces) => workspaces.into(),

--- a/packages/turbo-types/src/types/config.ts
+++ b/packages/turbo-types/src/types/config.ts
@@ -41,6 +41,15 @@ export interface WorkspaceSchema extends BaseSchema {
 
 export interface RootSchema extends BaseSchema {
   /**
+   * A SemVer version which, if using global turbo, ensures the global turbo version matches.
+   *
+   * This does not accept ranges, it must specify a precise version.
+   *
+   * @default
+   */
+  turboVersion?: string;
+
+  /**
    * A list of globs to include in the set of implicit global hash dependencies.
    *
    * The contents of these files will be included in the global hashing


### PR DESCRIPTION
This PR is stacked on top of #4182. The relevant changes: https://github.com/vercel/turbo/pull/3858/files/6323397c434ddf0f0ede7b3663b3de4ede36147c..45951366daaec56bc08b67d4cf828a4877ebe735

In order to make it possible for users to force version constraints on global `turbo`, add `turboVersion` to the root `turbo.json`.