### PR TITLE
place all pages in the same intermediate output directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7793,6 +7793,7 @@ dependencies = [
  "turbo-tasks-build",
  "turbo-tasks-env",
  "turbo-tasks-fs",
+ "turbo-tasks-hash",
  "turbopack-core",
  "turbopack-dev-server",
  "turbopack-ecmascript",

--- a/crates/next-core/src/app_source.rs
+++ b/crates/next-core/src/app_source.rs
@@ -7,7 +7,7 @@ use anyhow::{anyhow, Result};
 use indexmap::indexmap;
 use turbo_tasks::{TryJoinIterExt, Value, ValueToString};
 use turbo_tasks_env::{CustomProcessEnvVc, EnvMapVc, ProcessEnvVc};
-use turbo_tasks_fs::{rebase, rope::RopeBuilder, File, FileContent, FileSystemPathVc};
+use turbo_tasks_fs::{rope::RopeBuilder, File, FileContent, FileSystemPathVc};
 use turbopack::{
     ecmascript::EcmascriptInputTransform,
     transition::{TransitionVc, TransitionsByNameVc},
@@ -393,9 +393,7 @@ async fn create_app_source_for_directory(
     intermediate_output_path_root: FileSystemPathVc,
 ) -> Result<ContentSourceVc> {
     let AppStructure {
-        item,
-        ref children,
-        directory,
+        item, ref children, ..
     } = *app_structure.await?;
     let mut sources = Vec::new();
 
@@ -427,11 +425,7 @@ async fn create_app_source_for_directory(
                         page_path: page,
                         target,
                         project_path,
-                        intermediate_output_path: rebase(
-                            directory,
-                            project_path,
-                            intermediate_output_path_root,
-                        ),
+                        intermediate_output_path: intermediate_output_path_root,
                     }
                     .cell()
                     .into(),
@@ -460,11 +454,7 @@ async fn create_app_source_for_directory(
                         server_root,
                         entry_path: route,
                         project_path,
-                        intermediate_output_path: rebase(
-                            directory,
-                            project_path,
-                            intermediate_output_path_root,
-                        ),
+                        intermediate_output_path: intermediate_output_path_root,
                         output_root: intermediate_output_path_root,
                     }
                     .cell()

--- a/crates/next-core/src/page_source.rs
+++ b/crates/next-core/src/page_source.rs
@@ -7,7 +7,7 @@ use turbo_tasks::{
     Value,
 };
 use turbo_tasks_env::{CustomProcessEnvVc, EnvMapVc, ProcessEnvVc};
-use turbo_tasks_fs::{rebase, FileContent, FileSystemPathVc};
+use turbo_tasks_fs::{FileContent, FileSystemPathVc};
 use turbopack::{transition::TransitionsByNameVc, ModuleAssetContextVc};
 use turbopack_core::{
     asset::AssetVc,
@@ -574,7 +574,7 @@ async fn create_page_source_for_directory(
                     server_root,
                     url,
                     false,
-                    rebase(page, project_path, output_root),
+                    output_root,
                     output_root,
                 ));
             }
@@ -597,7 +597,7 @@ async fn create_page_source_for_directory(
                     server_root,
                     url,
                     true,
-                    rebase(api, project_path, output_root),
+                    output_root,
                     output_root,
                 ));
             }

--- a/crates/turbopack-node/Cargo.toml
+++ b/crates/turbopack-node/Cargo.toml
@@ -22,6 +22,7 @@ tokio = { workspace = true, features = ["full"] }
 turbo-tasks = { workspace = true }
 turbo-tasks-env = { workspace = true }
 turbo-tasks-fs = { workspace = true }
+turbo-tasks-hash = { workspace = true }
 turbopack-core = { workspace = true }
 turbopack-dev-server = { workspace = true }
 turbopack-ecmascript = { workspace = true }


### PR DESCRIPTION
### Description

The isolation is unnecessary and we can reuse files when we share directories

### Testing Instructions

Open multiple pages without client-side navigation in multiple tabs concurrently.
