### PR TITLE
revert workspace dependency to allow building correctly

### DIFF
--- a/crates/next-binding/Cargo.toml
+++ b/crates/next-binding/Cargo.toml
@@ -103,7 +103,7 @@ __swc_testing = ["__swc", "testing"]
 mdxjs = { optional = true, workspace = true }
 modularize_imports = { optional = true, workspace = true }
 # TODO: Not sure what's going on, but using `workspace = true` noops `default-features = false`?
-next-dev = { optional = true, workspace = true, default-features = false, features = [
+next-dev = { optional = true, path = "../next-dev", default-features = false, features = [
   "custom_allocator",
 ] }
 node-file-trace = { optional = true, workspace = true }

--- a/crates/next-dev-tests/Cargo.toml
+++ b/crates/next-dev-tests/Cargo.toml
@@ -29,7 +29,7 @@ httpmock = { workspace = true, features = ["standalone"] }
 lazy_static = { workspace = true }
 mime = { workspace = true }
 next-core = { workspace = true }
-next-dev = { workspace = true }
+next-dev = { path = "../next-dev" }
 owo-colors = { workspace = true }
 parking_lot = { workspace = true }
 rand = { workspace = true }


### PR DESCRIPTION
### Description

Cargo always uses default features for workspace dependencies, so we can't use that here. See also comment.

### Testing Instructions

```
$ cargo tree -p next-binding -i openssl --target x86_64-unknown-linux-gnu -e features
error: package ID specification `openssl` did not match any packages
```
