### PR TITLE
Drop deprecated experimental go flag

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,9 +7,6 @@
   ],
   "eslint.packageManager": "pnpm",
   "debug.javascript.unmapMissingSources": true,
-  "gopls": {
-    "experimentalWorkspaceModule": true
-  },
   "go.lintTool": "golangci-lint",
   "files.associations": {
     "libturbo.h": "c",
@@ -24,5 +21,5 @@
   "rust-analyzer.linkedProjects": ["nextpack/Cargo.toml"],
   "search.exclude": {
     "crates/turbopack-tests/tests/snapshot/**": true
-  },
+  }
 }


### PR DESCRIPTION
### Description

`Gopls` no longer supports or requires `experimentalWorkspaceModule`. The feature (which we don't use) is now built in by default

### Testing Instructions

Open VSCode w/ Go extension, verify no deprecation warning