### PR TITLE
Re-repair Root Inference

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2393,17 +2393,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
-name = "globset"
-version = "0.4.10"
+name = "glob-match"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "029d74589adefde59de1a0c4f4732695c32805624aec7b68d91503d4dba79afc"
-dependencies = [
- "aho-corasick",
- "bstr 1.2.0",
- "fnv",
- "log",
- "regex",
-]
+checksum = "9985c9503b412198aa4197559e9a318524ebc4519c229bfa05a535828c950b9d"
 
 [[package]]
 name = "gloo-timers"
@@ -8084,7 +8077,7 @@ dependencies = [
  "dirs-next",
  "dunce",
  "env_logger 0.10.0",
- "globset",
+ "glob-match",
  "hostname",
  "indicatif",
  "itertools",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2393,6 +2393,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
+name = "globset"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "029d74589adefde59de1a0c4f4732695c32805624aec7b68d91503d4dba79afc"
+dependencies = [
+ "aho-corasick",
+ "bstr 1.2.0",
+ "fnv",
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "gloo-timers"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8071,6 +8084,7 @@ dependencies = [
  "dirs-next",
  "dunce",
  "env_logger 0.10.0",
+ "globset",
  "hostname",
  "indicatif",
  "itertools",

--- a/crates/turborepo-lib/Cargo.toml
+++ b/crates/turborepo-lib/Cargo.toml
@@ -32,7 +32,7 @@ dialoguer = { version = "0.10.3", features = ["fuzzy-select"] }
 dirs-next = "2.0.0"
 dunce = "1.0"
 env_logger = "0.10.0"
-globset = "0.4.10"
+glob-match = "0.2.1"
 hostname = "0.3.1"
 indicatif = "0.17.3"
 lazy_static = "1.4.0"

--- a/crates/turborepo-lib/Cargo.toml
+++ b/crates/turborepo-lib/Cargo.toml
@@ -32,6 +32,7 @@ dialoguer = { version = "0.10.3", features = ["fuzzy-select"] }
 dirs-next = "2.0.0"
 dunce = "1.0"
 env_logger = "0.10.0"
+globset = "0.4.10"
 hostname = "0.3.1"
 indicatif = "0.17.3"
 lazy_static = "1.4.0"

--- a/crates/turborepo-lib/src/package_manager.rs
+++ b/crates/turborepo-lib/src/package_manager.rs
@@ -4,7 +4,6 @@ use std::{
 };
 
 use anyhow::{anyhow, Result};
-use glob_match;
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
@@ -64,20 +63,19 @@ impl Globs {
         let search_value = target
             .strip_prefix(root)?
             .to_str()
-            .ok_or(anyhow!("The relative path is not UTF8."))?;
+            .ok_or_else(|| anyhow!("The relative path is not UTF8."))?;
 
         let includes = &self
             .inclusions
             .iter()
-            .find(|inclusion| glob_match::glob_match(inclusion, search_value))
-            .is_some();
+            .any(|inclusion| glob_match::glob_match(inclusion, search_value));
+
         let excludes = &self
             .exclusions
             .iter()
-            .find(|exclusion| glob_match::glob_match(exclusion, search_value))
-            .is_some();
+            .any(|exclusion| glob_match::glob_match(exclusion, search_value));
 
-        return Ok(*includes && !excludes);
+        Ok(*includes && !excludes)
     }
 }
 

--- a/crates/turborepo-lib/src/package_manager.rs
+++ b/crates/turborepo-lib/src/package_manager.rs
@@ -55,13 +55,13 @@ pub enum PackageManager {
 #[derive(Debug)]
 pub struct Globs {
     #[allow(dead_code)]
-    inclusions: Vec<PathBuf>,
+    pub inclusions: Vec<PathBuf>,
     #[allow(dead_code)]
-    exclusions: Vec<PathBuf>,
+    pub exclusions: Vec<PathBuf>,
 }
 
 impl Globs {
-    pub fn test(&self, root: PathBuf, target: PathBuf) -> bool {
+    pub fn test(&self, _root: PathBuf, _target: PathBuf) -> bool {
         // TODO
         true
     }

--- a/crates/turborepo-lib/src/shim.rs
+++ b/crates/turborepo-lib/src/shim.rs
@@ -183,7 +183,7 @@ pub struct LocalTurboState {
 }
 
 impl LocalTurboState {
-    pub fn infer(repo_root: &PathBuf) -> Option<Self> {
+    pub fn infer(repo_root: &Path) -> Option<Self> {
         let local_turbo_path = repo_root.join("node_modules").join(".bin").join({
             #[cfg(windows)]
             {
@@ -266,6 +266,9 @@ impl RepoState {
                     return None;
                 }
 
+                // FIXME: This should be based upon detecting the pacakage manager.
+                // However, we don't have that functionality implemented in Rust yet.
+                // PackageManager::detect(path).get_workspace_globs().unwrap_or(None)
                 let workspace_globs = PackageManager::Pnpm
                     .get_workspace_globs(path)
                     .unwrap_or_else(|_| {
@@ -295,9 +298,9 @@ impl RepoState {
         //   1. [0].has_turbo_json && [0].workspace_globs.is_some()
         //   2. [0].has_turbo_json && [n].has_turbo_json && [n].is_workspace_root_of(0)
         //
-        //   If we elect to make any of the changes for early exits we need to expand
-        // the   test suite which presently relies on the fact that the
-        // selection runs in a   loop to avoid creating those test cases.
+        // If we elect to make any of the changes for early exits we need to expand test
+        // suite which presently relies on the fact that the selection runs in a loop to
+        // avoid creating those test cases.
 
         // We need to perform the same search strategy for _both_ turbo.json and _then_
         // package.json.

--- a/crates/turborepo-lib/src/shim.rs
+++ b/crates/turborepo-lib/src/shim.rs
@@ -245,7 +245,9 @@ impl InferInfo {
 
     pub fn is_workspace_root_of(&self, target_path: PathBuf) -> bool {
         match &self.workspace_globs {
-            Some(globs) => globs.test(self.path.to_path_buf(), target_path),
+            Some(globs) => globs
+                .test(self.path.to_path_buf(), target_path)
+                .unwrap_or(false),
             None => false,
         }
     }
@@ -616,19 +618,31 @@ mod test {
             output: PathBuf,
         }
 
-        let tests = [TestCase {
-            infer_infos: vec![InferInfo {
-                path: PathBuf::from("/a/b/c"),
-                has_package_json: true,
-                has_turbo_json: true,
-                package_has_workspaces: true,
-                workspace_globs: Some(Globs {
-                    inclusions: vec![PathBuf::from("packages/**")],
-                    exclusions: vec![],
-                }),
-            }],
-            output: PathBuf::from("/a/b/c"),
-        }];
+        let tests = [
+            TestCase {
+                infer_infos: vec![InferInfo {
+                    path: PathBuf::from("/a/b/c"),
+                    has_package_json: true,
+                    has_turbo_json: true,
+                    package_has_workspaces: true,
+                    workspace_globs: Some(Globs {
+                        inclusions: vec!["packages/**".to_string()],
+                        exclusions: vec![],
+                    }),
+                }],
+                output: PathBuf::from("/a/b/c"),
+            },
+            TestCase {
+                infer_infos: vec![InferInfo {
+                    path: PathBuf::from("/a/b/c"),
+                    has_package_json: true,
+                    has_turbo_json: true,
+                    package_has_workspaces: false,
+                    workspace_globs: None,
+                }],
+                output: PathBuf::from("/a/b/c"),
+            },
+        ];
 
         for test in tests {
             assert_eq!(

--- a/crates/turborepo-lib/src/shim.rs
+++ b/crates/turborepo-lib/src/shim.rs
@@ -236,10 +236,10 @@ struct InferInfo {
 }
 
 impl InferInfo {
-    pub fn has_package_json<'a>(info: &'a &InferInfo) -> bool {
+    pub fn has_package_json(info: &'_ &InferInfo) -> bool {
         info.has_package_json
     }
-    pub fn has_turbo_json<'a>(info: &'a &InferInfo) -> bool {
+    pub fn has_turbo_json(info: &'_ &InferInfo) -> bool {
         info.has_turbo_json
     }
 
@@ -265,7 +265,7 @@ impl RepoState {
                     .unwrap_or_else(|_| {
                         PackageManager::Npm
                             .get_workspace_globs(path)
-                            .unwrap_or_else(|_| None)
+                            .unwrap_or(None)
                     });
 
                 InferInfo {
@@ -279,7 +279,7 @@ impl RepoState {
             .filter(|info| info.has_package_json || info.has_turbo_json)
             .collect();
 
-        return potential_turbo_roots;
+        potential_turbo_roots
     }
 
     fn process_potential_turbo_roots(potential_turbo_roots: Vec<InferInfo>) -> Result<Self> {
@@ -306,7 +306,7 @@ impl RepoState {
                 .collect();
 
             // No potential roots checking by this comparator.
-            if check_roots.len() == 0 {
+            if check_roots.is_empty() {
                 continue;
 
             // If there is only one potential root, that's the winner.


### PR DESCRIPTION
Our inference got a little wonky once we started allowing `turbo.json` in workspaces. This PR restores the ideal selection of the root and reduces the number of syscalls as compared to our current implementation.