### PR TITLE
gracefully handle ctrlc on windows by proactively the killing go process

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1211,6 +1211,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbcf33c2a618cbe41ee43ae6e9f2e48368cd9f9db2896f10167d8d762679f639"
+dependencies = [
+ "nix",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "curl"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3121,6 +3131,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
+dependencies = [
+ "bitflags",
+ "cfg-if 1.0.0",
+ "libc",
+ "static_assertions",
+]
+
+[[package]]
 name = "node-file-trace"
 version = "0.1.0"
 dependencies = [
@@ -4531,6 +4553,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "shared_child"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0d94659ad3c2137fef23ae75b03d5241d633f8acded53d672decfa0e6e0caef"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -6280,6 +6312,7 @@ dependencies = [
  "build-target",
  "clap 4.1.8",
  "clap_complete",
+ "ctrlc",
  "dunce",
  "itertools",
  "log",
@@ -6288,6 +6321,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "shared_child",
  "tiny-gradient",
  "turborepo-lib",
 ]

--- a/crates/turborepo/Cargo.toml
+++ b/crates/turborepo/Cargo.toml
@@ -26,11 +26,13 @@ pretty_assertions = { workspace = true }
 anyhow = { workspace = true, features = ["backtrace"] }
 clap = { workspace = true, features = ["derive"] }
 clap_complete = { workspace = true }
+ctrlc = { version = "3.2.5", features = ["termination"] }
 dunce = { workspace = true }
 log = { workspace = true }
 predicates = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
+shared_child = "1.0.0"
 tiny-gradient = { workspace = true }
 turborepo-lib = { workspace = true }

--- a/crates/turborepo/src/main.rs
+++ b/crates/turborepo/src/main.rs
@@ -43,14 +43,23 @@ fn run_go_binary(args: Args) -> Result<i32> {
 
     let serialized_args = serde_json::to_string(&args)?;
     trace!("Invoking go binary with {}", serialized_args);
-    let mut command = process::Command::new(go_binary_path)
+    let mut command = process::Command::new(go_binary_path);
+    command
         .arg(serialized_args)
         .stdout(Stdio::inherit())
-        .stderr(Stdio::inherit())
-        .spawn()
-        .expect("Failed to execute turbo.");
+        .stderr(Stdio::inherit());
 
-    let exit_code = command.wait()?.code().unwrap_or(2);
+    let shared_child = shared_child::SharedChild::spawn(&mut command).unwrap();
+    let child_arc = std::sync::Arc::new(shared_child);
+
+    let child_arc_clone = child_arc.clone();
+    ctrlc::set_handler(move || {
+        // we are quiting anyways so just ignore
+        child_arc_clone.kill().ok().unwrap();
+    })
+    .expect("handler set");
+
+    let exit_code = child_arc.wait()?.code().unwrap_or(2);
 
     Ok(exit_code)
 }


### PR DESCRIPTION
### Description

Closes https://github.com/vercel/turbo/issues/3427

An issue was introduced on windows by the go binary approach where on certain repos the go daemon process would not be killed correctly and hang. This fixes that issue by registering a ctrl-c handler

### Testing Instructions

It is recommended that you download the kitchen-sink example on a windows machine. Start the daemon (the size of the repo seems to have an impact) and quit it. Before this change two ctrl-C handlers would fight for attention and the terminal would become unusable. After, one appears which you can dismiss with Y and then enter.
