### PR TITLE
avoid bundling and execution of modules just of watching

### DIFF
--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -558,21 +558,18 @@ pub async fn load_next_config(execution_context: ExecutionContextVc) -> Result<N
         FindContextFileResult::NotFound(_) => None,
     };
 
-    let config_changed = config_asset.map_or_else(
-        || CompletionVc::immutable(),
-        |config_asset| {
-            // This invalidates the execution when anything referenced by the config file
-            // changes
-            let config_asset = EcmascriptModuleAssetVc::new(
-                config_asset.into(),
-                context,
-                Value::new(EcmascriptModuleAssetType::Ecmascript),
-                EcmascriptInputTransformsVc::cell(vec![]),
-                context.compile_time_info(),
-            );
-            any_content_changed(config_asset.into())
-        },
-    );
+    let config_changed = config_asset.map_or_else(CompletionVc::immutable, |config_asset| {
+        // This invalidates the execution when anything referenced by the config file
+        // changes
+        let config_asset = EcmascriptModuleAssetVc::new(
+            config_asset.into(),
+            context,
+            Value::new(EcmascriptModuleAssetType::Ecmascript),
+            EcmascriptInputTransformsVc::cell(vec![]),
+            context.compile_time_info(),
+        );
+        any_content_changed(config_asset.into())
+    });
     let load_next_config_asset = context.process(
         next_asset("entry/config/next.js"),
         Value::new(ReferenceType::Entry(EntryReferenceSubType::Undefined)),

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -12,6 +12,7 @@ use turbo_tasks_fs::{json::parse_json_rope_with_source_context, FileSystemPathVc
 use turbopack::evaluate_context::node_evaluate_asset_context;
 use turbopack_core::{
     asset::Asset,
+    changed::any_content_changed,
     context::AssetContext,
     ident::AssetIdentVc,
     reference_type::{EntryReferenceSubType, ReferenceType},
@@ -23,8 +24,7 @@ use turbopack_core::{
     source_asset::SourceAssetVc,
 };
 use turbopack_ecmascript::{
-    chunk::EcmascriptChunkPlaceablesVc, EcmascriptInputTransformsVc, EcmascriptModuleAssetType,
-    EcmascriptModuleAssetVc,
+    EcmascriptInputTransformsVc, EcmascriptModuleAssetType, EcmascriptModuleAssetVc,
 };
 use turbopack_node::{
     evaluate::{evaluate, JavaScriptValue},
@@ -558,18 +558,21 @@ pub async fn load_next_config(execution_context: ExecutionContextVc) -> Result<N
         FindContextFileResult::NotFound(_) => None,
     };
 
-    let runtime_entries = config_asset.map(|config_asset| {
-        // TODO this is a hack to add the config to the bundling to make it watched
-        let config_chunk = EcmascriptModuleAssetVc::new(
-            config_asset.into(),
-            context,
-            Value::new(EcmascriptModuleAssetType::Ecmascript),
-            EcmascriptInputTransformsVc::cell(vec![]),
-            context.compile_time_info(),
-        )
-        .as_ecmascript_chunk_placeable();
-        EcmascriptChunkPlaceablesVc::cell(vec![config_chunk])
-    });
+    let config_changed = config_asset.map_or_else(
+        || CompletionVc::immutable(),
+        |config_asset| {
+            // This invalidates the execution when anything referenced by the config file
+            // changes
+            let config_asset = EcmascriptModuleAssetVc::new(
+                config_asset.into(),
+                context,
+                Value::new(EcmascriptModuleAssetType::Ecmascript),
+                EcmascriptInputTransformsVc::cell(vec![]),
+                context.compile_time_info(),
+            );
+            any_content_changed(config_asset.into())
+        },
+    );
     let load_next_config_asset = context.process(
         next_asset("entry/config/next.js"),
         Value::new(ReferenceType::Entry(EntryReferenceSubType::Undefined)),
@@ -582,9 +585,9 @@ pub async fn load_next_config(execution_context: ExecutionContextVc) -> Result<N
         config_asset.map_or_else(|| AssetIdentVc::from_path(project_path), |c| c.ident()),
         context,
         intermediate_output_path,
-        runtime_entries,
+        None,
         vec![],
-        CompletionVc::immutable(),
+        config_changed,
         /* debug */ false,
     )
     .await?;

--- a/crates/next-dev/src/lib.rs
+++ b/crates/next-dev/src/lib.rs
@@ -389,11 +389,10 @@ async fn source(
         execution_context,
         next_config,
         server_addr,
-        CompletionsVc::cell(vec![
+        CompletionsVc::all(vec![
             app_structure.routes_changed(),
             pages_structure.routes_changed(),
-        ])
-        .all(),
+        ]),
     )
     .into();
     let source = RouterContentSource {

--- a/crates/turbo-tasks/src/completion.rs
+++ b/crates/turbo-tasks/src/completion.rs
@@ -49,8 +49,19 @@ pub struct Completions(Vec<CompletionVc>);
 
 #[turbo_tasks::value_impl]
 impl CompletionsVc {
+    /// Merges multiple completions into one. The passed list will be part of
+    /// the cache key, so this function should not be used with varying lists.
+    ///
+    /// Varying lists should use `CompletionsVc::cell(list).completed()`
+    /// instead.
     #[turbo_tasks::function]
-    pub async fn all(self) -> anyhow::Result<CompletionVc> {
+    pub fn all(completions: Vec<CompletionVc>) -> CompletionVc {
+        CompletionsVc::cell(completions).completed()
+    }
+
+    /// Merges the list of completions into one.
+    #[turbo_tasks::function]
+    pub async fn completed(self) -> anyhow::Result<CompletionVc> {
         for c in self.await?.iter() {
             c.await?;
         }

--- a/crates/turbopack-core/src/changed.rs
+++ b/crates/turbopack-core/src/changed.rs
@@ -1,0 +1,43 @@
+use anyhow::Result;
+use turbo_tasks::{
+    graph::{GraphTraversal, NonDeterministic, SkipDuplicates},
+    CompletionVc, CompletionsVc,
+};
+
+use crate::{
+    asset::{Asset, AssetVc},
+    reference::all_referenced_assets,
+};
+
+async fn get_referenced_assets(parent: AssetVc) -> Result<impl Iterator<Item = AssetVc> + Send> {
+    Ok(all_referenced_assets(parent)
+        .await?
+        .clone_value()
+        .into_iter())
+}
+
+/// Returns a completion that changes when any content of any asset in the whole
+/// asset graph changes.
+#[turbo_tasks::function]
+pub async fn any_content_changed(root: AssetVc) -> Result<CompletionVc> {
+    let completions = GraphTraversal::<NonDeterministic<_>>::visit(
+        [root],
+        SkipDuplicates::new(get_referenced_assets),
+    )
+    .await
+    .completed()?
+    .into_iter()
+    .map(|asset| content_changed(asset))
+    .collect();
+
+    Ok(CompletionsVc::cell(completions).completed())
+}
+
+/// Returns a completion that changes when the content of the given asset
+/// changes.
+#[turbo_tasks::function]
+pub async fn content_changed(asset: AssetVc) -> Result<CompletionVc> {
+    // Reading the file content is enough to add as dependency
+    asset.content().file_content().await?;
+    Ok(CompletionVc::new())
+}

--- a/crates/turbopack-core/src/changed.rs
+++ b/crates/turbopack-core/src/changed.rs
@@ -27,7 +27,7 @@ pub async fn any_content_changed(root: AssetVc) -> Result<CompletionVc> {
     .await
     .completed()?
     .into_iter()
-    .map(|asset| content_changed(asset))
+    .map(content_changed)
     .collect();
 
     Ok(CompletionsVc::cell(completions).completed())

--- a/crates/turbopack-core/src/issue/mod.rs
+++ b/crates/turbopack-core/src/issue/mod.rs
@@ -467,7 +467,7 @@ impl PlainIssue {
         hasher.write_ref(&self.title);
         hasher.write_ref(
             // Normalize syspaths from Windows. These appear in stack traces.
-            &self.description.replace("\\", "/"),
+            &self.description.replace('\\', "/"),
         );
         hasher.write_ref(&self.detail);
         hasher.write_ref(&self.documentation_link);

--- a/crates/turbopack-core/src/lib.rs
+++ b/crates/turbopack-core/src/lib.rs
@@ -6,6 +6,7 @@
 #![feature(lint_reasons)]
 
 pub mod asset;
+pub mod changed;
 pub mod chunk;
 pub mod code_builder;
 pub mod compile_time_info;

--- a/crates/turbopack-dev-server/src/http.rs
+++ b/crates/turbopack-dev-server/src/http.rs
@@ -102,18 +102,19 @@ pub async fn process_request_with_content_source(
 
                 // naively checking if content is `compressible`.
                 let mut should_compress = false;
-                let should_compress_predicate =
-                    |mime: &Mime| match (mime.type_(), mime.subtype(), mime.suffix()) {
+                let should_compress_predicate = |mime: &Mime| {
+                    matches!(
+                        (mime.type_(), mime.subtype(), mime.suffix()),
                         (_, mime::PLAIN, _)
-                        | (_, mime::JSON, _)
-                        | (mime::TEXT, _, _)
-                        | (mime::APPLICATION, mime::XML, _)
-                        | (mime::APPLICATION, mime::JAVASCRIPT, _)
-                        | (_, _, Some(mime::XML))
-                        | (_, _, Some(mime::JSON))
-                        | (_, _, Some(mime::TEXT)) => true,
-                        _ => false,
-                    };
+                            | (_, mime::JSON, _)
+                            | (mime::TEXT, _, _)
+                            | (mime::APPLICATION, mime::XML, _)
+                            | (mime::APPLICATION, mime::JAVASCRIPT, _)
+                            | (_, _, Some(mime::XML))
+                            | (_, _, Some(mime::JSON))
+                            | (_, _, Some(mime::TEXT))
+                    )
+                };
 
                 if let Some(content_type) = file.content_type() {
                     header_map.append(

--- a/crates/turbopack-node/src/lib.rs
+++ b/crates/turbopack-node/src/lib.rs
@@ -67,7 +67,7 @@ async fn emit(
             .flatten()
             .collect(),
     )
-    .all())
+    .completed())
 }
 
 /// List of the all assets of the "internal" subgraph and a list of boundary

--- a/crates/turbopack-node/src/transforms/postcss.rs
+++ b/crates/turbopack-node/src/transforms/postcss.rs
@@ -3,7 +3,7 @@ use indexmap::indexmap;
 use serde::{Deserialize, Serialize};
 use turbo_tasks::{
     primitives::{JsonValueVc, StringsVc},
-    CompletionVc, TryJoinIterExt, Value,
+    CompletionVc, CompletionsVc, TryJoinIterExt, Value,
 };
 use turbo_tasks_fs::{
     json::parse_json_rope_with_source_context, File, FileContent, FileSystemEntryType,
@@ -11,6 +11,7 @@ use turbo_tasks_fs::{
 };
 use turbopack_core::{
     asset::{Asset, AssetContent, AssetContentVc, AssetVc},
+    changed::any_content_changed,
     context::{AssetContext, AssetContextVc},
     ident::AssetIdentVc,
     reference_type::{EntryReferenceSubType, ReferenceType},
@@ -20,8 +21,8 @@ use turbopack_core::{
     virtual_asset::VirtualAssetVc,
 };
 use turbopack_ecmascript::{
-    chunk::EcmascriptChunkPlaceablesVc, EcmascriptInputTransform, EcmascriptInputTransformsVc,
-    EcmascriptModuleAssetType, EcmascriptModuleAssetVc, InnerAssetsVc,
+    EcmascriptInputTransform, EcmascriptInputTransformsVc, EcmascriptModuleAssetType,
+    EcmascriptModuleAssetVc, InnerAssetsVc,
 };
 
 use super::util::{emitted_assets_to_virtual_assets, EmittedAsset};
@@ -131,21 +132,23 @@ struct ProcessPostCssResult {
 async fn extra_configs(
     context: AssetContextVc,
     postcss_config_path: FileSystemPathVc,
-) -> Result<EcmascriptChunkPlaceablesVc> {
+) -> Result<CompletionVc> {
     let config_paths = [postcss_config_path.parent().join("tailwind.config.js")];
     let configs = config_paths
         .into_iter()
         .map(|path| async move {
             Ok(
                 matches!(&*path.get_type().await?, FileSystemEntryType::File).then(|| {
-                    EcmascriptModuleAssetVc::new(
-                        SourceAssetVc::new(path).into(),
-                        context,
-                        Value::new(EcmascriptModuleAssetType::Ecmascript),
-                        EcmascriptInputTransformsVc::cell(vec![]),
-                        context.compile_time_info(),
+                    any_content_changed(
+                        EcmascriptModuleAssetVc::new(
+                            SourceAssetVc::new(path).into(),
+                            context,
+                            Value::new(EcmascriptModuleAssetType::Ecmascript),
+                            EcmascriptInputTransformsVc::cell(vec![]),
+                            context.compile_time_info(),
+                        )
+                        .into(),
                     )
-                    .as_ecmascript_chunk_placeable()
                 }),
             )
         })
@@ -155,7 +158,7 @@ async fn extra_configs(
         .flatten()
         .collect::<Vec<_>>();
 
-    Ok(EcmascriptChunkPlaceablesVc::cell(configs))
+    Ok(CompletionsVc::cell(configs).completed())
 }
 
 #[turbo_tasks::function]
@@ -214,8 +217,8 @@ impl PostCssTransformedAssetVc {
         let content = content.content().to_str()?;
         let context = this.evaluate_context;
 
-        // TODO this is a hack to get these files watched.
-        let extra_configs = extra_configs(context, config_path);
+        // This invalidates the transform when the config changes.
+        let extra_configs_changed = extra_configs(context, config_path);
 
         let postcss_executor = postcss_executor(context, config_path);
         let css_fs_path = this.source.ident().path().await?;
@@ -228,12 +231,12 @@ impl PostCssTransformedAssetVc {
             this.source.ident(),
             context,
             intermediate_output_path,
-            Some(extra_configs),
+            None,
             vec![
                 JsonValueVc::cell(content.into()),
                 JsonValueVc::cell(css_path.into()),
             ],
-            CompletionVc::immutable(),
+            extra_configs_changed,
             /* debug */ false,
         )
         .await?;


### PR DESCRIPTION
### Description

* use completions to signal additional invalidations for evaluation
* avoid adding these modules as runtime entries, since that will unnecessarily code generate, bundle and execute these modules
* gets rid of the watch_files_hack

### Testing Instructions

* change postcss.config, next.config.js, etc. -> changes will be reflected by the app and process restarts

<!--
  When the below is checked (default) our PR bot will automatically
  assign labels to your PR based on the content to help the team
  organize and review it faster.
-->

- [x] Auto label
