### PR TITLE
fix prisma example ReferenceError

### DIFF
--- a/examples/with-prisma/apps/web/pages/api/users.ts
+++ b/examples/with-prisma/apps/web/pages/api/users.ts
@@ -1,4 +1,4 @@
-import { client } from "database";
+import { prisma } from "database";
 
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -17,7 +17,7 @@ export default async function handler(
   }
 
   try {
-    const users = await client.user.findMany();
+    const users = await prisma.user.findMany();
     if (!users)
       throw {
         message: "Failed to retrieve users",

--- a/examples/with-prisma/packages/database/src/client.ts
+++ b/examples/with-prisma/packages/database/src/client.ts
@@ -4,7 +4,7 @@ declare global {
   var prisma: PrismaClient | undefined;
 }
 
-export const client = global.prisma || new PrismaClient();
+export const prisma = global.prisma || new PrismaClient();
 
 if (process.env.NODE_ENV !== "production") global.prisma = prisma;
 


### PR DESCRIPTION
The prisma example currently exports the variable `client` but it should be `prisma`.

`database:db:seed: ReferenceError: prisma is not defined`