### PR TITLE
[WIP]: speed up rope iteration and serving

### DIFF
--- a/crates/turbo-tasks-fs/src/rope.rs
+++ b/crates/turbo-tasks-fs/src/rope.rs
@@ -353,7 +353,7 @@ impl<'de> Deserialize<'de> for Rope {
 impl PartialEq for Rope {
     // Ropes with similar contents are equals, regardless of their structure.
     fn eq(&self, other: &Self) -> bool {
-        if Arc::ptr_eq(&self.data, &other.data) {
+        if self.data.ptr_eq(&other.data) {
             return true;
         }
         if self.len() != other.len() {
@@ -392,10 +392,14 @@ impl PartialEq for Rope {
         let mut left = RopeReader::new(left, index);
         let mut right = RopeReader::new(right, index);
         loop {
-            match (left.fill_buf(), right.fill_buf()) {
+            match (left.next(), right.next()) {
                 // fill_buf should always return Ok, with either some number of bytes or 0 bytes
                 // when consumed.
-                (Ok(a), Ok(b)) => {
+                (Some(mut a), Some(mut b)) => {
+                    if a.ptr_eq(&b) {
+                        continue;
+                    }
+
                     let len = min(a.len(), b.len());
 
                     // When one buffer is consumed, both must be consumed.
@@ -407,12 +411,17 @@ impl PartialEq for Rope {
                         return false;
                     }
 
-                    left.consume(len);
-                    right.consume(len);
+                    if len < a.len() {
+                        a.advance(len);
+                        left.stack.push(StackElem::Local(a));
+                    }
+                    if len < b.len() {
+                        b.advance(len);
+                        right.stack.push(StackElem::Local(b));
+                    }
                 }
 
-                // If an error is ever returned (which shouldn't happen for us) for either/both,
-                // then we can't prove equality.
+                (None, None) => return true,
                 _ => return false,
             }
         }
@@ -498,6 +507,13 @@ impl RopeElem {
     fn maybe_eq(&self, other: &Self) -> Option<bool> {
         match (self, other) {
             (Local(a), Local(b)) => {
+                if a.ptr_eq(b) {
+                    return Some(true);
+                }
+
+                // We might as well do contents equality, because there's no faster way to do
+                // it. Returning a false result here is actually pretty fast, and allows us to
+                // skip creating the RopeReader struct.
                 if a.len() == b.len() {
                     return Some(a == b);
                 }
@@ -507,7 +523,7 @@ impl RopeElem {
                 None
             }
             (Shared(a), Shared(b)) => {
-                if Arc::ptr_eq(&a.0, &b.0) {
+                if a.ptr_eq(b) {
                     return Some(true);
                 }
 
@@ -683,6 +699,22 @@ impl From<RopeElem> for StackElem {
             Local(bytes) => Self::Local(bytes),
             Shared(inner) => Self::Shared(inner, 0),
         }
+    }
+}
+
+trait PtrEq {
+    fn ptr_eq(&self, other: &Self) -> bool;
+}
+
+impl PtrEq for Bytes {
+    fn ptr_eq(&self, other: &Self) -> bool {
+        self.len() == other.len() && self.as_ptr() == other.as_ptr()
+    }
+}
+
+impl PtrEq for InnerRope {
+    fn ptr_eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.0, &other.0)
     }
 }
 

--- a/crates/turbo-tasks-fs/src/rope.rs
+++ b/crates/turbo-tasks-fs/src/rope.rs
@@ -12,7 +12,6 @@ use std::{
 
 use anyhow::{Context, Result};
 use bytes::Bytes;
-use futures::Stream;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use tokio::io::{AsyncRead, ReadBuf};
 use turbo_tasks_hash::{DeterministicHash, DeterministicHasher};
@@ -677,19 +676,6 @@ impl<'a> BufRead for RopeReader<'a> {
         } else {
             self.stack.pop();
         }
-    }
-}
-
-impl<'a> Stream for RopeReader<'a> {
-    // The Result<Bytes> item type is required for this to be streamable into a
-    // [Hyper::Body].
-    type Item = Result<Bytes>;
-
-    // Returns a "result" of reading the next shared bytes reference. This
-    // differs from [Read::read] by not copying any memory.
-    fn poll_next(self: Pin<&mut Self>, _cx: &mut TaskContext<'_>) -> Poll<Option<Self::Item>> {
-        let this = self.get_mut();
-        Poll::Ready(this.next().cloned().map(Ok))
     }
 }
 

--- a/crates/turbo-tasks-fs/src/rope.rs
+++ b/crates/turbo-tasks-fs/src/rope.rs
@@ -119,7 +119,7 @@ impl<T: Into<Bytes>> From<T> for Rope {
         } else {
             Rope {
                 length: bytes.len(),
-                data: InnerRope::from(Box::from([Local(bytes)])),
+                data: InnerRope::from(vec![Local(bytes)]),
             }
         }
     }
@@ -201,7 +201,7 @@ impl RopeBuilder {
         self.finish();
         Rope {
             length: self.length,
-            data: InnerRope::from(self.committed.into_boxed_slice()),
+            data: InnerRope::from(self.committed),
         }
     }
 }
@@ -470,8 +470,8 @@ impl DeterministicHash for InnerRope {
     }
 }
 
-impl From<Box<[RopeElem]>> for InnerRope {
-    fn from(els: Box<[RopeElem]>) -> Self {
+impl From<Vec<RopeElem>> for InnerRope {
+    fn from(els: Vec<RopeElem>) -> Self {
         if cfg!(debug_assertions) {
             // It's important that an InnerRope never contain an empty Bytes section.
             for el in els.iter() {
@@ -690,7 +690,7 @@ mod test {
     }
     impl From<Vec<RopeElem>> for RopeElem {
         fn from(value: Vec<RopeElem>) -> Self {
-            RopeElem::Shared(InnerRope::from(value.into_boxed_slice()))
+            RopeElem::Shared(InnerRope::from(value))
         }
     }
     impl From<Rope> for RopeElem {
@@ -700,7 +700,7 @@ mod test {
     }
     impl Rope {
         fn new(value: Vec<RopeElem>) -> Self {
-            let data = InnerRope::from(value.into_boxed_slice());
+            let data = InnerRope::from(value);
             Rope {
                 length: data.len(),
                 data,

--- a/crates/turbo-tasks-fs/src/rope.rs
+++ b/crates/turbo-tasks-fs/src/rope.rs
@@ -37,9 +37,9 @@ pub struct Rope {
 }
 
 /// An Arc container for ropes. This indirection allows for easily sharing the
-/// contents between Ropes (and also RopeBuilders/RopeReaders).
-#[derive(Clone, Debug, Default)]
-struct InnerRope(Arc<Box<[RopeElem]>>);
+/// contents between Ropes (and also [RopeBuilder]s/[RopeReader]s).
+#[derive(Clone, Debug)]
+struct InnerRope(Arc<[RopeElem]>);
 
 /// Differentiates the types of stored bytes in a rope.
 #[derive(Clone, Debug)]
@@ -100,7 +100,8 @@ impl Rope {
         self.length == 0
     }
 
-    /// Returns a Read/AsyncRead/Stream/Iterator instance over all bytes.
+    /// Returns a [Read]/[AsyncRead]/[Stream]/[Iterator] instance over all
+    /// bytes.
     pub fn read(&self) -> RopeReader {
         RopeReader::new(&self.data, 0)
     }
@@ -453,6 +454,12 @@ impl InnerRope {
     }
 }
 
+impl Default for InnerRope {
+    fn default() -> Self {
+        InnerRope(Arc::new([]))
+    }
+}
+
 impl DeterministicHash for InnerRope {
     /// Ropes with similar contents hash the same, regardless of their
     /// structure. Notice the InnerRope does not contain a length (and any
@@ -482,12 +489,12 @@ impl From<Box<[RopeElem]>> for InnerRope {
                 }
             }
         }
-        InnerRope(Arc::new(els))
+        InnerRope(Arc::from(els))
     }
 }
 
 impl Deref for InnerRope {
-    type Target = Arc<Box<[RopeElem]>>;
+    type Target = Arc<[RopeElem]>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
@@ -532,7 +539,7 @@ impl DeterministicHash for RopeElem {
     }
 }
 
-/// Implements the Read/AsyncRead/Stream/Iterator trait over a Rope.
+/// Implements the [Read]/[AsyncRead]/[Stream]/[Iterator] trait over a [Rope].
 #[derive(Debug, Default)]
 pub struct RopeReader {
     /// The Rope's tree is kept as a cloned stack, allowing us to accomplish

--- a/crates/turbo-tasks-fs/src/rope.rs
+++ b/crates/turbo-tasks-fs/src/rope.rs
@@ -22,7 +22,7 @@ static EMPTY_BUF: &[u8] = &[];
 
 /// A Rope provides an efficient structure for sharing bytes/strings between
 /// multiple sources. Cloning a Rope is extremely cheap (Arc and usize), and
-/// the sharing contents of one Rope can be done by just cloning an Arc.
+/// sharing the contents of one Rope can be done by just cloning an Arc.
 ///
 /// Ropes are immutable, in order to construct one see [RopeBuilder].
 #[turbo_tasks::value(shared, serialization = "custom", eq = "manual")]
@@ -388,7 +388,7 @@ impl PartialEq for Rope {
         }
 
         // At this point, we need to do slower contents equality. It's possible we'll
-        // still get some memory reference quality for Bytes.
+        // still get some memory reference equality for Bytes.
         let mut left = RopeReader::new(left, index);
         let mut right = RopeReader::new(right, index);
         loop {


### PR DESCRIPTION
This is just a test to see if `Bytes` equality is secretly very slow. It uses slice equality, which [uses `memcmp`](https://github.com/rust-lang/rust/blob/31f858d9a511f24fedb8ed997b28304fec809630/library/core/src/slice/cmp.rs#L77-L94) for [`&[u8]`](https://github.com/rust-lang/rust/blob/31f858d9a511f24fedb8ed997b28304fec809630/library/core/src/slice/cmp.rs#L226-L227). But maybe `memcmp` doesn't have the obvious optimization for pointer equality? This is the only reason that I can think of leading to the performance improvements in #3955. The rope traversal can't be that expensive, right?