### PR TITLE
Make the script error ordering deterministic.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,5 +24,5 @@
   "rust-analyzer.linkedProjects": ["nextpack/Cargo.toml"],
   "search.exclude": {
     "crates/turbopack-tests/tests/snapshot/**": true
-  },
+  }
 }

--- a/cli/integration_tests/monorepo_one_script_error/monorepo/apps/my-app/package.json
+++ b/cli/integration_tests/monorepo_one_script_error/monorepo/apps/my-app/package.json
@@ -2,6 +2,6 @@
   "name": "my-app",
   "scripts": {
     "okay": "echo 'working'",
-    "error": "echo 'intentionally failing' && exit 2"
+    "error": "exit 2"
   }
 }

--- a/cli/integration_tests/monorepo_one_script_error/run.t
+++ b/cli/integration_tests/monorepo_one_script_error/run.t
@@ -8,18 +8,17 @@ Note that npm reports any failed script as exit code 1, even though we "exit 2"
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running error in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:okay: cache miss, executing 5eaa36f5c1d36f8d
+  my-app:okay: cache miss, executing 32478bc54ccf0adb
   my-app:okay: 
   my-app:okay: > okay
   my-app:okay: > echo 'working'
   my-app:okay: 
   my-app:okay: working
-  my-app:error: cache miss, executing 19a93de426a177b1
+  my-app:error: cache miss, executing 1c682ef8cade4542
   my-app:error: 
   my-app:error: > error
-  my-app:error: > echo 'intentionally failing' && exit 2
+  my-app:error: > exit 2
   my-app:error: 
-  my-app:error: intentionally failing
   my-app:error: npm ERR! Lifecycle script `error` failed with error: 
   my-app:error: npm ERR! Error: command failed 
   my-app:error: npm ERR!   in workspace: my-app 
@@ -39,18 +38,17 @@ Make sure error isn't cached
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running error in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:okay: cache hit, replaying output 5eaa36f5c1d36f8d
+  my-app:okay: cache hit, replaying output 32478bc54ccf0adb
   my-app:okay: 
   my-app:okay: > okay
   my-app:okay: > echo 'working'
   my-app:okay: 
   my-app:okay: working
-  my-app:error: cache miss, executing 19a93de426a177b1
+  my-app:error: cache miss, executing 1c682ef8cade4542
   my-app:error: 
   my-app:error: > error
-  my-app:error: > echo 'intentionally failing' && exit 2
+  my-app:error: > exit 2
   my-app:error: 
-  my-app:error: intentionally failing
   my-app:error: npm ERR! Lifecycle script `error` failed with error: 
   my-app:error: npm ERR! Error: command failed 
   my-app:error: npm ERR!   in workspace: my-app 


### PR DESCRIPTION
`stdout` and `stdin` don't necessarily provide guarantees in terms of ordering. We're looking at both in the logs. To ensure determinism (because this isn't what this test is testing), simply remove the write to `stdout`.