### PR TITLE
Update Next.js to 13.2.4-canary.0

### DIFF
--- a/crates/next-core/js/package.json
+++ b/crates/next-core/js/package.json
@@ -12,7 +12,7 @@
     "@vercel/turbopack-runtime": "latest",
     "anser": "^2.1.1",
     "css.escape": "^1.5.1",
-    "next": "13.1.7-canary.28",
+    "next": "13.2.4-canary.0",
     "platform": "1.3.6",
     "react-dom": "^18.2.0",
     "react": "^18.2.0",

--- a/crates/next-dev-tests/tests/package.json
+++ b/crates/next-dev-tests/tests/package.json
@@ -9,7 +9,7 @@
     "autoprefixer": "^10.4.13",
     "babel-loader": "^9.1.2",
     "loader-runner": "^4.3.0",
-    "next": "13.1.7-canary.28",
+    "next": "13.2.4-canary.0",
     "postcss": "^8.4.20",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/crates/next-dev/benches/bundlers/turbopack/mod.rs
+++ b/crates/next-dev/benches/bundlers/turbopack/mod.rs
@@ -49,7 +49,7 @@ impl Bundler for Turbopack {
         npm::install(
             install_dir,
             &[
-                NpmPackage::new("next", "13.1.7-canary.28"),
+                NpmPackage::new("next", "13.2.4-canary.0"),
                 // Dependency on this is inserted by swc's preset_env
                 NpmPackage::new("@swc/helpers", "^0.4.11"),
             ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,7 +134,7 @@ importers:
       anser: ^2.1.1
       css.escape: ^1.5.1
       find-up: ^6.3.0
-      next: 13.1.7-canary.28
+      next: 13.2.4-canary.0
       platform: 1.3.6
       react: ^18.2.0
       react-dom: ^18.2.0
@@ -145,7 +145,7 @@ importers:
       '@vercel/turbopack-runtime': link:../../turbopack-ecmascript/js
       anser: 2.1.1
       css.escape: 1.5.1
-      next: 13.1.7-canary.28_biqbaboplfbrettd7655fr4n2y
+      next: 13.2.4-canary.0_biqbaboplfbrettd7655fr4n2y
       platform: 1.3.6
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
@@ -179,7 +179,7 @@ importers:
       autoprefixer: ^10.4.13
       babel-loader: ^9.1.2
       loader-runner: ^4.3.0
-      next: 13.1.7-canary.28
+      next: 13.2.4-canary.0
       postcss: ^8.4.20
       react: ^18.2.0
       react-dom: ^18.2.0
@@ -194,7 +194,7 @@ importers:
       autoprefixer: 10.4.13_postcss@8.4.20
       babel-loader: 9.1.2_la66t7xldg4uecmyawueag5wkm
       loader-runner: 4.3.0
-      next: 13.1.7-canary.28_pjwopsidmaokadturxaafygjp4
+      next: 13.2.4-canary.0_pjwopsidmaokadturxaafygjp4
       postcss: 8.4.20
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
@@ -1897,8 +1897,8 @@ packages:
   /@next/env/13.0.6:
     resolution: {integrity: sha512-yceT6DCHKqPRS1cAm8DHvDvK74DLIkDQdm5iV+GnIts8h0QbdHvkUIkdOvQoOODgpr6018skbmSQp12z5OWIQQ==}
 
-  /@next/env/13.1.7-canary.28:
-    resolution: {integrity: sha512-urnc6aGE0r34euoenPD6kSdGn+Tzwl+g+m4UaEeLpaPCF2110/rd1WIwR4izqG8hxG6GUBj0R+T0XfFgmyNydg==}
+  /@next/env/13.2.4-canary.0:
+    resolution: {integrity: sha512-zh3+D4qTGhDJMM6RuciIOEBA6pHeO6EE3U7LFSknX79BwVqsWpDa59yFeelmrXXh8hHCdOajrReISPICeoQRNw==}
 
   /@next/eslint-plugin-next/12.3.1:
     resolution: {integrity: sha512-sw+lTf6r6P0j+g/n9y4qdWWI2syPqZx+uc0+B/fRENqfR3KpSid6MIKqc9gNwGhJASazEQ5b3w8h4cAET213jw==}
@@ -1941,8 +1941,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@next/swc-android-arm-eabi/13.1.7-canary.28:
-    resolution: {integrity: sha512-6NfztI8OnbN5dhdIuLxKq6VgMittoEM7Z/RrhwZmaa5jL/qFgX2U0JupkXsP/NT5BAnVK2ZfQwcc7OkLoX6Lww==}
+  /@next/swc-android-arm-eabi/13.2.4-canary.0:
+    resolution: {integrity: sha512-i8ZrvlgYkoUhkBNNRo+mChzMB7KhGOVoe1tWbogWngTo63ljrId0HlcPfNFNOGccggUPmSmIgkzXv5+wS1MN9Q==}
     engines: {node: '>= 10'}
     cpu: [arm]
     os: [android]
@@ -1966,8 +1966,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@next/swc-android-arm64/13.1.7-canary.28:
-    resolution: {integrity: sha512-LfIt74SQsO2o5oKnS6P+9sFTnJUGW4osGEV3voGnqyKSQKNL/x0JrT9ebntEyf4qELc7UpNaguTdI3xgrAiXEQ==}
+  /@next/swc-android-arm64/13.2.4-canary.0:
+    resolution: {integrity: sha512-IJSJyXp3rNXaMuWdMSfaSwBMejzzTkzfAq1miXVHwxQt06OP2lAlRdBj1XBFqPLgxVdhtJFeukiBLA6WbMesFw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [android]
@@ -1991,8 +1991,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@next/swc-darwin-arm64/13.1.7-canary.28:
-    resolution: {integrity: sha512-BCwhRUHiamB/ktOusnS0re4W373o4HurQPvGM1k5YRekeHDWeawGGrEktCFJCjxNTMzu+VfFCxXJIMm/JhTUgg==}
+  /@next/swc-darwin-arm64/13.2.4-canary.0:
+    resolution: {integrity: sha512-e60xAA4bX4K1WLtW61rqW7JalmCES4IZSwutLiV5+oikqPNFV2rWbkPC/otgL4wOJmNo6GO0XpkKofMnQolo+A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
@@ -2016,8 +2016,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@next/swc-darwin-x64/13.1.7-canary.28:
-    resolution: {integrity: sha512-girCRXjOgbJtuiP9V7IKSrFcYHFAcBldt5d4YPEbLtLuo1q56WHHPbGvYWWetaLbKmSvMxxUQDmEHkEcqWZgNA==}
+  /@next/swc-darwin-x64/13.2.4-canary.0:
+    resolution: {integrity: sha512-QnfNzyyzxgD2SO4VZipAE7c/HnYl6pz7MKphDb3U/AbkzsncZYfFXbxxMo4GSAu1AQ4QdKwcDFAM3PBelKIppg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
@@ -2041,8 +2041,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@next/swc-freebsd-x64/13.1.7-canary.28:
-    resolution: {integrity: sha512-JhH+Pgu5Vx3h0/P9IB+z0shpP2T08SGu29IQIWicAuliz684mrott3i7QiFuer3FzHCY8fxuJQNKD2/cn4sgoA==}
+  /@next/swc-freebsd-x64/13.2.4-canary.0:
+    resolution: {integrity: sha512-0m8pOp3cQvGFS3Q98LrCKJL3eHiXBsl81dFbkizQaZb7h/p3LZ0LBYN6i1GVelB1JXxfO1sJA2L2eu4tASNcwQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [freebsd]
@@ -2066,8 +2066,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@next/swc-linux-arm-gnueabihf/13.1.7-canary.28:
-    resolution: {integrity: sha512-mFD8pdgb3iNjQ+4614h6ZJwqFj4sDms1mi9BZ3AZ+MZy5vqBgiq8KF933RoiIcZMoKRt5gziD0vX/pY7LyeLxA==}
+  /@next/swc-linux-arm-gnueabihf/13.2.4-canary.0:
+    resolution: {integrity: sha512-fTKY0WHyYb7xYw9gKkW6+yHrIAj6jA5eoC41ePNpssbwqsIyHZKHDjiGHLYU7/Uq7i/GU+/O+Y9V5eRKsfGOCA==}
     engines: {node: '>= 10'}
     cpu: [arm]
     os: [linux]
@@ -2091,8 +2091,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@next/swc-linux-arm64-gnu/13.1.7-canary.28:
-    resolution: {integrity: sha512-2rB5eBfOBFlWWJd9pFG79d5mjz8370XwtXxkbIUqaukNVA8COYYMTrm0D5tiCGBvRgEZXpNHCMxQMif5e7AhSA==}
+  /@next/swc-linux-arm64-gnu/13.2.4-canary.0:
+    resolution: {integrity: sha512-bKpw2Dxml5OOfvTWWmAifEc3nDgAzSLailkqPAeKzK7ag21NSizABPB3YpfixTUeBF5ftamhP0U4M36O6av4zg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -2116,8 +2116,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@next/swc-linux-arm64-musl/13.1.7-canary.28:
-    resolution: {integrity: sha512-9qls07LNqiUgGMbFi861X9aMw7GNNJaWtUEl3NR1tncAftxCWKSwDV2Ju/a2+Ts2Mts6awpi8pBNDfZrVYNAKg==}
+  /@next/swc-linux-arm64-musl/13.2.4-canary.0:
+    resolution: {integrity: sha512-Z8bxSnofNGiXzJZj41pnwQYoITR398ASNzEXe0Sq9kNvZuKoUn7WANpqbE9EFVrQn726czHrpSdSjujINA0aag==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -2141,8 +2141,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@next/swc-linux-x64-gnu/13.1.7-canary.28:
-    resolution: {integrity: sha512-/HqW+OmTwJ28QpPCXGjgFsWYPJdpwGq5/vcTITQJaWIWRJN7dkpLraGZ8U0VQYOlbu25b0aKqHZ3r7Uf/TM7NQ==}
+  /@next/swc-linux-x64-gnu/13.2.4-canary.0:
+    resolution: {integrity: sha512-3N8HhgKcldKv6VKE1pozPjgLi/8tEmUyqXbT/u1cG0HDDhJj6CxCnZoBPS7u6JzhbfTjqwPdvt6IcyJkevFRsA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -2166,8 +2166,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@next/swc-linux-x64-musl/13.1.7-canary.28:
-    resolution: {integrity: sha512-+wa7Q6OBHLumMghMVWXoxZPXibWm9cyJaF3eqjMg8W3HLkZbEciBp4ZihnjpQPNMLnUBtGLup3AabxbnwPyzVg==}
+  /@next/swc-linux-x64-musl/13.2.4-canary.0:
+    resolution: {integrity: sha512-G7fAzeK68piPXfbgQ4uc7zTg7RTE8Yg/FZt6Yd2S9DNvsO2PHWgKitMZZUOpHn/5OY9sg/ne1lwcegRIDmU9yA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -2191,8 +2191,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@next/swc-win32-arm64-msvc/13.1.7-canary.28:
-    resolution: {integrity: sha512-pmQnhZgUaulYnInujnVQ8tuLYapEPpWwPAoXoBgAcaMgSve7Wa2zvGv1EyMzDSeWnozDcIULkKff0KlQVPockA==}
+  /@next/swc-win32-arm64-msvc/13.2.4-canary.0:
+    resolution: {integrity: sha512-4t3SyyqieUuEMuLvuRs+R0m+6Ocm9DiPq1xLBu5noaxOgMSYyPjUFZbhL2bfG1OQb6VyZmaeGpN4ZDfS5Mjixw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
@@ -2216,8 +2216,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@next/swc-win32-ia32-msvc/13.1.7-canary.28:
-    resolution: {integrity: sha512-n2m67mHeJYQRZxZXyZaiLbISMesfLIEHwppvhjPwEGJeYu4rFqAa9Fd7zTpcoNn3uSZjYjGtoTRwjyqtn5caHg==}
+  /@next/swc-win32-ia32-msvc/13.2.4-canary.0:
+    resolution: {integrity: sha512-+KDwr1SMEbbCc9rMJlQSbyGJMrfcyjTfa7TpsRpYmb4g9fGFCpXfKpyS8MVStH/k1Ye27X1WQZsOsS9RIdRWGg==}
     engines: {node: '>= 10'}
     cpu: [ia32]
     os: [win32]
@@ -2241,8 +2241,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@next/swc-win32-x64-msvc/13.1.7-canary.28:
-    resolution: {integrity: sha512-sGfbSG1wwzp4v2KRSTIfGtYMY4qJOoS59JzfWBNbLIvsfi3o2/W+41eNBfvlubGlp4CNX9+JBvDNu3qaeFI6AA==}
+  /@next/swc-win32-x64-msvc/13.2.4-canary.0:
+    resolution: {integrity: sha512-GMUCU4jFwHUDTMM5RZVHjLj+uR24vqUKrOhgT8SHPBVU05Rq68loq4frGU5HVl7m7jAk5TTjoIMLR6WuR8Qxmw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -9666,8 +9666,8 @@ packages:
       - '@babel/core'
       - babel-plugin-macros
 
-  /next/13.1.7-canary.28_biqbaboplfbrettd7655fr4n2y:
-    resolution: {integrity: sha512-z8CrJmzkNVb7+DN9r8vbjnEbY15GS1xEoVPwROJk+A8VYvbLzDKy5bPAHD8Llbzl51UQ4LUiGHWW+hQ8yVlxuw==}
+  /next/13.2.4-canary.0_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-vWGAI05RK5y+qZRBtV3PylLtGEhU0vhC9RwgCJK9mxRdZdPgK6BcZMLYnQnNJNv8DGhYx3iNVfTMFaHGR4nBtw==}
     engines: {node: '>=14.6.0'}
     hasBin: true
     peerDependencies:
@@ -9687,7 +9687,7 @@ packages:
       sass:
         optional: true
     dependencies:
-      '@next/env': 13.1.7-canary.28
+      '@next/env': 13.2.4-canary.0
       '@swc/helpers': 0.4.14
       caniuse-lite: 1.0.30001439
       postcss: 8.4.14
@@ -9695,26 +9695,26 @@ packages:
       react-dom: 18.2.0_react@18.2.0
       styled-jsx: 5.1.1_react@18.2.0
     optionalDependencies:
-      '@next/swc-android-arm-eabi': 13.1.7-canary.28
-      '@next/swc-android-arm64': 13.1.7-canary.28
-      '@next/swc-darwin-arm64': 13.1.7-canary.28
-      '@next/swc-darwin-x64': 13.1.7-canary.28
-      '@next/swc-freebsd-x64': 13.1.7-canary.28
-      '@next/swc-linux-arm-gnueabihf': 13.1.7-canary.28
-      '@next/swc-linux-arm64-gnu': 13.1.7-canary.28
-      '@next/swc-linux-arm64-musl': 13.1.7-canary.28
-      '@next/swc-linux-x64-gnu': 13.1.7-canary.28
-      '@next/swc-linux-x64-musl': 13.1.7-canary.28
-      '@next/swc-win32-arm64-msvc': 13.1.7-canary.28
-      '@next/swc-win32-ia32-msvc': 13.1.7-canary.28
-      '@next/swc-win32-x64-msvc': 13.1.7-canary.28
+      '@next/swc-android-arm-eabi': 13.2.4-canary.0
+      '@next/swc-android-arm64': 13.2.4-canary.0
+      '@next/swc-darwin-arm64': 13.2.4-canary.0
+      '@next/swc-darwin-x64': 13.2.4-canary.0
+      '@next/swc-freebsd-x64': 13.2.4-canary.0
+      '@next/swc-linux-arm-gnueabihf': 13.2.4-canary.0
+      '@next/swc-linux-arm64-gnu': 13.2.4-canary.0
+      '@next/swc-linux-arm64-musl': 13.2.4-canary.0
+      '@next/swc-linux-x64-gnu': 13.2.4-canary.0
+      '@next/swc-linux-x64-musl': 13.2.4-canary.0
+      '@next/swc-win32-arm64-msvc': 13.2.4-canary.0
+      '@next/swc-win32-ia32-msvc': 13.2.4-canary.0
+      '@next/swc-win32-x64-msvc': 13.2.4-canary.0
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
     dev: false
 
-  /next/13.1.7-canary.28_pjwopsidmaokadturxaafygjp4:
-    resolution: {integrity: sha512-z8CrJmzkNVb7+DN9r8vbjnEbY15GS1xEoVPwROJk+A8VYvbLzDKy5bPAHD8Llbzl51UQ4LUiGHWW+hQ8yVlxuw==}
+  /next/13.2.4-canary.0_pjwopsidmaokadturxaafygjp4:
+    resolution: {integrity: sha512-vWGAI05RK5y+qZRBtV3PylLtGEhU0vhC9RwgCJK9mxRdZdPgK6BcZMLYnQnNJNv8DGhYx3iNVfTMFaHGR4nBtw==}
     engines: {node: '>=14.6.0'}
     hasBin: true
     peerDependencies:
@@ -9734,7 +9734,7 @@ packages:
       sass:
         optional: true
     dependencies:
-      '@next/env': 13.1.7-canary.28
+      '@next/env': 13.2.4-canary.0
       '@swc/helpers': 0.4.14
       caniuse-lite: 1.0.30001439
       postcss: 8.4.14
@@ -9742,19 +9742,19 @@ packages:
       react-dom: 18.2.0_react@18.2.0
       styled-jsx: 5.1.1_2exiyaescjxorpwwmy4ejghgte
     optionalDependencies:
-      '@next/swc-android-arm-eabi': 13.1.7-canary.28
-      '@next/swc-android-arm64': 13.1.7-canary.28
-      '@next/swc-darwin-arm64': 13.1.7-canary.28
-      '@next/swc-darwin-x64': 13.1.7-canary.28
-      '@next/swc-freebsd-x64': 13.1.7-canary.28
-      '@next/swc-linux-arm-gnueabihf': 13.1.7-canary.28
-      '@next/swc-linux-arm64-gnu': 13.1.7-canary.28
-      '@next/swc-linux-arm64-musl': 13.1.7-canary.28
-      '@next/swc-linux-x64-gnu': 13.1.7-canary.28
-      '@next/swc-linux-x64-musl': 13.1.7-canary.28
-      '@next/swc-win32-arm64-msvc': 13.1.7-canary.28
-      '@next/swc-win32-ia32-msvc': 13.1.7-canary.28
-      '@next/swc-win32-x64-msvc': 13.1.7-canary.28
+      '@next/swc-android-arm-eabi': 13.2.4-canary.0
+      '@next/swc-android-arm64': 13.2.4-canary.0
+      '@next/swc-darwin-arm64': 13.2.4-canary.0
+      '@next/swc-darwin-x64': 13.2.4-canary.0
+      '@next/swc-freebsd-x64': 13.2.4-canary.0
+      '@next/swc-linux-arm-gnueabihf': 13.2.4-canary.0
+      '@next/swc-linux-arm64-gnu': 13.2.4-canary.0
+      '@next/swc-linux-arm64-musl': 13.2.4-canary.0
+      '@next/swc-linux-x64-gnu': 13.2.4-canary.0
+      '@next/swc-linux-x64-musl': 13.2.4-canary.0
+      '@next/swc-win32-arm64-msvc': 13.2.4-canary.0
+      '@next/swc-win32-ia32-msvc': 13.2.4-canary.0
+      '@next/swc-win32-x64-msvc': 13.2.4-canary.0
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros


### PR DESCRIPTION
### Description

Updates our Next.js CI dependencies to 13.2.4-canary.0.

### To do

- [ ] Need to update to a canary that has https://github.com/vercel/next.js/pull/46681 instead
- [ ] Update comptime snapshots

### Testing Instructions

CI.

- [x] Auto label
