### PR TITLE
chore(turborepo-lib): use compile error for feature validation

### DIFF
--- a/crates/turborepo-lib/build.rs
+++ b/crates/turborepo-lib/build.rs
@@ -1,13 +1,4 @@
-#[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
-fn check_tls_config() {}
-#[cfg(not(any(feature = "native-tls", feature = "rustls-tls")))]
-fn check_tls_config() {
-    panic!("You must enable one of the TLS features: native-tls or rustls-tls");
-}
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    check_tls_config();
-
     let tonic_build_result = tonic_build::configure()
         .build_server(true)
         .file_descriptor_set_path("src/daemon/file_descriptor_set.bin")

--- a/crates/turborepo-lib/src/lib.rs
+++ b/crates/turborepo-lib/src/lib.rs
@@ -54,3 +54,9 @@ pub fn get_version() -> &'static str {
 pub fn main() -> Result<i32, shim::Error> {
     shim::run()
 }
+
+#[cfg(all(feature = "native-tls", feature = "rustls-tls"))]
+compile_error!("You can't enable both the `native-tls` and `rustls-tls` feature.");
+
+#[cfg(all(not(feature = "native-tls"), not(feature = "rustls-tls")))]
+compile_error!("You have to enable one of the TLS features: `native-tls` or `rustls-tls`");


### PR DESCRIPTION
### Description

Makes the TLS feature compile error easier to understand, currently it will tell you the build script failed and you have to look for the panic message.
