### PR TITLE
prevent emitting debug symbols in release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,9 +73,6 @@ default-members = [
   "xtask",
 ]
 
-[profile.release]
-debug = 1
-
 [profile.dev.package.turbo-tasks-macros]
 opt-level = 3
 


### PR DESCRIPTION
### Description

We have recently noticed quite large rust binaries. This was due to debug symbols being enabled across the repo. We can (and should) revert this.
