### PR TITLE
send a SIGTERM on unix rather than just killing the process

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2815,9 +2815,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 
 [[package]]
 name = "libgit2-sys"
@@ -6496,6 +6496,7 @@ dependencies = [
  "ctrlc",
  "dunce",
  "itertools",
+ "libc",
  "log",
  "pretty_assertions",
  "serde",

--- a/crates/turborepo/Cargo.toml
+++ b/crates/turborepo/Cargo.toml
@@ -29,6 +29,7 @@ clap_complete = { workspace = true }
 command-group = { version = "2.0.1", features = ["with-tokio"] }
 ctrlc = { version = "3.2.5", features = ["termination"] }
 dunce = { workspace = true }
+libc = "0.2.140"
 log = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }


### PR DESCRIPTION
### Description

In attempting to fix a zombie process on windows, we accidentally introduced a similar issue on unix. This makes sure to gracefully stop the go binary so that it may in turn gracefully stop its children rather than leave them hanging.

### Testing Instructions

Check out front. On 1.8.4 running multiple `turbo dev --filter vercel-site` can sometimes cause a race condition where the node process is left hanging causing errors regarding ports being used. It seems to happen in a bout 1 in 5 or so runs and only when quitting at specific times. Checking out this PR, you can observe that crtl-c works as expected, and the existing, correct, windows behaviour still works.
