### PR TITLE
Remove non-functional css property

### DIFF
--- a/docs/components/pages/landing/index.module.css
+++ b/docs/components/pages/landing/index.module.css
@@ -106,7 +106,6 @@
   backface-visibility: hidden;
   perspective: 1000;
   transform: translate3d(0, 0, 0);
-  transfom: translateZ(0);
 }
 
 .counter-border:hover {


### PR DESCRIPTION
**Context:**
A typographical error in a css property resulted in extraneous css.

**Action:**
This commit removes the property in question for housekeeping the style sheet.

Even if correct, I believe the property would have had no effect on rendering or side effect with run-time style modification.  The property has a value of `0` and is not marked important.

**Alternatives at discretion of maintainers:**

- Fix the typo `transfom` -> `transform`. 

This alternative was tested locally and had no effect on document render at each of the project's breakpoints in Chrome, Firefox, and Safari (latest releases 26FEB2023), but was not tested on other browsers or mobile.  I selected the removal option as a result of this incomplete testing.

**Versioning / Stability / Urgency:**
Does not address critical, breaking, or security issues.  Low priority.