### PR TITLE
fix(signal handling for child process)

### DIFF
--- a/cli/internal/run/real_run.go
+++ b/cli/internal/run/real_run.go
@@ -133,8 +133,15 @@ func RealRun(
 
 	for _, err := range errs {
 		if errors.As(err, &exitCodeErr) {
-			if exitCodeErr.ExitCode > exitCode {
-				exitCode = exitCodeErr.ExitCode
+			// If a process gets killed via a signal, Go reports it's exit code as -1.
+			// We take the absolute value of the exit code so we don't select '0' as
+			// the greatest exit code.
+			childExit := exitCodeErr.ExitCode
+			if childExit < 0 {
+				childExit = -childExit
+			}
+			if childExit > exitCode {
+				exitCode = childExit
 			}
 		} else if exitCode == 0 {
 			// We hit some error, it shouldn't be exit code 0


### PR DESCRIPTION
### Description
Fixes #4227

As mentioned in the issue if a child process gets killed via signal, Go will report the exit code as `-1`. This causes issues as turbo will take the highest exit code which if all other tasks are successful will be `0`.

### Testing Instructions
Opted for manual testing here as writing a test scenario for this would either require some code shuffling for a unit test or a convoluted integration test.
- See repro described in #4227 
- Verify that turbo now exits with `1` if a child process got killed: 
![Screen Shot 2023-03-21 at 1 14 34 PM](https://user-images.githubusercontent.com/4131117/226731309-6746a44d-db6a-4226-92d7-9ad20220e33e.png)

