### PR TITLE
Throw an error when a task graph cannot run to completion.

### DIFF
--- a/cli/integration_tests/composable_config/composing-persistent.t
+++ b/cli/integration_tests/composable_config/composing-persistent.t
@@ -11,9 +11,9 @@ This test covers:
 # persistent-task-1-parent dependsOn persistent-task-1
 # persistent-task-1 is persistent:true in the root workspace, and does NOT get overriden in the workspace
   $ ${TURBO} run persistent-task-1-parent --filter=persistent
-   ERROR  run failed: error preparing engine: Invalid persistent task dependency:
+   ERROR  run failed: error preparing engine: Invalid persistent task configuration:
   "persistent#persistent-task-1" is a persistent task, "persistent#persistent-task-1-parent" cannot depend on it
-  Turbo error: error preparing engine: Invalid persistent task dependency:
+  Turbo error: error preparing engine: Invalid persistent task configuration:
   "persistent#persistent-task-1" is a persistent task, "persistent#persistent-task-1-parent" cannot depend on it
   [1]
 
@@ -44,17 +44,17 @@ This test covers:
 # persistent-task-3 is persistent:true in the root workspace
 # persistent-task-3 is defined in workspace, but does NOT have the persistent flag
   $ ${TURBO} run persistent-task-3-parent --filter=persistent
-   ERROR  run failed: error preparing engine: Invalid persistent task dependency:
+   ERROR  run failed: error preparing engine: Invalid persistent task configuration:
   "persistent#persistent-task-3" is a persistent task, "persistent#persistent-task-3-parent" cannot depend on it
-  Turbo error: error preparing engine: Invalid persistent task dependency:
+  Turbo error: error preparing engine: Invalid persistent task configuration:
   "persistent#persistent-task-3" is a persistent task, "persistent#persistent-task-3-parent" cannot depend on it
   [1]
 
 # persistent-task-4-parent dependsOn persistent-task-4
 # persistent-task-4 has no config in the root workspace, and is set to true in the workspace
   $ ${TURBO} run persistent-task-4-parent --filter=persistent
-   ERROR  run failed: error preparing engine: Invalid persistent task dependency:
+   ERROR  run failed: error preparing engine: Invalid persistent task configuration:
   "persistent#persistent-task-4" is a persistent task, "persistent#persistent-task-4-parent" cannot depend on it
-  Turbo error: error preparing engine: Invalid persistent task dependency:
+  Turbo error: error preparing engine: Invalid persistent task configuration:
   "persistent#persistent-task-4" is a persistent task, "persistent#persistent-task-4-parent" cannot depend on it
   [1]

--- a/cli/integration_tests/persistent_dependencies/10-too-many/apps/one/package.json
+++ b/cli/integration_tests/persistent_dependencies/10-too-many/apps/one/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "one",
+  "scripts": {
+    "build": "echo build"
+  }
+}

--- a/cli/integration_tests/persistent_dependencies/10-too-many/apps/two/package.json
+++ b/cli/integration_tests/persistent_dependencies/10-too-many/apps/two/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "two",
+  "scripts": {
+    "build": "echo build"
+  }
+}

--- a/cli/integration_tests/persistent_dependencies/10-too-many/package.json
+++ b/cli/integration_tests/persistent_dependencies/10-too-many/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "10-too-many",
+  "workspaces": [
+    "apps/*"
+  ]
+}

--- a/cli/integration_tests/persistent_dependencies/10-too-many/turbo.json
+++ b/cli/integration_tests/persistent_dependencies/10-too-many/turbo.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "pipeline": {
+    "build": {
+      "persistent": true
+    }
+  }
+}

--- a/cli/integration_tests/persistent_dependencies/persistent-1-topological.t
+++ b/cli/integration_tests/persistent_dependencies/persistent-1-topological.t
@@ -14,8 +14,8 @@
 // app-a#dev
 // └── pkg-a#dev
   $ ${TURBO} run dev
-   ERROR  run failed: error preparing engine: Invalid persistent task dependency:
+   ERROR  run failed: error preparing engine: Invalid persistent task configuration:
   "pkg-a#dev" is a persistent task, "app-a#dev" cannot depend on it
-  Turbo error: error preparing engine: Invalid persistent task dependency:
+  Turbo error: error preparing engine: Invalid persistent task configuration:
   "pkg-a#dev" is a persistent task, "app-a#dev" cannot depend on it
   [1]

--- a/cli/integration_tests/persistent_dependencies/persistent-10-too-many.t
+++ b/cli/integration_tests/persistent_dependencies/persistent-10-too-many.t
@@ -1,0 +1,10 @@
+# Setup
+  $ . ${TESTDIR}/../setup.sh
+  $ . ${TESTDIR}/setup.sh $(pwd) 10-too-many
+
+  $ ${TURBO} run build --concurrency=1
+   ERROR  run failed: error preparing engine: Invalid persistent task configuration:
+  You have 2 persistent tasks but `turbo` is configured for concurrency of 1. Set --concurrency to at least 3
+  Turbo error: error preparing engine: Invalid persistent task configuration:
+  You have 2 persistent tasks but `turbo` is configured for concurrency of 1. Set --concurrency to at least 3
+  [1]

--- a/cli/integration_tests/persistent_dependencies/persistent-10-too-many.t
+++ b/cli/integration_tests/persistent_dependencies/persistent-10-too-many.t
@@ -8,3 +8,10 @@
   Turbo error: error preparing engine: Invalid persistent task configuration:
   You have 2 persistent tasks but `turbo` is configured for concurrency of 1. Set --concurrency to at least 3
   [1]
+
+  $ ${TURBO} run build --concurrency=2
+   ERROR  run failed: error preparing engine: Invalid persistent task configuration:
+  You have 2 persistent tasks but `turbo` is configured for concurrency of 2. Set --concurrency to at least 3
+  Turbo error: error preparing engine: Invalid persistent task configuration:
+  You have 2 persistent tasks but `turbo` is configured for concurrency of 2. Set --concurrency to at least 3
+  [1]

--- a/cli/integration_tests/persistent_dependencies/persistent-2-same-workspace.t
+++ b/cli/integration_tests/persistent_dependencies/persistent-2-same-workspace.t
@@ -14,8 +14,8 @@
 // └── app-a#dev
 //
   $ ${TURBO} run build
-   ERROR  run failed: error preparing engine: Invalid persistent task dependency:
+   ERROR  run failed: error preparing engine: Invalid persistent task configuration:
   "app-a#dev" is a persistent task, "app-a#build" cannot depend on it
-  Turbo error: error preparing engine: Invalid persistent task dependency:
+  Turbo error: error preparing engine: Invalid persistent task configuration:
   "app-a#dev" is a persistent task, "app-a#build" cannot depend on it
   [1]

--- a/cli/integration_tests/persistent_dependencies/persistent-3-workspace-specific.t
+++ b/cli/integration_tests/persistent_dependencies/persistent-3-workspace-specific.t
@@ -18,8 +18,8 @@
 #
 # The regex match is liberal, because the build task from either workspace can throw the error
   $ ${TURBO} run build
-   ERROR  run failed: error preparing engine: Invalid persistent task dependency:
+   ERROR  run failed: error preparing engine: Invalid persistent task configuration:
   "pkg-a#dev" is a persistent task, .*-a#build" cannot depend on it (re)
-  Turbo error: error preparing engine: Invalid persistent task dependency:
+  Turbo error: error preparing engine: Invalid persistent task configuration:
   "pkg-a#dev" is a persistent task, .*-a#build" cannot depend on it (re)
   [1]

--- a/cli/integration_tests/persistent_dependencies/persistent-4-cross-workspace.t
+++ b/cli/integration_tests/persistent_dependencies/persistent-4-cross-workspace.t
@@ -8,8 +8,8 @@
 # app-a#dev
 # └── pkg-a#dev
   $ ${TURBO} run dev
-   ERROR  run failed: error preparing engine: Invalid persistent task dependency:
+   ERROR  run failed: error preparing engine: Invalid persistent task configuration:
   "pkg-a#dev" is a persistent task, "app-a#dev" cannot depend on it
-  Turbo error: error preparing engine: Invalid persistent task dependency:
+  Turbo error: error preparing engine: Invalid persistent task configuration:
   "pkg-a#dev" is a persistent task, "app-a#dev" cannot depend on it
   [1]

--- a/cli/integration_tests/persistent_dependencies/persistent-5-root-workspace.t
+++ b/cli/integration_tests/persistent_dependencies/persistent-5-root-workspace.t
@@ -14,8 +14,8 @@
 # └── //#dev
 #
   $ ${TURBO} run build
-   ERROR  run failed: error preparing engine: Invalid persistent task dependency:
+   ERROR  run failed: error preparing engine: Invalid persistent task configuration:
   "//#dev" is a persistent task, "app-a#build" cannot depend on it
-  Turbo error: error preparing engine: Invalid persistent task dependency:
+  Turbo error: error preparing engine: Invalid persistent task configuration:
   "//#dev" is a persistent task, "app-a#build" cannot depend on it
   [1]

--- a/cli/integration_tests/persistent_dependencies/persistent-7-topological-nested.t
+++ b/cli/integration_tests/persistent_dependencies/persistent-7-topological-nested.t
@@ -21,8 +21,8 @@
 # error message should say. Leaving as-is so we don't have to implement special casing logic to handle
 # this case.
   $ ${TURBO} run dev
-   ERROR  run failed: error preparing engine: Invalid persistent task dependency:
+   ERROR  run failed: error preparing engine: Invalid persistent task configuration:
   "pkg-b#dev" is a persistent task, "pkg-a#dev" cannot depend on it
-  Turbo error: error preparing engine: Invalid persistent task dependency:
+  Turbo error: error preparing engine: Invalid persistent task configuration:
   "pkg-b#dev" is a persistent task, "pkg-a#dev" cannot depend on it
   [1]

--- a/cli/integration_tests/persistent_dependencies/persistent-8-topological-with-extra.t
+++ b/cli/integration_tests/persistent_dependencies/persistent-8-topological-with-extra.t
@@ -20,8 +20,8 @@
 // 		 └── workspace-c#build
 // 		 		 └── workspace-z#dev	// this one is persistent
   $ ${TURBO} run build
-   ERROR  run failed: error preparing engine: Invalid persistent task dependency:
+   ERROR  run failed: error preparing engine: Invalid persistent task configuration:
   "pkg-z#dev" is a persistent task, "pkg-b#build" cannot depend on it
-  Turbo error: error preparing engine: Invalid persistent task dependency:
+  Turbo error: error preparing engine: Invalid persistent task configuration:
   "pkg-z#dev" is a persistent task, "pkg-b#build" cannot depend on it
   [1]

--- a/cli/integration_tests/persistent_dependencies/persistent-9-cross-workspace-nested.t
+++ b/cli/integration_tests/persistent_dependencies/persistent-9-cross-workspace-nested.t
@@ -13,8 +13,8 @@
 // 		 		 └── workspace-z#dev // this one is persistent
 //
   $ ${TURBO} run build
-   ERROR  run failed: error preparing engine: Invalid persistent task dependency:
+   ERROR  run failed: error preparing engine: Invalid persistent task configuration:
   "app-z#dev" is a persistent task, "app-c#build" cannot depend on it
-  Turbo error: error preparing engine: Invalid persistent task dependency:
+  Turbo error: error preparing engine: Invalid persistent task configuration:
   "app-z#dev" is a persistent task, "app-c#build" cannot depend on it
   [1]

--- a/cli/internal/core/engine.go
+++ b/cli/internal/core/engine.go
@@ -466,7 +466,7 @@ func (e *Engine) ValidatePersistentDependencies(graph *graph.CompleteGraph, conc
 
 	if validationError != nil {
 		return validationError
-	} else if persistentCount > concurrency {
+	} else if persistentCount >= concurrency {
 		return fmt.Errorf("You have %v persistent tasks but `turbo` is configured for concurrency of %v. Set --concurrency to at least %v", persistentCount, concurrency, persistentCount+1)
 	}
 

--- a/cli/internal/core/engine.go
+++ b/cli/internal/core/engine.go
@@ -389,8 +389,9 @@ func (e *Engine) AddDep(fromTaskID string, toTaskID string) error {
 
 // ValidatePersistentDependencies checks if any task dependsOn persistent tasks and throws
 // an error if that task is actually implemented
-func (e *Engine) ValidatePersistentDependencies(graph *graph.CompleteGraph) error {
+func (e *Engine) ValidatePersistentDependencies(graph *graph.CompleteGraph, concurrency int) error {
 	var validationError error
+	persistentCount := 0
 
 	// Adding in a lock because otherwise walking the graph can introduce a data race
 	// (reproducible with `go test -race`)
@@ -409,6 +410,11 @@ func (e *Engine) ValidatePersistentDependencies(graph *graph.CompleteGraph) erro
 		// up when running tests with the `-race` flag.
 		sema.Acquire()
 		defer sema.Release()
+
+		currentTaskDefinition, currentTaskExists := e.completeGraph.TaskDefinitions[vertexName]
+		if currentTaskExists && currentTaskDefinition.Persistent {
+			persistentCount++
+		}
 
 		currentPackageName, currentTaskName := util.GetPackageTaskFromId(vertexName)
 
@@ -458,8 +464,13 @@ func (e *Engine) ValidatePersistentDependencies(graph *graph.CompleteGraph) erro
 		return fmt.Errorf("Validation failed: %v", err)
 	}
 
-	// May or may not be set (could be nil)
-	return validationError
+	if validationError != nil {
+		return validationError
+	} else if persistentCount > concurrency {
+		return fmt.Errorf("You have %v persistent tasks but `turbo` is configured for concurrency of %v. Set --concurrency to at least %v", persistentCount, concurrency, persistentCount+1)
+	}
+
+	return nil
 }
 
 // getTaskDefinitionChain gets a set of TaskDefinitions that apply to the taskID.

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -450,8 +450,8 @@ func buildTaskGraphEngine(
 	}
 
 	// Check that no tasks would be blocked by a persistent task
-	if err := engine.ValidatePersistentDependencies(g); err != nil {
-		return nil, fmt.Errorf("Invalid persistent task dependency:\n%v", err)
+	if err := engine.ValidatePersistentDependencies(g, rs.Opts.runOpts.concurrency); err != nil {
+		return nil, fmt.Errorf("Invalid persistent task configuration:\n%v", err)
 	}
 
 	return engine, nil


### PR DESCRIPTION
Throw an error if the task graph will never run to completion.

Setting `--concurrency` for the user to N+1 is likely a worse experience by linearizing everything that _isn't_ persistent, this gives the user enough information to tune their invocation.

Fixes #4195