### PR TITLE
build: Make `turbo-malloc` not depend on mimalloc on linux

### DIFF
--- a/crates/turbo-malloc/Cargo.toml
+++ b/crates/turbo-malloc/Cargo.toml
@@ -9,8 +9,8 @@ autobenches = false
 [lib]
 bench = false
 
-[dependencies]
-mimalloc = { version = "0.1.32", optional = true }
+[target.'cfg(not(target_os = "linux"))'.dependencies]
+mimalloc = { version = "0.1.32", features = [], optional = true }
 
 [target.'cfg(all(target_os = "linux", not(target_arch = "aarch64")))'.dependencies]
 mimalloc = { version = "0.1.32", features = [


### PR DESCRIPTION
### Description

This PR fixes the build failure caught at https://github.com/vercel/next.js/pull/46909


### Testing Instructions

I reverted https://github.com/vercel/turbo/blob/80516ff6f24cd1e83bc4e99a76bff9f0c9e2c42c partially