### PR TITLE
Client timeout

### DIFF
--- a/cli/cmd/turbo/main.go
+++ b/cli/cmd/turbo/main.go
@@ -23,6 +23,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	exitCode := cmd.RunWithArgs(args, turboVersion)
+	exitCode := cmd.RunWithArgs(&args, turboVersion)
 	os.Exit(exitCode)
 }

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/fsnotify/fsnotify v1.5.4
 	github.com/gobwas/glob v0.2.3
 	github.com/google/chrometracing v0.0.0-20210413150014-55fded0163e7
+	github.com/google/go-cmp v0.5.8
 	github.com/google/uuid v1.3.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/hashicorp/go-gatedio v0.5.0
@@ -26,7 +27,6 @@ require (
 	github.com/karrick/godirwalk v1.16.1
 	github.com/mattn/go-isatty v0.0.14
 	github.com/mitchellh/cli v1.1.5
-	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/moby/sys/sequential v0.5.0
 	github.com/muhammadmuzzammil1998/jsonc v1.0.0
@@ -36,7 +36,6 @@ require (
 	github.com/sabhiram/go-gitignore v0.0.0-20201211210132-54b8a0bf510f
 	github.com/schollz/progressbar/v3 v3.9.0
 	github.com/spf13/cobra v1.3.0
-	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.12.0
 	github.com/stretchr/testify v1.8.0
 	github.com/yookoala/realpath v1.0.0
@@ -55,18 +54,15 @@ require (
 	github.com/bgentry/speakeasy v0.1.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/google/go-cmp v0.5.8 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/imdario/mergo v0.3.11 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
-	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/magiconair/properties v1.8.6 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-runewidth v0.0.13 // indirect
-	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b // indirect
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect
 	github.com/mitchellh/copystructure v1.0.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.1 // indirect
@@ -80,6 +76,7 @@ require (
 	github.com/spf13/afero v1.8.2 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/subosito/gotenv v1.3.0 // indirect
 	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4 // indirect
 	golang.org/x/net v0.0.0-20220520000938-2e3eb7b945c2 // indirect

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -64,7 +64,6 @@ github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030I
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Masterminds/sprig/v3 v3.2.1 h1:n6EPaDyLSvCEa3frruQvAiHuNp2dhBlMSmkEr+HuzGc=
 github.com/Masterminds/sprig/v3 v3.2.1/go.mod h1:UoaO7Yp8KlPnJIYWTFkMaqPUYKTfGFPhxNuwnnxkKlk=
-github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63nhn5WAunQHLTznkw5W8b1Xc0dNjp83s=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/adrg/xdg v0.3.3 h1:s/tV7MdqQnzB1nKY8aqHvAMD+uCiuEDzVB5HLRY849U=
@@ -115,7 +114,6 @@ github.com/cncf/xds/go v0.0.0-20211130200136-a8f946100490/go.mod h1:eXthEFrGJvWH
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
-github.com/creack/pty v1.1.17 h1:QeVUsEDNrLBW4tMgZHvxy18sKtr6VI492kBhUfhDJNI=
 github.com/creack/pty v1.1.17/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -285,7 +283,6 @@ github.com/hashicorp/memberlist v0.2.2/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOn
 github.com/hashicorp/memberlist v0.3.0/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
 github.com/hashicorp/serf v0.9.5/go.mod h1:UWDWwZeL5cuWDJdl0C6wrvrUwEqtQ4ZKBKKENpqIUyk=
 github.com/hashicorp/serf v0.9.6/go.mod h1:TXZNMjZQijwlDvp+r0b63xZ45H7JmCmgg4gpTwn9UV4=
-github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec h1:qv2VnGeEQHchGaZ/u7lxST/RaJw+cv273q79D81Xbog=
 github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec/go.mod h1:Q48J4R4DvxnHolD5P8pOtXigYlRuPLGl6moFx3ulM68=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huandu/xstrings v1.3.2 h1:L18LIDzqlW6xN2rEkpdV8+oL/IXWJ1APd+vsdYy4Wdw=
@@ -309,7 +306,6 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/k0kubun/go-ansi v0.0.0-20180517002512-3bf9e2903213/go.mod h1:vNUNkEQ1e29fT/6vq2aBdFsgNPmy8qMdSay1npru+Sw=
 github.com/karrick/godirwalk v1.16.1 h1:DynhcF+bztK8gooS0+NDJFrdNZjJ3gzVzC545UNA9iw=
 github.com/karrick/godirwalk v1.16.1/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
-github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
@@ -343,7 +339,6 @@ github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27k
 github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4OSgU=
 github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
-github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b h1:j7+1HpAFS1zy5+Q4qx1fWh90gTKwiN4QCGoY9TWyyO4=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
@@ -355,7 +350,6 @@ github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db h1:62I3jR2Em
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db/go.mod h1:l0dey0ia/Uv7NcFFVbCLtqEBQbrT4OCwCSKTEv6enCw=
 github.com/mitchellh/copystructure v1.0.0 h1:Laisrj+bAB6b/yJwB5Bt3ITZhGJdqmxquMKeZ+mmkFQ=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
-github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=

--- a/cli/integration_tests/no_args.t
+++ b/cli/integration_tests/no_args.t
@@ -19,22 +19,22 @@ Make sure exit code is 2 when no args are passed
     unlink      Unlink the current directory from your Vercel organization and disable Remote Caching
   
   Options:
-        --version                   
-        --skip-infer                Skip any attempts to infer which version of Turbo the project is configured to use
-        --no-update-notifier        Disable the turbo update notification
-        --api <API>                 Override the endpoint for API calls
-        --color                     Force color usage in the terminal
-        --cpuprofile <CPU_PROFILE>  Specify a file to save a cpu profile
-        --cwd <CWD>                 The directory in which to run turbo
-        --heap <HEAP>               Specify a file to save a pprof heap profile
-        --login <LOGIN>             Override the login endpoint
-        --no-color                  Suppress color usage in the terminal
-        --preflight                 When enabled, turbo will precede HTTP requests with an OPTIONS request for authorization
-        --team <TEAM>               Set the team slug for API calls
-        --token <TOKEN>             Set the auth token for API calls
-        --trace <TRACE>             Specify a file to save a pprof trace
-        --verbosity <COUNT>         Verbosity level
-    -h, --help                      Print help
+        --version                         
+        --skip-infer                      Skip any attempts to infer which version of Turbo the project is configured to use
+        --api <API>                       Override the endpoint for API calls
+        --color                           Force color usage in the terminal
+        --cpuprofile <CPU_PROFILE>        Specify a file to save a cpu profile
+        --cwd <CWD>                       The directory in which to run turbo
+        --heap <HEAP>                     Specify a file to save a pprof heap profile
+        --login <LOGIN>                   Override the login endpoint
+        --no-color                        Suppress color usage in the terminal
+        --preflight                       When enabled, turbo will precede HTTP requests with an OPTIONS request for authorization
+        --remote-cache-timeout <TIMEOUT>  Set a timeout for all HTTP requests
+        --team <TEAM>                     Set the team slug for API calls
+        --token <TOKEN>                   Set the auth token for API calls
+        --trace <TRACE>                   Specify a file to save a pprof trace
+        --verbosity <COUNT>               Verbosity level
+    -h, --help                            Print help
   
   Run Arguments:
         --cache-dir <CACHE_DIR>          Override the filesystem cache directory

--- a/cli/integration_tests/no_args.t
+++ b/cli/integration_tests/no_args.t
@@ -21,6 +21,7 @@ Make sure exit code is 2 when no args are passed
   Options:
         --version                         
         --skip-infer                      Skip any attempts to infer which version of Turbo the project is configured to use
+        --no-update-notifier              Disable the turbo update notification
         --api <API>                       Override the endpoint for API calls
         --color                           Force color usage in the terminal
         --cpuprofile <CPU_PROFILE>        Specify a file to save a cpu profile

--- a/cli/integration_tests/turbo_help.t
+++ b/cli/integration_tests/turbo_help.t
@@ -21,6 +21,7 @@ Test help flag
   Options:
         --version                         
         --skip-infer                      Skip any attempts to infer which version of Turbo the project is configured to use
+        --no-update-notifier              Disable the turbo update notification
         --api <API>                       Override the endpoint for API calls
         --color                           Force color usage in the terminal
         --cpuprofile <CPU_PROFILE>        Specify a file to save a cpu profile
@@ -84,6 +85,7 @@ Test help flag
   Options:
         --version                         
         --skip-infer                      Skip any attempts to infer which version of Turbo the project is configured to use
+        --no-update-notifier              Disable the turbo update notification
         --api <API>                       Override the endpoint for API calls
         --color                           Force color usage in the terminal
         --cpuprofile <CPU_PROFILE>        Specify a file to save a cpu profile
@@ -133,6 +135,7 @@ Test help flag for link command
         --no-gitignore                    Do not create or modify .gitignore (default false)
         --version                         
         --skip-infer                      Skip any attempts to infer which version of Turbo the project is configured to use
+        --no-update-notifier              Disable the turbo update notification
         --api <API>                       Override the endpoint for API calls
         --color                           Force color usage in the terminal
         --cpuprofile <CPU_PROFILE>        Specify a file to save a cpu profile
@@ -160,6 +163,7 @@ Test help flag for unlink command
   Options:
         --version                         
         --skip-infer                      Skip any attempts to infer which version of Turbo the project is configured to use
+        --no-update-notifier              Disable the turbo update notification
         --api <API>                       Override the endpoint for API calls
         --color                           Force color usage in the terminal
         --cpuprofile <CPU_PROFILE>        Specify a file to save a cpu profile
@@ -188,6 +192,7 @@ Test help flag for login command
         --sso-team <SSO_TEAM>             
         --version                         
         --skip-infer                      Skip any attempts to infer which version of Turbo the project is configured to use
+        --no-update-notifier              Disable the turbo update notification
         --api <API>                       Override the endpoint for API calls
         --color                           Force color usage in the terminal
         --cpuprofile <CPU_PROFILE>        Specify a file to save a cpu profile
@@ -215,6 +220,7 @@ Test help flag for logout command
   Options:
         --version                         
         --skip-infer                      Skip any attempts to infer which version of Turbo the project is configured to use
+        --no-update-notifier              Disable the turbo update notification
         --api <API>                       Override the endpoint for API calls
         --color                           Force color usage in the terminal
         --cpuprofile <CPU_PROFILE>        Specify a file to save a cpu profile

--- a/cli/integration_tests/turbo_help.t
+++ b/cli/integration_tests/turbo_help.t
@@ -19,22 +19,22 @@ Test help flag
     unlink      Unlink the current directory from your Vercel organization and disable Remote Caching
   
   Options:
-        --version                   
-        --skip-infer                Skip any attempts to infer which version of Turbo the project is configured to use
-        --no-update-notifier        Disable the turbo update notification
-        --api <API>                 Override the endpoint for API calls
-        --color                     Force color usage in the terminal
-        --cpuprofile <CPU_PROFILE>  Specify a file to save a cpu profile
-        --cwd <CWD>                 The directory in which to run turbo
-        --heap <HEAP>               Specify a file to save a pprof heap profile
-        --login <LOGIN>             Override the login endpoint
-        --no-color                  Suppress color usage in the terminal
-        --preflight                 When enabled, turbo will precede HTTP requests with an OPTIONS request for authorization
-        --team <TEAM>               Set the team slug for API calls
-        --token <TOKEN>             Set the auth token for API calls
-        --trace <TRACE>             Specify a file to save a pprof trace
-        --verbosity <COUNT>         Verbosity level
-    -h, --help                      Print help
+        --version                         
+        --skip-infer                      Skip any attempts to infer which version of Turbo the project is configured to use
+        --api <API>                       Override the endpoint for API calls
+        --color                           Force color usage in the terminal
+        --cpuprofile <CPU_PROFILE>        Specify a file to save a cpu profile
+        --cwd <CWD>                       The directory in which to run turbo
+        --heap <HEAP>                     Specify a file to save a pprof heap profile
+        --login <LOGIN>                   Override the login endpoint
+        --no-color                        Suppress color usage in the terminal
+        --preflight                       When enabled, turbo will precede HTTP requests with an OPTIONS request for authorization
+        --remote-cache-timeout <TIMEOUT>  Set a timeout for all HTTP requests
+        --team <TEAM>                     Set the team slug for API calls
+        --token <TOKEN>                   Set the auth token for API calls
+        --trace <TRACE>                   Specify a file to save a pprof trace
+        --verbosity <COUNT>               Verbosity level
+    -h, --help                            Print help
   
   Run Arguments:
         --cache-dir <CACHE_DIR>          Override the filesystem cache directory
@@ -82,22 +82,22 @@ Test help flag
     unlink      Unlink the current directory from your Vercel organization and disable Remote Caching
   
   Options:
-        --version                   
-        --skip-infer                Skip any attempts to infer which version of Turbo the project is configured to use
-        --no-update-notifier        Disable the turbo update notification
-        --api <API>                 Override the endpoint for API calls
-        --color                     Force color usage in the terminal
-        --cpuprofile <CPU_PROFILE>  Specify a file to save a cpu profile
-        --cwd <CWD>                 The directory in which to run turbo
-        --heap <HEAP>               Specify a file to save a pprof heap profile
-        --login <LOGIN>             Override the login endpoint
-        --no-color                  Suppress color usage in the terminal
-        --preflight                 When enabled, turbo will precede HTTP requests with an OPTIONS request for authorization
-        --team <TEAM>               Set the team slug for API calls
-        --token <TOKEN>             Set the auth token for API calls
-        --trace <TRACE>             Specify a file to save a pprof trace
-        --verbosity <COUNT>         Verbosity level
-    -h, --help                      Print help
+        --version                         
+        --skip-infer                      Skip any attempts to infer which version of Turbo the project is configured to use
+        --api <API>                       Override the endpoint for API calls
+        --color                           Force color usage in the terminal
+        --cpuprofile <CPU_PROFILE>        Specify a file to save a cpu profile
+        --cwd <CWD>                       The directory in which to run turbo
+        --heap <HEAP>                     Specify a file to save a pprof heap profile
+        --login <LOGIN>                   Override the login endpoint
+        --no-color                        Suppress color usage in the terminal
+        --preflight                       When enabled, turbo will precede HTTP requests with an OPTIONS request for authorization
+        --remote-cache-timeout <TIMEOUT>  Set a timeout for all HTTP requests
+        --team <TEAM>                     Set the team slug for API calls
+        --token <TOKEN>                   Set the auth token for API calls
+        --trace <TRACE>                   Specify a file to save a pprof trace
+        --verbosity <COUNT>               Verbosity level
+    -h, --help                            Print help
   
   Run Arguments:
         --cache-dir <CACHE_DIR>          Override the filesystem cache directory
@@ -130,23 +130,23 @@ Test help flag for link command
   Usage: turbo link [OPTIONS]
   
   Options:
-        --no-gitignore              Do not create or modify .gitignore (default false)
-        --version                   
-        --skip-infer                Skip any attempts to infer which version of Turbo the project is configured to use
-        --no-update-notifier        Disable the turbo update notification
-        --api <API>                 Override the endpoint for API calls
-        --color                     Force color usage in the terminal
-        --cpuprofile <CPU_PROFILE>  Specify a file to save a cpu profile
-        --cwd <CWD>                 The directory in which to run turbo
-        --heap <HEAP>               Specify a file to save a pprof heap profile
-        --login <LOGIN>             Override the login endpoint
-        --no-color                  Suppress color usage in the terminal
-        --preflight                 When enabled, turbo will precede HTTP requests with an OPTIONS request for authorization
-        --team <TEAM>               Set the team slug for API calls
-        --token <TOKEN>             Set the auth token for API calls
-        --trace <TRACE>             Specify a file to save a pprof trace
-        --verbosity <COUNT>         Verbosity level
-    -h, --help                      Print help
+        --no-gitignore                    Do not create or modify .gitignore (default false)
+        --version                         
+        --skip-infer                      Skip any attempts to infer which version of Turbo the project is configured to use
+        --api <API>                       Override the endpoint for API calls
+        --color                           Force color usage in the terminal
+        --cpuprofile <CPU_PROFILE>        Specify a file to save a cpu profile
+        --cwd <CWD>                       The directory in which to run turbo
+        --heap <HEAP>                     Specify a file to save a pprof heap profile
+        --login <LOGIN>                   Override the login endpoint
+        --no-color                        Suppress color usage in the terminal
+        --preflight                       When enabled, turbo will precede HTTP requests with an OPTIONS request for authorization
+        --remote-cache-timeout <TIMEOUT>  Set a timeout for all HTTP requests
+        --team <TEAM>                     Set the team slug for API calls
+        --token <TOKEN>                   Set the auth token for API calls
+        --trace <TRACE>                   Specify a file to save a pprof trace
+        --verbosity <COUNT>               Verbosity level
+    -h, --help                            Print help
   
   Run Arguments:
         --single-package  Run turbo in single-package mode
@@ -158,22 +158,22 @@ Test help flag for unlink command
   Usage: turbo unlink [OPTIONS]
   
   Options:
-        --version                   
-        --skip-infer                Skip any attempts to infer which version of Turbo the project is configured to use
-        --no-update-notifier        Disable the turbo update notification
-        --api <API>                 Override the endpoint for API calls
-        --color                     Force color usage in the terminal
-        --cpuprofile <CPU_PROFILE>  Specify a file to save a cpu profile
-        --cwd <CWD>                 The directory in which to run turbo
-        --heap <HEAP>               Specify a file to save a pprof heap profile
-        --login <LOGIN>             Override the login endpoint
-        --no-color                  Suppress color usage in the terminal
-        --preflight                 When enabled, turbo will precede HTTP requests with an OPTIONS request for authorization
-        --team <TEAM>               Set the team slug for API calls
-        --token <TOKEN>             Set the auth token for API calls
-        --trace <TRACE>             Specify a file to save a pprof trace
-        --verbosity <COUNT>         Verbosity level
-    -h, --help                      Print help
+        --version                         
+        --skip-infer                      Skip any attempts to infer which version of Turbo the project is configured to use
+        --api <API>                       Override the endpoint for API calls
+        --color                           Force color usage in the terminal
+        --cpuprofile <CPU_PROFILE>        Specify a file to save a cpu profile
+        --cwd <CWD>                       The directory in which to run turbo
+        --heap <HEAP>                     Specify a file to save a pprof heap profile
+        --login <LOGIN>                   Override the login endpoint
+        --no-color                        Suppress color usage in the terminal
+        --preflight                       When enabled, turbo will precede HTTP requests with an OPTIONS request for authorization
+        --remote-cache-timeout <TIMEOUT>  Set a timeout for all HTTP requests
+        --team <TEAM>                     Set the team slug for API calls
+        --token <TOKEN>                   Set the auth token for API calls
+        --trace <TRACE>                   Specify a file to save a pprof trace
+        --verbosity <COUNT>               Verbosity level
+    -h, --help                            Print help
   
   Run Arguments:
         --single-package  Run turbo in single-package mode
@@ -185,23 +185,23 @@ Test help flag for login command
   Usage: turbo login [OPTIONS]
   
   Options:
-        --sso-team <SSO_TEAM>       
-        --version                   
-        --skip-infer                Skip any attempts to infer which version of Turbo the project is configured to use
-        --no-update-notifier        Disable the turbo update notification
-        --api <API>                 Override the endpoint for API calls
-        --color                     Force color usage in the terminal
-        --cpuprofile <CPU_PROFILE>  Specify a file to save a cpu profile
-        --cwd <CWD>                 The directory in which to run turbo
-        --heap <HEAP>               Specify a file to save a pprof heap profile
-        --login <LOGIN>             Override the login endpoint
-        --no-color                  Suppress color usage in the terminal
-        --preflight                 When enabled, turbo will precede HTTP requests with an OPTIONS request for authorization
-        --team <TEAM>               Set the team slug for API calls
-        --token <TOKEN>             Set the auth token for API calls
-        --trace <TRACE>             Specify a file to save a pprof trace
-        --verbosity <COUNT>         Verbosity level
-    -h, --help                      Print help
+        --sso-team <SSO_TEAM>             
+        --version                         
+        --skip-infer                      Skip any attempts to infer which version of Turbo the project is configured to use
+        --api <API>                       Override the endpoint for API calls
+        --color                           Force color usage in the terminal
+        --cpuprofile <CPU_PROFILE>        Specify a file to save a cpu profile
+        --cwd <CWD>                       The directory in which to run turbo
+        --heap <HEAP>                     Specify a file to save a pprof heap profile
+        --login <LOGIN>                   Override the login endpoint
+        --no-color                        Suppress color usage in the terminal
+        --preflight                       When enabled, turbo will precede HTTP requests with an OPTIONS request for authorization
+        --remote-cache-timeout <TIMEOUT>  Set a timeout for all HTTP requests
+        --team <TEAM>                     Set the team slug for API calls
+        --token <TOKEN>                   Set the auth token for API calls
+        --trace <TRACE>                   Specify a file to save a pprof trace
+        --verbosity <COUNT>               Verbosity level
+    -h, --help                            Print help
   
   Run Arguments:
         --single-package  Run turbo in single-package mode
@@ -213,22 +213,22 @@ Test help flag for logout command
   Usage: turbo logout [OPTIONS]
   
   Options:
-        --version                   
-        --skip-infer                Skip any attempts to infer which version of Turbo the project is configured to use
-        --no-update-notifier        Disable the turbo update notification
-        --api <API>                 Override the endpoint for API calls
-        --color                     Force color usage in the terminal
-        --cpuprofile <CPU_PROFILE>  Specify a file to save a cpu profile
-        --cwd <CWD>                 The directory in which to run turbo
-        --heap <HEAP>               Specify a file to save a pprof heap profile
-        --login <LOGIN>             Override the login endpoint
-        --no-color                  Suppress color usage in the terminal
-        --preflight                 When enabled, turbo will precede HTTP requests with an OPTIONS request for authorization
-        --team <TEAM>               Set the team slug for API calls
-        --token <TOKEN>             Set the auth token for API calls
-        --trace <TRACE>             Specify a file to save a pprof trace
-        --verbosity <COUNT>         Verbosity level
-    -h, --help                      Print help
+        --version                         
+        --skip-infer                      Skip any attempts to infer which version of Turbo the project is configured to use
+        --api <API>                       Override the endpoint for API calls
+        --color                           Force color usage in the terminal
+        --cpuprofile <CPU_PROFILE>        Specify a file to save a cpu profile
+        --cwd <CWD>                       The directory in which to run turbo
+        --heap <HEAP>                     Specify a file to save a pprof heap profile
+        --login <LOGIN>                   Override the login endpoint
+        --no-color                        Suppress color usage in the terminal
+        --preflight                       When enabled, turbo will precede HTTP requests with an OPTIONS request for authorization
+        --remote-cache-timeout <TIMEOUT>  Set a timeout for all HTTP requests
+        --team <TEAM>                     Set the team slug for API calls
+        --token <TOKEN>                   Set the auth token for API calls
+        --trace <TRACE>                   Specify a file to save a pprof trace
+        --verbosity <COUNT>               Verbosity level
+    -h, --help                            Print help
   
   Run Arguments:
         --single-package  Run turbo in single-package mode

--- a/cli/internal/cache/cache.go
+++ b/cli/internal/cache/cache.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"sync"
 
-	"github.com/spf13/pflag"
 	"github.com/vercel/turbo/cli/internal/analytics"
 	"github.com/vercel/turbo/cli/internal/fs"
 	"github.com/vercel/turbo/cli/internal/turbopath"
@@ -81,14 +80,6 @@ func (o *Opts) resolveCacheDir(repoRoot turbopath.AbsoluteSystemPath) turbopath.
 
 var _remoteOnlyHelp = `Ignore the local filesystem cache for all tasks. Only
 allow reading and caching artifacts using the remote cache.`
-
-// AddFlags adds cache-related flags to the given FlagSet
-func AddFlags(opts *Opts, flags *pflag.FlagSet) {
-	// skipping remote caching not currently a flag
-	flags.BoolVar(&opts.SkipFilesystem, "remote-only", false, _remoteOnlyHelp)
-	flags.StringVar(&opts.OverrideDir, "cache-dir", "", "Override the filesystem cache directory.")
-	flags.IntVar(&opts.Workers, "cache-workers", 10, "Set the number of concurrent cache operations")
-}
 
 // New creates a new cache
 func New(opts Opts, repoRoot turbopath.AbsoluteSystemPath, client client, recorder analytics.Recorder, onCacheRemoved OnCacheRemoved) (Cache, error) {

--- a/cli/internal/client/client.go
+++ b/cli/internal/client/client.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-retryablehttp"
-	"github.com/spf13/pflag"
 	"github.com/vercel/turbo/cli/internal/ci"
 	"github.com/vercel/turbo/cli/internal/util"
 )
@@ -66,12 +65,6 @@ type Opts struct {
 
 // ClientTimeout Exported ClientTimeout used in run.go
 const ClientTimeout uint64 = 20
-
-// AddFlags adds flags specific to the api client to the given flagset
-func AddFlags(opts *Opts, flags *pflag.FlagSet) {
-	flags.BoolVar(&opts.UsePreflight, "preflight", false, "When enabled, turbo will precede HTTP requests with an OPTIONS request for authorization")
-	flags.Uint64Var(&opts.Timeout, "remote-cache-timeout", ClientTimeout, "Set the remote cache client timeout")
-}
 
 // New creates a new ApiClient
 func NewClient(remoteConfig RemoteConfig, logger hclog.Logger, turboVersion string, opts Opts) *ApiClient {

--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -19,7 +19,7 @@ import (
 	"github.com/vercel/turbo/cli/internal/util"
 )
 
-func initializeOutputFiles(helper *cmdutil.Helper, parsedArgs turbostate.ParsedArgsFromRust) error {
+func initializeOutputFiles(helper *cmdutil.Helper, parsedArgs *turbostate.ParsedArgsFromRust) error {
 	if parsedArgs.Trace != "" {
 		cleanup, err := createTraceFile(parsedArgs.Trace)
 		if err != nil {
@@ -46,7 +46,7 @@ func initializeOutputFiles(helper *cmdutil.Helper, parsedArgs turbostate.ParsedA
 }
 
 // RunWithArgs runs turbo with the ParsedArgsFromRust that is passed from the Rust side.
-func RunWithArgs(args turbostate.ParsedArgsFromRust, turboVersion string) int {
+func RunWithArgs(args *turbostate.ParsedArgsFromRust, turboVersion string) int {
 	util.InitPrintf()
 	// TODO: replace this with a context
 	signalWatcher := signals.NewWatcher()
@@ -58,18 +58,18 @@ func RunWithArgs(args turbostate.ParsedArgsFromRust, turboVersion string) int {
 		fmt.Printf("%v", err)
 		return 1
 	}
-	defer helper.Cleanup(&args)
+	defer helper.Cleanup(args)
 
 	doneCh := make(chan struct{})
 	var execErr error
 	go func() {
 		command := args.Command
 		if command.Daemon != nil {
-			execErr = daemon.ExecuteDaemon(ctx, helper, signalWatcher, &args)
+			execErr = daemon.ExecuteDaemon(ctx, helper, signalWatcher, args)
 		} else if command.Prune != nil {
-			execErr = prune.ExecutePrune(helper, &args)
+			execErr = prune.ExecutePrune(helper, args)
 		} else if command.Run != nil {
-			execErr = run.ExecuteRun(ctx, helper, signalWatcher, &args)
+			execErr = run.ExecuteRun(ctx, helper, signalWatcher, args)
 		} else {
 			execErr = fmt.Errorf("unknown command: %v", command)
 		}

--- a/cli/internal/cmdutil/cmdutil.go
+++ b/cli/internal/cmdutil/cmdutil.go
@@ -176,17 +176,17 @@ func (h *Helper) GetCmdBase(cliConfig *turbostate.ParsedArgsFromRust) (*CmdBase,
 	}
 
 	// Primacy: Arg > Env
-	val, ok := os.LookupEnv("TURBO_REMOTE_CACHE_TIMEOUT")
-	if ok {
-		number, err := strconv.ParseUint(val, 10, 64)
-		if err == nil {
-			h.clientOpts.Timeout = number
-		}
-	}
-
 	timeout, err := cliConfig.GetRemoteCacheTimeout()
 	if err == nil {
 		h.clientOpts.Timeout = timeout
+	} else {
+		val, ok := os.LookupEnv("TURBO_REMOTE_CACHE_TIMEOUT")
+		if ok {
+			number, err := strconv.ParseUint(val, 10, 64)
+			if err == nil {
+				h.clientOpts.Timeout = number
+			}
+		}
 	}
 
 	apiClient := client.NewClient(

--- a/cli/internal/cmdutil/cmdutil.go
+++ b/cli/internal/cmdutil/cmdutil.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"strconv"
 	"sync"
 
 	"github.com/hashicorp/go-hclog"
@@ -183,6 +184,22 @@ func (h *Helper) GetCmdBase(cliConfig config.CLIConfigProvider) (*CmdBase, error
 			remoteConfig.TeamID = vercelArtifactsOwner
 		}
 	}
+
+	val, ok := os.LookupEnv("TURBO_REMOTE_CACHE_TIMEOUT")
+	if ok {
+		number, err := strconv.ParseUint(val, 10, 64)
+		if err == nil {
+			h.clientOpts.Timeout = number
+		} else {
+			terminal.Warn(fmt.Sprintf("%s Unable to parse TURBO_REMOTE_CACHE_TIMEOUT: %s", ui.WARNING_PREFIX, prefix, color.YellowString(" %v", err)))
+		}
+	}
+
+	timeout, err := flags.GetUint64("remote-cache-timeout")
+	if flags.Lookup("remote-cache-timeout").Changed && err == nil {
+		h.clientOpts.Timeout = timeout
+	}
+
 	apiClient := client.NewClient(
 		remoteConfig,
 		logger,

--- a/cli/internal/cmdutil/cmdutil.go
+++ b/cli/internal/cmdutil/cmdutil.go
@@ -190,14 +190,7 @@ func (h *Helper) GetCmdBase(cliConfig config.CLIConfigProvider) (*CmdBase, error
 		number, err := strconv.ParseUint(val, 10, 64)
 		if err == nil {
 			h.clientOpts.Timeout = number
-		} else {
-			terminal.Warn(fmt.Sprintf("%s Unable to parse TURBO_REMOTE_CACHE_TIMEOUT: %s", ui.WARNING_PREFIX, prefix, color.YellowString(" %v", err)))
 		}
-	}
-
-	timeout, err := flags.GetUint64("remote-cache-timeout")
-	if flags.Lookup("remote-cache-timeout").Changed && err == nil {
-		h.clientOpts.Timeout = timeout
 	}
 
 	apiClient := client.NewClient(

--- a/cli/internal/cmdutil/cmdutil.go
+++ b/cli/internal/cmdutil/cmdutil.go
@@ -60,7 +60,7 @@ func (h *Helper) RegisterCleanup(cleanup io.Closer) {
 
 // Cleanup runs the register cleanup handlers. It requires the flags
 // to the root command so that it can construct a UI if necessary
-func (h *Helper) Cleanup(cliConfig config.CLIConfigProvider) {
+func (h *Helper) Cleanup(cliConfig *turbostate.ParsedArgsFromRust) {
 	h.cleanupsMu.Lock()
 	defer h.cleanupsMu.Unlock()
 	var ui cli.Ui
@@ -74,12 +74,12 @@ func (h *Helper) Cleanup(cliConfig config.CLIConfigProvider) {
 	}
 }
 
-func (h *Helper) getUI(flags config.CLIConfigProvider) cli.Ui {
+func (h *Helper) getUI(cliConfig *turbostate.ParsedArgsFromRust) cli.Ui {
 	colorMode := ui.GetColorModeFromEnv()
-	if flags.GetNoColor() {
+	if cliConfig.GetNoColor() {
 		colorMode = ui.ColorModeSuppressed
 	}
-	if flags.GetColor() {
+	if cliConfig.GetColor() {
 		colorMode = ui.ColorModeForced
 	}
 	return ui.BuildColoredUi(colorMode)
@@ -124,7 +124,7 @@ func (h *Helper) getLogger() (hclog.Logger, error) {
 
 // NewHelper returns a new helper instance to hold configuration values for the root
 // turbo command.
-func NewHelper(turboVersion string, args turbostate.ParsedArgsFromRust) *Helper {
+func NewHelper(turboVersion string, args *turbostate.ParsedArgsFromRust) *Helper {
 	return &Helper{
 		TurboVersion:   turboVersion,
 		UserConfigPath: config.DefaultUserConfigPath(),
@@ -134,7 +134,7 @@ func NewHelper(turboVersion string, args turbostate.ParsedArgsFromRust) *Helper 
 
 // GetCmdBase returns a CmdBase instance configured with values from this helper.
 // It additionally returns a mechanism to set an error, so
-func (h *Helper) GetCmdBase(cliConfig config.CLIConfigProvider) (*CmdBase, error) {
+func (h *Helper) GetCmdBase(cliConfig *turbostate.ParsedArgsFromRust) (*CmdBase, error) {
 	// terminal is for color/no-color output
 	terminal := h.getUI(cliConfig)
 	// logger is configured with verbosity level using --verbosity flag from end users

--- a/cli/internal/cmdutil/cmdutil.go
+++ b/cli/internal/cmdutil/cmdutil.go
@@ -125,7 +125,7 @@ func (h *Helper) getLogger() (hclog.Logger, error) {
 
 // AddFlags adds common flags for all turbo commands to the given flagset and binds
 // them to this instance of Helper
-func (h *Helper) AddFlags(flags *pflag.FlagSet) {
+func (h *Helper) addFlags(flags *pflag.FlagSet) {
 	flags.CountVarP(&h.verbosity, "verbosity", "v", "verbosity")
 	client.AddFlags(&h.clientOpts, flags)
 	config.AddRepoConfigFlags(flags)

--- a/cli/internal/cmdutil/cmdutil_test.go
+++ b/cli/internal/cmdutil/cmdutil_test.go
@@ -3,7 +3,6 @@ package cmdutil
 import (
 	"os"
 	"testing"
-	"time"
 
 	"github.com/spf13/pflag"
 	"github.com/vercel/turbo/cli/internal/fs"
@@ -43,51 +42,4 @@ func TestTokenEnvVar(t *testing.T) {
 			assert.Equal(t, base.RemoteConfig.Token, expectedToken)
 		})
 	}
-}
-
-func TestTuroRemoteCacheTimeoutEnvVar(t *testing.T) {
-	// Set up an empty config so we're just testing environment variables
-	userConfigPath := fs.AbsoluteSystemPathFromUpstream(t.TempDir()).UntypedJoin("turborepo", "config.json")
-	expectedTimeout := "600"
-
-	t.Cleanup(func() {
-		_ = os.Unsetenv("TURBO_REMOTE_CACHE_TIMEOUT")
-	})
-
-	flags := pflag.NewFlagSet("test-flags", pflag.ContinueOnError)
-	h := NewHelper("test-version")
-	h.AddFlags(flags)
-	h.UserConfigPath = userConfigPath
-
-	err := os.Setenv("TURBO_REMOTE_CACHE_TIMEOUT", expectedTimeout)
-	if err != nil {
-		t.Fatalf("setenv %v", err)
-	}
-
-	base, err := h.GetCmdBase(flags)
-	if err != nil {
-		t.Fatalf("failed to get command base %v", err)
-	}
-
-	assert.Equal(t, base.APIClient.HttpClient.HTTPClient.Timeout, time.Duration(600)*time.Second)
-}
-
-func TestRemoteCacheTimeoutFlag(t *testing.T) {
-	// Set up an empty config so we're just testing environment variables
-	userConfigPath := fs.AbsoluteSystemPathFromUpstream(t.TempDir()).UntypedJoin("turborepo", "config.json")
-	expectedTimeout := "600"
-
-	flags := pflag.NewFlagSet("test-flags", pflag.ContinueOnError)
-	h := NewHelper("test-version")
-	h.AddFlags(flags)
-	h.UserConfigPath = userConfigPath
-
-	assert.NilError(t, flags.Set("remote-cache-timeout", expectedTimeout), "flags.Set")
-
-	base, err := h.GetCmdBase(flags)
-	if err != nil {
-		t.Fatalf("failed to get command base %v", err)
-	}
-
-	assert.Equal(t, base.APIClient.HttpClient.HTTPClient.Timeout, time.Duration(600)*time.Second)
 }

--- a/cli/internal/cmdutil/cmdutil_test.go
+++ b/cli/internal/cmdutil/cmdutil_test.go
@@ -3,6 +3,7 @@ package cmdutil
 import (
 	"os"
 	"testing"
+	"time"
 
 	"github.com/spf13/pflag"
 	"github.com/vercel/turbo/cli/internal/fs"
@@ -11,7 +12,6 @@ import (
 )
 
 func TestTokenEnvVar(t *testing.T) {
-
 	// Set up an empty config so we're just testing environment variables
 	userConfigPath := fs.AbsoluteSystemPathFromUpstream(t.TempDir()).UntypedJoin("turborepo", "config.json")
 	expectedPrefix := "my-token"
@@ -26,7 +26,7 @@ func TestTokenEnvVar(t *testing.T) {
 			}
 			flags := pflag.NewFlagSet("test-flags", pflag.ContinueOnError)
 			h := NewHelper("test-version", args)
-			h.AddFlags(flags)
+			h.addFlags(flags)
 			h.UserConfigPath = userConfigPath
 
 			expectedToken := expectedPrefix + v
@@ -42,4 +42,82 @@ func TestTokenEnvVar(t *testing.T) {
 			assert.Equal(t, base.RemoteConfig.Token, expectedToken)
 		})
 	}
+}
+
+func TestRemoteCacheTimeoutEnvVar(t *testing.T) {
+	key := "TURBO_REMOTE_CACHE_TIMEOUT"
+	expectedTimeout := "600"
+	t.Run(key, func(t *testing.T) {
+		t.Cleanup(func() {
+			_ = os.Unsetenv(key)
+		})
+		args := turbostate.ParsedArgsFromRust{
+			CWD: "",
+		}
+		flags := pflag.NewFlagSet("test-flags", pflag.ContinueOnError)
+		h := NewHelper("test-version", args)
+		h.addFlags(flags)
+
+		err := os.Setenv(key, expectedTimeout)
+		if err != nil {
+			t.Fatalf("setenv %v", err)
+		}
+
+		base, err := h.GetCmdBase(args)
+		if err != nil {
+			t.Fatalf("failed to get command base %v", err)
+		}
+		assert.Equal(t, base.APIClient.HttpClient.HTTPClient.Timeout, time.Duration(600)*time.Second)
+	})
+}
+
+func TestRemoteCacheTimeoutFlag(t *testing.T) {
+	expectedTimeout := "599"
+
+	args := turbostate.ParsedArgsFromRust{
+		CWD: "",
+	}
+	flags := pflag.NewFlagSet("test-flags", pflag.ContinueOnError)
+	h := NewHelper("test-version", args)
+	h.addFlags(flags)
+
+	assert.NilError(t, flags.Set("remote-cache-timeout", expectedTimeout), "flags.Set")
+
+	base, err := h.GetCmdBase(args)
+	if err != nil {
+		t.Fatalf("failed to get command base %v", err)
+	}
+
+	assert.Equal(t, base.APIClient.HttpClient.HTTPClient.Timeout, time.Duration(599)*time.Second)
+}
+
+func TestRemoteCacheTimeoutPrimacy(t *testing.T) {
+	key := "TURBO_REMOTE_CACHE_TIMEOUT"
+	value := "600"
+	flagValue := "599"
+
+	t.Run(key, func(t *testing.T) {
+		t.Cleanup(func() {
+			_ = os.Unsetenv(key)
+		})
+		args := turbostate.ParsedArgsFromRust{
+			CWD: "",
+		}
+		flags := pflag.NewFlagSet("test-flags", pflag.ContinueOnError)
+		h := NewHelper("test-version", args)
+		h.addFlags(flags)
+
+		assert.NilError(t, flags.Set("remote-cache-timeout", flagValue), "flags.Set")
+
+		err := os.Setenv(key, value)
+		if err != nil {
+			t.Fatalf("setenv %v", err)
+		}
+
+		base, err := h.GetCmdBase(args)
+		if err != nil {
+			t.Fatalf("failed to get command base %v", err)
+		}
+		assert.Equal(t, base.APIClient.HttpClient.HTTPClient.Timeout, time.Duration(599)*time.Second)
+	})
 }

--- a/cli/internal/cmdutil/cmdutil_test.go
+++ b/cli/internal/cmdutil/cmdutil_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/spf13/pflag"
 	"github.com/vercel/turbo/cli/internal/fs"
 	"github.com/vercel/turbo/cli/internal/turbostate"
 	"gotest.tools/v3/assert"
@@ -24,9 +23,7 @@ func TestTokenEnvVar(t *testing.T) {
 			args := turbostate.ParsedArgsFromRust{
 				CWD: "",
 			}
-			flags := pflag.NewFlagSet("test-flags", pflag.ContinueOnError)
 			h := NewHelper("test-version", args)
-			h.addFlags(flags)
 			h.UserConfigPath = userConfigPath
 
 			expectedToken := expectedPrefix + v
@@ -54,9 +51,7 @@ func TestRemoteCacheTimeoutEnvVar(t *testing.T) {
 		args := turbostate.ParsedArgsFromRust{
 			CWD: "",
 		}
-		flags := pflag.NewFlagSet("test-flags", pflag.ContinueOnError)
 		h := NewHelper("test-version", args)
-		h.addFlags(flags)
 
 		err := os.Setenv(key, expectedTimeout)
 		if err != nil {
@@ -72,16 +67,11 @@ func TestRemoteCacheTimeoutEnvVar(t *testing.T) {
 }
 
 func TestRemoteCacheTimeoutFlag(t *testing.T) {
-	expectedTimeout := "599"
-
 	args := turbostate.ParsedArgsFromRust{
-		CWD: "",
+		CWD:                "",
+		RemoteCacheTimeout: 599,
 	}
-	flags := pflag.NewFlagSet("test-flags", pflag.ContinueOnError)
 	h := NewHelper("test-version", args)
-	h.addFlags(flags)
-
-	assert.NilError(t, flags.Set("remote-cache-timeout", expectedTimeout), "flags.Set")
 
 	base, err := h.GetCmdBase(args)
 	if err != nil {
@@ -93,21 +83,17 @@ func TestRemoteCacheTimeoutFlag(t *testing.T) {
 
 func TestRemoteCacheTimeoutPrimacy(t *testing.T) {
 	key := "TURBO_REMOTE_CACHE_TIMEOUT"
-	value := "600"
-	flagValue := "599"
+	value := "2"
 
 	t.Run(key, func(t *testing.T) {
 		t.Cleanup(func() {
 			_ = os.Unsetenv(key)
 		})
 		args := turbostate.ParsedArgsFromRust{
-			CWD: "",
+			CWD:                "",
+			RemoteCacheTimeout: 1,
 		}
-		flags := pflag.NewFlagSet("test-flags", pflag.ContinueOnError)
 		h := NewHelper("test-version", args)
-		h.addFlags(flags)
-
-		assert.NilError(t, flags.Set("remote-cache-timeout", flagValue), "flags.Set")
 
 		err := os.Setenv(key, value)
 		if err != nil {
@@ -118,6 +104,6 @@ func TestRemoteCacheTimeoutPrimacy(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to get command base %v", err)
 		}
-		assert.Equal(t, base.APIClient.HttpClient.HTTPClient.Timeout, time.Duration(599)*time.Second)
+		assert.Equal(t, base.APIClient.HttpClient.HTTPClient.Timeout, time.Duration(1)*time.Second)
 	})
 }

--- a/cli/internal/cmdutil/cmdutil_test.go
+++ b/cli/internal/cmdutil/cmdutil_test.go
@@ -20,7 +20,7 @@ func TestTokenEnvVar(t *testing.T) {
 			t.Cleanup(func() {
 				_ = os.Unsetenv(v)
 			})
-			args := turbostate.ParsedArgsFromRust{
+			args := &turbostate.ParsedArgsFromRust{
 				CWD: "",
 			}
 			h := NewHelper("test-version", args)
@@ -48,7 +48,7 @@ func TestRemoteCacheTimeoutEnvVar(t *testing.T) {
 		t.Cleanup(func() {
 			_ = os.Unsetenv(key)
 		})
-		args := turbostate.ParsedArgsFromRust{
+		args := &turbostate.ParsedArgsFromRust{
 			CWD: "",
 		}
 		h := NewHelper("test-version", args)
@@ -67,7 +67,7 @@ func TestRemoteCacheTimeoutEnvVar(t *testing.T) {
 }
 
 func TestRemoteCacheTimeoutFlag(t *testing.T) {
-	args := turbostate.ParsedArgsFromRust{
+	args := &turbostate.ParsedArgsFromRust{
 		CWD:                "",
 		RemoteCacheTimeout: 599,
 	}
@@ -89,7 +89,7 @@ func TestRemoteCacheTimeoutPrimacy(t *testing.T) {
 		t.Cleanup(func() {
 			_ = os.Unsetenv(key)
 		})
-		args := turbostate.ParsedArgsFromRust{
+		args := &turbostate.ParsedArgsFromRust{
 			CWD:                "",
 			RemoteCacheTimeout: 1,
 		}

--- a/cli/internal/cmdutil/cmdutil_test.go
+++ b/cli/internal/cmdutil/cmdutil_test.go
@@ -3,6 +3,7 @@ package cmdutil
 import (
 	"os"
 	"testing"
+	"time"
 
 	"github.com/spf13/pflag"
 	"github.com/vercel/turbo/cli/internal/fs"
@@ -42,4 +43,51 @@ func TestTokenEnvVar(t *testing.T) {
 			assert.Equal(t, base.RemoteConfig.Token, expectedToken)
 		})
 	}
+}
+
+func TestTuroRemoteCacheTimeoutEnvVar(t *testing.T) {
+	// Set up an empty config so we're just testing environment variables
+	userConfigPath := fs.AbsoluteSystemPathFromUpstream(t.TempDir()).UntypedJoin("turborepo", "config.json")
+	expectedTimeout := "600"
+
+	t.Cleanup(func() {
+		_ = os.Unsetenv("TURBO_REMOTE_CACHE_TIMEOUT")
+	})
+
+	flags := pflag.NewFlagSet("test-flags", pflag.ContinueOnError)
+	h := NewHelper("test-version")
+	h.AddFlags(flags)
+	h.UserConfigPath = userConfigPath
+
+	err := os.Setenv("TURBO_REMOTE_CACHE_TIMEOUT", expectedTimeout)
+	if err != nil {
+		t.Fatalf("setenv %v", err)
+	}
+
+	base, err := h.GetCmdBase(flags)
+	if err != nil {
+		t.Fatalf("failed to get command base %v", err)
+	}
+
+	assert.Equal(t, base.APIClient.HttpClient.HTTPClient.Timeout, time.Duration(600)*time.Second)
+}
+
+func TestRemoteCacheTimeoutFlag(t *testing.T) {
+	// Set up an empty config so we're just testing environment variables
+	userConfigPath := fs.AbsoluteSystemPathFromUpstream(t.TempDir()).UntypedJoin("turborepo", "config.json")
+	expectedTimeout := "600"
+
+	flags := pflag.NewFlagSet("test-flags", pflag.ContinueOnError)
+	h := NewHelper("test-version")
+	h.AddFlags(flags)
+	h.UserConfigPath = userConfigPath
+
+	assert.NilError(t, flags.Set("remote-cache-timeout", expectedTimeout), "flags.Set")
+
+	base, err := h.GetCmdBase(flags)
+	if err != nil {
+		t.Fatalf("failed to get command base %v", err)
+	}
+
+	assert.Equal(t, base.APIClient.HttpClient.HTTPClient.Timeout, time.Duration(600)*time.Second)
 }

--- a/cli/internal/config/config_file.go
+++ b/cli/internal/config/config_file.go
@@ -3,7 +3,6 @@ package config
 import (
 	"os"
 
-	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"github.com/vercel/turbo/cli/internal/client"
 	"github.com/vercel/turbo/cli/internal/fs"
@@ -11,56 +10,16 @@ import (
 )
 
 // CLIConfigProvider is an interface for providing configuration values from the CLI
-// It can be implemented by either a pflag.FlagSet struct or a turbostate.Args struct.
+// It is implemented by a turbostate.Args struct.
 type CLIConfigProvider interface {
 	GetColor() bool
 	GetNoColor() bool
 	GetLogin() (string, error)
 	GetAPI() (string, error)
+	GetRemoteCacheTimeout() (uint64, error)
 	GetTeam() (string, error)
 	GetToken() (string, error)
 	GetCwd() (string, error)
-}
-
-// FlagSet is a wrapper so that the CLIConfigProvider interface can be implemented
-// on pflag.FlagSet.
-type FlagSet struct {
-	*pflag.FlagSet
-}
-
-// GetColor returns the value of the `color` flag. Used to implement CLIConfigProvider interface.
-func (p FlagSet) GetColor() bool {
-	return p.Changed("color")
-}
-
-// GetNoColor returns the value of the `no-color` flag. Used to implement CLIConfigProvider interface.
-func (p FlagSet) GetNoColor() bool {
-	return p.Changed("no-color")
-}
-
-// GetLogin returns the value of the `login` flag. Used to implement CLIConfigProvider interface.
-func (p FlagSet) GetLogin() (string, error) {
-	return p.GetString("login")
-}
-
-// GetAPI returns the value of the `api` flag. Used to implement CLIConfigProvider interface.
-func (p FlagSet) GetAPI() (string, error) {
-	return p.GetString("api")
-}
-
-// GetTeam returns the value of the `team` flag. Used to implement CLIConfigProvider interface.
-func (p FlagSet) GetTeam() (string, error) {
-	return p.GetString("team")
-}
-
-// GetToken returns the value of the `token` flag. Used to implement CLIConfigProvider interface.
-func (p FlagSet) GetToken() (string, error) {
-	return p.GetString("token")
-}
-
-// GetCwd returns the value of the `cwd` flag. Used to implement CLIConfigProvider interface.
-func (p FlagSet) GetCwd() (string, error) {
-	return p.GetString("cwd")
 }
 
 // RepoConfig is a configuration object for the logged-in turborepo.com user
@@ -174,11 +133,6 @@ func ReadUserConfigFile(path turbopath.AbsoluteSystemPath, cliConfig CLIConfigPr
 	}, nil
 }
 
-// AddUserConfigFlags adds per-user configuration item flags to the given flagset
-func AddUserConfigFlags(flags *pflag.FlagSet) {
-	flags.String("token", "", "Set the auth token for API calls")
-}
-
 // DefaultUserConfigPath returns the default platform-dependent place that
 // we store the user-specific configuration.
 func DefaultUserConfigPath() turbopath.AbsoluteSystemPath {
@@ -242,13 +196,6 @@ func ReadRepoConfigFile(path turbopath.AbsoluteSystemPath, cliConfig CLIConfigPr
 		repoViper: repoViper,
 		path:      path,
 	}, nil
-}
-
-// AddRepoConfigFlags adds per-repository configuration items to the given flagset
-func AddRepoConfigFlags(flags *pflag.FlagSet) {
-	flags.String("team", "", "Set the team slug for API calls")
-	flags.String("api", "", "Override the endpoint for API calls")
-	flags.String("login", "", "Override the login endpoint")
 }
 
 // GetRepoConfigPath reads the user-specific configuration values

--- a/cli/internal/config/config_file.go
+++ b/cli/internal/config/config_file.go
@@ -7,20 +7,8 @@ import (
 	"github.com/vercel/turbo/cli/internal/client"
 	"github.com/vercel/turbo/cli/internal/fs"
 	"github.com/vercel/turbo/cli/internal/turbopath"
+	"github.com/vercel/turbo/cli/internal/turbostate"
 )
-
-// CLIConfigProvider is an interface for providing configuration values from the CLI
-// It is implemented by a turbostate.Args struct.
-type CLIConfigProvider interface {
-	GetColor() bool
-	GetNoColor() bool
-	GetLogin() (string, error)
-	GetAPI() (string, error)
-	GetRemoteCacheTimeout() (uint64, error)
-	GetTeam() (string, error)
-	GetToken() (string, error)
-	GetCwd() (string, error)
-}
 
 // RepoConfig is a configuration object for the logged-in turborepo.com user
 type RepoConfig struct {
@@ -109,7 +97,7 @@ func (uc *UserConfig) Delete() error {
 // ReadUserConfigFile creates a UserConfig using the
 // specified path as the user config file. Note that the path or its parents
 // do not need to exist. On a write to this configuration, they will be created.
-func ReadUserConfigFile(path turbopath.AbsoluteSystemPath, cliConfig CLIConfigProvider) (*UserConfig, error) {
+func ReadUserConfigFile(path turbopath.AbsoluteSystemPath, cliConfig *turbostate.ParsedArgsFromRust) (*UserConfig, error) {
 	userViper := viper.New()
 	userViper.SetConfigFile(path.ToString())
 	userViper.SetConfigType("json")
@@ -148,7 +136,7 @@ const (
 // specified path as the repo config file. Note that the path or its
 // parents do not need to exist. On a write to this configuration, they
 // will be created.
-func ReadRepoConfigFile(path turbopath.AbsoluteSystemPath, cliConfig CLIConfigProvider) (*RepoConfig, error) {
+func ReadRepoConfigFile(path turbopath.AbsoluteSystemPath, cliConfig *turbostate.ParsedArgsFromRust) (*RepoConfig, error) {
 	repoViper := viper.New()
 	repoViper.SetConfigFile(path.ToString())
 	repoViper.SetConfigType("json")

--- a/cli/internal/config/config_file_test.go
+++ b/cli/internal/config/config_file_test.go
@@ -9,6 +9,8 @@ import (
 	"gotest.tools/v3/assert"
 )
 
+var _ CLIConfigProvider = (*turbostate.ParsedArgsFromRust)(nil)
+
 func TestReadRepoConfigWhenMissing(t *testing.T) {
 	testDir := fs.AbsoluteSystemPathFromUpstream(t.TempDir()).UntypedJoin("config.json")
 	args := turbostate.ParsedArgsFromRust{

--- a/cli/internal/config/config_file_test.go
+++ b/cli/internal/config/config_file_test.go
@@ -9,11 +9,9 @@ import (
 	"gotest.tools/v3/assert"
 )
 
-var _ CLIConfigProvider = (*turbostate.ParsedArgsFromRust)(nil)
-
 func TestReadRepoConfigWhenMissing(t *testing.T) {
 	testDir := fs.AbsoluteSystemPathFromUpstream(t.TempDir()).UntypedJoin("config.json")
-	args := turbostate.ParsedArgsFromRust{
+	args := &turbostate.ParsedArgsFromRust{
 		CWD: "",
 	}
 
@@ -31,7 +29,7 @@ func TestReadRepoConfigSetTeamAndAPIFlag(t *testing.T) {
 
 	slug := "my-team-slug"
 	apiURL := "http://my-login-url"
-	args := turbostate.ParsedArgsFromRust{
+	args := &turbostate.ParsedArgsFromRust{
 		CWD:  "",
 		Team: slug,
 		API:  apiURL,
@@ -59,7 +57,7 @@ func TestReadRepoConfigSetTeamAndAPIFlag(t *testing.T) {
 
 func TestRepoConfigIncludesDefaults(t *testing.T) {
 	testConfigFile := fs.AbsoluteSystemPathFromUpstream(t.TempDir()).UntypedJoin("turborepo", "config.json")
-	args := turbostate.ParsedArgsFromRust{
+	args := &turbostate.ParsedArgsFromRust{
 		CWD: "",
 	}
 
@@ -85,7 +83,7 @@ func TestRepoConfigIncludesDefaults(t *testing.T) {
 func TestWriteRepoConfig(t *testing.T) {
 	repoRoot := fs.AbsoluteSystemPathFromUpstream(t.TempDir())
 	testConfigFile := repoRoot.UntypedJoin(".turbo", "config.json")
-	args := turbostate.ParsedArgsFromRust{
+	args := &turbostate.ParsedArgsFromRust{
 		CWD: "",
 	}
 
@@ -117,7 +115,7 @@ func TestWriteRepoConfig(t *testing.T) {
 
 func TestWriteUserConfig(t *testing.T) {
 	configPath := fs.AbsoluteSystemPathFromUpstream(t.TempDir()).UntypedJoin("turborepo", "config.json")
-	args := turbostate.ParsedArgsFromRust{
+	args := &turbostate.ParsedArgsFromRust{
 		CWD: "",
 	}
 
@@ -147,7 +145,7 @@ func TestWriteUserConfig(t *testing.T) {
 
 func TestUserConfigFlags(t *testing.T) {
 	configPath := fs.AbsoluteSystemPathFromUpstream(t.TempDir()).UntypedJoin("turborepo", "config.json")
-	args := turbostate.ParsedArgsFromRust{
+	args := &turbostate.ParsedArgsFromRust{
 		CWD:   "",
 		Token: "my-token",
 	}

--- a/cli/internal/daemon/lifecycle.go
+++ b/cli/internal/daemon/lifecycle.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"context"
 	"fmt"
+
 	"github.com/vercel/turbo/cli/internal/turbostate"
 
 	"github.com/pkg/errors"

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -74,6 +74,7 @@ func optsFromArgs(args *turbostate.ParsedArgsFromRust) (*Opts, error) {
 	scope.OptsFromArgs(&opts.scopeOpts, args)
 
 	// Cache flags
+	opts.clientOpts.Timeout = args.RemoteCacheTimeout
 	opts.cacheOpts.SkipFilesystem = runPayload.RemoteOnly
 	opts.cacheOpts.OverrideDir = runPayload.CacheDir
 	opts.cacheOpts.Workers = runPayload.CacheWorkers

--- a/cli/internal/run/run_spec.go
+++ b/cli/internal/run/run_spec.go
@@ -4,6 +4,7 @@ package run
 
 import (
 	"github.com/vercel/turbo/cli/internal/cache"
+	"github.com/vercel/turbo/cli/internal/client"
 	"github.com/vercel/turbo/cli/internal/runcache"
 	"github.com/vercel/turbo/cli/internal/scope"
 	"github.com/vercel/turbo/cli/internal/util"
@@ -39,6 +40,7 @@ func (rs *runSpec) ArgsForTask(task string) []string {
 type Opts struct {
 	runOpts      runOpts
 	cacheOpts    cache.Opts
+	clientOpts   client.Opts
 	runcacheOpts runcache.Opts
 	scopeOpts    scope.Opts
 }
@@ -48,6 +50,9 @@ func getDefaultOptions() *Opts {
 	return &Opts{
 		runOpts: runOpts{
 			concurrency: 10,
+		},
+		clientOpts: client.Opts{
+			Timeout: client.ClientTimeout,
 		},
 	}
 }

--- a/cli/internal/turbostate/turbostate.go
+++ b/cli/internal/turbostate/turbostate.go
@@ -93,42 +93,42 @@ type ParsedArgsFromRust struct {
 	Command            Command `json:"command"`
 }
 
-// GetColor returns the value of the `color` flag. Used to implement CLIConfigProvider interface.
+// GetColor returns the value of the `color` flag.
 func (a ParsedArgsFromRust) GetColor() bool {
 	return a.Color
 }
 
-// GetNoColor returns the value of the `token` flag. Used to implement CLIConfigProvider interface.
+// GetNoColor returns the value of the `token` flag.
 func (a ParsedArgsFromRust) GetNoColor() bool {
 	return a.NoColor
 }
 
-// GetLogin returns the value of the `login` flag. Used to implement CLIConfigProvider interface.
+// GetLogin returns the value of the `login` flag.
 func (a ParsedArgsFromRust) GetLogin() (string, error) {
 	return a.Login, nil
 }
 
-// GetAPI returns the value of the `api` flag. Used to implement CLIConfigProvider interface.
+// GetAPI returns the value of the `api` flag.
 func (a ParsedArgsFromRust) GetAPI() (string, error) {
 	return a.API, nil
 }
 
-// GetTeam returns the value of the `team` flag. Used to implement CLIConfigProvider interface.
+// GetTeam returns the value of the `team` flag.
 func (a ParsedArgsFromRust) GetTeam() (string, error) {
 	return a.Team, nil
 }
 
-// GetToken returns the value of the `token` flag. Used to implement CLIConfigProvider interface.
+// GetToken returns the value of the `token` flag.
 func (a ParsedArgsFromRust) GetToken() (string, error) {
 	return a.Token, nil
 }
 
-// GetCwd returns the value of the `cwd` flag. Used to implement CLIConfigProvider interface.
+// GetCwd returns the value of the `cwd` flag.
 func (a ParsedArgsFromRust) GetCwd() (string, error) {
 	return a.CWD, nil
 }
 
-// GetRemoteCacheTimeout returns the value of the `remote-cache-timeout` flag. Used to implement CLIConfigProvider interface.
+// GetRemoteCacheTimeout returns the value of the `remote-cache-timeout` flag.
 func (a ParsedArgsFromRust) GetRemoteCacheTimeout() (uint64, error) {
 	if a.RemoteCacheTimeout != 0 {
 		return a.RemoteCacheTimeout, nil

--- a/cli/internal/turbostate/turbostate.go
+++ b/cli/internal/turbostate/turbostate.go
@@ -93,8 +93,6 @@ type ParsedArgsFromRust struct {
 	Command            Command `json:"command"`
 }
 
-// var _ config.CLIConfigProvider = (*ParsedArgsFromRust)(nil)
-
 // GetColor returns the value of the `color` flag. Used to implement CLIConfigProvider interface.
 func (a ParsedArgsFromRust) GetColor() bool {
 	return a.Color

--- a/cli/internal/turbostate/turbostate.go
+++ b/cli/internal/turbostate/turbostate.go
@@ -3,7 +3,9 @@
 // to Go via a JSON payload.
 package turbostate
 
-import "github.com/vercel/turbo/cli/internal/config"
+import (
+	"fmt"
+)
 
 // RepoState is the state for repository. Consists of the root for the repo
 // along with the mode (single package or multi package)
@@ -91,7 +93,7 @@ type ParsedArgsFromRust struct {
 	Command            Command `json:"command"`
 }
 
-var _ config.CLIConfigProvider = (*ParsedArgsFromRust)(nil)
+// var _ config.CLIConfigProvider = (*ParsedArgsFromRust)(nil)
 
 // GetColor returns the value of the `color` flag. Used to implement CLIConfigProvider interface.
 func (a ParsedArgsFromRust) GetColor() bool {
@@ -126,4 +128,13 @@ func (a ParsedArgsFromRust) GetToken() (string, error) {
 // GetCwd returns the value of the `cwd` flag. Used to implement CLIConfigProvider interface.
 func (a ParsedArgsFromRust) GetCwd() (string, error) {
 	return a.CWD, nil
+}
+
+// GetRemoteCacheTimeout returns the value of the `remote-cache-timeout` flag. Used to implement CLIConfigProvider interface.
+func (a ParsedArgsFromRust) GetRemoteCacheTimeout() (uint64, error) {
+	if a.RemoteCacheTimeout != 0 {
+		return a.RemoteCacheTimeout, nil
+	} else {
+		return 0, fmt.Errorf("No remote cache timeout provided.")
+	}
 }

--- a/cli/internal/turbostate/turbostate.go
+++ b/cli/internal/turbostate/turbostate.go
@@ -74,20 +74,21 @@ type Command struct {
 // ParsedArgsFromRust are the parsed command line arguments passed
 // from the Rust shim
 type ParsedArgsFromRust struct {
-	API        string  `json:"api"`
-	Color      bool    `json:"color"`
-	CPUProfile string  `json:"cpu_profile"`
-	CWD        string  `json:"cwd"`
-	Heap       string  `json:"heap"`
-	Login      string  `json:"login"`
-	NoColor    bool    `json:"no_color"`
-	Preflight  bool    `json:"preflight"`
-	Team       string  `json:"team"`
-	Token      string  `json:"token"`
-	Trace      string  `json:"trace"`
-	Verbosity  int     `json:"verbosity"`
-	TestRun    bool    `json:"test_run"`
-	Command    Command `json:"command"`
+	API                string  `json:"api"`
+	Color              bool    `json:"color"`
+	CPUProfile         string  `json:"cpu_profile"`
+	CWD                string  `json:"cwd"`
+	Heap               string  `json:"heap"`
+	Login              string  `json:"login"`
+	NoColor            bool    `json:"no_color"`
+	Preflight          bool    `json:"preflight"`
+	RemoteCacheTimeout uint64  `json:"remote_cache_timeout"`
+	Team               string  `json:"team"`
+	Token              string  `json:"token"`
+	Trace              string  `json:"trace"`
+	Verbosity          int     `json:"verbosity"`
+	TestRun            bool    `json:"test_run"`
+	Command            Command `json:"command"`
 }
 
 var _ config.CLIConfigProvider = (*ParsedArgsFromRust)(nil)

--- a/cli/internal/turbostate/turbostate.go
+++ b/cli/internal/turbostate/turbostate.go
@@ -132,7 +132,6 @@ func (a ParsedArgsFromRust) GetCwd() (string, error) {
 func (a ParsedArgsFromRust) GetRemoteCacheTimeout() (uint64, error) {
 	if a.RemoteCacheTimeout != 0 {
 		return a.RemoteCacheTimeout, nil
-	} else {
-		return 0, fmt.Errorf("No remote cache timeout provided.")
 	}
+	return 0, fmt.Errorf("no remote cache timeout provided")
 }

--- a/cli/internal/util/parse_concurrency.go
+++ b/cli/internal/util/parse_concurrency.go
@@ -37,10 +37,3 @@ func ParseConcurrency(concurrencyRaw string) (int, error) {
 		}
 	}
 }
-
-// ConcurrencyValue allows pflag to accept either a number or percentage
-// of available CPUs as a value for concurrency
-type ConcurrencyValue struct {
-	Value *int
-	raw   string
-}

--- a/crates/turborepo-lib/src/cli.rs
+++ b/crates/turborepo-lib/src/cli.rs
@@ -94,8 +94,8 @@ pub struct Args {
     #[clap(long, global = true)]
     pub preflight: bool,
     /// Set a timeout for all HTTP requests.
-    #[clap(long, global = true, value_parser)]
-    pub remote_cache_timeout: u64,
+    #[clap(long, value_name = "TIMEOUT", global = true, value_parser)]
+    pub remote_cache_timeout: Option<u64>,
     /// Set the team slug for API calls
     #[clap(long, global = true, value_parser)]
     pub team: Option<String>,

--- a/crates/turborepo-lib/src/cli.rs
+++ b/crates/turborepo-lib/src/cli.rs
@@ -95,7 +95,7 @@ pub struct Args {
     pub preflight: bool,
     /// Set a timeout for all HTTP requests.
     #[clap(long, global = true, value_parser)]
-    pub remote_cache_timeout: Option<u64>,
+    pub remote_cache_timeout: u64,
     /// Set the team slug for API calls
     #[clap(long, global = true, value_parser)]
     pub team: Option<String>,

--- a/crates/turborepo-lib/src/cli.rs
+++ b/crates/turborepo-lib/src/cli.rs
@@ -93,6 +93,9 @@ pub struct Args {
     /// for authorization
     #[clap(long, global = true)]
     pub preflight: bool,
+    /// Set a timeout for all HTTP requests.
+    #[clap(long, global = true, value_parser)]
+    pub remote_cache_timeout: Option<u64>,
     /// Set the team slug for API calls
     #[clap(long, global = true, value_parser)]
     pub team: Option<String>,

--- a/crates/turborepo-lib/src/client.rs
+++ b/crates/turborepo-lib/src/client.rs
@@ -1,6 +1,7 @@
 use std::{env, future::Future};
 
 use anyhow::{anyhow, Result};
+use config::{Config, Environment};
 use lazy_static::lazy_static;
 use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
@@ -93,6 +94,11 @@ pub struct User {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UserResponse {
     pub user: User,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Default)]
+struct ClientConfigValue {
+    remote_cache_timeout: u64,
 }
 
 pub struct APIClient {
@@ -264,9 +270,15 @@ impl APIClient {
         false
     }
 
-    pub fn new(base_url: impl AsRef<str>, timeout: u64) -> Result<Self> {
+    pub fn new(base_url: impl AsRef<str>, timeout: Option<u64>) -> Result<Self> {
+        let config: ClientConfigValue = Config::builder()
+            .add_source(Environment::with_prefix("turbo"))
+            .set_override_option("remote_cache_timeout", timeout)?
+            .build()?
+            .try_deserialize()?;
+
         let client = reqwest::Client::builder()
-            .timeout(std::time::Duration::from_secs(timeout))
+            .timeout(std::time::Duration::from_secs(config.remote_cache_timeout))
             .build()?;
 
         Ok(APIClient {

--- a/crates/turborepo-lib/src/client.rs
+++ b/crates/turborepo-lib/src/client.rs
@@ -1,7 +1,6 @@
 use std::{env, future::Future};
 
 use anyhow::{anyhow, Result};
-use config::{Config, Environment};
 use lazy_static::lazy_static;
 use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
@@ -94,11 +93,6 @@ pub struct User {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UserResponse {
     pub user: User,
-}
-
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Default)]
-struct ClientConfigValue {
-    remote_cache_timeout: u64,
 }
 
 pub struct APIClient {
@@ -270,15 +264,9 @@ impl APIClient {
         false
     }
 
-    pub fn new(base_url: impl AsRef<str>, timeout: Option<u64>) -> Result<Self> {
-        let config: ClientConfigValue = Config::builder()
-            .add_source(Environment::with_prefix("turbo"))
-            .set_override_option("remote_cache_timeout", timeout)?
-            .build()?
-            .try_deserialize()?;
-
+    pub fn new(base_url: impl AsRef<str>, timeout: u64) -> Result<Self> {
         let client = reqwest::Client::builder()
-            .timeout(std::time::Duration::from_secs(config.remote_cache_timeout))
+            .timeout(std::time::Duration::from_secs(timeout))
             .build()?;
 
         Ok(APIClient {

--- a/crates/turborepo-lib/src/client.rs
+++ b/crates/turborepo-lib/src/client.rs
@@ -264,10 +264,13 @@ impl APIClient {
         false
     }
 
-    pub fn new(base_url: impl AsRef<str>, timeout: u64) -> Result<Self> {
-        let client = reqwest::Client::builder()
-            .timeout(std::time::Duration::from_secs(timeout))
-            .build()?;
+    pub fn new(base_url: impl AsRef<str>, timeout: Option<u64>) -> Result<Self> {
+        let client = match timeout {
+            Some(timeout) => reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(timeout))
+                .build()?,
+            None => reqwest::Client::builder().build()?,
+        };
 
         Ok(APIClient {
             client,

--- a/crates/turborepo-lib/src/client.rs
+++ b/crates/turborepo-lib/src/client.rs
@@ -264,9 +264,9 @@ impl APIClient {
         false
     }
 
-    pub fn new(base_url: impl AsRef<str>) -> Result<Self> {
+    pub fn new(base_url: impl AsRef<str>, timeout: u64) -> Result<Self> {
         let client = reqwest::Client::builder()
-            .timeout(std::time::Duration::from_secs(20))
+            .timeout(std::time::Duration::from_secs(timeout))
             .build()?;
 
         Ok(APIClient {

--- a/crates/turborepo-lib/src/commands/link.rs
+++ b/crates/turborepo-lib/src/commands/link.rs
@@ -311,7 +311,7 @@ mod test {
             UserResponse,
         },
         commands::{link, CommandBase},
-        config::{RepoConfigLoader, UserConfigLoader},
+        config::{ClientConfigLoader, RepoConfigLoader, UserConfigLoader},
         ui::UI,
         Args,
     };
@@ -334,6 +334,7 @@ mod test {
         let mut base = CommandBase {
             repo_root: Default::default(),
             ui: UI::new(false),
+            client_config: OnceCell::from(ClientConfigLoader::new().load().unwrap()),
             user_config: OnceCell::from(
                 UserConfigLoader::new(user_config_file.path().to_path_buf())
                     .with_token(Some("token".to_string()))

--- a/crates/turborepo-lib/src/commands/login.rs
+++ b/crates/turborepo-lib/src/commands/login.rs
@@ -312,7 +312,7 @@ mod test {
             login::{get_token_and_redirect, SsoPayload, EXPECTED_TOKEN_TEST},
             CommandBase,
         },
-        config::{RepoConfigLoader, UserConfigLoader},
+        config::{ClientConfigLoader, RepoConfigLoader, UserConfigLoader},
         ui::UI,
         Args,
     };
@@ -332,6 +332,7 @@ mod test {
         let mut base = CommandBase {
             repo_root: Default::default(),
             ui: UI::new(false),
+            client_config: OnceCell::from(ClientConfigLoader::new().load().unwrap()),
             user_config: OnceCell::from(
                 UserConfigLoader::new(user_config_file.path().to_path_buf())
                     .load()
@@ -406,6 +407,7 @@ mod test {
         let mut base = CommandBase {
             repo_root: Default::default(),
             ui: UI::new(false),
+            client_config: OnceCell::from(ClientConfigLoader::new().load().unwrap()),
             user_config: OnceCell::from(
                 UserConfigLoader::new(user_config_file.path().to_path_buf())
                     .load()

--- a/crates/turborepo-lib/src/commands/mod.rs
+++ b/crates/turborepo-lib/src/commands/mod.rs
@@ -108,7 +108,7 @@ impl CommandBase {
     pub fn api_client(&mut self) -> Result<APIClient> {
         let repo_config = self.repo_config()?;
         let api_url = repo_config.api_url();
-        let timeout = self.args.remote_cache_timeout.unwrap_or(20);
+        let timeout = self.args.remote_cache_timeout;
         APIClient::new(api_url, timeout)
     }
 }

--- a/crates/turborepo-lib/src/commands/mod.rs
+++ b/crates/turborepo-lib/src/commands/mod.rs
@@ -108,7 +108,6 @@ impl CommandBase {
     pub fn api_client(&mut self) -> Result<APIClient> {
         let repo_config = self.repo_config()?;
         let api_url = repo_config.api_url();
-        let timeout = self.args.remote_cache_timeout;
-        APIClient::new(api_url, timeout)
+        APIClient::new(api_url, self.args.remote_cache_timeout)
     }
 }

--- a/crates/turborepo-lib/src/commands/mod.rs
+++ b/crates/turborepo-lib/src/commands/mod.rs
@@ -108,6 +108,7 @@ impl CommandBase {
     pub fn api_client(&mut self) -> Result<APIClient> {
         let repo_config = self.repo_config()?;
         let api_url = repo_config.api_url();
-        APIClient::new(api_url)
+        let timeout = self.args.remote_cache_timeout;
+        APIClient::new(api_url, timeout)
     }
 }

--- a/crates/turborepo-lib/src/commands/mod.rs
+++ b/crates/turborepo-lib/src/commands/mod.rs
@@ -108,7 +108,7 @@ impl CommandBase {
     pub fn api_client(&mut self) -> Result<APIClient> {
         let repo_config = self.repo_config()?;
         let api_url = repo_config.api_url();
-        let timeout = self.args.remote_cache_timeout;
+        let timeout = self.args.remote_cache_timeout.unwrap_or(20);
         APIClient::new(api_url, timeout)
     }
 }

--- a/crates/turborepo-lib/src/commands/mod.rs
+++ b/crates/turborepo-lib/src/commands/mod.rs
@@ -77,7 +77,7 @@ impl CommandBase {
 
     fn create_client_config(&self) -> Result<()> {
         let client_config = ClientConfigLoader::new()
-            .with_remote_cache_timeout(self.args.remote_cache_timeout.clone())
+            .with_remote_cache_timeout(self.args.remote_cache_timeout)
             .load()?;
         self.client_config.set(client_config)?;
 

--- a/crates/turborepo-lib/src/config/client.rs
+++ b/crates/turborepo-lib/src/config/client.rs
@@ -1,5 +1,7 @@
+use std::collections::HashMap;
+
 use anyhow::Result;
-use config::{Config, Environment};
+use config::{Config, ConfigError, Environment};
 use serde::{Deserialize, Serialize};
 
 const DEFAULT_TIMEOUT: u64 = 20;
@@ -17,12 +19,22 @@ struct ClientConfigValue {
 #[derive(Debug, Clone)]
 pub struct ClientConfigLoader {
     remote_cache_timeout: Option<u64>,
+    environment: Option<HashMap<String, String>>,
 }
 
 impl ClientConfig {
     #[allow(dead_code)]
-    pub fn remote_cache_timeout(&self) -> u64 {
-        self.config.remote_cache_timeout.unwrap_or(DEFAULT_TIMEOUT)
+    pub fn remote_cache_timeout(&self) -> Option<u64> {
+        match self.config.remote_cache_timeout {
+            // Pass 0 to get no timeout.
+            Some(0) => None,
+
+            // Pass any non-zero uint64 to get a timeout of that duration measured in seconds.
+            Some(other) => Some(other),
+
+            // If the _config_ doesn't have a remote_cache_timeout, give them the default.
+            None => Some(DEFAULT_TIMEOUT),
+        }
     }
 }
 
@@ -32,6 +44,7 @@ impl ClientConfigLoader {
     pub fn new() -> Self {
         Self {
             remote_cache_timeout: None,
+            environment: None,
         }
     }
 
@@ -43,17 +56,167 @@ impl ClientConfigLoader {
     }
 
     #[allow(dead_code)]
+    pub fn with_environment(mut self, environment: Option<HashMap<String, String>>) -> Self {
+        self.environment = environment;
+        self
+    }
+
+    #[allow(dead_code)]
     pub fn load(self) -> Result<ClientConfig> {
         let Self {
             remote_cache_timeout,
+            environment,
         } = self;
 
-        let config: ClientConfigValue = Config::builder()
-            .add_source(Environment::with_prefix("turbo"))
+        let config_attempt: Result<ClientConfigValue, ConfigError> = Config::builder()
+            .set_default("remote_cache_timeout", DEFAULT_TIMEOUT)?
+            .add_source(Environment::with_prefix("turbo").source(environment))
             .set_override_option("remote_cache_timeout", remote_cache_timeout)?
             .build()?
-            .try_deserialize()?;
+            .try_deserialize();
 
-        Ok(ClientConfig { config })
+        // This goes wrong when TURBO_REMOTE_CACHE_TIMEOUT can't be deserialized to u64
+        match config_attempt {
+            Err(_) => Ok(ClientConfig {
+                config: ClientConfigValue {
+                    remote_cache_timeout: None,
+                },
+            }),
+            Ok(config) => Ok(ClientConfig { config }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_client_default() -> Result<()> {
+        let config = ClientConfigLoader::new().load()?;
+
+        assert_eq!(config.remote_cache_timeout(), Some(DEFAULT_TIMEOUT));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_client_arg_variable() -> Result<()> {
+        let arg_value = Some(1);
+
+        let config = ClientConfigLoader::new()
+            .with_remote_cache_timeout(arg_value)
+            .load()?;
+
+        assert_eq!(config.remote_cache_timeout(), arg_value);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_client_env_variable() -> Result<()> {
+        let env_value = String::from("2");
+
+        let config = ClientConfigLoader::new()
+            .with_environment({
+                let mut env = HashMap::new();
+                env.insert("TURBO_REMOTE_CACHE_TIMEOUT".into(), env_value.clone());
+                Some(env)
+            })
+            .load()?;
+
+        assert_eq!(
+            config.remote_cache_timeout(),
+            Some(env_value.parse::<u64>().unwrap())
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_client_arg_env_variable() -> Result<()> {
+        struct TestCase {
+            arg: Option<u64>,
+            env: String,
+            output: Option<u64>,
+        }
+
+        let tests = [
+            TestCase {
+                arg: Some(0),
+                env: String::from("0"),
+                output: None,
+            },
+            TestCase {
+                arg: Some(0),
+                env: String::from("2"),
+                output: None,
+            },
+            TestCase {
+                arg: Some(0),
+                env: String::from("garbage"),
+                output: None,
+            },
+            TestCase {
+                arg: Some(0),
+                env: String::from(""),
+                output: None,
+            },
+            TestCase {
+                arg: Some(1),
+                env: String::from("0"),
+                output: Some(1),
+            },
+            TestCase {
+                arg: Some(1),
+                env: String::from("2"),
+                output: Some(1),
+            },
+            TestCase {
+                arg: Some(1),
+                env: String::from("garbage"),
+                output: Some(1),
+            },
+            TestCase {
+                arg: Some(1),
+                env: String::from(""),
+                output: Some(1),
+            },
+            TestCase {
+                arg: None,
+                env: String::from("0"),
+                output: None,
+            },
+            TestCase {
+                arg: None,
+                env: String::from("2"),
+                output: Some(2),
+            },
+            TestCase {
+                arg: None,
+                env: String::from("garbage"),
+                output: Some(DEFAULT_TIMEOUT),
+            },
+            TestCase {
+                arg: None,
+                env: String::from(""),
+                output: Some(DEFAULT_TIMEOUT),
+            },
+        ];
+
+        for test in tests {
+            let config = ClientConfigLoader::new()
+                .with_remote_cache_timeout(test.arg)
+                .with_environment({
+                    let mut env = HashMap::new();
+                    env.insert("TURBO_REMOTE_CACHE_TIMEOUT".into(), test.env);
+                    Some(env)
+                })
+                .load()?;
+
+            assert_eq!(config.remote_cache_timeout(), test.output);
+        }
+
+        Ok(())
     }
 }

--- a/crates/turborepo-lib/src/config/client.rs
+++ b/crates/turborepo-lib/src/config/client.rs
@@ -1,0 +1,59 @@
+use anyhow::Result;
+use config::{Config, Environment};
+use serde::{Deserialize, Serialize};
+
+const DEFAULT_TIMEOUT: u64 = 20;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClientConfig {
+    config: ClientConfigValue,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+struct ClientConfigValue {
+    remote_cache_timeout: Option<u64>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ClientConfigLoader {
+    remote_cache_timeout: Option<u64>,
+}
+
+impl ClientConfig {
+    #[allow(dead_code)]
+    pub fn remote_cache_timeout(&self) -> u64 {
+        self.config.remote_cache_timeout.unwrap_or(DEFAULT_TIMEOUT)
+    }
+}
+
+impl ClientConfigLoader {
+    /// Creates a loader that will load the client config
+    #[allow(dead_code)]
+    pub fn new() -> Self {
+        Self {
+            remote_cache_timeout: None,
+        }
+    }
+
+    /// Set an override for token that the user provided via the command line
+    #[allow(dead_code)]
+    pub fn with_remote_cache_timeout(mut self, remote_cache_timeout: Option<u64>) -> Self {
+        self.remote_cache_timeout = remote_cache_timeout;
+        self
+    }
+
+    #[allow(dead_code)]
+    pub fn load(self) -> Result<ClientConfig> {
+        let Self {
+            remote_cache_timeout,
+        } = self;
+
+        let config: ClientConfigValue = Config::builder()
+            .add_source(Environment::with_prefix("turbo"))
+            .set_override_option("remote_cache_timeout", remote_cache_timeout)?
+            .build()?
+            .try_deserialize()?;
+
+        Ok(ClientConfig { config })
+    }
+}

--- a/crates/turborepo-lib/src/config/mod.rs
+++ b/crates/turborepo-lib/src/config/mod.rs
@@ -1,3 +1,4 @@
+mod client;
 mod env;
 mod repo;
 mod user;
@@ -5,6 +6,7 @@ mod user;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
+pub use client::{ClientConfig, ClientConfigLoader};
 #[cfg(not(windows))]
 use dirs_next::config_dir;
 // Go's xdg implementation uses FOLDERID_LocalAppData for config home


### PR DESCRIPTION
This commit authored in part by @tm1000.

Closes #1993
Closes #2096
Closes #2428

Notes:
- You may want to look at the original diff: https://github.com/vercel/turbo/pull/2428/files?w=1
- I've completely removed `pflag` at this point. It was only being used in tests.
- I've added a new "config" in Rust land, for the API client. It only accepts `timeout` right now.