### PR TITLE
Use references to link the manifest loader item to the manifest chunk

### DIFF
--- a/crates/turbopack-core/src/chunk/mod.rs
+++ b/crates/turbopack-core/src/chunk/mod.rs
@@ -359,7 +359,7 @@ pub trait FromChunkableAsset: ChunkItem + Sized + Debug {
     async fn from_async_asset(
         context: ChunkingContextVc,
         asset: ChunkableAssetVc,
-    ) -> Result<Option<(Self, ChunkableAssetVc)>>;
+    ) -> Result<Option<Self>>;
 }
 
 pub async fn chunk_content_split<I: FromChunkableAsset>(
@@ -509,12 +509,10 @@ async fn chunk_content_internal<I: FromChunkableAsset>(
                                 .push(ChunkGroupVc::from_asset(chunkable_asset, context));
                         }
                         ChunkingType::SeparateAsync => {
-                            if let Some((manifest_loader_item, manifest_chunk)) =
+                            if let Some(chunk_item) =
                                 I::from_async_asset(context, chunkable_asset).await?
                             {
-                                inner_chunk_items.push(manifest_loader_item);
-                                inner_chunk_groups
-                                    .push(ChunkGroupVc::from_asset(manifest_chunk, context));
+                                inner_chunk_items.push(chunk_item);
                             } else {
                                 external_asset_references.push(reference);
                                 continue 'outer;

--- a/crates/turbopack-css/src/chunk/mod.rs
+++ b/crates/turbopack-css/src/chunk/mod.rs
@@ -419,7 +419,7 @@ impl FromChunkableAsset for CssChunkItemVc {
     async fn from_async_asset(
         _context: ChunkingContextVc,
         _asset: ChunkableAssetVc,
-    ) -> Result<Option<(Self, ChunkableAssetVc)>> {
+    ) -> Result<Option<Self>> {
         Ok(None)
     }
 }

--- a/crates/turbopack-ecmascript/src/chunk/mod.rs
+++ b/crates/turbopack-ecmascript/src/chunk/mod.rs
@@ -1247,12 +1247,9 @@ impl FromChunkableAsset for EcmascriptChunkItemVc {
     async fn from_async_asset(
         context: ChunkingContextVc,
         asset: ChunkableAssetVc,
-    ) -> Result<Option<(Self, ChunkableAssetVc)>> {
+    ) -> Result<Option<Self>> {
         let chunk = ManifestChunkAssetVc::new(asset, context);
-        Ok(Some((
-            ManifestLoaderItemVc::new(context, chunk).into(),
-            chunk.into(),
-        )))
+        Ok(Some(ManifestLoaderItemVc::new(context, chunk).into()))
     }
 }
 

--- a/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
+++ b/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
@@ -157,7 +157,7 @@ impl PatternMappingVc {
 
         if let Some(chunkable) = ChunkableAssetVc::resolve_from(asset).await? {
             if *resolve_type == ResolveType::EsmAsync {
-                if let Some((loader, _)) =
+                if let Some(loader) =
                     EcmascriptChunkItemVc::from_async_asset(context, chunkable).await?
                 {
                     return Ok(PatternMappingVc::cell(PatternMapping::Single(


### PR DESCRIPTION
Now that we have `ChunkableAssetReference`, we no longer need to special-case async asset references in chunk_content_internal.