### PR TITLE
fix(docs): consistent cta sizes on pack & repo

### DIFF
--- a/docs/components/pages/repo-home/RepoHero.tsx
+++ b/docs/components/pages/repo-home/RepoHero.tsx
@@ -84,7 +84,7 @@ export function RepoHero() {
         </FadeIn>
         <FadeIn
           delay={0.3}
-          className="z-50 flex flex-col items-center w-full max-w-md gap-5 px-6 md:max-w-lg"
+          className="z-50 flex flex-col items-center w-full max-w-md gap-5 px-6"
         >
           <div className="flex flex-col w-full gap-3 md:!flex-row">
             <CTAButton>


### PR DESCRIPTION
The "Get Started" CTA's were slightly different on /pack vs /repo. This updates them to be consistent. 