### PR TITLE
docs: Document common question around turborepo-ffi

### DIFF
--- a/crates/turborepo-ffi/README.md
+++ b/crates/turborepo-ffi/README.md
@@ -1,0 +1,24 @@
+# Turborepo FFI
+
+This crate provides a C-compatible FFI for dependencies that are being
+ported from Go to Rust. The dependencies use protobuf to send and receive
+values from Go.
+
+The crate produces a staticlib which is then linked to the Go code
+in `cli/internal/ffi/ffi.go` using CGO.
+
+## Common Questions
+
+- Why do I get linker errors in Go when I use this crate?
+  Can't I link C dependencies in Rust?
+
+Because this crate produces a staticlib, it cannot link C dependencies.
+This is because a staticlib is an _input_ to the linker and therefore
+cannot bundle its C dependencies. Instead, you need to pass the libraries
+to the CGO linker. You can do so by editing `cli/internal/ffi/ffi.go`,
+where the linker flags are defined.
+
+To find the libraries needed to link against, you can use rustc's `native-static-libs`
+feature to print them.
+
+For more information, read [here](https://users.rust-lang.org/t/solved-statically-linking-rust-library-yields-undefined-references/53815/5)


### PR DESCRIPTION
### Description

A few people have asked about why we get linker errors on the Go side when they come from the Rust code. I wrote up a small README explaining why and linking to the relevant forum post

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
