### PR TITLE
fix and improve error handling

### DIFF
--- a/crates/turbopack-core/src/error.rs
+++ b/crates/turbopack-core/src/error.rs
@@ -1,0 +1,60 @@
+use std::fmt::{Display, Formatter, Result};
+
+pub struct PrettyPrintError<'a>(pub &'a anyhow::Error);
+
+impl<'a> Display for PrettyPrintError<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        let mut i = 0;
+        let mut has_details = false;
+
+        let descriptions = self
+            .0
+            .chain()
+            .map(|cause| cause.to_string())
+            .collect::<Vec<_>>();
+
+        for description in &descriptions {
+            let hidden = description.starts_with("Execution of ");
+            if !hidden {
+                let header =
+                    description
+                        .split_once('\n')
+                        .map_or(description.as_str(), |(header, _)| {
+                            has_details = true;
+                            header
+                        });
+                match i {
+                    0 => write!(f, "{}", header)?,
+                    1 => write!(f, "\n\nCaused by:\n- {}", header)?,
+                    _ => write!(f, "\n- {}", header)?,
+                }
+                i += 1;
+            } else {
+                has_details = true;
+            }
+        }
+        if has_details {
+            write!(f, "\n\nDeveloper details:")?;
+            for description in descriptions {
+                f.write_str("\n");
+                WithDash(&description).fmt(f)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+struct WithDash<'a>(&'a str);
+
+impl<'a> Display for WithDash<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        let mut lines = self.0.lines();
+        if let Some(line) = lines.next() {
+            write!(f, "- {}", line)?;
+        }
+        for line in lines {
+            write!(f, "\n  {}", line)?;
+        }
+        Ok(())
+    }
+}

--- a/crates/turbopack-core/src/error.rs
+++ b/crates/turbopack-core/src/error.rs
@@ -1,5 +1,7 @@
 use std::fmt::{Display, Formatter, Result};
 
+/// Implements [Display] to print the error message in a friendly way.
+/// Puts a summary first and details after that.
 pub struct PrettyPrintError<'a>(pub &'a anyhow::Error);
 
 impl<'a> Display for PrettyPrintError<'a> {
@@ -14,6 +16,7 @@ impl<'a> Display for PrettyPrintError<'a> {
             .collect::<Vec<_>>();
 
         for description in &descriptions {
+            // see turbo-tasks-memory/src/task.rs for the error message
             let hidden = description.starts_with("Execution of ");
             if !hidden {
                 let header =
@@ -34,7 +37,7 @@ impl<'a> Display for PrettyPrintError<'a> {
             }
         }
         if has_details {
-            write!(f, "\n\nDeveloper details:")?;
+            write!(f, "\n\nDebug info:")?;
             for description in descriptions {
                 f.write_str("\n");
                 WithDash(&description).fmt(f)?;
@@ -44,6 +47,7 @@ impl<'a> Display for PrettyPrintError<'a> {
     }
 }
 
+/// Indents all lines after the first one. Puts a dash before the first line.
 struct WithDash<'a>(&'a str);
 
 impl<'a> Display for WithDash<'a> {

--- a/crates/turbopack-core/src/lib.rs
+++ b/crates/turbopack-core/src/lib.rs
@@ -12,6 +12,7 @@ pub mod code_builder;
 pub mod compile_time_info;
 pub mod context;
 pub mod environment;
+pub mod error;
 pub mod ident;
 pub mod introspect;
 pub mod issue;

--- a/crates/turbopack-dev-server/src/lib.rs
+++ b/crates/turbopack-dev-server/src/lib.rs
@@ -28,7 +28,10 @@ use turbo_tasks::{
     run_once_with_reason, trace::TraceRawVcs, util::FormatDuration, CollectiblesSource, RawVc,
     TransientInstance, TransientValue, TurboTasksApi,
 };
-use turbopack_core::issue::{IssueReporter, IssueReporterVc, IssueVc};
+use turbopack_core::{
+    error::PrettyPrintError,
+    issue::{IssueReporter, IssueReporterVc, IssueVc},
+};
 
 use self::{
     source::{ContentSourceResultVc, ContentSourceVc},
@@ -202,13 +205,13 @@ impl DevServerBuilder {
                             Ok(r) => Ok::<_, hyper::http::Error>(r),
                             Err(e) => {
                                 println!(
-                                    "[500] error: {:?} ({})",
-                                    e,
-                                    FormatDuration(start.elapsed())
+                                    "[500] error ({}): {}",
+                                    FormatDuration(start.elapsed()),
+                                    PrettyPrintError(&e),
                                 );
                                 Ok(Response::builder()
                                     .status(500)
-                                    .body(hyper::Body::from(format!("{:?}", e,)))?)
+                                    .body(hyper::Body::from(format!("{}", PrettyPrintError(&e))))?)
                             }
                         }
                     }

--- a/crates/turbopack-dev/js/src/runtime.nodejs.js
+++ b/crates/turbopack-dev/js/src/runtime.nodejs.js
@@ -21,15 +21,7 @@ let BACKEND;
         }
 
         for (const moduleId of params.runtimeModuleIds) {
-          try {
-            getOrInstantiateRuntimeModule(moduleId, chunkPath);
-          } catch (err) {
-            console.error(
-              `The following error occurred while evaluating runtime entries of ${chunkPath}:`
-            );
-            console.error(err);
-            return;
-          }
+          getOrInstantiateRuntimeModule(moduleId, chunkPath);
         }
       }
     },

--- a/crates/turbopack-dev/js/src/runtime.none.js
+++ b/crates/turbopack-dev/js/src/runtime.none.js
@@ -116,15 +116,7 @@ let BACKEND;
    */
   function instantiateRuntimeModules(runtimeModuleIds, chunkPath) {
     for (const moduleId of runtimeModuleIds) {
-      try {
-        getOrInstantiateRuntimeModule(moduleId, chunkPath);
-      } catch (err) {
-        console.error(
-          `The following error occurred while evaluating runtime entries of ${chunkPath}:`
-        );
-        console.error(err);
-        return;
-      }
+      getOrInstantiateRuntimeModule(moduleId, chunkPath);
     }
   }
 })();

--- a/crates/turbopack-node/src/render/render_proxy.rs
+++ b/crates/turbopack-node/src/render/render_proxy.rs
@@ -2,7 +2,7 @@ use anyhow::{bail, Result};
 use turbo_tasks::primitives::StringVc;
 use turbo_tasks_env::ProcessEnvVc;
 use turbo_tasks_fs::FileSystemPathVc;
-use turbopack_core::{asset::AssetVc, chunk::ChunkingContextVc};
+use turbopack_core::{asset::AssetVc, chunk::ChunkingContextVc, error::PrettyPrintError};
 use turbopack_dev_server::source::{BodyVc, ProxyResult, ProxyResultVc};
 use turbopack_ecmascript::{chunk::EcmascriptChunkPlaceablesVc, EcmascriptModuleAssetVc};
 
@@ -121,7 +121,7 @@ async fn proxy_error(
     error: anyhow::Error,
     operation: Option<NodeJsOperation>,
 ) -> Result<ProxyResultVc> {
-    let message = format!("{error:?}");
+    let message = format!("{}", PrettyPrintError(&error));
 
     let status = match operation {
         Some(operation) => Some(operation.wait_or_kill().await?),

--- a/crates/turbopack-node/src/render/render_static.rs
+++ b/crates/turbopack-node/src/render/render_static.rs
@@ -5,6 +5,7 @@ use turbo_tasks_fs::{File, FileContent, FileSystemPathVc};
 use turbopack_core::{
     asset::{Asset, AssetContentVc, AssetVc},
     chunk::ChunkingContextVc,
+    error::PrettyPrintError,
 };
 use turbopack_dev_server::{
     html::DevHtmlAssetVc,
@@ -147,7 +148,8 @@ async fn static_error(
     operation: Option<NodeJsOperation>,
     fallback_page: DevHtmlAssetVc,
 ) -> Result<AssetContentVc> {
-    let message = format!("{error:?}")
+    let error = format!("{}", PrettyPrintError(&error));
+    let message = error
         // TODO this is pretty inefficient
         .replace('&', "&amp;")
         .replace('>', "&gt;")
@@ -174,7 +176,7 @@ async fn static_error(
 
     let issue = RenderingIssue {
         context: path,
-        message: StringVc::cell(format!("{error:?}")),
+        message: StringVc::cell(error),
         status: status.and_then(|status| status.code()),
     };
 


### PR DESCRIPTION
### Description

* fixes a bug that swallowed the errors
* pretty print anyhow errors when printing them

Before:

```
[500] error: Execution of get_from_source failed

Caused by:
    0: Execution of resolve_source_request failed
    1: Execution of CombinedContentSource::get failed
    2: Execution of CombinedContentSource::get failed
    3: Execution of IssueContextContentSource::get failed
    4: Execution of CombinedContentSource::get failed
    5: Execution of CombinedContentSource::get failed
    6: Execution of NodeRenderContentSource::content_source failed
    7: Execution of external_asset_entrypoints failed
    8: Execution of separate_assets failed
    9: Execution of NodeJsBootstrapAsset::references failed
   10: Execution of turbopack_core::chunk::ChunkGroupVc::chunks failed
   11: Execution of CssChunk::references failed
   12: Execution of css_chunk_content_single_entry failed
   13: Execution of analyze_css_stylesheet failed
   14: Execution of parse failed
   15: Execution of PostCssTransformedAsset::content failed
   16: Execution of turbopack_node::transforms::postcss::PostCssTransformedAssetVc::process failed
   17: Execution of evaluate failed
   18: failed to receive message
   19: stdout stream ended unexpectedly (13ms)
```

After:

```
[500] error (11ms): failed to receive message

Caused by:
- reading packet length
- unexpected end of file

Developer details:
- Execution of get_from_source failed
- Execution of resolve_source_request failed
- Execution of CombinedContentSource::get failed
- Execution of CombinedContentSource::get failed
- Execution of IssueContextContentSource::get failed
- Execution of CombinedContentSource::get failed
- Execution of CombinedContentSource::get failed
- Execution of NodeRenderContentSource::content_source failed
- Execution of external_asset_entrypoints failed
- Execution of separate_assets failed
- Execution of NodeJsBootstrapAsset::references failed
- Execution of turbopack_core::chunk::ChunkGroupVc::chunks failed
- Execution of CssChunk::references failed
- Execution of css_chunk_content_single_entry failed
- Execution of analyze_css_stylesheet failed
- Execution of parse failed
- Execution of PostCssTransformedAsset::content failed
- Execution of turbopack_node::transforms::postcss::PostCssTransformedAssetVc::process failed
- Execution of evaluate failed
- failed to receive message
- reading packet length
- unexpected end of file
```

fixes WEB-737
