### PR TITLE
Update getting started to depend on turbo.json for order

### DIFF
--- a/docs/pages/repo/docs/getting-started/existing-monorepo.mdx
+++ b/docs/pages/repo/docs/getting-started/existing-monorepo.mdx
@@ -140,7 +140,7 @@ The rough execution order for a given package is based on the `dependsOn` keys:
 After execution, the full pipeline can run:
 
 ```sh
-npx turbo run build test lint deploy
+npx turbo run deploy
 ```
 
 `turbo` will then schedule the execution of each task(s) to optimize usage of the machine's resources.


### PR DESCRIPTION
With the improvements to dependOn, it seems to be that this is the new best practice and not having the order defined in the `npx turbo run ...`

This would make it easier for new adopters how to structure their turborepo project