### PR TITLE
Support exclusions in inputs

### DIFF
--- a/cli/integration_tests/inputs_test/monorepo/.gitignore
+++ b/cli/integration_tests/inputs_test/monorepo/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.turbo
+.npmrc

--- a/cli/integration_tests/inputs_test/monorepo/apps/my-app/excluded.txt
+++ b/cli/integration_tests/inputs_test/monorepo/apps/my-app/excluded.txt
@@ -1,0 +1,1 @@
+initial value

--- a/cli/integration_tests/inputs_test/monorepo/apps/my-app/included.txt
+++ b/cli/integration_tests/inputs_test/monorepo/apps/my-app/included.txt
@@ -1,0 +1,1 @@
+included value

--- a/cli/integration_tests/inputs_test/monorepo/apps/my-app/package.json
+++ b/cli/integration_tests/inputs_test/monorepo/apps/my-app/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "my-app",
+  "scripts": {
+    "build": "echo 'building'"
+  },
+  "dependencies": {
+    "util": "*"
+  }
+}

--- a/cli/integration_tests/inputs_test/monorepo/bar.txt
+++ b/cli/integration_tests/inputs_test/monorepo/bar.txt
@@ -1,0 +1,1 @@
+other file, not a global dependency

--- a/cli/integration_tests/inputs_test/monorepo/foo.txt
+++ b/cli/integration_tests/inputs_test/monorepo/foo.txt
@@ -1,0 +1,1 @@
+global dep! all tasks depend on this content!

--- a/cli/integration_tests/inputs_test/monorepo/package.json
+++ b/cli/integration_tests/inputs_test/monorepo/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "monorepo",
+  "workspaces": [
+    "apps/**",
+    "packages/**"
+  ]
+}

--- a/cli/integration_tests/inputs_test/monorepo/packages/util/package.json
+++ b/cli/integration_tests/inputs_test/monorepo/packages/util/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "util",
+  "scripts": {
+    "build": "echo 'building'"
+  }
+}

--- a/cli/integration_tests/inputs_test/monorepo/turbo.json
+++ b/cli/integration_tests/inputs_test/monorepo/turbo.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "globalDependencies": ["foo.txt"],
+  "globalEnv": ["SOME_ENV_VAR"],
+  "pipeline": {
+    "build": {
+      "env": ["NODE_ENV"],
+      "outputs": []
+    },
+    // this comment verifies that turbo can read .json files with comments
+    "my-app#build": {
+      "inputs": ["*.txt", "!excluded.txt"],
+      "outputs": ["banana.txt", "apple.json"]
+    }
+  }
+}

--- a/cli/integration_tests/inputs_test/run.t
+++ b/cli/integration_tests/inputs_test/run.t
@@ -1,0 +1,37 @@
+Setup
+  $ . ${TESTDIR}/../setup.sh
+  $ . ${TESTDIR}/setup.sh $(pwd)
+
+Running build for my-app succeeds
+  $ ${TURBO} run build --filter=my-app
+  \xe2\x80\xa2 Packages in scope: my-app (esc)
+  \xe2\x80\xa2 Running build in 1 packages (esc)
+  \xe2\x80\xa2 Remote caching disabled (esc)
+  my-app:build: cache miss, executing b7cf611b2774bb9a
+  my-app:build: 
+  my-app:build: > build
+  my-app:build: > echo 'building'
+  my-app:build: 
+  my-app:build: building
+  
+   Tasks:    1 successful, 1 total
+  Cached:    0 cached, 1 total
+    Time:\s*[\.0-9]+m?s  (re)
+  
+Update exluded file and try again
+  $ echo "new excluded value" > apps/my-app/excluded.txt
+  $ ${TURBO} run build --filter=my-app
+  \xe2\x80\xa2 Packages in scope: my-app (esc)
+  \xe2\x80\xa2 Running build in 1 packages (esc)
+  \xe2\x80\xa2 Remote caching disabled (esc)
+  my-app:build: cache hit, replaying output b7cf611b2774bb9a
+  my-app:build: 
+  my-app:build: > build
+  my-app:build: > echo 'building'
+  my-app:build: 
+  my-app:build: building
+  
+   Tasks:    1 successful, 1 total
+  Cached:    1 cached, 1 total
+    Time:\s*[\.0-9]+m?s >>> FULL TURBO (re)
+  

--- a/cli/integration_tests/inputs_test/setup.sh
+++ b/cli/integration_tests/inputs_test/setup.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+TARGET_DIR=$1
+cp -a ${SCRIPT_DIR}/monorepo/. ${TARGET_DIR}/
+${SCRIPT_DIR}/../setup_git.sh ${TARGET_DIR}

--- a/cli/internal/globby/globby.go
+++ b/cli/internal/globby/globby.go
@@ -101,7 +101,10 @@ func globWalkFs(fsys iofs.FS, fsysRoot string, basePath string, includePatterns 
 		// This will not error as it follows the call to checkRelativePath.
 		iofsRelativePath, _ := fs.IofsRelativePath(fsysRoot, excludePath)
 
-		// Excludes operate on entire folders.
+		// In case this is a file pattern and not a directory, add the exact pattern.
+		processedExcludes = append(processedExcludes, iofsRelativePath)
+		// TODO: we need to either document or change this behavior
+		// Excludes operate on entire folders, so we also exclude everything under this in case it represents a directory
 		processedExcludes = append(processedExcludes, filepath.Join(iofsRelativePath, "**"))
 	}
 

--- a/cli/internal/globby/globby_test.go
+++ b/cli/internal/globby/globby_test.go
@@ -414,7 +414,6 @@ func TestGlobFilesFs(t *testing.T) {
 			wantAll: []string{
 				"/repos/some-app/dist",
 				"/repos/some-app/dist/index.html",
-				"/repos/some-app/dist/js",
 			},
 			wantFiles: []string{
 				"/repos/some-app/dist/index.html",
@@ -658,6 +657,24 @@ func TestGlobFilesFs(t *testing.T) {
 				"/repos/some-app/dist/js/index.js",
 				"/repos/some-app/dist/js/lib.js",
 				"/repos/some-app/dist/js/node_modules/browserify.js",
+			},
+		},
+		{
+			name: "exclude single file",
+			files: []string{
+				"/repos/some-app/included.txt",
+				"/repos/some-app/excluded.txt",
+			},
+			args: args{
+				basePath:        "/repos/some-app",
+				includePatterns: []string{"*.txt"},
+				excludePatterns: []string{"excluded.txt"},
+			},
+			wantAll: []string{
+				"/repos/some-app/included.txt",
+			},
+			wantFiles: []string{
+				"/repos/some-app/included.txt",
 			},
 		},
 	}

--- a/cli/internal/taskhash/taskhash_test.go
+++ b/cli/internal/taskhash/taskhash_test.go
@@ -32,6 +32,7 @@ func Test_manuallyHashPackage(t *testing.T) {
 		"child-dir/libA/some-file":              {"some-file-contents", "7e59c6a6ea9098c6d3beb00e753e2c54ea502311"},
 		"child-dir/libA/some-dir/other-file":    {"some-file-contents", "7e59c6a6ea9098c6d3beb00e753e2c54ea502311"},
 		"child-dir/libA/some-dir/another-one":   {"some-file-contents", "7e59c6a6ea9098c6d3beb00e753e2c54ea502311"},
+		"child-dir/libA/some-dir/excluded-file": {"some-file-contents", "7e59c6a6ea9098c6d3beb00e753e2c54ea502311"},
 		"child-dir/libA/ignoreme":               {"anything", ""},
 		"child-dir/libA/ignorethisdir/anything": {"anything", ""},
 		"child-dir/libA/pkgignoreme":            {"anything", ""},
@@ -110,14 +111,14 @@ func Test_manuallyHashPackage(t *testing.T) {
 	}
 
 	count = 0
-	justFileHashes, err := manuallyHashPackage(pkg, []string{filepath.FromSlash("**/*file")}, repoRoot)
+	justFileHashes, err := manuallyHashPackage(pkg, []string{filepath.FromSlash("**/*file"), "!" + filepath.FromSlash("some-dir/excluded-file")}, repoRoot)
 	if err != nil {
 		t.Fatalf("failed to calculate manual hashes: %v", err)
 	}
 	for path, spec := range files {
 		systemPath := path.ToSystemPath()
 		if systemPath.HasPrefix(pkgName) {
-			shouldInclude := strings.HasSuffix(systemPath.ToString(), "file")
+			shouldInclude := strings.HasSuffix(systemPath.ToString(), "file") && !strings.HasSuffix(systemPath.ToString(), "excluded-file")
 			relPath := systemPath[len(pkgName)+1:]
 			got, ok := justFileHashes[relPath.ToUnixPath()]
 			if !ok && shouldInclude {


### PR DESCRIPTION
### Description

 - Support exclusion globs (`!some-glob`) in `inputs` specifications
 - Modify file hashing for a package to only consider `git status` in the case where we aren't using `inputs`. `inputs` already uses `git hash-object` which operates on the state of the working tree, as opposed to `git ls-tree` which operates on a particular commit. This additionally fixes an issue where a dirty file not included in `inputs` could get included in the hash.
 - Fix manual file hashing to use the correct prefix on globs (and to support exclusions)
 - Modify globby to allow excluding individual files, not just directories

Note the `globby_test.go` behavior change: previously specifying `foo/**` would ignore files nested under `foo/`, it will now also include `foo` itself. This has the consequence that if `foo` is a file and not a directory, it is going from not-ignored to ignored.

We have behavior to force excludes in globby to apply to directories, but AFAICT we don't document this behavior. My preference would be to drop it so that we have a unified globbing syntax. However, other options include:
 1. The code I have here, with the aforementioned side-effect
 2. Special-casing user input that ends in `**` to maintain both behaviors

### Testing Instructions

A new integration test uses `inputs` with an exclusion to exclude a file from the hash. The excluded file is modified in the test, then hash matching and full turbo are verified.

Globby has a new test as well for excluding a single file, vs a directory. See above for additional globby test details

`taskhash_test.go` has an additional edge case to handle excluding files in `inputs` specifications that fall back to manual file hashing.
