### PR TITLE
fix test paths on windows

### DIFF
--- a/crates/turbopack-tests/tests/snapshot.rs
+++ b/crates/turbopack-tests/tests/snapshot.rs
@@ -90,6 +90,7 @@ fn default_entry() -> String {
 
 #[testing::fixture("tests/snapshot/*/*/")]
 fn test(resource: PathBuf) {
+    let resource = canonicalize(resource).unwrap();
     // Separating this into a different function fixes my IDE's types for some
     // reason...
     run(resource).unwrap();


### PR DESCRIPTION
### Description

windows has `\\?\` magic
