### PR TITLE
feat(turbopack_ecmascript): support legacy decorators transform

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5004,6 +5004,7 @@ dependencies = [
  "swc_ecma_quote_macros",
  "swc_ecma_transforms_base",
  "swc_ecma_transforms_module",
+ "swc_ecma_transforms_proposal",
  "swc_ecma_transforms_react",
  "swc_ecma_transforms_typescript",
  "swc_ecma_utils",

--- a/crates/turbopack-ecmascript/Cargo.toml
+++ b/crates/turbopack-ecmascript/Cargo.toml
@@ -49,6 +49,7 @@ swc_core = { workspace = true, features = [
   "ecma_transforms_module",
   "ecma_transforms_react",
   "ecma_transforms_typescript",
+  "ecma_transforms_proposal",
   "ecma_quote",
   "ecma_visit",
   "ecma_visit_path",

--- a/crates/turbopack-ecmascript/src/transform/mod.rs
+++ b/crates/turbopack-ecmascript/src/transform/mod.rs
@@ -42,6 +42,14 @@ pub enum EcmascriptInputTransform {
         #[serde(default)]
         use_define_for_class_fields: bool,
     },
+    Decorators {
+        #[serde(default)]
+        is_legacy: bool,
+        #[serde(default)]
+        is_ecma: bool,
+        #[serde(default)]
+        emit_decorators_metadata: bool,
+    },
 }
 
 /// The CustomTransformer trait allows you to implement your own custom SWC
@@ -192,6 +200,13 @@ impl EcmascriptInputTransform {
                     ..Default::default()
                 };
                 program.visit_mut_with(&mut strip_with_config(config, top_level_mark));
+            }
+            EcmascriptInputTransform::Decorators {
+                is_legacy,
+                is_ecma,
+                emit_decorators_metadata,
+            } => {
+                unimplemented!("a")
             }
             EcmascriptInputTransform::ClientDirective(transition_name) => {
                 let transition_name = &*transition_name.await?;

--- a/crates/turbopack-ecmascript/src/transform/mod.rs
+++ b/crates/turbopack-ecmascript/src/transform/mod.rs
@@ -211,13 +211,16 @@ impl EcmascriptInputTransform {
             } => {
                 use swc_core::ecma::transforms::proposal::decorators::{decorators, Config};
                 let config = Config {
-                    legacy: is_legacy,
-                    emit_metadata: emit_decorators_metadata,
-                    use_define_for_class_fields,
+                    legacy: *is_legacy,
+                    emit_metadata: *emit_decorators_metadata,
+                    use_define_for_class_fields: *use_define_for_class_fields,
                 };
 
                 let p = std::mem::replace(program, Program::Module(Module::dummy()));
-                *program = p.fold_with(&mut decorators(config));
+                *program = p.fold_with(&mut chain!(
+                    decorators(config),
+                    inject_helpers(unresolved_mark)
+                ));
             }
             EcmascriptInputTransform::ClientDirective(transition_name) => {
                 let transition_name = &*transition_name.await?;

--- a/crates/turbopack-ecmascript/src/transform/mod.rs
+++ b/crates/turbopack-ecmascript/src/transform/mod.rs
@@ -205,11 +205,19 @@ impl EcmascriptInputTransform {
             }
             EcmascriptInputTransform::Decorators {
                 is_legacy,
-                is_ecma,
+                is_ecma: _,
                 emit_decorators_metadata,
                 use_define_for_class_fields,
             } => {
-                unimplemented!("a")
+                use swc_core::ecma::transforms::proposal::decorators::{decorators, Config};
+                let config = Config {
+                    legacy: is_legacy,
+                    emit_metadata: emit_decorators_metadata,
+                    use_define_for_class_fields,
+                };
+
+                let p = std::mem::replace(program, Program::Module(Module::dummy()));
+                *program = p.fold_with(&mut decorators(config));
             }
             EcmascriptInputTransform::ClientDirective(transition_name) => {
                 let transition_name = &*transition_name.await?;

--- a/crates/turbopack-ecmascript/src/transform/mod.rs
+++ b/crates/turbopack-ecmascript/src/transform/mod.rs
@@ -49,6 +49,8 @@ pub enum EcmascriptInputTransform {
         is_ecma: bool,
         #[serde(default)]
         emit_decorators_metadata: bool,
+        #[serde(default)]
+        use_define_for_class_fields: bool,
     },
 }
 
@@ -205,6 +207,7 @@ impl EcmascriptInputTransform {
                 is_legacy,
                 is_ecma,
                 emit_decorators_metadata,
+                use_define_for_class_fields,
             } => {
                 unimplemented!("a")
             }

--- a/crates/turbopack/src/module_options/mod.rs
+++ b/crates/turbopack/src/module_options/mod.rs
@@ -126,6 +126,7 @@ impl ModuleOptionsVc {
                     is_legacy: kind == &DecoratorsKind::Legacy,
                     is_ecma: kind == &DecoratorsKind::Ecma,
                     emit_decorators_metadata: options.emit_decorators_metadata,
+                    use_define_for_class_fields: options.use_define_for_class_fields,
                 })
         } else {
             None

--- a/crates/turbopack/src/module_options/module_options_context.rs
+++ b/crates/turbopack/src/module_options/module_options_context.rs
@@ -50,6 +50,7 @@ pub struct DecoratorsOptions {
     /// ref: https://github.com/swc-project/swc/blob/d4ebb5e6efbed0758f25e46e8f74d7c47ec6cb8f/crates/swc_ecma_parser/src/lib.rs#L327
     /// [TODO]: this option is not actively being used currently.
     pub decorators_before_export: bool,
+    pub use_define_for_class_fields: bool,
 }
 
 #[turbo_tasks::value_impl]

--- a/crates/turbopack/src/module_options/module_options_context.rs
+++ b/crates/turbopack/src/module_options/module_options_context.rs
@@ -24,6 +24,48 @@ pub struct WebpackLoadersOptions {
     pub placeholder_for_future_extensions: (),
 }
 
+/// The kind of decorators transform to use.
+/// [TODO]: might need bikeshed for the name (Ecma)
+#[derive(Clone, PartialEq, Eq, Debug, TraceRawVcs, Serialize, Deserialize)]
+pub enum DecoratorsKind {
+    Legacy,
+    Ecma,
+}
+
+/// Configuration options for the decorators transform.
+/// This is not part of Typescript transform: while there are typescript
+/// specific transforms (legay decorators), there is an ecma decorator transform
+/// as well for the JS.
+#[turbo_tasks::value(shared)]
+#[derive(Default, Clone, Debug)]
+pub struct DecoratorsOptions {
+    pub decorators_kind: Option<DecoratorsKind>,
+    /// Option to control whether to emit decorator metadata.
+    /// (https://www.typescriptlang.org/tsconfig#emitDecoratorMetadata)
+    /// This'll be applied only if `decorators_type` and
+    /// `enable_typescript_transform` is enabled.
+    pub emit_decorators_metadata: bool,
+    /// Mimic babel's `decorators.decoratorsBeforeExport` option.
+    /// This'll be applied only if `decorators_type` is enabled.
+    /// ref: https://github.com/swc-project/swc/blob/d4ebb5e6efbed0758f25e46e8f74d7c47ec6cb8f/crates/swc_ecma_parser/src/lib.rs#L327
+    /// [TODO]: this option is not actively being used currently.
+    pub decorators_before_export: bool,
+}
+
+#[turbo_tasks::value_impl]
+impl DecoratorsOptionsVc {
+    #[turbo_tasks::function]
+    pub fn default() -> Self {
+        Self::cell(Default::default())
+    }
+}
+
+impl Default for DecoratorsOptionsVc {
+    fn default() -> Self {
+        Self::default()
+    }
+}
+
 /// Subset of Typescript options configured via tsconfig.json or jsconfig.json,
 /// which affects the runtime transform output.
 #[turbo_tasks::value(shared)]
@@ -81,6 +123,8 @@ pub struct ModuleOptionsContext {
     pub enable_types: bool,
     #[serde(default)]
     pub enable_typescript_transform: Option<TypescriptTransformOptionsVc>,
+    #[serde(default)]
+    pub decorators: Option<DecoratorsOptionsVc>,
     #[serde(default)]
     pub enable_mdx: bool,
     #[serde(default)]


### PR DESCRIPTION
### Description

Partially implements WEB-667. 

This is second attempt to implement decorators support. The crux is pretty much same as previous changes to support runtime ts config options - PR enables to accept & perform decorators transform. One thing to note is we apply this transform for the ecma / typescript regardless, since decorators can be applied in either cases.

Given next-* is moved to next.js, subsequent changes to next.js is required to close the issue. Will work on once this lands.