### PR TITLE
Add `dynamic_embed_contents` feature

### DIFF
--- a/crates/turbo-tasks-fs/Cargo.toml
+++ b/crates/turbo-tasks-fs/Cargo.toml
@@ -13,6 +13,9 @@ name = "mod"
 harness = false
 
 [features]
+# Enables dynamic linking (and hot reloading) of embedded files/dirs.
+# A binary built with this option **is not portable**, the directory
+# path will be embedded into the binary.
 dynamic_embed_contents = []
 
 [dependencies]

--- a/crates/turbo-tasks-fs/Cargo.toml
+++ b/crates/turbo-tasks-fs/Cargo.toml
@@ -13,7 +13,7 @@ name = "mod"
 harness = false
 
 [features]
-static_embed = []
+dynamic_embed_contents = []
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/turbo-tasks-fs/Cargo.toml
+++ b/crates/turbo-tasks-fs/Cargo.toml
@@ -12,6 +12,9 @@ bench = false
 name = "mod"
 harness = false
 
+[features]
+static_embed = []
+
 [dependencies]
 anyhow = { workspace = true }
 auto-hash-map = { workspace = true }

--- a/crates/turbo-tasks-fs/src/embed/dir.rs
+++ b/crates/turbo-tasks-fs/src/embed/dir.rs
@@ -36,12 +36,12 @@ macro_rules! embed_directory {
 
         // make sure the types the `include_dir!` proc macro refers to are in scope
         use turbo_tasks_fs::embed::include_dir;
-        #[cfg(debug_assertions)]
+        #[cfg(all(debug_assertions, not(feature = "static_embed")))]
         {
           let path = $path.replace("$CARGO_MANIFEST_DIR", env!("CARGO_MANIFEST_DIR"));
           turbo_tasks_fs::embed::directory_from_relative_path($name, path)
         }
-        #[cfg(not(debug_assertions))]
+        #[cfg(any(not(debug_assertions), feature = "static_embed"))]
         {
            // check that the directory exists at compile time even for debug builds
            static dir: include_dir::Dir<'static> = turbo_tasks_fs::embed::include_dir!($path);

--- a/crates/turbo-tasks-fs/src/embed/dir.rs
+++ b/crates/turbo-tasks-fs/src/embed/dir.rs
@@ -36,12 +36,12 @@ macro_rules! embed_directory {
 
         // make sure the types the `include_dir!` proc macro refers to are in scope
         use turbo_tasks_fs::embed::include_dir;
-        #[cfg(all(debug_assertions, not(feature = "static_embed")))]
+        #[cfg(all(debug_assertions, feature = "dynamic_embed_contents"))]
         {
           let path = $path.replace("$CARGO_MANIFEST_DIR", env!("CARGO_MANIFEST_DIR"));
           turbo_tasks_fs::embed::directory_from_relative_path($name, path)
         }
-        #[cfg(any(not(debug_assertions), feature = "static_embed"))]
+        #[cfg(not(all(debug_assertions, feature = "dynamic_embed_contents")))]
         {
            // check that the directory exists at compile time even for debug builds
            static dir: include_dir::Dir<'static> = turbo_tasks_fs::embed::include_dir!($path);

--- a/crates/turbo-tasks-fs/src/embed/file.rs
+++ b/crates/turbo-tasks-fs/src/embed/file.rs
@@ -32,7 +32,7 @@ pub async fn content_from_str(string: &str) -> Result<FileContentVc> {
 /// Loads a file's content from disk and invalidates on change (debug builds).
 ///
 /// In production, this will embed a file's content into the binary directly.
-#[cfg(debug_assertions)]
+#[cfg(all(debug_assertions, not(feature = "static_embed")))]
 #[macro_export]
 macro_rules! embed_file {
     ($path:expr) => {{
@@ -44,7 +44,7 @@ macro_rules! embed_file {
 }
 
 /// Embeds a file's content into the binary (production).
-#[cfg(not(debug_assertions))]
+#[cfg(any(not(debug_assertions), feature = "static_embed"))]
 #[macro_export]
 macro_rules! embed_file {
     ($path:expr) => {

--- a/crates/turbo-tasks-fs/src/embed/file.rs
+++ b/crates/turbo-tasks-fs/src/embed/file.rs
@@ -32,7 +32,7 @@ pub async fn content_from_str(string: &str) -> Result<FileContentVc> {
 /// Loads a file's content from disk and invalidates on change (debug builds).
 ///
 /// In production, this will embed a file's content into the binary directly.
-#[cfg(all(debug_assertions, not(feature = "static_embed")))]
+#[cfg(all(debug_assertions, feature = "dynamic_embed_contents"))]
 #[macro_export]
 macro_rules! embed_file {
     ($path:expr) => {{
@@ -44,7 +44,7 @@ macro_rules! embed_file {
 }
 
 /// Embeds a file's content into the binary (production).
-#[cfg(any(not(debug_assertions), feature = "static_embed"))]
+#[cfg(not(all(debug_assertions, feature = "dynamic_embed_contents")))]
 #[macro_export]
 macro_rules! embed_file {
     ($path:expr) => {


### PR DESCRIPTION
Based on https://vercel.slack.com/archives/C04KC8A53T7/p1678496137453779?thread_ts=1678468241.013549&cid=C04KC8A53T7, our Next.js test suite is failing because the default test compilation is not portable. This is because the `embed_dir` and `embed_file` statically link the directory path into the binary, but do not statically embed the contents. If this same binary is executed on another machine that doesn't follow the exact same directory structure, it'll fail to embed the internal assets.