### PR TITLE
If a graph walk task fails, stop the walk. 

### DIFF
--- a/cli/internal/core/engine_test.go
+++ b/cli/internal/core/engine_test.go
@@ -1,0 +1,88 @@
+package core
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/vercel/turbo/cli/internal/fs"
+	"github.com/vercel/turbo/cli/internal/graph"
+	"github.com/vercel/turbo/cli/internal/workspace"
+	"gotest.tools/v3/assert"
+
+	"github.com/pyr-sh/dag"
+)
+
+func TestShortCircuiting(t *testing.T) {
+	var workspaceGraph dag.AcyclicGraph
+	workspaceGraph.Add("a")
+	workspaceGraph.Add("b")
+	workspaceGraph.Add("c")
+	// Dependencies: a -> b -> c
+	workspaceGraph.Connect(dag.BasicEdge("a", "b"))
+	workspaceGraph.Connect(dag.BasicEdge("b", "c"))
+
+	buildTask := &fs.BookkeepingTaskDefinition{}
+	err := buildTask.UnmarshalJSON([]byte("{\"dependsOn\": [\"^build\"]}"))
+	assert.NilError(t, err, "BookkeepingTaskDefinition unmarshall")
+
+	pipeline := map[string]fs.BookkeepingTaskDefinition{
+		"build": *buildTask,
+	}
+
+	p := NewEngine(&graph.CompleteGraph{
+		WorkspaceGraph:  workspaceGraph,
+		Pipeline:        pipeline,
+		TaskDefinitions: map[string]*fs.TaskDefinition{},
+		WorkspaceInfos: workspace.Catalog{
+			PackageJSONs: map[string]*fs.PackageJSON{
+				"//": {},
+				"a":  {},
+				"b":  {},
+				"c":  {},
+			},
+			TurboConfigs: map[string]*fs.TurboJSON{
+				"//": {
+					Pipeline: pipeline,
+				},
+			},
+		},
+	}, false)
+
+	p.AddTask("build")
+
+	err = p.Prepare(&EngineBuildingOptions{
+		Packages:  []string{"a", "b", "c"},
+		TaskNames: []string{"build"},
+		TasksOnly: false,
+	})
+
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	executed := map[string]bool{
+		"a#build": false,
+		"b#build": false,
+		"c#build": false,
+	}
+	expectedErr := errors.New("an error occurred")
+	// b#build is going to error, we expect to not execute a#build, which depends on b
+	testVisitor := func(taskID string) error {
+		println(taskID)
+		executed[taskID] = true
+		if taskID == "b#build" {
+			return expectedErr
+		}
+		return nil
+	}
+
+	errs := p.Execute(testVisitor, EngineExecutionOptions{
+		Concurrency: 10,
+	})
+	assert.Equal(t, len(errs), 1)
+	assert.Equal(t, errs[0], expectedErr)
+
+	assert.Equal(t, executed["c#build"], true)
+	assert.Equal(t, executed["b#build"], true)
+	assert.Equal(t, executed["a#build"], false)
+}

--- a/cli/internal/run/real_run.go
+++ b/cli/internal/run/real_run.go
@@ -259,7 +259,7 @@ func (ec *execContext) exec(ctx gocontext.Context, packageTask *nodes.PackageTas
 
 		ec.logError(progressLogger, prettyPrefix, err)
 		if !ec.rs.Opts.runOpts.continueOnError {
-			os.Exit(1)
+			return nil, errors.Wrapf(err, "failed to initialize output capture for task %v", packageTask.TaskID)
 		}
 	}
 
@@ -315,6 +315,8 @@ func (ec *execContext) exec(ctx gocontext.Context, packageTask *nodes.PackageTas
 			ec.processes.Close()
 		} else {
 			prefixedUI.Warn("command finished with error, but continuing...")
+			// Set to nil so we don't short-circuit any other execution
+			err = nil
 		}
 
 		// If there was an error, flush the buffered output


### PR DESCRIPTION
### Description

Backstory: I was investigating what needs to be done to support unifying our output to support grouping log output. I encountered an `os.Exit` sitting in run, and while attempting to address that, discovered that we don't fully stop on error even when we mean to. We stop executing _scripts_ but we continue to walk the graph, meaning that we can trigger cache restorations.

This PR:
 - Adds a short-circuiting mechanism to our graph walk so that tasks started after the failed tasks are skipped. Note that tasks started concurrently with the failed task may still run.
 - Remove the `os.Exit` for the case where we fail to do the setup work to capture task outputs
 - Adds a test for short-circuiting using a custom visitor to deterministically inject an error into graph traversal 

### Testing Instructions

New test in `engine_test.go` demonstrates short-circuiting by injecting an error into graph traversal.

I opted for a unit test in this case because using a failing script in an integration test will not trigger the broken behavior. We shut down the script-running facility once a script fails. The error needs to occur outside of the user's script to demonstrate the bug, hence a custom graph visitor.