### PR TITLE
enable rust codepath in release process

### DIFF
--- a/cli/combined-release.yml
+++ b/cli/combined-release.yml
@@ -6,7 +6,7 @@ builds:
   - id: turbo
     builder: prebuilt
     tags:
-      - go
+      - rust
     goos:
       - linux
       - windows

--- a/cli/combined-shim.yml
+++ b/cli/combined-shim.yml
@@ -6,7 +6,7 @@ builds:
   - id: turbo
     builder: prebuilt
     tags:
-      - go
+      - rust
     goos:
       - linux
       - windows

--- a/cli/cross-release.yml
+++ b/cli/cross-release.yml
@@ -10,7 +10,7 @@ builds:
   - id: turbo
     main: ./cmd/turbo
     tags:
-      - go
+      - rust
     binary: bin/go-turbo
     flags:
       - -trimpath

--- a/cli/darwin-release.yml
+++ b/cli/darwin-release.yml
@@ -10,7 +10,7 @@ builds:
   - id: turbo
     main: ./cmd/turbo
     tags:
-      - go
+      - rust
     binary: bin/go-turbo
     flags:
       - -trimpath


### PR DESCRIPTION
This enables the 'go sandwich' by flipping the go tag in our release pipeline.