### PR TITLE
feat(overlay): apply data-* header for the error desc

### DIFF
--- a/crates/next-core/js/src/overlay/internal/container/RuntimeError.tsx
+++ b/crates/next-core/js/src/overlay/internal/container/RuntimeError.tsx
@@ -255,7 +255,11 @@ export function RuntimeErrorsDialogBody({
           </small>
         </LeftRightDialogHeader>
       </div>
-      <h2 id="nextjs__container_errors_desc" data-severity="error">
+      <h2
+        data-nextjs-turbo-dialog-body
+        id="nextjs__container_errors_desc"
+        data-severity="error"
+      >
         {activeError.error.name}:{" "}
         <HotlinkedText
           text={decodeMagicIdentifiers(activeError.error.message)}


### PR DESCRIPTION
Partially resolves WEB-671.

There are some test cases use `data-nextjs-dialog-header` to lookup its inner text to verify error output. Due to differences of error overlay layout between turbopack / next-dev, those 2 have different inner texts.

PR applies a workaround, by introducing new data tag `data-nextjs-turbo-dialog-body`. Next.js upstream will need following update to utilize this tag in its test suites.