### PR TITLE
Deadlock while memory usage reaching the limitation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf46fee83e5ccffc220104713af3292ff9bc7c64c7de289f66dae8e38d826833"
 dependencies = [
- "concurrent-queue 2.1.0",
+ "concurrent-queue",
  "event-listener",
  "futures-core",
 ]
@@ -184,7 +184,7 @@ checksum = "17adb73da160dfb475c183343c8cccd80721ea5a605d3eb57125f0a7b7a92d0b"
 dependencies = [
  "async-lock",
  "async-task",
- "concurrent-queue 2.1.0",
+ "concurrent-queue",
  "fastrand",
  "futures-lite",
  "slab",
@@ -213,7 +213,7 @@ checksum = "8c374dda1ed3e7d8f0d9ba58715f924862c63eae6849c92d3a18e7fbde9e2794"
 dependencies = [
  "async-lock",
  "autocfg",
- "concurrent-queue 2.1.0",
+ "concurrent-queue",
  "futures-lite",
  "libc",
  "log",
@@ -692,12 +692,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
-name = "cache-padded"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
-
-[[package]]
 name = "cargo-lock"
 version = "8.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -988,15 +982,6 @@ checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
 dependencies = [
  "bytes",
  "memchr",
-]
-
-[[package]]
-name = "concurrent-queue"
-version = "1.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af4780a44ab5696ea9e28294517f1fffb421a83a25af521333c838635509db9c"
-dependencies = [
- "cache-padded",
 ]
 
 [[package]]
@@ -7533,7 +7518,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "auto-hash-map",
- "concurrent-queue 1.2.4",
+ "concurrent-queue",
  "dashmap",
  "erased-serde",
  "event-listener",
@@ -7607,7 +7592,7 @@ dependencies = [
  "auto-hash-map",
  "bitflags",
  "bytes",
- "concurrent-queue 1.2.4",
+ "concurrent-queue",
  "criterion 0.3.6",
  "dunce",
  "futures",
@@ -7669,7 +7654,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "auto-hash-map",
- "concurrent-queue 1.2.4",
+ "concurrent-queue",
  "criterion 0.3.6",
  "dashmap",
  "lazy_static",

--- a/crates/turbo-tasks-fs/Cargo.toml
+++ b/crates/turbo-tasks-fs/Cargo.toml
@@ -17,7 +17,7 @@ anyhow = "1.0.47"
 auto-hash-map = { path = "../auto-hash-map" }
 bitflags = "1.3.2"
 bytes = "1.1.0"
-concurrent-queue = "1.2.2"
+concurrent-queue = "2.1.0"
 dunce = "1.0.3"
 futures = "0.3.25"
 futures-retry = "0.6.0"

--- a/crates/turbo-tasks-memory/Cargo.toml
+++ b/crates/turbo-tasks-memory/Cargo.toml
@@ -12,7 +12,7 @@ bench = false
 [dependencies]
 anyhow = "1.0.47"
 auto-hash-map = { path = "../auto-hash-map" }
-concurrent-queue = "1.2.2"
+concurrent-queue = "2.1.0"
 dashmap = "5.4.0"
 nohash-hasher = "0.2.0"
 num_cpus = "1.13.1"

--- a/crates/turbo-tasks/Cargo.toml
+++ b/crates/turbo-tasks/Cargo.toml
@@ -18,7 +18,7 @@ hanging_detection = []
 [dependencies]
 anyhow = "1.0.47"
 auto-hash-map = { path = "../auto-hash-map" }
-concurrent-queue = "1.2.2"
+concurrent-queue = "2.1.0"
 dashmap = "5.4.0"
 erased-serde = "0.3.20"
 event-listener = "2.5.3"


### PR DESCRIPTION
Upgrade `concurrent-queue` seems to solve this issue in some cases... But it still appears if given a smaller `memory_limit`.

Reproduce it by `cargo run --bin node-file-trace -- print -c . --memory-limit 128000000 -e "crates/turbopack/tests/node-file-trace/integration/remark-prism.mjs"`

If this command works fine, you can decrease the memory limit value and try again. I can 100% reproduce deadlock on my computer. The CPU usage is 100% and nothing prints on the console and the stack traces are always the same.