### PR TITLE
fix: ensure that memory is free'd using the same allocator

### DIFF
--- a/cli/internal/ffi/bindings.h
+++ b/cli/internal/ffi/bindings.h
@@ -8,6 +8,8 @@ typedef struct Buffer {
   uint8_t *data;
 } Buffer;
 
+void free_buffer(struct Buffer buffer);
+
 struct Buffer get_turbo_data_dir(void);
 
 struct Buffer changed_files(struct Buffer buffer);

--- a/cli/internal/ffi/ffi.go
+++ b/cli/internal/ffi/ffi.go
@@ -25,7 +25,7 @@ func Unmarshal[M proto.Message](b C.Buffer, c M) error {
 		return err
 	}
 
-	b.Free()
+	C.free_buffer(b)
 
 	return nil
 }

--- a/crates/turborepo-ffi/src/lib.rs
+++ b/crates/turborepo-ffi/src/lib.rs
@@ -11,6 +11,16 @@ pub struct Buffer {
     data: *mut u8,
 }
 
+#[no_mangle]
+pub extern "C" fn free_buffer(buffer: Buffer) {
+    // SAFETY
+    // we are responsible for freeing the memory allocated on the rust side
+    // we do this by converting the raw pointer to a Vec and letting it drop
+    // this is safe because we know that the memory was allocated by rust
+    // and that the length is correct
+    let _ = unsafe { Vec::from_raw_parts(buffer.data, buffer.len as usize, buffer.len as usize) };
+}
+
 impl<T: prost::Message> From<T> for Buffer {
     fn from(value: T) -> Self {
         let mut bytes = ManuallyDrop::new(value.encode_to_vec());


### PR DESCRIPTION
We were encountering segfaults on certain combinations of go / rust versions. This was determined to be due to differing allocators. Memory reserved on one side of the sandwich and free'd on the other would sometimes work depending on toolchains / platform. This resolves that problem.

To complicate things, this issue would only arise during cross-compilation, and not when building on the target OS / arch.

### Testing Instructions

I am going to run a dry run canary that we can re-test, though I have manualy verified the cross-compilation for win amd64.
