### PR TITLE
Remove env-var linting comments.

### DIFF
--- a/examples/kitchen-sink/apps/api/src/index.ts
+++ b/examples/kitchen-sink/apps/api/src/index.ts
@@ -1,7 +1,6 @@
 import { createServer } from "./server";
 import { log } from "logger";
 
-// eslint-disable-next-line turbo/no-undeclared-env-vars
 const port = process.env.PORT || 5001;
 const server = createServer();
 

--- a/examples/kitchen-sink/turbo.json
+++ b/examples/kitchen-sink/turbo.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "globalDependencies": ["**/.env.*local"],
+  "globalEnv": ["PORT"],
   "pipeline": {
     "build": {
       "outputs": [

--- a/examples/with-docker/apps/api/src/index.ts
+++ b/examples/with-docker/apps/api/src/index.ts
@@ -1,7 +1,6 @@
 import { createServer } from "./server";
 import { log } from "logger";
 
-// eslint-disable-next-line turbo/no-undeclared-env-vars
 const port = process.env.PORT || 3001;
 const server = createServer();
 

--- a/examples/with-docker/turbo.json
+++ b/examples/with-docker/turbo.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "globalDependencies": ["**/.env.*local"],
+  "globalEnv": ["PORT"],
   "pipeline": {
     "build": {
       "outputs": ["dist/**", ".next/**", "public/dist/**"],


### PR DESCRIPTION
We had a couple `eslint-disable-next-line turbo/no-undeclared-env-vars` sneak in somehow! Removing those and adding PORT to the `globalEnv`.