### PR TITLE
Parallelize cache state processing.

### DIFF
--- a/cli/integration_tests/basic_monorepo/cache_state.t
+++ b/cli/integration_tests/basic_monorepo/cache_state.t
@@ -1,0 +1,21 @@
+Setup
+  $ . ${TESTDIR}/../setup.sh
+  $ . ${TESTDIR}/setup.sh $(pwd)
+
+Run a build to get a local cache.
+  $ ${TURBO} run build --output-logs=none
+  \xe2\x80\xa2 Packages in scope: my-app, util (esc)
+  \xe2\x80\xa2 Running build in 2 packages (esc)
+  \xe2\x80\xa2 Remote caching disabled (esc)
+  
+   Tasks:    2 successful, 2 total
+  Cached:    0 cached, 2 total
+    Time:\s+[.0-9]+m?s  (re)
+  
+
+Validate cache state according to dry-run
+  $ ${TURBO} run build --dry=json | jq '.tasks | map(select(.taskId == "my-app#build")) | .[0].cacheState'
+  {
+    "local": true,
+    "remote": false
+  }

--- a/cli/internal/cache/async_cache.go
+++ b/cli/internal/cache/async_cache.go
@@ -54,7 +54,7 @@ func (c *asyncCache) Fetch(anchor turbopath.AbsoluteSystemPath, key string, file
 	return c.realCache.Fetch(anchor, key, files)
 }
 
-func (c *asyncCache) Exists(key string) (ItemStatus, error) {
+func (c *asyncCache) Exists(key string) ItemStatus {
 	return c.realCache.Exists(key)
 }
 

--- a/cli/internal/cache/cache.go
+++ b/cli/internal/cache/cache.go
@@ -22,7 +22,7 @@ type Cache interface {
 	// Fetch returns true if there is a cache it. It is expected to move files
 	// into their correct position as a side effect
 	Fetch(anchor turbopath.AbsoluteSystemPath, hash string, files []string) (bool, []turbopath.AnchoredSystemPath, int, error)
-	Exists(hash string) (ItemStatus, error)
+	Exists(hash string) ItemStatus
 	// Put caches files for a given hash
 	Put(anchor turbopath.AbsoluteSystemPath, hash string, duration int, files []turbopath.AnchoredSystemPath) error
 	Clean(anchor turbopath.AbsoluteSystemPath)
@@ -277,18 +277,15 @@ func (mplex *cacheMultiplexer) Fetch(anchor turbopath.AbsoluteSystemPath, key st
 	return false, nil, 0, nil
 }
 
-func (mplex *cacheMultiplexer) Exists(target string) (ItemStatus, error) {
+func (mplex *cacheMultiplexer) Exists(target string) ItemStatus {
 	syncCacheState := ItemStatus{}
 	for _, cache := range mplex.caches {
-		itemStatus, err := cache.Exists(target)
-		if err != nil {
-			return syncCacheState, err
-		}
+		itemStatus := cache.Exists(target)
 		syncCacheState.Local = syncCacheState.Local || itemStatus.Local
 		syncCacheState.Remote = syncCacheState.Remote || itemStatus.Remote
 	}
 
-	return syncCacheState, nil
+	return syncCacheState
 }
 
 func (mplex *cacheMultiplexer) Clean(anchor turbopath.AbsoluteSystemPath) {

--- a/cli/internal/cache/cache_fs.go
+++ b/cli/internal/cache/cache_fs.go
@@ -74,15 +74,15 @@ func (f *fsCache) Fetch(anchor turbopath.AbsoluteSystemPath, hash string, _unuse
 	return true, restoredFiles, meta.Duration, nil
 }
 
-func (f *fsCache) Exists(hash string) (ItemStatus, error) {
+func (f *fsCache) Exists(hash string) ItemStatus {
 	uncompressedCachePath := f.cacheDirectory.UntypedJoin(hash + ".tar")
 	compressedCachePath := f.cacheDirectory.UntypedJoin(hash + ".tar.zst")
 
 	if compressedCachePath.FileExists() || uncompressedCachePath.FileExists() {
-		return ItemStatus{Local: true}, nil
+		return ItemStatus{Local: true}
 	}
 
-	return ItemStatus{Local: false}, nil
+	return ItemStatus{Local: false}
 }
 
 func (f *fsCache) logFetch(hit bool, hash string, duration int) {

--- a/cli/internal/cache/cache_http.go
+++ b/cli/internal/cache/cache_http.go
@@ -155,14 +155,14 @@ func (cache *httpCache) Fetch(anchor turbopath.AbsoluteSystemPath, key string, _
 	return hit, files, duration, err
 }
 
-func (cache *httpCache) Exists(key string) (ItemStatus, error) {
+func (cache *httpCache) Exists(key string) ItemStatus {
 	cache.requestLimiter.acquire()
 	defer cache.requestLimiter.release()
 	hit, err := cache.exists(key)
 	if err != nil {
-		return ItemStatus{}, fmt.Errorf("failed to verify files from HTTP cache: %w", err)
+		return ItemStatus{Remote: false}
 	}
-	return ItemStatus{Remote: hit}, err
+	return ItemStatus{Remote: hit}
 }
 
 func (cache *httpCache) logFetch(hit bool, hash string, duration int) {

--- a/cli/internal/cache/cache_noop.go
+++ b/cli/internal/cache/cache_noop.go
@@ -14,8 +14,8 @@ func (c *noopCache) Put(anchor turbopath.AbsoluteSystemPath, key string, duratio
 func (c *noopCache) Fetch(anchor turbopath.AbsoluteSystemPath, key string, files []string) (bool, []turbopath.AnchoredSystemPath, int, error) {
 	return false, nil, 0, nil
 }
-func (c *noopCache) Exists(key string) (ItemStatus, error) {
-	return ItemStatus{}, nil
+func (c *noopCache) Exists(key string) ItemStatus {
+	return ItemStatus{}
 }
 
 func (c *noopCache) Clean(anchor turbopath.AbsoluteSystemPath) {}

--- a/cli/internal/cache/cache_test.go
+++ b/cli/internal/cache/cache_test.go
@@ -29,15 +29,15 @@ func (tc *testCache) Fetch(anchor turbopath.AbsoluteSystemPath, hash string, fil
 	return false, nil, 0, nil
 }
 
-func (tc *testCache) Exists(hash string) (ItemStatus, error) {
+func (tc *testCache) Exists(hash string) ItemStatus {
 	if tc.disabledErr != nil {
-		return ItemStatus{}, nil
+		return ItemStatus{}
 	}
 	_, ok := tc.entries[hash]
 	if ok {
-		return ItemStatus{Local: true}, nil
+		return ItemStatus{Local: true}
 	}
-	return ItemStatus{}, nil
+	return ItemStatus{}
 }
 
 func (tc *testCache) Put(anchor turbopath.AbsoluteSystemPath, hash string, duration int, files []turbopath.AnchoredSystemPath) error {
@@ -129,24 +129,18 @@ func TestExists(t *testing.T) {
 		caches: caches,
 	}
 
-	itemStatus, err := mplex.Exists("some-hash")
-	if err != nil {
-		t.Errorf("got error verifying files: %v", err)
-	}
+	itemStatus := mplex.Exists("some-hash")
 	if itemStatus.Local {
 		t.Error("did not expect file to exist")
 	}
 
-	err = mplex.Put("unused-target", "some-hash", 5, []turbopath.AnchoredSystemPath{"a-file"})
+	err := mplex.Put("unused-target", "some-hash", 5, []turbopath.AnchoredSystemPath{"a-file"})
 	if err != nil {
 		// don't leak the cache removal
 		t.Errorf("Put got error %v, want <nil>", err)
 	}
 
-	itemStatus, err = mplex.Exists("some-hash")
-	if err != nil {
-		t.Errorf("got error verifying files: %v", err)
-	}
+	itemStatus = mplex.Exists("some-hash")
 	if !itemStatus.Local {
 		t.Error("failed to find previously stored files")
 	}

--- a/cli/internal/run/dry_run.go
+++ b/cli/internal/run/dry_run.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"text/tabwriter"
 
 	"github.com/mitchellh/cli"
@@ -93,15 +94,22 @@ func DryRun(
 		tracker,
 		rs,
 		base,
-		turboCache,
 	)
 
 	if err != nil {
 		return err
 	}
 
+	// We walk the graph with no concurrency.
+	// Populating the cache state is parallelizable.
+	// Do this _after_ walking the graph.
+	withCacheState, err := checkCacheState(turboCache, taskSummaries)
+	if err != nil {
+		return err
+	}
+
 	// Assign the Task Summaries to the main summary
-	summary.Tasks = taskSummaries
+	summary.Tasks = withCacheState
 
 	// Render the dry run as json
 	if dryRunJSON {
@@ -121,7 +129,7 @@ func DryRun(
 	return nil
 }
 
-func executeDryRun(ctx gocontext.Context, engine *core.Engine, g *graph.CompleteGraph, taskHashes *taskhash.Tracker, rs *runSpec, base *cmdutil.CmdBase, turboCache cache.Cache) ([]taskSummary, error) {
+func executeDryRun(ctx gocontext.Context, engine *core.Engine, g *graph.CompleteGraph, taskHashes *taskhash.Tracker, rs *runSpec, base *cmdutil.CmdBase) ([]taskSummary, error) {
 	taskIDs := []taskSummary{}
 
 	dryRunExecFunc := func(ctx gocontext.Context, packageTask *nodes.PackageTask) error {
@@ -152,11 +160,6 @@ func executeDryRun(ctx gocontext.Context, engine *core.Engine, g *graph.Complete
 			return err
 		}
 
-		itemStatus, err := turboCache.Exists(hash)
-		if err != nil {
-			return err
-		}
-
 		taskIDs = append(taskIDs, taskSummary{
 			TaskID:                 packageTask.TaskID,
 			Task:                   packageTask.Task,
@@ -169,7 +172,6 @@ func executeDryRun(ctx gocontext.Context, engine *core.Engine, g *graph.Complete
 			Command:                command,
 
 			Hash:         hash,        // TODO(mehulkar): Move this to PackageTask
-			CacheState:   itemStatus,  // TODO(mehulkar): Move this to PackageTask
 			Dependencies: ancestors,   // TODO(mehulkar): Move this to PackageTask
 			Dependents:   descendents, // TODO(mehulkar): Move this to PackageTask
 		})
@@ -196,6 +198,42 @@ func executeDryRun(ctx gocontext.Context, engine *core.Engine, g *graph.Complete
 	}
 
 	return taskIDs, nil
+}
+
+func checkCacheState(turboCache cache.Cache, taskSummaries []taskSummary) ([]taskSummary, error) {
+	maxParallelRequests := 8
+	taskCount := len(taskSummaries)
+
+	parallelRequestCount := maxParallelRequests
+	if taskCount < maxParallelRequests {
+		parallelRequestCount = taskCount
+	}
+
+	queue := make(chan int, taskCount)
+
+	var returnErr error
+
+	wg := &sync.WaitGroup{}
+	for i := 0; i < parallelRequestCount; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for index := range queue {
+				task := taskSummaries[index]
+				itemStatus, err := turboCache.Exists(task.Hash)
+				task.CacheState = itemStatus // TODO(mehulkar): Move this to PackageTask
+				returnErr = err
+			}
+		}()
+	}
+
+	for index := range taskSummaries {
+		queue <- index
+	}
+	close(queue)
+	wg.Wait()
+
+	return taskSummaries, returnErr
 }
 
 func renderDryRunSinglePackageJSON(summary *dryRunSummary) (string, error) {

--- a/cli/internal/run/dry_run.go
+++ b/cli/internal/run/dry_run.go
@@ -103,8 +103,7 @@ func DryRun(
 	// We walk the graph with no concurrency.
 	// Populating the cache state is parallelizable.
 	// Do this _after_ walking the graph.
-	err = populateCacheState(turboCache, taskSummaries)
-	if err != nil {
+	if err := populateCacheState(turboCache, taskSummaries); err != nil {
 		return err
 	}
 
@@ -223,7 +222,9 @@ func populateCacheState(turboCache cache.Cache, taskSummaries []*taskSummary) er
 				task := taskSummaries[index]
 				itemStatus, err := turboCache.Exists(task.Hash)
 				task.CacheState = itemStatus
-				returnErr = err
+				if err != nil {
+					returnErr = err
+				}
 			}
 		}()
 	}

--- a/cli/internal/run/dry_run.go
+++ b/cli/internal/run/dry_run.go
@@ -219,7 +219,7 @@ func checkCacheState(turboCache cache.Cache, taskSummaries []taskSummary) ([]tas
 		go func() {
 			defer wg.Done()
 			for index := range queue {
-				task := taskSummaries[index]
+				task := &taskSummaries[index]
 				itemStatus, err := turboCache.Exists(task.Hash)
 				task.CacheState = itemStatus // TODO(mehulkar): Move this to PackageTask
 				returnErr = err

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -346,9 +346,14 @@ func (r *run) run(ctx gocontext.Context, targets []string) error {
 		// the tasks that we expect to run based on the user command.
 		// Currently, we only emit this on dry runs, but it may be useful for real runs later also.
 		summary := &dryRunSummary{
+<<<<<<< HEAD
 			Packages:          packagesInScope,
 			GlobalHashSummary: newGlobalHashSummary(globalHashable),
 			Tasks:             []taskSummary{},
+=======
+			Packages: packagesInScope,
+			Tasks:    []*taskSummary{},
+>>>>>>> 84c8e14c7 (Make reference behavior better.)
 		}
 
 		return DryRun(

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -346,14 +346,9 @@ func (r *run) run(ctx gocontext.Context, targets []string) error {
 		// the tasks that we expect to run based on the user command.
 		// Currently, we only emit this on dry runs, but it may be useful for real runs later also.
 		summary := &dryRunSummary{
-<<<<<<< HEAD
 			Packages:          packagesInScope,
 			GlobalHashSummary: newGlobalHashSummary(globalHashable),
-			Tasks:             []taskSummary{},
-=======
-			Packages: packagesInScope,
-			Tasks:    []*taskSummary{},
->>>>>>> 84c8e14c7 (Make reference behavior better.)
+			Tasks:             []*taskSummary{},
 		}
 
 		return DryRun(


### PR DESCRIPTION
In a dry run we walk the graph without concurrency. That's fine, except that we check the state of the cache (which can involve a network call) in the same loop.

This splits the checking of the cache state into a followup process.