### PR TITLE
Amend incorrect file referenced in Getting Started

### DIFF
--- a/docs/pages/repo/docs/getting-started/create-new.mdx
+++ b/docs/pages/repo/docs/getting-started/create-new.mdx
@@ -229,7 +229,7 @@ For instance, `packages/ui` depends on `tsconfig`:
 
 <Tabs items={['npm', 'yarn', 'pnpm']} storageKey="selected-pkg-manager">
   <Tab>
-    ```json filename="apps/web/package.json"
+    ```json filename="packages/ui/package.json"
     {
       "devDependencies": {
         "tsconfig": "*"
@@ -238,7 +238,7 @@ For instance, `packages/ui` depends on `tsconfig`:
     ```
   </Tab>
   <Tab>
-    ```json filename="apps/web/package.json"
+    ```json filename="packages/ui/package.json"
     {
       "devDependencies": {
         "tsconfig": "*"
@@ -247,7 +247,7 @@ For instance, `packages/ui` depends on `tsconfig`:
     ```
   </Tab>
   <Tab>
-    ```json filename="apps/web/package.json"
+    ```json filename="packages/ui/package.json"
     {
       "devDependencies": {
         "tsconfig": "workspace:*"


### PR DESCRIPTION
### Description
Not sure if I've misunderstood the documentation, but I believe an incorrect file is referenced in one of the code snippets on the "Getting Started" page. See below for before and after screenshots.

**Before my changes**
<img width="874" alt="Screenshot 2023-03-10 at 5 08 45 pm" src="https://user-images.githubusercontent.com/39115672/224237186-51b4c370-ecce-44d3-901a-7c883993bdee.png">

**After my changes**
<img width="870" alt="Screenshot 2023-03-10 at 5 13 29 pm" src="https://user-images.githubusercontent.com/39115672/224237987-4b1d2b5b-1f63-432c-b400-dbb96303041f.png">


### Testing Instructions
1. Visit the page http://localhost:3000/repo/docs/getting-started/create-new in the docs app
2. Scroll down to the section **Understanding tsconfig**
3. The file referenced should now be changed from `apps/web/package.json` to `packages/ui/package.json` under the text **For instance, packages/ui depends on tsconfig:**
4. Make sure to check for each version that the correct file is referenced. That is, click on `npm`, `yarn` and `pnpm`
