### PR TITLE
Fix getting workspace ignores in case of non-monorepo

### DIFF
--- a/cli/internal/packagemanager/yarn.go
+++ b/cli/internal/packagemanager/yarn.go
@@ -40,6 +40,18 @@ var nodejsYarn = PackageManager{
 		// For example: `apps/*/node_modules/**/+(package.json|yarn.json)`
 		// The `extglob` `+(package.json|yarn.json)` (from micromatch) after node_modules/** is redundant.
 
+		// In case of a non-monorepo the workspaces field is empty and getWorkspaceGlobs would fail,
+		// and should therefore be handled separately.
+		pkg, err := fs.ReadPackageJSON(rootpath.UntypedJoin("package.json"))
+		if err != nil {
+			return nil, fmt.Errorf("package.json: %w", err)
+		}
+		if len(pkg.Workspaces) == 0 {
+			ignores := make([]string, 1)
+			ignores[0] = "node_modules/**"
+			return ignores, nil
+		}
+
 		globs, err := pm.getWorkspaceGlobs(rootpath)
 		if err != nil {
 			return nil, err

--- a/cli/internal/packagemanager/yarn.go
+++ b/cli/internal/packagemanager/yarn.go
@@ -1,6 +1,7 @@
 package packagemanager
 
 import (
+	"errors"
 	"fmt"
 	"os/exec"
 	"path/filepath"
@@ -12,7 +13,7 @@ import (
 	"github.com/vercel/turbo/cli/internal/turbopath"
 )
 
-type NoWorkspacesFoundError struct {}
+type NoWorkspacesFoundError struct{}
 
 func (e *NoWorkspacesFoundError) Error() string {
 	return "package.json: no workspaces found. Turborepo requires Yarn workspaces to be defined in the root package.json"
@@ -49,12 +50,13 @@ var nodejsYarn = PackageManager{
 		globs, err := pm.getWorkspaceGlobs(rootpath)
 		if err != nil {
 			// In case of a non-monorepo, the workspaces field is empty and only node_modules in the root should be ignored
-			_, ok := err.(*NoWorkspacesFoundError)
-			if ok {
+			var e *NoWorkspacesFoundError
+			if errors.As(err, &e) {
 				ignores := make([]string, 1)
 				ignores[0] = "node_modules/**"
 				return ignores, nil
 			}
+
 			return nil, err
 		}
 

--- a/cli/internal/packagemanager/yarn.go
+++ b/cli/internal/packagemanager/yarn.go
@@ -52,9 +52,7 @@ var nodejsYarn = PackageManager{
 			// In case of a non-monorepo, the workspaces field is empty and only node_modules in the root should be ignored
 			var e *NoWorkspacesFoundError
 			if errors.As(err, &e) {
-				ignores := make([]string, 1)
-				ignores[0] = "node_modules/**"
-				return ignores, nil
+				return []string{"node_modules/**"}, nil
 			}
 
 			return nil, err


### PR DESCRIPTION
### Description

Hey @mehulkar I tried to fix #4140 .
This is my first time reading or writing in go so it's likely I may have done something wrong.

The way I did it is a bit redundant, as in the case of a monorepo the call to `getWorkspaceGlobs` is made 2 times and so is not the most efficient. Unfortunately I think I lack a lot of context to try and come up with a better solution, but I felt like trying :)