### PR TITLE
fix(create-turbo): update create-turbo eslint template (#4160

### DIFF
--- a/packages/create-turbo/templates/_shared_ts/packages/eslint-config-custom/index.js
+++ b/packages/create-turbo/templates/_shared_ts/packages/eslint-config-custom/index.js
@@ -3,4 +3,9 @@ module.exports = {
   rules: {
     "@next/next/no-html-link-for-pages": "off",
   },
+  parserOptions: {
+    babelOptions: {
+      presets: [require.resolve("next/babel")],
+    },
+  },
 };


### PR DESCRIPTION
### Description

Fix "cannot find module next/babel" issue


