### PR TITLE
Run all examples in same Github Action run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -313,7 +313,6 @@ jobs:
     needs: determine_jobs
     if: needs.determine_jobs.outputs.examples == 'true'
     timeout-minutes: 30
-
     strategy:
       fail-fast: false
       matrix:
@@ -322,39 +321,6 @@ jobs:
             runner: ubuntu-latest
           - name: macos
             runner: macos-latest
-        manager: [yarn, npm]
-        example: [with-yarn, with-npm, non-monorepo]
-        include:
-          - os:
-              name: ubuntu
-              runner: ubuntu-latest
-            manager: pnpm
-            example: basic
-          - os:
-              name: macos
-              runner: macos-latest
-            manager: pnpm
-            example: basic
-          - os:
-              name: ubuntu
-              runner: ubuntu-latest
-            manager: pnpm
-            example: kitchen-sink
-          - os:
-              name: macos
-              runner: macos-latest
-            manager: pnpm
-            example: kitchen-sink
-          - os:
-              name: ubuntu
-              runner: ubuntu-latest
-            manager: pnpm
-            example: with-svelte
-          - os:
-              name: macos
-              runner: macos-latest
-            manager: pnpm
-            example: with-svelte
 
     runs-on: ${{ matrix.os.runner }}
     steps:
@@ -404,7 +370,7 @@ jobs:
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
           TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
           TURBO_REMOTE_ONLY: true
-        run: turbo run test --filter="turborepo-tests-examples" -- "${{ matrix.example }}" "${{ matrix.manager }}"
+        run: turbo run test --filter="turborepo-tests-examples"
 
   rust_prepare:
     name: Check rust crates

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,15 @@ Then from the root directory, you can run:
   ```
 - Example tests
   ```bash
-  pnpm test -- --filter=turborepo-tests-examples -- <example-name> <packagemanager>
+  pnpm test -- --filter=turborepo-tests-examples
+  ```
+  You can run these test serially by setting an environment variable
+  ```bash
+  PRYSK_SERIAL=true pnpm test -- --filter=turborepo-tests-examples
+  ```
+  You can run a single example test by passing the example name and a package manager
+  ```bash
+  pnpm test -- --filter=turborepo-tests-examples -- <example-name> <pnpm|yarn|npm>
   ```
 
 ## Debugging Turborepo

--- a/turborepo-tests/examples/run-example.sh
+++ b/turborepo-tests/examples/run-example.sh
@@ -1,19 +1,53 @@
 #!/bin/bash
-
 set -e
 
+#### Usage
+# Run all tests in parallel
+# ./run-example.sh
+#
+#
+# Or run all tests serially
+# ./run-example.sh
+#
+#
+# Run a single test
+# ./run-example.sh <folder-name> <package-manager>
+# Example:
+# ./run-example.sh basic yarn
+
+# Setup prysk
+echo "Setting up virtualenv..."
 python3 -m venv .cram_env
-.cram_env/bin/pip install prysk
+
+echo "Setting up pip..."
+.cram_env/bin/python3 -m pip install --quiet --upgrade pip
+echo "Installing prysk..."
+.cram_env/bin/pip3 install --quiet prysk
 
 export folder=$1
 export pkgManager=$2
 
-TEST_FILE="tests/$2-$1.t"
+# If both arguments were provided, we'll try to run a specific test
+if [ -n "$1" ] && [ -n "$2" ]; then
+  TEST_FILE="tests/$2-$1.t"
+  if [ -f "$TEST_FILE" ]; then
+    echo "Running $TEST_FILE"
+    .cram_env/bin/prysk --shell="$(which bash)" "$TEST_FILE" --keep-tmpdir
+  else
+    echo "Could not find $TEST_FILE"
+    exit 1
+  fi
 
-if [ -f "$TEST_FILE" ]; then
-  echo "Running $TEST_FILE"
-  .cram_env/bin/prysk --shell="$(which bash)" "$TEST_FILE"
+  # exit if both args were provided and we haven't already exited
+  exit
+fi
+
+echo "No arguments provided, running all tests"
+if [ "$PRYSK_SERIAL" == "true" ]; then
+  echo "Running example tests serially"
+  .cram_env/bin/prysk --shell="$(which bash)" "tests"
 else
-  echo "Could not find $TEST_FILE"
-  exit 1
+  echo "Running example tests in parallel"
+  .cram_env/bin/pip3 install --quiet pytest "prysk[pytest-plugin]" pytest-xdist
+  .cram_env/bin/pytest -n auto --prysk-shell="$(which bash)" "tests"
 fi

--- a/turborepo-tests/examples/tests/setup.sh
+++ b/turborepo-tests/examples/tests/setup.sh
@@ -48,4 +48,5 @@ fi
 # Delete .git directory if it's there, we'll set up a new git repo
 [ ! -d .git ] || rm -rf .git
 
-"$MONOREPO_ROOT_DIR/turborepo-tests/helpers/setup_git.sh" "${TARGET_DIR}"
+# Second arg passed is false, which will skip the npm install in setup_git.sh
+"$MONOREPO_ROOT_DIR/turborepo-tests/helpers/setup_git.sh" "${TARGET_DIR}" "false"

--- a/turborepo-tests/examples/tests/yarn-with-npm.t
+++ b/turborepo-tests/examples/tests/yarn-with-npm.t
@@ -1,5 +1,5 @@
   $ . ${TESTDIR}/setup.sh with-npm yarn
 # run twice and make sure it works
-  $ yarn build lint > /dev/null 2>&1
-  $ yarn build lint > /dev/null 2>&1
+  $ yarn turbo build lint > /dev/null 2>&1
+  $ yarn turbo build lint > /dev/null 2>&1
   $ git diff

--- a/turborepo-tests/helpers/setup_git.sh
+++ b/turborepo-tests/helpers/setup_git.sh
@@ -1,11 +1,19 @@
 #!/usr/bin/env bash
 
 TARGET_DIR=$1
+
+# If a second parameter isn't passed, default to true
+SHOULD_INSTALL=${2:-true}
+
 git init ${TARGET_DIR} --quiet --initial-branch=main
 GIT_ARGS="--git-dir=${TARGET_DIR}/.git --work-tree=${TARGET_DIR}"
 git ${GIT_ARGS} config user.email "turbo-test@example.com"
 git ${GIT_ARGS} config user.name "Turbo Test"
 echo "script-shell=$(which bash)" > ${TARGET_DIR}/.npmrc
-npm --prefix=${TARGET_DIR} install --silent
+
+if [ $SHOULD_INSTALL == "true" ]; then
+  npm --prefix=${TARGET_DIR} install --silent
+fi
+
 git ${GIT_ARGS} add .
 git ${GIT_ARGS} commit -m "Initial" --quiet


### PR DESCRIPTION
Compiling turbo is the slowest part of running these tests in CI, so instead of doing it 18 times, we can do it once and run the tests all together. We can also parallelize at the test level instead.

Anecdotally, 

**Before**:
Each CLI example took ~10m (x18 jobs). Expand the `test` workflow here in this example: https://github.com/vercel/turbo/pull/4000/checks

**After this**
All `example_tests/` also took 10m23s, but only 2 jobs run. The actual test time is a little bit larger, but since the bulk of the time for the job is building Turbo, I think this is a win. Expand the `test` workflow here: https://github.com/vercel/turbo/pull/4190/checks

## Parallalization

```bash
hyperfine -r=3 \
    --show-output --ignore-failure \
    --export-markdown=turbo-example-tests.md  \
    'pnpm run run-example' 'PARALLEL=true pnpm run run-example'
```

(I benchmarked both by enabling `PARALLEL=true`, but in this PR, only the parallel version is available)

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `pnpm run run-example` | 145.596 ± 0.406 | 145.128 | 145.854 | 2.07 ± 0.02 |
| `PARALLEL=true pnpm run run-example` | 70.198 ± 0.644 | 69.507 | 70.780 | 1.00 |