### PR TITLE
Calculate TaskHash while constructing PackageTask

### DIFF
--- a/cli/integration_tests/basic_monorepo/verbosity.t
+++ b/cli/integration_tests/basic_monorepo/verbosity.t
@@ -51,8 +51,8 @@ Verbosity level 2
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo.: start (re)
   [-0-9:.TWZ+]+ \[DEBUG] turbo: task hash env vars for util:build: vars=\[] (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turbo.: start (re)
   [-0-9:.TWZ+]+ \[DEBUG] turbo: task hash: value=d09a52ea72495c87 (re)
   util:build: cache bypass, force executing d09a52ea72495c87
   util:build: 
@@ -81,8 +81,8 @@ Verbosity level 2
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo.: start (re)
   [-0-9:.TWZ+]+ \[DEBUG] turbo: task hash env vars for util:build: vars=\[] (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turbo.: start (re)
   [-0-9:.TWZ+]+ \[DEBUG] turbo: task hash: value=d09a52ea72495c87 (re)
   util:build: cache bypass, force executing d09a52ea72495c87
   util:build: 

--- a/cli/internal/graph/graph.go
+++ b/cli/internal/graph/graph.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/pyr-sh/dag"
 	"github.com/vercel/turbo/cli/internal/fs"
 	"github.com/vercel/turbo/cli/internal/nodes"
@@ -42,7 +43,13 @@ type CompleteGraph struct {
 // GetPackageTaskVisitor wraps a `visitor` function that is used for walking the TaskGraph
 // during execution (or dry-runs). The function returned here does not execute any tasks itself,
 // but it helps curry some data from the Complete Graph and pass it into the visitor function.
-func (g *CompleteGraph) GetPackageTaskVisitor(ctx gocontext.Context, visitor func(ctx gocontext.Context, packageTask *nodes.PackageTask) error) func(taskID string) error {
+func (g *CompleteGraph) GetPackageTaskVisitor(
+	ctx gocontext.Context,
+	taskGraph *dag.AcyclicGraph,
+	getArgs func(taskID string) []string,
+	logger hclog.Logger,
+	visitor func(ctx gocontext.Context, packageTask *nodes.PackageTask) error,
+) func(taskID string) error {
 	return func(taskID string) error {
 		packageName, taskName := util.GetPackageTaskFromId(taskID)
 		pkg, ok := g.WorkspaceInfos.PackageJSONs[packageName]
@@ -65,6 +72,19 @@ func (g *CompleteGraph) GetPackageTaskVisitor(ctx gocontext.Context, visitor fun
 			Outputs:         taskDefinition.Outputs.Inclusions,
 			ExcludedOutputs: taskDefinition.Outputs.Exclusions,
 		}
+
+		hash, err := g.TaskHashTracker.CalculateTaskHash(
+			packageTask,
+			taskGraph.DownEdges(taskID),
+			logger,
+			getArgs(taskID),
+		)
+
+		if err != nil {
+			return fmt.Errorf("Hashing error: %v", err)
+		}
+
+		packageTask.Hash = hash
 
 		packageTask.ExpandedInputs = g.TaskHashTracker.GetExpandedInputs(packageTask)
 

--- a/cli/internal/graph/graph.go
+++ b/cli/internal/graph/graph.go
@@ -77,7 +77,7 @@ func (g *CompleteGraph) GetPackageTaskVisitor(
 			packageTask,
 			taskGraph.DownEdges(taskID),
 			logger,
-			getArgs(taskID),
+			getArgs(taskName),
 		)
 
 		if err != nil {

--- a/cli/internal/nodes/packagetask.go
+++ b/cli/internal/nodes/packagetask.go
@@ -21,6 +21,7 @@ type PackageTask struct {
 	ExcludedOutputs []string
 	LogFile         string
 	ExpandedInputs  map[turbopath.AnchoredUnixPath]string
+	Hash            string
 }
 
 // OutputPrefix returns the prefix to be used for logging and ui for this task


### PR DESCRIPTION
### Description

We want to calculate this earlier, because it has some important side effects such as gathering the hashable inputs, etc. By moving this up the chain, we can ensure that more information is available for run summary and dry run summary in a consistent way.

#### Stacked PRs:
1. https://github.com/vercel/turbo/pull/4016 (this one)
2. https://github.com/vercel/turbo/pull/4021
3. https://github.com/vercel/turbo/pull/4020

### Testing Instructions

`cd cli && make integration-tests`

- [X] Auto label
