### PR TITLE
Run Examples tests before release

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -294,104 +294,6 @@ jobs:
         # Turbo has already been built in previous step, no need to rebuild
         run: pnpm -- turbo run e2e-prebuilt --filter=cli
 
-  go_examples:
-    name: Go Cli Examples
-    needs: determine_jobs
-    if: needs.determine_jobs.outputs.examples == 'true'
-    timeout-minutes: 30
-
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - name: ubuntu
-            runner: ubuntu-latest
-          - name: macos
-            runner: macos-latest
-        manager: [yarn, npm]
-        example: [with-yarn, with-npm, non-monorepo]
-        include:
-          - os:
-              name: ubuntu
-              runner: ubuntu-latest
-            manager: pnpm
-            example: basic
-          - os:
-              name: macos
-              runner: macos-latest
-            manager: pnpm
-            example: basic
-          - os:
-              name: ubuntu
-              runner: ubuntu-latest
-            manager: pnpm
-            example: kitchen-sink
-          - os:
-              name: macos
-              runner: macos-latest
-            manager: pnpm
-            example: kitchen-sink
-          - os:
-              name: ubuntu
-              runner: ubuntu-latest
-            manager: pnpm
-            example: with-svelte
-          - os:
-              name: macos
-              runner: macos-latest
-            manager: pnpm
-            example: with-svelte
-
-    runs-on: ${{ matrix.os.runner }}
-    steps:
-      # Used by scripts/check-examples.sh
-      - name: Install Sponge
-        shell: bash
-        run: |
-          if [ "$RUNNER_OS" == "Linux" ]; then
-            sudo apt-get install -y moreutils
-          else
-            brew install moreutils
-          fi
-
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - uses: ./.github/actions/setup-turborepo-environment
-        with:
-          target: ${{ matrix.os.name }}
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-
-      - name: Setup Pnpm
-        uses: pnpm/action-setup@v2.2.4
-        with:
-          version: 7.2.1
-
-      - name: Make sure pnpm always has a cache
-        shell: bash
-        run: |
-          mkdir -p `pnpm store path`
-
-      - name: Disable corepack
-        shell: bash
-        run: corepack disable
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16
-          cache: ${{ matrix.manager }}
-          cache-dependency-path: package.json
-
-      - name: Check \"${{ matrix.example }}\" example with \"${{ matrix.manager }}\"
-        shell: bash
-        env:
-          FORCE_COLOR: true
-          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-          TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
-          TURBO_REMOTE_ONLY: true
-        run: pnpm -- turbo run run-example -- "${{ matrix.example }}" "${{ matrix.manager }}"
-
   rust_prepare:
     name: Check rust crates
     runs-on: ubuntu-latest-16-core-oss
@@ -1059,7 +961,6 @@ jobs:
       - determine_jobs
       - go_lint
       - go_unit
-      - go_examples
       - go_e2e
       - go_integration
       - rust_prepare
@@ -1170,7 +1071,6 @@ jobs:
       - determine_jobs
       - go_lint
       - go_unit
-      - go_examples
       - go_e2e
       - go_integration
       - rust_prepare
@@ -1211,7 +1111,6 @@ jobs:
           subjob ${{needs.determine_jobs.result}} "Determining jobs"
           subjob ${{needs.go_lint.result}} "Go lints"
           subjob ${{needs.go_unit.result}} "Go unit tests"
-          subjob ${{needs.go_examples.result}} "Go examples"
           subjob ${{needs.go_e2e.result}} "Go e2e tests"
           subjob ${{needs.go_integration.result}} "Go integration tests"
           subjob ${{needs.rust_prepare.result}} "Rust prepare"

--- a/.github/workflows/turborepo-release-step-2.yml
+++ b/.github/workflows/turborepo-release-step-2.yml
@@ -11,19 +11,97 @@ on:
 
 jobs:
   smoke-test:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-false: false
+      matrix:
+        os:
+          - name: ubuntu
+            runner: ubuntu-latest
+          - name: macos
+            runner: macos-latest
+        manager: [yarn, npm]
+        example: [with-yarn, with-npm, non-monorepo]
+        include:
+          - os:
+              name: ubuntu
+              runner: ubuntu-latest
+            manager: pnpm
+            example: basic
+          - os:
+              name: macos
+              runner: macos-latest
+            manager: pnpm
+            example: basic
+          - os:
+              name: ubuntu
+              runner: ubuntu-latest
+            manager: pnpm
+            example: kitchen-sink
+          - os:
+              name: macos
+              runner: macos-latest
+            manager: pnpm
+            example: kitchen-sink
+          - os:
+              name: ubuntu
+              runner: ubuntu-latest
+            manager: pnpm
+            example: with-svelte
+          - os:
+              name: macos
+              runner: macos-latest
+            manager: pnpm
+            example: with-svelte
+
+    runs-on: ${{ matrix.os.runner }}
     steps:
-      - uses: actions/checkout@v3
+      # Used by scripts/check-examples.sh
+      - name: Install Sponge
+        shell: bash
+        run: |
+          if [ "$RUNNER_OS" == "Linux" ]; then
+            sudo apt-get install -y moreutils
+          else
+            brew install moreutils
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - uses: ./.github/actions/setup-turborepo-environment
         with:
-          ref: ${{ inputs.release_branch }}
-      - uses: ./.github/actions/setup-node
-        with:
-          enable-corepack: false
-      - uses: ./.github/actions/setup-go
-        with:
+          target: ${{ matrix.os.name }}
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-      - name: Test
-        run: pnpm -- turbo run test --filter=cli --color
+
+      - name: Setup Pnpm
+        uses: pnpm/action-setup@v2.2.4
+        with:
+          version: 7.2.1
+
+      - name: Make sure pnpm always has a cache
+        shell: bash
+        run: |
+          mkdir -p `pnpm store path`
+
+      - name: Disable corepack
+        shell: bash
+        run: corepack disable
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: ${{ matrix.manager }}
+          cache-dependency-path: package.json
+
+      - name: Check \"${{ matrix.example }}\" example with \"${{ matrix.manager }}\"
+        shell: bash
+        env:
+          FORCE_COLOR: true
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+          TURBO_REMOTE_ONLY: true
+        run: pnpm -- turbo run run-example -- "${{ matrix.example }}" "${{ matrix.manager }}"
 
   darwin:
     needs: [smoke-test]

--- a/.github/workflows/turborepo-release-step-2.yml
+++ b/.github/workflows/turborepo-release-step-2.yml
@@ -10,7 +10,7 @@ on:
         description: "Staging branch to run release from"
 
 jobs:
-  smoke-test:
+  smoke-test-with-examples:
     strategy:
       fail-false: false
       matrix:
@@ -104,7 +104,7 @@ jobs:
         run: pnpm -- turbo run run-example -- "${{ matrix.example }}" "${{ matrix.manager }}"
 
   darwin:
-    needs: [smoke-test]
+    needs: [smoke-test-with-examples]
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
@@ -134,7 +134,7 @@ jobs:
 
   # compiles linux and windows in a container
   cross:
-    needs: [smoke-test]
+    needs: [smoke-test-with-examples]
     runs-on: ubuntu-latest
     container:
       image: docker://ghcr.io/vercel/turbo-cross:v1.18.5

--- a/turbo.json
+++ b/turbo.json
@@ -29,6 +29,7 @@
       "dependsOn": ["^build"]
     },
     "//#run-example": {
+      "dependsOn": ["cli#build"],
       "inputs": [
         "examples/**/*.ts",
         "examples/**/*.tsx",


### PR DESCRIPTION
Instead of running tests on examples on every PR, we could run them before release instead, as its typically a slower, more deliberate process anyway. Currently, the `smoke-test` job just runs _unit_ tests, which isn't particularly helpful. 

This does mean that the release process gets a lot slower, but we may be able to add a "skip smoke test" option, if we find that releases need to be published quickly. 