### PR TITLE
Add root eslint config in with-gatsby example

### DIFF
--- a/examples/with-gatsby/.eslintrc.js
+++ b/examples/with-gatsby/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  root: true,
+  // This tells ESLint to load the config from the package `eslint-config-custom`
+  extends: ["custom"],
+};


### PR DESCRIPTION
I'm still not able to get this to work though... test can be exercised with `./scripts/run-example.sh gatsby pnpm`

In `./scripts/run-example.sh`, you can add a `--keep-tmpdir` to go play around in the repo after it's run the test to see what's going on.