### PR TITLE
disable bloom filter for now

### DIFF
--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -44,7 +44,8 @@ use crate::{
 pub fn next_client_defines() -> CompileTimeDefinesVc {
     compile_time_defines!(
         process.turbopack = true,
-        process.env.NODE_ENV = "development"
+        process.env.NODE_ENV = "development",
+        process.env.__NEXT_CLIENT_ROUTER_FILTER_ENABLED = false
     )
     .cell()
 }

--- a/crates/next-core/src/next_edge/context.rs
+++ b/crates/next-core/src/next_edge/context.rs
@@ -19,7 +19,8 @@ use crate::{
 pub fn next_edge_defines() -> CompileTimeDefinesVc {
     compile_time_defines!(
         process.turbopack = true,
-        process.env.NODE_ENV = "development"
+        process.env.NODE_ENV = "development",
+        process.env.__NEXT_CLIENT_ROUTER_FILTER_ENABLED = false
     )
     .cell()
 }

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -161,7 +161,8 @@ pub async fn get_server_resolve_options_context(
 pub fn next_server_defines() -> CompileTimeDefinesVc {
     compile_time_defines!(
         process.turbopack = true,
-        process.env.NODE_ENV = "development"
+        process.env.NODE_ENV = "development",
+        process.env.__NEXT_CLIENT_ROUTER_FILTER_ENABLED = false
     )
     .cell()
 }


### PR DESCRIPTION
it currently breaks because it imports `crypto` in edge environment which isn't allowed.

We need to fix this properly eventually...