### PR TITLE
chore(owners): remove pnpm-lock.yaml

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,8 +17,9 @@
 /version.txt @vercel/turbo-oss
 .github/turborepo-release.yml @vercel/turbo-oss
 
-# Nobody owns this file, so nobody should get tagged on changes
+# Nobody owns these files, so nobody should get tagged on changes
 Cargo.lock
+pnpm-lock.yaml
 
 # Turbopack-specific things
 /.config/nextest.toml


### PR DESCRIPTION
Similar to Cargo.lock changes, remove owners from pnpm-lock to avoid unnecessary tags