### PR TITLE
feat(turbo-utils): bundle to esm (#3952

### DIFF
--- a/packages/turbo-utils/package.json
+++ b/packages/turbo-utils/package.json
@@ -15,6 +15,7 @@
   "bugs": {
     "url": "https://github.com/vercel/turbo/issues"
   },
+  "module": "dist/index.mjs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/packages/turbo-utils/tsup.config.ts
+++ b/packages/turbo-utils/tsup.config.ts
@@ -1,8 +1,12 @@
 import { defineConfig, Options } from "tsup";
 
 export default defineConfig((options: Options) => ({
-  entry: ["src/index.ts"],
+  entry: ["src/**/*.ts"],
+  treeshake: true,
+  splitting: true,
+  format: ["esm", "cjs"],
   dts: true,
+  minify: true,
   clean: true,
   ...options,
 }));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -797,20 +797,12 @@ packages:
     resolution: {integrity: sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==}
     engines: {node: '>=6.9.0'}
 
-  /@babel/helper-function-name/7.19.0:
-    resolution: {integrity: sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/template': 7.20.7
-      '@babel/types': 7.21.0
-
   /@babel/helper-function-name/7.21.0:
     resolution: {integrity: sha512-HfK1aMRanKHpxemaY2gqBmL04iAPOPRj7DxtNbiDOrJK+gdwkiNRVpCpUJYbUT+aZyemKN8brqTOxzCaG6ExRg==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/template': 7.20.7
       '@babel/types': 7.21.0
-    dev: true
 
   /@babel/helper-hoist-variables/7.18.6:
     resolution: {integrity: sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==}
@@ -1106,11 +1098,11 @@ packages:
       '@babel/code-frame': 7.18.6
       '@babel/generator': 7.20.7
       '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-function-name': 7.19.0
+      '@babel/helper-function-name': 7.21.0
       '@babel/helper-hoist-variables': 7.18.6
       '@babel/helper-split-export-declaration': 7.18.6
       '@babel/parser': 7.20.7
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.0
       debug: 4.3.4
       globals: 11.12.0
     transitivePeerDependencies:


### PR DESCRIPTION
Now that we're throwing a few more things in turbo-utils, we should bundle it to esm instead of cjs to support code splitting. This is an internal package, and everything that consumes this bundles to cjs, so compatibility isn't an issue, and this will ensure each package that uses a util from turbo-utils only gets what it needs instead of the entire package.

I tested this locally to see the bundle size difference. 

For turbo-ignore, the bundle size drops from `245K` to `229K`. No _huge_ (~6%) but worth it. 