### PR TITLE
debug print errors for nested vcs

### DIFF
--- a/crates/turbo-tasks-macros/src/derive/value_debug_format_macro.rs
+++ b/crates/turbo-tasks-macros/src/derive/value_debug_format_macro.rs
@@ -64,7 +64,13 @@ fn format_named(ident: &Ident, fields: &FieldsNamed) -> (TokenStream2, TokenStre
                 vec![#(
                     FormattingField::new(
                         stringify!(#fields_idents),
-                        #fields_idents.value_debug_format(depth.saturating_sub(1)).try_to_value_debug_string().await?.await?.to_string(),
+                        match #fields_idents.value_debug_format(depth.saturating_sub(1)).try_to_value_debug_string().await {
+                            Ok(result) => match result.await {
+                                Ok(result) => result.to_string(),
+                                Err(err) => format!("{:?}", err),
+                            },
+                            Err(err) => format!("{:?}", err),
+                        },
                     ),
                 )*],
             )
@@ -82,7 +88,13 @@ fn format_unnamed(ident: &Ident, fields: &FieldsUnnamed) -> (TokenStream2, Token
             FormattingStruct::new_unnamed(
                 stringify!(#ident),
                 vec![#(
-                    #fields_idents.value_debug_format(depth.saturating_sub(1)).try_to_value_debug_string().await?.await?.to_string(),
+                    match #fields_idents.value_debug_format(depth.saturating_sub(1)).try_to_value_debug_string().await {
+                        Ok(result) => match result.await {
+                            Ok(result) => result.to_string(),
+                            Err(err) => format!("{:?}", err),
+                        },
+                        Err(err) => format!("{:?}", err),
+                    },
                 )*],
             )
         },

--- a/crates/turbo-tasks-macros/src/derive/value_debug_format_macro.rs
+++ b/crates/turbo-tasks-macros/src/derive/value_debug_format_macro.rs
@@ -52,10 +52,24 @@ pub fn derive_value_debug_format(input: TokenStream) -> TokenStream {
     .into()
 }
 
+/// Formats a single field nested inside named or unnamed fields.
+fn format_field(value: TokenStream2) -> TokenStream2 {
+    quote! {
+        match #value.value_debug_format(depth.saturating_sub(1)).try_to_value_debug_string().await {
+            Ok(result) => match result.await {
+                Ok(result) => result.to_string(),
+                Err(err) => format!("{:?}", err),
+            },
+            Err(err) => format!("{:?}", err),
+        }
+    }
+}
+
 /// Formats a struct or enum variant with named fields (e.g. `struct Foo {
 /// bar: u32 }`, `Foo::Bar { baz: u32 }`).
 fn format_named(ident: &Ident, fields: &FieldsNamed) -> (TokenStream2, TokenStream2) {
     let (captures, fields_idents) = generate_destructuring(fields.named.iter(), &ignore_field);
+    let fields_values = fields_idents.iter().cloned().map(format_field);
     (
         captures,
         quote! {
@@ -64,13 +78,7 @@ fn format_named(ident: &Ident, fields: &FieldsNamed) -> (TokenStream2, TokenStre
                 vec![#(
                     FormattingField::new(
                         stringify!(#fields_idents),
-                        match #fields_idents.value_debug_format(depth.saturating_sub(1)).try_to_value_debug_string().await {
-                            Ok(result) => match result.await {
-                                Ok(result) => result.to_string(),
-                                Err(err) => format!("{:?}", err),
-                            },
-                            Err(err) => format!("{:?}", err),
-                        },
+                        #fields_values,
                     ),
                 )*],
             )
@@ -82,19 +90,14 @@ fn format_named(ident: &Ident, fields: &FieldsNamed) -> (TokenStream2, TokenStre
 /// Foo(u32)`, `Foo::Bar(u32)`).
 fn format_unnamed(ident: &Ident, fields: &FieldsUnnamed) -> (TokenStream2, TokenStream2) {
     let (captures, fields_idents) = generate_destructuring(fields.unnamed.iter(), &ignore_field);
+    let fields_values = fields_idents.into_iter().map(format_field);
     (
         captures,
         quote! {
             FormattingStruct::new_unnamed(
                 stringify!(#ident),
                 vec![#(
-                    match #fields_idents.value_debug_format(depth.saturating_sub(1)).try_to_value_debug_string().await {
-                        Ok(result) => match result.await {
-                            Ok(result) => result.to_string(),
-                            Err(err) => format!("{:?}", err),
-                        },
-                        Err(err) => format!("{:?}", err),
-                    },
+                    #fields_values,
                 )*],
             )
         },


### PR DESCRIPTION
### Description

It's annoying to debug when the whole dbg will throw an error if any nested Vc is in error state.
Instead we want to print the errors here.

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->

<!--
  When the below is checked (default) our PR bot will automatically
  assign labels to your PR based on the content to help the team
  organize and review it faster.
-->

[X] Auto label
