### PR TITLE
fix: Turbo SCM with Windows paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6895,7 +6895,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "rand",
  "static_assertions",
 ]

--- a/crates/turborepo-scm/src/git.rs
+++ b/crates/turborepo-scm/src/git.rs
@@ -370,7 +370,15 @@ mod tests {
             None,
             true,
         )?;
-        assert_eq!(files, HashSet::from(["src/bar.js".to_string()]));
+        #[cfg(not(windows))]
+        {
+            assert_eq!(files, HashSet::from(["src/bar.js".to_string()]));
+        }
+
+        #[cfg(windows)]
+        {
+            assert_eq!(files, HashSet::from(["src\\bar.js".to_string()]));
+        }
 
         commit_file(&repo, Path::new("subdir/src/bar.js"), Some(first_commit))?;
 

--- a/crates/turborepo-scm/src/git.rs
+++ b/crates/turborepo-scm/src/git.rs
@@ -355,6 +355,8 @@ mod tests {
         config.set_str("user.email", "test@example.com")?;
 
         fs::create_dir(repo_root.path().join("subdir"))?;
+        // Create additional nested directory to test that we return a system path
+        // and not a normalized unix path
         fs::create_dir(repo_root.path().join("subdir").join("src"))?;
 
         let file = repo_root.path().join("subdir").join("foo.js");

--- a/crates/turborepo-scm/src/git.rs
+++ b/crates/turborepo-scm/src/git.rs
@@ -355,12 +355,13 @@ mod tests {
         config.set_str("user.email", "test@example.com")?;
 
         fs::create_dir(repo_root.path().join("subdir"))?;
+        fs::create_dir(repo_root.path().join("subdir").join("src"))?;
 
         let file = repo_root.path().join("subdir").join("foo.js");
         fs::write(file, "let z = 0;")?;
         let first_commit = commit_file(&repo, Path::new("subdir/foo.js"), None)?;
 
-        let new_file = repo_root.path().join("subdir").join("bar.js");
+        let new_file = repo_root.path().join("subdir").join("src").join("bar.js");
         fs::write(new_file, "let y = 1;")?;
 
         let files = super::changed_files(
@@ -369,9 +370,9 @@ mod tests {
             None,
             true,
         )?;
-        assert_eq!(files, HashSet::from(["bar.js".to_string()]));
+        assert_eq!(files, HashSet::from(["src/bar.js".to_string()]));
 
-        commit_file(&repo, Path::new("subdir/bar.js"), Some(first_commit))?;
+        commit_file(&repo, Path::new("subdir/src/bar.js"), Some(first_commit))?;
 
         let files = super::changed_files(
             repo_root.path().to_path_buf(),
@@ -383,7 +384,7 @@ mod tests {
             false,
         )?;
 
-        assert_eq!(files, HashSet::from(["bar.js".to_string()]));
+        assert_eq!(files, HashSet::from(["src/bar.js".to_string()]));
 
         Ok(())
     }

--- a/crates/turborepo-scm/src/git.rs
+++ b/crates/turborepo-scm/src/git.rs
@@ -66,8 +66,9 @@ pub fn changed_files(
     Ok(files)
 }
 
-// Gets the system version of both paths by calling `fs_util::canonicalize`,
-// then strips the `monorepo_root` from the `file_path`.
+// Gets the system version of `monorepo_root` and `file_path` by calling
+// `fs_util::canonicalize`, then strips the `monorepo_root` from the
+// `file_path`.
 fn get_stripped_system_file_path(
     repo_root: &ProjectRoot,
     file_path: &Path,

--- a/crates/turborepo-scm/src/git.rs
+++ b/crates/turborepo-scm/src/git.rs
@@ -370,12 +370,12 @@ mod tests {
             None,
             true,
         )?;
-        #[cfg(not(windows))]
+        #[cfg(not(target_os = "windows"))]
         {
             assert_eq!(files, HashSet::from(["src/bar.js".to_string()]));
         }
 
-        #[cfg(windows)]
+        #[cfg(target_os = "windows")]
         {
             assert_eq!(files, HashSet::from(["src\\bar.js".to_string()]));
         }

--- a/crates/turborepo-scm/src/git.rs
+++ b/crates/turborepo-scm/src/git.rs
@@ -370,12 +370,13 @@ mod tests {
             None,
             true,
         )?;
-        #[cfg(not(target_os = "windows"))]
+
+        #[cfg(unix)]
         {
             assert_eq!(files, HashSet::from(["src/bar.js".to_string()]));
         }
 
-        #[cfg(target_os = "windows")]
+        #[cfg(windows)]
         {
             assert_eq!(files, HashSet::from(["src\\bar.js".to_string()]));
         }
@@ -392,7 +393,15 @@ mod tests {
             false,
         )?;
 
-        assert_eq!(files, HashSet::from(["src/bar.js".to_string()]));
+        #[cfg(unix)]
+        {
+            assert_eq!(files, HashSet::from(["src/bar.js".to_string()]));
+        }
+
+        #[cfg(windows)]
+        {
+            assert_eq!(files, HashSet::from(["src\\bar.js".to_string()]));
+        }
 
         Ok(())
     }

--- a/crates/turborepo-scm/src/git.rs
+++ b/crates/turborepo-scm/src/git.rs
@@ -89,8 +89,8 @@ fn add_changed_files_from_unstaged_changes(
             // error if the base path is not a prefix of the original path.
             // However since we're passing a pathspec to `git2` we know that the
             // base path is a prefix of the original path.
-            let project_relative_file_path = ForwardRelativePath::new(file_path)?
-                .strip_prefix(monorepo_root.as_forward_relative_path())?;
+            let project_relative_file_path =
+                ForwardRelativePath::new(file_path)?.strip_prefix(monorepo_root)?;
 
             files.insert(project_relative_file_path.to_string());
         }
@@ -122,12 +122,8 @@ fn add_changed_files_from_commits(
     for delta in diff.deltas() {
         let file = delta.old_file();
         if let Some(path) = file.path() {
-            let path = path.strip_prefix(monorepo_root.as_forward_relative_path().as_path())?;
-            files.insert(
-                path.to_str()
-                    .ok_or_else(|| Error::NonUtf8Path(path.to_path_buf()))?
-                    .to_string(),
-            );
+            let path = ForwardRelativePath::new(path)?.strip_prefix(monorepo_root)?;
+            files.insert(path.to_string());
         }
     }
 

--- a/crates/turborepo-scm/src/git.rs
+++ b/crates/turborepo-scm/src/git.rs
@@ -5,7 +5,10 @@ use std::{
 
 use anyhow::anyhow;
 use git2::{DiffFormat, DiffOptions, Repository};
-use turborepo_paths::{fs_util, project::ProjectRoot, project_relative_path::ProjectRelativePath};
+use turborepo_paths::{
+    forward_relative_path::ForwardRelativePath, fs_util, project::ProjectRoot,
+    project_relative_path::ProjectRelativePath,
+};
 
 use crate::Error;
 
@@ -86,15 +89,10 @@ fn add_changed_files_from_unstaged_changes(
             // error if the base path is not a prefix of the original path.
             // However since we're passing a pathspec to `git2` we know that the
             // base path is a prefix of the original path.
-            let project_relative_file_path =
-                file_path.strip_prefix(monorepo_root.as_forward_relative_path().as_path())?;
+            let project_relative_file_path = ForwardRelativePath::new(file_path)?
+                .strip_prefix(monorepo_root.as_forward_relative_path())?;
 
-            files.insert(
-                project_relative_file_path
-                    .to_str()
-                    .ok_or_else(|| Error::NonUtf8Path(file_path.to_path_buf()))?
-                    .to_string(),
-            );
+            files.insert(project_relative_file_path.to_string());
         }
     }
 


### PR DESCRIPTION
### Description

Fixes a bug where turborepo-scm would return unix style paths on Windows.

### Testing Instructions

`test_changed_files_with_subdir_as_monorepo_root` is modified to test that the path returned is a system path
