### PR TITLE
Fix/handle cross compile release

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,6 +19,7 @@
 # Nobody owns these files, so nobody should get tagged on changes
 Cargo.lock
 pnpm-lock.yaml
+.gitignore
 
 # Turbopack-specific things
 /.config/nextest.toml

--- a/.github/workflows/turborepo-release-step-2.yml
+++ b/.github/workflows/turborepo-release-step-2.yml
@@ -36,6 +36,10 @@ jobs:
       - uses: ./.github/actions/setup-go
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - uses: actions-rs/toolchain@v1
+      - run: |
+          rustup target add x86_64-apple-darwin
+          rustup target add aarch64-apple-darwin
       - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@v3
         with:
@@ -68,6 +72,16 @@ jobs:
       - uses: ./.github/actions/setup-go
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - run: apt-get install -y build-essential musl-tools clang llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu
+      - uses: actions-rs/toolchain@v1
+      - run: |
+          rustup target add x86_64-pc-windows-gnu
+          rustup target add aarch64-unknown-linux-musl
+          rustup target add x86_64-unknown-linux-musl
+      - run: |
+          curl -L https://github.com/arlyon/turbo/releases/download/zlib/libz.a > /usr/x86_64-w64-mingw32/lib/libz.a
+          curl -L https://github.com/nicholaslyang/turbo/releases/download/zlib-aarch64-linux-musl/libz.a > /usr/aarch64-linux-gnu/lib/libz.a
+          curl -L https://github.com/nicholaslyang/turbo/releases/download/zlib-x86_64-linux-musl/libz.a > /usr/lib/libz.a
       - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@v3
         with:
@@ -79,6 +93,7 @@ jobs:
       - name: Build Artifacts
         run: cd cli && make build-go-turbo-cross
         env:
+          CC_aarch64_unknown_linux_musl: aarch64-linux-gnu-gcc
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
       - name: Upload Artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/turborepo-release-step-2.yml
+++ b/.github/workflows/turborepo-release-step-2.yml
@@ -79,6 +79,9 @@ jobs:
           rustup target add aarch64-unknown-linux-musl
           rustup target add x86_64-unknown-linux-musl
       - run: |
+          # for convenience we have precompiled libraries for the various toolchains (windows and musl)
+          # these were built locally and are hosted on github releases, since we plan on stripping this
+          # out entirely asap
           curl -L https://github.com/arlyon/turbo/releases/download/zlib/libz.a > /usr/x86_64-w64-mingw32/lib/libz.a
           curl -L https://github.com/nicholaslyang/turbo/releases/download/zlib-aarch64-linux-musl/libz.a > /usr/aarch64-linux-gnu/lib/libz.a
           curl -L https://github.com/nicholaslyang/turbo/releases/download/zlib-x86_64-linux-musl/libz.a > /usr/lib/libz.a

--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,7 @@ sweep.timestamp
 
 crates/turborepo-ffi/bindings.h
 crates/turborepo-ffi/ffi/proto/*
-cli/internal/ffi/libturborepo_ffi.a
+cli/internal/ffi/libturborepo_ffi*.a
 
 # Prysk test error files
 *.t.err

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -9,6 +9,9 @@ else
 	UNAME := $(shell uname -s)
 endif
 
+GOARCH:=$(shell go env GOARCH | xargs)
+GOOS:=$(shell go env GOOS | xargs)
+
 # Strip debug info
 GO_FLAGS += "-ldflags=-s -w"
 
@@ -31,14 +34,68 @@ go-turbo$(EXT): $(GENERATED_FILES) $(SRC_FILES) go.mod turborepo-ffi-install
 	CGO_ENABLED=1 go build $(GO_FLAGS) -tags $(GO_TAG) -o go-turbo$(EXT) ./cmd/turbo
 
 .PHONY: turborepo-ffi-install
-turborepo-ffi-install: turborepo-ffi
-	cp -r ../crates/turborepo-ffi/bindings.h \
-	      ../crates/turborepo-ffi/target/release/libturborepo_ffi.a \
-	      ./internal/ffi
+turborepo-ffi-install: turborepo-ffi turborepo-ffi-copy-bindings
+	cp ../crates/turborepo-ffi/target/release/libturborepo_ffi.a ./internal/ffi/libturborepo_ffi_$(GOOS)_$(GOARCH).a
 
 .PHONY: turborepo-ffi
 turborepo-ffi:
-	cd ../crates/turborepo-ffi && CARGO_TARGET_DIR=./target cargo build --release
+	cd ../crates/turborepo-ffi && cargo build --release --target-dir ./target
+
+.PHONY: turborepo-ffi-copy-bindings
+turborepo-ffi-copy-bindings:
+	cp ../crates/turborepo-ffi/bindings.h ./internal/ffi/bindings.h
+
+#
+# ffi cross compiling
+#
+# these targets are used to build the ffi library for each platform
+# when doing a release. they _may_ work on your local machine, but
+# they're not intended to be used for development.
+#
+
+.PHONY: turborepo-ffi-install-windows-amd64
+turborepo-ffi-install-windows-amd64: turborepo-ffi-windows-amd64 turborepo-ffi-copy-bindings
+	cp ../crates/turborepo-ffi/target/x86_64-pc-windows-gnu/release/libturborepo_ffi.a ./internal/ffi/libturborepo_ffi_windows_amd64.a
+
+.PHONY: turborepo-ffi-install-darwin-arm64
+turborepo-ffi-install-darwin-arm64: turborepo-ffi-darwin-arm64 turborepo-ffi-copy-bindings
+	cp ../crates/turborepo-ffi/target/aarch64-apple-darwin/release/libturborepo_ffi.a ./internal/ffi/libturborepo_ffi_darwin_arm64.a
+
+.PHONY: turborepo-ffi-install-darwin-amd64
+turborepo-ffi-install-darwin-amd64: turborepo-ffi-darwin-amd64 turborepo-ffi-copy-bindings
+	cp ../crates/turborepo-ffi/target/x86_64-apple-darwin/release/libturborepo_ffi.a ./internal/ffi/libturborepo_ffi_darwin_amd64.a
+
+.PHONY: turborepo-ffi-install-linux-arm64
+turborepo-ffi-install-linux-arm64: turborepo-ffi-linux-arm64 turborepo-ffi-copy-bindings
+	cp ../crates/turborepo-ffi/target/aarch64-unknown-linux-musl/release/libturborepo_ffi.a ./internal/ffi/libturborepo_ffi_linux_arm64.a
+
+.PHONY: turborepo-ffi-install-linux-amd64
+turborepo-ffi-install-linux-amd64: turborepo-ffi-linux-amd64 turborepo-ffi-copy-bindings
+	cp ../crates/turborepo-ffi/target/x86_64-unknown-linux-musl/release/libturborepo_ffi.a ./internal/ffi/libturborepo_ffi_linux_amd64.a
+
+.PHONY: turborepo-ffi-windows-amd64
+turborepo-ffi-windows-amd64:
+	cd ../crates/turborepo-ffi && cargo build --release --target-dir ./target --target x86_64-pc-windows-gnu
+
+.PHONY: turborepo-ffi-darwin-arm64
+turborepo-ffi-darwin-arm64:
+	cd ../crates/turborepo-ffi && cargo build --release --target-dir ./target --target aarch64-apple-darwin
+
+.PHONY: turborepo-ffi-darwin-amd64
+turborepo-ffi-darwin-amd64:
+	cd ../crates/turborepo-ffi && cargo build --release --target-dir ./target --target x86_64-apple-darwin
+
+.PHONY: turborepo-ffi-linux-arm64
+turborepo-ffi-linux-arm64:
+	cd ../crates/turborepo-ffi && cargo build --release --target-dir ./target --target aarch64-unknown-linux-musl
+
+.PHONY: turborepo-ffi-linux-amd64
+turborepo-ffi-linux-amd64:
+	cd ../crates/turborepo-ffi && cargo build --release --target-dir ./target --target x86_64-unknown-linux-musl
+
+#
+# end
+#
 
 .PHONY: turborepo-ffi-proto
 turborepo-ffi-proto:
@@ -73,7 +130,7 @@ endif
 clean-go:
 	go clean -testcache ./...
 
-test-go: $(GENERATED_FILES) $(GO_FILES) go.mod go.sum
+test-go: $(GENERATED_FILES) $(GO_FILES) go.mod go.sum turborepo-ffi-install
 	go test $(TURBO_RACE) -tags $(GO_TAG) ./...
 
 # protos need to be compiled before linting, since linting needs to pick up

--- a/cli/cross-release.yml
+++ b/cli/cross-release.yml
@@ -19,6 +19,10 @@ builds:
     mod_timestamp: "{{ .CommitTimestamp }}"
     env:
       - CGO_ENABLED=1
+    hooks:
+      pre:
+        - cmd: make turborepo-ffi-install-{{ .Os }}-{{ .Arch }}
+          output: true
     targets:
       - linux_arm64
       - linux_amd64

--- a/cli/darwin-release.yml
+++ b/cli/darwin-release.yml
@@ -12,6 +12,10 @@ builds:
     tags:
       - rust
     binary: bin/go-turbo
+    hooks:
+      pre:
+        - cmd: make turborepo-ffi-install-{{ .Os }}-{{ .Arch }}
+          output: true
     flags:
       - -trimpath
     ldflags:

--- a/cli/internal/ffi/ffi.go
+++ b/cli/internal/ffi/ffi.go
@@ -2,9 +2,11 @@ package ffi
 
 // #include "bindings.h"
 //
-// #cgo darwin LDFLAGS: -L${SRCDIR} -lturborepo_ffi -lz -liconv
-// #cgo linux LDFLAGS: -L${SRCDIR} -lturborepo_ffi -lz
-// #cgo windows LDFLAGS: -L${SRCDIR} -lturborepo_ffi -lole32 -lbcrypt -lws2_32 -luserenv
+// #cgo darwin,arm64 LDFLAGS:  -L${SRCDIR} -lturborepo_ffi_darwin_arm64  -lz -liconv
+// #cgo darwin,amd64 LDFLAGS:  -L${SRCDIR} -lturborepo_ffi_darwin_amd64  -lz -liconv
+// #cgo linux,arm64 LDFLAGS:   -L${SRCDIR} -lturborepo_ffi_linux_arm64   -lz
+// #cgo linux,amd64 LDFLAGS:   -L${SRCDIR} -lturborepo_ffi_linux_amd64   -lz
+// #cgo windows,amd64 LDFLAGS: -L${SRCDIR} -lturborepo_ffi_windows_amd64 -lole32 -lbcrypt -lws2_32 -luserenv
 import "C"
 
 import (


### PR DESCRIPTION
We are currently not cross-compiling during release. This makes a few changes to the go sandwich to make this possible.