### PR TITLE
feat(turbopack_ecmascript): support partial tsconfig for the transform

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5817,6 +5817,7 @@ dependencies = [
  "swc_ecma_transforms_base",
  "swc_ecma_transforms_module",
  "swc_ecma_transforms_optimization",
+ "swc_ecma_transforms_proposal",
  "swc_ecma_transforms_react",
  "swc_ecma_transforms_testing",
  "swc_ecma_transforms_typescript",

--- a/crates/turbopack-ecmascript/Cargo.toml
+++ b/crates/turbopack-ecmascript/Cargo.toml
@@ -52,6 +52,7 @@ swc_core = { workspace = true, features = [
   "ecma_transforms_module",
   "ecma_transforms_react",
   "ecma_transforms_typescript",
+  "ecma_transforms_proposal",
   "ecma_quote",
   "ecma_visit",
   "ecma_visit_path",

--- a/crates/turbopack-ecmascript/src/parse.rs
+++ b/crates/turbopack-ecmascript/src/parse.rs
@@ -23,10 +23,12 @@ use turbo_tasks::{
     primitives::{StringVc, U64Vc},
     Value, ValueToString,
 };
-use turbo_tasks_fs::{FileContent, FileSystemPath};
+use turbo_tasks_fs::{FileContent, FileJsonContentVc, FileSystemPath};
 use turbo_tasks_hash::hash_xxh3_hash64;
 use turbopack_core::{
     asset::{Asset, AssetContent, AssetVc},
+    resolve::{find_context_file, node::node_cjs_resolve_options, FindContextFileResult},
+    source_asset::SourceAssetVc,
     source_map::{GenerateSourceMap, GenerateSourceMapVc, SourceMapVc},
 };
 use turbopack_swc_utils::emitter::IssueEmitter;
@@ -35,6 +37,7 @@ use super::EcmascriptModuleAssetType;
 use crate::{
     analyzer::graph::EvalContext,
     transform::{EcmascriptInputTransformsVc, TransformContext},
+    typescript::resolve::{read_tsconfigs, tsconfig},
     utils::WrapFuture,
     EcmascriptInputTransform,
 };
@@ -138,6 +141,23 @@ pub async fn parse(
     let fs_path = &*source.ident().path().await?;
     let file_path_hash = *hash_ident(source.ident().to_string()).await? as u128;
     let ty = ty.into_value();
+    let tsconfig = if let EcmascriptModuleAssetType::Ecmascript = &ty {
+        None
+    } else {
+        let tsconfig = find_context_file(source.ident().path(), tsconfig());
+        match *tsconfig.await? {
+            FindContextFileResult::Found(path, _) => Some(
+                read_tsconfigs(
+                    path.read(),
+                    SourceAssetVc::new(path).into(),
+                    node_cjs_resolve_options(path.root()),
+                )
+                .await?,
+            ),
+            FindContextFileResult::NotFound(_) => None,
+        }
+    };
+
     Ok(match &*content.await? {
         AssetContent::File(file) => match &*file.await? {
             FileContent::NotFound => ParseResult::NotFound.cell(),
@@ -151,6 +171,7 @@ pub async fn parse(
                         source,
                         ty,
                         transforms,
+                        tsconfig,
                     )
                     .await
                     {
@@ -178,6 +199,7 @@ async fn parse_content(
     source: AssetVc,
     ty: EcmascriptModuleAssetType,
     transforms: &[EcmascriptInputTransform],
+    tsconfig: Option<Vec<(FileJsonContentVc, AssetVc)>>,
 ) -> Result<ParseResultVc> {
     let source_map: Arc<SourceMap> = Default::default();
     let handler = Handler::with_emitter(
@@ -284,6 +306,7 @@ async fn parse_content(
                 file_path_str: &fs_path.path,
                 file_name_str: fs_path.file_name(),
                 file_name_hash: file_path_hash,
+                tsconfig: &tsconfig,
             };
             for transform in transforms.iter() {
                 transform.apply(&mut parsed_program, &context).await?;

--- a/crates/turbopack-ecmascript/src/parse.rs
+++ b/crates/turbopack-ecmascript/src/parse.rs
@@ -141,21 +141,17 @@ pub async fn parse(
     let fs_path = &*source.ident().path().await?;
     let file_path_hash = *hash_ident(source.ident().to_string()).await? as u128;
     let ty = ty.into_value();
-    let tsconfig = if let EcmascriptModuleAssetType::Ecmascript = &ty {
-        None
-    } else {
-        let tsconfig = find_context_file(source.ident().path(), tsconfig());
-        match *tsconfig.await? {
-            FindContextFileResult::Found(path, _) => Some(
-                read_tsconfigs(
-                    path.read(),
-                    SourceAssetVc::new(path).into(),
-                    node_cjs_resolve_options(path.root()),
-                )
-                .await?,
-            ),
-            FindContextFileResult::NotFound(_) => None,
-        }
+    let tsconfig = find_context_file(source.ident().path(), tsconfig());
+    let tsconfig = match *tsconfig.await? {
+        FindContextFileResult::Found(path, _) => Some(
+            read_tsconfigs(
+                path.read(),
+                SourceAssetVc::new(path).into(),
+                node_cjs_resolve_options(path.root()),
+            )
+            .await?,
+        ),
+        FindContextFileResult::NotFound(_) => None,
     };
 
     Ok(match &*content.await? {

--- a/crates/turbopack/src/module_options/mod.rs
+++ b/crates/turbopack/src/module_options/mod.rs
@@ -83,7 +83,10 @@ impl ModuleOptionsVc {
                 }
             }
         }
-        let mut transforms = custom_ecmascript_app_transforms.clone();
+        // We apply decorators _before_ any ts transforms, as some of decorator requires
+        // type information.
+        let mut transforms = vec![EcmascriptInputTransform::Decorators];
+        transforms.extend(custom_ecmascript_app_transforms.iter().cloned());
         transforms.extend(custom_ecmascript_transforms.iter().cloned());
 
         // Order of transforms is important. e.g. if the React transform occurs before


### PR DESCRIPTION
Resolves WEB-667, WEB-659.

This PR allows to specify partial tsconfig (specifically, `useDefineForClassFields` / legacy decorators for now) into ecmatransform. There are few tsconfig options affect to the runtime output of typescript need to be specified when performing transform,  useDefineForClassFields is one of them.

 For now, PR attempts to fix `test/development/basic/define-class-fields.test.ts` / `test/development/basic/legacy-decorators.test.ts` by enabling one options. .swcrc is still not being honored in this changes.