### PR TITLE
Handle deleted files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3529,6 +3529,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecba01bf2678719532c5e3059e0b5f0811273d94b397088b82e3bd0a78c78fdd"
 
 [[package]]
+name = "path-slash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
+
+[[package]]
 name = "pathdiff"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7129,6 +7135,7 @@ dependencies = [
  "anyhow",
  "dunce",
  "git2",
+ "path-slash",
  "tempfile",
  "thiserror",
  "turborepo-paths",

--- a/crates/turborepo-scm/Cargo.toml
+++ b/crates/turborepo-scm/Cargo.toml
@@ -10,6 +10,7 @@ license = "MPL-2.0"
 anyhow = { workspace = true }
 dunce = { workspace = true }
 git2 = { version = "0.16.1", default-features = false }
+path-slash = "0.2.1"
 thiserror = { workspace = true }
 turborepo-paths = { path = "../turborepo-paths" }
 


### PR DESCRIPTION
### Description

Previously, we used `fs_util::canonicalize` as a way of converting from slashes in paths. That returns an error if the underlying file doesn't exist, which in turn breaks our ability to handle deleted files.

This PR:
 - renames several paths to be more explicit
 - dedupes some path calculation
 - uses a path_slash library to implement the equivalent from Go's `FromSlash` (NOTE: this is probably not the right location for this code. I would be happy to have suggestions as to how to incorporate this into the path library cc @nathanhammond @NicholasLYang @chris-olszewski )
 - adds a test for deleted files that fails on `main`

### Testing Instructions

Added new test for deleted files.
