### PR TITLE
Always release the current main branch

### DIFF
--- a/.github/workflows/turbopack-nightly-release.yml
+++ b/.github/workflows/turbopack-nightly-release.yml
@@ -13,16 +13,9 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v3
 
-      - name: Get latest commit that passes CI
-        uses: talentpair/last-green-commit-action@d95cfa836b22ef047dd0a8ddb1e6d9567982d702
-        id: green_commit
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Tag nightly
         id: tag_version
         uses: ./.github/actions/turbopack-bump
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          commit_sha: ${{ steps.green_commit.outputs.result }}
           prefix: "turbopack-"


### PR DESCRIPTION
### Description

It's not really helpful that we have to wait for main CI to succeed until we can publish a version.

Also note that the action we used to use is broken anyway: https://github.com/talentpair/last-green-commit-action/issues/277
