### PR TITLE
refactor: Removed includeUntracked because it's always set to true

### DIFF
--- a/cli/internal/ffi/ffi.go
+++ b/cli/internal/ffi/ffi.go
@@ -116,16 +116,15 @@ func stringToRef(s string) *string {
 }
 
 // ChangedFiles returns the files changed in between two commits, the workdir and the index, and optionally untracked files
-func ChangedFiles(repoRoot string, monorepoRoot string, fromCommit string, toCommit string, includeUntracked bool) ([]string, error) {
+func ChangedFiles(repoRoot string, monorepoRoot string, fromCommit string, toCommit string) ([]string, error) {
 	fromCommitRef := stringToRef(fromCommit)
 	toCommitRef := stringToRef(toCommit)
 
 	req := ffi_proto.ChangedFilesReq{
-		RepoRoot:         repoRoot,
-		FromCommit:       fromCommitRef,
-		ToCommit:         toCommitRef,
-		IncludeUntracked: includeUntracked,
-		MonorepoRoot:     monorepoRoot,
+		RepoRoot:     repoRoot,
+		FromCommit:   fromCommitRef,
+		ToCommit:     toCommitRef,
+		MonorepoRoot: monorepoRoot,
 	}
 
 	reqBuf := Marshal(&req)

--- a/cli/internal/scm/git_go.go
+++ b/cli/internal/scm/git_go.go
@@ -24,7 +24,7 @@ type git struct {
 }
 
 // ChangedFiles returns a list of modified files since the given commit, optionally including untracked files.
-func (g *git) ChangedFiles(fromCommit string, toCommit string, includeUntracked bool, relativeTo string) ([]string, error) {
+func (g *git) ChangedFiles(fromCommit string, toCommit string, relativeTo string) ([]string, error) {
 	if relativeTo == "" {
 		relativeTo = g.repoRoot
 	}
@@ -54,15 +54,13 @@ func (g *git) ChangedFiles(fromCommit string, toCommit string, includeUntracked 
 		committedChanges := strings.Split(string(out), "\n")
 		files = append(files, committedChanges...)
 	}
-	if includeUntracked {
-		command = []string{"ls-files", "--other", "--exclude-standard"}
-		out, err = exec.Command("git", append(command, relSuffix...)...).CombinedOutput()
-		if err != nil {
-			return nil, errors.Wrap(err, "finding untracked files")
-		}
-		untracked := strings.Split(string(out), "\n")
-		files = append(files, untracked...)
+	command = []string{"ls-files", "--other", "--exclude-standard"}
+	out, err = exec.Command("git", append(command, relSuffix...)...).CombinedOutput()
+	if err != nil {
+		return nil, errors.Wrap(err, "finding untracked files")
 	}
+	untracked := strings.Split(string(out), "\n")
+	files = append(files, untracked...)
 	// git will report changed files relative to the worktree: re-relativize to relativeTo
 	normalized := make([]string, 0)
 	for _, f := range files {

--- a/cli/internal/scm/git_rust.go
+++ b/cli/internal/scm/git_rust.go
@@ -19,8 +19,8 @@ type git struct {
 }
 
 // ChangedFiles returns a list of modified files since the given commit, optionally including untracked files.
-func (g *git) ChangedFiles(fromCommit string, toCommit string, includeUntracked bool, monorepoRoot string) ([]string, error) {
-	return ffi.ChangedFiles(g.repoRoot, monorepoRoot, fromCommit, toCommit, includeUntracked)
+func (g *git) ChangedFiles(fromCommit string, toCommit string, monorepoRoot string) ([]string, error) {
+	return ffi.ChangedFiles(g.repoRoot, monorepoRoot, fromCommit, toCommit)
 }
 
 func (g *git) PreviousContent(fromCommit string, filePath string) ([]byte, error) {

--- a/cli/internal/scm/scm.go
+++ b/cli/internal/scm/scm.go
@@ -19,8 +19,8 @@ var ErrFallback = errors.New("cannot find a .git folder. Falling back to manual 
 
 // An SCM represents an SCM implementation that we can ask for various things.
 type SCM interface {
-	// ChangedFiles returns a list of modified files since the given commit, optionally including untracked files.*/
-	ChangedFiles(fromCommit string, toCommit string, includeUntracked bool, relativeTo string) ([]string, error)
+	// ChangedFiles returns a list of modified files since the given commit, including untracked files
+	ChangedFiles(fromCommit string, toCommit string, relativeTo string) ([]string, error)
 	// PreviousContent Returns the content of the file at fromCommit
 	PreviousContent(fromCommit string, filePath string) ([]byte, error)
 }

--- a/cli/internal/scm/stub.go
+++ b/cli/internal/scm/stub.go
@@ -5,7 +5,7 @@ package scm
 
 type stub struct{}
 
-func (s *stub) ChangedFiles(fromCommit string, toCommit string, includeUntracked bool, relativeTo string) ([]string, error) {
+func (s *stub) ChangedFiles(fromCommit string, toCommit string, relativeTo string) ([]string, error) {
 	return nil, nil
 }
 

--- a/cli/internal/scope/scope.go
+++ b/cli/internal/scope/scope.go
@@ -199,7 +199,7 @@ func (o *Opts) getPackageChangeFunc(scm scm.SCM, cwd turbopath.AbsoluteSystemPat
 		// scope changed files more deeply if we know there are no global dependencies.
 		var changedFiles []string
 		if fromRef != "" {
-			scmChangedFiles, err := scm.ChangedFiles(fromRef, toRef, true, cwd.ToStringDuringMigration())
+			scmChangedFiles, err := scm.ChangedFiles(fromRef, toRef, cwd.ToStringDuringMigration())
 			if err != nil {
 				return nil, err
 			}

--- a/cli/internal/scope/scope_test.go
+++ b/cli/internal/scope/scope_test.go
@@ -25,7 +25,7 @@ type mockSCM struct {
 	contents map[string][]byte
 }
 
-func (m *mockSCM) ChangedFiles(_fromCommit string, _toCommit string, _includeUntracked bool, _relativeTo string) ([]string, error) {
+func (m *mockSCM) ChangedFiles(_fromCommit string, _toCommit string, _relativeTo string) ([]string, error) {
 	return m.changed, nil
 }
 

--- a/crates/turborepo-ffi/messages.proto
+++ b/crates/turborepo-ffi/messages.proto
@@ -28,7 +28,6 @@ message ChangedFilesReq {
   string monorepo_root = 2;
   optional string from_commit = 3;
   optional string to_commit = 4;
-  bool include_untracked = 5;
 }
 
 message ChangedFilesResp {

--- a/crates/turborepo-ffi/src/lib.rs
+++ b/crates/turborepo-ffi/src/lib.rs
@@ -76,7 +76,6 @@ pub extern "C" fn changed_files(buffer: Buffer) -> Buffer {
         req.repo_root.into(),
         req.monorepo_root.into(),
         commit_range,
-        req.include_untracked,
     ) {
         Ok(files) => {
             let files: Vec<_> = files.into_iter().collect();

--- a/crates/turborepo-scm/src/git.rs
+++ b/crates/turborepo-scm/src/git.rs
@@ -27,7 +27,6 @@ pub fn changed_files(
     repo_root: PathBuf,
     monorepo_root: PathBuf,
     commit_range: Option<(&str, &str)>,
-    include_untracked: bool,
 ) -> Result<HashSet<String>, Error> {
     // Initialize repository at repo root
     let repo = Repository::open(&repo_root)?;
@@ -44,13 +43,7 @@ pub fn changed_files(
     let monorepo_root = repo_root.relativize(&monorepo_root)?;
 
     let mut files = HashSet::new();
-    add_changed_files_from_unstaged_changes(
-        &repo_root,
-        &repo,
-        monorepo_root.as_ref(),
-        &mut files,
-        include_untracked,
-    )?;
+    add_changed_files_from_unstaged_changes(&repo_root, &repo, monorepo_root.as_ref(), &mut files)?;
 
     if let Some((from_commit, to_commit)) = commit_range {
         add_changed_files_from_commits(
@@ -102,11 +95,10 @@ fn add_changed_files_from_unstaged_changes(
     repo: &Repository,
     monorepo_root: &ProjectRelativePath,
     files: &mut HashSet<String>,
-    include_untracked: bool,
 ) -> Result<(), Error> {
     let mut options = DiffOptions::new();
-    options.include_untracked(include_untracked);
-    options.recurse_untracked_dirs(include_untracked);
+    options.include_untracked(true);
+    options.recurse_untracked_dirs(true);
 
     options.pathspec(monorepo_root.to_string());
 


### PR DESCRIPTION
### Description

I realized that we only call `ChangedFiles` in one place and in that place `includeUntracked` is always set to true. So I just removed it as a parameter.

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
