### PR TITLE
refactor: remove `react/jsx-key` ESLint rule

### DIFF
--- a/docs/pages/repo/docs/handbook/linting/eslint.mdx
+++ b/docs/pages/repo/docs/handbook/linting/eslint.mdx
@@ -33,7 +33,6 @@ module.exports = {
   extends: ["next", "turbo", "prettier"],
   rules: {
     "@next/next/no-html-link-for-pages": "off",
-    "react/jsx-key": "off",
   },
 };
 ```

--- a/examples/basic/packages/eslint-config-custom/index.js
+++ b/examples/basic/packages/eslint-config-custom/index.js
@@ -2,7 +2,6 @@ module.exports = {
   extends: ["next", "turbo", "prettier"],
   rules: {
     "@next/next/no-html-link-for-pages": "off",
-    "react/jsx-key": "off",
   },
   parserOptions: {
     babelOptions: {

--- a/examples/design-system/packages/eslint-config-acme/index.js
+++ b/examples/design-system/packages/eslint-config-acme/index.js
@@ -2,7 +2,6 @@ module.exports = {
   extends: ["next", "turbo", "prettier"],
   rules: {
     "@next/next/no-html-link-for-pages": "off",
-    "react/jsx-key": "off",
   },
   parserOptions: {
     babelOptions: {

--- a/examples/with-changesets/packages/eslint-config-acme/index.js
+++ b/examples/with-changesets/packages/eslint-config-acme/index.js
@@ -2,7 +2,6 @@ module.exports = {
   extends: ["next", "turbo", "prettier"],
   rules: {
     "@next/next/no-html-link-for-pages": "off",
-    "react/jsx-key": "off",
   },
   parserOptions: {
     babelOptions: {

--- a/examples/with-npm/packages/eslint-config-custom/index.js
+++ b/examples/with-npm/packages/eslint-config-custom/index.js
@@ -2,6 +2,5 @@ module.exports = {
   extends: ["next", "turbo", "prettier"],
   rules: {
     "@next/next/no-html-link-for-pages": "off",
-    "react/jsx-key": "off",
   },
 };

--- a/examples/with-prisma/packages/config/eslint-preset.js
+++ b/examples/with-prisma/packages/config/eslint-preset.js
@@ -7,7 +7,6 @@ module.exports = {
   },
   rules: {
     "@next/next/no-html-link-for-pages": "off",
-    "react/jsx-key": "off",
   },
   parserOptions: {
     babelOptions: {

--- a/examples/with-rollup/packages/eslint-config-custom/index.js
+++ b/examples/with-rollup/packages/eslint-config-custom/index.js
@@ -2,7 +2,6 @@ module.exports = {
   extends: ["next", "turbo", "prettier"],
   rules: {
     "@next/next/no-html-link-for-pages": "off",
-    "react/jsx-key": "off",
   },
   parserOptions: {
     babelOptions: {

--- a/examples/with-tailwind/packages/eslint-config-custom/index.js
+++ b/examples/with-tailwind/packages/eslint-config-custom/index.js
@@ -2,7 +2,6 @@ module.exports = {
   extends: ["next", "turbo", "prettier"],
   rules: {
     "@next/next/no-html-link-for-pages": "off",
-    "react/jsx-key": "off",
   },
   parserOptions: {
     babelOptions: {

--- a/examples/with-yarn/packages/eslint-config-custom/index.js
+++ b/examples/with-yarn/packages/eslint-config-custom/index.js
@@ -2,6 +2,5 @@ module.exports = {
   extends: ["next", "turbo", "prettier"],
   rules: {
     "@next/next/no-html-link-for-pages": "off",
-    "react/jsx-key": "off",
   },
 };

--- a/packages/create-turbo/templates/_shared_ts/packages/eslint-config-custom/index.js
+++ b/packages/create-turbo/templates/_shared_ts/packages/eslint-config-custom/index.js
@@ -2,6 +2,5 @@ module.exports = {
   extends: ["next", "turbo", "prettier"],
   rules: {
     "@next/next/no-html-link-for-pages": "off",
-    "react/jsx-key": "off",
   },
 };


### PR DESCRIPTION
It was added in vercel/turbo#779 as a temporary fix but forgotten about.