### PR TITLE
fix consistency issue with reading collectibles

### DIFF
--- a/crates/turbo-tasks-memory/src/cell.rs
+++ b/crates/turbo-tasks-memory/src/cell.rs
@@ -11,6 +11,8 @@ use turbo_tasks::{
     TaskId, TurboTasksBackendApi,
 };
 
+use crate::MemoryBackend;
+
 #[derive(Default, Debug)]
 pub(crate) enum Cell {
     /// No content has been set yet, or it was removed for memory pressure
@@ -204,7 +206,11 @@ impl Cell {
         }
     }
 
-    pub fn assign(&mut self, content: CellContent, turbo_tasks: &dyn TurboTasksBackendApi) {
+    pub fn assign(
+        &mut self,
+        content: CellContent,
+        turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackend>,
+    ) {
         match self {
             Cell::Empty => {
                 *self = Cell::Value {
@@ -287,7 +293,7 @@ impl Cell {
     }
 
     /// Drops the cell after GC. Will notify all dependent tasks and events.
-    pub fn gc_drop(self, turbo_tasks: &dyn TurboTasksBackendApi) {
+    pub fn gc_drop(self, turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackend>) {
         match self {
             Cell::Empty => {}
             Cell::Recomputing {

--- a/crates/turbo-tasks-memory/src/gc.rs
+++ b/crates/turbo-tasks-memory/src/gc.rs
@@ -152,7 +152,7 @@ impl GcQueue {
         &self,
         factor: u8,
         backend: &MemoryBackend,
-        turbo_tasks: &dyn TurboTasksBackendApi,
+        turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackend>,
     ) -> Option<(GcPriority, usize, GcStats)> {
         // Process through the inactive propagation queue.
         while let Ok(task) = self.inactive_propagate_queue.pop() {

--- a/crates/turbo-tasks-memory/src/memory_backend_with_pg.rs
+++ b/crates/turbo-tasks-memory/src/memory_backend_with_pg.rs
@@ -1526,6 +1526,15 @@ impl<P: PersistedGraph> Backend for MemoryBackendWithPersistedGraph<P> {
         }
     }
 
+    fn connect_task(
+        &self,
+        _task: TaskId,
+        _parent_task: TaskId,
+        _turbo_tasks: &dyn TurboTasksBackendApi,
+    ) {
+        todo!()
+    }
+
     fn create_transient_task(
         &self,
         task_type: TransientTaskType,

--- a/crates/turbo-tasks-memory/src/memory_backend_with_pg.rs
+++ b/crates/turbo-tasks-memory/src/memory_backend_with_pg.rs
@@ -134,7 +134,7 @@ enum BackgroundJob {
     DeactivatePersisted(TaskId),
 }
 
-pub struct MemoryBackendWithPersistedGraph<P: PersistedGraph> {
+pub struct MemoryBackendWithPersistedGraph<P: PersistedGraph + 'static> {
     pub pg: P,
     tasks: NoMoveVec<Task>,
     cache: DashMap<PersistentTaskType, TaskId>,
@@ -189,7 +189,7 @@ impl<P: PersistedGraph> MemoryBackendWithPersistedGraph<P> {
     fn state_mut(
         &self,
         task: TaskId,
-        turbo_tasks: &dyn TurboTasksBackendApi,
+        turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>,
     ) -> (MutexGuard<'_, TaskState>, &Task) {
         let task_info = self.tasks.get(*task).unwrap();
         let mut state = task_info.task_state.lock().unwrap();
@@ -200,7 +200,7 @@ impl<P: PersistedGraph> MemoryBackendWithPersistedGraph<P> {
     fn mem_state_mut(
         &self,
         task: TaskId,
-        turbo_tasks: &dyn TurboTasksBackendApi,
+        turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>,
     ) -> (MutexGuard<'_, TaskState>, &Task) {
         let task_info = self.tasks.get(*task).unwrap();
         loop {
@@ -234,7 +234,7 @@ impl<P: PersistedGraph> MemoryBackendWithPersistedGraph<P> {
         task: TaskId,
         task_info: &Task,
         task_state: &mut TaskState,
-        turbo_tasks: &dyn TurboTasksBackendApi,
+        turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>,
     ) {
         if task_state.memory.is_none() && task_state.persisted.is_none() {
             if let TaskType::Persistent(_) = &task_info.task_type {
@@ -257,7 +257,7 @@ impl<P: PersistedGraph> MemoryBackendWithPersistedGraph<P> {
         task: TaskId,
         task_state: &mut TaskState,
         delayed_activate: &mut Vec<TaskId>,
-        turbo_tasks: &dyn TurboTasksBackendApi,
+        turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>,
     ) {
         if task_state.memory.is_none() {
             if let Some((data, state)) = self.pg_read(task, turbo_tasks) {
@@ -317,7 +317,7 @@ impl<P: PersistedGraph> MemoryBackendWithPersistedGraph<P> {
     fn lookup(
         &self,
         task_type: &PersistentTaskType,
-        turbo_tasks: &dyn TurboTasksBackendApi,
+        turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>,
     ) -> Option<TaskId> {
         for i in 0..task_type.len() {
             let partial = task_type.partial(i);
@@ -336,7 +336,12 @@ impl<P: PersistedGraph> MemoryBackendWithPersistedGraph<P> {
         self.pg_lookup_one(task_type, turbo_tasks)
     }
 
-    fn connect(&self, parent_task: TaskId, task: TaskId, turbo_tasks: &dyn TurboTasksBackendApi) {
+    fn connect(
+        &self,
+        parent_task: TaskId,
+        task: TaskId,
+        turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>,
+    ) {
         // connect() will never be called concurrently for the same parent_task
         // therefore it's safe to add the task into children before incrementing
         // active_parents.
@@ -361,7 +366,7 @@ impl<P: PersistedGraph> MemoryBackendWithPersistedGraph<P> {
         &self,
         parent_task: TaskId,
         task: TaskId,
-        turbo_tasks: &dyn TurboTasksBackendApi,
+        turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>,
     ) {
         // The active_parents count was already initialized with 1
         // When this was incorrect, we need to revert that.
@@ -385,7 +390,11 @@ impl<P: PersistedGraph> MemoryBackendWithPersistedGraph<P> {
         }
     }
 
-    fn schedule_background_job(&self, job: BackgroundJob, turbo_tasks: &dyn TurboTasksBackendApi) {
+    fn schedule_background_job(
+        &self,
+        job: BackgroundJob,
+        turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>,
+    ) {
         let id = self.background_job_id_factory.get();
         // SAFETY: It's a fresh id
         unsafe {
@@ -394,7 +403,11 @@ impl<P: PersistedGraph> MemoryBackendWithPersistedGraph<P> {
         turbo_tasks.schedule_backend_background_job(id);
     }
 
-    fn activate_persisted(&self, task: TaskId, turbo_tasks: &dyn TurboTasksBackendApi) {
+    fn activate_persisted(
+        &self,
+        task: TaskId,
+        turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>,
+    ) {
         if let Some(ActivateResult {
             keeps_external_active,
             external,
@@ -425,7 +438,11 @@ impl<P: PersistedGraph> MemoryBackendWithPersistedGraph<P> {
         }
     }
 
-    fn deactivate_persisted(&self, task: TaskId, turbo_tasks: &dyn TurboTasksBackendApi) {
+    fn deactivate_persisted(
+        &self,
+        task: TaskId,
+        turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>,
+    ) {
         if let Some(DeactivateResult {
             more_tasks_to_deactivate,
         }) = self.pg_deactivate_when_needed(task, turbo_tasks)
@@ -445,7 +462,7 @@ impl<P: PersistedGraph> MemoryBackendWithPersistedGraph<P> {
         &self,
         task: TaskId,
         by: u32,
-        turbo_tasks: &dyn TurboTasksBackendApi,
+        turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>,
     ) {
         let mut delayed_activate = Vec::new();
         self.try_increment_active_parents(task, true, by, &mut delayed_activate, turbo_tasks);
@@ -469,7 +486,7 @@ impl<P: PersistedGraph> MemoryBackendWithPersistedGraph<P> {
         force: bool,
         by: u32,
         delayed_activate: &mut Vec<TaskId>,
-        turbo_tasks: &dyn TurboTasksBackendApi,
+        turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>,
     ) {
         let task_info = self.tasks.get(*task).unwrap();
         let prev = task_info.active_parents.fetch_add(by, Ordering::Relaxed);
@@ -496,7 +513,7 @@ impl<P: PersistedGraph> MemoryBackendWithPersistedGraph<P> {
         task: TaskId,
         state: MutexGuard<TaskState>,
         task_info: &Task,
-        turbo_tasks: &dyn TurboTasksBackendApi,
+        turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>,
     ) {
         let mut delayed_activate = Vec::new();
         self.activate_task_inner(task, state, task_info, &mut delayed_activate, turbo_tasks);
@@ -520,7 +537,7 @@ impl<P: PersistedGraph> MemoryBackendWithPersistedGraph<P> {
         mut state: MutexGuard<TaskState>,
         task_info: &Task,
         delayed_activate: &mut Vec<TaskId>,
-        turbo_tasks: &dyn TurboTasksBackendApi,
+        turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>,
     ) {
         let TaskState {
             ref mut active,
@@ -586,7 +603,7 @@ impl<P: PersistedGraph> MemoryBackendWithPersistedGraph<P> {
         &self,
         task: TaskId,
         by: u32,
-        turbo_tasks: &dyn TurboTasksBackendApi,
+        turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>,
     ) {
         self.decrement_active_parents_limited(&[(task, by)], 0, turbo_tasks);
     }
@@ -595,7 +612,7 @@ impl<P: PersistedGraph> MemoryBackendWithPersistedGraph<P> {
         &self,
         tasks: &[(TaskId, u32)],
         remaining_depth: u8,
-        turbo_tasks: &dyn TurboTasksBackendApi,
+        turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>,
     ) {
         let mut delayed_deactivate = Vec::new();
         for (task, by) in tasks {
@@ -621,7 +638,7 @@ impl<P: PersistedGraph> MemoryBackendWithPersistedGraph<P> {
         by: u32,
         remaining_depth: u8,
         delayed_deactivate: &mut Vec<TaskId>,
-        turbo_tasks: &dyn TurboTasksBackendApi,
+        turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>,
     ) {
         let task_info = self.tasks.get(*task).unwrap();
         let prev = task_info.active_parents.fetch_sub(by, Ordering::Relaxed);
@@ -656,7 +673,7 @@ impl<P: PersistedGraph> MemoryBackendWithPersistedGraph<P> {
         task: TaskId,
         state: MutexGuard<TaskState>,
         task_info: &Task,
-        turbo_tasks: &dyn TurboTasksBackendApi,
+        turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>,
     ) {
         let mut delayed_deactivate = Vec::new();
         self.deactivate_task_inner(
@@ -675,7 +692,11 @@ impl<P: PersistedGraph> MemoryBackendWithPersistedGraph<P> {
         }
     }
 
-    fn deactivate_tasks(&self, tasks: &[TaskId], turbo_tasks: &dyn TurboTasksBackendApi) {
+    fn deactivate_tasks(
+        &self,
+        tasks: &[TaskId],
+        turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>,
+    ) {
         let mut delayed_deactivate = Vec::new();
         for task in tasks {
             let (state, task_info) = self.state_mut(*task, turbo_tasks);
@@ -703,7 +724,7 @@ impl<P: PersistedGraph> MemoryBackendWithPersistedGraph<P> {
         task_info: &Task,
         remaining_depth: u8,
         delayed_deactivate: &mut Vec<TaskId>,
-        turbo_tasks: &dyn TurboTasksBackendApi,
+        turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>,
     ) {
         let mut deactivate_persisted = false;
         let TaskState {
@@ -738,7 +759,10 @@ impl<P: PersistedGraph> MemoryBackendWithPersistedGraph<P> {
         }
     }
 
-    fn persist(&self, turbo_tasks: &dyn TurboTasksBackendApi) -> bool {
+    fn persist(
+        &self,
+        turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>,
+    ) -> bool {
         loop {
             if let Ok(mut task) = self.persist_queue1.pop() {
                 self.persist_queue1_queued.remove(&task);
@@ -879,7 +903,11 @@ impl<P: PersistedGraph> MemoryBackendWithPersistedGraph<P> {
                 .any(|q| !q.lock().unwrap().is_empty())
     }
 
-    fn increase_persist_workers(&self, n: usize, turbo_tasks: &dyn TurboTasksBackendApi) {
+    fn increase_persist_workers(
+        &self,
+        n: usize,
+        turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>,
+    ) {
         loop {
             let capacity = self.persist_capacity.load(Ordering::Acquire);
             if capacity == 0 {
@@ -905,7 +933,7 @@ impl<P: PersistedGraph> MemoryBackendWithPersistedGraph<P> {
 }
 
 impl<P: PersistedGraph> Backend for MemoryBackendWithPersistedGraph<P> {
-    fn startup(&self, turbo_tasks: &dyn TurboTasksBackendApi) {
+    fn startup(&self, turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>) {
         let (tasks_to_activate, tasks_to_deactivate) =
             self.pg_get_pending_active_update(turbo_tasks);
         let tasks = self.pg_get_active_external_tasks(turbo_tasks);
@@ -975,11 +1003,15 @@ impl<P: PersistedGraph> Backend for MemoryBackendWithPersistedGraph<P> {
         }
     }
 
-    fn stop(&self, turbo_tasks: &dyn TurboTasksBackendApi) {
+    fn stop(&self, turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>) {
         self.pg_stop(turbo_tasks);
     }
 
-    fn invalidate_task(&self, task: TaskId, turbo_tasks: &dyn TurboTasksBackendApi) {
+    fn invalidate_task(
+        &self,
+        task: TaskId,
+        turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>,
+    ) {
         let (mut state, _) = self.state_mut(task, turbo_tasks);
 
         if let Some(MemoryTaskState { freshness, .. }) = &mut state.memory {
@@ -1002,7 +1034,11 @@ impl<P: PersistedGraph> Backend for MemoryBackendWithPersistedGraph<P> {
         }
     }
 
-    fn invalidate_tasks(&self, tasks: Vec<TaskId>, turbo_tasks: &dyn TurboTasksBackendApi) {
+    fn invalidate_tasks(
+        &self,
+        tasks: Vec<TaskId>,
+        turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>,
+    ) {
         for task in tasks {
             self.invalidate_task(task, turbo_tasks);
         }
@@ -1025,7 +1061,7 @@ impl<P: PersistedGraph> Backend for MemoryBackendWithPersistedGraph<P> {
     fn try_start_task_execution(
         &self,
         task: TaskId,
-        turbo_tasks: &dyn TurboTasksBackendApi,
+        turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>,
     ) -> Option<TaskExecutionSpec> {
         let (mut state, task_info) = self.mem_state_mut(task, turbo_tasks);
         let mem_state = state.memory.as_mut().unwrap();
@@ -1078,7 +1114,7 @@ impl<P: PersistedGraph> Backend for MemoryBackendWithPersistedGraph<P> {
         &self,
         task: TaskId,
         result: Result<Result<RawVc>, Option<Cow<'static, str>>>,
-        turbo_tasks: &dyn TurboTasksBackendApi,
+        turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>,
     ) {
         let (mut state, _task_info) = self.mem_state_mut(task, turbo_tasks);
         let TaskState { ref mut memory, .. } = *state;
@@ -1113,7 +1149,7 @@ impl<P: PersistedGraph> Backend for MemoryBackendWithPersistedGraph<P> {
         duration: Duration,
         _instant: Instant,
         _stateful: bool,
-        turbo_tasks: &dyn TurboTasksBackendApi,
+        turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>,
     ) -> bool {
         #[cfg(feature = "log_running_tasks")]
         {
@@ -1174,7 +1210,7 @@ impl<P: PersistedGraph> Backend for MemoryBackendWithPersistedGraph<P> {
     fn run_backend_job<'a>(
         &'a self,
         id: BackendJobId,
-        turbo_tasks: &'a dyn TurboTasksBackendApi,
+        turbo_tasks: &'a dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>,
     ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
         if id == self.persist_job {
             return Box::pin(async {
@@ -1220,7 +1256,7 @@ impl<P: PersistedGraph> Backend for MemoryBackendWithPersistedGraph<P> {
         task: TaskId,
         reader: TaskId,
         _strongly_consistent: bool,
-        turbo_tasks: &dyn TurboTasksBackendApi,
+        turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>,
     ) -> Result<Result<RawVc, EventListener>> {
         let (mut state, _task_info) = self.mem_state_mut(task, turbo_tasks);
         let TaskState {
@@ -1259,7 +1295,7 @@ impl<P: PersistedGraph> Backend for MemoryBackendWithPersistedGraph<P> {
         &self,
         task: TaskId,
         _strongly_consistent: bool,
-        turbo_tasks: &dyn TurboTasksBackendApi,
+        turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>,
     ) -> Result<Result<RawVc, EventListener>> {
         let (state, task_info) = self.mem_state_mut(task, turbo_tasks);
         let mem_state = state.memory.as_ref().unwrap();
@@ -1280,7 +1316,7 @@ impl<P: PersistedGraph> Backend for MemoryBackendWithPersistedGraph<P> {
         task: TaskId,
         index: CellId,
         reader: TaskId,
-        turbo_tasks: &dyn TurboTasksBackendApi,
+        turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>,
     ) -> Result<Result<CellContent, EventListener>> {
         let (mut state, _task_info) = self.mem_state_mut(task, turbo_tasks);
         let TaskState {
@@ -1345,7 +1381,7 @@ impl<P: PersistedGraph> Backend for MemoryBackendWithPersistedGraph<P> {
         &self,
         task: TaskId,
         index: CellId,
-        turbo_tasks: &dyn TurboTasksBackendApi,
+        turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>,
     ) -> Result<Result<CellContent, EventListener>> {
         let (mut state, _) = self.mem_state_mut(task, turbo_tasks);
         let TaskState {
@@ -1383,7 +1419,7 @@ impl<P: PersistedGraph> Backend for MemoryBackendWithPersistedGraph<P> {
         &self,
         task: TaskId,
         index: CellId,
-        turbo_tasks: &dyn TurboTasksBackendApi,
+        turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>,
     ) -> Result<CellContent> {
         let (state, _) = self.mem_state_mut(task, turbo_tasks);
         let mem_state = state.memory.as_ref().unwrap();
@@ -1402,7 +1438,7 @@ impl<P: PersistedGraph> Backend for MemoryBackendWithPersistedGraph<P> {
         _task: TaskId,
         _trait_id: TraitTypeId,
         _reader: TaskId,
-        _turbo_tasks: &dyn TurboTasksBackendApi,
+        _turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>,
     ) -> RawVcSetVc {
         todo!()
     }
@@ -1412,7 +1448,7 @@ impl<P: PersistedGraph> Backend for MemoryBackendWithPersistedGraph<P> {
         _trait_id: TraitTypeId,
         _collectible: RawVc,
         _task: TaskId,
-        _turbo_tasks: &dyn TurboTasksBackendApi,
+        _turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>,
     ) {
         todo!()
     }
@@ -1422,7 +1458,7 @@ impl<P: PersistedGraph> Backend for MemoryBackendWithPersistedGraph<P> {
         _trait_id: TraitTypeId,
         _collectible: RawVc,
         _task: TaskId,
-        _turbo_tasks: &dyn TurboTasksBackendApi,
+        _turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>,
     ) {
         todo!()
     }
@@ -1432,7 +1468,7 @@ impl<P: PersistedGraph> Backend for MemoryBackendWithPersistedGraph<P> {
         task: TaskId,
         index: CellId,
         content: CellContent,
-        turbo_tasks: &dyn TurboTasksBackendApi,
+        turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>,
     ) {
         let (mut state, task_info) = self.mem_state_mut(task, turbo_tasks);
         let TaskState {
@@ -1473,7 +1509,7 @@ impl<P: PersistedGraph> Backend for MemoryBackendWithPersistedGraph<P> {
         &self,
         task_type: PersistentTaskType,
         parent_task: TaskId,
-        turbo_tasks: &dyn TurboTasksBackendApi,
+        turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>,
     ) -> TaskId {
         if let Some(task) = self.cache.get(&task_type) {
             self.connect(parent_task, *task, turbo_tasks);
@@ -1530,7 +1566,7 @@ impl<P: PersistedGraph> Backend for MemoryBackendWithPersistedGraph<P> {
         &self,
         _task: TaskId,
         _parent_task: TaskId,
-        _turbo_tasks: &dyn TurboTasksBackendApi,
+        _turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>,
     ) {
         todo!()
     }
@@ -1538,7 +1574,7 @@ impl<P: PersistedGraph> Backend for MemoryBackendWithPersistedGraph<P> {
     fn create_transient_task(
         &self,
         task_type: TransientTaskType,
-        turbo_tasks: &dyn TurboTasksBackendApi,
+        turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>,
     ) -> TaskId {
         let task = turbo_tasks.get_fresh_task_id();
         let task = task.into();
@@ -1565,9 +1601,9 @@ impl<P: PersistedGraph> Backend for MemoryBackendWithPersistedGraph<P> {
     }
 }
 
-struct MemoryBackendPersistedGraphApi<'a, P: PersistedGraph> {
+struct MemoryBackendPersistedGraphApi<'a, P: PersistedGraph + 'static> {
     backend: &'a MemoryBackendWithPersistedGraph<P>,
-    turbo_tasks: &'a dyn TurboTasksBackendApi,
+    turbo_tasks: &'a dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>,
 }
 
 impl<'a, P: PersistedGraph> PersistedGraphApi for MemoryBackendPersistedGraphApi<'a, P> {
@@ -1616,7 +1652,7 @@ impl<P: PersistedGraph> MemoryBackendWithPersistedGraph<P> {
     fn pg_read(
         &self,
         task: TaskId,
-        turbo_tasks: &dyn TurboTasksBackendApi,
+        turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>,
     ) -> Option<(TaskData, ReadTaskState)> {
         self.pg
             .read(
@@ -1632,7 +1668,7 @@ impl<P: PersistedGraph> MemoryBackendWithPersistedGraph<P> {
     fn pg_lookup_one(
         &self,
         task_type: &PersistentTaskType,
-        turbo_tasks: &dyn TurboTasksBackendApi,
+        turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>,
     ) -> Option<TaskId> {
         self.pg
             .lookup_one(
@@ -1648,7 +1684,7 @@ impl<P: PersistedGraph> MemoryBackendWithPersistedGraph<P> {
     fn pg_lookup(
         &self,
         partial_task_type: &PersistentTaskType,
-        turbo_tasks: &dyn TurboTasksBackendApi,
+        turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>,
     ) -> bool {
         self.pg
             .lookup(
@@ -1661,7 +1697,11 @@ impl<P: PersistedGraph> MemoryBackendWithPersistedGraph<P> {
             .unwrap()
     }
 
-    fn pg_is_persisted(&self, task: TaskId, turbo_tasks: &dyn TurboTasksBackendApi) -> bool {
+    fn pg_is_persisted(
+        &self,
+        task: TaskId,
+        turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>,
+    ) -> bool {
         self.pg
             .is_persisted(
                 task,
@@ -1678,7 +1718,7 @@ impl<P: PersistedGraph> MemoryBackendWithPersistedGraph<P> {
         task: TaskId,
         data: TaskData,
         state: PersistTaskState,
-        turbo_tasks: &dyn TurboTasksBackendApi,
+        turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>,
     ) -> Option<PersistResult> {
         self.pg
             .persist(
@@ -1697,7 +1737,7 @@ impl<P: PersistedGraph> MemoryBackendWithPersistedGraph<P> {
     fn pg_activate_when_needed(
         &self,
         task: TaskId,
-        turbo_tasks: &dyn TurboTasksBackendApi,
+        turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>,
     ) -> Option<ActivateResult> {
         self.pg
             .activate_when_needed(
@@ -1714,7 +1754,7 @@ impl<P: PersistedGraph> MemoryBackendWithPersistedGraph<P> {
     fn pg_deactivate_when_needed(
         &self,
         task: TaskId,
-        turbo_tasks: &dyn TurboTasksBackendApi,
+        turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>,
     ) -> Option<DeactivateResult> {
         self.pg
             .deactivate_when_needed(
@@ -1731,7 +1771,7 @@ impl<P: PersistedGraph> MemoryBackendWithPersistedGraph<P> {
     fn pg_set_externally_active(
         &self,
         task: TaskId,
-        turbo_tasks: &dyn TurboTasksBackendApi,
+        turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>,
     ) -> bool {
         self.pg
             .set_externally_active(
@@ -1748,7 +1788,7 @@ impl<P: PersistedGraph> MemoryBackendWithPersistedGraph<P> {
     fn pg_unset_externally_active(
         &self,
         task: TaskId,
-        turbo_tasks: &dyn TurboTasksBackendApi,
+        turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>,
     ) -> bool {
         self.pg
             .unset_externally_active(
@@ -1762,7 +1802,11 @@ impl<P: PersistedGraph> MemoryBackendWithPersistedGraph<P> {
     }
 
     #[must_use]
-    fn pg_make_dirty(&self, task: TaskId, turbo_tasks: &dyn TurboTasksBackendApi) -> bool {
+    fn pg_make_dirty(
+        &self,
+        task: TaskId,
+        turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>,
+    ) -> bool {
         self.pg
             .make_dirty(
                 task,
@@ -1778,7 +1822,7 @@ impl<P: PersistedGraph> MemoryBackendWithPersistedGraph<P> {
     fn pg_make_dependent_dirty(
         &self,
         vc: RawVc,
-        turbo_tasks: &dyn TurboTasksBackendApi,
+        turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>,
     ) -> Vec<TaskId> {
         self.pg
             .make_dependent_dirty(
@@ -1791,7 +1835,11 @@ impl<P: PersistedGraph> MemoryBackendWithPersistedGraph<P> {
             .unwrap()
     }
 
-    fn pg_make_clean(&self, task: TaskId, turbo_tasks: &dyn TurboTasksBackendApi) {
+    fn pg_make_clean(
+        &self,
+        task: TaskId,
+        turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>,
+    ) {
         self.pg
             .make_clean(
                 task,
@@ -1808,7 +1856,7 @@ impl<P: PersistedGraph> MemoryBackendWithPersistedGraph<P> {
     #[must_use]
     fn pg_remove_outdated_externally_active(
         &self,
-        turbo_tasks: &dyn TurboTasksBackendApi,
+        turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>,
     ) -> Vec<TaskId> {
         self.pg
             .remove_outdated_externally_active(&MemoryBackendPersistedGraphApi {
@@ -1819,7 +1867,10 @@ impl<P: PersistedGraph> MemoryBackendWithPersistedGraph<P> {
     }
 
     #[must_use]
-    fn pg_get_active_external_tasks(&self, turbo_tasks: &dyn TurboTasksBackendApi) -> Vec<TaskId> {
+    fn pg_get_active_external_tasks(
+        &self,
+        turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>,
+    ) -> Vec<TaskId> {
         self.pg
             .get_active_external_tasks(&MemoryBackendPersistedGraphApi {
                 backend: self,
@@ -1829,7 +1880,10 @@ impl<P: PersistedGraph> MemoryBackendWithPersistedGraph<P> {
     }
 
     #[must_use]
-    fn pg_get_dirty_active_tasks(&self, turbo_tasks: &dyn TurboTasksBackendApi) -> Vec<TaskId> {
+    fn pg_get_dirty_active_tasks(
+        &self,
+        turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>,
+    ) -> Vec<TaskId> {
         self.pg
             .get_dirty_active_tasks(&MemoryBackendPersistedGraphApi {
                 backend: self,
@@ -1841,7 +1895,7 @@ impl<P: PersistedGraph> MemoryBackendWithPersistedGraph<P> {
     #[must_use]
     fn pg_get_pending_active_update(
         &self,
-        turbo_tasks: &dyn TurboTasksBackendApi,
+        turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>,
     ) -> (Vec<TaskId>, Vec<TaskId>) {
         self.pg
             .get_pending_active_update(&MemoryBackendPersistedGraphApi {
@@ -1851,7 +1905,7 @@ impl<P: PersistedGraph> MemoryBackendWithPersistedGraph<P> {
             .unwrap()
     }
 
-    fn pg_stop(&self, turbo_tasks: &dyn TurboTasksBackendApi) {
+    fn pg_stop(&self, turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackendWithPersistedGraph<P>>) {
         self.pg
             .stop(&MemoryBackendPersistedGraphApi {
                 backend: self,

--- a/crates/turbo-tasks-memory/src/scope.rs
+++ b/crates/turbo-tasks-memory/src/scope.rs
@@ -115,6 +115,8 @@ impl<'a> Iterator for TaskScopesIterator<'a> {
 pub struct TaskScope {
     #[cfg(feature = "print_scope_updates")]
     pub id: TaskScopeId,
+    /// If true, this scope will propagate collectibles to parent scopes
+    propagate_collectibles: bool,
     /// Total number of tasks
     tasks: AtomicUsize,
     /// Number of tasks that are not Done, unfinished child scopes also count as
@@ -127,6 +129,21 @@ pub struct TaskScope {
     unfinished_tasks: AtomicIsize,
     /// State that requires locking
     pub state: Mutex<TaskScopeState>,
+}
+
+#[derive(Debug, Default)]
+struct ScopeCollectiblesInfo {
+    collectibles: CountHashSet<RawVc>,
+    dependent_tasks: AutoSet<TaskId, BuildNoHashHasher<TaskId>>,
+    read_collectibles_task: Option<TaskId>,
+}
+
+impl ScopeCollectiblesInfo {
+    fn is_unset(&self) -> bool {
+        self.collectibles.is_unset()
+            && self.dependent_tasks.is_empty()
+            && self.read_collectibles_task.is_none()
+    }
 }
 
 #[derive(Debug)]
@@ -153,14 +170,7 @@ pub struct TaskScopeState {
     /// When they change these tasks are invalidated
     dependent_tasks: AutoSet<TaskId, BuildNoHashHasher<TaskId>>,
     /// Emitted collectibles with count and dependent_tasks by trait type
-    collectibles: AutoMap<
-        TraitTypeId,
-        (
-            CountHashSet<RawVc>,
-            AutoSet<TaskId, BuildNoHashHasher<TaskId>>,
-        ),
-        BuildNoHashHasher<TraitTypeId>,
-    >,
+    collectibles: AutoMap<TraitTypeId, ScopeCollectiblesInfo, BuildNoHashHasher<TraitTypeId>>,
 }
 
 impl TaskScope {
@@ -169,25 +179,30 @@ impl TaskScope {
         Self {
             #[cfg(feature = "print_scope_updates")]
             id,
+            propagate_collectibles: true,
             tasks: AtomicUsize::new(tasks),
             unfinished_tasks: AtomicIsize::new(0),
-            state: Mutex::new(TaskScopeState {
+            state: Mutex::new(TaskScopeState::new(
                 #[cfg(feature = "print_scope_updates")]
                 id,
-                active: 0,
-                dirty_tasks: AutoSet::default(),
-                children: CountHashSet::new(),
-                collectibles: AutoMap::default(),
-                dependent_tasks: AutoSet::default(),
-                event: Event::new(move || {
-                    #[cfg(feature = "print_scope_updates")]
-                    return format!("TaskScope({id})::event");
-                    #[cfg(not(feature = "print_scope_updates"))]
-                    return "TaskScope::event".to_owned();
-                }),
-                has_unfinished_tasks: false,
-                parents: CountHashSet::new(),
-            }),
+                false,
+            )),
+        }
+    }
+
+    #[allow(unused_variables)]
+    pub fn new_no_collectibles(id: TaskScopeId, tasks: usize) -> Self {
+        Self {
+            #[cfg(feature = "print_scope_updates")]
+            id,
+            propagate_collectibles: false,
+            tasks: AtomicUsize::new(tasks),
+            unfinished_tasks: AtomicIsize::new(tasks as isize),
+            state: Mutex::new(TaskScopeState::new(
+                #[cfg(feature = "print_scope_updates")]
+                id,
+                tasks > 0,
+            )),
         }
     }
 
@@ -196,25 +211,14 @@ impl TaskScope {
         Self {
             #[cfg(feature = "print_scope_updates")]
             id,
+            propagate_collectibles: true,
             tasks: AtomicUsize::new(tasks),
             unfinished_tasks: AtomicIsize::new(unfinished as isize),
-            state: Mutex::new(TaskScopeState {
+            state: Mutex::new(TaskScopeState::new_active(
                 #[cfg(feature = "print_scope_updates")]
                 id,
-                active: 1,
-                dirty_tasks: AutoSet::default(),
-                children: CountHashSet::new(),
-                collectibles: AutoMap::default(),
-                dependent_tasks: AutoSet::default(),
-                event: Event::new(move || {
-                    #[cfg(feature = "print_scope_updates")]
-                    return format!("TaskScope({id})::event");
-                    #[cfg(not(feature = "print_scope_updates"))]
-                    return "TaskScope::event".to_owned();
-                }),
-                has_unfinished_tasks: false,
-                parents: CountHashSet::new(),
-            }),
+                tasks > 0,
+            )),
         }
     }
 
@@ -343,10 +347,14 @@ impl TaskScope {
         Task::add_dependency_to_current(TaskDependency::ScopeChildren(self_id));
 
         let current = {
-            let (c, dependent_tasks) = state.collectibles.entry(trait_id).or_default();
+            let ScopeCollectiblesInfo {
+                collectibles,
+                dependent_tasks,
+                ..
+            } = state.collectibles.entry(trait_id).or_default();
             dependent_tasks.insert(reader);
             Task::add_dependency_to_current(TaskDependency::ScopeCollectibles(self_id, trait_id));
-            c.clone()
+            collectibles.clone()
         };
         drop(state);
 
@@ -365,12 +373,16 @@ impl TaskScope {
     ) {
         let mut state = self.state.lock();
         if let Entry::Occupied(mut entry) = state.collectibles.entry(trait_type) {
-            let (collectibles, dependent_tasks) = entry.get_mut();
-            dependent_tasks.remove(&reader);
-            if collectibles.is_unset() && dependent_tasks.is_empty() {
+            let info = entry.get_mut();
+            info.dependent_tasks.remove(&reader);
+            if info.is_unset() {
                 entry.remove();
             }
         }
+    }
+
+    pub(crate) fn is_propagating_collectibles(&self) -> bool {
+        self.propagate_collectibles
     }
 
     pub(crate) fn assert_unused(&self) {
@@ -393,11 +405,12 @@ impl TaskScope {
             "Scope dependent tasks not correctly cleaned up: {:?}",
             state.dependent_tasks
         );
-        assert!(
-            state.collectibles.is_empty(),
-            "Scope collectibles not correctly cleaned up: {:?}",
-            state.collectibles
-        );
+        // TODO read_collectibles_tasks need to be cleaned up
+        // assert!(
+        //     state.collectibles.is_empty(),
+        //     "Scope collectibles not correctly cleaned up: {:?}",
+        //     state.collectibles
+        // );
         // assert!(
         // state.dirty_tasks.is_empty(),
         // "Scope dirty tasks not correctly cleaned up: {:?}",
@@ -444,9 +457,59 @@ pub struct ScopeCollectibleChangeEffect {
 }
 
 impl TaskScopeState {
+    /// creates a state that is not active
+    fn new(
+        #[cfg(feature = "print_scope_updates")] id: TaskScopeId,
+        has_unfinished_tasks: bool,
+    ) -> Self {
+        Self {
+            #[cfg(feature = "print_scope_updates")]
+            id,
+            active: 0,
+            dirty_tasks: AutoSet::default(),
+            children: CountHashSet::new(),
+            collectibles: AutoMap::default(),
+            dependent_tasks: AutoSet::default(),
+            event: Event::new(move || {
+                #[cfg(feature = "print_scope_updates")]
+                return format!("TaskScope({id})::event");
+                #[cfg(not(feature = "print_scope_updates"))]
+                return "TaskScope::event".to_owned();
+            }),
+            has_unfinished_tasks,
+            parents: CountHashSet::new(),
+        }
+    }
+
+    /// creates a state that is active
+    fn new_active(
+        #[cfg(feature = "print_scope_updates")] id: TaskScopeId,
+        has_unfinished_tasks: bool,
+    ) -> Self {
+        Self {
+            #[cfg(feature = "print_scope_updates")]
+            id,
+            active: 1,
+            dirty_tasks: AutoSet::default(),
+            children: CountHashSet::new(),
+            collectibles: AutoMap::default(),
+            dependent_tasks: AutoSet::default(),
+            event: Event::new(move || {
+                #[cfg(feature = "print_scope_updates")]
+                return format!("TaskScope({id})::event");
+                #[cfg(not(feature = "print_scope_updates"))]
+                return "TaskScope::event".to_owned();
+            }),
+            has_unfinished_tasks,
+            parents: CountHashSet::new(),
+        }
+    }
+
+    /// returns true if the scope is active
     pub fn is_active(&self) -> bool {
         self.active > 0
     }
+
     /// increments the active counter, returns list of tasks that need to be
     /// scheduled and list of child scope that need to be incremented after
     /// releasing the scope lock
@@ -457,6 +520,7 @@ impl TaskScopeState {
     ) -> Option<AutoSet<TaskId, BuildNoHashHasher<TaskId>>> {
         self.increment_active_by(1, more_jobs)
     }
+
     /// increments the active counter, returns list of tasks that need to be
     /// scheduled and list of child scope that need to be incremented after
     /// releasing the scope lock
@@ -475,11 +539,13 @@ impl TaskScopeState {
             None
         }
     }
+
     /// decrement the active counter, returns list of child scopes that need to
     /// be decremented after releasing the scope lock
     pub fn decrement_active(&mut self, more_jobs: &mut Vec<TaskScopeId>) {
         self.decrement_active_by(1, more_jobs);
     }
+
     /// decrement the active counter, returns list of child scopes that need to
     /// be decremented after releasing the scope lock. Returns `true` when the
     /// scope has become inactive.
@@ -564,13 +630,11 @@ impl TaskScopeState {
         let mut set = self.take_dependent_tasks();
         self.collectibles = take(&mut self.collectibles)
             .into_iter()
-            .map(|(key, (collectibles, mut dependent_tasks))| {
-                set.extend(take(&mut dependent_tasks));
-                (key, (collectibles, dependent_tasks))
+            .map(|(key, mut info)| {
+                set.extend(take(&mut info.dependent_tasks));
+                (key, info)
             })
-            .filter(|(_, (collectibles, dependent_tasks))| {
-                !collectibles.is_unset() || !dependent_tasks.is_empty()
-            })
+            .filter(|(_, info)| !info.is_unset())
             .collect();
         set
     }
@@ -581,7 +645,6 @@ impl TaskScopeState {
     #[must_use]
     pub fn add_collectible(
         &mut self,
-
         trait_id: TraitTypeId,
         collectible: RawVc,
     ) -> Option<ScopeCollectibleChangeEffect> {
@@ -600,14 +663,14 @@ impl TaskScopeState {
     ) -> Option<ScopeCollectibleChangeEffect> {
         match self.collectibles.entry(trait_id) {
             Entry::Occupied(mut entry) => {
-                let (collectibles, dependent_tasks) = entry.get_mut();
-                if collectibles.add_count(collectible, count) {
+                let info = entry.get_mut();
+                if info.collectibles.add_count(collectible, count) {
                     log_scope_update!("add_collectible {} -> {}", *self.id, collectible);
                     Some(ScopeCollectibleChangeEffect {
-                        notify: take(dependent_tasks),
+                        notify: take(&mut info.dependent_tasks),
                     })
                 } else {
-                    if collectibles.is_unset() && dependent_tasks.is_empty() {
+                    if info.is_unset() {
                         entry.remove();
                     }
                     None
@@ -616,7 +679,7 @@ impl TaskScopeState {
             Entry::Vacant(entry) => {
                 let result = entry
                     .insert(Default::default())
-                    .0
+                    .collectibles
                     .add_count(collectible, count);
                 debug_assert!(result, "this must be always a new entry");
                 log_scope_update!("add_collectible {} -> {}", *self.id, collectible);
@@ -651,15 +714,15 @@ impl TaskScopeState {
     ) -> Option<ScopeCollectibleChangeEffect> {
         match self.collectibles.entry(trait_id) {
             Entry::Occupied(mut entry) => {
-                let (collectibles, dependent_tasks) = entry.get_mut();
-                let old_value = collectibles.get(&collectible);
+                let info = entry.get_mut();
+                let old_value = info.collectibles.get(&collectible);
                 let new_value = old_value - count as isize;
                 // NOTE: The read_collectibles need to be invalidated when negative count
                 // changes. Each negative count will eliminate one child scope emitted
                 // collectible. So changing from -1 to -2 might affect the visible collectibles.
-                if collectibles.remove_count(collectible, count) || new_value < 0 {
-                    let notify = take(dependent_tasks);
-                    if collectibles.is_unset() {
+                if info.collectibles.remove_count(collectible, count) || new_value < 0 {
+                    let notify = take(&mut info.dependent_tasks);
+                    if info.is_unset() {
                         entry.remove();
                     }
                     log_scope_update!(
@@ -675,7 +738,7 @@ impl TaskScopeState {
             Entry::Vacant(e) => {
                 let result = e
                     .insert(Default::default())
-                    .0
+                    .collectibles
                     .remove_count(collectible, count);
 
                 debug_assert!(!result, "this must never be visible from outside");
@@ -686,5 +749,24 @@ impl TaskScopeState {
 
     pub fn take_dependent_tasks(&mut self) -> AutoSet<TaskId, BuildNoHashHasher<TaskId>> {
         take(&mut self.dependent_tasks)
+    }
+
+    pub fn get_read_collectibles_task(
+        &mut self,
+        trait_id: TraitTypeId,
+        create_new: impl FnOnce() -> TaskId,
+    ) -> TaskId {
+        let task_id = &mut self
+            .collectibles
+            .entry(trait_id)
+            .or_default()
+            .read_collectibles_task;
+        if let Some(task_id) = *task_id {
+            task_id
+        } else {
+            let new_task_id = create_new();
+            *task_id = Some(new_task_id);
+            new_task_id
+        }
     }
 }

--- a/crates/turbo-tasks-memory/tests/collectibles.rs
+++ b/crates/turbo-tasks-memory/tests/collectibles.rs
@@ -1,24 +1,35 @@
 #![feature(min_specialization)]
 
-use std::collections::HashSet;
+use std::{collections::HashSet, time::Duration};
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use tokio::time::sleep;
 use turbo_tasks::{emit, primitives::StringVc, CollectiblesSource, ValueToString, ValueToStringVc};
 use turbo_tasks_testing::{register, run};
 register!();
 
 #[tokio::test]
+async fn emitting() {
+    run! {
+        let result = my_emitting_function_with_result("");
+        let list = result.peek_collectibles::<ValueToStringVc>().strongly_consistent().await?;
+        assert_eq!(list.len(), 1);
+        assert_eq!(list.into_iter().next().unwrap().to_string().await?.as_str(), "123");
+        assert_eq!(result.strongly_consistent().await?.0, 42);
+    }
+}
+
+#[tokio::test]
 async fn transitive_emitting() {
     run! {
         let result = my_transitive_emitting_function("", "");
-        let list = result.peek_collectibles::<ValueToStringVc>().await?;
+        let list = result.peek_collectibles::<ValueToStringVc>().strongly_consistent().await?;
         assert_eq!(list.len(), 2);
         let mut expected = ["123", "42"].into_iter().collect::<HashSet<_>>();
         for collectible in list {
             assert!(expected.remove(collectible.to_string().await?.as_str()))
         }
-        assert_eq!(result.await?.0, 0);
+        assert_eq!(result.strongly_consistent().await?.0, 0);
     }
 }
 
@@ -26,13 +37,13 @@ async fn transitive_emitting() {
 async fn multi_emitting() {
     run! {
         let result = my_multi_emitting_function();
-        let list = result.peek_collectibles::<ValueToStringVc>().await?;
+        let list = result.peek_collectibles::<ValueToStringVc>().strongly_consistent().await?;
         assert_eq!(list.len(), 2);
         let mut expected = ["123", "42"].into_iter().collect::<HashSet<_>>();
         for collectible in list {
             assert!(expected.remove(collectible.to_string().await?.as_str()))
         }
-        assert_eq!(result.await?.0, 0);
+        assert_eq!(result.strongly_consistent().await?.0, 0);
     }
 }
 
@@ -40,11 +51,11 @@ async fn multi_emitting() {
 async fn taking_collectibles() {
     run! {
         let result = my_collecting_function();
-        let list = result.take_collectibles::<ValueToStringVc>().await?;
+        let list = result.take_collectibles::<ValueToStringVc>().strongly_consistent().await?;
         // my_collecting_function already processed the collectibles so the list should
         // be empty
         assert!(list.is_empty());
-        assert_eq!(result.await?.0, 0);
+        assert_eq!(result.strongly_consistent().await?.0, 0);
     }
 }
 
@@ -52,11 +63,11 @@ async fn taking_collectibles() {
 async fn taking_collectibles_extra_layer() {
     run! {
         let result = my_collecting_function_indirect();
-        let list = result.take_collectibles::<ValueToStringVc>().await?;
+        let list = result.take_collectibles::<ValueToStringVc>().strongly_consistent().await?;
         // my_collecting_function already processed the collectibles so the list should
         // be empty
         assert!(list.is_empty());
-        assert_eq!(result.await?.0, 0);
+        assert_eq!(result.strongly_consistent().await?.0, 0);
     }
 }
 
@@ -64,36 +75,39 @@ async fn taking_collectibles_extra_layer() {
 async fn taking_collectibles_parallel() {
     run! {
         let result = my_transitive_emitting_function("", "a");
-        let list = result.take_collectibles::<ValueToStringVc>().await?;
+        let list = result.take_collectibles::<ValueToStringVc>().strongly_consistent().await?;
         assert_eq!(list.len(), 2);
-        assert_eq!(result.await?.0, 0);
+        assert_eq!(result.strongly_consistent().await?.0, 0);
 
         let result = my_transitive_emitting_function("", "b");
-        let list = result.take_collectibles::<ValueToStringVc>().await?;
+        let list = result.take_collectibles::<ValueToStringVc>().strongly_consistent().await?;
         assert_eq!(list.len(), 2);
-        assert_eq!(result.await?.0, 0);
+        assert_eq!(result.strongly_consistent().await?.0, 0);
 
         let result = my_transitive_emitting_function_with_child_scope("", "b", "1");
-        let list = result.take_collectibles::<ValueToStringVc>().await?;
+        let list = result.take_collectibles::<ValueToStringVc>().strongly_consistent().await?;
         assert_eq!(list.len(), 2);
-        assert_eq!(result.await?.0, 0);
+        assert_eq!(result.strongly_consistent().await?.0, 0);
 
         let result = my_transitive_emitting_function_with_child_scope("", "b", "2");
-        let list = result.take_collectibles::<ValueToStringVc>().await?;
+        let list = result.take_collectibles::<ValueToStringVc>().strongly_consistent().await?;
         assert_eq!(list.len(), 2);
-        assert_eq!(result.await?.0, 0);
+        assert_eq!(result.strongly_consistent().await?.0, 0);
 
         let result = my_transitive_emitting_function_with_child_scope("", "c", "3");
-        let list = result.take_collectibles::<ValueToStringVc>().await?;
+        let list = result.take_collectibles::<ValueToStringVc>().strongly_consistent().await?;
         assert_eq!(list.len(), 2);
-        assert_eq!(result.await?.0, 0);
+        assert_eq!(result.strongly_consistent().await?.0, 0);
     }
 }
 
 #[turbo_tasks::function]
 async fn my_collecting_function() -> Result<ThingVc> {
     let result = my_transitive_emitting_function("", "");
-    result.take_collectibles::<ValueToStringVc>().await?;
+    let list = result.take_collectibles::<ValueToStringVc>().await?;
+    if list.len() != 2 {
+        bail!("Expected 2 collectibles, got {}", list.len());
+    }
     Ok(result)
 }
 
@@ -103,7 +117,9 @@ async fn my_collecting_function_indirect() -> Result<ThingVc> {
     let list = result.peek_collectibles::<ValueToStringVc>().await?;
     // my_collecting_function already processed the collectibles so the list should
     // be empty
-    assert!(list.is_empty());
+    if !list.is_empty() {
+        bail!("Expected 0 collectibles, got {}", list.len());
+    }
     Ok(result)
 }
 
@@ -139,6 +155,15 @@ async fn my_emitting_function(_key: &str) -> Result<()> {
     emit(ThingVc::new(123).as_value_to_string());
     emit(ThingVc::new(42).as_value_to_string());
     Ok(())
+}
+
+#[turbo_tasks::function]
+async fn my_emitting_function_with_result(_key: &str) -> Result<ThingVc> {
+    sleep(Duration::from_millis(100)).await;
+    println!("emitting");
+    emit(ThingVc::new(123).as_value_to_string());
+    println!("emitted");
+    Ok(ThingVc::new(42))
 }
 
 #[turbo_tasks::value(shared)]

--- a/crates/turbo-tasks-memory/tests/collectibles.rs
+++ b/crates/turbo-tasks-memory/tests/collectibles.rs
@@ -3,6 +3,7 @@
 use std::collections::HashSet;
 
 use anyhow::Result;
+use tokio::time::sleep;
 use turbo_tasks::{emit, primitives::StringVc, CollectiblesSource, ValueToString, ValueToStringVc};
 use turbo_tasks_testing::{register, run};
 register!();
@@ -134,6 +135,7 @@ async fn my_transitive_emitting_function_with_child_scope(
 
 #[turbo_tasks::function]
 async fn my_emitting_function(_key: &str) -> Result<()> {
+    sleep(Duration::from_millis(100)).await;
     emit(ThingVc::new(123).as_value_to_string());
     emit(ThingVc::new(42).as_value_to_string());
     Ok(())

--- a/crates/turbo-tasks-testing/src/lib.rs
+++ b/crates/turbo-tasks-testing/src/lib.rs
@@ -200,6 +200,10 @@ impl TurboTasksApi for VcStorage {
         let cell = map.entry((task, index)).or_default();
         *cell = content;
     }
+
+    fn connect_task(&self, _task: TaskId) {
+        // no-op
+    }
 }
 
 impl VcStorage {

--- a/crates/turbo-tasks/src/backend.rs
+++ b/crates/turbo-tasks/src/backend.rs
@@ -314,6 +314,13 @@ pub trait Backend: Sync + Send {
         turbo_tasks: &dyn TurboTasksBackendApi,
     ) -> TaskId;
 
+    fn connect_task(
+        &self,
+        task: TaskId,
+        parent_task: TaskId,
+        turbo_tasks: &dyn TurboTasksBackendApi,
+    );
+
     fn create_transient_task(
         &self,
         task_type: TransientTaskType,

--- a/crates/turbo-tasks/src/backend.rs
+++ b/crates/turbo-tasks/src/backend.rs
@@ -175,17 +175,17 @@ pub trait Backend: Sync + Send {
     fn initialize(&mut self, task_id_provider: &dyn TaskIdProvider) {}
 
     #[allow(unused_variables)]
-    fn startup(&self, turbo_tasks: &dyn TurboTasksBackendApi) {}
+    fn startup(&self, turbo_tasks: &dyn TurboTasksBackendApi<Self>) {}
 
     #[allow(unused_variables)]
-    fn stop(&self, turbo_tasks: &dyn TurboTasksBackendApi) {}
+    fn stop(&self, turbo_tasks: &dyn TurboTasksBackendApi<Self>) {}
 
     #[allow(unused_variables)]
-    fn idle_start(&self, turbo_tasks: &dyn TurboTasksBackendApi) {}
+    fn idle_start(&self, turbo_tasks: &dyn TurboTasksBackendApi<Self>) {}
 
-    fn invalidate_task(&self, task: TaskId, turbo_tasks: &dyn TurboTasksBackendApi);
+    fn invalidate_task(&self, task: TaskId, turbo_tasks: &dyn TurboTasksBackendApi<Self>);
 
-    fn invalidate_tasks(&self, tasks: Vec<TaskId>, turbo_tasks: &dyn TurboTasksBackendApi);
+    fn invalidate_tasks(&self, tasks: Vec<TaskId>, turbo_tasks: &dyn TurboTasksBackendApi<Self>);
 
     fn get_task_description(&self, task: TaskId) -> String;
 
@@ -202,14 +202,14 @@ pub trait Backend: Sync + Send {
     fn try_start_task_execution(
         &self,
         task: TaskId,
-        turbo_tasks: &dyn TurboTasksBackendApi,
+        turbo_tasks: &dyn TurboTasksBackendApi<Self>,
     ) -> Option<TaskExecutionSpec>;
 
     fn task_execution_result(
         &self,
         task: TaskId,
         result: Result<Result<RawVc>, Option<Cow<'static, str>>>,
-        turbo_tasks: &dyn TurboTasksBackendApi,
+        turbo_tasks: &dyn TurboTasksBackendApi<Self>,
     );
 
     fn task_execution_completed(
@@ -218,13 +218,13 @@ pub trait Backend: Sync + Send {
         duration: Duration,
         instant: Instant,
         stateful: bool,
-        turbo_tasks: &dyn TurboTasksBackendApi,
+        turbo_tasks: &dyn TurboTasksBackendApi<Self>,
     ) -> bool;
 
     fn run_backend_job<'a>(
         &'a self,
         id: BackendJobId,
-        turbo_tasks: &'a dyn TurboTasksBackendApi,
+        turbo_tasks: &'a dyn TurboTasksBackendApi<Self>,
     ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>>;
 
     fn try_read_task_output(
@@ -232,7 +232,7 @@ pub trait Backend: Sync + Send {
         task: TaskId,
         reader: TaskId,
         strongly_consistent: bool,
-        turbo_tasks: &dyn TurboTasksBackendApi,
+        turbo_tasks: &dyn TurboTasksBackendApi<Self>,
     ) -> Result<Result<RawVc, EventListener>>;
 
     /// INVALIDATION: Be careful with this, it will not track dependencies, so
@@ -241,7 +241,7 @@ pub trait Backend: Sync + Send {
         &self,
         task: TaskId,
         strongly_consistent: bool,
-        turbo_tasks: &dyn TurboTasksBackendApi,
+        turbo_tasks: &dyn TurboTasksBackendApi<Self>,
     ) -> Result<Result<RawVc, EventListener>>;
 
     fn try_read_task_cell(
@@ -249,7 +249,7 @@ pub trait Backend: Sync + Send {
         task: TaskId,
         index: CellId,
         reader: TaskId,
-        turbo_tasks: &dyn TurboTasksBackendApi,
+        turbo_tasks: &dyn TurboTasksBackendApi<Self>,
     ) -> Result<Result<CellContent, EventListener>>;
 
     /// INVALIDATION: Be careful with this, it will not track dependencies, so
@@ -258,7 +258,7 @@ pub trait Backend: Sync + Send {
         &self,
         task: TaskId,
         index: CellId,
-        turbo_tasks: &dyn TurboTasksBackendApi,
+        turbo_tasks: &dyn TurboTasksBackendApi<Self>,
     ) -> Result<Result<CellContent, EventListener>>;
 
     /// INVALIDATION: Be careful with this, it will not track dependencies, so
@@ -267,7 +267,7 @@ pub trait Backend: Sync + Send {
         &self,
         current_task: TaskId,
         index: CellId,
-        turbo_tasks: &dyn TurboTasksBackendApi,
+        turbo_tasks: &dyn TurboTasksBackendApi<Self>,
     ) -> Result<CellContent> {
         match self.try_read_task_cell_untracked(current_task, index, turbo_tasks)? {
             Ok(content) => Ok(content),
@@ -280,7 +280,7 @@ pub trait Backend: Sync + Send {
         task: TaskId,
         trait_id: TraitTypeId,
         reader: TaskId,
-        turbo_tasks: &dyn TurboTasksBackendApi,
+        turbo_tasks: &dyn TurboTasksBackendApi<Self>,
     ) -> RawVcSetVc;
 
     fn emit_collectible(
@@ -288,7 +288,7 @@ pub trait Backend: Sync + Send {
         trait_type: TraitTypeId,
         collectible: RawVc,
         task: TaskId,
-        turbo_tasks: &dyn TurboTasksBackendApi,
+        turbo_tasks: &dyn TurboTasksBackendApi<Self>,
     );
 
     fn unemit_collectible(
@@ -296,7 +296,7 @@ pub trait Backend: Sync + Send {
         trait_type: TraitTypeId,
         collectible: RawVc,
         task: TaskId,
-        turbo_tasks: &dyn TurboTasksBackendApi,
+        turbo_tasks: &dyn TurboTasksBackendApi<Self>,
     );
 
     fn update_task_cell(
@@ -304,35 +304,35 @@ pub trait Backend: Sync + Send {
         task: TaskId,
         index: CellId,
         content: CellContent,
-        turbo_tasks: &dyn TurboTasksBackendApi,
+        turbo_tasks: &dyn TurboTasksBackendApi<Self>,
     );
 
     fn get_or_create_persistent_task(
         &self,
         task_type: PersistentTaskType,
         parent_task: TaskId,
-        turbo_tasks: &dyn TurboTasksBackendApi,
+        turbo_tasks: &dyn TurboTasksBackendApi<Self>,
     ) -> TaskId;
 
     fn connect_task(
         &self,
         task: TaskId,
         parent_task: TaskId,
-        turbo_tasks: &dyn TurboTasksBackendApi,
+        turbo_tasks: &dyn TurboTasksBackendApi<Self>,
     );
 
     fn create_transient_task(
         &self,
         task_type: TransientTaskType,
-        turbo_tasks: &dyn TurboTasksBackendApi,
+        turbo_tasks: &dyn TurboTasksBackendApi<Self>,
     ) -> TaskId;
 }
 
 impl PersistentTaskType {
-    pub async fn run_resolve_native(
+    pub async fn run_resolve_native<B: Backend + 'static>(
         fn_id: FunctionId,
         inputs: Vec<TaskInput>,
-        turbo_tasks: Arc<dyn TurboTasksBackendApi>,
+        turbo_tasks: Arc<dyn TurboTasksBackendApi<B>>,
     ) -> Result<RawVc> {
         let mut resolved_inputs = Vec::with_capacity(inputs.len());
         for input in inputs.into_iter() {
@@ -341,11 +341,11 @@ impl PersistentTaskType {
         Ok(turbo_tasks.native_call(fn_id, resolved_inputs))
     }
 
-    pub async fn run_resolve_trait(
+    pub async fn run_resolve_trait<B: Backend + 'static>(
         trait_type: TraitTypeId,
         name: Cow<'static, str>,
         inputs: Vec<TaskInput>,
-        turbo_tasks: Arc<dyn TurboTasksBackendApi>,
+        turbo_tasks: Arc<dyn TurboTasksBackendApi<B>>,
     ) -> Result<RawVc> {
         let mut resolved_inputs = Vec::with_capacity(inputs.len());
         let mut iter = inputs.into_iter();
@@ -388,9 +388,9 @@ impl PersistentTaskType {
         }
     }
 
-    pub fn run(
+    pub fn run<B: Backend + 'static>(
         self,
-        turbo_tasks: Arc<dyn TurboTasksBackendApi>,
+        turbo_tasks: Arc<dyn TurboTasksBackendApi<B>>,
     ) -> Pin<Box<dyn Future<Output = Result<RawVc>> + Send>> {
         match self {
             PersistentTaskType::Native(fn_id, inputs) => {

--- a/crates/turbo-tasks/src/manager.rs
+++ b/crates/turbo-tasks/src/manager.rs
@@ -108,6 +108,8 @@ pub trait TurboTasksApi: TurboTasksCallApi + Sync + Send {
 
     fn read_current_task_cell(&self, index: CellId) -> Result<CellContent>;
     fn update_current_task_cell(&self, index: CellId, content: CellContent);
+
+    fn connect_task(&self, task: TaskId);
 }
 
 /// The type of stats reporting.
@@ -884,6 +886,11 @@ impl<B: Backend> TurboTasksApi for TurboTasks<B> {
             content,
             self,
         );
+    }
+
+    fn connect_task(&self, task: TaskId) {
+        self.backend
+            .connect_task(task, current_task("connecting task"), self);
     }
 }
 

--- a/crates/turbo-tasks/src/manager.rs
+++ b/crates/turbo-tasks/src/manager.rs
@@ -198,6 +198,8 @@ pub trait TurboTasksBackendApi<B: Backend + 'static>:
     fn set_stats_type(&self, stats_type: StatsType);
     /// Returns the duration from the start of the program to the given instant.
     fn program_duration_until(&self, instant: Instant) -> Duration;
+    /// Returns a reference to the backend.
+    fn backend(&self) -> &B;
 }
 
 impl StatsType {
@@ -899,6 +901,9 @@ impl<B: Backend + 'static> TurboTasksApi for TurboTasks<B> {
 impl<B: Backend + 'static> TurboTasksBackendApi<B> for TurboTasks<B> {
     fn pin(&self) -> Arc<dyn TurboTasksBackendApi<B>> {
         self.pin()
+    }
+    fn backend(&self) -> &B {
+        &self.backend
     }
     #[track_caller]
     fn schedule_backend_background_job(&self, id: BackendJobId) {

--- a/crates/turbopack-core/src/issue/mod.rs
+++ b/crates/turbopack-core/src/issue/mod.rs
@@ -301,11 +301,11 @@ impl IssueVc {
         source: T,
     ) -> Result<CapturedIssuesVc> {
         Ok(CapturedIssuesVc::cell(CapturedIssues {
-            issues: source.peek_collectibles().await?,
+            issues: source.peek_collectibles().strongly_consistent().await?,
             #[cfg(feature = "issue_path")]
             processing_path: ItemIssueProcessingPathVc::cell(ItemIssueProcessingPath(
                 None,
-                source.peek_collectibles().await?,
+                source.peek_collectibles().strongly_consistent().await?,
             )),
         }))
     }
@@ -318,11 +318,11 @@ impl IssueVc {
         source: T,
     ) -> Result<CapturedIssuesVc> {
         Ok(CapturedIssuesVc::cell(CapturedIssues {
-            issues: source.take_collectibles().await?,
+            issues: source.take_collectibles().strongly_consistent().await?,
             #[cfg(feature = "issue_path")]
             processing_path: ItemIssueProcessingPathVc::cell(ItemIssueProcessingPath(
                 None,
-                source.take_collectibles().await?,
+                source.take_collectibles().strongly_consistent().await?,
             )),
         }))
     }


### PR DESCRIPTION
connect original task to collectibles reading to fix strongly consistency

move read collectibles tasks to task and scope instead of a separate cache

reading collectibles is no longer strongly consistent by default, it's opt-in now