### PR TITLE
Filter out summaries of tasks that didn't execute

### DIFF
--- a/cli/integration_tests/basic_monorepo/cache_state.t
+++ b/cli/integration_tests/basic_monorepo/cache_state.t
@@ -4,8 +4,8 @@ Setup
 
 Run a build to get a local cache.
   $ ${TURBO} run build --output-logs=none
-  \xe2\x80\xa2 Packages in scope: my-app, util (esc)
-  \xe2\x80\xa2 Running build in 2 packages (esc)
+  \xe2\x80\xa2 Packages in scope: another, my-app, util (esc)
+  \xe2\x80\xa2 Running build in 3 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
   
    Tasks:    2 successful, 2 total

--- a/cli/integration_tests/basic_monorepo/dry_run.t
+++ b/cli/integration_tests/basic_monorepo/dry_run.t
@@ -9,9 +9,10 @@ Setup
 # The first part of the file is Packages in Scope
   $ cat tmp-1.txt
   Packages in Scope
-  Name   Path          
-  my-app apps/my-app   
-  util   packages/util 
+  Name    Path             
+  another packages/another 
+  my-app  apps/my-app      
+  util    packages/util    
 
 # Part 2 of the logs are Global Hash INputs
   $ cat tmp-2.txt

--- a/cli/integration_tests/basic_monorepo/infer_pkg.t
+++ b/cli/integration_tests/basic_monorepo/infer_pkg.t
@@ -5,6 +5,7 @@ Setup
 Run a dry run
   $ ${TURBO} build --dry=json | jq .packages
   [
+    "another",
     "my-app",
     "util"
   ]
@@ -19,6 +20,7 @@ Run a dry run in a directory
 Ensure we don't infer packages if --cwd is supplied
   $ ${TURBO} build --cwd=../.. --dry=json | jq .packages
   [
+    "another",
     "my-app",
     "util"
   ]

--- a/cli/integration_tests/basic_monorepo/monorepo/packages/another/package.json
+++ b/cli/integration_tests/basic_monorepo/monorepo/packages/another/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "another",
+  "scripts": {}
+}

--- a/cli/integration_tests/basic_monorepo/run.t
+++ b/cli/integration_tests/basic_monorepo/run.t
@@ -29,8 +29,8 @@ Setup
 
 # Bad command
   $ ${TURBO} run something
-  \xe2\x80\xa2 Packages in scope: //, my-app, util (esc)
-  \xe2\x80\xa2 Running something in 3 packages (esc)
+  \xe2\x80\xa2 Packages in scope: //, another, my-app, util (esc)
+  \xe2\x80\xa2 Running something in 4 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
   root task something (turbo run build) looks like it invokes turbo and might cause a loop
   

--- a/cli/integration_tests/basic_monorepo/run_summary.t
+++ b/cli/integration_tests/basic_monorepo/run_summary.t
@@ -43,6 +43,9 @@ Setup
     "apps/my-app/.turbo/turbo-build.log"
   ]
 
+  $ cat $(/bin/ls .turbo/runs/*.json | head -n1) | jq '.tasks | map(select(.taskId == "another#build"))'
+  []
+
 # Without env var, no summary file is generated
   $ rm -rf .turbo/runs
   $ ${TURBO} run build > /dev/null

--- a/cli/internal/run/real_run.go
+++ b/cli/internal/run/real_run.go
@@ -106,9 +106,11 @@ func RealRun(
 		if taskExecutionSummary != nil {
 			taskSummary.ExpandedOutputs = taskHashTracker.GetExpandedOutputs(taskSummary.TaskID)
 			taskSummary.Execution = taskExecutionSummary
+
+			// lock since multiple things to be appending to this array at the same time
 			mu.Lock()
 			taskSummaries = append(taskSummaries, taskSummary)
-			// don't hold the lock while we run ec.exec
+			// not using defer, just release the lock
 			mu.Unlock()
 		}
 

--- a/cli/internal/run/real_run.go
+++ b/cli/internal/run/real_run.go
@@ -94,18 +94,24 @@ func RealRun(
 	taskSummaries := []*runsummary.TaskSummary{}
 	execFunc := func(ctx gocontext.Context, packageTask *nodes.PackageTask, taskSummary *runsummary.TaskSummary) error {
 		deps := engine.TaskGraph.DownEdges(packageTask.TaskID)
-		mu.Lock()
-		taskSummaries = append(taskSummaries, taskSummary)
-		// don't hold the lock while we run ec.exec
-		mu.Unlock()
-
 		// deps here are passed in to calculate the task hash
 		taskExecutionSummary, err := ec.exec(ctx, packageTask, deps)
 		if err != nil {
 			return err
 		}
-		taskSummary.Execution = taskExecutionSummary
-		taskSummary.ExpandedOutputs = taskHashTracker.GetExpandedOutputs(taskSummary.TaskID)
+
+		// taskExecutionSummary will be nil if the task never executed
+		// (i.e. if the workspace didn't implement the script corresponding to the task)
+		// We don't need to collect any of the outputs or execution if the task didn't execute.
+		if taskExecutionSummary != nil {
+			taskSummary.ExpandedOutputs = taskHashTracker.GetExpandedOutputs(taskSummary.TaskID)
+			taskSummary.Execution = taskExecutionSummary
+			mu.Lock()
+			taskSummaries = append(taskSummaries, taskSummary)
+			// don't hold the lock while we run ec.exec
+			mu.Unlock()
+		}
+
 		return nil
 	}
 
@@ -196,7 +202,8 @@ func (ec *execContext) exec(ctx gocontext.Context, packageTask *nodes.PackageTas
 	if packageTask.Command == "" {
 		progressLogger.Debug("no task in package, skipping")
 		progressLogger.Debug("done", "status", "skipped", "duration", time.Since(cmdTime))
-		return taskExecutionSummary, nil
+		// Return nil here because there was no execution, so there is no task execution summary
+		return nil, nil
 	}
 
 	var prefix string


### PR DESCRIPTION
Related conversation about why we don't just filter tasks that don't have scripts out of the graph entirely: https://github.com/vercel/turbo/issues/937

Doing this only for task summaries, because in Dry Runs, we explicitly include these: https://github.com/vercel/turbo/pull/1225