### PR TITLE
docs: added backend tab for internal pkgs

### DIFF
--- a/docs/pages/repo/docs/handbook/sharing-code/internal-packages.mdx
+++ b/docs/pages/repo/docs/handbook/sharing-code/internal-packages.mdx
@@ -191,7 +191,7 @@ The fix is simple - we need to tell Next.js to bundle the files from certain pac
   <Tab>
 If you want to use `math-helpers` with a backend app, you'll need a bundler like [Webpack](https://webpack.js.org/), [Parcel](https://parceljs.org/) or [Rollup](https://rollupjs.org/) to bundle your internal package with your app. For this example, we'll use Webpack.
 
-You'll likely want not bundle any `node_modules` or node imports like `path`. In order to exclude all these from your bundle, we can use something like [`webpack-node-externals`](https://www.npmjs.com/package/webpack-node-externals) or the equivalent in your bundler of choice.
+You'll likely not want to bundle any `node_modules` or node imports like `path`. In order to exclude all these from your bundle, we can use something like [`webpack-node-externals`](https://www.npmjs.com/package/webpack-node-externals) or the equivalent in your bundler of choice.
 
 In Webpack 5, your `webpack.config.js` will look something like this:
 

--- a/docs/pages/repo/docs/handbook/sharing-code/internal-packages.mdx
+++ b/docs/pages/repo/docs/handbook/sharing-code/internal-packages.mdx
@@ -153,7 +153,7 @@ Go back to `packages/math-helpers/package.json` and add two fields, `main` and `
 
 Now, anything that imports our `math-helpers` module will be pointed directly towards the `src/index.ts` file - _that's_ the file that they will import.
 
-Go back to `apps/web/pages/index.tsx`. The error should be gone!
+Go back to the file where you're importing `math-helpers`. The error should be gone!
 
 ### 5. Try running the app
 
@@ -163,7 +163,7 @@ Now, try running that app's dev script. In the default turborepo, this will be a
 turbo dev
 ```
 
-<Tabs items={['Next.js', 'Vite']} storageKey="selected-framework">
+<Tabs items={['Next.js', 'Vite', "Webpack (Backend)"]} storageKey="selected-framework">
   <Tab>
 
 When it starts running, you'll likely see an error in your web browser:
@@ -188,11 +188,43 @@ The fix is simple - we need to tell Next.js to bundle the files from certain pac
   <Tab>
     Because `vite` transpiles modules by default, there's no more setup needed! Skip to step 7.
   </Tab>
+  <Tab>
+If you want to use `math-helpers` with a backend app, you'll need a bundler like [Webpack](https://webpack.js.org/), [Parcel](https://parceljs.org/) or [Rollup](https://rollupjs.org/) to bundle your internal package with your app. For this example, we'll use Webpack.
+
+You'll likely want not bundle any `node_modules` or node imports like `path`. In order to exclude all these from your bundle, we can use something like [`webpack-node-externals`](https://www.npmjs.com/package/webpack-node-externals) or the equivalent in your bundler of choice.
+
+In Webpack 5, your `webpack.config.js` will look something like this:
+
+```ts filename="apps/backend-app/webpack.config.js"
+const nodeExternals = require('webpack-node-externals');
+...
+module.exports = {
+    ...
+    externalsPresets: { node: true }, // in order to ignore built-in modules like path, fs, etc.
+    externals: [nodeExternals()], // in order to ignore all modules in node_modules folder
+    ...
+};
+```
+
+However, when you bundle your app and try to run the output file with `node`, you'll likely see an error in your terminal similar to this:
+
+```
+export const add = (a: number, b: number)
+^^^^^^
+
+SyntaxError: Unexpected token 'export'
+```
+
+This is what happens when you try and import an un-bundled file into a backend app.
+
+The fix is simple - we need to tell Webpack to bundle certain `node_modules` that your backend app imports.
+
+  </Tab>
 </Tabs>
 
 ### 6. Configuring your app
 
-<Tabs items={['Next.js', 'Vite']} storageKey="selected-framework">
+<Tabs items={['Next.js', 'Vite', "Webpack (Backend)"]} storageKey="selected-framework">
   <Tab>
 
     We can do that using `transpilePackages` in `next.config.js` (requires v13.1+):
@@ -213,6 +245,24 @@ The fix is simple - we need to tell Next.js to bundle the files from certain pac
   </Tab>
   <Tab>
     No configuration is needed!
+  </Tab>
+  <Tab>
+    We can do that by adding `math-helpers` into the `allowList` option of `webpack-node-externals` or the equivalent if you're using another bundler:
+    ```ts filename="apps/backend-app/webpack.config.js"
+    const nodeExternals = require('webpack-node-externals');
+    ...
+    module.exports = {
+        ...
+        externalsPresets: { node: true },
+        externals: [nodeExternals({allowlist: ["math-helpers"]})],
+        ...
+    };
+```
+
+    Rebuild and try to run your bundled app again.
+
+    **The error has disappeared!**
+
   </Tab>
 </Tabs>
 


### PR DESCRIPTION
### Description
I had a very difficult time trying to integrate Nest.js apps and internal packages in Turborepo. This is because I didn't understand that in order to use the internal package I needed to bundle it with my app and tell Webpack to allow my internal package as a `node_module` that needed to be bundled. I eventually figured it out by reading the Next.js tabs of the Internal Packages docs and connecting the dots.

However, I feel like the Internal Packages docs only put emphasis on the frontend experience and doesn't mention anything about how people could use internal packages if they had a backend app.

This PR adds a "Webpack (Backend)" tab to the "Try running the app" and "Configuring your app" which lets the user know what they need to do in order to use an internal package in a backend app.
