### PR TITLE
docs: replace /contact/turborepo with /contact/sales

### DIFF
--- a/docs/components/FullTurboCTA.tsx
+++ b/docs/components/FullTurboCTA.tsx
@@ -17,7 +17,7 @@ function FullTurboCTA() {
       </div>
       <div className="flex-none">
         <Link
-          href="https://vercel.com/contact/turborepo?utm_source=turbo.build&utm_medium=referral&utm_campaign=turborepo_side_banner"
+          href="https://vercel.com/contact/sales?utm_source=turbo.build&utm_medium=referral&utm_campaign=turborepo_side_banner"
           className="justify-center block px-4 py-2 text-black no-underline bg-white rounded-full dark:bg-opacity-5 dark:text-white"
         >
           Talk to an Expert

--- a/docs/components/Navigation.tsx
+++ b/docs/components/Navigation.tsx
@@ -28,8 +28,8 @@ function Navigation(props) {
       // https://github.com/shuding/nextra/issues/1028
       route: "enterprise",
       href: `https://vercel.com/${
-        site === "repo" ? "solutions" : "contact"
-      }/turborepo?utm_source=turbo.build&utm_medium=referral&utm_campaign=header-enterpriseLink`,
+        site === "repo" ? "solutions/turborepo" : "contact/sales"
+      }?utm_source=turbo.build&utm_medium=referral&utm_campaign=header-enterpriseLink`,
       id: "contextual-enterprise",
       key: "contextual-enterprise",
     });

--- a/docs/pages/blog/you-might-not-need-typescript-project-references.mdx
+++ b/docs/pages/blog/you-might-not-need-typescript-project-references.mdx
@@ -92,4 +92,4 @@ As previously mentioned, this pattern actually has very little to do with Turbor
 
 ## Speaking of long build times...
 
-Shameless plug here. If you are reading this post, and you're struggling with slow build and test times, I'd love to show you how Turborepo can help. I guarantee that Turborepo will cut your monorepo's build time by 50% or more. [You can request a live demo right here.](https://vercel.com/contact/turborepo?utm_source=turbo.build&utm_medium=referral&utm_campaign=blog-project-references)
+Shameless plug here. If you are reading this post, and you're struggling with slow build and test times, I'd love to show you how Turborepo can help. I guarantee that Turborepo will cut your monorepo's build time by 50% or more. [You can request a live demo right here.](https://vercel.com/contact/sales?utm_source=turbo.build&utm_medium=referral&utm_campaign=blog-project-references)


### PR DESCRIPTION
### Description
/sales/turborepo is deprecated

### Testing Instructions
Click `Enterprise` in the header 
