### PR TITLE
Fix issue with merging dependsOn from Workspace Configs

### DIFF
--- a/cli/integration_tests/composable_config/composing-add-keys.t
+++ b/cli/integration_tests/composable_config/composing-add-keys.t
@@ -15,13 +15,13 @@ Setup
   \xe2\x80\xa2 Packages in scope: add-keys (esc)
   \xe2\x80\xa2 Running add-keys-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  add-keys:add-keys-underlying-task: cache miss, executing a33d34272db64281
+  add-keys:add-keys-underlying-task: cache miss, executing 78349dfba4d58116
   add-keys:add-keys-underlying-task: 
   add-keys:add-keys-underlying-task: > add-keys-underlying-task
   add-keys:add-keys-underlying-task: > echo "running add-keys-underlying-task"
   add-keys:add-keys-underlying-task: 
   add-keys:add-keys-underlying-task: running add-keys-underlying-task
-  add-keys:add-keys-task: cache miss, executing f4bbaa26e53aac6f
+  add-keys:add-keys-task: cache miss, executing c3b35d8aaef32d5b
   add-keys:add-keys-task: 
   add-keys:add-keys-task: > add-keys-task
   add-keys:add-keys-task: > echo "running add-keys-task" > out/foo.min.txt
@@ -43,13 +43,13 @@ Setup
   \xe2\x80\xa2 Packages in scope: add-keys (esc)
   \xe2\x80\xa2 Running add-keys-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  add-keys:add-keys-underlying-task: cache hit, replaying output a33d34272db64281
+  add-keys:add-keys-underlying-task: cache hit, replaying output 78349dfba4d58116
   add-keys:add-keys-underlying-task: 
   add-keys:add-keys-underlying-task: > add-keys-underlying-task
   add-keys:add-keys-underlying-task: > echo "running add-keys-underlying-task"
   add-keys:add-keys-underlying-task: 
   add-keys:add-keys-underlying-task: running add-keys-underlying-task
-  add-keys:add-keys-task: cache hit, suppressing output f4bbaa26e53aac6f
+  add-keys:add-keys-task: cache hit, suppressing output c3b35d8aaef32d5b
   
    Tasks:    2 successful, 2 total
   Cached:    2 cached, 2 total
@@ -61,13 +61,13 @@ Setup
   \xe2\x80\xa2 Packages in scope: add-keys (esc)
   \xe2\x80\xa2 Running add-keys-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  add-keys:add-keys-underlying-task: cache miss, executing dfc32b367b1c6a9a
+  add-keys:add-keys-underlying-task: cache miss, executing 1626b8684b31ff83
   add-keys:add-keys-underlying-task: 
   add-keys:add-keys-underlying-task: > add-keys-underlying-task
   add-keys:add-keys-underlying-task: > echo "running add-keys-underlying-task"
   add-keys:add-keys-underlying-task: 
   add-keys:add-keys-underlying-task: running add-keys-underlying-task
-  add-keys:add-keys-task: cache miss, executing e0596a25ab3888ea
+  add-keys:add-keys-task: cache miss, executing da7c8429d1c793ba
   add-keys:add-keys-task: 
   add-keys:add-keys-task: > add-keys-task
   add-keys:add-keys-task: > echo "running add-keys-task" > out/foo.min.txt
@@ -82,13 +82,13 @@ Setup
   \xe2\x80\xa2 Packages in scope: add-keys (esc)
   \xe2\x80\xa2 Running add-keys-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  add-keys:add-keys-underlying-task: cache hit, replaying output dfc32b367b1c6a9a
+  add-keys:add-keys-underlying-task: cache hit, replaying output 1626b8684b31ff83
   add-keys:add-keys-underlying-task: 
   add-keys:add-keys-underlying-task: > add-keys-underlying-task
   add-keys:add-keys-underlying-task: > echo "running add-keys-underlying-task"
   add-keys:add-keys-underlying-task: 
   add-keys:add-keys-underlying-task: running add-keys-underlying-task
-  add-keys:add-keys-task: cache miss, executing 2ff6e32f88af5a65
+  add-keys:add-keys-task: cache miss, executing 72e64a10a351980c
   add-keys:add-keys-task: 
   add-keys:add-keys-task: > add-keys-task
   add-keys:add-keys-task: > echo "running add-keys-task" > out/foo.min.txt

--- a/cli/integration_tests/composable_config/composing-add-tasks.t
+++ b/cli/integration_tests/composable_config/composing-add-tasks.t
@@ -6,7 +6,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: add-tasks (esc)
   \xe2\x80\xa2 Running added-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  add-tasks:added-task: cache miss, executing 8f82d0bc5ced2f1c
+  add-tasks:added-task: cache miss, executing 301e333fc0e306e9
   add-tasks:added-task: 
   add-tasks:added-task: > added-task
   add-tasks:added-task: > echo "running added-task" > out/foo.min.txt

--- a/cli/integration_tests/composable_config/composing-cache.t
+++ b/cli/integration_tests/composable_config/composing-cache.t
@@ -14,7 +14,7 @@ This test covers:
   \xe2\x80\xa2 Packages in scope: cached (esc)
   \xe2\x80\xa2 Running cached-task-1 in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  cached:cached-task-1: cache miss, executing e74036fd7badaaf6
+  cached:cached-task-1: cache miss, executing 26af2215a5ceec12
   cached:cached-task-1: 
   cached:cached-task-1: > cached-task-1
   cached:cached-task-1: > echo 'cached-task-1' > out/foo.min.txt
@@ -39,7 +39,7 @@ This test covers:
   \xe2\x80\xa2 Packages in scope: cached (esc)
   \xe2\x80\xa2 Running cached-task-2 in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  cached:cached-task-2: cache bypass, force executing a98a2c287f1d2763
+  cached:cached-task-2: cache bypass, force executing 90e566e56bf1dc12
   cached:cached-task-2: 
   cached:cached-task-2: > cached-task-2
   cached:cached-task-2: > echo 'cached-task-2' > out/foo.min.txt
@@ -61,7 +61,7 @@ no `cache` config in root, cache:false in workspace
   \xe2\x80\xa2 Packages in scope: cached (esc)
   \xe2\x80\xa2 Running cached-task-3 in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  cached:cached-task-3: cache bypass, force executing 8a426151da6db286
+  cached:cached-task-3: cache bypass, force executing a54ad1f951b3f194
   cached:cached-task-3: 
   cached:cached-task-3: > cached-task-3
   cached:cached-task-3: > echo 'cached-task-3' > out/foo.min.txt
@@ -85,7 +85,7 @@ we already have a workspace that doesn't have a config
   \xe2\x80\xa2 Packages in scope: missing-workspace-config (esc)
   \xe2\x80\xa2 Running cached-task-4 in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  missing-workspace-config:cached-task-4: cache bypass, force executing ecbdd1ee8d9f34a5
+  missing-workspace-config:cached-task-4: cache bypass, force executing b200610f021ed0b8
   missing-workspace-config:cached-task-4: 
   missing-workspace-config:cached-task-4: > cached-task-4
   missing-workspace-config:cached-task-4: > echo 'cached-task-4' > out/foo.min.txt

--- a/cli/integration_tests/composable_config/composing-config-change.t
+++ b/cli/integration_tests/composable_config/composing-config-change.t
@@ -4,13 +4,13 @@ Setup
 
 # 1. First run, check the hash
   $ ${TURBO} run config-change-task --filter=config-change --dry=json | jq .tasks[0].hash
-  "b17ced7629048d97"
+  "bbd88577648790db"
 
 2. Run again and assert task hash stays the same
   $ ${TURBO} run config-change-task --filter=config-change --dry=json | jq .tasks[0].hash
-  "b17ced7629048d97"
+  "bbd88577648790db"
 
 3. Change turbo.json and assert that hash changes
   $ cp $TARGET_DIR/apps/config-change/turbo-changed.json $TARGET_DIR/apps/config-change/turbo.json
   $ ${TURBO} run config-change-task --filter=config-change --dry=json | jq .tasks[0].hash
-  "6c56b35e06abb856"
+  "f0e74a964afd751f"

--- a/cli/integration_tests/composable_config/composing-cross-workspace.t
+++ b/cli/integration_tests/composable_config/composing-cross-workspace.t
@@ -5,13 +5,13 @@ Setup
   \xe2\x80\xa2 Packages in scope: cross-workspace (esc)
   \xe2\x80\xa2 Running cross-workspace-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  blank-pkg:cross-workspace-underlying-task: cache miss, executing e1997d6444832f47
+  blank-pkg:cross-workspace-underlying-task: cache miss, executing 8489d29bbcbbad66
   blank-pkg:cross-workspace-underlying-task: 
   blank-pkg:cross-workspace-underlying-task: > cross-workspace-underlying-task
   blank-pkg:cross-workspace-underlying-task: > echo "cross-workspace-underlying-task from blank-pkg"
   blank-pkg:cross-workspace-underlying-task: 
   blank-pkg:cross-workspace-underlying-task: cross-workspace-underlying-task from blank-pkg
-  cross-workspace:cross-workspace-task: cache miss, executing 6fd8bbb8fdb12e2e
+  cross-workspace:cross-workspace-task: cache miss, executing b5f0e030cae7046a
   cross-workspace:cross-workspace-task: 
   cross-workspace:cross-workspace-task: > cross-workspace-task
   cross-workspace:cross-workspace-task: > echo "cross-workspace-task"

--- a/cli/integration_tests/composable_config/composing-missing-workspace-config-deps.t
+++ b/cli/integration_tests/composable_config/composing-missing-workspace-config-deps.t
@@ -16,14 +16,14 @@ Setup
   \xe2\x80\xa2 Remote caching disabled (esc)
 
   $ cat tmp.log | grep "missing-workspace-config:missing-workspace-config-task-with-deps"
-  missing-workspace-config:missing-workspace-config-task-with-deps: cache miss, executing 35e5f5b0b58468a8
+  missing-workspace-config:missing-workspace-config-task-with-deps: cache miss, executing 663ecc932e855517
   missing-workspace-config:missing-workspace-config-task-with-deps: 
   missing-workspace-config:missing-workspace-config-task-with-deps: > missing-workspace-config-task-with-deps
   missing-workspace-config:missing-workspace-config-task-with-deps: > echo "running missing-workspace-config-task-with-deps" > out/foo.min.txt
   missing-workspace-config:missing-workspace-config-task-with-deps: 
 
   $ cat tmp.log | grep "missing-workspace-config:missing-workspace-config-underlying-task"
-  missing-workspace-config:missing-workspace-config-underlying-task: cache miss, executing 73dd0ecdcdc4a3f4
+  missing-workspace-config:missing-workspace-config-underlying-task: cache miss, executing f5b6890c769fbfc0
   missing-workspace-config:missing-workspace-config-underlying-task: 
   missing-workspace-config:missing-workspace-config-underlying-task: > missing-workspace-config-underlying-task
   missing-workspace-config:missing-workspace-config-underlying-task: > echo "running missing-workspace-config-underlying-task"
@@ -31,7 +31,7 @@ Setup
   missing-workspace-config:missing-workspace-config-underlying-task: running missing-workspace-config-underlying-task
 
   $ cat tmp.log | grep "blank-pkg:missing-workspace-config-underlying-topo-task"
-  blank-pkg:missing-workspace-config-underlying-topo-task: cache miss, executing 7a03890dc4926724
+  blank-pkg:missing-workspace-config-underlying-topo-task: cache miss, executing 9ed2e168d7105985
   blank-pkg:missing-workspace-config-underlying-topo-task: 
   blank-pkg:missing-workspace-config-underlying-topo-task: > missing-workspace-config-underlying-topo-task
   blank-pkg:missing-workspace-config-underlying-topo-task: > echo "missing-workspace-config-underlying-topo-task from blank-pkg"

--- a/cli/integration_tests/composable_config/composing-missing-workspace-config.t
+++ b/cli/integration_tests/composable_config/composing-missing-workspace-config.t
@@ -12,7 +12,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: missing-workspace-config (esc)
   \xe2\x80\xa2 Running missing-workspace-config-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  missing-workspace-config:missing-workspace-config-task: cache miss, executing b4851e92e758d2a8
+  missing-workspace-config:missing-workspace-config-task: cache miss, executing 05c61aea3d614094
   missing-workspace-config:missing-workspace-config-task: 
   missing-workspace-config:missing-workspace-config-task: > missing-workspace-config-task
   missing-workspace-config:missing-workspace-config-task: > echo "running missing-workspace-config-task" > out/foo.min.txt
@@ -34,7 +34,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: missing-workspace-config (esc)
   \xe2\x80\xa2 Running missing-workspace-config-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  missing-workspace-config:missing-workspace-config-task: cache hit, suppressing output b4851e92e758d2a8
+  missing-workspace-config:missing-workspace-config-task: cache hit, suppressing output 05c61aea3d614094
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total
@@ -46,7 +46,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: missing-workspace-config (esc)
   \xe2\x80\xa2 Running missing-workspace-config-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  missing-workspace-config:missing-workspace-config-task: cache miss, executing 1ca45c09eccb3931
+  missing-workspace-config:missing-workspace-config-task: cache miss, executing 95c3172b0e76df0c
   missing-workspace-config:missing-workspace-config-task: 
   missing-workspace-config:missing-workspace-config-task: > missing-workspace-config-task
   missing-workspace-config:missing-workspace-config-task: > echo "running missing-workspace-config-task" > out/foo.min.txt
@@ -63,7 +63,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: missing-workspace-config (esc)
   \xe2\x80\xa2 Running missing-workspace-config-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  missing-workspace-config:missing-workspace-config-task: cache hit, suppressing output 1ca45c09eccb3931
+  missing-workspace-config:missing-workspace-config-task: cache hit, suppressing output 95c3172b0e76df0c
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total
@@ -74,7 +74,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: missing-workspace-config (esc)
   \xe2\x80\xa2 Running missing-workspace-config-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  missing-workspace-config:missing-workspace-config-task: cache miss, executing 06fd150c6e5e8a1b
+  missing-workspace-config:missing-workspace-config-task: cache miss, executing dae96fa19e30c806
   missing-workspace-config:missing-workspace-config-task: 
   missing-workspace-config:missing-workspace-config-task: > missing-workspace-config-task
   missing-workspace-config:missing-workspace-config-task: > echo "running missing-workspace-config-task" > out/foo.min.txt
@@ -90,7 +90,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: missing-workspace-config (esc)
   \xe2\x80\xa2 Running cached-task-4 in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  missing-workspace-config:cached-task-4: cache bypass, force executing aaa8d1d189163b4c
+  missing-workspace-config:cached-task-4: cache bypass, force executing 90119c5212ddbefe
   missing-workspace-config:cached-task-4: 
   missing-workspace-config:cached-task-4: > cached-task-4
   missing-workspace-config:cached-task-4: > echo 'cached-task-4' > out/foo.min.txt

--- a/cli/integration_tests/composable_config/composing-omit-keys-deps.t
+++ b/cli/integration_tests/composable_config/composing-omit-keys-deps.t
@@ -16,14 +16,14 @@ Setup
   \xe2\x80\xa2 Running omit-keys-task-with-deps in 1 packages (esc)
 
   $ cat tmp.log | grep "omit-keys:omit-keys-task-with-deps"
-  omit-keys:omit-keys-task-with-deps: cache miss, executing 5a57686e181e021a
+  omit-keys:omit-keys-task-with-deps: cache miss, executing 2964125aa804147b
   omit-keys:omit-keys-task-with-deps: 
   omit-keys:omit-keys-task-with-deps: > omit-keys-task-with-deps
   omit-keys:omit-keys-task-with-deps: > echo "running omit-keys-task-with-deps" > out/foo.min.txt
   omit-keys:omit-keys-task-with-deps: 
 
   $ cat tmp.log | grep "omit-keys:omit-keys-underlying-task"
-  omit-keys:omit-keys-underlying-task: cache miss, executing a16948b5c74ccef9
+  omit-keys:omit-keys-underlying-task: cache miss, executing bd4cb773a11bcef0
   omit-keys:omit-keys-underlying-task: 
   omit-keys:omit-keys-underlying-task: > omit-keys-underlying-task
   omit-keys:omit-keys-underlying-task: > echo "running omit-keys-underlying-task"
@@ -31,7 +31,7 @@ Setup
   omit-keys:omit-keys-underlying-task: running omit-keys-underlying-task
 
   $ cat tmp.log | grep "blank-pkg:omit-keys-underlying-topo-task"
-  blank-pkg:omit-keys-underlying-topo-task: cache miss, executing ea682b492b632165
+  blank-pkg:omit-keys-underlying-topo-task: cache miss, executing 3f55273c022aa041
   blank-pkg:omit-keys-underlying-topo-task: 
   blank-pkg:omit-keys-underlying-topo-task: > omit-keys-underlying-topo-task
   blank-pkg:omit-keys-underlying-topo-task: > echo "omit-keys-underlying-topo-task from blank-pkg"

--- a/cli/integration_tests/composable_config/composing-omit-keys.t
+++ b/cli/integration_tests/composable_config/composing-omit-keys.t
@@ -15,7 +15,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: omit-keys (esc)
   \xe2\x80\xa2 Running omit-keys-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  omit-keys:omit-keys-task: cache miss, executing a2c5f2a3a6b20d6e
+  omit-keys:omit-keys-task: cache miss, executing 2fe73e4bc4e0f517
   omit-keys:omit-keys-task: 
   omit-keys:omit-keys-task: > omit-keys-task
   omit-keys:omit-keys-task: > echo "running omit-keys-task" > out/foo.min.txt
@@ -37,7 +37,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: omit-keys (esc)
   \xe2\x80\xa2 Running omit-keys-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  omit-keys:omit-keys-task: cache hit, suppressing output a2c5f2a3a6b20d6e
+  omit-keys:omit-keys-task: cache hit, suppressing output 2fe73e4bc4e0f517
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total
@@ -49,7 +49,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: omit-keys (esc)
   \xe2\x80\xa2 Running omit-keys-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  omit-keys:omit-keys-task: cache miss, executing b8b6909ecb130e0f
+  omit-keys:omit-keys-task: cache miss, executing 5039bd112be78dca
   omit-keys:omit-keys-task: 
   omit-keys:omit-keys-task: > omit-keys-task
   omit-keys:omit-keys-task: > echo "running omit-keys-task" > out/foo.min.txt
@@ -66,7 +66,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: omit-keys (esc)
   \xe2\x80\xa2 Running omit-keys-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  omit-keys:omit-keys-task: cache hit, suppressing output b8b6909ecb130e0f
+  omit-keys:omit-keys-task: cache hit, suppressing output 5039bd112be78dca
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total
@@ -77,7 +77,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: omit-keys (esc)
   \xe2\x80\xa2 Running omit-keys-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  omit-keys:omit-keys-task: cache miss, executing bb73a08ebe0a4ed6
+  omit-keys:omit-keys-task: cache miss, executing e14f331c81bc375b
   omit-keys:omit-keys-task: 
   omit-keys:omit-keys-task: > omit-keys-task
   omit-keys:omit-keys-task: > echo "running omit-keys-task" > out/foo.min.txt

--- a/cli/integration_tests/composable_config/composing-override-values-deps.t
+++ b/cli/integration_tests/composable_config/composing-override-values-deps.t
@@ -6,43 +6,37 @@ Setup
 # The workspace does not have a turbo.json config. This test checks that both regular dependencies
 # and Topological dependencies are retained from the root config.
 
-# 1. First run, assert that dependet tasks run `dependsOn`
-  $ ${TURBO} run override-values-task-with-deps --filter=override-values > tmp.log
-# Validate in pieces. `omit-key` task has two dependsOn values, and those tasks
-# can run in non-deterministic order. So we need to validate the logs in the pieces.
-  $ cat tmp.log | grep "in scope" -A 2
+# Run override-values-task-with-deps. In the root turbo.json it has two dependsOn values
+# but in the workspace, we override to dependsOn: []. This test validates that only the
+# top level task "override-values-task-with-deps" should run. None of the dependencies should run.
+  $ ${TURBO} run override-values-task-with-deps --filter=override-values
   \xe2\x80\xa2 Packages in scope: override-values (esc)
   \xe2\x80\xa2 Running override-values-task-with-deps in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-
-  $ cat tmp.log | grep "override-values:override-values-task-with-deps"
-  override-values:override-values-task-with-deps: cache miss, executing 28b15810eec6414c
+  override-values:override-values-task-with-deps: cache miss, executing 79d527063be89252
   override-values:override-values-task-with-deps: 
   override-values:override-values-task-with-deps: > override-values-task-with-deps
   override-values:override-values-task-with-deps: > echo "running override-values-task-with-deps" > out/foo.min.txt
   override-values:override-values-task-with-deps: 
-
-  $ cat tmp.log | grep "override-values:override-values-underlying-task"
-  override-values:override-values-underlying-task: cache miss, executing 783a94e433071496
-  override-values:override-values-underlying-task: 
-  override-values:override-values-underlying-task: > override-values-underlying-task
-  override-values:override-values-underlying-task: > echo "running override-values-underlying-task"
-  override-values:override-values-underlying-task: 
-  override-values:override-values-underlying-task: running override-values-underlying-task
-
-  $ cat tmp.log | grep "blank-pkg:override-values-underlying-topo-task"
-  blank-pkg:override-values-underlying-topo-task: cache miss, executing f0958e21dc79dfbc
-  blank-pkg:override-values-underlying-topo-task: 
-  blank-pkg:override-values-underlying-topo-task: > override-values-underlying-topo-task
-  blank-pkg:override-values-underlying-topo-task: > echo "override-values-underlying-topo-task from blank-pkg"
-  blank-pkg:override-values-underlying-topo-task: 
-  blank-pkg:override-values-underlying-topo-task: override-values-underlying-topo-task from blank-pkg
-
-  $ cat tmp.log | grep "Tasks:" -A 2
-   Tasks:    3 successful, 3 total
-  Cached:    0 cached, 3 total
+  
+   Tasks:    1 successful, 1 total
+  Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
 
+# This is the same test as above, but with --dry and testing the resolvedTaskDefinition has the same value for dependsOn
+  $ ${TURBO} run override-values-task-with-deps --filter=override-values --dry=json | jq '.tasks | map(select(.taskId == "override-values#override-values-task-with-deps")) | .[0].resolvedTaskDefinition'
+  {
+    "outputs": [],
+    "cache": true,
+    "dependsOn": [],
+    "inputs": [],
+    "outputMode": "full",
+    "env": [],
+    "persistent": false
+  }
+
+# This task is similar, but `dependsOn` in the root turbo.json _only_ has a topological dependency
+# This test was written to validate a common case of `build: dependsOn: [^build]`
   $ ${TURBO} run override-values-task-with-deps-2 --filter=override-values --dry=json | jq '.tasks | map(select(.taskId == "override-values#override-values-task-with-deps-2")) | .[0].resolvedTaskDefinition'
   {
     "outputs": [],

--- a/cli/integration_tests/composable_config/composing-override-values-deps.t
+++ b/cli/integration_tests/composable_config/composing-override-values-deps.t
@@ -42,3 +42,14 @@ Setup
    Tasks:    3 successful, 3 total
   Cached:    0 cached, 3 total
     Time:\s*[\.0-9]+m?s  (re)
+
+  $ ${TURBO} run override-values-task-with-deps-2 --filter=override-values --dry=json | jq '.tasks | map(select(.taskId == "override-values#override-values-task-with-deps-2")) | .[0].resolvedTaskDefinition'
+  {
+    "outputs": [],
+    "cache": true,
+    "dependsOn": [],
+    "inputs": [],
+    "outputMode": "full",
+    "env": [],
+    "persistent": false
+  }

--- a/cli/integration_tests/composable_config/composing-override-values-deps.t
+++ b/cli/integration_tests/composable_config/composing-override-values-deps.t
@@ -22,6 +22,7 @@ Setup
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
+  
 
 # This is the same test as above, but with --dry and testing the resolvedTaskDefinition has the same value for dependsOn
   $ ${TURBO} run override-values-task-with-deps --filter=override-values --dry=json | jq '.tasks | map(select(.taskId == "override-values#override-values-task-with-deps")) | .[0].resolvedTaskDefinition'

--- a/cli/integration_tests/composable_config/composing-override-values.t
+++ b/cli/integration_tests/composable_config/composing-override-values.t
@@ -12,7 +12,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: override-values (esc)
   \xe2\x80\xa2 Running override-values-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  override-values:override-values-task: cache miss, executing 51d1d668d9adffe5
+  override-values:override-values-task: cache miss, executing 64b8a8ba99f9baa7
   override-values:override-values-task: 
   override-values:override-values-task: > override-values-task
   override-values:override-values-task: > echo "running override-values-task" > lib/bar.min.txt
@@ -34,7 +34,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: override-values (esc)
   \xe2\x80\xa2 Running override-values-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  override-values:override-values-task: cache hit, replaying output 51d1d668d9adffe5
+  override-values:override-values-task: cache hit, replaying output 64b8a8ba99f9baa7
   override-values:override-values-task: 
   override-values:override-values-task: > override-values-task
   override-values:override-values-task: > echo "running override-values-task" > lib/bar.min.txt
@@ -50,7 +50,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: override-values (esc)
   \xe2\x80\xa2 Running override-values-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  override-values:override-values-task: cache miss, executing 8f07b7ef52189a94
+  override-values:override-values-task: cache miss, executing 0f08526572c2a107
   override-values:override-values-task: 
   override-values:override-values-task: > override-values-task
   override-values:override-values-task: > echo "running override-values-task" > lib/bar.min.txt
@@ -66,7 +66,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: override-values (esc)
   \xe2\x80\xa2 Running override-values-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  override-values:override-values-task: cache hit, replaying output 8f07b7ef52189a94
+  override-values:override-values-task: cache hit, replaying output 0f08526572c2a107
   override-values:override-values-task: 
   override-values:override-values-task: > override-values-task
   override-values:override-values-task: > echo "running override-values-task" > lib/bar.min.txt
@@ -81,7 +81,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: override-values (esc)
   \xe2\x80\xa2 Running override-values-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  override-values:override-values-task: cache miss, executing 7106c9435e784aaf
+  override-values:override-values-task: cache miss, executing 5d695a1fd2398949
   override-values:override-values-task: 
   override-values:override-values-task: > override-values-task
   override-values:override-values-task: > echo "running override-values-task" > lib/bar.min.txt
@@ -96,7 +96,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: override-values (esc)
   \xe2\x80\xa2 Running override-values-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  override-values:override-values-task: cache hit, replaying output 7106c9435e784aaf
+  override-values:override-values-task: cache hit, replaying output 5d695a1fd2398949
   override-values:override-values-task: 
   override-values:override-values-task: > override-values-task
   override-values:override-values-task: > echo "running override-values-task" > lib/bar.min.txt

--- a/cli/integration_tests/composable_config/composing-persistent.t
+++ b/cli/integration_tests/composable_config/composing-persistent.t
@@ -23,13 +23,13 @@ This test covers:
   \xe2\x80\xa2 Packages in scope: persistent (esc)
   \xe2\x80\xa2 Running persistent-task-2-parent in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  persistent:persistent-task-2: cache miss, executing 5b8a1c3719e1add7
+  persistent:persistent-task-2: cache miss, executing df57e68183799739
   persistent:persistent-task-2: 
   persistent:persistent-task-2: > persistent-task-2
   persistent:persistent-task-2: > echo 'persistent-task-2'
   persistent:persistent-task-2: 
   persistent:persistent-task-2: persistent-task-2
-  persistent:persistent-task-2-parent: cache miss, executing e352678c40ca2536
+  persistent:persistent-task-2-parent: cache miss, executing f45c950ae9896d1a
   persistent:persistent-task-2-parent: 
   persistent:persistent-task-2-parent: > persistent-task-2-parent
   persistent:persistent-task-2-parent: > echo 'persistent-task-2-parent'

--- a/cli/integration_tests/composable_config/monorepo/apps/override-values/package.json
+++ b/cli/integration_tests/composable_config/monorepo/apps/override-values/package.json
@@ -3,6 +3,7 @@
   "scripts": {
     "override-values-task": "echo \"running override-values-task\" > lib/bar.min.txt",
     "override-values-task-with-deps": "echo \"running override-values-task-with-deps\" > out/foo.min.txt",
+    "override-values-task-with-deps-2": "echo \"running override-values-task-with-deps-2\" > out/foo2.min.txt",
     "override-values-underlying-task": "echo \"running override-values-underlying-task\""
   },
   "dependencies": {

--- a/cli/integration_tests/composable_config/monorepo/apps/override-values/turbo.json
+++ b/cli/integration_tests/composable_config/monorepo/apps/override-values/turbo.json
@@ -10,6 +10,9 @@
     },
     "override-values-task-with-deps": {
       "dependsOn": []
+    },
+    "override-values-task-with-deps-2": {
+      "dependsOn": []
     }
   }
 }

--- a/cli/integration_tests/composable_config/monorepo/turbo.json
+++ b/cli/integration_tests/composable_config/monorepo/turbo.json
@@ -50,6 +50,9 @@
         "^override-values-underlying-topo-task"
       ]
     },
+    "override-values-task-with-deps-2": {
+      "dependsOn": ["^override-values-underlying-topo-task"]
+    },
     "override-values-underlying-task": {},
     "override-values-underlying-topo-task": {},
 

--- a/cli/internal/fs/turbo_json_test.go
+++ b/cli/internal/fs/turbo_json_test.go
@@ -37,7 +37,7 @@ func Test_ReadTurboConfig(t *testing.T) {
 
 	pipelineExpected := map[string]BookkeepingTaskDefinition{
 		"build": {
-			definedFields: util.SetFromStrings([]string{"Outputs", "OutputMode", "TopologicalDependencies"}),
+			definedFields: util.SetFromStrings([]string{"Outputs", "OutputMode", "DependsOn"}),
 			TaskDefinition: TaskDefinition{
 				Outputs:                 TaskOutputs{Inclusions: []string{".next/**", "dist/**"}, Exclusions: []string{"dist/assets/**"}},
 				TopologicalDependencies: []string{"build"},
@@ -48,7 +48,7 @@ func Test_ReadTurboConfig(t *testing.T) {
 			},
 		},
 		"lint": {
-			definedFields: util.SetFromStrings([]string{"Outputs", "OutputMode", "ShouldCache"}),
+			definedFields: util.SetFromStrings([]string{"Outputs", "OutputMode", "ShouldCache", "DependsOn"}),
 			TaskDefinition: TaskDefinition{
 				Outputs:                 TaskOutputs{},
 				TopologicalDependencies: []string{},
@@ -70,7 +70,7 @@ func Test_ReadTurboConfig(t *testing.T) {
 			},
 		},
 		"publish": {
-			definedFields: util.SetFromStrings([]string{"Inputs", "Outputs", "TaskDependencies", "TopologicalDependencies", "ShouldCache"}),
+			definedFields: util.SetFromStrings([]string{"Inputs", "Outputs", "DependsOn", "ShouldCache"}),
 			TaskDefinition: TaskDefinition{
 				Outputs:                 TaskOutputs{Inclusions: []string{"dist/**"}},
 				TopologicalDependencies: []string{"build", "publish"},
@@ -120,7 +120,7 @@ func Test_LoadTurboConfig_BothCorrectAndLegacy(t *testing.T) {
 
 	pipelineExpected := map[string]BookkeepingTaskDefinition{
 		"build": {
-			definedFields: util.SetFromStrings([]string{"Outputs", "OutputMode", "TopologicalDependencies"}),
+			definedFields: util.SetFromStrings([]string{"Outputs", "OutputMode", "DependsOn"}),
 			TaskDefinition: TaskDefinition{
 				Outputs:                 TaskOutputs{Inclusions: []string{".next/**", "dist/**"}, Exclusions: []string{"dist/assets/**"}},
 				TopologicalDependencies: []string{"build"},


### PR DESCRIPTION
Overriding `dependsOn` with _both_ a task dependency and a topo dependency seems to work, but _just_ one topo dependency doesn't work.. not sure why that would be, but test case seems to prove it also.