### PR TITLE
feat(docs): move reference up in priority (#4007

### DIFF
--- a/docs/pages/repo/docs/_meta.json
+++ b/docs/pages/repo/docs/_meta.json
@@ -5,9 +5,9 @@
   "installing": "Installing Turborepo",
   "getting-started": "Getting Started",
   "core-concepts": "Core Concepts",
-  "handbook": "Monorepo Handbook",
-  "ci": "CI Recipes",
   "reference": "API Reference",
+  "ci": "CI Recipes",
+  "handbook": "Monorepo Handbook",
   "changelog": {
     "title": "Changelog",
     "href": "https://github.com/vercel/turbo/releases",


### PR DESCRIPTION
Based on recent feedback in discord (come hang! https://turbo.build/discord) we're moving the reference (api and cli docs) up in the sidebar to help with discoverability. 