### PR TITLE
improve handling of syntax errors in HMR

### DIFF
--- a/crates/turbopack-cli-utils/src/lib.rs
+++ b/crates/turbopack-cli-utils/src/lib.rs
@@ -1,7 +1,6 @@
 #![feature(async_closure)]
 #![feature(min_specialization)]
 #![feature(round_char_boundary)]
-#![feature(main_separator_str)]
 
 pub mod issue;
 

--- a/crates/turbopack-ecmascript/src/lib.rs
+++ b/crates/turbopack-ecmascript/src/lib.rs
@@ -42,7 +42,9 @@ use swc_core::{
 pub use transform::{
     EcmascriptInputTransform, EcmascriptInputTransformsVc, NextJsPageExportFilter,
 };
-use turbo_tasks::{primitives::StringVc, ReadRef, TryJoinIterExt, Value, ValueToString};
+use turbo_tasks::{
+    primitives::StringVc, trace::TraceRawVcs, RawVc, ReadRef, TryJoinIterExt, Value, ValueToString,
+};
 use turbo_tasks_fs::FileSystemPathVc;
 use turbopack_core::{
     asset::{Asset, AssetContentVc, AssetOptionVc, AssetVc},
@@ -93,6 +95,13 @@ fn modifier() -> StringVc {
     StringVc::cell("ecmascript".to_string())
 }
 
+#[derive(PartialEq, Eq, Clone, TraceRawVcs)]
+struct MemoizedSuccessfulAnalysis {
+    operation: RawVc,
+    references: AssetReferencesReadRef,
+    exports: EcmascriptExportsReadRef,
+}
+
 #[turbo_tasks::value]
 pub struct EcmascriptModuleAsset {
     pub source: AssetVc,
@@ -102,13 +111,8 @@ pub struct EcmascriptModuleAsset {
     pub compile_time_info: CompileTimeInfoVc,
     pub inner_assets: Option<InnerAssetsVc>,
     #[turbo_tasks(debug_ignore)]
-    pub last_successful_analyse: turbo_tasks::State<
-        Option<(
-            AnalyzeEcmascriptModuleResultVc,
-            AssetReferencesReadRef,
-            EcmascriptExportsReadRef,
-        )>,
-    >,
+    #[serde(skip)]
+    last_successful_analysis: turbo_tasks::State<Option<MemoizedSuccessfulAnalysis>>,
 }
 
 /// An optional [EcmascriptModuleAsset]
@@ -132,7 +136,7 @@ impl EcmascriptModuleAssetVc {
             transforms,
             compile_time_info,
             inner_assets: None,
-            last_successful_analyse: Default::default(),
+            last_successful_analysis: Default::default(),
         })
     }
 
@@ -152,7 +156,7 @@ impl EcmascriptModuleAssetVc {
             transforms,
             compile_time_info,
             inner_assets: Some(inner_assets),
-            last_successful_analyse: Default::default(),
+            last_successful_analysis: Default::default(),
         })
     }
 
@@ -166,40 +170,50 @@ impl EcmascriptModuleAssetVc {
     }
 
     #[turbo_tasks::function]
-    pub async fn analyze(self, failsafe: bool) -> Result<AnalyzeEcmascriptModuleResultVc> {
+    pub async fn analyze(self) -> Result<AnalyzeEcmascriptModuleResultVc> {
         let this = self.await?;
-        let result = analyze_ecmascript_module(
+        Ok(analyze_ecmascript_module(
             this.source,
             self.as_resolve_origin(),
             Value::new(this.ty),
             this.transforms,
             this.compile_time_info,
-        );
-        if failsafe {
-            let result_value = result.await?;
-            if result_value.successful {
-                this.last_successful_analyse.set(Some((
-                    result,
-                    result_value.references.await?,
-                    result_value.exports.await?,
-                )));
-            } else {
-                if let Some((last_operation, last_references, last_exports)) =
-                    &*this.last_successful_analyse.get()
-                {
-                    let last_operation: turbo_tasks::RawVc = last_operation.into();
-                    last_operation.connect();
-                    return Ok(AnalyzeEcmascriptModuleResult {
-                        references: ReadRef::cell(last_references.clone()),
-                        exports: ReadRef::cell(last_exports.clone()),
-                        code_generation: result_value.code_generation,
-                        successful: false,
-                    }
-                    .cell());
+        ))
+    }
+
+    #[turbo_tasks::function]
+    pub async fn failsafe_analyze(self) -> Result<AnalyzeEcmascriptModuleResultVc> {
+        let this = self.await?;
+        let result = self.analyze();
+        let result_value = result.await?;
+        if result_value.successful {
+            this.last_successful_analysis
+                .set(Some(MemoizedSuccessfulAnalysis {
+                    operation: result.into(),
+                    // We need to store the ReadRefs since we want to keep a snapshot.
+                    references: result_value.references.await?,
+                    exports: result_value.exports.await?,
+                }));
+        } else {
+            if let Some(MemoizedSuccessfulAnalysis {
+                operation,
+                references,
+                exports,
+            }) = &*this.last_successful_analysis.get()
+            {
+                // It's important to connect to the last operation here to keep it active, so
+                // it's potentially recomputed when garbage collected
+                operation.connect();
+                return Ok(AnalyzeEcmascriptModuleResult {
+                    references: ReadRef::cell(references.clone()),
+                    exports: ReadRef::cell(exports.clone()),
+                    code_generation: result_value.code_generation,
+                    successful: false,
                 }
+                .cell());
             }
         }
-        Ok(result)
+        Ok(ReadRef::cell(result_value))
     }
 
     #[turbo_tasks::function]
@@ -232,7 +246,7 @@ impl Asset for EcmascriptModuleAsset {
 
     #[turbo_tasks::function]
     async fn references(self_vc: EcmascriptModuleAssetVc) -> Result<AssetReferencesVc> {
-        Ok(self_vc.analyze(true).await?.references)
+        Ok(self_vc.failsafe_analyze().await?.references)
     }
 }
 
@@ -260,7 +274,7 @@ impl EcmascriptChunkPlaceable for EcmascriptModuleAsset {
 
     #[turbo_tasks::function]
     async fn get_exports(self_vc: EcmascriptModuleAssetVc) -> Result<EcmascriptExportsVc> {
-        Ok(self_vc.analyze(true).await?.exports)
+        Ok(self_vc.failsafe_analyze().await?.exports)
     }
 }
 
@@ -324,7 +338,7 @@ impl EcmascriptChunkItem for ModuleChunkItem {
             references,
             code_generation,
             ..
-        } = &*self.module.analyze(false).await?;
+        } = &*self.module.analyze().await?;
         let context = self.context;
         let mut code_gens = Vec::new();
         for r in references.await?.iter() {

--- a/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/crates/turbopack-ecmascript/src/references/mod.rs
@@ -109,11 +109,12 @@ use crate::{
     EcmascriptInputTransformsVc,
 };
 
-#[turbo_tasks::value]
+#[turbo_tasks::value(shared)]
 pub struct AnalyzeEcmascriptModuleResult {
     pub references: AssetReferencesVc,
     pub code_generation: CodeGenerateablesVc,
     pub exports: EcmascriptExportsVc,
+    pub successful: bool,
 }
 
 /// A temporary analysis result builder to pass around, to be turned into an
@@ -122,6 +123,7 @@ pub(crate) struct AnalyzeEcmascriptModuleResultBuilder {
     references: Vec<AssetReferenceVc>,
     code_gens: Vec<CodeGenerateableVc>,
     exports: EcmascriptExports,
+    successful: bool,
 }
 
 impl AnalyzeEcmascriptModuleResultBuilder {
@@ -130,6 +132,7 @@ impl AnalyzeEcmascriptModuleResultBuilder {
             references: Vec::new(),
             code_gens: Vec::new(),
             exports: EcmascriptExports::None,
+            successful: false,
         }
     }
 
@@ -154,6 +157,11 @@ impl AnalyzeEcmascriptModuleResultBuilder {
         self.exports = exports;
     }
 
+    /// Sets whether the analysis was successful.
+    pub fn set_successful(&mut self, successful: bool) {
+        self.successful = successful;
+    }
+
     /// Builds the final analysis result. Resolves internal Vcs for performance
     /// in using them.
     pub async fn build(mut self) -> Result<AnalyzeEcmascriptModuleResultVc> {
@@ -168,6 +176,7 @@ impl AnalyzeEcmascriptModuleResultBuilder {
                 references: AssetReferencesVc::cell(self.references),
                 code_generation: CodeGenerateablesVc::cell(self.code_gens),
                 exports: self.exports.into(),
+                successful: self.successful,
             },
         ))
     }
@@ -1405,6 +1414,7 @@ pub(crate) async fn analyze_ecmascript_module(
                     }
                 }
             }
+            analysis.set_successful(true);
         }
         ParseResult::Unparseable | ParseResult::NotFound => {}
     };

--- a/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/crates/turbopack-ecmascript/src/references/mod.rs
@@ -114,6 +114,7 @@ pub struct AnalyzeEcmascriptModuleResult {
     pub references: AssetReferencesVc,
     pub code_generation: CodeGenerateablesVc,
     pub exports: EcmascriptExportsVc,
+    /// `true` when the analysis was successful.
     pub successful: bool,
 }
 

--- a/crates/turbopack-mdx/src/lib.rs
+++ b/crates/turbopack-mdx/src/lib.rs
@@ -88,8 +88,8 @@ impl MdxModuleAssetVc {
     }
 
     #[turbo_tasks::function]
-    async fn analyze(self) -> Result<AnalyzeEcmascriptModuleResultVc> {
-        Ok(into_ecmascript_module_asset(&self).await?.analyze())
+    async fn analyze(self, failsafe: bool) -> Result<AnalyzeEcmascriptModuleResultVc> {
+        Ok(into_ecmascript_module_asset(&self).await?.analyze(failsafe))
     }
 }
 
@@ -107,7 +107,7 @@ impl Asset for MdxModuleAsset {
 
     #[turbo_tasks::function]
     async fn references(self_vc: MdxModuleAssetVc) -> Result<AssetReferencesVc> {
-        Ok(self_vc.analyze().await?.references)
+        Ok(self_vc.analyze(true).await?.references)
     }
 }
 

--- a/crates/turbopack-mdx/src/lib.rs
+++ b/crates/turbopack-mdx/src/lib.rs
@@ -88,8 +88,10 @@ impl MdxModuleAssetVc {
     }
 
     #[turbo_tasks::function]
-    async fn analyze(self, failsafe: bool) -> Result<AnalyzeEcmascriptModuleResultVc> {
-        Ok(into_ecmascript_module_asset(&self).await?.analyze(failsafe))
+    async fn failsafe_analyze(self) -> Result<AnalyzeEcmascriptModuleResultVc> {
+        Ok(into_ecmascript_module_asset(&self)
+            .await?
+            .failsafe_analyze())
     }
 }
 
@@ -107,7 +109,7 @@ impl Asset for MdxModuleAsset {
 
     #[turbo_tasks::function]
     async fn references(self_vc: MdxModuleAssetVc) -> Result<AssetReferencesVc> {
-        Ok(self_vc.analyze(true).await?.references)
+        Ok(self_vc.failsafe_analyze().await?.references)
     }
 }
 


### PR DESCRIPTION
### Description

It's a bit ugly and I dislike the way it's implemented, but this will help for now.

* When using HMR and introducing an parse error to a module, this keeps the previous references and exports type to keep the environment intact and avoid unloading a bunch of modules

depends on https://github.com/vercel/turbo/pull/3975 to work correctly