### PR TITLE
add possible unknown mutation to objects and arrays

### DIFF
--- a/crates/next-core/src/util.rs
+++ b/crates/next-core/src/util.rs
@@ -194,7 +194,7 @@ fn parse_config_from_js_value(module_asset: AssetVc, value: &JsValue) -> NextSou
         .as_issue()
         .emit()
     };
-    if let JsValue::Object(_, parts) = value {
+    if let JsValue::Object { parts, .. } = value {
         for part in parts {
             match part {
                 ObjectPart::Spread(_) => invalid_config(

--- a/crates/next-dev-tests/tests/integration/turbopack/basic/comptime/input/index.js
+++ b/crates/next-dev-tests/tests/integration/turbopack/basic/comptime/input/index.js
@@ -39,6 +39,27 @@ it("should not follow conditional references", () => {
   expect(func.toString()).not.toContain("import(");
 });
 
+it("should allow to mutate objects", () => {
+  const obj = { a: true, b: false };
+  if (!obj.a) {
+    throw new Error("should not be executed");
+  }
+  if (obj.b) {
+    throw new Error("should not be executed");
+  }
+  function changeIt(o) {
+    o.a = false;
+    o.b = true;
+  }
+  changeIt(obj);
+  if (obj.a) {
+    throw new Error("should not be executed");
+  }
+  if (!obj.b) {
+    throw new Error("should not be executed");
+  }
+});
+
 it("should allow replacements in IIFEs", () => {
   (function func() {
     if (false) {

--- a/crates/turbopack-ecmascript/src/analyzer/builtin.rs
+++ b/crates/turbopack-ecmascript/src/analyzer/builtin.rs
@@ -20,8 +20,8 @@ pub fn early_replace_builtin(value: &mut JsValue) -> bool {
             JsValue::Constant(_)
             | JsValue::Url(_)
             | JsValue::WellKnownObject(_)
-            | JsValue::Array(_, _)
-            | JsValue::Object(_, _)
+            | JsValue::Array { .. }
+            | JsValue::Object { .. }
             | JsValue::Alternatives(_, _)
             | JsValue::Concat(_, _)
             | JsValue::Add(_, _)
@@ -79,7 +79,11 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
                 true
             }
             // matching property access on an array like `[1,2,3].prop` or `[1,2,3][1]`
-            JsValue::Array(_, array) => {
+            &mut JsValue::Array {
+                ref mut items,
+                mutable,
+                ..
+            } => {
                 fn items_to_alternatives(items: &mut Vec<JsValue>, prop: &mut JsValue) -> JsValue {
                     items.push(JsValue::Unknown(
                         Some(Arc::new(JsValue::member(
@@ -95,8 +99,11 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
                     // We can replace this with the value at the index
                     JsValue::Constant(ConstantValue::Num(num @ ConstantNumber(_))) => {
                         if let Some(index) = num.as_u32_index() {
-                            if index < array.len() {
-                                *value = array.swap_remove(index);
+                            if index < items.len() {
+                                *value = items.swap_remove(index);
+                                if mutable {
+                                    value.add_unknown_mutations();
+                                }
                                 true
                             } else {
                                 *value = JsValue::Unknown(
@@ -130,13 +137,17 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
                     // otherwise we can say that this might gives an item of the array
                     // but we also add an unknown value to the alternatives for other properties
                     _ => {
-                        *value = items_to_alternatives(array, prop);
+                        *value = items_to_alternatives(items, prop);
                         true
                     }
                 }
             }
             // matching property access on an object like `{a: 1, b: 2}.a`
-            JsValue::Object(_, parts) => {
+            &mut JsValue::Object {
+                ref mut parts,
+                mutable,
+                ..
+            } => {
                 fn parts_to_alternatives(
                     parts: &mut Vec<ObjectPart>,
                     prop: &mut Box<JsValue>,
@@ -220,6 +231,9 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
                                                     false,
                                                 );
                                             }
+                                            if mutable {
+                                                value.add_unknown_mutations();
+                                            }
                                             return true;
                                         }
                                     } else {
@@ -241,6 +255,9 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
                                 prop,
                                 true,
                             );
+                        }
+                        if mutable {
+                            value.add_unknown_mutations();
                         }
                         true
                     }
@@ -267,7 +284,7 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
         JsValue::MemberCall(_, box ref mut obj, box ref mut prop, ref mut args) => {
             match obj {
                 // matching calls on an array like `[1,2,3].concat([4,5,6])`
-                JsValue::Array(_, items) => {
+                JsValue::Array { items, mutable, .. } => {
                     // matching cases where the property is a const string
                     if let Some(str) = prop.as_str() {
                         match str {
@@ -276,7 +293,7 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
                                 if args.iter().all(|arg| {
                                     matches!(
                                         arg,
-                                        JsValue::Array(..)
+                                        JsValue::Array { .. }
                                             | JsValue::Constant(_)
                                             | JsValue::Url(_)
                                             | JsValue::Concat(..)
@@ -288,8 +305,15 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
                                 }) {
                                     for arg in args {
                                         match arg {
-                                            JsValue::Array(_, inner) => {
+                                            JsValue::Array {
+                                                items: inner,
+                                                mutable: inner_mutable,
+                                                ..
+                                            } => {
                                                 items.extend(take(inner));
+                                                if *inner_mutable {
+                                                    *mutable = true;
+                                                }
                                             }
                                             JsValue::Constant(_)
                                             | JsValue::Url(_)
@@ -372,16 +396,22 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
             true
         }
         // match object literals
-        JsValue::Object(_, parts) => {
+        JsValue::Object { parts, mutable, .. } => {
             // If the object contains any spread, we might be able to flatten that
             if parts
                 .iter()
-                .any(|part| matches!(part, ObjectPart::Spread(JsValue::Object(..))))
+                .any(|part| matches!(part, ObjectPart::Spread(JsValue::Object { .. })))
             {
                 let old_parts = take(parts);
                 for part in old_parts {
-                    if let ObjectPart::Spread(JsValue::Object(_, inner_parts)) = part {
+                    if let ObjectPart::Spread(JsValue::Object {
+                        parts: inner_parts,
+                        mutable: inner_mutable,
+                        ..
+                    }) = part
+                    {
                         parts.extend(inner_parts);
+                        *mutable |= inner_mutable;
                     } else {
                         parts.push(part);
                     }

--- a/crates/turbopack-ecmascript/src/analyzer/builtin.rs
+++ b/crates/turbopack-ecmascript/src/analyzer/builtin.rs
@@ -311,7 +311,7 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
                                                 ..
                                             } => {
                                                 items.extend(take(inner));
-                                                *mutable |= inner_mutable;
+                                                *mutable |= *inner_mutable;
                                             }
                                             JsValue::Constant(_)
                                             | JsValue::Url(_)

--- a/crates/turbopack-ecmascript/src/analyzer/builtin.rs
+++ b/crates/turbopack-ecmascript/src/analyzer/builtin.rs
@@ -311,9 +311,7 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
                                                 ..
                                             } => {
                                                 items.extend(take(inner));
-                                                if *inner_mutable {
-                                                    *mutable = true;
-                                                }
+                                                *mutable |= inner_mutable;
                                             }
                                             JsValue::Constant(_)
                                             | JsValue::Url(_)

--- a/crates/turbopack-ecmascript/src/analyzer/graph.rs
+++ b/crates/turbopack-ecmascript/src/analyzer/graph.rs
@@ -1321,10 +1321,10 @@ impl VisitAstPath for Analyzer<'_> {
 
             Pat::Array(arr) => {
                 match &value {
-                    Some(JsValue::Array(_, value)) => {
+                    Some(JsValue::Array { items, .. }) => {
                         ast_path.with(AstParentNodeRef::Pat(pat, PatField::Array), |ast_path| {
                             for (idx, elem) in arr.elems.iter().enumerate() {
-                                self.current_value = value.get(idx).cloned();
+                                self.current_value = items.get(idx).cloned();
                                 ast_path.with(
                                     AstParentNodeRef::ArrayPat(arr, ArrayPatField::Elems(idx)),
                                     |ast_path| {

--- a/crates/turbopack-ecmascript/src/analyzer/well_known.rs
+++ b/crates/turbopack-ecmascript/src/analyzer/well_known.rs
@@ -118,11 +118,17 @@ pub async fn well_known_function_call(
 }
 
 pub fn object_assign(args: Vec<JsValue>) -> JsValue {
-    if args.iter().all(|arg| matches!(arg, JsValue::Object(..))) {
+    if args.iter().all(|arg| matches!(arg, JsValue::Object { .. })) {
         if let Some(mut merged_object) = args.into_iter().reduce(|mut acc, cur| {
-            if let JsValue::Object(_, parts) = &mut acc {
-                if let JsValue::Object(_, next_parts) = &cur {
+            if let JsValue::Object { parts, mutable, .. } = &mut acc {
+                if let JsValue::Object {
+                    parts: next_parts,
+                    mutable: next_mutable,
+                    ..
+                } = &cur
+                {
                     parts.extend_from_slice(next_parts);
+                    *mutable |= *next_mutable;
                 }
             }
             acc

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/array-map/graph-effects.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/array-map/graph-effects.snapshot
@@ -1,8 +1,8 @@
 [
     Member {
-        obj: Array(
-            3,
-            [
+        obj: Array {
+            total_nodes: 3,
+            items: [
                 Constant(
                     StrWord(
                         Atom('../lib/a.js' type=dynamic),
@@ -14,7 +14,8 @@
                     ),
                 ),
             ],
-        ),
+            mutable: true,
+        },
         prop: Constant(
             StrWord(
                 Atom('map' type=static),
@@ -67,9 +68,9 @@
         },
     },
     MemberCall {
-        obj: Array(
-            3,
-            [
+        obj: Array {
+            total_nodes: 3,
+            items: [
                 Constant(
                     StrWord(
                         Atom('../lib/a.js' type=dynamic),
@@ -81,7 +82,8 @@
                     ),
                 ),
             ],
-        ),
+            mutable: true,
+        },
         prop: Constant(
             StrWord(
                 Atom('map' type=static),
@@ -182,9 +184,9 @@
         },
     },
     Member {
-        obj: Array(
-            3,
-            [
+        obj: Array {
+            total_nodes: 3,
+            items: [
                 Constant(
                     StrWord(
                         Atom('../lib/a.js' type=dynamic),
@@ -196,7 +198,8 @@
                     ),
                 ),
             ],
-        ),
+            mutable: true,
+        },
         prop: Constant(
             StrWord(
                 Atom('map' type=static),
@@ -249,9 +252,9 @@
         },
     },
     MemberCall {
-        obj: Array(
-            3,
-            [
+        obj: Array {
+            total_nodes: 3,
+            items: [
                 Constant(
                     StrWord(
                         Atom('../lib/a.js' type=dynamic),
@@ -263,7 +266,8 @@
                     ),
                 ),
             ],
-        ),
+            mutable: true,
+        },
         prop: Constant(
             StrWord(
                 Atom('map' type=static),
@@ -364,9 +368,9 @@
         },
     },
     Member {
-        obj: Array(
-            3,
-            [
+        obj: Array {
+            total_nodes: 3,
+            items: [
                 Constant(
                     StrWord(
                         Atom('../lib/a.js' type=dynamic),
@@ -378,7 +382,8 @@
                     ),
                 ),
             ],
-        ),
+            mutable: true,
+        },
         prop: Constant(
             StrWord(
                 Atom('map' type=static),
@@ -431,9 +436,9 @@
         },
     },
     MemberCall {
-        obj: Array(
-            3,
-            [
+        obj: Array {
+            total_nodes: 3,
+            items: [
                 Constant(
                     StrWord(
                         Atom('../lib/a.js' type=dynamic),
@@ -445,7 +450,8 @@
                     ),
                 ),
             ],
-        ),
+            mutable: true,
+        },
         prop: Constant(
             StrWord(
                 Atom('map' type=static),

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/array-map/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/array-map/graph.snapshot
@@ -10,9 +10,9 @@
                     Constant(
                         Undefined,
                     ),
-                    Array(
-                        2,
-                        [
+                    Array {
+                        total_nodes: 2,
+                        items: [
                             Variable(
                                 (
                                     Atom('file' type=static),
@@ -20,7 +20,8 @@
                                 ),
                             ),
                         ],
-                    ),
+                        mutable: true,
+                    },
                 ],
             ),
         ),
@@ -82,9 +83,9 @@
     ),
     (
         "a",
-        Array(
-            3,
-            [
+        Array {
+            total_nodes: 3,
+            items: [
                 Constant(
                     StrWord(
                         Atom('../lib/a.js' type=dynamic),
@@ -96,15 +97,16 @@
                     ),
                 ),
             ],
-        ),
+            mutable: true,
+        },
     ),
     (
         "b",
         MemberCall(
             6,
-            Array(
-                3,
-                [
+            Array {
+                total_nodes: 3,
+                items: [
                     Constant(
                         StrWord(
                             Atom('../lib/a.js' type=dynamic),
@@ -116,7 +118,8 @@
                         ),
                     ),
                 ],
-            ),
+                mutable: true,
+            },
             Constant(
                 StrWord(
                     Atom('map' type=static),
@@ -136,9 +139,9 @@
         "c",
         MemberCall(
             6,
-            Array(
-                3,
-                [
+            Array {
+                total_nodes: 3,
+                items: [
                     Constant(
                         StrWord(
                             Atom('../lib/a.js' type=dynamic),
@@ -150,7 +153,8 @@
                         ),
                     ),
                 ],
-            ),
+                mutable: true,
+            },
             Constant(
                 StrWord(
                     Atom('map' type=static),
@@ -170,9 +174,9 @@
         "d",
         MemberCall(
             6,
-            Array(
-                3,
-                [
+            Array {
+                total_nodes: 3,
+                items: [
                     Constant(
                         StrWord(
                             Atom('../lib/a.js' type=dynamic),
@@ -184,7 +188,8 @@
                         ),
                     ),
                 ],
-            ),
+                mutable: true,
+            },
             Constant(
                 StrWord(
                     Atom('map' type=static),

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/array/graph-effects.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/array/graph-effects.snapshot
@@ -1,8 +1,8 @@
 [
     Member {
-        obj: Array(
-            3,
-            [
+        obj: Array {
+            total_nodes: 3,
+            items: [
                 Constant(
                     Num(
                         ConstantNumber(
@@ -16,7 +16,8 @@
                     ),
                 ),
             ],
-        ),
+            mutable: true,
+        },
         prop: Member(
             3,
             FreeVar(

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/array/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/array/graph.snapshot
@@ -21,9 +21,9 @@
         "c",
         Member(
             7,
-            Array(
-                3,
-                [
+            Array {
+                total_nodes: 3,
+                items: [
                     Constant(
                         Num(
                             ConstantNumber(
@@ -37,7 +37,8 @@
                         ),
                     ),
                 ],
-            ),
+                mutable: true,
+            },
             Member(
                 3,
                 FreeVar(
@@ -55,9 +56,9 @@
     ),
     (
         "d1",
-        Array(
-            3,
-            [
+        Array {
+            total_nodes: 3,
+            items: [
                 Constant(
                     Num(
                         ConstantNumber(
@@ -71,7 +72,8 @@
                     ),
                 ),
             ],
-        ),
+            mutable: true,
+        },
     ),
     (
         "d2",

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/array/resolved-explained.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/array/resolved-explained.snapshot
@@ -20,7 +20,8 @@ d2 = (1 | "foo" | ???*0*)
 - *2* FreeVar(global)
   ⚠️  unknown global
 
-d3 = "foo"
+d3 = ("foo" | ???*0*)
+- *0* unknown mutation
 
 d4 = ???*0*
 - *0* [1, "foo"][2]

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/esbuild-reduced/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/esbuild-reduced/graph.snapshot
@@ -90,9 +90,9 @@
     ),
     (
         "knownWindowsPackages",
-        Object(
-            7,
-            [
+        Object {
+            total_nodes: 7,
+            parts: [
                 KeyValue(
                     Constant(
                         StrWord(
@@ -130,7 +130,8 @@
                     ),
                 ),
             ],
-        ),
+            mutable: true,
+        },
     ),
     (
         "path",
@@ -229,9 +230,9 @@
                     Constant(
                         Undefined,
                     ),
-                    Object(
-                        5,
-                        [
+                    Object {
+                        total_nodes: 5,
+                        parts: [
                             KeyValue(
                                 Constant(
                                     StrWord(
@@ -259,7 +260,8 @@
                                 ),
                             ),
                         ],
-                    ),
+                        mutable: true,
+                    },
                 ],
             ),
         ),

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/esbuild-reduced/resolved-effects.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/esbuild-reduced/resolved-effects.snapshot
@@ -7,7 +7,15 @@
 0 -> 4 call = (...) => (undefined | {"pkg": pkg, "subpath": subpath})()
 
 0 -> 6 member call = require*0*["resolve"](
-    `${(???*1* | ???*2* | "esbuild-windows-arm64" | "esbuild-windows-32" | "esbuild-windows-64" | ???*3*)}/${(???*5* | ???*6* | "esbuild.exe")}`
+    `${(
+          | ???*1*
+          | ???*2*
+          | "esbuild-windows-arm64"
+          | "esbuild-windows-32"
+          | "esbuild-windows-64"
+          | ???*3*
+          | ???*5*
+        )}/${(???*6* | ???*7* | "esbuild.exe" | ???*8*)}`
 )
 - *0* require: The require method from CommonJS
 - *1* undefined["pkg"]
@@ -18,9 +26,11 @@
   ⚠️  unknown object prototype methods or values
 - *4* FreeVar(platformKey)
   ⚠️  unknown global
-- *5* undefined["subpath"]
+- *5* unknown mutation
+- *6* undefined["subpath"]
   ⚠️  nested operation
-- *6* subpath
+- *7* subpath
   ⚠️  pattern without value
+- *8* unknown mutation
 
 0 -> 7 call = (...) => (undefined | binPath)()

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/esbuild-reduced/resolved-explained.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/esbuild-reduced/resolved-explained.snapshot
@@ -2,7 +2,15 @@ binPath = (???*0* | ???*1*)
 - *0* binPath
   ⚠️  pattern without value
 - *1* require.resolve*2*(
-        `${(???*3* | ???*4* | "esbuild-windows-arm64" | "esbuild-windows-32" | "esbuild-windows-64" | ???*5*)}/${(???*7* | ???*8* | "esbuild.exe")}`
+        `${(
+              | ???*3*
+              | ???*4*
+              | "esbuild-windows-arm64"
+              | "esbuild-windows-32"
+              | "esbuild-windows-64"
+              | ???*5*
+              | ???*7*
+            )}/${(???*8* | ???*9* | "esbuild.exe" | ???*10*)}`
     )
   ⚠️  resolve.resolve non constant
 - *2* require.resolve: The require.resolve method from CommonJS
@@ -14,10 +22,12 @@ binPath = (???*0* | ???*1*)
   ⚠️  unknown object prototype methods or values
 - *6* FreeVar(platformKey)
   ⚠️  unknown global
-- *7* undefined["subpath"]
+- *7* unknown mutation
+- *8* undefined["subpath"]
   ⚠️  nested operation
-- *8* subpath
+- *9* subpath
   ⚠️  pattern without value
+- *10* unknown mutation
 
 e = ???*0*
 - *0* e
@@ -52,6 +62,7 @@ pkg#4 = (
   | "esbuild-windows-32"
   | "esbuild-windows-64"
   | ???*1*
+  | ???*3*
 )
 - *0* pkg
   ⚠️  pattern without value
@@ -59,6 +70,7 @@ pkg#4 = (
   ⚠️  unknown object prototype methods or values
 - *2* FreeVar(platformKey)
   ⚠️  unknown global
+- *3* unknown mutation
 
 pkgAndSubpathForCurrentPlatform = (...) => (undefined | {"pkg": pkg, "subpath": subpath})
 
@@ -66,15 +78,24 @@ subpath#3 = (???*0* | "esbuild.exe")
 - *0* subpath
   ⚠️  pattern without value
 
-subpath#4 = (undefined["subpath"] | ???*0* | "esbuild.exe")
+subpath#4 = (undefined["subpath"] | ???*0* | "esbuild.exe" | ???*1*)
 - *0* subpath
   ⚠️  pattern without value
+- *1* unknown mutation
 
 x = (undefined | ???*0* | ???*1*)
 - *0* binPath
   ⚠️  pattern without value
 - *1* require.resolve*2*(
-        `${(???*3* | ???*4* | "esbuild-windows-arm64" | "esbuild-windows-32" | "esbuild-windows-64" | ???*5*)}/${(???*7* | ???*8* | "esbuild.exe")}`
+        `${(
+              | ???*3*
+              | ???*4*
+              | "esbuild-windows-arm64"
+              | "esbuild-windows-32"
+              | "esbuild-windows-64"
+              | ???*5*
+              | ???*7*
+            )}/${(???*8* | ???*9* | "esbuild.exe" | ???*10*)}`
     )
   ⚠️  resolve.resolve non constant
 - *2* require.resolve: The require.resolve method from CommonJS
@@ -86,7 +107,9 @@ x = (undefined | ???*0* | ???*1*)
   ⚠️  unknown object prototype methods or values
 - *6* FreeVar(platformKey)
   ⚠️  unknown global
-- *7* undefined["subpath"]
+- *7* unknown mutation
+- *8* undefined["subpath"]
   ⚠️  nested operation
-- *8* subpath
+- *9* subpath
   ⚠️  pattern without value
+- *10* unknown mutation

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/esbuild/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/esbuild/graph.snapshot
@@ -10,17 +10,17 @@
                     Constant(
                         Undefined,
                     ),
-                    Array(
-                        10,
-                        [
+                    Array {
+                        total_nodes: 10,
+                        items: [
                             Constant(
                                 StrWord(
                                     Atom('node' type=inline),
                                 ),
                             ),
-                            Array(
-                                8,
-                                [
+                            Array {
+                                total_nodes: 8,
+                                items: [
                                     MemberCall(
                                         7,
                                         Variable(
@@ -56,12 +56,14 @@
                                         ],
                                     ),
                                 ],
-                            ),
+                                mutable: true,
+                            },
                         ],
-                    ),
-                    Array(
-                        4,
-                        [
+                        mutable: true,
+                    },
+                    Array {
+                        total_nodes: 4,
+                        items: [
                             Call(
                                 2,
                                 Variable(
@@ -72,12 +74,14 @@
                                 ),
                                 [],
                             ),
-                            Array(
-                                1,
-                                [],
-                            ),
+                            Array {
+                                total_nodes: 1,
+                                items: [],
+                                mutable: true,
+                            },
                         ],
-                    ),
+                        mutable: true,
+                    },
                 ],
             ),
         ),
@@ -394,9 +398,9 @@
     ),
     (
         "knownUnixlikePackages",
-        Object(
-            31,
-            [
+        Object {
+            total_nodes: 31,
+            parts: [
                 KeyValue(
                     Constant(
                         StrWord(
@@ -578,13 +582,14 @@
                     ),
                 ),
             ],
-        ),
+            mutable: true,
+        },
     ),
     (
         "knownWindowsPackages",
-        Object(
-            7,
-            [
+        Object {
+            total_nodes: 7,
+            parts: [
                 KeyValue(
                     Constant(
                         StrWord(
@@ -622,7 +627,8 @@
                     ),
                 ),
             ],
-        ),
+            mutable: true,
+        },
     ),
     (
         "os",
@@ -753,9 +759,9 @@
                     Constant(
                         Undefined,
                     ),
-                    Object(
-                        5,
-                        [
+                    Object {
+                        total_nodes: 5,
+                        parts: [
                             KeyValue(
                                 Constant(
                                     StrWord(
@@ -783,7 +789,8 @@
                                 ),
                             ),
                         ],
-                    ),
+                        mutable: true,
+                    },
                 ],
             ),
         ),

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/esbuild/resolved-effects.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/esbuild/resolved-effects.snapshot
@@ -16,7 +16,7 @@
 0 -> 11 call = (...) => (undefined | {"pkg": pkg, "subpath": subpath})()
 
 0 -> 13 member call = require*0*["resolve"](
-    `${(???*1* | ???*2* | ???*3* | "esbuild-linux-64")}/${(???*4* | ???*5* | "esbuild.exe" | "bin/esbuild")}`
+    `${(???*1* | ???*2* | ???*3* | ???*4* | "esbuild-linux-64")}/${(???*5* | ???*6* | "esbuild.exe" | "bin/esbuild" | ???*7*)}`
 )
 - *0* require: The require method from CommonJS
 - *1* undefined["pkg"]
@@ -25,14 +25,16 @@
   ⚠️  pattern without value
 - *3* FreeVar(undefined)
   ⚠️  unknown global
-- *4* undefined["subpath"]
+- *4* unknown mutation
+- *5* undefined["subpath"]
   ⚠️  nested operation
-- *5* subpath
+- *6* subpath
   ⚠️  pattern without value
+- *7* unknown mutation
 
 0 -> 14 call = ???*0*(
-    (undefined["pkg"] | ???*1* | ???*2* | "esbuild-linux-64"),
-    (undefined["subpath"] | ???*3* | "esbuild.exe" | "bin/esbuild")
+    (undefined["pkg"] | ???*1* | ???*2* | ???*3* | "esbuild-linux-64"),
+    (undefined["subpath"] | ???*4* | "esbuild.exe" | "bin/esbuild" | ???*5*)
 )
 - *0* FreeVar(downloadedBinPath)
   ⚠️  unknown global
@@ -40,16 +42,18 @@
   ⚠️  pattern without value
 - *2* FreeVar(undefined)
   ⚠️  unknown global
-- *3* subpath
+- *3* unknown mutation
+- *4* subpath
   ⚠️  pattern without value
+- *5* unknown mutation
 
-0 -> 16 member call = ???*0*["existsSync"]((???*1* | ???*2* | ???*9*))
+0 -> 16 member call = ???*0*["existsSync"]((???*1* | ???*2* | ???*11*))
 - *0* FreeVar(fs)
   ⚠️  unknown global
 - *1* binPath
   ⚠️  pattern without value
 - *2* require.resolve*3*(
-        `${(???*4* | ???*5* | ???*6* | "esbuild-linux-64")}/${(???*7* | ???*8* | "esbuild.exe" | "bin/esbuild")}`
+        `${(???*4* | ???*5* | ???*6* | ???*7* | "esbuild-linux-64")}/${(???*8* | ???*9* | "esbuild.exe" | "bin/esbuild" | ???*10*)}`
     )
   ⚠️  resolve.resolve non constant
 - *3* require.resolve: The require.resolve method from CommonJS
@@ -59,13 +63,15 @@
   ⚠️  pattern without value
 - *6* FreeVar(undefined)
   ⚠️  unknown global
-- *7* undefined["subpath"]
+- *7* unknown mutation
+- *8* undefined["subpath"]
   ⚠️  nested operation
-- *8* subpath
+- *9* subpath
   ⚠️  pattern without value
-- *9* ???*10*(pkg, subpath)
+- *10* unknown mutation
+- *11* ???*12*(pkg, subpath)
   ⚠️  unknown callee
-- *10* FreeVar(downloadedBinPath)
+- *12* FreeVar(downloadedBinPath)
   ⚠️  unknown global
 
 0 -> 17 conditional = !(???*0*)
@@ -75,13 +81,14 @@
   ⚠️  unknown global
 
 17 -> 19 member call = require*0*["resolve"](
-    (undefined["pkg"] | ???*1* | ???*2* | "esbuild-linux-64")
+    (undefined["pkg"] | ???*1* | ???*2* | ???*3* | "esbuild-linux-64")
 )
 - *0* require: The require method from CommonJS
 - *1* pkg
   ⚠️  pattern without value
 - *2* FreeVar(undefined)
   ⚠️  unknown global
+- *3* unknown mutation
 
 0 -> 20 call = require*0*("pnpapi")
 - *0* require: The require method from CommonJS
@@ -95,15 +102,16 @@
 - *0* path: The Node.js path module: https://nodejs.org/api/path.html
 
 21 -> 28 member call = path*0*["basename"](
-    (undefined["subpath"] | ???*1* | "esbuild.exe" | "bin/esbuild")
+    (undefined["subpath"] | ???*1* | "esbuild.exe" | "bin/esbuild" | ???*2*)
 )
 - *0* path: The Node.js path module: https://nodejs.org/api/path.html
 - *1* subpath
   ⚠️  pattern without value
+- *2* unknown mutation
 
 21 -> 29 member call = path*0*["join"](
     ""esbuild"/resolved/lib",
-    `pnpapi-${(???*1* | ???*2* | ???*3* | "esbuild-linux-64")}-${???*4*}`
+    `pnpapi-${(???*1* | ???*2* | ???*3* | ???*4* | "esbuild-linux-64")}-${???*5*}`
 )
 - *0* path: The Node.js path module: https://nodejs.org/api/path.html
 - *1* undefined["pkg"]
@@ -112,18 +120,20 @@
   ⚠️  pattern without value
 - *3* FreeVar(undefined)
   ⚠️  unknown global
-- *4* ???*5*(
-        (undefined["subpath"] | ???*7* | "esbuild.exe" | "bin/esbuild")
+- *4* unknown mutation
+- *5* ???*6*(
+        (undefined["subpath"] | ???*8* | "esbuild.exe" | "bin/esbuild" | ???*9*)
     )
   ⚠️  unknown callee
-- *5* path*6*["basename"]
+- *6* path*7*["basename"]
   ⚠️  unsupported property on Node.js path module
-- *6* path: The Node.js path module: https://nodejs.org/api/path.html
-- *7* subpath
+- *7* path: The Node.js path module: https://nodejs.org/api/path.html
+- *8* subpath
   ⚠️  pattern without value
+- *9* unknown mutation
 
 21 -> 31 member call = ???*0*["existsSync"](
-    `"esbuild"/resolved/lib${("/" | "")}pnpapi-${(???*1* | ???*2* | ???*3* | "esbuild-linux-64")}-${???*4*}`
+    `"esbuild"/resolved/lib${("/" | "")}pnpapi-${(???*1* | ???*2* | ???*3* | ???*4* | "esbuild-linux-64")}-${???*5*}`
 )
 - *0* FreeVar(fs)
   ⚠️  unknown global
@@ -133,15 +143,17 @@
   ⚠️  pattern without value
 - *3* FreeVar(undefined)
   ⚠️  unknown global
-- *4* ???*5*(
-        (undefined["subpath"] | ???*7* | "esbuild.exe" | "bin/esbuild")
+- *4* unknown mutation
+- *5* ???*6*(
+        (undefined["subpath"] | ???*8* | "esbuild.exe" | "bin/esbuild" | ???*9*)
     )
   ⚠️  unknown callee
-- *5* path*6*["basename"]
+- *6* path*7*["basename"]
   ⚠️  unsupported property on Node.js path module
-- *6* path: The Node.js path module: https://nodejs.org/api/path.html
-- *7* subpath
+- *7* path: The Node.js path module: https://nodejs.org/api/path.html
+- *8* subpath
   ⚠️  pattern without value
+- *9* unknown mutation
 
 21 -> 32 conditional = !(???*0*)
 - *0* ???*1*["existsSync"](binTargetPath)
@@ -150,15 +162,15 @@
   ⚠️  unknown global
 
 32 -> 34 member call = ???*0*["copyFileSync"](
-    (???*1* | ???*2* | ???*9*),
-    `"esbuild"/resolved/lib${("/" | "")}pnpapi-${(???*11* | ???*12* | ???*13* | "esbuild-linux-64")}-${???*14*}`
+    (???*1* | ???*2* | ???*11*),
+    `"esbuild"/resolved/lib${("/" | "")}pnpapi-${(???*13* | ???*14* | ???*15* | ???*16* | "esbuild-linux-64")}-${???*17*}`
 )
 - *0* FreeVar(fs)
   ⚠️  unknown global
 - *1* binPath
   ⚠️  pattern without value
 - *2* require.resolve*3*(
-        `${(???*4* | ???*5* | ???*6* | "esbuild-linux-64")}/${(???*7* | ???*8* | "esbuild.exe" | "bin/esbuild")}`
+        `${(???*4* | ???*5* | ???*6* | ???*7* | "esbuild-linux-64")}/${(???*8* | ???*9* | "esbuild.exe" | "bin/esbuild" | ???*10*)}`
     )
   ⚠️  resolve.resolve non constant
 - *3* require.resolve: The require.resolve method from CommonJS
@@ -168,32 +180,36 @@
   ⚠️  pattern without value
 - *6* FreeVar(undefined)
   ⚠️  unknown global
-- *7* undefined["subpath"]
+- *7* unknown mutation
+- *8* undefined["subpath"]
   ⚠️  nested operation
-- *8* subpath
+- *9* subpath
   ⚠️  pattern without value
-- *9* ???*10*(pkg, subpath)
+- *10* unknown mutation
+- *11* ???*12*(pkg, subpath)
   ⚠️  unknown callee
-- *10* FreeVar(downloadedBinPath)
+- *12* FreeVar(downloadedBinPath)
   ⚠️  unknown global
-- *11* undefined["pkg"]
+- *13* undefined["pkg"]
   ⚠️  nested operation
-- *12* pkg
+- *14* pkg
   ⚠️  pattern without value
-- *13* FreeVar(undefined)
+- *15* FreeVar(undefined)
   ⚠️  unknown global
-- *14* ???*15*(
-        (undefined["subpath"] | ???*17* | "esbuild.exe" | "bin/esbuild")
+- *16* unknown mutation
+- *17* ???*18*(
+        (undefined["subpath"] | ???*20* | "esbuild.exe" | "bin/esbuild" | ???*21*)
     )
   ⚠️  unknown callee
-- *15* path*16*["basename"]
+- *18* path*19*["basename"]
   ⚠️  unsupported property on Node.js path module
-- *16* path: The Node.js path module: https://nodejs.org/api/path.html
-- *17* subpath
+- *19* path: The Node.js path module: https://nodejs.org/api/path.html
+- *20* subpath
   ⚠️  pattern without value
+- *21* unknown mutation
 
 32 -> 36 member call = ???*0*["chmodSync"](
-    `"esbuild"/resolved/lib${("/" | "")}pnpapi-${(???*1* | ???*2* | ???*3* | "esbuild-linux-64")}-${???*4*}`,
+    `"esbuild"/resolved/lib${("/" | "")}pnpapi-${(???*1* | ???*2* | ???*3* | ???*4* | "esbuild-linux-64")}-${???*5*}`,
     493
 )
 - *0* FreeVar(fs)
@@ -204,15 +220,17 @@
   ⚠️  pattern without value
 - *3* FreeVar(undefined)
   ⚠️  unknown global
-- *4* ???*5*(
-        (undefined["subpath"] | ???*7* | "esbuild.exe" | "bin/esbuild")
+- *4* unknown mutation
+- *5* ???*6*(
+        (undefined["subpath"] | ???*8* | "esbuild.exe" | "bin/esbuild" | ???*9*)
     )
   ⚠️  unknown callee
-- *5* path*6*["basename"]
+- *6* path*7*["basename"]
   ⚠️  unsupported property on Node.js path module
-- *6* path: The Node.js path module: https://nodejs.org/api/path.html
-- *7* subpath
+- *7* path: The Node.js path module: https://nodejs.org/api/path.html
+- *8* subpath
   ⚠️  pattern without value
+- *9* unknown mutation
 
 0 -> 38 member call = path*0*["basename"]("__filename")
 - *0* path: The Node.js path module: https://nodejs.org/api/path.html

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/esbuild/resolved-explained.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/esbuild/resolved-explained.snapshot
@@ -12,11 +12,11 @@
 args = ???*0*
 - *0* max number of linking steps reached
 
-binPath = (???*0* | ???*1* | ???*8*)
+binPath = (???*0* | ???*1* | ???*10*)
 - *0* binPath
   ⚠️  pattern without value
 - *1* require.resolve*2*(
-        `${(???*3* | ???*4* | ???*5* | "esbuild-linux-64")}/${(???*6* | ???*7* | "esbuild.exe" | "bin/esbuild")}`
+        `${(???*3* | ???*4* | ???*5* | ???*6* | "esbuild-linux-64")}/${(???*7* | ???*8* | "esbuild.exe" | "bin/esbuild" | ???*9*)}`
     )
   ⚠️  resolve.resolve non constant
 - *2* require.resolve: The require.resolve method from CommonJS
@@ -26,31 +26,35 @@ binPath = (???*0* | ???*1* | ???*8*)
   ⚠️  pattern without value
 - *5* FreeVar(undefined)
   ⚠️  unknown global
-- *6* undefined["subpath"]
+- *6* unknown mutation
+- *7* undefined["subpath"]
   ⚠️  nested operation
-- *7* subpath
+- *8* subpath
   ⚠️  pattern without value
-- *8* ???*9*(pkg, subpath)
+- *9* unknown mutation
+- *10* ???*11*(pkg, subpath)
   ⚠️  unknown callee
-- *9* FreeVar(downloadedBinPath)
+- *11* FreeVar(downloadedBinPath)
   ⚠️  unknown global
 
-binTargetPath = `"esbuild"/resolved/lib${("/" | "")}pnpapi-${(???*0* | ???*1* | ???*2* | "esbuild-linux-64")}-${???*3*}`
+binTargetPath = `"esbuild"/resolved/lib${("/" | "")}pnpapi-${(???*0* | ???*1* | ???*2* | ???*3* | "esbuild-linux-64")}-${???*4*}`
 - *0* undefined["pkg"]
   ⚠️  nested operation
 - *1* pkg
   ⚠️  pattern without value
 - *2* FreeVar(undefined)
   ⚠️  unknown global
-- *3* ???*4*(
-        (undefined["subpath"] | ???*6* | "esbuild.exe" | "bin/esbuild")
+- *3* unknown mutation
+- *4* ???*5*(
+        (undefined["subpath"] | ???*7* | "esbuild.exe" | "bin/esbuild" | ???*8*)
     )
   ⚠️  unknown callee
-- *4* path*5*["basename"]
+- *5* path*6*["basename"]
   ⚠️  unsupported property on Node.js path module
-- *5* path: The Node.js path module: https://nodejs.org/api/path.html
-- *6* subpath
+- *6* path: The Node.js path module: https://nodejs.org/api/path.html
+- *7* subpath
   ⚠️  pattern without value
+- *8* unknown mutation
 
 command = ???*0*
 - *0* max number of linking steps reached
@@ -113,17 +117,19 @@ path = path*0*
 path2 = path*0*
 - *0* path: The Node.js path module: https://nodejs.org/api/path.html
 
-pkg#3 = (???*0* | ???*1* | "esbuild-linux-64")
+pkg#3 = (???*0* | ???*1* | ???*2* | "esbuild-linux-64")
 - *0* pkg
   ⚠️  pattern without value
 - *1* FreeVar(undefined)
   ⚠️  unknown global
+- *2* unknown mutation
 
-pkg#4 = (undefined["pkg"] | ???*0* | ???*1* | "esbuild-linux-64")
+pkg#4 = (undefined["pkg"] | ???*0* | ???*1* | ???*2* | "esbuild-linux-64")
 - *0* pkg
   ⚠️  pattern without value
 - *1* FreeVar(undefined)
   ⚠️  unknown global
+- *2* unknown mutation
 
 pkgAndSubpathForCurrentPlatform = (...) => (undefined | {"pkg": pkg, "subpath": subpath})
 
@@ -133,9 +139,10 @@ subpath#3 = (???*0* | "esbuild.exe" | "bin/esbuild")
 - *0* subpath
   ⚠️  pattern without value
 
-subpath#4 = (undefined["subpath"] | ???*0* | "esbuild.exe" | "bin/esbuild")
+subpath#4 = (undefined["subpath"] | ???*0* | "esbuild.exe" | "bin/esbuild" | ???*1*)
 - *0* subpath
   ⚠️  pattern without value
+- *1* unknown mutation
 
 x = ???*0*
 - *0* max number of linking steps reached

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/fn-array-2/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/fn-array-2/graph.snapshot
@@ -24,9 +24,9 @@
                     Constant(
                         Undefined,
                     ),
-                    Array(
-                        5,
-                        [
+                    Array {
+                        total_nodes: 5,
+                        items: [
                             Concat(
                                 3,
                                 [
@@ -51,7 +51,8 @@
                                 ),
                             ),
                         ],
-                    ),
+                        mutable: true,
+                    },
                 ],
             ),
         ),

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/fn-array-2/resolved-explained.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/fn-array-2/resolved-explained.snapshot
@@ -10,9 +10,11 @@ c = (...) => (undefined | [`${a}${x}`, a])
 
 d = (undefined | ["12", "1"])
 
-e = (undefined[0] | "12")
+e = (undefined[0] | "12" | ???*0*)
+- *0* unknown mutation
 
-f = (undefined[1] | "1")
+f = (undefined[1] | "1" | ???*0*)
+- *0* unknown mutation
 
 x = ???*0*
 - *0* arguments[1]

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/fn-array/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/fn-array/graph.snapshot
@@ -24,9 +24,9 @@
                     Constant(
                         Undefined,
                     ),
-                    Array(
-                        5,
-                        [
+                    Array {
+                        total_nodes: 5,
+                        items: [
                             Concat(
                                 3,
                                 [
@@ -51,7 +51,8 @@
                                 ),
                             ),
                         ],
-                    ),
+                        mutable: true,
+                    },
                 ],
             ),
         ),

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/fn-array/resolved-explained.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/fn-array/resolved-explained.snapshot
@@ -10,6 +10,8 @@ c = (...) => (undefined | [`${a}${b}`, a])
 
 d = (undefined | ["12", "1"])
 
-e = (undefined[0] | "12")
+e = (undefined[0] | "12" | ???*0*)
+- *0* unknown mutation
 
-f = (undefined[1] | "1")
+f = (undefined[1] | "1" | ???*0*)
+- *0* unknown mutation

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/md5-reduced/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/md5-reduced/graph.snapshot
@@ -1606,9 +1606,9 @@
                     Constant(
                         Undefined,
                     ),
-                    Array(
-                        5,
-                        [
+                    Array {
+                        total_nodes: 5,
+                        items: [
                             Variable(
                                 (
                                     Atom('a' type=static),
@@ -1634,7 +1634,8 @@
                                 ),
                             ),
                         ],
-                    ),
+                        mutable: true,
+                    },
                 ],
             ),
         ),

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/md5_2/graph-effects.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/md5_2/graph-effects.snapshot
@@ -27663,9 +27663,9 @@
         ),
         args: [
             Value(
-                Array(
-                    5,
-                    [
+                Array {
+                    total_nodes: 5,
+                    items: [
                         Variable(
                             (
                                 Atom('a' type=static),
@@ -27691,7 +27691,8 @@
                             ),
                         ),
                     ],
-                ),
+                    mutable: true,
+                },
             ),
         ],
         ast_path: [

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/md5_2/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/md5_2/graph.snapshot
@@ -24,9 +24,9 @@
                             ),
                         ),
                         [
-                            Array(
-                                5,
-                                [
+                            Array {
+                                total_nodes: 5,
+                                items: [
                                     Variable(
                                         (
                                             Atom('a' type=static),
@@ -52,7 +52,8 @@
                                         ),
                                     ),
                                 ],
-                            ),
+                                mutable: true,
+                            },
                         ],
                     ),
                 ],

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/member-call/graph-effects.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/member-call/graph-effects.snapshot
@@ -149,9 +149,9 @@
                 ),
             ),
             Value(
-                Array(
-                    4,
-                    [
+                Array {
+                    total_nodes: 4,
+                    items: [
                         Constant(
                             Num(
                                 ConstantNumber(
@@ -174,7 +174,8 @@
                             ),
                         ),
                     ],
-                ),
+                    mutable: true,
+                },
             ),
             Value(
                 Concat(
@@ -235,12 +236,12 @@
     Member {
         obj: Member(
             7,
-            Array(
-                5,
-                [
-                    Array(
-                        4,
-                        [
+            Array {
+                total_nodes: 5,
+                items: [
+                    Array {
+                        total_nodes: 4,
+                        items: [
                             Constant(
                                 Num(
                                     ConstantNumber(
@@ -263,9 +264,11 @@
                                 ),
                             ),
                         ],
-                    ),
+                        mutable: true,
+                    },
                 ],
-            ),
+                mutable: true,
+            },
             Constant(
                 Num(
                     ConstantNumber(
@@ -326,12 +329,12 @@
         },
     },
     Member {
-        obj: Array(
-            5,
-            [
-                Array(
-                    4,
-                    [
+        obj: Array {
+            total_nodes: 5,
+            items: [
+                Array {
+                    total_nodes: 4,
+                    items: [
                         Constant(
                             Num(
                                 ConstantNumber(
@@ -354,9 +357,11 @@
                             ),
                         ),
                     ],
-                ),
+                    mutable: true,
+                },
             ],
-        ),
+            mutable: true,
+        },
         prop: Constant(
             Num(
                 ConstantNumber(
@@ -419,12 +424,12 @@
     MemberCall {
         obj: Member(
             7,
-            Array(
-                5,
-                [
-                    Array(
-                        4,
-                        [
+            Array {
+                total_nodes: 5,
+                items: [
+                    Array {
+                        total_nodes: 4,
+                        items: [
                             Constant(
                                 Num(
                                     ConstantNumber(
@@ -447,9 +452,11 @@
                                 ),
                             ),
                         ],
-                    ),
+                        mutable: true,
+                    },
                 ],
-            ),
+                mutable: true,
+            },
             Constant(
                 Num(
                     ConstantNumber(
@@ -465,9 +472,9 @@
         ),
         args: [
             Value(
-                Array(
-                    5,
-                    [
+                Array {
+                    total_nodes: 5,
+                    items: [
                         Constant(
                             Num(
                                 ConstantNumber(
@@ -495,7 +502,8 @@
                             ),
                         ),
                     ],
-                ),
+                    mutable: true,
+                },
             ),
         ],
         ast_path: [
@@ -538,12 +546,12 @@
     Member {
         obj: Member(
             7,
-            Array(
-                5,
-                [
-                    Array(
-                        4,
-                        [
+            Array {
+                total_nodes: 5,
+                items: [
+                    Array {
+                        total_nodes: 4,
+                        items: [
                             Constant(
                                 Num(
                                     ConstantNumber(
@@ -566,9 +574,11 @@
                                 ),
                             ),
                         ],
-                    ),
+                        mutable: true,
+                    },
                 ],
-            ),
+                mutable: true,
+            },
             Constant(
                 Num(
                     ConstantNumber(
@@ -629,12 +639,12 @@
         },
     },
     Member {
-        obj: Array(
-            5,
-            [
-                Array(
-                    4,
-                    [
+        obj: Array {
+            total_nodes: 5,
+            items: [
+                Array {
+                    total_nodes: 4,
+                    items: [
                         Constant(
                             Num(
                                 ConstantNumber(
@@ -657,9 +667,11 @@
                             ),
                         ),
                     ],
-                ),
+                    mutable: true,
+                },
             ],
-        ),
+            mutable: true,
+        },
         prop: Constant(
             Num(
                 ConstantNumber(
@@ -722,12 +734,12 @@
     MemberCall {
         obj: Member(
             7,
-            Array(
-                5,
-                [
-                    Array(
-                        4,
-                        [
+            Array {
+                total_nodes: 5,
+                items: [
+                    Array {
+                        total_nodes: 4,
+                        items: [
                             Constant(
                                 Num(
                                     ConstantNumber(
@@ -750,9 +762,11 @@
                                 ),
                             ),
                         ],
-                    ),
+                        mutable: true,
+                    },
                 ],
-            ),
+                mutable: true,
+            },
             Constant(
                 Num(
                     ConstantNumber(
@@ -962,9 +976,9 @@
         ),
         args: [
             Value(
-                Array(
-                    4,
-                    [
+                Array {
+                    total_nodes: 4,
+                    items: [
                         Constant(
                             Num(
                                 ConstantNumber(
@@ -987,7 +1001,8 @@
                             ),
                         ),
                     ],
-                ),
+                    mutable: true,
+                },
             ),
         ],
         ast_path: [

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/member-call/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/member-call/graph.snapshot
@@ -1,9 +1,9 @@
 [
     (
         "array",
-        Array(
-            4,
-            [
+        Array {
+            total_nodes: 4,
+            items: [
                 Constant(
                     Num(
                         ConstantNumber(
@@ -26,16 +26,17 @@
                     ),
                 ),
             ],
-        ),
+            mutable: true,
+        },
     ),
     (
         "arrays",
         Alternatives(
             9,
             [
-                Array(
-                    4,
-                    [
+                Array {
+                    total_nodes: 4,
+                    items: [
                         Constant(
                             Num(
                                 ConstantNumber(
@@ -58,10 +59,11 @@
                             ),
                         ),
                     ],
-                ),
-                Array(
-                    4,
-                    [
+                    mutable: true,
+                },
+                Array {
+                    total_nodes: 4,
+                    items: [
                         Constant(
                             Num(
                                 ConstantNumber(
@@ -84,7 +86,8 @@
                             ),
                         ),
                     ],
-                ),
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -125,9 +128,9 @@
                         ),
                     ),
                 ),
-                Array(
-                    4,
-                    [
+                Array {
+                    total_nodes: 4,
+                    items: [
                         Constant(
                             Num(
                                 ConstantNumber(
@@ -150,7 +153,8 @@
                             ),
                         ),
                     ],
-                ),
+                    mutable: true,
+                },
                 Concat(
                     3,
                     [
@@ -186,9 +190,9 @@
                 ),
             ),
             [
-                Array(
-                    4,
-                    [
+                Array {
+                    total_nodes: 4,
+                    items: [
                         Constant(
                             Num(
                                 ConstantNumber(
@@ -211,7 +215,8 @@
                             ),
                         ),
                     ],
-                ),
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -259,12 +264,12 @@
             14,
             Member(
                 7,
-                Array(
-                    5,
-                    [
-                        Array(
-                            4,
-                            [
+                Array {
+                    total_nodes: 5,
+                    items: [
+                        Array {
+                            total_nodes: 4,
+                            items: [
                                 Constant(
                                     Num(
                                         ConstantNumber(
@@ -287,9 +292,11 @@
                                     ),
                                 ),
                             ],
-                        ),
+                            mutable: true,
+                        },
                     ],
-                ),
+                    mutable: true,
+                },
                 Constant(
                     Num(
                         ConstantNumber(
@@ -304,9 +311,9 @@
                 ),
             ),
             [
-                Array(
-                    5,
-                    [
+                Array {
+                    total_nodes: 5,
+                    items: [
                         Constant(
                             Num(
                                 ConstantNumber(
@@ -334,7 +341,8 @@
                             ),
                         ),
                     ],
-                ),
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -344,12 +352,12 @@
             13,
             Member(
                 7,
-                Array(
-                    5,
-                    [
-                        Array(
-                            4,
-                            [
+                Array {
+                    total_nodes: 5,
+                    items: [
+                        Array {
+                            total_nodes: 4,
+                            items: [
                                 Constant(
                                     Num(
                                         ConstantNumber(
@@ -372,9 +380,11 @@
                                     ),
                                 ),
                             ],
-                        ),
+                            mutable: true,
+                        },
                     ],
-                ),
+                    mutable: true,
+                },
                 Constant(
                     Num(
                         ConstantNumber(

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/member-call/resolved-effects.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/member-call/resolved-effects.snapshot
@@ -1,11 +1,14 @@
-0 -> 3 member call = [1, 2, 3]["concat"](4, 5, 6, [7, 8, 9], `hello ${2}`)
+0 -> 3 member call = [1, 2, 3]["concat"](4, 5, 6, [7, 8, 9], `hello ${(2 | ???*0*)}`)
+- *0* unknown mutation
 
-0 -> 6 member call = [1, 2, 3]["concat"]([4, 5, 6, ???*0*])
-- *0* FreeVar(unknown)
+0 -> 6 member call = ([1, 2, 3] | ???*0*)["concat"]([4, 5, 6, ???*1*])
+- *0* unknown mutation
+- *1* FreeVar(unknown)
   ⚠️  unknown global
 
-0 -> 9 member call = [1, 2, 3]["concat"](4, 5, 6, ???*0*)
-- *0* FreeVar(unknown)
+0 -> 9 member call = ([1, 2, 3] | ???*0*)["concat"](4, 5, 6, ???*1*)
+- *0* unknown mutation
+- *1* FreeVar(unknown)
   ⚠️  unknown global
 
 0 -> 12 member call = [1, 2, 3]["concat"]([7, 8, 9])

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/member-call/resolved-explained.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/member-call/resolved-explained.snapshot
@@ -2,22 +2,35 @@ array = [1, 2, 3]
 
 arrays = ([1, 2, 3] | [4, 5, 6])
 
-concatenated_array = [1, 2, 3, 4, 5, 6, 7, 8, 9, `hello ${2}`]
+concatenated_array = [1, 2, 3, 4, 5, 6, 7, 8, 9, `hello ${(2 | ???*0*)}`]
+- *0* unknown mutation
 
 concatenated_array_options = [1, 2, 3, 7, 8, 9]
 
-item = 2
+item = (2 | ???*0*)
+- *0* unknown mutation
 
-item_options = (2 | 5)
+item_options = (2 | ???*0* | 5)
+- *0* unknown mutation
 
-pick_array1 = [1, 2, 3, 4, 5, 6, ???*0*]
+pick_array1 = ([1, 2, 3, 4, 5, 6, ???*0*] | ???*1*)
 - *0* FreeVar(unknown)
   ⚠️  unknown global
+- *1* ???*2*["concat"]([4, 5, 6, ???*3*])
+  ⚠️  unknown callee object
+- *2* unknown mutation
+- *3* FreeVar(unknown)
+  ⚠️  unknown global
 
-pick_array2 = ???*0*
+pick_array2 = (???*0* | ???*3*)
 - *0* ???*1*(4, 5, 6, ???*2*)
   ⚠️  unknown callee
 - *1* [1, 2, 3]["concat"]
   ⚠️  non-num constant property on array
 - *2* FreeVar(unknown)
+  ⚠️  unknown global
+- *3* ???*4*["concat"](4, 5, 6, ???*5*)
+  ⚠️  unknown callee object
+- *4* unknown mutation
+- *5* FreeVar(unknown)
   ⚠️  unknown global

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/object/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/object/graph.snapshot
@@ -477,9 +477,9 @@
     ),
     (
         "object",
-        Object(
-            7,
-            [
+        Object {
+            total_nodes: 7,
+            parts: [
                 KeyValue(
                     Constant(
                         StrWord(
@@ -523,13 +523,14 @@
                     ),
                 ),
             ],
-        ),
+            mutable: true,
+        },
     ),
     (
         "object2",
-        Object(
-            11,
-            [
+        Object {
+            total_nodes: 11,
+            parts: [
                 KeyValue(
                     Constant(
                         StrWord(
@@ -601,13 +602,14 @@
                     ),
                 ),
             ],
-        ),
+            mutable: true,
+        },
     ),
     (
         "object_spread",
-        Object(
-            6,
-            [
+        Object {
+            total_nodes: 6,
+            parts: [
                 KeyValue(
                     Constant(
                         StrWord(
@@ -645,13 +647,14 @@
                     ),
                 ),
             ],
-        ),
+            mutable: true,
+        },
     ),
     (
         "unknown_spread",
-        Object(
-            6,
-            [
+        Object {
+            total_nodes: 6,
+            parts: [
                 KeyValue(
                     Constant(
                         StrWord(
@@ -688,6 +691,7 @@
                     ),
                 ),
             ],
-        ),
+            mutable: true,
+        },
     ),
 ]

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/object/resolved-explained.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/object/resolved-explained.snapshot
@@ -1,12 +1,17 @@
-a = 1
+a = (1 | ???*0*)
+- *0* unknown mutation
 
-a1 = 1
+a1 = (1 | ???*0*)
+- *0* unknown mutation
 
-a2 = 1
+a2 = (1 | ???*0*)
+- *0* unknown mutation
 
-a3 = 1
+a3 = (1 | ???*0*)
+- *0* unknown mutation
 
-a4 = 1
+a4 = (1 | ???*0*)
+- *0* unknown mutation
 
 a5 = ???*0*
 - *0* {"a": 1, ...???*1*, "b": 2}["a"]
@@ -14,33 +19,46 @@ a5 = ???*0*
 - *1* FreeVar(global)
   ⚠️  unknown global
 
-a6 = (1 | 2 | 4)
+a6 = (1 | 2 | 4 | ???*0*)
+- *0* unknown mutation
 
-b = 2
+b = (2 | ???*0*)
+- *0* unknown mutation
 
-b1 = 2
+b1 = (2 | ???*0*)
+- *0* unknown mutation
 
-b2 = 2
+b2 = (2 | ???*0*)
+- *0* unknown mutation
 
-b3 = 22
+b3 = (22 | ???*0*)
+- *0* unknown mutation
 
-b4 = 2
+b4 = (2 | ???*0*)
+- *0* unknown mutation
 
-b5 = 2
+b5 = (2 | ???*0*)
+- *0* unknown mutation
 
-b6 = (2 | 4 | ???*0*)
+b6 = (2 | 4 | ???*0* | ???*1*)
 - *0* {}["b"]
   ⚠️  unknown object prototype methods or values
+- *1* unknown mutation
 
-c = 3
+c = (3 | ???*0*)
+- *0* unknown mutation
 
-c1 = 3
+c1 = (3 | ???*0*)
+- *0* unknown mutation
 
-c2 = 3
+c2 = (3 | ???*0*)
+- *0* unknown mutation
 
-c3 = 3
+c3 = (3 | ???*0*)
+- *0* unknown mutation
 
-c4 = 3
+c4 = (3 | ???*0*)
+- *0* unknown mutation
 
 c5 = ???*0*
 - *0* {"a": 1, ...???*1*, "b": 2}["c"]
@@ -48,33 +66,41 @@ c5 = ???*0*
 - *1* FreeVar(global)
   ⚠️  unknown global
 
-c6 = (3 | 4)
+c6 = (3 | 4 | ???*0*)
+- *0* unknown mutation
 
-d = ???*0*
+d = (???*0* | ???*1*)
 - *0* FreeVar(undefined)
   ⚠️  unknown global
+- *1* unknown mutation
 
-d1 = ???*0*
+d1 = (???*0* | ???*1*)
 - *0* FreeVar(undefined)
   ⚠️  unknown global
+- *1* unknown mutation
 
-d2 = ???*0*
+d2 = (???*0* | ???*1*)
 - *0* FreeVar(undefined)
   ⚠️  unknown global
+- *1* unknown mutation
 
-d3 = ???*0*
+d3 = (???*0* | ???*1*)
 - *0* FreeVar(undefined)
   ⚠️  unknown global
+- *1* unknown mutation
 
-d4 = ???*0*
+d4 = (???*0* | ???*1*)
 - *0* FreeVar(undefined)
   ⚠️  unknown global
+- *1* unknown mutation
 
-d6 = (2 | 4 | ???*0*)
+d6 = (2 | 4 | ???*0* | ???*1*)
 - *0* {}["d"]
   ⚠️  unknown object prototype methods or values
+- *1* unknown mutation
 
-e6 = 5
+e6 = (5 | ???*0*)
+- *0* unknown mutation
 
 object = {"a": 1, "b": 2, "c": 3}
 

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/peg/graph-effects.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/peg/graph-effects.snapshot
@@ -18574,12 +18574,12 @@
         ),
         args: [
             Value(
-                Array(
-                    4,
-                    [
-                        Array(
-                            3,
-                            [
+                Array {
+                    total_nodes: 4,
+                    items: [
+                        Array {
+                            total_nodes: 3,
+                            items: [
                                 Constant(
                                     StrWord(
                                         Atom('0' type=inline),
@@ -18591,9 +18591,11 @@
                                     ),
                                 ),
                             ],
-                        ),
+                            mutable: true,
+                        },
                     ],
-                ),
+                    mutable: true,
+                },
             ),
             Value(
                 Constant(
@@ -19518,9 +19520,9 @@
         ),
         args: [
             Value(
-                Array(
-                    5,
-                    [
+                Array {
+                    total_nodes: 5,
+                    items: [
                         Constant(
                             StrWord(
                                 Atom(' ' type=inline),
@@ -19543,7 +19545,8 @@
                             ),
                         ),
                     ],
-                ),
+                    mutable: true,
+                },
             ),
             Value(
                 Constant(
@@ -19694,9 +19697,9 @@
         ),
         args: [
             Value(
-                Array(
-                    3,
-                    [
+                Array {
+                    total_nodes: 3,
+                    items: [
                         Constant(
                             StrWord(
                                 Atom('
@@ -19709,7 +19712,8 @@
                             ),
                         ),
                     ],
-                ),
+                    mutable: true,
+                },
             ),
             Value(
                 Constant(
@@ -21435,12 +21439,12 @@
         ),
         args: [
             Value(
-                Array(
-                    8,
-                    [
-                        Array(
-                            3,
-                            [
+                Array {
+                    total_nodes: 8,
+                    items: [
+                        Array {
+                            total_nodes: 3,
+                            items: [
                                 Constant(
                                     StrWord(
                                         Atom('a' type=static),
@@ -21452,10 +21456,11 @@
                                     ),
                                 ),
                             ],
-                        ),
-                        Array(
-                            3,
-                            [
+                            mutable: true,
+                        },
+                        Array {
+                            total_nodes: 3,
+                            items: [
                                 Constant(
                                     StrWord(
                                         Atom('A' type=inline),
@@ -21467,14 +21472,16 @@
                                     ),
                                 ),
                             ],
-                        ),
+                            mutable: true,
+                        },
                         Constant(
                             StrWord(
                                 Atom('_' type=inline),
                             ),
                         ),
                     ],
-                ),
+                    mutable: true,
+                },
             ),
             Value(
                 Constant(
@@ -21550,12 +21557,12 @@
         ),
         args: [
             Value(
-                Array(
-                    11,
-                    [
-                        Array(
-                            3,
-                            [
+                Array {
+                    total_nodes: 11,
+                    items: [
+                        Array {
+                            total_nodes: 3,
+                            items: [
                                 Constant(
                                     StrWord(
                                         Atom('a' type=static),
@@ -21567,10 +21574,11 @@
                                     ),
                                 ),
                             ],
-                        ),
-                        Array(
-                            3,
-                            [
+                            mutable: true,
+                        },
+                        Array {
+                            total_nodes: 3,
+                            items: [
                                 Constant(
                                     StrWord(
                                         Atom('A' type=inline),
@@ -21582,10 +21590,11 @@
                                     ),
                                 ),
                             ],
-                        ),
-                        Array(
-                            3,
-                            [
+                            mutable: true,
+                        },
+                        Array {
+                            total_nodes: 3,
+                            items: [
                                 Constant(
                                     StrWord(
                                         Atom('0' type=inline),
@@ -21597,14 +21606,16 @@
                                     ),
                                 ),
                             ],
-                        ),
+                            mutable: true,
+                        },
                         Constant(
                             StrWord(
                                 Atom('_' type=inline),
                             ),
                         ),
                     ],
-                ),
+                    mutable: true,
+                },
             ),
             Value(
                 Constant(
@@ -23273,12 +23284,12 @@
         ),
         args: [
             Value(
-                Array(
-                    7,
-                    [
-                        Array(
-                            3,
-                            [
+                Array {
+                    total_nodes: 7,
+                    items: [
+                        Array {
+                            total_nodes: 3,
+                            items: [
                                 Constant(
                                     StrWord(
                                         Atom('0' type=inline),
@@ -23290,10 +23301,11 @@
                                     ),
                                 ),
                             ],
-                        ),
-                        Array(
-                            3,
-                            [
+                            mutable: true,
+                        },
+                        Array {
+                            total_nodes: 3,
+                            items: [
                                 Constant(
                                     StrWord(
                                         Atom('a' type=static),
@@ -23305,9 +23317,11 @@
                                     ),
                                 ),
                             ],
-                        ),
+                            mutable: true,
+                        },
                     ],
-                ),
+                    mutable: true,
+                },
             ),
             Value(
                 Constant(
@@ -26854,9 +26868,9 @@
         ),
         args: [
             Value(
-                Array(
-                    4,
-                    [
+                Array {
+                    total_nodes: 4,
+                    items: [
                         Call(
                             3,
                             Variable(
@@ -26875,7 +26889,8 @@
                             ],
                         ),
                     ],
-                ),
+                    mutable: true,
+                },
             ),
             Value(
                 MemberCall(

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/peg/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/peg/graph.snapshot
@@ -50,9 +50,9 @@
                     Constant(
                         Undefined,
                     ),
-                    Object(
-                        5,
-                        [
+                    Object {
+                        total_nodes: 5,
+                        parts: [
                             KeyValue(
                                 Constant(
                                     StrWord(
@@ -79,7 +79,8 @@
                                 ),
                             ),
                         ],
-                    ),
+                        mutable: true,
+                    },
                 ],
             ),
         ),
@@ -142,9 +143,9 @@
                     Constant(
                         Undefined,
                     ),
-                    Object(
-                        6,
-                        [
+                    Object {
+                        total_nodes: 6,
+                        parts: [
                             KeyValue(
                                 Constant(
                                     StrWord(
@@ -175,7 +176,8 @@
                                 ),
                             ),
                         ],
-                    ),
+                        mutable: true,
+                    },
                 ],
             ),
         ),
@@ -457,9 +459,9 @@
                     Constant(
                         Undefined,
                     ),
-                    Object(
-                        5,
-                        [
+                    Object {
+                        total_nodes: 5,
+                        parts: [
                             KeyValue(
                                 Constant(
                                     StrWord(
@@ -487,7 +489,8 @@
                                 ),
                             ),
                         ],
-                    ),
+                        mutable: true,
+                    },
                 ],
             ),
         ),
@@ -524,9 +527,9 @@
                     Constant(
                         Undefined,
                     ),
-                    Object(
-                        5,
-                        [
+                    Object {
+                        total_nodes: 5,
+                        parts: [
                             KeyValue(
                                 Constant(
                                     StrWord(
@@ -553,7 +556,8 @@
                                 ),
                             ),
                         ],
-                    ),
+                        mutable: true,
+                    },
                 ],
             ),
         ),
@@ -569,9 +573,9 @@
                     Constant(
                         Undefined,
                     ),
-                    Object(
-                        5,
-                        [
+                    Object {
+                        total_nodes: 5,
+                        parts: [
                             KeyValue(
                                 Constant(
                                     StrWord(
@@ -598,7 +602,8 @@
                                 ),
                             ),
                         ],
-                    ),
+                        mutable: true,
+                    },
                 ],
             ),
         ),
@@ -614,9 +619,9 @@
                     Constant(
                         Undefined,
                     ),
-                    Object(
-                        5,
-                        [
+                    Object {
+                        total_nodes: 5,
+                        parts: [
                             KeyValue(
                                 Constant(
                                     StrWord(
@@ -643,7 +648,8 @@
                                 ),
                             ),
                         ],
-                    ),
+                        mutable: true,
+                    },
                 ],
             ),
         ),
@@ -679,9 +685,9 @@
                     Constant(
                         Undefined,
                     ),
-                    Object(
-                        5,
-                        [
+                    Object {
+                        total_nodes: 5,
+                        parts: [
                             KeyValue(
                                 Constant(
                                     StrWord(
@@ -706,7 +712,8 @@
                                 ),
                             ),
                         ],
-                    ),
+                        mutable: true,
+                    },
                 ],
             ),
         ),
@@ -722,9 +729,9 @@
                     Constant(
                         Undefined,
                     ),
-                    Object(
-                        5,
-                        [
+                    Object {
+                        total_nodes: 5,
+                        parts: [
                             KeyValue(
                                 Constant(
                                     StrWord(
@@ -749,7 +756,8 @@
                                 ),
                             ),
                         ],
-                    ),
+                        mutable: true,
+                    },
                 ],
             ),
         ),
@@ -808,9 +816,9 @@
                     Constant(
                         Undefined,
                     ),
-                    Object(
-                        7,
-                        [
+                    Object {
+                        total_nodes: 7,
+                        parts: [
                             KeyValue(
                                 Constant(
                                     StrWord(
@@ -850,7 +858,8 @@
                                 ),
                             ),
                         ],
-                    ),
+                        mutable: true,
+                    },
                 ],
             ),
         ),
@@ -895,9 +904,9 @@
                     Constant(
                         Undefined,
                     ),
-                    Object(
-                        9,
-                        [
+                    Object {
+                        total_nodes: 9,
+                        parts: [
                             KeyValue(
                                 Constant(
                                     StrWord(
@@ -950,7 +959,8 @@
                                 ),
                             ),
                         ],
-                    ),
+                        mutable: true,
+                    },
                 ],
             ),
         ),
@@ -1004,9 +1014,9 @@
                     Constant(
                         Undefined,
                     ),
-                    Object(
-                        7,
-                        [
+                    Object {
+                        total_nodes: 7,
+                        parts: [
                             KeyValue(
                                 Constant(
                                     StrWord(
@@ -1046,7 +1056,8 @@
                                 ),
                             ),
                         ],
-                    ),
+                        mutable: true,
+                    },
                 ],
             ),
         ),
@@ -1062,9 +1073,9 @@
                     Constant(
                         Undefined,
                     ),
-                    Object(
-                        9,
-                        [
+                    Object {
+                        total_nodes: 9,
+                        parts: [
                             KeyValue(
                                 Constant(
                                     StrWord(
@@ -1117,7 +1128,8 @@
                                 ),
                             ),
                         ],
-                    ),
+                        mutable: true,
+                    },
                 ],
             ),
         ),
@@ -1133,9 +1145,9 @@
                     Constant(
                         Undefined,
                     ),
-                    Object(
-                        5,
-                        [
+                    Object {
+                        total_nodes: 5,
+                        parts: [
                             KeyValue(
                                 Constant(
                                     StrWord(
@@ -1163,7 +1175,8 @@
                                 ),
                             ),
                         ],
-                    ),
+                        mutable: true,
+                    },
                 ],
             ),
         ),
@@ -1179,9 +1192,9 @@
                     Constant(
                         Undefined,
                     ),
-                    Object(
-                        5,
-                        [
+                    Object {
+                        total_nodes: 5,
+                        parts: [
                             KeyValue(
                                 Constant(
                                     StrWord(
@@ -1208,7 +1221,8 @@
                                 ),
                             ),
                         ],
-                    ),
+                        mutable: true,
+                    },
                 ],
             ),
         ),
@@ -1267,9 +1281,9 @@
                     Constant(
                         Undefined,
                     ),
-                    Object(
-                        5,
-                        [
+                    Object {
+                        total_nodes: 5,
+                        parts: [
                             KeyValue(
                                 Constant(
                                     StrWord(
@@ -1296,7 +1310,8 @@
                                 ),
                             ),
                         ],
-                    ),
+                        mutable: true,
+                    },
                 ],
             ),
         ),
@@ -1312,9 +1327,9 @@
                     Constant(
                         Undefined,
                     ),
-                    Object(
-                        5,
-                        [
+                    Object {
+                        total_nodes: 5,
+                        parts: [
                             KeyValue(
                                 Constant(
                                     StrWord(
@@ -1341,7 +1356,8 @@
                                 ),
                             ),
                         ],
-                    ),
+                        mutable: true,
+                    },
                 ],
             ),
         ),
@@ -1357,9 +1373,9 @@
                     Constant(
                         Undefined,
                     ),
-                    Object(
-                        8,
-                        [
+                    Object {
+                        total_nodes: 8,
+                        parts: [
                             KeyValue(
                                 Constant(
                                     StrWord(
@@ -1400,7 +1416,8 @@
                                 ),
                             ),
                         ],
-                    ),
+                        mutable: true,
+                    },
                 ],
             ),
         ),
@@ -1420,10 +1437,11 @@
                         None,
                         "spread is not supported",
                     ),
-                    Array(
-                        1,
-                        [],
-                    ),
+                    Array {
+                        total_nodes: 1,
+                        items: [],
+                        mutable: true,
+                    },
                 ],
             ),
         ),
@@ -1628,9 +1646,9 @@
                     Constant(
                         Undefined,
                     ),
-                    Object(
-                        5,
-                        [
+                    Object {
+                        total_nodes: 5,
+                        parts: [
                             KeyValue(
                                 Constant(
                                     StrWord(
@@ -1657,7 +1675,8 @@
                                 ),
                             ),
                         ],
-                    ),
+                        mutable: true,
+                    },
                 ],
             ),
         ),
@@ -1757,9 +1776,9 @@
                     Constant(
                         Undefined,
                     ),
-                    Object(
-                        13,
-                        [
+                    Object {
+                        total_nodes: 13,
+                        parts: [
                             KeyValue(
                                 Constant(
                                     StrWord(
@@ -1838,7 +1857,8 @@
                                 ),
                             ),
                         ],
-                    ),
+                        mutable: true,
+                    },
                 ],
             ),
         ),
@@ -1854,9 +1874,9 @@
                     Constant(
                         Undefined,
                     ),
-                    Object(
-                        5,
-                        [
+                    Object {
+                        total_nodes: 5,
+                        parts: [
                             KeyValue(
                                 Constant(
                                     StrWord(
@@ -1880,7 +1900,8 @@
                                 ),
                             ),
                         ],
-                    ),
+                        mutable: true,
+                    },
                 ],
             ),
         ),
@@ -1896,9 +1917,9 @@
                     Constant(
                         Undefined,
                     ),
-                    Object(
-                        5,
-                        [
+                    Object {
+                        total_nodes: 5,
+                        parts: [
                             KeyValue(
                                 Constant(
                                     StrWord(
@@ -1925,7 +1946,8 @@
                                 ),
                             ),
                         ],
-                    ),
+                        mutable: true,
+                    },
                 ],
             ),
         ),
@@ -1941,9 +1963,9 @@
                     Constant(
                         Undefined,
                     ),
-                    Object(
-                        5,
-                        [
+                    Object {
+                        total_nodes: 5,
+                        parts: [
                             KeyValue(
                                 Constant(
                                     StrWord(
@@ -1970,7 +1992,8 @@
                                 ),
                             ),
                         ],
-                    ),
+                        mutable: true,
+                    },
                 ],
             ),
         ),
@@ -2007,9 +2030,9 @@
                     Constant(
                         Undefined,
                     ),
-                    Object(
-                        5,
-                        [
+                    Object {
+                        total_nodes: 5,
+                        parts: [
                             KeyValue(
                                 Constant(
                                     StrWord(
@@ -2034,7 +2057,8 @@
                                 ),
                             ),
                         ],
-                    ),
+                        mutable: true,
+                    },
                 ],
             ),
         ),
@@ -2071,9 +2095,9 @@
                     Constant(
                         Undefined,
                     ),
-                    Object(
-                        7,
-                        [
+                    Object {
+                        total_nodes: 7,
+                        parts: [
                             KeyValue(
                                 Constant(
                                     StrWord(
@@ -2113,7 +2137,8 @@
                                 ),
                             ),
                         ],
-                    ),
+                        mutable: true,
+                    },
                 ],
             ),
         ),
@@ -2129,9 +2154,9 @@
                     Constant(
                         Undefined,
                     ),
-                    Object(
-                        9,
-                        [
+                    Object {
+                        total_nodes: 9,
+                        parts: [
                             KeyValue(
                                 Constant(
                                     StrWord(
@@ -2181,7 +2206,8 @@
                                 ),
                             ),
                         ],
-                    ),
+                        mutable: true,
+                    },
                 ],
             ),
         ),
@@ -2218,9 +2244,9 @@
                     Constant(
                         Undefined,
                     ),
-                    Object(
-                        7,
-                        [
+                    Object {
+                        total_nodes: 7,
+                        parts: [
                             KeyValue(
                                 Constant(
                                     StrWord(
@@ -2260,7 +2286,8 @@
                                 ),
                             ),
                         ],
-                    ),
+                        mutable: true,
+                    },
                 ],
             ),
         ),
@@ -2276,9 +2303,9 @@
                     Constant(
                         Undefined,
                     ),
-                    Object(
-                        5,
-                        [
+                    Object {
+                        total_nodes: 5,
+                        parts: [
                             KeyValue(
                                 Constant(
                                     StrWord(
@@ -2305,7 +2332,8 @@
                                 ),
                             ),
                         ],
-                    ),
+                        mutable: true,
+                    },
                 ],
             ),
         ),
@@ -2321,9 +2349,9 @@
                     Constant(
                         Undefined,
                     ),
-                    Object(
-                        5,
-                        [
+                    Object {
+                        total_nodes: 5,
+                        parts: [
                             KeyValue(
                                 Constant(
                                     StrWord(
@@ -2348,7 +2376,8 @@
                                 ),
                             ),
                         ],
-                    ),
+                        mutable: true,
+                    },
                 ],
             ),
         ),
@@ -2364,9 +2393,9 @@
                     Constant(
                         Undefined,
                     ),
-                    Object(
-                        7,
-                        [
+                    Object {
+                        total_nodes: 7,
+                        parts: [
                             KeyValue(
                                 Constant(
                                     StrWord(
@@ -2406,7 +2435,8 @@
                                 ),
                             ),
                         ],
-                    ),
+                        mutable: true,
+                    },
                 ],
             ),
         ),
@@ -2491,9 +2521,9 @@
                     Constant(
                         Undefined,
                     ),
-                    Object(
-                        9,
-                        [
+                    Object {
+                        total_nodes: 9,
+                        parts: [
                             KeyValue(
                                 Constant(
                                     StrWord(
@@ -2543,7 +2573,8 @@
                                 ),
                             ),
                         ],
-                    ),
+                        mutable: true,
+                    },
                 ],
             ),
         ),
@@ -2559,9 +2590,9 @@
                     Constant(
                         Undefined,
                     ),
-                    Object(
-                        7,
-                        [
+                    Object {
+                        total_nodes: 7,
+                        parts: [
                             KeyValue(
                                 Constant(
                                     StrWord(
@@ -2601,7 +2632,8 @@
                                 ),
                             ),
                         ],
-                    ),
+                        mutable: true,
+                    },
                 ],
             ),
         ),
@@ -2617,9 +2649,9 @@
                     Constant(
                         Undefined,
                     ),
-                    Object(
-                        7,
-                        [
+                    Object {
+                        total_nodes: 7,
+                        parts: [
                             KeyValue(
                                 Constant(
                                     StrWord(
@@ -2645,15 +2677,17 @@
                                             None,
                                             "spread is not supported",
                                         ),
-                                        Array(
-                                            1,
-                                            [],
-                                        ),
+                                        Array {
+                                            total_nodes: 1,
+                                            items: [],
+                                            mutable: true,
+                                        },
                                     ],
                                 ),
                             ),
                         ],
-                    ),
+                        mutable: true,
+                    },
                 ],
             ),
         ),
@@ -2724,9 +2758,9 @@
                     Constant(
                         Undefined,
                     ),
-                    Object(
-                        5,
-                        [
+                    Object {
+                        total_nodes: 5,
+                        parts: [
                             KeyValue(
                                 Constant(
                                     StrWord(
@@ -2753,7 +2787,8 @@
                                 ),
                             ),
                         ],
-                    ),
+                        mutable: true,
+                    },
                 ],
             ),
         ),
@@ -2769,9 +2804,9 @@
                     Constant(
                         Undefined,
                     ),
-                    Object(
-                        3,
-                        [
+                    Object {
+                        total_nodes: 3,
+                        parts: [
                             KeyValue(
                                 Constant(
                                     StrWord(
@@ -2785,7 +2820,8 @@
                                 ),
                             ),
                         ],
-                    ),
+                        mutable: true,
+                    },
                 ],
             ),
         ),
@@ -2801,9 +2837,9 @@
                     Constant(
                         Undefined,
                     ),
-                    Object(
-                        3,
-                        [
+                    Object {
+                        total_nodes: 3,
+                        parts: [
                             KeyValue(
                                 Constant(
                                     StrWord(
@@ -2817,7 +2853,8 @@
                                 ),
                             ),
                         ],
-                    ),
+                        mutable: true,
+                    },
                 ],
             ),
         ),
@@ -2833,9 +2870,9 @@
                     Constant(
                         Undefined,
                     ),
-                    Object(
-                        5,
-                        [
+                    Object {
+                        total_nodes: 5,
+                        parts: [
                             KeyValue(
                                 Constant(
                                     StrWord(
@@ -2859,7 +2896,8 @@
                                 ),
                             ),
                         ],
-                    ),
+                        mutable: true,
+                    },
                 ],
             ),
         ),
@@ -2875,9 +2913,9 @@
                     Constant(
                         Undefined,
                     ),
-                    Object(
-                        5,
-                        [
+                    Object {
+                        total_nodes: 5,
+                        parts: [
                             KeyValue(
                                 Constant(
                                     StrWord(
@@ -2901,7 +2939,8 @@
                                 ),
                             ),
                         ],
-                    ),
+                        mutable: true,
+                    },
                 ],
             ),
         ),
@@ -2917,9 +2956,9 @@
                     Constant(
                         Undefined,
                     ),
-                    Object(
-                        14,
-                        [
+                    Object {
+                        total_nodes: 14,
+                        parts: [
                             KeyValue(
                                 Constant(
                                     StrWord(
@@ -2992,7 +3031,8 @@
                                 ),
                             ),
                         ],
-                    ),
+                        mutable: true,
+                    },
                 ],
             ),
         ),
@@ -3059,9 +3099,9 @@
                     Constant(
                         Undefined,
                     ),
-                    Object(
-                        8,
-                        [
+                    Object {
+                        total_nodes: 8,
+                        parts: [
                             KeyValue(
                                 Constant(
                                     StrWord(
@@ -3103,7 +3143,8 @@
                                 ),
                             ),
                         ],
-                    ),
+                        mutable: true,
+                    },
                 ],
             ),
         ),
@@ -3119,9 +3160,9 @@
                     Constant(
                         Undefined,
                     ),
-                    Object(
-                        5,
-                        [
+                    Object {
+                        total_nodes: 5,
+                        parts: [
                             KeyValue(
                                 Constant(
                                     StrWord(
@@ -3146,7 +3187,8 @@
                                 ),
                             ),
                         ],
-                    ),
+                        mutable: true,
+                    },
                 ],
             ),
         ),
@@ -3162,9 +3204,9 @@
                     Constant(
                         Undefined,
                     ),
-                    Object(
-                        5,
-                        [
+                    Object {
+                        total_nodes: 5,
+                        parts: [
                             KeyValue(
                                 Constant(
                                     StrWord(
@@ -3189,7 +3231,8 @@
                                 ),
                             ),
                         ],
-                    ),
+                        mutable: true,
+                    },
                 ],
             ),
         ),
@@ -3259,9 +3302,9 @@
         Function(
             10,
             13694,
-            Object(
-                9,
-                [
+            Object {
+                total_nodes: 9,
+                parts: [
                     KeyValue(
                         Constant(
                             StrWord(
@@ -3314,7 +3357,8 @@
                         ),
                     ),
                 ],
-            ),
+                mutable: true,
+            },
         ),
     ),
     (
@@ -3322,9 +3366,9 @@
         Function(
             10,
             16259,
-            Object(
-                9,
-                [
+            Object {
+                total_nodes: 9,
+                parts: [
                     KeyValue(
                         Constant(
                             StrWord(
@@ -3377,7 +3421,8 @@
                         ),
                     ),
                 ],
-            ),
+                mutable: true,
+            },
         ),
     ),
     (
@@ -3385,9 +3430,9 @@
         Function(
             10,
             169161,
-            Object(
-                9,
-                [
+            Object {
+                total_nodes: 9,
+                parts: [
                     KeyValue(
                         Constant(
                             StrWord(
@@ -3440,14 +3485,15 @@
                         ),
                     ),
                 ],
-            ),
+                mutable: true,
+            },
         ),
     ),
     (
         "DESCRIBE_EXPECTATION_FNS",
-        Object(
-            11,
-            [
+        Object {
+            total_nodes: 11,
+            parts: [
                 KeyValue(
                     Constant(
                         StrWord(
@@ -3514,7 +3560,8 @@
                     ),
                 ),
             ],
-        ),
+            mutable: true,
+        },
     ),
     (
         "alias#34",
@@ -4220,9 +4267,9 @@
                         ),
                     ),
                 ),
-                Object(
-                    9,
-                    [
+                Object {
+                    total_nodes: 9,
+                    parts: [
                         KeyValue(
                             Constant(
                                 StrWord(
@@ -4266,7 +4313,8 @@
                             ),
                         ),
                     ],
-                ),
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -5297,10 +5345,11 @@
                         #21,
                     ),
                 ),
-                Object(
-                    1,
-                    [],
-                ),
+                Object {
+                    total_nodes: 1,
+                    parts: [],
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -5357,10 +5406,11 @@
     ),
     (
         "peg$FAILED",
-        Object(
-            1,
-            [],
-        ),
+        Object {
+            total_nodes: 1,
+            parts: [],
+            mutable: true,
+        },
     ),
     (
         "peg$SyntaxError",
@@ -5383,9 +5433,9 @@
                     Constant(
                         Undefined,
                     ),
-                    Object(
-                        3,
-                        [
+                    Object {
+                        total_nodes: 3,
+                        parts: [
                             KeyValue(
                                 Constant(
                                     StrWord(
@@ -5399,7 +5449,8 @@
                                 ),
                             ),
                         ],
-                    ),
+                        mutable: true,
+                    },
                 ],
             ),
         ),
@@ -5747,12 +5798,12 @@
                 ),
             ),
             [
-                Array(
-                    8,
-                    [
-                        Array(
-                            3,
-                            [
+                Array {
+                    total_nodes: 8,
+                    items: [
+                        Array {
+                            total_nodes: 3,
+                            items: [
                                 Constant(
                                     StrWord(
                                         Atom('a' type=static),
@@ -5764,10 +5815,11 @@
                                     ),
                                 ),
                             ],
-                        ),
-                        Array(
-                            3,
-                            [
+                            mutable: true,
+                        },
+                        Array {
+                            total_nodes: 3,
+                            items: [
                                 Constant(
                                     StrWord(
                                         Atom('A' type=inline),
@@ -5779,14 +5831,16 @@
                                     ),
                                 ),
                             ],
-                        ),
+                            mutable: true,
+                        },
                         Constant(
                             StrWord(
                                 Atom('_' type=inline),
                             ),
                         ),
                     ],
-                ),
+                    mutable: true,
+                },
                 Constant(
                     False,
                 ),
@@ -5838,12 +5892,12 @@
                 ),
             ),
             [
-                Array(
-                    11,
-                    [
-                        Array(
-                            3,
-                            [
+                Array {
+                    total_nodes: 11,
+                    items: [
+                        Array {
+                            total_nodes: 3,
+                            items: [
                                 Constant(
                                     StrWord(
                                         Atom('a' type=static),
@@ -5855,10 +5909,11 @@
                                     ),
                                 ),
                             ],
-                        ),
-                        Array(
-                            3,
-                            [
+                            mutable: true,
+                        },
+                        Array {
+                            total_nodes: 3,
+                            items: [
                                 Constant(
                                     StrWord(
                                         Atom('A' type=inline),
@@ -5870,10 +5925,11 @@
                                     ),
                                 ),
                             ],
-                        ),
-                        Array(
-                            3,
-                            [
+                            mutable: true,
+                        },
+                        Array {
+                            total_nodes: 3,
+                            items: [
                                 Constant(
                                     StrWord(
                                         Atom('0' type=inline),
@@ -5885,14 +5941,16 @@
                                     ),
                                 ),
                             ],
-                        ),
+                            mutable: true,
+                        },
                         Constant(
                             StrWord(
                                 Atom('_' type=inline),
                             ),
                         ),
                     ],
-                ),
+                    mutable: true,
+                },
                 Constant(
                     False,
                 ),
@@ -6361,12 +6419,12 @@
                 ),
             ),
             [
-                Array(
-                    7,
-                    [
-                        Array(
-                            3,
-                            [
+                Array {
+                    total_nodes: 7,
+                    items: [
+                        Array {
+                            total_nodes: 3,
+                            items: [
                                 Constant(
                                     StrWord(
                                         Atom('0' type=inline),
@@ -6378,10 +6436,11 @@
                                     ),
                                 ),
                             ],
-                        ),
-                        Array(
-                            3,
-                            [
+                            mutable: true,
+                        },
+                        Array {
+                            total_nodes: 3,
+                            items: [
                                 Constant(
                                     StrWord(
                                         Atom('a' type=static),
@@ -6393,9 +6452,11 @@
                                     ),
                                 ),
                             ],
-                        ),
+                            mutable: true,
+                        },
                     ],
-                ),
+                    mutable: true,
+                },
                 Constant(
                     False,
                 ),
@@ -7664,12 +7725,12 @@
                 ),
             ),
             [
-                Array(
-                    4,
-                    [
-                        Array(
-                            3,
-                            [
+                Array {
+                    total_nodes: 4,
+                    items: [
+                        Array {
+                            total_nodes: 3,
+                            items: [
                                 Constant(
                                     StrWord(
                                         Atom('0' type=inline),
@@ -7681,9 +7742,11 @@
                                     ),
                                 ),
                             ],
-                        ),
+                            mutable: true,
+                        },
                     ],
-                ),
+                    mutable: true,
+                },
                 Constant(
                     False,
                 ),
@@ -7817,9 +7880,9 @@
                 ),
             ),
             [
-                Array(
-                    5,
-                    [
+                Array {
+                    total_nodes: 5,
+                    items: [
                         Constant(
                             StrWord(
                                 Atom(' ' type=inline),
@@ -7842,7 +7905,8 @@
                             ),
                         ),
                     ],
-                ),
+                    mutable: true,
+                },
                 Constant(
                     False,
                 ),
@@ -7902,9 +7966,9 @@
                 ),
             ),
             [
-                Array(
-                    3,
-                    [
+                Array {
+                    total_nodes: 3,
+                    items: [
                         Constant(
                             StrWord(
                                 Atom('
@@ -7917,7 +7981,8 @@
                             ),
                         ),
                     ],
-                ),
+                    mutable: true,
+                },
                 Constant(
                     False,
                 ),
@@ -8442,9 +8507,9 @@
                     Constant(
                         Undefined,
                     ),
-                    Object(
-                        9,
-                        [
+                    Object {
+                        total_nodes: 9,
+                        parts: [
                             KeyValue(
                                 Constant(
                                     StrWord(
@@ -8497,7 +8562,8 @@
                                 ),
                             ),
                         ],
-                    ),
+                        mutable: true,
+                    },
                 ],
             ),
         ),
@@ -8513,18 +8579,18 @@
                     Constant(
                         Undefined,
                     ),
-                    Object(
-                        25,
-                        [
+                    Object {
+                        total_nodes: 25,
+                        parts: [
                             KeyValue(
                                 Constant(
                                     StrWord(
                                         Atom('start' type=static),
                                     ),
                                 ),
-                                Object(
-                                    11,
-                                    [
+                                Object {
+                                    total_nodes: 11,
+                                    parts: [
                                         KeyValue(
                                             Constant(
                                                 StrWord(
@@ -8581,7 +8647,8 @@
                                             ),
                                         ),
                                     ],
-                                ),
+                                    mutable: true,
+                                },
                             ),
                             KeyValue(
                                 Constant(
@@ -8589,9 +8656,9 @@
                                         Atom('end' type=static),
                                     ),
                                 ),
-                                Object(
-                                    11,
-                                    [
+                                Object {
+                                    total_nodes: 11,
+                                    parts: [
                                         KeyValue(
                                             Constant(
                                                 StrWord(
@@ -8648,10 +8715,12 @@
                                             ),
                                         ),
                                     ],
-                                ),
+                                    mutable: true,
+                                },
                             ),
                         ],
-                    ),
+                        mutable: true,
+                    },
                 ],
             ),
         ),
@@ -9465,9 +9534,9 @@
                     Constant(
                         Undefined,
                     ),
-                    Object(
-                        3,
-                        [
+                    Object {
+                        total_nodes: 3,
+                        parts: [
                             KeyValue(
                                 Constant(
                                     StrWord(
@@ -9481,7 +9550,8 @@
                                 ),
                             ),
                         ],
-                    ),
+                        mutable: true,
+                    },
                 ],
             ),
         ),
@@ -9517,9 +9587,9 @@
                     Constant(
                         Undefined,
                     ),
-                    Object(
-                        7,
-                        [
+                    Object {
+                        total_nodes: 7,
+                        parts: [
                             KeyValue(
                                 Constant(
                                     StrWord(
@@ -9559,17 +9629,19 @@
                                 ),
                             ),
                         ],
-                    ),
+                        mutable: true,
+                    },
                 ],
             ),
         ),
     ),
     (
         "peg$maxFailExpected",
-        Array(
-            1,
-            [],
-        ),
+        Array {
+            total_nodes: 1,
+            items: [],
+            mutable: true,
+        },
     ),
     (
         "peg$maxFailPos",
@@ -9603,9 +9675,9 @@
                     Constant(
                         Undefined,
                     ),
-                    Object(
-                        5,
-                        [
+                    Object {
+                        total_nodes: 5,
+                        parts: [
                             KeyValue(
                                 Constant(
                                     StrWord(
@@ -9632,7 +9704,8 @@
                                 ),
                             ),
                         ],
-                    ),
+                        mutable: true,
+                    },
                 ],
             ),
         ),
@@ -11592,12 +11665,12 @@
     ),
     (
         "peg$posDetailsCache",
-        Array(
-            6,
-            [
-                Object(
-                    5,
-                    [
+        Array {
+            total_nodes: 6,
+            items: [
+                Object {
+                    total_nodes: 5,
+                    parts: [
                         KeyValue(
                             Constant(
                                 StrWord(
@@ -11627,9 +11700,11 @@
                             ),
                         ),
                     ],
-                ),
+                    mutable: true,
+                },
             ],
-        ),
+            mutable: true,
+        },
     ),
     (
         "peg$result",
@@ -12186,9 +12261,9 @@
     ),
     (
         "peg$startRuleFunctions",
-        Object(
-            3,
-            [
+        Object {
+            total_nodes: 3,
+            parts: [
                 KeyValue(
                     Constant(
                         StrWord(
@@ -12203,7 +12278,8 @@
                     ),
                 ),
             ],
-        ),
+            mutable: true,
+        },
     ),
     (
         "peg$subclass",
@@ -12511,10 +12587,11 @@
                     ),
                     "pattern without value",
                 ),
-                Array(
-                    1,
-                    [],
-                ),
+                Array {
+                    total_nodes: 1,
+                    items: [],
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -16469,9 +16546,9 @@
                         #21,
                     ),
                 ),
-                Array(
-                    3,
-                    [
+                Array {
+                    total_nodes: 3,
+                    items: [
                         Variable(
                             (
                                 Atom('s1' type=inline),
@@ -16485,7 +16562,8 @@
                             ),
                         ),
                     ],
-                ),
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -16540,9 +16618,9 @@
                         #21,
                     ),
                 ),
-                Array(
-                    3,
-                    [
+                Array {
+                    total_nodes: 3,
+                    items: [
                         Variable(
                             (
                                 Atom('s1' type=inline),
@@ -16556,7 +16634,8 @@
                             ),
                         ),
                     ],
-                ),
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -16611,9 +16690,9 @@
                         #21,
                     ),
                 ),
-                Array(
-                    3,
-                    [
+                Array {
+                    total_nodes: 3,
+                    items: [
                         Variable(
                             (
                                 Atom('s1' type=inline),
@@ -16627,7 +16706,8 @@
                             ),
                         ),
                     ],
-                ),
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -16682,9 +16762,9 @@
                         #21,
                     ),
                 ),
-                Array(
-                    3,
-                    [
+                Array {
+                    total_nodes: 3,
+                    items: [
                         Variable(
                             (
                                 Atom('s1' type=inline),
@@ -16698,7 +16778,8 @@
                             ),
                         ),
                     ],
-                ),
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -16753,9 +16834,9 @@
                         #21,
                     ),
                 ),
-                Array(
-                    3,
-                    [
+                Array {
+                    total_nodes: 3,
+                    items: [
                         Variable(
                             (
                                 Atom('s1' type=inline),
@@ -16769,7 +16850,8 @@
                             ),
                         ),
                     ],
-                ),
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -16824,9 +16906,9 @@
                         #21,
                     ),
                 ),
-                Array(
-                    3,
-                    [
+                Array {
+                    total_nodes: 3,
+                    items: [
                         Variable(
                             (
                                 Atom('s1' type=inline),
@@ -16840,7 +16922,8 @@
                             ),
                         ),
                     ],
-                ),
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -16895,9 +16978,9 @@
                         #21,
                     ),
                 ),
-                Array(
-                    3,
-                    [
+                Array {
+                    total_nodes: 3,
+                    items: [
                         Variable(
                             (
                                 Atom('s1' type=inline),
@@ -16911,7 +16994,8 @@
                             ),
                         ),
                     ],
-                ),
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -16966,9 +17050,9 @@
                         #21,
                     ),
                 ),
-                Array(
-                    3,
-                    [
+                Array {
+                    total_nodes: 3,
+                    items: [
                         Variable(
                             (
                                 Atom('s1' type=inline),
@@ -16982,7 +17066,8 @@
                             ),
                         ),
                     ],
-                ),
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -17037,9 +17122,9 @@
                         #21,
                     ),
                 ),
-                Array(
-                    3,
-                    [
+                Array {
+                    total_nodes: 3,
+                    items: [
                         Variable(
                             (
                                 Atom('s1' type=inline),
@@ -17053,7 +17138,8 @@
                             ),
                         ),
                     ],
-                ),
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -17108,9 +17194,9 @@
                         #21,
                     ),
                 ),
-                Array(
-                    3,
-                    [
+                Array {
+                    total_nodes: 3,
+                    items: [
                         Variable(
                             (
                                 Atom('s1' type=inline),
@@ -17124,7 +17210,8 @@
                             ),
                         ),
                     ],
-                ),
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -17179,9 +17266,9 @@
                         #21,
                     ),
                 ),
-                Array(
-                    3,
-                    [
+                Array {
+                    total_nodes: 3,
+                    items: [
                         Variable(
                             (
                                 Atom('s1' type=inline),
@@ -17195,7 +17282,8 @@
                             ),
                         ),
                     ],
-                ),
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -17570,9 +17658,9 @@
                         #21,
                     ),
                 ),
-                Array(
-                    3,
-                    [
+                Array {
+                    total_nodes: 3,
+                    items: [
                         Variable(
                             (
                                 Atom('s1' type=inline),
@@ -17586,7 +17674,8 @@
                             ),
                         ),
                     ],
-                ),
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -17641,9 +17730,9 @@
                         #21,
                     ),
                 ),
-                Array(
-                    3,
-                    [
+                Array {
+                    total_nodes: 3,
+                    items: [
                         Variable(
                             (
                                 Atom('s1' type=inline),
@@ -17657,7 +17746,8 @@
                             ),
                         ),
                     ],
-                ),
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -17712,9 +17802,9 @@
                         #21,
                     ),
                 ),
-                Array(
-                    3,
-                    [
+                Array {
+                    total_nodes: 3,
+                    items: [
                         Variable(
                             (
                                 Atom('s1' type=inline),
@@ -17728,7 +17818,8 @@
                             ),
                         ),
                     ],
-                ),
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -17760,9 +17851,9 @@
                         #21,
                     ),
                 ),
-                Array(
-                    3,
-                    [
+                Array {
+                    total_nodes: 3,
+                    items: [
                         Variable(
                             (
                                 Atom('s1' type=inline),
@@ -17776,7 +17867,8 @@
                             ),
                         ),
                     ],
-                ),
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -17808,9 +17900,9 @@
                         #21,
                     ),
                 ),
-                Array(
-                    3,
-                    [
+                Array {
+                    total_nodes: 3,
+                    items: [
                         Variable(
                             (
                                 Atom('s1' type=inline),
@@ -17824,7 +17916,8 @@
                             ),
                         ),
                     ],
-                ),
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -17856,9 +17949,9 @@
                         #21,
                     ),
                 ),
-                Array(
-                    3,
-                    [
+                Array {
+                    total_nodes: 3,
+                    items: [
                         Variable(
                             (
                                 Atom('s1' type=inline),
@@ -17872,7 +17965,8 @@
                             ),
                         ),
                     ],
-                ),
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -17904,9 +17998,9 @@
                         #21,
                     ),
                 ),
-                Array(
-                    3,
-                    [
+                Array {
+                    total_nodes: 3,
+                    items: [
                         Variable(
                             (
                                 Atom('s1' type=inline),
@@ -17920,7 +18014,8 @@
                             ),
                         ),
                     ],
-                ),
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -19773,10 +19868,11 @@
                     ),
                     "pattern without value",
                 ),
-                Array(
-                    1,
-                    [],
-                ),
+                Array {
+                    total_nodes: 1,
+                    items: [],
+                    mutable: true,
+                },
                 Variable(
                     (
                         Atom('peg$FAILED' type=dynamic),
@@ -21117,10 +21213,11 @@
                     ),
                     "pattern without value",
                 ),
-                Array(
-                    1,
-                    [],
-                ),
+                Array {
+                    total_nodes: 1,
+                    items: [],
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -21198,10 +21295,11 @@
                     ),
                     "pattern without value",
                 ),
-                Array(
-                    1,
-                    [],
-                ),
+                Array {
+                    total_nodes: 1,
+                    items: [],
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -22030,10 +22128,11 @@
                     ),
                     "pattern without value",
                 ),
-                Array(
-                    1,
-                    [],
-                ),
+                Array {
+                    total_nodes: 1,
+                    items: [],
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -22421,10 +22520,11 @@
                     ),
                     "pattern without value",
                 ),
-                Array(
-                    1,
-                    [],
-                ),
+                Array {
+                    total_nodes: 1,
+                    items: [],
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -22502,10 +22602,11 @@
                     ),
                     "pattern without value",
                 ),
-                Array(
-                    1,
-                    [],
-                ),
+                Array {
+                    total_nodes: 1,
+                    items: [],
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -22525,10 +22626,11 @@
                     ),
                     "pattern without value",
                 ),
-                Array(
-                    1,
-                    [],
-                ),
+                Array {
+                    total_nodes: 1,
+                    items: [],
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -22548,10 +22650,11 @@
                     ),
                     "pattern without value",
                 ),
-                Array(
-                    1,
-                    [],
-                ),
+                Array {
+                    total_nodes: 1,
+                    items: [],
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -22571,10 +22674,11 @@
                     ),
                     "pattern without value",
                 ),
-                Array(
-                    1,
-                    [],
-                ),
+                Array {
+                    total_nodes: 1,
+                    items: [],
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -22652,10 +22756,11 @@
                     ),
                     "pattern without value",
                 ),
-                Array(
-                    1,
-                    [],
-                ),
+                Array {
+                    total_nodes: 1,
+                    items: [],
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -22675,10 +22780,11 @@
                     ),
                     "pattern without value",
                 ),
-                Array(
-                    1,
-                    [],
-                ),
+                Array {
+                    total_nodes: 1,
+                    items: [],
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -22698,10 +22804,11 @@
                     ),
                     "pattern without value",
                 ),
-                Array(
-                    1,
-                    [],
-                ),
+                Array {
+                    total_nodes: 1,
+                    items: [],
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -22721,10 +22828,11 @@
                     ),
                     "pattern without value",
                 ),
-                Array(
-                    1,
-                    [],
-                ),
+                Array {
+                    total_nodes: 1,
+                    items: [],
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -22744,10 +22852,11 @@
                     ),
                     "pattern without value",
                 ),
-                Array(
-                    1,
-                    [],
-                ),
+                Array {
+                    total_nodes: 1,
+                    items: [],
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -22767,10 +22876,11 @@
                     ),
                     "pattern without value",
                 ),
-                Array(
-                    1,
-                    [],
-                ),
+                Array {
+                    total_nodes: 1,
+                    items: [],
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -22848,10 +22958,11 @@
                     ),
                     "pattern without value",
                 ),
-                Array(
-                    1,
-                    [],
-                ),
+                Array {
+                    total_nodes: 1,
+                    items: [],
+                    mutable: true,
+                },
                 Variable(
                     (
                         Atom('peg$FAILED' type=dynamic),
@@ -22924,10 +23035,11 @@
                     ),
                     "pattern without value",
                 ),
-                Array(
-                    1,
-                    [],
-                ),
+                Array {
+                    total_nodes: 1,
+                    items: [],
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -23063,10 +23175,11 @@
                     ),
                     "pattern without value",
                 ),
-                Array(
-                    1,
-                    [],
-                ),
+                Array {
+                    total_nodes: 1,
+                    items: [],
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -23086,10 +23199,11 @@
                     ),
                     "pattern without value",
                 ),
-                Array(
-                    1,
-                    [],
-                ),
+                Array {
+                    total_nodes: 1,
+                    items: [],
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -23159,10 +23273,11 @@
                     ),
                     "pattern without value",
                 ),
-                Array(
-                    1,
-                    [],
-                ),
+                Array {
+                    total_nodes: 1,
+                    items: [],
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -23309,10 +23424,11 @@
                     ),
                     "pattern without value",
                 ),
-                Array(
-                    1,
-                    [],
-                ),
+                Array {
+                    total_nodes: 1,
+                    items: [],
+                    mutable: true,
+                },
                 Variable(
                     (
                         Atom('peg$FAILED' type=dynamic),
@@ -25546,10 +25662,11 @@
                     ),
                     "pattern without value",
                 ),
-                Array(
-                    1,
-                    [],
-                ),
+                Array {
+                    total_nodes: 1,
+                    items: [],
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -25569,10 +25686,11 @@
                     ),
                     "pattern without value",
                 ),
-                Array(
-                    1,
-                    [],
-                ),
+                Array {
+                    total_nodes: 1,
+                    items: [],
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -25608,9 +25726,9 @@
                         #21,
                     ),
                 ),
-                Array(
-                    3,
-                    [
+                Array {
+                    total_nodes: 3,
+                    items: [
                         Variable(
                             (
                                 Atom('s4' type=inline),
@@ -25624,7 +25742,8 @@
                             ),
                         ),
                     ],
-                ),
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -25654,9 +25773,9 @@
                     ),
                     [],
                 ),
-                Array(
-                    5,
-                    [
+                Array {
+                    total_nodes: 5,
+                    items: [
                         Variable(
                             (
                                 Atom('s4' type=inline),
@@ -25682,7 +25801,8 @@
                             ),
                         ),
                     ],
-                ),
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -25712,9 +25832,9 @@
                     ),
                     [],
                 ),
-                Array(
-                    3,
-                    [
+                Array {
+                    total_nodes: 3,
+                    items: [
                         Variable(
                             (
                                 Atom('s4' type=inline),
@@ -25728,7 +25848,8 @@
                             ),
                         ),
                     ],
-                ),
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -25891,9 +26012,9 @@
                     ),
                     [],
                 ),
-                Array(
-                    5,
-                    [
+                Array {
+                    total_nodes: 5,
+                    items: [
                         Variable(
                             (
                                 Atom('s4' type=inline),
@@ -25919,7 +26040,8 @@
                             ),
                         ),
                     ],
-                ),
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -25949,9 +26071,9 @@
                     ),
                     [],
                 ),
-                Array(
-                    5,
-                    [
+                Array {
+                    total_nodes: 5,
+                    items: [
                         Variable(
                             (
                                 Atom('s4' type=inline),
@@ -25977,7 +26099,8 @@
                             ),
                         ),
                     ],
-                ),
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -26007,9 +26130,9 @@
                     ),
                     [],
                 ),
-                Array(
-                    5,
-                    [
+                Array {
+                    total_nodes: 5,
+                    items: [
                         Variable(
                             (
                                 Atom('s4' type=inline),
@@ -26035,7 +26158,8 @@
                             ),
                         ),
                     ],
-                ),
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -26065,9 +26189,9 @@
                     ),
                     [],
                 ),
-                Array(
-                    5,
-                    [
+                Array {
+                    total_nodes: 5,
+                    items: [
                         Variable(
                             (
                                 Atom('s4' type=inline),
@@ -26093,7 +26217,8 @@
                             ),
                         ),
                     ],
-                ),
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -26181,9 +26306,9 @@
                     ),
                     [],
                 ),
-                Array(
-                    5,
-                    [
+                Array {
+                    total_nodes: 5,
+                    items: [
                         Variable(
                             (
                                 Atom('s4' type=inline),
@@ -26209,7 +26334,8 @@
                             ),
                         ),
                     ],
-                ),
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -26239,9 +26365,9 @@
                     ),
                     [],
                 ),
-                Array(
-                    5,
-                    [
+                Array {
+                    total_nodes: 5,
+                    items: [
                         Variable(
                             (
                                 Atom('s4' type=inline),
@@ -26267,7 +26393,8 @@
                             ),
                         ),
                     ],
-                ),
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -26297,9 +26424,9 @@
                     ),
                     [],
                 ),
-                Array(
-                    5,
-                    [
+                Array {
+                    total_nodes: 5,
+                    items: [
                         Variable(
                             (
                                 Atom('s4' type=inline),
@@ -26325,7 +26452,8 @@
                             ),
                         ),
                     ],
-                ),
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -26355,9 +26483,9 @@
                     ),
                     [],
                 ),
-                Array(
-                    5,
-                    [
+                Array {
+                    total_nodes: 5,
+                    items: [
                         Variable(
                             (
                                 Atom('s4' type=inline),
@@ -26383,7 +26511,8 @@
                             ),
                         ),
                     ],
-                ),
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -26413,9 +26542,9 @@
                     ),
                     [],
                 ),
-                Array(
-                    5,
-                    [
+                Array {
+                    total_nodes: 5,
+                    items: [
                         Variable(
                             (
                                 Atom('s4' type=inline),
@@ -26441,7 +26570,8 @@
                             ),
                         ),
                     ],
-                ),
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -26471,9 +26601,9 @@
                     ),
                     [],
                 ),
-                Array(
-                    5,
-                    [
+                Array {
+                    total_nodes: 5,
+                    items: [
                         Variable(
                             (
                                 Atom('s4' type=inline),
@@ -26499,7 +26629,8 @@
                             ),
                         ),
                     ],
-                ),
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -26903,9 +27034,9 @@
                     ),
                     [],
                 ),
-                Array(
-                    3,
-                    [
+                Array {
+                    total_nodes: 3,
+                    items: [
                         Variable(
                             (
                                 Atom('s4' type=inline),
@@ -26919,7 +27050,8 @@
                             ),
                         ),
                     ],
-                ),
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -27059,10 +27191,11 @@
                     ),
                     "pattern without value",
                 ),
-                Array(
-                    1,
-                    [],
-                ),
+                Array {
+                    total_nodes: 1,
+                    items: [],
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -27123,9 +27256,9 @@
                         #21,
                     ),
                 ),
-                Array(
-                    3,
-                    [
+                Array {
+                    total_nodes: 3,
+                    items: [
                         Variable(
                             (
                                 Atom('s5' type=inline),
@@ -27139,7 +27272,8 @@
                             ),
                         ),
                     ],
-                ),
+                    mutable: true,
+                },
             ],
         ),
     ),
@@ -28372,10 +28506,11 @@
                     ),
                     "pattern without value",
                 ),
-                Array(
-                    1,
-                    [],
-                ),
+                Array {
+                    total_nodes: 1,
+                    items: [],
+                    mutable: true,
+                },
                 Variable(
                     (
                         Atom('peg$FAILED' type=dynamic),

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/peg/resolved-explained.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/peg/resolved-explained.snapshot
@@ -391,22 +391,28 @@ description#79 = ???*0*
 descriptions = ???*0*
 - *0* unknown new expression
 
-details = ({"line": 1, "column": 1} | ???*0* | {"line": (1 | ???*2*), "column": (1 | ???*5*)})
+details = (
+  | {"line": 1, "column": 1}
+  | ???*0*
+  | {"line": (1 | ???*2* | ???*3*), "column": (1 | ???*6* | ???*7*)}
+)
 - *0* [][???*1*]
   ⚠️  unknown array prototype methods or values
 - *1* arguments[0]
   ⚠️  function calls are not analysed yet
-- *2* ???*3*["line"]
+- *2* unknown mutation
+- *3* ???*4*["line"]
   ⚠️  unknown object
-- *3* [][???*4*]
+- *4* [][???*5*]
   ⚠️  unknown array prototype methods or values
-- *4* arguments[0]
+- *5* arguments[0]
   ⚠️  function calls are not analysed yet
-- *5* ???*6*["column"]
+- *6* unknown mutation
+- *7* ???*8*["column"]
   ⚠️  unknown object
-- *6* [][???*7*]
+- *8* [][???*9*]
   ⚠️  unknown array prototype methods or values
-- *7* arguments[0]
+- *9* arguments[0]
   ⚠️  function calls are not analysed yet
 
 digits = ???*0*

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/react-dom-production/resolved-effects.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/react-dom-production/resolved-effects.snapshot
@@ -1614,7 +1614,7 @@ ${La}${a}`
 - *1* unsupported expression
 
 568 -> 571 call = (...) => undefined(
-    (null[(null | ???*0* | 0)] | ???*1* | ???*3* | ???*4* | ???*6*)
+    (null[(null | ???*0* | 0)] | ???*1* | ???*3* | ???*4* | ???*6* | ???*7*)
 )
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
@@ -1628,10 +1628,11 @@ ${La}${a}`
   ⚠️  unknown array prototype methods or values
 - *5* arguments[0]
   ⚠️  function calls are not analysed yet
-- *6* ???*7*[(null | ???*8* | 0)]
+- *6* unknown mutation
+- *7* ???*8*[(null | ???*9* | 0)]
   ⚠️  unknown object
-- *7* unsupported expression
-- *8* arguments[0]
+- *8* unsupported expression
+- *9* arguments[0]
   ⚠️  function calls are not analysed yet
 
 0 -> 572 call = ???*0*(???*1*)
@@ -2060,7 +2061,7 @@ ${La}${a}`
 - *0* unsupported expression
 
 747 -> 748 call = (...) => (undefined | null | a)(
-    (???*0* | undefined | null | ???*1* | ???*2* | [???*4*])
+    (???*0* | undefined | null | ???*1* | ???*2* | [???*4*] | ???*5*)
 )
 - *0* arguments[1]
   ⚠️  function calls are not analysed yet
@@ -2072,9 +2073,10 @@ ${La}${a}`
   ⚠️  circular variable reference
 - *4* arguments[4]
   ⚠️  function calls are not analysed yet
+- *5* unknown mutation
 
 747 -> 749 call = (???*0* | (...) => undefined)(
-    (???*1* | undefined | null | ???*2* | ???*3* | [???*5*])
+    (???*1* | undefined | null | ???*2* | ???*3* | [???*5*] | ???*6*)
 )
 - *0* Fc
   ⚠️  pattern without value
@@ -2088,8 +2090,9 @@ ${La}${a}`
   ⚠️  circular variable reference
 - *5* arguments[4]
   ⚠️  function calls are not analysed yet
+- *6* unknown mutation
 
-0 -> 753 member call = (???*0* | undefined | null | ???*1* | ???*2* | [???*4*])["indexOf"](???*5*)
+0 -> 753 member call = (???*0* | undefined | null | ???*1* | ???*2* | [???*4*] | ???*5*)["indexOf"](???*6*)
 - *0* arguments[1]
   ⚠️  function calls are not analysed yet
 - *1* b
@@ -2100,10 +2103,11 @@ ${La}${a}`
   ⚠️  circular variable reference
 - *4* arguments[4]
   ⚠️  function calls are not analysed yet
-- *5* arguments[4]
+- *5* unknown mutation
+- *6* arguments[4]
   ⚠️  function calls are not analysed yet
 
-0 -> 755 member call = (???*0* | undefined | null | ???*1* | ???*2* | [???*4*])["push"](???*5*)
+0 -> 755 member call = (???*0* | undefined | null | ???*1* | ???*2* | [???*4*] | ???*5*)["push"](???*6*)
 - *0* arguments[1]
   ⚠️  function calls are not analysed yet
 - *1* b
@@ -2114,7 +2118,8 @@ ${La}${a}`
   ⚠️  circular variable reference
 - *4* arguments[4]
   ⚠️  function calls are not analysed yet
-- *5* arguments[4]
+- *5* unknown mutation
+- *6* arguments[4]
   ⚠️  function calls are not analysed yet
 
 0 -> 756 call = (...) => (undefined | a)(
@@ -3987,22 +3992,29 @@ ${La}${a}`
 - *2* c
   ⚠️  pattern without value
 
-0 -> 1279 conditional = (???*0* | ???*3* | ???*7*)
+0 -> 1279 conditional = (???*0* | ???*3* | ???*7* | ???*11*)
 - *0* ???*1*(???*2*)
   ⚠️  unknown callee
 - *1* undefined["hasOwnProperty"]
   ⚠️  nested operation
 - *2* c
   ⚠️  pattern without value
-- *3* ???*4*["hasOwnProperty"](???*6*)
-  ⚠️  unknown callee object
-- *4* {}[???*5*]
-  ⚠️  unknown object prototype methods or values
-- *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+- *3* (???*4* | ???*5*)(???*6*)
+  ⚠️  non-function callee
+- *4* FreeVar(undefined)
+  ⚠️  unknown global
+- *5* unknown mutation
 - *6* c
   ⚠️  pattern without value
-- *7* unsupported expression
+- *7* ???*8*["hasOwnProperty"](???*10*)
+  ⚠️  unknown callee object
+- *8* {}[???*9*]
+  ⚠️  unknown object prototype methods or values
+- *9* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *10* c
+  ⚠️  pattern without value
+- *11* unsupported expression
 
 0 -> 1282 call = (...) => (undefined | Xe[a] | a | ???*0*)("animationend")
 - *0* unsupported expression
@@ -4085,23 +4097,32 @@ ${La}${a}`
 - *12* "abort auxClick cancel canPlay canPlayThrough click close contextMenu copy cut drag dragEnd dragEnter dragExit dragLeave dragOver dragStart drop durationChange emptied encrypted ended error gotPointerCapture input invalid keyDown keyPress keyUp load loadedData loadedMetadata loadStart lostPointerCapture mouseDown mouseMove mouseOut mouseOver mouseUp paste pause play playing pointerCancel pointerDown pointerMove pointerOut pointerOver pointerUp progress rateChange reset resize seeked seeking stalled submit suspend timeUpdate touchCancel touchEnd touchStart volumeChange scroll toggle touchMove waiting wheel"["split"]
   ⚠️  nested operation
 
-0 -> 1301 call = (...) => undefined((undefined | ???*0* | "animationend" | ???*1*), "onAnimationEnd")
+0 -> 1301 call = (...) => undefined(
+    (undefined | ???*0* | ???*1* | "animationend" | ???*2*),
+    "onAnimationEnd"
+)
 - *0* FreeVar(undefined)
   ⚠️  unknown global
-- *1* unsupported expression
+- *1* unknown mutation
+- *2* unsupported expression
 
 0 -> 1302 call = (...) => undefined(
-    (undefined | ???*0* | "animationiteration" | ???*1*),
+    (undefined | ???*0* | ???*1* | "animationiteration" | ???*2*),
     "onAnimationIteration"
 )
 - *0* FreeVar(undefined)
   ⚠️  unknown global
-- *1* unsupported expression
+- *1* unknown mutation
+- *2* unsupported expression
 
-0 -> 1303 call = (...) => undefined((undefined | ???*0* | "animationstart" | ???*1*), "onAnimationStart")
+0 -> 1303 call = (...) => undefined(
+    (undefined | ???*0* | ???*1* | "animationstart" | ???*2*),
+    "onAnimationStart"
+)
 - *0* FreeVar(undefined)
   ⚠️  unknown global
-- *1* unsupported expression
+- *1* unknown mutation
+- *2* unsupported expression
 
 0 -> 1304 call = (...) => undefined("dblclick", "onDoubleClick")
 
@@ -4109,10 +4130,14 @@ ${La}${a}`
 
 0 -> 1306 call = (...) => undefined("focusout", "onBlur")
 
-0 -> 1307 call = (...) => undefined((undefined | ???*0* | "transitionend" | ???*1*), "onTransitionEnd")
+0 -> 1307 call = (...) => undefined(
+    (undefined | ???*0* | ???*1* | "transitionend" | ???*2*),
+    "onTransitionEnd"
+)
 - *0* FreeVar(undefined)
   ⚠️  unknown global
-- *1* unsupported expression
+- *1* unknown mutation
+- *2* unsupported expression
 
 0 -> 1308 call = (...) => undefined("onMouseEnter", ["mouseout", "mouseover"])
 
@@ -5397,9 +5422,10 @@ ${La}${a}`
 - *3* a
   ⚠️  circular variable reference
 
-0 -> 1657 call = (...) => undefined((undefined | {"current": false}), (undefined["current"] | false))
+0 -> 1657 call = (...) => undefined((undefined | {"current": false}), (undefined["current"] | false | ???*0*))
+- *0* unknown mutation
 
-0 -> 1659 conditional = !((???*0* | ???*2* | ???*3*))
+0 -> 1659 conditional = !((???*0* | ???*2* | ???*3* | ???*4*))
 - *0* ???*1*["stateNode"]
   ⚠️  unknown object
 - *1* arguments[0]
@@ -5408,6 +5434,7 @@ ${La}${a}`
   ⚠️  nested operation
 - *3* FreeVar(undefined)
   ⚠️  unknown global
+- *4* unknown mutation
 
 1659 -> 1660 call = (...) => (
   | undefined
@@ -5424,20 +5451,22 @@ ${La}${a}`
   ⚠️  unknown global
 
 0 -> 1662 call = (...) => (undefined | c | A({}, c, d))(
-    (???*0* | undefined | {} | undefined["current"] | ???*1*),
-    ???*4*,
-    ({} | undefined["current"])
+    (???*0* | undefined | {} | undefined["current"] | ???*1* | ???*2*),
+    ???*5*,
+    ({} | undefined["current"] | ???*6*)
 )
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
-- *1* ???*2*({}, c, d)
+- *1* unknown mutation
+- *2* ???*3*({}, c, d)
   ⚠️  unknown callee
-- *2* ???*3*["assign"]
+- *3* ???*4*["assign"]
   ⚠️  unknown object
-- *3* FreeVar(Object)
+- *4* FreeVar(Object)
   ⚠️  unknown global
-- *4* arguments[1]
+- *5* arguments[1]
   ⚠️  function calls are not analysed yet
+- *6* unknown mutation
 
 0 -> 1664 call = (...) => undefined((undefined | {"current": false}))
 
@@ -5445,15 +5474,16 @@ ${La}${a}`
 
 0 -> 1666 call = (...) => undefined(
     (undefined | {"current": {}}),
-    (???*0* | undefined | {} | undefined["current"] | ???*1*)
+    (???*0* | undefined | {} | undefined["current"] | ???*1* | ???*2*)
 )
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
-- *1* ???*2*({}, c, d)
+- *1* unknown mutation
+- *2* ???*3*({}, c, d)
   ⚠️  unknown callee
-- *2* ???*3*["assign"]
+- *3* ???*4*["assign"]
   ⚠️  unknown object
-- *3* FreeVar(Object)
+- *4* FreeVar(Object)
   ⚠️  unknown global
 
 0 -> 1667 call = (...) => undefined((undefined | {"current": false}))
@@ -5479,18 +5509,19 @@ ${La}${a}`
 0 -> 1672 conditional = (!((false | true)) | ???*0*)
 - *0* unsupported expression
 
-1672 -> 1675 call = (null[0] | ???*0* | ???*1* | ???*4*)(true)
+1672 -> 1675 call = (null[0] | ???*0* | ???*1* | ???*2* | ???*5*)(true)
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
-- *1* ???*2*[0]
+- *1* unknown mutation
+- *2* ???*3*[0]
   ⚠️  unknown object
-- *2* ???*3*["slice"]((a + 1))
+- *3* ???*4*["slice"]((a + 1))
   ⚠️  unknown callee object
-- *3* eg
+- *4* eg
   ⚠️  circular variable reference
-- *4* ???*5*(!(0))
+- *5* ???*6*(!(0))
   ⚠️  unknown callee
-- *5* d
+- *6* d
   ⚠️  circular variable reference
 
 1672 -> 1677 member call = (null | [???*0*] | ???*1*)["slice"]((0 + 1))
@@ -6430,13 +6461,14 @@ ${La}${a}`
 - *1* arguments[5]
   ⚠️  function calls are not analysed yet
 
-0 -> 2020 call = (...) => (undefined | b)((???*0* | undefined | ???*2* | {}))
+0 -> 2020 call = (...) => (undefined | b)((???*0* | undefined | ???*2* | ???*3* | {}))
 - *0* ???*1*["contextType"]
   ⚠️  unknown object
 - *1* arguments[1]
   ⚠️  function calls are not analysed yet
 - *2* FreeVar(undefined)
   ⚠️  unknown global
+- *3* unknown mutation
 
 0 -> 2021 call = (...) => (undefined | (???*0* && ???*1*))((???*2* | ???*3*))
 - *0* unsupported expression
@@ -6445,13 +6477,14 @@ ${La}${a}`
   ⚠️  function calls are not analysed yet
 - *3* unknown new expression
 
-0 -> 2024 call = (...) => (undefined | Vf | d["__reactInternalMemoizedMaskedChildContext"] | e)((???*0* | ???*1*), ({} | undefined["current"]))
+0 -> 2024 call = (...) => (undefined | Vf | d["__reactInternalMemoizedMaskedChildContext"] | e)((???*0* | ???*1*), ({} | undefined["current"] | ???*3*))
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* a
   ⚠️  circular variable reference
+- *3* unknown mutation
 
 0 -> 2038 member call = ???*0*["componentWillReceiveProps"](???*1*, ???*2*)
 - *0* arguments[1]
@@ -6487,11 +6520,12 @@ ${La}${a}`
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 
-0 -> 2054 call = (...) => (undefined | b)((???*0* | {} | undefined["current"]))
+0 -> 2054 call = (...) => (undefined | b)((???*0* | {} | undefined["current"] | ???*2*))
 - *0* ???*1*["contextType"]
   ⚠️  unknown object
 - *1* arguments[1]
   ⚠️  function calls are not analysed yet
+- *2* unknown mutation
 
 0 -> 2055 call = (...) => (undefined | (???*0* && ???*1*))((???*2* | ???*3*))
 - *0* unsupported expression
@@ -6505,15 +6539,16 @@ ${La}${a}`
 - *5* arguments[0]
   ⚠️  function calls are not analysed yet
 
-0 -> 2058 call = (...) => (undefined | Vf | d["__reactInternalMemoizedMaskedChildContext"] | e)(???*0*, (???*1* | {} | undefined["current"]))
+0 -> 2058 call = (...) => (undefined | Vf | d["__reactInternalMemoizedMaskedChildContext"] | e)(???*0*, (???*1* | {} | undefined["current"] | ???*3*))
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["contextType"]
   ⚠️  unknown object
 - *2* arguments[1]
   ⚠️  function calls are not analysed yet
+- *3* unknown mutation
 
-0 -> 2062 call = (...) => undefined(???*0*, (???*1* | ???*2*), (???*5* | {} | undefined["current"]), ???*7*)
+0 -> 2062 call = (...) => undefined(???*0*, (???*1* | ???*2*), (???*5* | {} | undefined["current"] | ???*7*), ???*8*)
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 - *1* arguments[1]
@@ -6528,7 +6563,8 @@ ${La}${a}`
   ⚠️  unknown object
 - *6* arguments[1]
   ⚠️  function calls are not analysed yet
-- *7* arguments[2]
+- *7* unknown mutation
+- *8* arguments[2]
   ⚠️  function calls are not analysed yet
 
 0 -> 2072 member call = ???*0*["componentWillMount"]()
@@ -8098,14 +8134,17 @@ ${La}${a}`
 
 0 -> 2475 call = (...) => undefined((undefined | {"current": {}}))
 
-0 -> 2477 call = (...) => (undefined | a)((undefined["current"] | {}))
+0 -> 2477 call = (...) => (undefined | a)((undefined["current"] | {} | ???*0*))
+- *0* unknown mutation
 
-0 -> 2479 call = (...) => (undefined | a)((undefined["current"] | {}))
+0 -> 2479 call = (...) => (undefined | a)((undefined["current"] | {} | ???*0*))
+- *0* unknown mutation
 
-0 -> 2481 call = (...) => (undefined | kb(b) | "http://www.w3.org/1999/xhtml" | a)((undefined | undefined["current"] | {}), ???*0*)
-- *0* ???*1*["type"]
+0 -> 2481 call = (...) => (undefined | kb(b) | "http://www.w3.org/1999/xhtml" | a)((undefined | undefined["current"] | {} | ???*0*), ???*1*)
+- *0* unknown mutation
+- *1* ???*2*["type"]
   ⚠️  unknown object
-- *1* arguments[0]
+- *2* arguments[0]
   ⚠️  function calls are not analysed yet
 
 0 -> 2482 call = (...) => undefined((undefined | {"current": {}}), ???*0*)
@@ -8121,8 +8160,10 @@ ${La}${a}`
       | "http://www.w3.org/1999/xhtml"
       | undefined["current"]
       | {}
+      | ???*0*
     )
 )
+- *0* unknown mutation
 
 0 -> 2485 call = (...) => undefined((undefined | {"current": {}}))
 
@@ -8278,7 +8319,7 @@ ${La}${a}`
     )
 )(
     ???*7*,
-    (undefined["memoizedState"] | null["memoizedState"] | ???*8* | null)
+    (undefined["memoizedState"] | null["memoizedState"] | ???*8* | null | ???*10*)
 )
 - *0* ???*1*["is"]
   ⚠️  unknown object
@@ -8293,6 +8334,7 @@ ${La}${a}`
 - *8* ???*9*["memoizedState"]
   ⚠️  unknown object
 - *9* unsupported expression
+- *10* unknown mutation
 
 0 -> 2600 call = (...) => (undefined | P)()
 
@@ -8311,21 +8353,22 @@ ${La}${a}`
   ⚠️  unknown global
 
 0 -> 2611 call = ???*0*(
-    (undefined["memoizedState"] | null["memoizedState"] | ???*1* | null | ???*3*),
-    ???*5*
+    (undefined["memoizedState"] | null["memoizedState"] | ???*1* | null | ???*3* | ???*4*),
+    ???*6*
 )
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["memoizedState"]
   ⚠️  unknown object
 - *2* unsupported expression
-- *3* ???*4*(f, g["action"])
+- *3* unknown mutation
+- *4* ???*5*(f, g["action"])
   ⚠️  unknown callee
-- *4* arguments[0]
+- *5* arguments[0]
   ⚠️  function calls are not analysed yet
-- *5* ???*6*["action"]
+- *6* ???*7*["action"]
   ⚠️  unknown object
-- *6* unsupported expression
+- *7* unsupported expression
 
 0 -> 2614 call = (
   | ???*0*
@@ -8334,8 +8377,8 @@ ${La}${a}`
       | ((???*2* && (???*3* || ???*4*)) || (???*5* && ???*6*))
     )
 )(
-    (undefined["memoizedState"] | null["memoizedState"] | ???*7* | null | ???*9*),
-    (undefined["memoizedState"] | null["memoizedState"] | ???*11* | null)
+    (undefined["memoizedState"] | null["memoizedState"] | ???*7* | null | ???*9* | ???*10*),
+    (undefined["memoizedState"] | null["memoizedState"] | ???*12* | null | ???*14*)
 )
 - *0* ???*1*["is"]
   ⚠️  unknown object
@@ -8349,13 +8392,15 @@ ${La}${a}`
 - *7* ???*8*["memoizedState"]
   ⚠️  unknown object
 - *8* unsupported expression
-- *9* ???*10*(f, g["action"])
+- *9* unknown mutation
+- *10* ???*11*(f, g["action"])
   ⚠️  unknown callee
-- *10* arguments[0]
+- *11* arguments[0]
   ⚠️  function calls are not analysed yet
-- *11* ???*12*["memoizedState"]
+- *12* ???*13*["memoizedState"]
   ⚠️  unknown object
-- *12* unsupported expression
+- *13* unsupported expression
+- *14* unknown mutation
 
 0 -> 2619 call = (...) => (undefined | P)()
 
@@ -8370,8 +8415,8 @@ ${La}${a}`
       | ((???*2* && (???*3* || ???*4*)) || (???*5* && ???*6*))
     )
 )(
-    (undefined["memoizedState"] | null["memoizedState"] | ???*7* | null),
-    ???*9*()
+    (undefined["memoizedState"] | null["memoizedState"] | ???*7* | null | ???*9*),
+    ???*10*()
 )
 - *0* ???*1*["is"]
   ⚠️  unknown object
@@ -8385,7 +8430,8 @@ ${La}${a}`
 - *7* ???*8*["memoizedState"]
   ⚠️  unknown object
 - *8* unsupported expression
-- *9* arguments[1]
+- *9* unknown mutation
+- *10* arguments[1]
   ⚠️  function calls are not analysed yet
 
 0 -> 2626 member call = (...) => (undefined | c(*anonymous function 67764*))["bind"](
@@ -8660,12 +8706,12 @@ ${La}${a}`
 - *3* arguments[1]
   ⚠️  function calls are not analysed yet
 
-0 -> 2646 member call = (???*0* | ???*1* | null)["push"](
+0 -> 2646 member call = (???*0* | ???*1* | null | ???*3*)["push"](
     (
-      | ???*3*
+      | ???*4*
       | {
-            "getSnapshot": (???*4* | null["updateQueue"] | ???*5* | {"lastEffect": null, "stores": null}),
-            "value": (???*7* | ???*8* | null)
+            "getSnapshot": (???*5* | null["updateQueue"] | ???*6* | {"lastEffect": null, "stores": null}),
+            "value": (???*8* | ???*9* | null | ???*11*)
         }
     )
 )
@@ -8675,20 +8721,22 @@ ${La}${a}`
   ⚠️  unknown object
 - *2* arguments[1]
   ⚠️  function calls are not analysed yet
-- *3* arguments[0]
+- *3* unknown mutation
+- *4* arguments[0]
   ⚠️  function calls are not analysed yet
-- *4* arguments[1]
+- *5* arguments[1]
   ⚠️  function calls are not analysed yet
-- *5* ???*6*["updateQueue"]
+- *6* ???*7*["updateQueue"]
   ⚠️  unknown object
-- *6* arguments[1]
+- *7* arguments[1]
   ⚠️  function calls are not analysed yet
-- *7* arguments[2]
+- *8* arguments[2]
   ⚠️  function calls are not analysed yet
-- *8* ???*9*["stores"]
+- *9* ???*10*["stores"]
   ⚠️  unknown object
-- *9* arguments[1]
+- *10* arguments[1]
   ⚠️  function calls are not analysed yet
+- *11* unknown mutation
 
 0 -> 2649 call = (...) => (undefined | !(He(a, c)) | !(0))(???*0*)
 - *0* arguments[1]
@@ -9617,6 +9665,7 @@ ${La}${a}`
         }
       | ???*2*
       | ???*3*
+      | ???*4*
     )
 )
 - *0* a
@@ -9624,15 +9673,16 @@ ${La}${a}`
 - *1* a
   ⚠️  circular variable reference
 - *2* unsupported expression
-- *3* ???*4*[1]
+- *3* unknown mutation
+- *4* ???*5*[1]
   ⚠️  unknown object
-- *4* ???*5*(null, ???*6*)
+- *5* ???*6*(null, ???*7*)
   ⚠️  unknown callee
-- *5* (...) => undefined["bind"]
+- *6* (...) => undefined["bind"]
   ⚠️  nested operation
-- *6* ???*7*[1]
+- *7* ???*8*[1]
   ⚠️  unknown object
-- *7* a
+- *8* a
   ⚠️  circular variable reference
 
 0 -> 2819 call = (...) => (undefined | P)()
@@ -9856,8 +9906,8 @@ ${La}${a}`
             "next": null
         }
     ),
-    (null["memoizedState"] | ???*12*),
-    ???*14*
+    (null["memoizedState"] | ???*12* | ???*14*),
+    ???*15*
 )
 - *0* unsupported expression
 - *1* unsupported expression
@@ -9880,7 +9930,8 @@ ${La}${a}`
 - *12* ???*13*["memoizedState"]
   ⚠️  unknown object
 - *13* unsupported expression
-- *14* arguments[0]
+- *14* unknown mutation
+- *15* arguments[0]
   ⚠️  function calls are not analysed yet
 
 0 -> 2854 call = (...) => (undefined | [b["memoizedState"], c["dispatch"]])((...) => (undefined | b(a) | b))
@@ -9909,8 +9960,8 @@ ${La}${a}`
             "next": null
         }
     ),
-    (null["memoizedState"] | ???*12*),
-    ???*14*
+    (null["memoizedState"] | ???*12* | ???*14*),
+    ???*15*
 )
 - *0* unsupported expression
 - *1* unsupported expression
@@ -9933,7 +9984,8 @@ ${La}${a}`
 - *12* ???*13*["memoizedState"]
   ⚠️  unknown object
 - *13* unsupported expression
-- *14* arguments[0]
+- *14* unknown mutation
+- *15* arguments[0]
   ⚠️  function calls are not analysed yet
 
 0 -> 2863 call = (...) => (undefined | [f, d])((...) => (undefined | b(a) | b))
@@ -10479,20 +10531,24 @@ ${La}${a}`
 - *6* arguments[4]
   ⚠️  function calls are not analysed yet
 
-0 -> 3002 call = (...) => undefined((undefined | {"current": 0}), (0 | undefined["current"] | ???*0*))
-- *0* arguments[1]
+0 -> 3002 call = (...) => undefined((undefined | {"current": 0}), (0 | undefined["current"] | ???*0* | ???*1*))
+- *0* unknown mutation
+- *1* arguments[1]
   ⚠️  function calls are not analysed yet
 
-0 -> 3008 call = (...) => undefined((undefined | {"current": 0}), (0 | undefined["current"] | ???*0*))
-- *0* arguments[1]
+0 -> 3008 call = (...) => undefined((undefined | {"current": 0}), (0 | undefined["current"] | ???*0* | ???*1*))
+- *0* unknown mutation
+- *1* arguments[1]
   ⚠️  function calls are not analysed yet
 
-0 -> 3011 call = (...) => undefined((undefined | {"current": 0}), (0 | undefined["current"] | ???*0*))
-- *0* arguments[1]
+0 -> 3011 call = (...) => undefined((undefined | {"current": 0}), (0 | undefined["current"] | ???*0* | ???*1*))
+- *0* unknown mutation
+- *1* arguments[1]
   ⚠️  function calls are not analysed yet
 
-0 -> 3014 call = (...) => undefined((undefined | {"current": 0}), (0 | undefined["current"] | ???*0*))
-- *0* arguments[1]
+0 -> 3014 call = (...) => undefined((undefined | {"current": 0}), (0 | undefined["current"] | ???*0* | ???*1*))
+- *0* unknown mutation
+- *1* arguments[1]
   ⚠️  function calls are not analysed yet
 
 0 -> 3015 call = (...) => undefined((???*0* | ???*1*), ???*2*, ???*3*, ???*6*)
@@ -10523,14 +10579,18 @@ ${La}${a}`
 - *4* c
   ⚠️  circular variable reference
 
-0 -> 3024 call = (...) => (undefined | Vf | d["__reactInternalMemoizedMaskedChildContext"] | e)(???*0*, ({} | undefined["current"] | undefined | ???*1*))
+0 -> 3024 call = (...) => (undefined | Vf | d["__reactInternalMemoizedMaskedChildContext"] | e)(
+    ???*0*,
+    ({} | undefined["current"] | ???*1* | undefined | ???*2*)
+)
 - *0* arguments[1]
   ⚠️  function calls are not analysed yet
-- *1* ???*2*["__reactInternalMemoizedMaskedChildContext"]
+- *1* unknown mutation
+- *2* ???*3*["__reactInternalMemoizedMaskedChildContext"]
   ⚠️  unknown object
-- *2* ???*3*["stateNode"]
+- *3* ???*4*["stateNode"]
   ⚠️  unknown object
-- *3* arguments[1]
+- *4* arguments[1]
   ⚠️  function calls are not analysed yet
 
 0 -> 3025 call = (...) => undefined(???*0*, ???*1*)
@@ -10544,8 +10604,8 @@ ${La}${a}`
     ???*1*,
     (???*2* | undefined | ???*3*),
     (???*5* | undefined | ???*6*),
-    ({} | undefined["current"] | undefined | ???*7*),
-    ???*10*
+    ({} | undefined["current"] | ???*7* | undefined | ???*8*),
+    ???*11*
 )
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
@@ -10560,13 +10620,14 @@ ${La}${a}`
 - *5* arguments[3]
   ⚠️  function calls are not analysed yet
 - *6* unsupported expression
-- *7* ???*8*["__reactInternalMemoizedMaskedChildContext"]
+- *7* unknown mutation
+- *8* ???*9*["__reactInternalMemoizedMaskedChildContext"]
   ⚠️  unknown object
-- *8* ???*9*["stateNode"]
+- *9* ???*10*["stateNode"]
   ⚠️  unknown object
-- *9* arguments[1]
+- *10* arguments[1]
   ⚠️  function calls are not analysed yet
-- *10* arguments[4]
+- *11* arguments[4]
   ⚠️  function calls are not analysed yet
 
 0 -> 3027 call = (...) => (undefined | a)()
@@ -10694,8 +10755,8 @@ ${La}${a}`
     ???*2*,
     ???*3*,
     ???*4*,
-    (???*6* | undefined | ???*9* | {} | undefined["current"]),
-    ???*10*
+    (???*6* | undefined | ???*9* | ???*10* | {} | undefined["current"]),
+    ???*11*
 )
 - *0* arguments[1]
   ⚠️  function calls are not analysed yet
@@ -10715,7 +10776,8 @@ ${La}${a}`
   ⚠️  function calls are not analysed yet
 - *9* FreeVar(undefined)
   ⚠️  unknown global
-- *10* max number of linking steps reached
+- *10* unknown mutation
+- *11* max number of linking steps reached
 
 0 -> 3072 member call = ???*0*["componentWillMount"]()
 - *0* ???*1*["stateNode"]
@@ -10743,7 +10805,7 @@ ${La}${a}`
 - *2* max number of linking steps reached
 
 0 -> 3098 call = (...) => (undefined | b)(
-    (???*0* | undefined | ???*3* | {} | undefined["current"])
+    (???*0* | undefined | ???*3* | ???*4* | {} | undefined["current"])
 )
 - *0* ???*1*["context"]
   ⚠️  unknown object
@@ -10753,6 +10815,7 @@ ${La}${a}`
   ⚠️  function calls are not analysed yet
 - *3* FreeVar(undefined)
   ⚠️  unknown global
+- *4* unknown mutation
 
 0 -> 3099 call = (...) => (undefined | (???*0* && ???*1*))(???*2*)
 - *0* unsupported expression
@@ -10762,7 +10825,7 @@ ${La}${a}`
 
 0 -> 3101 call = (...) => (undefined | Vf | d["__reactInternalMemoizedMaskedChildContext"] | e)(
     ???*0*,
-    (???*1* | undefined | ???*4* | {} | undefined["current"])
+    (???*1* | undefined | ???*4* | ???*5* | {} | undefined["current"])
 )
 - *0* arguments[1]
   ⚠️  function calls are not analysed yet
@@ -10774,12 +10837,13 @@ ${La}${a}`
   ⚠️  function calls are not analysed yet
 - *4* FreeVar(undefined)
   ⚠️  unknown global
+- *5* unknown mutation
 
 0 -> 3106 call = (...) => undefined(
     ???*0*,
     ???*1*,
     ???*3*,
-    (???*4* | undefined | ???*7* | {} | undefined["current"])
+    (???*4* | undefined | ???*7* | ???*8* | {} | undefined["current"])
 )
 - *0* arguments[1]
   ⚠️  function calls are not analysed yet
@@ -10796,6 +10860,7 @@ ${La}${a}`
   ⚠️  function calls are not analysed yet
 - *7* FreeVar(undefined)
   ⚠️  unknown global
+- *8* unknown mutation
 
 0 -> 3109 call = (...) => undefined(???*0*, ???*1*, ???*2*, ???*4*)
 - *0* arguments[1]
@@ -10826,7 +10891,7 @@ ${La}${a}`
     ???*3*,
     ???*4*,
     ???*6*,
-    (???*8* | undefined | ???*11* | {} | undefined["current"])
+    (???*8* | undefined | ???*11* | ???*12* | {} | undefined["current"])
 )
 - *0* arguments[1]
   ⚠️  function calls are not analysed yet
@@ -10850,11 +10915,12 @@ ${La}${a}`
   ⚠️  function calls are not analysed yet
 - *11* FreeVar(undefined)
   ⚠️  unknown global
+- *12* unknown mutation
 
 0 -> 3119 member call = ???*0*["componentWillUpdate"](
     ???*2*,
     ???*3*,
-    (???*5* | undefined | ???*8* | {} | undefined["current"])
+    (???*5* | undefined | ???*8* | ???*9* | {} | undefined["current"])
 )
 - *0* ???*1*["stateNode"]
   ⚠️  unknown object
@@ -10873,11 +10939,12 @@ ${La}${a}`
   ⚠️  function calls are not analysed yet
 - *8* FreeVar(undefined)
   ⚠️  unknown global
+- *9* unknown mutation
 
 0 -> 3122 member call = ???*0*["UNSAFE_componentWillUpdate"](
     ???*2*,
     ???*3*,
-    (???*5* | undefined | ???*8* | {} | undefined["current"])
+    (???*5* | undefined | ???*8* | ???*9* | {} | undefined["current"])
 )
 - *0* ???*1*["stateNode"]
   ⚠️  unknown object
@@ -10896,6 +10963,7 @@ ${La}${a}`
   ⚠️  function calls are not analysed yet
 - *8* FreeVar(undefined)
   ⚠️  unknown global
+- *9* unknown mutation
 
 0 -> 3148 call = (...) => (undefined | $i(a, b, f) | b["child"])(???*0*, ???*1*, ???*2*, ???*3*, (true | false), ???*4*)
 - *0* arguments[0]
@@ -11430,12 +11498,16 @@ ${La}${a}`
 - *7* arguments[1]
   ⚠️  function calls are not analysed yet
 
-0 -> 3392 call = (...) => undefined((undefined | {"current": 0}), (???*0* | undefined["current"] | 0 | ???*2*))
+0 -> 3392 call = (...) => undefined(
+    (undefined | {"current": 0}),
+    (???*0* | undefined["current"] | 0 | ???*2* | ???*3*)
+)
 - *0* ???*1*["pendingProps"]
   ⚠️  unknown object
 - *1* arguments[1]
   ⚠️  function calls are not analysed yet
-- *2* unsupported expression
+- *2* unknown mutation
+- *3* unsupported expression
 
 0 -> 3397 call = (...) => (undefined | b | null)(
     (???*0* | ???*1* | null["alternate"] | null["sibling"])
@@ -11660,7 +11732,8 @@ ${La}${a}`
 - *4* arguments[2]
   ⚠️  function calls are not analysed yet
 
-0 -> 3484 call = (...) => undefined((undefined | {"current": 0}), (undefined["current"] | 0))
+0 -> 3484 call = (...) => undefined((undefined | {"current": 0}), (undefined["current"] | 0 | ???*0*))
+- *0* unknown mutation
 
 0 -> 3486 call = (...) => (undefined | null | b["child"])((???*0* | undefined | null | ???*1*), ???*3*, ???*4*)
 - *0* arguments[0]
@@ -11702,7 +11775,8 @@ ${La}${a}`
 3491 -> 3497 conditional = ???*0*
 - *0* unsupported expression
 
-0 -> 3512 call = (...) => (undefined | a)((undefined["current"] | {}))
+0 -> 3512 call = (...) => (undefined | a)((undefined["current"] | {} | ???*0*))
+- *0* unknown mutation
 
 0 -> 3513 call = (...) => (
   | undefined
@@ -12391,7 +12465,8 @@ ${La}${a}`
 0 -> 3636 call = (...) => undefined(???*0*)
 - *0* max number of linking steps reached
 
-0 -> 3638 call = (...) => (undefined | a)((undefined["current"] | {}))
+0 -> 3638 call = (...) => (undefined | a)((undefined["current"] | {} | ???*0*))
+- *0* unknown mutation
 
 0 -> 3641 conditional = ???*0*
 - *0* unsupported expression
@@ -12425,7 +12500,8 @@ ${La}${a}`
 3647 -> 3651 call = (...) => (undefined | b)(???*0*)
 - *0* max number of linking steps reached
 
-3641 -> 3653 call = (...) => (undefined | a)((undefined["current"] | {}))
+3641 -> 3653 call = (...) => (undefined | a)((undefined["current"] | {} | ???*0*))
+- *0* unknown mutation
 
 3641 -> 3654 call = (...) => (undefined | !(1) | !(0))(???*0*)
 - *0* max number of linking steps reached
@@ -12755,9 +12831,11 @@ ${La}${a}`
 - *0* FreeVar(Error)
   ⚠️  unknown global
 
-3791 -> 3799 call = (...) => (undefined | a)((undefined["current"] | {}))
+3791 -> 3799 call = (...) => (undefined | a)((undefined["current"] | {} | ???*0*))
+- *0* unknown mutation
 
-3791 -> 3801 call = (...) => (undefined | a)((undefined["current"] | {}))
+3791 -> 3801 call = (...) => (undefined | a)((undefined["current"] | {} | ???*0*))
+- *0* unknown mutation
 
 3791 -> 3802 call = (...) => (undefined | !(1) | !(0))(???*0*)
 - *0* max number of linking steps reached
@@ -15397,7 +15475,7 @@ ${La}${a}`
       | yj(a, b, c)
       | ej(a, b, c)
     )
-)(???*1*, ???*3*, (0 | undefined["current"] | ???*4*))
+)(???*1*, ???*3*, (0 | undefined["current"] | ???*4* | ???*5*))
 - *0* Wk
   ⚠️  pattern without value
 - *1* ???*2*["alternate"]
@@ -15406,14 +15484,15 @@ ${La}${a}`
   ⚠️  function calls are not analysed yet
 - *3* arguments[0]
   ⚠️  function calls are not analysed yet
-- *4* arguments[1]
+- *4* unknown mutation
+- *5* arguments[1]
   ⚠️  function calls are not analysed yet
 
 0 -> 4908 call = (...) => (undefined | FreeVar(undefined))(???*0*)
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 
-0 -> 4913 call = (...) => (undefined | null | b | b["child"])(???*0*, (???*1* | ???*2*), (0 | undefined["current"] | ???*4*))
+0 -> 4913 call = (...) => (undefined | null | b | b["child"])(???*0*, (???*1* | ???*2*), (0 | undefined["current"] | ???*4* | ???*5*))
 - *0* max number of linking steps reached
 - *1* arguments[0]
   ⚠️  function calls are not analysed yet
@@ -15421,7 +15500,8 @@ ${La}${a}`
   ⚠️  unknown object
 - *3* b
   ⚠️  circular variable reference
-- *4* arguments[1]
+- *4* unknown mutation
+- *5* arguments[1]
   ⚠️  function calls are not analysed yet
 
 0 -> 4914 call = (...) => (undefined | b | null)(???*0*, (???*1* | ???*2*))
@@ -16492,8 +16572,9 @@ ${???*9*}`
 - *3* arguments[0]
   ⚠️  function calls are not analysed yet
 
-0 -> 5083 conditional = (???*0* | undefined["current"] | false)
+0 -> 5083 conditional = (???*0* | undefined["current"] | false | ???*1*)
 - *0* unsupported expression
+- *1* unknown mutation
 
 5083 -> 5086 conditional = ???*0*
 - *0* unsupported expression
@@ -16526,8 +16607,9 @@ ${???*9*}`
 - *0* max number of linking steps reached
 - *1* max number of linking steps reached
 
-0 -> 5098 call = (...) => (undefined | Vf | d["__reactInternalMemoizedMaskedChildContext"] | e)(???*0*, (undefined["current"] | {}))
+0 -> 5098 call = (...) => (undefined | Vf | d["__reactInternalMemoizedMaskedChildContext"] | e)(???*0*, (undefined["current"] | {} | ???*1*))
 - *0* max number of linking steps reached
+- *1* unknown mutation
 
 0 -> 5099 call = (...) => undefined(???*0*, (???*1* | ???*2* | ???*3*))
 - *0* max number of linking steps reached
@@ -17155,10 +17237,11 @@ ${???*9*}`
 - *6* unsupported expression
 - *7* unsupported expression
 
-5240 -> 5244 conditional = (???*0* | !((???*1* | false)))
+5240 -> 5244 conditional = (???*0* | !((???*1* | false | ???*2*)))
 - *0* unsupported expression
 - *1* undefined["current"]
   ⚠️  nested operation
+- *2* unknown mutation
 
 5244 -> 5245 call = (...) => (undefined | null | b["child"])(???*0*, ???*1*, (???*2* | ???*3* | ???*4*))
 - *0* max number of linking steps reached
@@ -17979,7 +18062,7 @@ ${???*9*}`
 0 -> 5506 call = (...) => (undefined | B() | Bk | ???*0*)()
 - *0* unsupported expression
 
-0 -> 5507 call = (...) => (undefined | 1 | ???*0* | Ck | a)((???*1* | undefined["current"] | ???*3*))
+0 -> 5507 call = (...) => (undefined | 1 | ???*0* | Ck | a)((???*1* | undefined["current"] | ???*3* | ???*4*))
 - *0* unsupported expression
 - *1* ???*2*["current"]
   ⚠️  unknown object
@@ -17987,6 +18070,7 @@ ${???*9*}`
   ⚠️  function calls are not analysed yet
 - *3* FreeVar(undefined)
   ⚠️  unknown global
+- *4* unknown mutation
 
 0 -> 5508 call = (...) => (undefined | Vf | bg(a, c, b) | b)(
     (???*0* | undefined | {} | ???*1* | ???*2* | ???*4*)
@@ -18021,11 +18105,12 @@ ${???*9*}`
       | undefined["current"]
       | ???*5*
       | ???*6*
+      | ???*7*
       | 4
       | 16
       | 536870912
       | null
-      | ???*7*
+      | ???*8*
     )
 )
 - *0* module<scheduler, {}>["unstable_now"]
@@ -18038,19 +18123,20 @@ ${???*9*}`
   ⚠️  function calls are not analysed yet
 - *5* FreeVar(undefined)
   ⚠️  unknown global
-- *6* C
+- *6* unknown mutation
+- *7* C
   ⚠️  circular variable reference
-- *7* arguments[0]
+- *8* arguments[0]
   ⚠️  function calls are not analysed yet
 
 0 -> 5515 call = (...) => (undefined | null | Zg(a, c))(
-    (???*0* | undefined["current"] | ???*2*),
+    (???*0* | undefined["current"] | ???*2* | ???*3*),
     (
-      | ???*3*
+      | ???*4*
       | undefined
       | {
-            "eventTime": (undefined | ???*4*() | ???*5*),
-            "lane": (undefined | 1 | ???*6* | 0 | 64 | ???*7* | ???*9* | 4 | 16 | 536870912 | null | ???*10*),
+            "eventTime": (undefined | ???*5*() | ???*6*),
+            "lane": (undefined | 1 | ???*7* | 0 | 64 | ???*8* | ???*10* | 4 | 16 | 536870912 | null | ???*11*),
             "tag": 0,
             "payload": null,
             "callback": null,
@@ -18060,18 +18146,19 @@ ${???*9*}`
     (
       | undefined
       | 1
-      | ???*11*
+      | ???*12*
       | 0
       | 64
-      | ???*12*
+      | ???*13*
       | undefined["current"]
-      | ???*14*
       | ???*15*
+      | ???*16*
+      | ???*17*
       | 4
       | 16
       | 536870912
       | null
-      | ???*16*
+      | ???*18*
     )
 )
 - *0* ???*1*["current"]
@@ -18080,52 +18167,55 @@ ${???*9*}`
   ⚠️  function calls are not analysed yet
 - *2* FreeVar(undefined)
   ⚠️  unknown global
-- *3* arguments[1]
+- *3* unknown mutation
+- *4* arguments[1]
   ⚠️  function calls are not analysed yet
-- *4* module<scheduler, {}>["unstable_now"]
+- *5* module<scheduler, {}>["unstable_now"]
   ⚠️  nested operation
-- *5* unsupported expression
 - *6* unsupported expression
-- *7* ???*8*["current"]
+- *7* unsupported expression
+- *8* ???*9*["current"]
   ⚠️  unknown object
-- *8* b
+- *9* b
   ⚠️  circular variable reference
-- *9* C
+- *10* C
   ⚠️  circular variable reference
-- *10* arguments[0]
+- *11* arguments[0]
   ⚠️  function calls are not analysed yet
-- *11* unsupported expression
-- *12* ???*13*["current"]
+- *12* unsupported expression
+- *13* ???*14*["current"]
   ⚠️  unknown object
-- *13* arguments[1]
+- *14* arguments[1]
   ⚠️  function calls are not analysed yet
-- *14* FreeVar(undefined)
+- *15* FreeVar(undefined)
   ⚠️  unknown global
-- *15* C
+- *16* unknown mutation
+- *17* C
   ⚠️  circular variable reference
-- *16* arguments[0]
+- *18* arguments[0]
   ⚠️  function calls are not analysed yet
 
 0 -> 5516 call = (...) => undefined(
     ???*0*,
-    (???*1* | undefined["current"] | ???*3*),
+    (???*1* | undefined["current"] | ???*3* | ???*4*),
     (
       | undefined
       | 1
-      | ???*4*
+      | ???*5*
       | 0
       | 64
-      | ???*5*
+      | ???*6*
       | undefined["current"]
-      | ???*7*
       | ???*8*
+      | ???*9*
+      | ???*10*
       | 4
       | 16
       | 536870912
       | null
-      | ???*9*
+      | ???*11*
     ),
-    (undefined | ???*10*() | ???*11*)
+    (undefined | ???*12*() | ???*13*)
 )
 - *0* max number of linking steps reached
 - *1* ???*2*["current"]
@@ -18134,39 +18224,42 @@ ${???*9*}`
   ⚠️  function calls are not analysed yet
 - *3* FreeVar(undefined)
   ⚠️  unknown global
-- *4* unsupported expression
-- *5* ???*6*["current"]
+- *4* unknown mutation
+- *5* unsupported expression
+- *6* ???*7*["current"]
   ⚠️  unknown object
-- *6* arguments[1]
+- *7* arguments[1]
   ⚠️  function calls are not analysed yet
-- *7* FreeVar(undefined)
+- *8* FreeVar(undefined)
   ⚠️  unknown global
-- *8* C
+- *9* unknown mutation
+- *10* C
   ⚠️  circular variable reference
-- *9* arguments[0]
+- *11* arguments[0]
   ⚠️  function calls are not analysed yet
-- *10* module<scheduler, {}>["unstable_now"]
+- *12* module<scheduler, {}>["unstable_now"]
   ⚠️  nested operation
-- *11* unsupported expression
+- *13* unsupported expression
 
 0 -> 5517 call = (...) => undefined(
     ???*0*,
-    (???*1* | undefined["current"] | ???*3*),
+    (???*1* | undefined["current"] | ???*3* | ???*4*),
     (
       | undefined
       | 1
-      | ???*4*
+      | ???*5*
       | 0
       | 64
-      | ???*5*
+      | ???*6*
       | undefined["current"]
-      | ???*7*
       | ???*8*
+      | ???*9*
+      | ???*10*
       | 4
       | 16
       | 536870912
       | null
-      | ???*9*
+      | ???*11*
     )
 )
 - *0* max number of linking steps reached
@@ -18176,16 +18269,18 @@ ${???*9*}`
   ⚠️  function calls are not analysed yet
 - *3* FreeVar(undefined)
   ⚠️  unknown global
-- *4* unsupported expression
-- *5* ???*6*["current"]
+- *4* unknown mutation
+- *5* unsupported expression
+- *6* ???*7*["current"]
   ⚠️  unknown object
-- *6* arguments[1]
+- *7* arguments[1]
   ⚠️  function calls are not analysed yet
-- *7* FreeVar(undefined)
+- *8* FreeVar(undefined)
   ⚠️  unknown global
-- *8* C
+- *9* unknown mutation
+- *10* C
   ⚠️  circular variable reference
-- *9* arguments[0]
+- *11* arguments[0]
   ⚠️  function calls are not analysed yet
 
 0 -> 5528 conditional = ???*0*
@@ -18831,10 +18926,10 @@ ${???*9*}`
 
 5674 -> 5676 member call = ???*0*["inject"](
     {
-        "bundleType": 0,
-        "version": "18.2.0",
-        "rendererPackageName": "react-dom",
-        "rendererConfig": ???*1*,
+        "bundleType": (0 | ???*1*),
+        "version": ("18.2.0" | ???*2*),
+        "rendererPackageName": ("react-dom" | ???*3*),
+        "rendererConfig": (???*4* | ???*5*),
         "overrideHookState": null,
         "overrideHookStateDeletePath": null,
         "overrideHookStateRenamePath": null,
@@ -18844,9 +18939,9 @@ ${???*9*}`
         "setErrorHandler": null,
         "setSuspenseHandler": null,
         "scheduleUpdate": null,
-        "currentDispatcherRef": ???*2*,
+        "currentDispatcherRef": ???*6*,
         "findHostInstanceByFiber": (...) => (undefined | null | a["stateNode"]),
-        "findFiberByHostInstance": (...) => (undefined | b | c | null),
+        "findFiberByHostInstance": ((...) => (undefined | b | c | null) | ???*8* | (...) => (undefined | null)),
         "findHostInstancesForRefresh": null,
         "scheduleRefresh": null,
         "scheduleRoot": null,
@@ -18857,12 +18952,17 @@ ${???*9*}`
 )
 - *0* FreeVar(__REACT_DEVTOOLS_GLOBAL_HOOK__)
   ⚠️  unknown global
-- *1* FreeVar(undefined)
+- *1* unknown mutation
+- *2* unknown mutation
+- *3* unknown mutation
+- *4* FreeVar(undefined)
   ⚠️  unknown global
-- *2* ???*3*["ReactCurrentDispatcher"]
+- *5* unknown mutation
+- *6* ???*7*["ReactCurrentDispatcher"]
   ⚠️  unknown object
-- *3* module<react, {}>["__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED"]
+- *7* module<react, {}>["__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED"]
   ⚠️  nested operation
+- *8* unknown mutation
 
 0 -> 5682 call = (...) => (undefined | !((!(a) || (???*0* && ???*1* && ???*2*))))(???*3*)
 - *0* unsupported expression

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/react-dom-production/resolved-explained.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/react-dom-production/resolved-explained.snapshot
@@ -7,10 +7,11 @@ $c = (...) => undefined
 
 $d = [9, 13, 27, 32]
 
-$e = (undefined | ???*0* | "animationend" | ???*1*)
+$e = (undefined | ???*0* | ???*1* | "animationend" | ???*2*)
 - *0* FreeVar(undefined)
   ⚠️  unknown global
-- *1* unsupported expression
+- *1* unknown mutation
+- *2* unsupported expression
 
 $f = (...) => undefined
 
@@ -1189,12 +1190,13 @@ P = (
   | null["memoizedState"]
   | ???*1*
   | null["next"]
+  | ???*3*
   | null["alternate"]
   | {
-        "memoizedState": (null["memoizedState"] | ???*3*),
-        "baseState": (null["baseState"] | ???*5*),
-        "baseQueue": (null["baseQueue"] | ???*7*),
-        "queue": (null["queue"] | ???*9*),
+        "memoizedState": (null["memoizedState"] | ???*4*),
+        "baseState": (null["baseState"] | ???*6*),
+        "baseQueue": (null["baseQueue"] | ???*8*),
+        "queue": (null["queue"] | ???*10*),
         "next": null
     }
 )
@@ -1203,18 +1205,19 @@ P = (
   ⚠️  unknown object
 - *2* arguments[1]
   ⚠️  function calls are not analysed yet
-- *3* ???*4*["memoizedState"]
+- *3* unknown mutation
+- *4* ???*5*["memoizedState"]
   ⚠️  unknown object
-- *4* unsupported expression
-- *5* ???*6*["baseState"]
+- *5* unsupported expression
+- *6* ???*7*["baseState"]
   ⚠️  unknown object
-- *6* unsupported expression
-- *7* ???*8*["baseQueue"]
+- *7* unsupported expression
+- *8* ???*9*["baseQueue"]
   ⚠️  unknown object
-- *8* unsupported expression
-- *9* ???*10*["queue"]
+- *9* unsupported expression
+- *10* ???*11*["queue"]
   ⚠️  unknown object
-- *10* unsupported expression
+- *11* unsupported expression
 
 Pa = (...) => (undefined | Ma(a["type"]) | Ma("Lazy") | Ma("Suspense") | Ma("SuspenseList") | a | "")
 
@@ -1650,7 +1653,8 @@ Xd = (undefined | (...) => (undefined | ???*0*))
 
 Xe = {}
 
-Xf = ({} | undefined["current"])
+Xf = ({} | undefined["current"] | ???*0*)
+- *0* unknown mutation
 
 Xg = (...) => undefined
 
@@ -1835,11 +1839,11 @@ a#103 = ???*0*
 a#104 = (
   | ???*0*
   | {
-        "blockedOn": (???*1* | undefined | null | ???*2* | ???*3* | [???*5*]),
-        "domEventName": ???*6*,
-        "eventSystemFlags": ???*7*,
-        "nativeEvent": ???*8*,
-        "targetContainers": [???*9*]
+        "blockedOn": (???*1* | undefined | null | ???*2* | ???*3* | [???*5*] | ???*6*),
+        "domEventName": ???*7*,
+        "eventSystemFlags": ???*8*,
+        "nativeEvent": ???*9*,
+        "targetContainers": [???*10*]
     }
 )
 - *0* arguments[0]
@@ -1854,13 +1858,14 @@ a#104 = (
   ⚠️  circular variable reference
 - *5* arguments[4]
   ⚠️  function calls are not analysed yet
-- *6* arguments[2]
+- *6* unknown mutation
+- *7* arguments[2]
   ⚠️  function calls are not analysed yet
-- *7* arguments[3]
+- *8* arguments[3]
   ⚠️  function calls are not analysed yet
-- *8* arguments[5]
+- *9* arguments[5]
   ⚠️  function calls are not analysed yet
-- *9* arguments[4]
+- *10* arguments[4]
   ⚠️  function calls are not analysed yet
 
 a#105 = ???*0*
@@ -1960,7 +1965,7 @@ a#127 = ???*0*
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 
-a#128 = (???*0* | "altKey" | "ctrlKey" | "metaKey" | "shiftKey" | ???*1* | ???*3*)
+a#128 = (???*0* | "altKey" | "ctrlKey" | "metaKey" | "shiftKey" | ???*1* | ???*3* | ???*4*)
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 - *1* {}[???*2*]
@@ -1969,6 +1974,7 @@ a#128 = (???*0* | "altKey" | "ctrlKey" | "metaKey" | "shiftKey" | ???*1* | ???*3
   ⚠️  function calls are not analysed yet
 - *3* FreeVar(undefined)
   ⚠️  unknown global
+- *4* unknown mutation
 
 a#129 = (???*0* | undefined | ???*1* | ???*2* | 13 | 0)
 - *0* arguments[0]
@@ -2371,7 +2377,7 @@ a#193 = ???*0*
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 
-a#194 = (???*0* | ???*1* | ???*2* | ???*4* | {})
+a#194 = (???*0* | ???*1* | ???*2* | ???*4* | ???*5* | {})
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
 - *1* unsupported expression
@@ -2381,15 +2387,17 @@ a#194 = (???*0* | ???*1* | ???*2* | ???*4* | {})
   ⚠️  function calls are not analysed yet
 - *4* FreeVar(undefined)
   ⚠️  unknown global
+- *5* unknown mutation
 
-a#195 = (???*0* | undefined | {} | undefined["current"] | ???*1*)
+a#195 = (???*0* | undefined | {} | undefined["current"] | ???*1* | ???*2*)
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
-- *1* ???*2*({}, c, d)
+- *1* unknown mutation
+- *2* ???*3*({}, c, d)
   ⚠️  unknown callee
-- *2* ???*3*["assign"]
+- *3* ???*4*["assign"]
   ⚠️  unknown object
-- *3* FreeVar(Object)
+- *4* FreeVar(Object)
   ⚠️  unknown global
 
 a#196 = ???*0*
@@ -2499,7 +2507,7 @@ a#216 = (
           | ???*1*
           | {"context": ???*2*, "memoizedValue": ???*3*, "next": null}
         ),
-        "memoizedValue": (???*5* | ???*7*),
+        "memoizedValue": (???*5* | ???*7* | ???*8*),
         "next": null
     }
 )
@@ -2519,6 +2527,7 @@ a#216 = (
   ⚠️  function calls are not analysed yet
 - *7* FreeVar(undefined)
   ⚠️  unknown global
+- *8* unknown mutation
 
 a#217 = ???*0*
 - *0* arguments[0]
@@ -2577,6 +2586,7 @@ a#225 = (
         "next": null
     }
   | ???*14*
+  | ???*15*
 )
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
@@ -2607,6 +2617,7 @@ a#225 = (
 - *13* c
   ⚠️  circular variable reference
 - *14* unsupported expression
+- *15* unknown mutation
 
 a#226 = ???*0*
 - *0* arguments[0]
@@ -2870,7 +2881,7 @@ a#275 = (
   | ???*0*
   | {
         "getSnapshot": (???*1* | null["updateQueue"] | ???*2* | {"lastEffect": null, "stores": null}),
-        "value": (???*4* | ???*5* | null)
+        "value": (???*4* | ???*5* | null | ???*7*)
     }
 )
 - *0* arguments[0]
@@ -2887,6 +2898,7 @@ a#275 = (
   ⚠️  unknown object
 - *6* arguments[1]
   ⚠️  function calls are not analysed yet
+- *7* unknown mutation
 
 a#276 = ???*0*
 - *0* arguments[0]
@@ -2973,14 +2985,14 @@ a#282 = (
           | {
                 "tag": ???*2*,
                 "create": (???*3* | null["updateQueue"] | ???*4* | {"lastEffect": null, "stores": null}),
-                "destroy": (???*6* | ???*7* | null),
-                "deps": (???*9* | ???*10* | null["next"]),
+                "destroy": (???*6* | ???*7* | null | ???*9*),
+                "deps": (???*10* | ???*11* | null["next"]),
                 "next": null
             }
         ),
-        "create": (???*12* | null["updateQueue"] | ???*13* | {"lastEffect": null, "stores": null}),
-        "destroy": (???*15* | ???*16* | null),
-        "deps": (???*18* | ???*19* | null["next"]),
+        "create": (???*13* | null["updateQueue"] | ???*14* | {"lastEffect": null, "stores": null}),
+        "destroy": (???*16* | ???*17* | null | ???*19*),
+        "deps": (???*20* | ???*21* | null["next"]),
         "next": null
     }
 )
@@ -3002,29 +3014,31 @@ a#282 = (
   ⚠️  unknown object
 - *8* arguments[1]
   ⚠️  function calls are not analysed yet
-- *9* arguments[3]
+- *9* unknown mutation
+- *10* arguments[3]
   ⚠️  function calls are not analysed yet
-- *10* ???*11*["next"]
+- *11* ???*12*["next"]
   ⚠️  unknown object
-- *11* arguments[2]
+- *12* arguments[2]
   ⚠️  function calls are not analysed yet
-- *12* arguments[1]
+- *13* arguments[1]
   ⚠️  function calls are not analysed yet
-- *13* ???*14*["updateQueue"]
+- *14* ???*15*["updateQueue"]
   ⚠️  unknown object
-- *14* arguments[1]
+- *15* arguments[1]
   ⚠️  function calls are not analysed yet
-- *15* arguments[2]
+- *16* arguments[2]
   ⚠️  function calls are not analysed yet
-- *16* ???*17*["lastEffect"]
+- *17* ???*18*["lastEffect"]
   ⚠️  unknown object
-- *17* arguments[1]
+- *18* arguments[1]
   ⚠️  function calls are not analysed yet
-- *18* arguments[3]
+- *19* unknown mutation
+- *20* arguments[3]
   ⚠️  function calls are not analysed yet
-- *19* ???*20*["next"]
+- *21* ???*22*["next"]
   ⚠️  unknown object
-- *20* arguments[2]
+- *22* arguments[2]
   ⚠️  function calls are not analysed yet
 
 a#283 = ???*0*
@@ -4473,10 +4487,11 @@ ae = (!(???*0*) | ???*1*)
 - *0* unsupported expression
 - *1* unsupported expression
 
-af = (undefined | ???*0* | "animationiteration" | ???*1*)
+af = (undefined | ???*0* | ???*1* | "animationiteration" | ???*2*)
 - *0* FreeVar(undefined)
   ⚠️  unknown global
-- *1* unsupported expression
+- *1* unknown mutation
+- *2* unsupported expression
 
 ag = (...) => undefined
 
@@ -4526,7 +4541,7 @@ b#103 = ???*0*
 - *0* arguments[1]
   ⚠️  function calls are not analysed yet
 
-b#104 = (???*0* | undefined | null | ???*1* | ???*2* | [???*4*])
+b#104 = (???*0* | undefined | null | ???*1* | ???*2* | [???*4*] | ???*5*)
 - *0* arguments[1]
   ⚠️  function calls are not analysed yet
 - *1* b
@@ -4537,6 +4552,7 @@ b#104 = (???*0* | undefined | null | ???*1* | ???*2* | [???*4*])
   ⚠️  circular variable reference
 - *4* arguments[4]
   ⚠️  function calls are not analysed yet
+- *5* unknown mutation
 
 b#105 = ???*0*
 - *0* arguments[1]
@@ -4928,7 +4944,8 @@ b#212 = (???*0* | ???*1*)
 - *3* FreeVar(Object)
   ⚠️  unknown global
 
-b#213 = (undefined["current"] | null)
+b#213 = (undefined["current"] | null | ???*0*)
+- *0* unknown mutation
 
 b#214 = ???*0*
 - *0* arguments[1]
@@ -4938,13 +4955,14 @@ b#215 = ???*0*
 - *0* arguments[1]
   ⚠️  function calls are not analysed yet
 
-b#216 = (???*0* | ???*2*)
+b#216 = (???*0* | ???*2* | ???*3*)
 - *0* ???*1*["_currentValue"]
   ⚠️  unknown object
 - *1* arguments[0]
   ⚠️  function calls are not analysed yet
 - *2* FreeVar(undefined)
   ⚠️  unknown global
+- *3* unknown mutation
 
 b#218 = ???*0*
 - *0* arguments[1]
@@ -5171,7 +5189,8 @@ b#254 = ???*0*
 b#261 = ???*0*
 - *0* max number of linking steps reached
 
-b#262 = (undefined | undefined["current"] | {})
+b#262 = (undefined | undefined["current"] | {} | ???*0*)
+- *0* unknown mutation
 
 b#264 = (???*0* | ???*1*)
 - *0* arguments[0]
@@ -5202,11 +5221,12 @@ b#27 = ???*0*
 - *4* ???["stack"]
   ⚠️  unknown object
 
-b#270 = (null["memoizedState"] | ???*0* | null["next"] | null)
+b#270 = (null["memoizedState"] | ???*0* | null["next"] | null | ???*2*)
 - *0* ???*1*["memoizedState"]
   ⚠️  unknown object
 - *1* arguments[1]
   ⚠️  function calls are not analysed yet
+- *2* unknown mutation
 
 b#271 = ???*0*
 - *0* arguments[1]
@@ -5508,10 +5528,11 @@ b#307 = (
   ⚠️  unknown object
 - *10* unsupported expression
 
-b#309 = (undefined[0] | undefined["memoizedState"] | null["memoizedState"] | ???*0* | null)
+b#309 = (undefined[0] | undefined["memoizedState"] | null["memoizedState"] | ???*0* | null | ???*2*)
 - *0* ???*1*["memoizedState"]
   ⚠️  unknown object
 - *1* unsupported expression
+- *2* unknown mutation
 
 b#310 = ???*0*
 - *0* arguments[1]
@@ -5555,10 +5576,11 @@ b#312 = (
   ⚠️  unknown object
 - *10* unsupported expression
 
-b#313 = (undefined["memoizedState"] | null["memoizedState"] | ???*0* | null)
+b#313 = (undefined["memoizedState"] | null["memoizedState"] | ???*0* | null | ???*2*)
 - *0* ???*1*["memoizedState"]
   ⚠️  unknown object
 - *1* unsupported expression
+- *2* unknown mutation
 
 b#314 = (
   | undefined
@@ -5595,10 +5617,11 @@ b#314 = (
   ⚠️  unknown object
 - *10* unsupported expression
 
-b#315 = (undefined["memoizedState"] | null["memoizedState"] | ???*0* | null)
+b#315 = (undefined["memoizedState"] | null["memoizedState"] | ???*0* | null | ???*2*)
 - *0* ???*1*["memoizedState"]
   ⚠️  unknown object
 - *1* unsupported expression
+- *2* unknown mutation
 
 b#316 = ???*0*
 - *0* arguments[1]
@@ -6227,11 +6250,12 @@ b#451 = (
           | undefined["current"]
           | ???*6*
           | ???*7*
+          | ???*8*
           | 4
           | 16
           | 536870912
           | null
-          | ???*8*
+          | ???*9*
         ),
         "tag": 0,
         "payload": null,
@@ -6251,9 +6275,10 @@ b#451 = (
   ⚠️  function calls are not analysed yet
 - *6* FreeVar(undefined)
   ⚠️  unknown global
-- *7* C
+- *7* unknown mutation
+- *8* C
   ⚠️  circular variable reference
-- *8* arguments[0]
+- *9* arguments[0]
   ⚠️  function calls are not analysed yet
 
 b#453 = ???*0*
@@ -6416,7 +6441,7 @@ b#52 = ???*0*
 b#53 = (???*0* | {} | null | ???*1*)
 - *0* arguments[1]
   ⚠️  function calls are not analysed yet
-- *1* ???*2*[(0 | ???*3* | ???*10*)]
+- *1* ???*2*[(0 | ???*3* | ???*10* | ???*18*)]
   ⚠️  unknown object
 - *2* arguments[0]
   ⚠️  function calls are not analysed yet
@@ -6434,20 +6459,31 @@ b#53 = (???*0* | {} | null | ???*1*)
   ⚠️  function calls are not analysed yet
 - *9* c
   ⚠️  circular variable reference
-- *10* ???*11*(`$${???*12*}`)
-  ⚠️  unknown callee
+- *10* (???*11* | ???*12*)(`$${???*13*}`)
+  ⚠️  non-function callee
 - *11* FreeVar(undefined)
   ⚠️  unknown global
-- *12* ???*13*["value"]
+- *12* unknown mutation
+- *13* ???*14*["value"]
   ⚠️  unknown object
-- *13* ???*14*[(???*15* | 0 | undefined | ???*16* | "")]
+- *14* ???*15*[(???*16* | 0 | undefined | ???*17* | "")]
   ⚠️  unknown object
-- *14* arguments[0]
+- *15* arguments[0]
   ⚠️  function calls are not analysed yet
-- *15* arguments[2]
+- *16* arguments[2]
   ⚠️  function calls are not analysed yet
-- *16* c
+- *17* c
   ⚠️  circular variable reference
+- *18* ???*19*(???*20*)
+  ⚠️  unknown callee
+- *19* null["hasOwnProperty"]
+  ⚠️  nested operation
+- *20* `$${???*21*}`
+  ⚠️  nested operation
+- *21* ???*22*["value"]
+  ⚠️  unknown object
+- *22* ???[(??? | 0 | undefined | ??? | "")]
+  ⚠️  unknown object
 
 b#54 = ???*0*
 - *0* arguments[1]
@@ -6703,10 +6739,11 @@ be = (null | ???*0*)
 - *1* FreeVar(document)
   ⚠️  unknown global
 
-bf = (undefined | ???*0* | "animationstart" | ???*1*)
+bf = (undefined | ???*0* | ???*1* | "animationstart" | ???*2*)
 - *0* FreeVar(undefined)
   ⚠️  unknown global
-- *1* unsupported expression
+- *1* unknown mutation
+- *2* unsupported expression
 
 bg = (...) => (undefined | c | A({}, c, d))
 
@@ -7159,7 +7196,9 @@ c#262 = (
   | "http://www.w3.org/1999/xhtml"
   | undefined["current"]
   | {}
+  | ???*0*
 )
+- *0* unknown mutation
 
 c#264 = ???*0*
 - *0* ???*1*["memoizedState"]
@@ -7173,28 +7212,31 @@ c#267 = ???*0*
 - *0* arguments[2]
   ⚠️  function calls are not analysed yet
 
-c#272 = (undefined["queue"] | null["queue"] | ???*0* | null)
+c#272 = (undefined["queue"] | null["queue"] | ???*0* | null | ???*2*)
 - *0* ???*1*["queue"]
   ⚠️  unknown object
 - *1* unsupported expression
+- *2* unknown mutation
 
-c#273 = (undefined["queue"] | null["queue"] | ???*0* | null)
+c#273 = (undefined["queue"] | null["queue"] | ???*0* | null | ???*2*)
 - *0* ???*1*["queue"]
   ⚠️  unknown object
 - *1* unsupported expression
+- *2* unknown mutation
 
 c#274 = (null | ???*0* | ???*1*)
 - *0* arguments[1]
   ⚠️  function calls are not analysed yet
 - *1* unsupported expression
 
-c#275 = (???*0* | ???*1* | null)
+c#275 = (???*0* | ???*1* | null | ???*3*)
 - *0* arguments[2]
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["stores"]
   ⚠️  unknown object
 - *2* arguments[1]
   ⚠️  function calls are not analysed yet
+- *3* unknown mutation
 
 c#276 = ???*0*
 - *0* arguments[2]
@@ -7214,13 +7256,14 @@ c#28 = ???*0*
 - *0* c
   ⚠️  pattern without value
 
-c#282 = (???*0* | ???*1* | null)
+c#282 = (???*0* | ???*1* | null | ???*3*)
 - *0* arguments[2]
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["lastEffect"]
   ⚠️  unknown object
 - *2* arguments[1]
   ⚠️  function calls are not analysed yet
+- *3* unknown mutation
 
 c#283 = ???*0*
 - *0* arguments[2]
@@ -8308,10 +8351,11 @@ ce = (!(???*0*) | ???*1* | !((null | ???*2*)))
 - *3* FreeVar(document)
   ⚠️  unknown global
 
-cf = (undefined | ???*0* | "transitionend" | ???*1*)
+cf = (undefined | ???*0* | ???*1* | "transitionend" | ???*2*)
 - *0* FreeVar(undefined)
   ⚠️  unknown global
-- *1* unsupported expression
+- *1* unknown mutation
+- *2* unsupported expression
 
 cg = (...) => (undefined | !(0))
 
@@ -8480,36 +8524,39 @@ d#193 = (???*0* | ???*2*())
 - *4* arguments[0]
   ⚠️  function calls are not analysed yet
 
-d#195 = (???*0* | undefined["stateNode"] | ???*2*)
+d#195 = (???*0* | undefined["stateNode"] | ???*2* | ???*3*)
 - *0* ???*1*["stateNode"]
   ⚠️  unknown object
 - *1* arguments[0]
   ⚠️  function calls are not analysed yet
 - *2* FreeVar(undefined)
   ⚠️  unknown global
+- *3* unknown mutation
 
-d#198 = (null[0] | ???*0* | ???*1* | ???*4*)
+d#198 = (null[0] | ???*0* | ???*1* | ???*2* | ???*5*)
 - *0* arguments[0]
   ⚠️  function calls are not analysed yet
-- *1* ???*2*[0]
+- *1* unknown mutation
+- *2* ???*3*[0]
   ⚠️  unknown object
-- *2* ???*3*["slice"]((a + 1))
+- *3* ???*4*["slice"]((a + 1))
   ⚠️  unknown callee object
-- *3* eg
+- *4* eg
   ⚠️  circular variable reference
-- *4* (null[0] | ???*5* | ???*6* | ???*9*)(!(0))
+- *5* (null[0] | ???*6* | ???*7* | ???*8* | ???*11*)(!(0))
   ⚠️  non-function callee
-- *5* arguments[0]
+- *6* arguments[0]
   ⚠️  function calls are not analysed yet
-- *6* ???*7*[0]
+- *7* unknown mutation
+- *8* ???*9*[0]
   ⚠️  unknown object
-- *7* ???*8*["slice"]((a + 1))
+- *9* ???*10*["slice"]((a + 1))
   ⚠️  unknown callee object
-- *8* eg
+- *10* eg
   ⚠️  circular variable reference
-- *9* ???*10*(!(0))
+- *11* ???*12*(!(0))
   ⚠️  unknown callee
-- *10* d
+- *12* d
   ⚠️  circular variable reference
 
 d#201 = ???*0*
@@ -8540,13 +8587,14 @@ d#224 = ???*0*
 - *1* arguments[1]
   ⚠️  function calls are not analysed yet
 
-d#225 = (???*0* | null["alternate"] | ???*2*)
+d#225 = (???*0* | null["alternate"] | ???*2* | ???*3*)
 - *0* ???*1*["alternate"]
   ⚠️  unknown object
 - *1* arguments[0]
   ⚠️  function calls are not analysed yet
 - *2* FreeVar(undefined)
   ⚠️  unknown global
+- *3* unknown mutation
 
 d#226 = ???*0*
 - *0* arguments[3]
@@ -8712,6 +8760,7 @@ d#274 = (
     }
   | undefined["queue"]
   | null["queue"]
+  | ???*11*
 )
 - *0* unsupported expression
 - *1* ???*2*["memoizedState"]
@@ -8730,6 +8779,7 @@ d#274 = (
 - *9* ???*10*["queue"]
   ⚠️  unknown object
 - *10* unsupported expression
+- *11* unknown mutation
 
 d#276 = ???*0*
 - *0* arguments[3]
@@ -8761,15 +8811,17 @@ d#29 = ???*0*
 - *0* l
   ⚠️  pattern without value
 
-d#291 = (undefined["memoizedState"] | null["memoizedState"] | ???*0* | null)
+d#291 = (undefined["memoizedState"] | null["memoizedState"] | ???*0* | null | ???*2*)
 - *0* ???*1*["memoizedState"]
   ⚠️  unknown object
 - *1* unsupported expression
+- *2* unknown mutation
 
-d#292 = (undefined["memoizedState"] | null["memoizedState"] | ???*0* | null)
+d#292 = (undefined["memoizedState"] | null["memoizedState"] | ???*0* | null | ???*2*)
 - *0* ???*1*["memoizedState"]
   ⚠️  unknown object
 - *1* unsupported expression
+- *2* unknown mutation
 
 d#294 = ???*0*
 - *0* ???*1*["transition"]
@@ -8961,12 +9013,13 @@ d#344 = ???*0*
 - *0* arguments[3]
   ⚠️  function calls are not analysed yet
 
-d#345 = (???*0* | undefined["current"] | 0 | ???*2*)
+d#345 = (???*0* | undefined["current"] | 0 | ???*2* | ???*3*)
 - *0* ???*1*["pendingProps"]
   ⚠️  unknown object
 - *1* arguments[1]
   ⚠️  function calls are not analysed yet
-- *2* unsupported expression
+- *2* unknown mutation
+- *3* unsupported expression
 
 d#348 = (???*0* | ???*3*)
 - *0* ???*1*["_context"]
@@ -9718,7 +9771,8 @@ e#233 = ???*0*
 - *0* arguments[4]
   ⚠️  function calls are not analysed yet
 
-e#234 = ({} | undefined["current"])
+e#234 = ({} | undefined["current"] | ???*0*)
+- *0* unknown mutation
 
 e#236 = ???*0*
 - *0* ???*1*["stateNode"]
@@ -10202,13 +10256,14 @@ e#450 = (
 - *4* C
   ⚠️  circular variable reference
 
-e#451 = (???*0* | undefined["current"] | ???*2*)
+e#451 = (???*0* | undefined["current"] | ???*2* | ???*3*)
 - *0* ???*1*["current"]
   ⚠️  unknown object
 - *1* arguments[1]
   ⚠️  function calls are not analysed yet
 - *2* FreeVar(undefined)
   ⚠️  unknown global
+- *3* unknown mutation
 
 e#463 = (???*0* | ???*1*)
 - *0* arguments[4]
@@ -10260,7 +10315,7 @@ e#481 = (false | true | ???*0* | ???*2*)
 - *6* e
   ⚠️  circular variable reference
 
-e#53 = (0 | ???*0* | ???*7*)
+e#53 = (0 | ???*0* | ???*7* | ???*15*)
 - *0* ???*1*["hasOwnProperty"](`$${???*2*}`)
   ⚠️  unknown callee object
 - *1* arguments[1]
@@ -10275,19 +10330,36 @@ e#53 = (0 | ???*0* | ???*7*)
   ⚠️  function calls are not analysed yet
 - *6* c
   ⚠️  circular variable reference
-- *7* ???*8*(`$${???*9*}`)
-  ⚠️  unknown callee
+- *7* (???*8* | ???*9*)(`$${???*10*}`)
+  ⚠️  non-function callee
 - *8* FreeVar(undefined)
   ⚠️  unknown global
-- *9* ???*10*["value"]
+- *9* unknown mutation
+- *10* ???*11*["value"]
   ⚠️  unknown object
-- *10* ???*11*[(???*12* | 0 | undefined | ???*13* | "")]
+- *11* ???*12*[(???*13* | 0 | undefined | ???*14* | "")]
   ⚠️  unknown object
-- *11* arguments[0]
+- *12* arguments[0]
   ⚠️  function calls are not analysed yet
-- *12* arguments[2]
+- *13* arguments[2]
   ⚠️  function calls are not analysed yet
-- *13* c
+- *14* c
+  ⚠️  circular variable reference
+- *15* ???*16*(???*17*)
+  ⚠️  unknown callee
+- *16* null["hasOwnProperty"]
+  ⚠️  nested operation
+- *17* `$${???*18*}`
+  ⚠️  nested operation
+- *18* ???*19*["value"]
+  ⚠️  unknown object
+- *19* ???*20*[(???*21* | 0 | undefined | ???*22* | "")]
+  ⚠️  unknown object
+- *20* arguments[0]
+  ⚠️  function calls are not analysed yet
+- *21* arguments[2]
+  ⚠️  function calls are not analysed yet
+- *22* c
   ⚠️  circular variable reference
 
 e#61 = ???*0*
@@ -10529,19 +10601,21 @@ f#233 = ???*0*
 - *0* arguments[5]
   ⚠️  function calls are not analysed yet
 
-f#234 = (???*0* | undefined | undefined["_currentValue"] | ???*2* | {})
+f#234 = (???*0* | undefined | undefined["_currentValue"] | ???*2* | ???*3* | {})
 - *0* ???*1*["contextType"]
   ⚠️  unknown object
 - *1* arguments[1]
   ⚠️  function calls are not analysed yet
 - *2* FreeVar(undefined)
   ⚠️  unknown global
+- *3* unknown mutation
 
-f#236 = (???*0* | {} | undefined["current"])
+f#236 = (???*0* | {} | undefined["current"] | ???*2*)
 - *0* ???*1*["contextType"]
   ⚠️  unknown object
 - *1* arguments[1]
   ⚠️  function calls are not analysed yet
+- *2* unknown mutation
 
 f#237 = (???*0* | ???*1*)
 - *0* arguments[0]
@@ -10588,13 +10662,14 @@ f#267 = (???*0* | 0)
 f#272 = ???*0*
 - *0* max number of linking steps reached
 
-f#273 = (undefined["memoizedState"] | null["memoizedState"] | ???*0* | null | ???*2*)
+f#273 = (undefined["memoizedState"] | null["memoizedState"] | ???*0* | null | ???*2* | ???*3*)
 - *0* ???*1*["memoizedState"]
   ⚠️  unknown object
 - *1* unsupported expression
-- *2* ???*3*(f, g["action"])
+- *2* unknown mutation
+- *3* ???*4*(f, g["action"])
   ⚠️  unknown callee
-- *3* arguments[0]
+- *4* arguments[0]
   ⚠️  function calls are not analysed yet
 
 f#274 = !(???*0*)
@@ -10688,12 +10763,13 @@ f#331 = (???*0* | null)
 - *1* arguments[0]
   ⚠️  function calls are not analysed yet
 
-f#333 = ({} | undefined["current"] | undefined | ???*0*)
-- *0* ???*1*["__reactInternalMemoizedMaskedChildContext"]
+f#333 = ({} | undefined["current"] | ???*0* | undefined | ???*1*)
+- *0* unknown mutation
+- *1* ???*2*["__reactInternalMemoizedMaskedChildContext"]
   ⚠️  unknown object
-- *1* ???*2*["stateNode"]
+- *2* ???*3*["stateNode"]
   ⚠️  unknown object
-- *2* arguments[1]
+- *3* arguments[1]
   ⚠️  function calls are not analysed yet
 
 f#334 = (true | false)
@@ -11033,10 +11109,11 @@ g#273 = (???*0* | ???*1*)
   ⚠️  unknown object
 - *2* unsupported expression
 
-g#284 = (null["memoizedState"] | ???*0*)
+g#284 = (null["memoizedState"] | ???*0* | ???*2*)
 - *0* ???*1*["memoizedState"]
   ⚠️  unknown object
 - *1* unsupported expression
+- *2* unknown mutation
 
 g#29 = ???*0*
 - *0* unsupported expression
@@ -11165,11 +11242,12 @@ g#451 = (
   | undefined["current"]
   | ???*3*
   | ???*4*
+  | ???*5*
   | 4
   | 16
   | 536870912
   | null
-  | ???*5*
+  | ???*6*
 )
 - *0* unsupported expression
 - *1* ???*2*["current"]
@@ -11178,9 +11256,10 @@ g#451 = (
   ⚠️  function calls are not analysed yet
 - *3* FreeVar(undefined)
   ⚠️  unknown global
-- *4* C
+- *4* unknown mutation
+- *5* C
   ⚠️  circular variable reference
-- *5* arguments[0]
+- *6* arguments[0]
   ⚠️  function calls are not analysed yet
 
 g#463 = (undefined | ???*0* | ???*1* | ???*3*)
@@ -11259,8 +11338,9 @@ gh = (...) => undefined
 
 gi = (...) => (undefined | [f, d])
 
-gj = (0 | undefined["current"] | ???*0*)
-- *0* arguments[1]
+gj = (0 | undefined["current"] | ???*0* | ???*1*)
+- *0* unknown mutation
+- *1* arguments[1]
   ⚠️  function calls are not analysed yet
 
 gk = (???*0*() | 0)
@@ -11653,7 +11733,7 @@ k#296 = ???*0*
 - *1* arguments[1]
   ⚠️  function calls are not analysed yet
 
-k#334 = (???*0* | undefined | undefined["_currentValue"] | ???*3* | {} | undefined["current"])
+k#334 = (???*0* | undefined | undefined["_currentValue"] | ???*3* | ???*4* | {} | undefined["current"])
 - *0* ???*1*["context"]
   ⚠️  unknown object
 - *1* ???*2*["stateNode"]
@@ -11662,6 +11742,7 @@ k#334 = (???*0* | undefined | undefined["_currentValue"] | ???*3* | {} | undefin
   ⚠️  function calls are not analysed yet
 - *3* FreeVar(undefined)
   ⚠️  unknown global
+- *4* unknown mutation
 
 k#339 = ???*0*
 - *0* max number of linking steps reached
@@ -12754,10 +12835,10 @@ vj = (...) => undefined
 vk = null
 
 vl = {
-    "bundleType": 0,
-    "version": "18.2.0",
-    "rendererPackageName": "react-dom",
-    "rendererConfig": ???*0*,
+    "bundleType": (0 | ???*0*),
+    "version": ("18.2.0" | ???*1*),
+    "rendererPackageName": ("react-dom" | ???*2*),
+    "rendererConfig": (???*3* | ???*4*),
     "overrideHookState": null,
     "overrideHookStateDeletePath": null,
     "overrideHookStateRenamePath": null,
@@ -12767,9 +12848,9 @@ vl = {
     "setErrorHandler": null,
     "setSuspenseHandler": null,
     "scheduleUpdate": null,
-    "currentDispatcherRef": ???*1*,
+    "currentDispatcherRef": ???*5*,
     "findHostInstanceByFiber": (...) => (undefined | null | a["stateNode"]),
-    "findFiberByHostInstance": (...) => (undefined | b | c | null),
+    "findFiberByHostInstance": ((...) => (undefined | b | c | null) | ???*7* | (...) => (undefined | null)),
     "findHostInstancesForRefresh": null,
     "scheduleRefresh": null,
     "scheduleRoot": null,
@@ -12777,12 +12858,17 @@ vl = {
     "getCurrentFiber": null,
     "reconcilerVersion": "18.2.0-next-9e3b772b8-20220608"
 }
-- *0* FreeVar(undefined)
+- *0* unknown mutation
+- *1* unknown mutation
+- *2* unknown mutation
+- *3* FreeVar(undefined)
   ⚠️  unknown global
-- *1* ???*2*["ReactCurrentDispatcher"]
+- *4* unknown mutation
+- *5* ???*6*["ReactCurrentDispatcher"]
   ⚠️  unknown object
-- *2* module<react, {}>["__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED"]
+- *6* module<react, {}>["__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED"]
   ⚠️  nested operation
+- *7* unknown mutation
 
 w#170 = ???*0*
 - *0* max number of linking steps reached

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/webpack-target-node/graph-effects.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/webpack-target-node/graph-effects.snapshot
@@ -670,9 +670,9 @@
                 ),
             ),
             Value(
-                Object(
-                    3,
-                    [
+                Object {
+                    total_nodes: 3,
+                    parts: [
                         KeyValue(
                             Constant(
                                 StrWord(
@@ -687,7 +687,8 @@
                             ),
                         ),
                     ],
-                ),
+                    mutable: true,
+                },
             ),
         ],
         ast_path: [
@@ -1779,9 +1780,9 @@
         ),
         args: [
             Value(
-                Object(
-                    5,
-                    [
+                Object {
+                    total_nodes: 5,
+                    parts: [
                         KeyValue(
                             Constant(
                                 StrWord(
@@ -1809,7 +1810,8 @@
                             ),
                         ),
                     ],
-                ),
+                    mutable: true,
+                },
             ),
         ],
         ast_path: [

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/webpack-target-node/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/webpack-target-node/graph.snapshot
@@ -141,10 +141,11 @@
     ),
     (
         "exports",
-        Object(
-            1,
-            [],
-        ),
+        Object {
+            total_nodes: 1,
+            parts: [],
+            mutable: true,
+        },
     ),
     (
         "handler",
@@ -224,12 +225,12 @@
     ),
     (
         "users",
-        Array(
-            10,
-            [
-                Object(
-                    3,
-                    [
+        Array {
+            total_nodes: 10,
+            items: [
+                Object {
+                    total_nodes: 3,
+                    parts: [
                         KeyValue(
                             Constant(
                                 StrWord(
@@ -245,10 +246,11 @@
                             ),
                         ),
                     ],
-                ),
-                Object(
-                    3,
-                    [
+                    mutable: true,
+                },
+                Object {
+                    total_nodes: 3,
+                    parts: [
                         KeyValue(
                             Constant(
                                 StrWord(
@@ -264,10 +266,11 @@
                             ),
                         ),
                     ],
-                ),
-                Object(
-                    3,
-                    [
+                    mutable: true,
+                },
+                Object {
+                    total_nodes: 3,
+                    parts: [
                         KeyValue(
                             Constant(
                                 StrWord(
@@ -283,8 +286,10 @@
                             ),
                         ),
                     ],
-                ),
+                    mutable: true,
+                },
             ],
-        ),
+            mutable: true,
+        },
     ),
 ]


### PR DESCRIPTION
Before the static evaluation didn't consider the fact that objects and arrays can be mutated. So we can't just assume for sure that they have certain properties/items. Instead we add an unknown mutation alternative to handle that.

This avoids `if(obj.prop)` to be replaced with `if(true)` when prop is initialized with true. It might be modified in future.