### PR TITLE
fix: make inputs relative to workspace root

### DIFF
--- a/cli/turbo.json
+++ b/cli/turbo.json
@@ -9,20 +9,18 @@
     "e2e": {
       "outputs": [],
       "inputs": [
-        "cli/**/*.go",
-        "cli/go.mod",
-        "cli/go.sum",
-        "cli/scripts/e2e/e2e.ts",
-        "shim/**/*.rs"
+        "**/*.go",
+        "go.mod",
+        "go.sum",
+        "scripts/e2e/e2e.ts"
       ]
     },
     "e2e-prebuilt": {
       "inputs": [
-        "cli/**/*.go",
-        "cli/go.mod",
-        "cli/go.sum",
-        "cli/scripts/e2e/e2e.ts",
-        "shim/**/*.rs"
+        "**/*.go",
+        "go.mod",
+        "go.sum",
+        "scripts/e2e/e2e.ts"
       ]
     },
     "integration-tests": {}

--- a/cli/turbo.json
+++ b/cli/turbo.json
@@ -8,20 +8,10 @@
 
     "e2e": {
       "outputs": [],
-      "inputs": [
-        "**/*.go",
-        "go.mod",
-        "go.sum",
-        "scripts/e2e/e2e.ts"
-      ]
+      "inputs": ["**/*.go", "go.mod", "go.sum", "scripts/e2e/e2e.ts"]
     },
     "e2e-prebuilt": {
-      "inputs": [
-        "**/*.go",
-        "go.mod",
-        "go.sum",
-        "scripts/e2e/e2e.ts"
-      ]
+      "inputs": ["**/*.go", "go.mod", "go.sum", "scripts/e2e/e2e.ts"]
     },
     "integration-tests": {}
   }


### PR DESCRIPTION
Inputs are relative to workspace and not repo root so we need to drop the `cli` prefix here. I removed the `shim/**` input as that directory no longer exists and to correctly capture these inputs we should Turbo-fy our crates instead of listing out all of the directories out here. Also, I'm not sure how we feel about a task depending on a file outside of the workspace.

Test plan:
```
pnpm -- turbo run e2e --filter=cli
echo "console.log('big change')" >> cli/scripts/e2e/e2e.ts
pnpm -- turbo run e2e --filter=cli
```
should no longer produce a cache hit on the second run