### PR TITLE
feat(ecmascript): transform ts input with runtime flags

### DIFF
--- a/crates/next-core/src/app_render/next_layout_entry_transition.rs
+++ b/crates/next-core/src/app_render/next_layout_entry_transition.rs
@@ -66,7 +66,9 @@ impl Transition for NextLayoutEntryTransition {
             context.into(),
             Value::new(EcmascriptModuleAssetType::Typescript),
             EcmascriptInputTransformsVc::cell(vec![
-                EcmascriptInputTransform::TypeScript,
+                EcmascriptInputTransform::TypeScript {
+                    use_define_for_class_fields: false,
+                },
                 EcmascriptInputTransform::React { refresh: false },
             ]),
             context.compile_time_info(),

--- a/crates/next-core/src/app_source.rs
+++ b/crates/next-core/src/app_source.rs
@@ -659,7 +659,9 @@ import BOOTSTRAP from {};
                 Value::new(EcmascriptModuleAssetType::Typescript),
                 EcmascriptInputTransformsVc::cell(vec![
                     EcmascriptInputTransform::React { refresh: false },
-                    EcmascriptInputTransform::TypeScript,
+                    EcmascriptInputTransform::TypeScript {
+                        use_define_for_class_fields: false,
+                    },
                 ]),
                 context.compile_time_info(),
             ),
@@ -727,7 +729,9 @@ impl AppRouteVc {
                 virtual_asset.into(),
                 this.context,
                 Value::new(EcmascriptModuleAssetType::Typescript),
-                EcmascriptInputTransformsVc::cell(vec![EcmascriptInputTransform::TypeScript]),
+                EcmascriptInputTransformsVc::cell(vec![EcmascriptInputTransform::TypeScript {
+                    use_define_for_class_fields: false,
+                }]),
                 this.context.compile_time_info(),
                 InnerAssetsVc::cell(indexmap! {
                     "ROUTE_CHUNK_GROUP".to_string() => entry

--- a/crates/next-core/src/lib.rs
+++ b/crates/next-core/src/lib.rs
@@ -28,6 +28,7 @@ pub mod react_refresh;
 pub mod router;
 pub mod router_source;
 mod runtime;
+mod typescript;
 mod util;
 mod web_entry_source;
 

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -38,6 +38,7 @@ use crate::{
         get_next_client_resolved_map,
     },
     react_refresh::assert_can_resolve_react_refresh,
+    typescript::get_typescript_transform_options,
     util::foreign_code_context_condition,
 };
 
@@ -128,6 +129,7 @@ pub async fn get_client_module_options_context(
             .await?
             .is_found();
 
+    let tsconfig = get_typescript_transform_options(project_path);
     let enable_webpack_loaders = {
         let options = &*next_config.webpack_loaders_options().await?;
         let loaders_options = WebpackLoadersOptions {
@@ -164,7 +166,7 @@ pub async fn get_client_module_options_context(
             ..Default::default()
         }),
         enable_webpack_loaders,
-        enable_typescript_transform: true,
+        enable_typescript_transform: Some(tsconfig),
         rules: vec![(
             foreign_code_context_condition(next_config).await?,
             module_options_context.clone().cell(),

--- a/crates/next-core/src/next_client/transition.rs
+++ b/crates/next-core/src/next_client/transition.rs
@@ -80,7 +80,9 @@ impl Transition for NextClientTransition {
             context.into(),
             Value::new(EcmascriptModuleAssetType::Typescript),
             EcmascriptInputTransformsVc::cell(vec![
-                EcmascriptInputTransform::TypeScript,
+                EcmascriptInputTransform::TypeScript {
+                    use_define_for_class_fields: false,
+                },
                 EcmascriptInputTransform::React { refresh: false },
             ]),
             context.compile_time_info(),

--- a/crates/next-core/src/next_client_component/server_to_client_transition.rs
+++ b/crates/next-core/src/next_client_component/server_to_client_transition.rs
@@ -54,7 +54,9 @@ impl Transition for NextServerToClientTransition {
             context.into(),
             Value::new(EcmascriptModuleAssetType::Typescript),
             EcmascriptInputTransformsVc::cell(vec![
-                EcmascriptInputTransform::TypeScript,
+                EcmascriptInputTransform::TypeScript {
+                    use_define_for_class_fields: false,
+                },
                 EcmascriptInputTransform::React { refresh: false },
             ]),
             context.compile_time_info(),

--- a/crates/next-core/src/next_edge/transition.rs
+++ b/crates/next-core/src/next_edge/transition.rs
@@ -101,7 +101,9 @@ impl Transition for NextEdgeTransition {
             virtual_asset.into(),
             context.into(),
             Value::new(EcmascriptModuleAssetType::Typescript),
-            EcmascriptInputTransformsVc::cell(vec![EcmascriptInputTransform::TypeScript]),
+            EcmascriptInputTransformsVc::cell(vec![EcmascriptInputTransform::TypeScript {
+                use_define_for_class_fields: false,
+            }]),
             context.compile_time_info(),
             InnerAssetsVc::cell(indexmap! {
                 "ENTRY".to_string() => asset

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -299,7 +299,7 @@ pub async fn get_server_module_options_context(
             ModuleOptionsContext {
                 enable_postcss_transform,
                 enable_webpack_loaders,
-                enable_typescript_transform: Some(Default::default()),
+                enable_typescript_transform: Some(tsconfig),
                 rules: vec![(
                     foreign_code_context_condition,
                     module_options_context.clone().cell(),

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -28,6 +28,7 @@ use crate::{
     next_build::{get_external_next_compiled_package_mapping, get_postcss_package_mapping},
     next_config::NextConfigVc,
     next_import_map::get_next_server_import_map,
+    typescript::get_typescript_transform_options,
     util::foreign_code_context_condition,
 };
 
@@ -228,6 +229,8 @@ pub async fn get_server_module_options_context(
             .clone_if()
     };
 
+    let tsconfig = get_typescript_transform_options(project_path);
+
     let module_options_context = match ty.into_value() {
         ServerContextType::Pages { .. } | ServerContextType::PagesData { .. } => {
             let module_options_context = ModuleOptionsContext {
@@ -239,7 +242,7 @@ pub async fn get_server_module_options_context(
                 enable_styled_jsx: true,
                 enable_postcss_transform,
                 enable_webpack_loaders,
-                enable_typescript_transform: true,
+                enable_typescript_transform: Some(tsconfig),
                 rules: vec![(
                     foreign_code_context_condition,
                     module_options_context.clone().cell(),
@@ -258,7 +261,7 @@ pub async fn get_server_module_options_context(
                 enable_styled_jsx: true,
                 enable_postcss_transform,
                 enable_webpack_loaders,
-                enable_typescript_transform: true,
+                enable_typescript_transform: Some(tsconfig),
                 rules: vec![(
                     foreign_code_context_condition,
                     module_options_context.clone().cell(),
@@ -279,7 +282,7 @@ pub async fn get_server_module_options_context(
                 enable_jsx: true,
                 enable_postcss_transform,
                 enable_webpack_loaders,
-                enable_typescript_transform: true,
+                enable_typescript_transform: Some(tsconfig),
                 rules: vec![(
                     foreign_code_context_condition,
                     module_options_context.clone().cell(),
@@ -296,7 +299,7 @@ pub async fn get_server_module_options_context(
             ModuleOptionsContext {
                 enable_postcss_transform,
                 enable_webpack_loaders,
-                enable_typescript_transform: true,
+                enable_typescript_transform: Some(Default::default()),
                 rules: vec![(
                     foreign_code_context_condition,
                     module_options_context.clone().cell(),
@@ -315,7 +318,7 @@ pub async fn get_server_module_options_context(
                 enable_styled_jsx: true,
                 enable_postcss_transform,
                 enable_webpack_loaders,
-                enable_typescript_transform: true,
+                enable_typescript_transform: Some(tsconfig),
                 rules: vec![(
                     foreign_code_context_condition,
                     module_options_context.clone().cell(),
@@ -333,7 +336,7 @@ pub async fn get_server_module_options_context(
 #[turbo_tasks::function]
 pub fn get_build_module_options_context() -> ModuleOptionsContextVc {
     ModuleOptionsContext {
-        enable_typescript_transform: true,
+        enable_typescript_transform: Some(Default::default()),
         ..Default::default()
     }
     .cell()

--- a/crates/next-core/src/page_loader.rs
+++ b/crates/next-core/src/page_loader.rs
@@ -86,7 +86,9 @@ impl PageLoaderAssetVc {
             loader_entry_asset,
             this.client_context,
             Value::new(EcmascriptModuleAssetType::Typescript),
-            EcmascriptInputTransformsVc::cell(vec![EcmascriptInputTransform::TypeScript]),
+            EcmascriptInputTransformsVc::cell(vec![EcmascriptInputTransform::TypeScript {
+                use_define_for_class_fields: false,
+            }]),
             this.client_context.compile_time_info(),
             InnerAssetsVc::cell(indexmap! {
                 "PAGE".to_string() => this.client_context.process(this.entry_asset, Value::new(ReferenceType::Entry(EntryReferenceSubType::Page)))

--- a/crates/next-core/src/page_source.rs
+++ b/crates/next-core/src/page_source.rs
@@ -718,7 +718,9 @@ impl SsrEntryVc {
                 this.context,
                 Value::new(EcmascriptModuleAssetType::Typescript),
                 EcmascriptInputTransformsVc::cell(vec![
-                    EcmascriptInputTransform::TypeScript,
+                    EcmascriptInputTransform::TypeScript {
+                        use_define_for_class_fields: false,
+                    },
                     EcmascriptInputTransform::React { refresh: false },
                 ]),
                 this.context.compile_time_info(),

--- a/crates/next-core/src/router.rs
+++ b/crates/next-core/src/router.rs
@@ -167,7 +167,9 @@ fn as_es_module_asset(asset: AssetVc, context: AssetContextVc) -> EcmascriptModu
         asset,
         context,
         Value::new(EcmascriptModuleAssetType::Typescript),
-        EcmascriptInputTransformsVc::cell(vec![EcmascriptInputTransform::TypeScript]),
+        EcmascriptInputTransformsVc::cell(vec![EcmascriptInputTransform::TypeScript {
+            use_define_for_class_fields: false,
+        }]),
         context.compile_time_info(),
     )
 }
@@ -250,7 +252,9 @@ fn route_executor(context: AssetContextVc, configs: InnerAssetsVc) -> AssetVc {
         next_asset("entry/router.ts"),
         context,
         Value::new(EcmascriptModuleAssetType::Typescript),
-        EcmascriptInputTransformsVc::cell(vec![EcmascriptInputTransform::TypeScript]),
+        EcmascriptInputTransformsVc::cell(vec![EcmascriptInputTransform::TypeScript {
+            use_define_for_class_fields: false,
+        }]),
         context.compile_time_info(),
         configs,
     )

--- a/crates/next-core/src/typescript.rs
+++ b/crates/next-core/src/typescript.rs
@@ -1,0 +1,45 @@
+use anyhow::Result;
+use turbo_tasks_fs::{FileJsonContent, FileSystemPathVc};
+use turbopack::module_options::{TypescriptTransformOptions, TypescriptTransformOptionsVc};
+use turbopack_core::{
+    resolve::{find_context_file, node::node_cjs_resolve_options, FindContextFileResult},
+    source_asset::SourceAssetVc,
+};
+use turbopack_ecmascript::typescript::resolve::{read_from_tsconfigs, read_tsconfigs, tsconfig};
+
+// Get the transform options for specifically for the typescript's runtime
+// outputs
+#[turbo_tasks::function]
+pub async fn get_typescript_transform_options(
+    project_path: FileSystemPathVc,
+) -> Result<TypescriptTransformOptionsVc> {
+    let tsconfig = find_context_file(project_path, tsconfig());
+    let tsconfig = match *tsconfig.await? {
+        FindContextFileResult::Found(path, _) => Some(
+            read_tsconfigs(
+                path.read(),
+                SourceAssetVc::new(path).into(),
+                node_cjs_resolve_options(path.root()),
+            )
+            .await?,
+        ),
+        FindContextFileResult::NotFound(_) => None,
+    };
+
+    let use_define_for_class_fields = if let Some(tsconfig) = tsconfig {
+        read_from_tsconfigs(&tsconfig, |json, _| {
+            json["compilerOptions"]["useDefineForClassFields"].as_bool()
+        })
+        .await?
+        .unwrap_or(false)
+    } else {
+        false
+    };
+
+    let ts_transform_options = TypescriptTransformOptions {
+        use_define_for_class_fields,
+        ..Default::default()
+    };
+
+    Ok(ts_transform_options.cell())
+}

--- a/crates/next-core/src/typescript.rs
+++ b/crates/next-core/src/typescript.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_tasks_fs::{FileJsonContent, FileSystemPathVc};
+use turbo_tasks_fs::FileSystemPathVc;
 use turbopack::module_options::{TypescriptTransformOptions, TypescriptTransformOptionsVc};
 use turbopack_core::{
     resolve::{find_context_file, node::node_cjs_resolve_options, FindContextFileResult},

--- a/crates/turbopack-node/src/evaluate.rs
+++ b/crates/turbopack-node/src/evaluate.rs
@@ -69,7 +69,9 @@ pub async fn get_evaluate_pool(
         SourceAssetVc::new(embed_file_path("ipc/evaluate.ts")).into(),
         context,
         Value::new(EcmascriptModuleAssetType::Typescript),
-        EcmascriptInputTransformsVc::cell(vec![EcmascriptInputTransform::TypeScript]),
+        EcmascriptInputTransformsVc::cell(vec![EcmascriptInputTransform::TypeScript {
+            use_define_for_class_fields: false,
+        }]),
         context.compile_time_info(),
     )
     .as_asset();
@@ -96,7 +98,9 @@ pub async fn get_evaluate_pool(
         .into(),
         context,
         Value::new(EcmascriptModuleAssetType::Typescript),
-        EcmascriptInputTransformsVc::cell(vec![EcmascriptInputTransform::TypeScript]),
+        EcmascriptInputTransformsVc::cell(vec![EcmascriptInputTransform::TypeScript {
+            use_define_for_class_fields: false,
+        }]),
         context.compile_time_info(),
         InnerAssetsVc::cell(indexmap! {
             "INNER".to_string() => module_asset,
@@ -113,7 +117,9 @@ pub async fn get_evaluate_pool(
             SourceAssetVc::new(embed_file_path("globals.ts")).into(),
             context,
             Value::new(EcmascriptModuleAssetType::Typescript),
-            EcmascriptInputTransformsVc::cell(vec![EcmascriptInputTransform::TypeScript]),
+            EcmascriptInputTransformsVc::cell(vec![EcmascriptInputTransform::TypeScript {
+                use_define_for_class_fields: false,
+            }]),
             context.compile_time_info(),
         )
         .as_ecmascript_chunk_placeable();

--- a/crates/turbopack-node/src/transforms/postcss.rs
+++ b/crates/turbopack-node/src/transforms/postcss.rs
@@ -183,7 +183,9 @@ fn postcss_executor(context: AssetContextVc, postcss_config_path: FileSystemPath
         .into(),
         context,
         Value::new(EcmascriptModuleAssetType::Typescript),
-        EcmascriptInputTransformsVc::cell(vec![EcmascriptInputTransform::TypeScript]),
+        EcmascriptInputTransformsVc::cell(vec![EcmascriptInputTransform::TypeScript {
+            use_define_for_class_fields: false,
+        }]),
         context.compile_time_info(),
         InnerAssetsVc::cell(indexmap! {
             "CONFIG".to_string() => config_asset

--- a/crates/turbopack-node/src/transforms/webpack.rs
+++ b/crates/turbopack-node/src/transforms/webpack.rs
@@ -120,7 +120,9 @@ fn webpack_loaders_executor(context: AssetContextVc) -> AssetVc {
         SourceAssetVc::new(embed_file_path("transforms/webpack-loaders.ts")).into(),
         context,
         Value::new(EcmascriptModuleAssetType::Typescript),
-        EcmascriptInputTransformsVc::cell(vec![EcmascriptInputTransform::TypeScript]),
+        EcmascriptInputTransformsVc::cell(vec![EcmascriptInputTransform::TypeScript {
+            use_define_for_class_fields: false,
+        }]),
         context.compile_time_info(),
     )
     .into()

--- a/crates/turbopack/src/evaluate_context.rs
+++ b/crates/turbopack/src/evaluate_context.rs
@@ -37,7 +37,7 @@ pub async fn node_evaluate_asset_context(
         }
         .cell(),
         ModuleOptionsContext {
-            enable_typescript_transform: true,
+            enable_typescript_transform: Some(Default::default()),
             ..Default::default()
         }
         .cell(),

--- a/crates/turbopack/src/module_options/mod.rs
+++ b/crates/turbopack/src/module_options/mod.rs
@@ -119,12 +119,8 @@ impl ModuleOptionsVc {
         let app_transforms = EcmascriptInputTransformsVc::cell(transforms);
         let vendor_transforms =
             EcmascriptInputTransformsVc::cell(custom_ecmascript_transforms.clone());
-        let ts_app_transforms = if enable_typescript_transform.is_some() {
-            let mut base_transforms = if let Some(transform) = ts_transform {
-                vec![transform.clone()]
-            } else {
-                vec![]
-            };
+        let ts_app_transforms = if let Some(transform) = ts_transform {
+            let mut base_transforms = vec![transform.clone()];
             base_transforms.extend(custom_ecmascript_transforms.iter().cloned());
             EcmascriptInputTransformsVc::cell(
                 base_transforms

--- a/crates/turbopack/src/module_options/mod.rs
+++ b/crates/turbopack/src/module_options/mod.rs
@@ -63,7 +63,7 @@ impl ModuleOptionsVc {
             enable_styled_jsx,
             enable_styled_components,
             enable_types,
-            enable_typescript_transform,
+            ref enable_typescript_transform,
             enable_mdx,
             ref enable_postcss_transform,
             ref enable_webpack_loaders,
@@ -107,11 +107,24 @@ impl ModuleOptionsVc {
             transforms.push(EcmascriptInputTransform::PresetEnv(env));
         }
 
+        let ts_transform = if let Some(options) = enable_typescript_transform {
+            let options = options.await?;
+            Some(EcmascriptInputTransform::TypeScript {
+                use_define_for_class_fields: options.use_define_for_class_fields,
+            })
+        } else {
+            None
+        };
+
         let app_transforms = EcmascriptInputTransformsVc::cell(transforms);
         let vendor_transforms =
             EcmascriptInputTransformsVc::cell(custom_ecmascript_transforms.clone());
-        let ts_app_transforms = if enable_typescript_transform {
-            let mut base_transforms = vec![EcmascriptInputTransform::TypeScript];
+        let ts_app_transforms = if enable_typescript_transform.is_some() {
+            let mut base_transforms = if let Some(transform) = ts_transform {
+                vec![transform.clone()]
+            } else {
+                vec![]
+            };
             base_transforms.extend(custom_ecmascript_transforms.iter().cloned());
             EcmascriptInputTransformsVc::cell(
                 base_transforms
@@ -126,11 +139,15 @@ impl ModuleOptionsVc {
 
         let css_transforms = CssInputTransformsVc::cell(vec![CssInputTransform::Nested]);
         let mdx_transforms = EcmascriptInputTransformsVc::cell(
-            vec![EcmascriptInputTransform::TypeScript]
-                .iter()
-                .chain(app_transforms.await?.iter())
-                .cloned()
-                .collect(),
+            if let Some(transform) = ts_transform {
+                vec![transform.clone()]
+            } else {
+                vec![]
+            }
+            .iter()
+            .chain(app_transforms.await?.iter())
+            .cloned()
+            .collect(),
         );
 
         let mut rules = vec![

--- a/crates/turbopack/src/module_options/module_options_context.rs
+++ b/crates/turbopack/src/module_options/module_options_context.rs
@@ -24,6 +24,28 @@ pub struct WebpackLoadersOptions {
     pub placeholder_for_future_extensions: (),
 }
 
+/// Subset of Typescript options configured via tsconfig.json or jsconfig.json,
+/// which affects the runtime transform output.
+#[turbo_tasks::value(shared)]
+#[derive(Default, Clone, Debug)]
+pub struct TypescriptTransformOptions {
+    pub use_define_for_class_fields: bool,
+}
+
+#[turbo_tasks::value_impl]
+impl TypescriptTransformOptionsVc {
+    #[turbo_tasks::function]
+    pub fn default() -> Self {
+        Self::cell(Default::default())
+    }
+}
+
+impl Default for TypescriptTransformOptionsVc {
+    fn default() -> Self {
+        Self::default()
+    }
+}
+
 impl WebpackLoadersOptions {
     pub fn is_empty(&self) -> bool {
         self.extension_to_loaders.is_empty()
@@ -58,7 +80,7 @@ pub struct ModuleOptionsContext {
     #[serde(default)]
     pub enable_types: bool,
     #[serde(default)]
-    pub enable_typescript_transform: bool,
+    pub enable_typescript_transform: Option<TypescriptTransformOptionsVc>,
     #[serde(default)]
     pub enable_mdx: bool,
     #[serde(default)]


### PR DESCRIPTION
### Description

Another attempt to close WEB-659.

The crux is same as previous PR, but attempt to change the location where it read config / bubble down the config values to the actual transform stage. Mainly, `enable_typescript_transform` is now accepting an option instead of boolean flag to down to `EcmaInputTransform::Typescript`, and `get_*_module_context()` reads the config value as needed.