### PR TITLE
separate app and pages structure extraction from source generation

### DIFF
--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -1,0 +1,316 @@
+use std::collections::HashMap;
+
+use anyhow::{bail, Result};
+use turbo_tasks::{
+    primitives::{StringVc, StringsVc},
+    CompletionVc, ValueToString,
+};
+use turbo_tasks_fs::{
+    DirectoryContent, DirectoryEntry, File, FileContentVc, FileSystemEntryType, FileSystemPathVc,
+};
+use turbopack_core::issue::{Issue, IssueSeverity, IssueSeverityVc, IssueVc};
+use turbopack_dev_server::source::specificity::SpecificityVc;
+
+use crate::{
+    app_render::{LayoutSegment, LayoutSegmentVc, LayoutSegmentsVc},
+    embed_js::wrap_with_next_js_fs,
+    next_config::NextConfigVc,
+};
+
+#[turbo_tasks::value]
+pub enum AppStructureItem {
+    Page {
+        segment: LayoutSegmentVc,
+        segments: LayoutSegmentsVc,
+        url: FileSystemPathVc,
+        specificity: SpecificityVc,
+        page: FileSystemPathVc,
+    },
+}
+
+#[turbo_tasks::value_impl]
+impl AppStructureItemVc {
+    #[turbo_tasks::function]
+    pub async fn routes_changed(self) -> Result<CompletionVc> {
+        match *self.await? {
+            AppStructureItem::Page { url, .. } => url.await?,
+        };
+        Ok(CompletionVc::new())
+    }
+}
+
+#[turbo_tasks::value]
+pub struct AppStructure {
+    pub directory: FileSystemPathVc,
+    pub item: Option<AppStructureItemVc>,
+    pub children: Vec<AppStructureVc>,
+}
+
+#[turbo_tasks::value_impl]
+impl AppStructureVc {
+    #[turbo_tasks::function]
+    pub async fn directory(self) -> Result<FileSystemPathVc> {
+        Ok(self.await?.directory)
+    }
+
+    #[turbo_tasks::function]
+    pub async fn routes_changed(self) -> Result<CompletionVc> {
+        if let Some(item) = self.await?.item {
+            item.routes_changed().await?;
+        }
+        for child in self.await?.children.iter() {
+            child.routes_changed().await?;
+        }
+        Ok(CompletionVc::new())
+    }
+}
+
+#[turbo_tasks::value(transparent)]
+pub struct OptionAppStructure(Option<AppStructureVc>);
+
+#[turbo_tasks::value_impl]
+impl OptionAppStructureVc {
+    #[turbo_tasks::function]
+    pub async fn routes_changed(self) -> Result<CompletionVc> {
+        if let Some(app_structure) = *self.await? {
+            app_structure.routes_changed().await?;
+        }
+        Ok(CompletionVc::new())
+    }
+}
+#[turbo_tasks::function]
+pub async fn find_app_structure(
+    project_path: FileSystemPathVc,
+    server_root: FileSystemPathVc,
+    next_config: NextConfigVc,
+) -> Result<OptionAppStructureVc> {
+    let project_path = wrap_with_next_js_fs(project_path);
+
+    if !*next_config.app_dir().await? {
+        return Ok(OptionAppStructureVc::cell(None));
+    }
+
+    let app = project_path.join("app");
+    let src_app = project_path.join("src/app");
+    let app_dir = if *app.get_type().await? == FileSystemEntryType::Directory {
+        app
+    } else if *src_app.get_type().await? == FileSystemEntryType::Directory {
+        src_app
+    } else {
+        return Ok(OptionAppStructureVc::cell(None));
+    }
+    .resolve()
+    .await?;
+
+    Ok(OptionAppStructureVc::cell(Some(get_app_structure(
+        app_dir,
+        server_root,
+        next_config.page_extensions(),
+    ))))
+}
+
+#[turbo_tasks::function]
+pub fn get_app_structure(
+    app_dir: FileSystemPathVc,
+    server_root: FileSystemPathVc,
+    page_extensions: StringsVc,
+) -> AppStructureVc {
+    get_app_structure_for_directory(
+        app_dir,
+        true,
+        SpecificityVc::exact(),
+        0,
+        server_root,
+        server_root,
+        LayoutSegmentsVc::cell(Vec::new()),
+        page_extensions,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+#[turbo_tasks::function]
+async fn get_app_structure_for_directory(
+    input_dir: FileSystemPathVc,
+    root: bool,
+    specificity: SpecificityVc,
+    position: u32,
+    target: FileSystemPathVc,
+    url: FileSystemPathVc,
+    layouts: LayoutSegmentsVc,
+    page_extensions: StringsVc,
+) -> Result<AppStructureVc> {
+    let mut layouts = layouts;
+    let mut page = None;
+    let mut files = HashMap::new();
+
+    let DirectoryContent::Entries(entries) = &*input_dir.read_dir().await? else {
+        bail!("{} is not a directory", input_dir.to_string().await?)
+    };
+
+    let allowed_extensions = &*page_extensions.await?;
+
+    for (name, entry) in entries.iter() {
+        if let &DirectoryEntry::File(file) = entry {
+            if let Some((name, ext)) = name.rsplit_once('.') {
+                if !allowed_extensions.iter().any(|allowed| allowed == ext) {
+                    continue;
+                }
+
+                match name {
+                    "page" => {
+                        page = Some(file);
+                    }
+                    "layout" | "error" | "loading" | "template" | "not-found" | "head" => {
+                        files.insert(name.to_string(), file);
+                    }
+                    _ => {
+                        // Any other file is ignored
+                    }
+                }
+            }
+        }
+    }
+
+    let layout = files.get("layout");
+
+    // If a page exists but no layout exists, create a basic root layout
+    // in `app/layout.js` or `app/layout.tsx`.
+    //
+    // TODO: Use let Some(page_file) = page in expression below when
+    // https://rust-lang.github.io/rfcs/2497-if-let-chains.html lands
+    if let (Some(page_file), None, true) = (page, layout, root) {
+        // Use the extension to determine if the page file is TypeScript.
+        // TODO: Use the presence of a tsconfig.json instead, like Next.js
+        // stable does.
+        let is_tsx = *page_file.extension().await? == "tsx";
+
+        let layout = if is_tsx {
+            input_dir.join("layout.tsx")
+        } else {
+            input_dir.join("layout.js")
+        };
+        files.insert("layout".to_string(), layout);
+        let content = if is_tsx {
+            include_str!("assets/layout.tsx")
+        } else {
+            include_str!("assets/layout.js")
+        };
+
+        layout.write(FileContentVc::from(File::from(content)));
+
+        AppStructureIssue {
+            severity: IssueSeverity::Warning.into(),
+            path: page_file,
+            message: StringVc::cell(format!(
+                "Your page {} did not have a root layout, we created {} for you.",
+                page_file.await?.path,
+                layout.await?.path,
+            )),
+        }
+        .cell()
+        .as_issue()
+        .emit();
+    }
+
+    let mut list = layouts.await?.clone_value();
+    let segment = LayoutSegment { files, target }.cell();
+    list.push(segment);
+    layouts = LayoutSegmentsVc::cell(list);
+
+    let mut children = Vec::new();
+    for (name, entry) in entries.iter() {
+        let DirectoryEntry::Directory(dir) = entry else {
+            continue;
+        };
+
+        let specificity = if name.starts_with("[[") || name.starts_with("[...") {
+            specificity.with_catch_all(position)
+        } else if name.starts_with('[') {
+            specificity.with_dynamic_segment(position)
+        } else {
+            specificity
+        };
+
+        let new_target = target.join(name);
+        let (new_root, new_url, position) = if name.starts_with('(') && name.ends_with(')') {
+            // This doesn't affect the url
+            (root, url, position)
+        } else {
+            // This adds to the url
+            (false, url.join(name), position + 1)
+        };
+
+        children.push((
+            name,
+            get_app_structure_for_directory(
+                *dir,
+                new_root,
+                specificity,
+                position,
+                new_target,
+                new_url,
+                layouts,
+                page_extensions,
+            )
+            .into(),
+        ));
+    }
+
+    let item = page.map(|page| {
+        AppStructureItem::Page {
+            page,
+            segment,
+            segments: layouts,
+            url,
+            specificity,
+        }
+        .cell()
+    });
+
+    // Ensure deterministic order since read_dir is not deterministic
+    children.sort_by_key(|(k, _)| *k);
+
+    Ok(AppStructure {
+        item,
+        directory: input_dir,
+        children: children.into_iter().map(|(_, v)| v).collect(),
+    }
+    .cell())
+}
+
+#[turbo_tasks::value(shared)]
+struct AppStructureIssue {
+    pub severity: IssueSeverityVc,
+    pub path: FileSystemPathVc,
+    pub message: StringVc,
+}
+
+#[turbo_tasks::value_impl]
+impl Issue for AppStructureIssue {
+    #[turbo_tasks::function]
+    fn severity(&self) -> IssueSeverityVc {
+        self.severity
+    }
+
+    #[turbo_tasks::function]
+    async fn title(&self) -> Result<StringVc> {
+        Ok(StringVc::cell(
+            "An issue occurred while preparing your Next.js app".to_string(),
+        ))
+    }
+
+    #[turbo_tasks::function]
+    fn category(&self) -> StringVc {
+        StringVc::cell("next app".to_string())
+    }
+
+    #[turbo_tasks::function]
+    fn context(&self) -> FileSystemPathVc {
+        self.path
+    }
+
+    #[turbo_tasks::function]
+    fn description(&self) -> StringVc {
+        self.message
+    }
+}

--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -17,6 +17,7 @@ use crate::{
     next_config::NextConfigVc,
 };
 
+/// A final route in the app directory.
 #[turbo_tasks::value]
 pub enum AppStructureItem {
     Page {
@@ -39,6 +40,7 @@ impl AppStructureItemVc {
     }
 }
 
+/// A (sub)directory in the app directory with all analyzed routes and folders.
 #[turbo_tasks::value]
 pub struct AppStructure {
     pub directory: FileSystemPathVc,
@@ -48,11 +50,14 @@ pub struct AppStructure {
 
 #[turbo_tasks::value_impl]
 impl AppStructureVc {
+    /// Returns the directory of this structure.
     #[turbo_tasks::function]
     pub async fn directory(self) -> Result<FileSystemPathVc> {
         Ok(self.await?.directory)
     }
 
+    /// Returns a completion that changes when any route in the whole tree
+    /// changes.
     #[turbo_tasks::function]
     pub async fn routes_changed(self) -> Result<CompletionVc> {
         if let Some(item) = self.await?.item {
@@ -70,6 +75,8 @@ pub struct OptionAppStructure(Option<AppStructureVc>);
 
 #[turbo_tasks::value_impl]
 impl OptionAppStructureVc {
+    /// Returns a completion that changes when any route in the whole tree
+    /// changes.
     #[turbo_tasks::function]
     pub async fn routes_changed(self) -> Result<CompletionVc> {
         if let Some(app_structure) = *self.await? {
@@ -78,6 +85,9 @@ impl OptionAppStructureVc {
         Ok(CompletionVc::new())
     }
 }
+
+/// Finds and returns the [AppStructure] of the app directory if enabled and
+/// existing.
 #[turbo_tasks::function]
 pub async fn find_app_structure(
     project_path: FileSystemPathVc,
@@ -109,6 +119,7 @@ pub async fn find_app_structure(
     ))))
 }
 
+/// Parses a directory as app directory and returns the [AppStructure].
 #[turbo_tasks::function]
 pub fn get_app_structure(
     app_dir: FileSystemPathVc,

--- a/crates/next-core/src/lib.rs
+++ b/crates/next-core/src/lib.rs
@@ -3,6 +3,7 @@
 
 mod app_render;
 mod app_source;
+pub mod app_structure;
 mod embed_js;
 pub mod env;
 mod fallback;
@@ -21,6 +22,7 @@ pub mod next_server;
 pub mod next_shared;
 mod page_loader;
 mod page_source;
+pub mod pages_structure;
 pub mod react_refresh;
 pub mod router;
 pub mod router_source;

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -5,7 +5,7 @@ use serde_json::Value as JsonValue;
 use turbo_tasks::{
     primitives::{BoolVc, StringsVc},
     trace::TraceRawVcs,
-    Value,
+    CompletionVc, Value,
 };
 use turbo_tasks_env::EnvMapVc;
 use turbo_tasks_fs::json::parse_json_rope_with_source_context;
@@ -581,6 +581,7 @@ pub async fn load_next_config(execution_context: ExecutionContextVc) -> Result<N
         intermediate_output_path,
         runtime_entries,
         vec![],
+        CompletionVc::immutable(),
         /* debug */ false,
     )
     .await?;

--- a/crates/next-core/src/pages_structure.rs
+++ b/crates/next-core/src/pages_structure.rs
@@ -8,6 +8,7 @@ use turbopack_dev_server::source::specificity::SpecificityVc;
 
 use crate::{embed_js::wrap_with_next_js_fs, next_config::NextConfigVc};
 
+/// A final route in the pages directory.
 #[turbo_tasks::value]
 pub enum PagesStructureItem {
     Page {
@@ -48,6 +49,8 @@ impl PagesStructureItemVc {
         }
     }
 
+    /// Returns a completion that changes when any route in the whole tree
+    /// changes.
     #[turbo_tasks::function]
     pub async fn routes_changed(self) -> Result<CompletionVc> {
         match *self.await? {
@@ -58,6 +61,8 @@ impl PagesStructureItemVc {
     }
 }
 
+/// A (sub)directory in the pages directory with all analyzed routes and
+/// folders.
 #[turbo_tasks::value]
 pub struct PagesStructure {
     pub directory: FileSystemPathVc,
@@ -67,11 +72,14 @@ pub struct PagesStructure {
 
 #[turbo_tasks::value_impl]
 impl PagesStructureVc {
+    /// Returns the directory of this structure.
     #[turbo_tasks::function]
     pub async fn directory(self) -> Result<FileSystemPathVc> {
         Ok(self.await?.directory)
     }
 
+    /// Returns a completion that changes when any route in the whole tree
+    /// changes.
     #[turbo_tasks::function]
     pub async fn routes_changed(self) -> Result<CompletionVc> {
         for item in self.await?.items.iter() {
@@ -98,6 +106,7 @@ impl OptionPagesStructureVc {
     }
 }
 
+/// Finds and returns the [PagesStructure] of the pages directory if existing.
 #[turbo_tasks::function]
 pub async fn find_pages_structure(
     project_path: FileSystemPathVc,
@@ -125,6 +134,7 @@ pub async fn find_pages_structure(
     ))))
 }
 
+/// Parses a directory as pages directory and returns the [PagesStructure].
 #[turbo_tasks::function]
 pub fn get_pages_structure(
     pages_dir: FileSystemPathVc,

--- a/crates/next-core/src/pages_structure.rs
+++ b/crates/next-core/src/pages_structure.rs
@@ -1,0 +1,224 @@
+use anyhow::Result;
+use turbo_tasks::{
+    primitives::{BoolVc, StringsVc},
+    CompletionVc,
+};
+use turbo_tasks_fs::{DirectoryContent, DirectoryEntry, FileSystemEntryType, FileSystemPathVc};
+use turbopack_dev_server::source::specificity::SpecificityVc;
+
+use crate::{embed_js::wrap_with_next_js_fs, next_config::NextConfigVc};
+
+#[turbo_tasks::value]
+pub enum PagesStructureItem {
+    Page {
+        url: FileSystemPathVc,
+        specificity: SpecificityVc,
+        page: FileSystemPathVc,
+    },
+    Api {
+        url: FileSystemPathVc,
+        specificity: SpecificityVc,
+        api: FileSystemPathVc,
+    },
+}
+
+#[turbo_tasks::value_impl]
+impl PagesStructureItemVc {
+    #[turbo_tasks::function]
+    async fn new(
+        url: FileSystemPathVc,
+        specificity: SpecificityVc,
+        file: FileSystemPathVc,
+        is_api: BoolVc,
+    ) -> Result<Self> {
+        if *is_api.await? {
+            Ok(PagesStructureItem::Api {
+                url,
+                specificity,
+                api: file,
+            }
+            .cell())
+        } else {
+            Ok(PagesStructureItem::Page {
+                url,
+                specificity,
+                page: file,
+            }
+            .cell())
+        }
+    }
+
+    #[turbo_tasks::function]
+    pub async fn routes_changed(self) -> Result<CompletionVc> {
+        match *self.await? {
+            PagesStructureItem::Page { url, .. } => url.await?,
+            PagesStructureItem::Api { url, .. } => url.await?,
+        };
+        Ok(CompletionVc::new())
+    }
+}
+
+#[turbo_tasks::value]
+pub struct PagesStructure {
+    pub directory: FileSystemPathVc,
+    pub items: Vec<PagesStructureItemVc>,
+    pub children: Vec<PagesStructureVc>,
+}
+
+#[turbo_tasks::value_impl]
+impl PagesStructureVc {
+    #[turbo_tasks::function]
+    pub async fn directory(self) -> Result<FileSystemPathVc> {
+        Ok(self.await?.directory)
+    }
+
+    #[turbo_tasks::function]
+    pub async fn routes_changed(self) -> Result<CompletionVc> {
+        for item in self.await?.items.iter() {
+            item.routes_changed().await?;
+        }
+        for child in self.await?.children.iter() {
+            child.routes_changed().await?;
+        }
+        Ok(CompletionVc::new())
+    }
+}
+
+#[turbo_tasks::value(transparent)]
+pub struct OptionPagesStructure(Option<PagesStructureVc>);
+
+#[turbo_tasks::value_impl]
+impl OptionPagesStructureVc {
+    #[turbo_tasks::function]
+    pub async fn routes_changed(self) -> Result<CompletionVc> {
+        if let Some(pages_structure) = *self.await? {
+            pages_structure.routes_changed().await?;
+        }
+        Ok(CompletionVc::new())
+    }
+}
+
+#[turbo_tasks::function]
+pub async fn find_pages_structure(
+    project_path: FileSystemPathVc,
+    server_root: FileSystemPathVc,
+    next_config: NextConfigVc,
+) -> Result<OptionPagesStructureVc> {
+    let project_path = wrap_with_next_js_fs(project_path);
+
+    let pages = project_path.join("pages");
+    let src_pages = project_path.join("src/pages");
+    let pages_dir = if *pages.get_type().await? == FileSystemEntryType::Directory {
+        pages
+    } else if *src_pages.get_type().await? == FileSystemEntryType::Directory {
+        src_pages
+    } else {
+        return Ok(OptionPagesStructureVc::cell(None));
+    }
+    .resolve()
+    .await?;
+
+    Ok(OptionPagesStructureVc::cell(Some(get_pages_structure(
+        pages_dir,
+        server_root,
+        next_config.page_extensions(),
+    ))))
+}
+
+#[turbo_tasks::function]
+pub fn get_pages_structure(
+    pages_dir: FileSystemPathVc,
+    server_root: FileSystemPathVc,
+    page_extensions: StringsVc,
+) -> PagesStructureVc {
+    get_pages_structure_for_directory(
+        pages_dir,
+        SpecificityVc::exact(),
+        0,
+        server_root,
+        server_root.join("api"),
+        page_extensions,
+    )
+}
+
+/// Handles a directory in the pages directory (or the pages directory itself).
+/// Calls itself recursively for sub directories or the
+/// [create_page_source_for_file] method for files.
+#[turbo_tasks::function]
+async fn get_pages_structure_for_directory(
+    input_dir: FileSystemPathVc,
+    specificity: SpecificityVc,
+    position: u32,
+    url: FileSystemPathVc,
+    server_api_path: FileSystemPathVc,
+    page_extensions: StringsVc,
+) -> Result<PagesStructureVc> {
+    let page_extensions_raw = &*page_extensions.await?;
+
+    let mut children = vec![];
+    let mut items = vec![];
+    let dir_content = input_dir.read_dir().await?;
+    if let DirectoryContent::Entries(entries) = &*dir_content {
+        for (name, entry) in entries.iter() {
+            let specificity = if name.starts_with("[[") || name.starts_with("[...") {
+                specificity.with_catch_all(position)
+            } else if name.starts_with('[') {
+                specificity.with_dynamic_segment(position)
+            } else {
+                specificity
+            };
+            match entry {
+                DirectoryEntry::File(file) => {
+                    if let Some((basename, extension)) = name.rsplit_once('.') {
+                        if page_extensions_raw
+                            .iter()
+                            .any(|allowed| allowed == extension)
+                        {
+                            let url = if basename == "index" {
+                                url.join("index.html")
+                            } else {
+                                url.join(basename).join("index.html")
+                            };
+                            items.push((
+                                name,
+                                PagesStructureItemVc::new(
+                                    url,
+                                    specificity,
+                                    *file,
+                                    url.is_inside(server_api_path),
+                                ),
+                            ))
+                        }
+                    }
+                }
+                DirectoryEntry::Directory(dir) => {
+                    children.push((
+                        name,
+                        get_pages_structure_for_directory(
+                            *dir,
+                            specificity,
+                            position + 1,
+                            url.join(name),
+                            server_api_path,
+                            page_extensions,
+                        ),
+                    ));
+                }
+                _ => {}
+            }
+        }
+    }
+
+    // Ensure deterministic order since read_dir is not deterministic
+    items.sort_by_key(|(k, _)| *k);
+
+    // Ensure deterministic order since read_dir is not deterministic
+    children.sort_by_key(|(k, _)| *k);
+
+    Ok(PagesStructure {
+        directory: input_dir,
+        items: items.into_iter().map(|(_, v)| v).collect(),
+        children: children.into_iter().map(|(_, v)| v).collect(),
+    }
+    .cell())
+}

--- a/crates/next-core/src/router.rs
+++ b/crates/next-core/src/router.rs
@@ -4,7 +4,7 @@ use anyhow::{bail, Result};
 use serde::Deserialize;
 use turbo_tasks::{
     primitives::{JsonValueVc, StringsVc},
-    Value,
+    CompletionVc, Value,
 };
 use turbo_tasks_fs::{
     json::parse_json_rope_with_source_context, to_sys_path, File, FileSystemPathVc,
@@ -281,6 +281,7 @@ pub async fn route(
     request: RouterRequestVc,
     next_config: NextConfigVc,
     server_addr: ServerAddrVc,
+    routes_changed: CompletionVc,
 ) -> Result<RouterResultVc> {
     let ExecutionContext {
         project_root,
@@ -321,6 +322,7 @@ pub async fn route(
             JsonValueVc::cell(request),
             JsonValueVc::cell(dir.to_string_lossy().into()),
         ],
+        routes_changed,
         false,
     )
     .await?;

--- a/crates/next-core/src/router_source.rs
+++ b/crates/next-core/src/router_source.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use indexmap::IndexSet;
-use turbo_tasks::{primitives::StringVc, Value};
+use turbo_tasks::{primitives::StringVc, CompletionVc, Value};
 use turbopack_core::{
     environment::ServerAddrVc,
     introspect::{Introspectable, IntrospectableChildrenVc, IntrospectableVc},
@@ -23,6 +23,7 @@ pub struct NextRouterContentSource {
     execution_context: ExecutionContextVc,
     next_config: NextConfigVc,
     server_addr: ServerAddrVc,
+    routes_changed: CompletionVc,
 }
 
 #[turbo_tasks::value_impl]
@@ -33,12 +34,14 @@ impl NextRouterContentSourceVc {
         execution_context: ExecutionContextVc,
         next_config: NextConfigVc,
         server_addr: ServerAddrVc,
+        routes_changed: CompletionVc,
     ) -> NextRouterContentSourceVc {
         NextRouterContentSource {
             inner,
             execution_context,
             next_config,
             server_addr,
+            routes_changed,
         }
         .cell()
     }
@@ -93,6 +96,7 @@ impl ContentSource for NextRouterContentSource {
             request,
             this.next_config,
             this.server_addr,
+            this.routes_changed,
         );
         let Ok(res) = res.await else {
             return Ok(this

--- a/crates/turbo-tasks/src/completion.rs
+++ b/crates/turbo-tasks/src/completion.rs
@@ -26,7 +26,7 @@ impl CompletionVc {
 // no #[turbo_tasks::value_impl] to inline new into the caller task
 // this ensures it's re-created on each execution
 impl CompletionVc {
-    /// This is always be a new completion and invalidates the reading task.
+    /// This will always be a new completion and invalidates the reading task.
     pub fn new() -> Self {
         CompletionVc::cell(Completion)
     }

--- a/crates/turbo-tasks/src/completion.rs
+++ b/crates/turbo-tasks/src/completion.rs
@@ -14,9 +14,19 @@ impl Default for CompletionVc {
     }
 }
 
+#[turbo_tasks::value_impl]
+impl CompletionVc {
+    /// This will always be the same and never invalidates the reading task.
+    #[turbo_tasks::function]
+    pub fn immutable() -> Self {
+        CompletionVc::cell(Completion)
+    }
+}
+
 // no #[turbo_tasks::value_impl] to inline new into the caller task
 // this ensures it's re-created on each execution
 impl CompletionVc {
+    /// This is always be a new completion and invalidates the reading task.
     pub fn new() -> Self {
         CompletionVc::cell(Completion)
     }

--- a/crates/turbopack-node/src/evaluate.rs
+++ b/crates/turbopack-node/src/evaluate.rs
@@ -49,6 +49,7 @@ pub async fn get_evaluate_pool(
     context: AssetContextVc,
     intermediate_output_path: FileSystemPathVc,
     runtime_entries: Option<EcmascriptChunkPlaceablesVc>,
+    additional_invalidation: CompletionVc,
     debug: bool,
 ) -> Result<NodeJsPoolVc> {
     let chunking_context = DevChunkingContextVc::builder(
@@ -114,6 +115,7 @@ pub async fn get_evaluate_pool(
         available_parallelism().map_or(1, |v| v.get()),
         debug,
     );
+    additional_invalidation.await?;
     Ok(pool.cell())
 }
 
@@ -150,6 +152,7 @@ pub async fn evaluate(
     intermediate_output_path: FileSystemPathVc,
     runtime_entries: Option<EcmascriptChunkPlaceablesVc>,
     args: Vec<JsonValueVc>,
+    additional_invalidation: CompletionVc,
     debug: bool,
 ) -> Result<JavaScriptValueVc> {
     let pool = get_evaluate_pool(
@@ -159,6 +162,7 @@ pub async fn evaluate(
         context,
         intermediate_output_path,
         runtime_entries,
+        additional_invalidation,
         debug,
     )
     .await?;

--- a/crates/turbopack-node/src/pool.rs
+++ b/crates/turbopack-node/src/pool.rs
@@ -105,6 +105,7 @@ impl NodeJsPoolProcess {
         let port = listener.local_addr().context("getting port")?.port();
         let mut cmd = Command::new("node");
         cmd.current_dir(cwd);
+        cmd.arg("--async-stack-traces");
         if debug {
             cmd.arg("--inspect-brk");
         }

--- a/crates/turbopack-node/src/pool.rs
+++ b/crates/turbopack-node/src/pool.rs
@@ -105,7 +105,6 @@ impl NodeJsPoolProcess {
         let port = listener.local_addr().context("getting port")?.port();
         let mut cmd = Command::new("node");
         cmd.current_dir(cwd);
-        cmd.arg("--async-stack-traces");
         if debug {
             cmd.arg("--inspect-brk");
         }

--- a/crates/turbopack-node/src/transforms/postcss.rs
+++ b/crates/turbopack-node/src/transforms/postcss.rs
@@ -4,7 +4,7 @@ use anyhow::{bail, Context, Result};
 use serde::{Deserialize, Serialize};
 use turbo_tasks::{
     primitives::{JsonValueVc, StringsVc},
-    TryJoinIterExt, Value,
+    CompletionVc, TryJoinIterExt, Value,
 };
 use turbo_tasks_fs::{
     json::parse_json_rope_with_source_context, File, FileContent, FileSystemEntryType,
@@ -228,6 +228,7 @@ impl PostCssTransformedAssetVc {
                 JsonValueVc::cell(content.into()),
                 JsonValueVc::cell(css_path.into()),
             ],
+            CompletionVc::immutable(),
             /* debug */ false,
         )
         .await?;

--- a/crates/turbopack-node/src/transforms/webpack.rs
+++ b/crates/turbopack-node/src/transforms/webpack.rs
@@ -1,7 +1,7 @@
 use anyhow::{bail, Context, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use turbo_tasks::{primitives::JsonValueVc, trace::TraceRawVcs, Value};
+use turbo_tasks::{primitives::JsonValueVc, trace::TraceRawVcs, CompletionVc, Value};
 use turbo_tasks_fs::{
     json::parse_json_rope_with_source_context, File, FileContent, FileSystemPathVc,
 };
@@ -170,6 +170,7 @@ impl WebpackLoadersProcessedAssetVc {
                 JsonValueVc::cell(resource_path.into()),
                 JsonValueVc::cell(json!(*loaders)),
             ],
+            CompletionVc::immutable(),
             /* debug */ false,
         )
         .await?;


### PR DESCRIPTION
We need to invalidate router node.js process when routes change for correctness

In future we can pass the routes list to next.js instead of only invalidating @jridgewell 

We also need the separated structure for next build @alexkirsz 