### PR TITLE
fix(examples): update kitchen-sink dev task

### DIFF
--- a/examples/kitchen-sink/turbo.json
+++ b/examples/kitchen-sink/turbo.json
@@ -21,6 +21,7 @@
       "dependsOn": ["^build"]
     },
     "dev": {
+      "dependsOn": ["^build"],
       "cache": false,
       "persistent": true
     },


### PR DESCRIPTION
### Description

When running `dev` before running a `build`, the packages won't be built when the apps needed them.

This fixes this by adding:
`"dependsOn": ["^build"]` on `dev` to enforce the correct `build` order _first_ (to make sure the `dev` script can run successfully every time), and then running `dev` to kickoff the watch processes in each workspace

### Testing Instructions

`pnpm dev`