### PR TITLE
Do not publish nightly Turbopack Releases

### DIFF
--- a/.github/workflows/turbopack-nightly-release.yml
+++ b/.github/workflows/turbopack-nightly-release.yml
@@ -26,11 +26,3 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           commit_sha: ${{ steps.green_commit.outputs.result }}
           prefix: "turbopack-"
-
-      - name: Create GitHub release
-        uses: ncipollo/release-action@v1
-        with:
-          tag: ${{ steps.tag_version.outputs.new_tag }}
-          name: Turbopack Nightly Release ${{ steps.tag_version.outputs.new_tag }}
-          body: ${{ steps.tag_version.outputs.changelog }}
-          prerelease: true


### PR DESCRIPTION
We'll still generate the tag, but won't be adding a prerelease release.
