### PR TITLE
feat(ecmascript): support jsximport/runtime options

### DIFF
--- a/crates/turbopack-tests/tests/snapshot.rs
+++ b/crates/turbopack-tests/tests/snapshot.rs
@@ -20,7 +20,7 @@ use turbo_tasks_memory::MemoryBackend;
 use turbopack::{
     condition::ContextCondition,
     ecmascript::{chunk::EcmascriptChunkPlaceablesVc, EcmascriptModuleAssetVc},
-    module_options::ModuleOptionsContext,
+    module_options::{JsxTransformOptions, JsxTransformOptionsVc, ModuleOptionsContext},
     resolve_options_context::ResolveOptionsContext,
     transition::TransitionsByNameVc,
     ModuleAssetContextVc,
@@ -191,7 +191,9 @@ async fn run_test(resource: &str) -> Result<FileSystemPathVc> {
         TransitionsByNameVc::cell(HashMap::new()),
         compile_time_info,
         ModuleOptionsContext {
-            enable_jsx: true,
+            enable_jsx: Some(JsxTransformOptionsVc::cell(JsxTransformOptions {
+                ..Default::default()
+            })),
             enable_emotion: true,
             enable_styled_components: true,
             preset_env_versions: Some(env),

--- a/crates/turbopack/src/module_options/mod.rs
+++ b/crates/turbopack/src/module_options/mod.rs
@@ -6,6 +6,7 @@ use anyhow::{Context, Result};
 pub use module_options_context::*;
 pub use module_rule::*;
 pub use rule_condition::*;
+use turbo_tasks::primitives::OptionStringVc;
 use turbo_tasks_fs::FileSystemPathVc;
 use turbopack_core::{
     reference_type::{ReferenceType, UrlReferenceSubType},
@@ -97,9 +98,12 @@ impl ModuleOptionsVc {
         if enable_styled_components {
             transforms.push(EcmascriptInputTransform::StyledComponents)
         }
-        if enable_jsx {
+        if let Some(enable_jsx) = enable_jsx {
+            let jsx = enable_jsx.await?;
             transforms.push(EcmascriptInputTransform::React {
                 refresh: enable_react_refresh,
+                import_source: OptionStringVc::cell(jsx.import_source.clone()),
+                runtime: OptionStringVc::cell(jsx.runtime.clone()),
             });
         }
 

--- a/crates/turbopack/src/module_options/module_options_context.rs
+++ b/crates/turbopack/src/module_options/module_options_context.rs
@@ -60,11 +60,19 @@ impl WebpackLoadersOptions {
     }
 }
 
+// [TODO]: should enabled_react_refresh belong to this options?
+#[turbo_tasks::value(shared)]
+#[derive(Default, Clone, Debug)]
+pub struct JsxTransformOptions {
+    pub import_source: Option<String>,
+    pub runtime: Option<String>,
+}
+
 #[turbo_tasks::value(shared)]
 #[derive(Default, Clone)]
 pub struct ModuleOptionsContext {
     #[serde(default)]
-    pub enable_jsx: bool,
+    pub enable_jsx: Option<JsxTransformOptionsVc>,
     #[serde(default)]
     pub enable_emotion: bool,
     #[serde(default)]


### PR DESCRIPTION
### Description

First part of WEB-719 implementation. PR expands enable_jsx option to accept few more configuration point to jsx transforms, mainly its import source. We'll likely to expand options more in the future.

One thing I noted in the code but didn't make change is `enable_react_refresh`, if it needs to be under the jsx option or should be independent. Given react_refresh only should be enabled when jsx is enabled, for me it makes more sense to move it.