### PR TITLE
fix(route_matcher): do not include empty segment

### DIFF
--- a/crates/next-core/src/next_route_matcher/path_regex.rs
+++ b/crates/next-core/src/next_route_matcher/path_regex.rs
@@ -93,7 +93,7 @@ impl PathRegexBuilder {
         R: AsRef<str>,
     {
         self.push_str(if self.include_slash() {
-            "(/[^?]+)?"
+            "(?:/([^?]+))?"
         } else {
             "([^?]+)?"
         });


### PR DESCRIPTION
### Description

Closes WEB-674

if a matcher tries to split path have a slash like `/x/y`, split gives a redundant empty segment `["", 'x', 'y']`.
