### PR TITLE
feat(place patches in json folder when pruning for docker)

### DIFF
--- a/cli/integration_tests/prune/docker.t
+++ b/cli/integration_tests/prune/docker.t
@@ -1,0 +1,22 @@
+Setup
+  $ . ${TESTDIR}/../setup.sh
+  $ . ${TESTDIR}/setup.sh $(pwd)
+
+  $ ${TURBO} prune --scope=web --docker
+  Generating pruned monorepo for web in .*out (re)
+   - Added shared
+   - Added util
+   - Added web
+Make sure patches are part of the json output
+  $ ls out/json
+  apps
+  package.json
+  packages
+  patches
+  pnpm-workspace.yaml
+
+Make sure the pnpm patches section is present
+  $ cat out/json/package.json | jq '.pnpm.patchedDependencies'
+  {
+    "is-number@7.0.0": "patches/is-number@7.0.0.patch"
+  }

--- a/cli/integration_tests/prune/monorepo_with_root_dep/apps/web/package.json
+++ b/cli/integration_tests/prune/monorepo_with_root_dep/apps/web/package.json
@@ -5,6 +5,7 @@
     "build": "echo 'building'"
   },
   "dependencies": {
+    "is-number": "^7.0.0",
     "shared": "workspace:*"
   }
 }

--- a/cli/integration_tests/prune/monorepo_with_root_dep/package.json
+++ b/cli/integration_tests/prune/monorepo_with_root_dep/package.json
@@ -3,5 +3,10 @@
   "packageManager": "pnpm@7.25.1",
   "devDependencies": {
     "util": "workspace:*"
+  },
+  "pnpm": {
+    "patchedDependencies": {
+      "is-number@7.0.0": "patches/is-number@7.0.0.patch"
+    }
   }
 }

--- a/cli/integration_tests/prune/monorepo_with_root_dep/patches/is-number@7.0.0.patch
+++ b/cli/integration_tests/prune/monorepo_with_root_dep/patches/is-number@7.0.0.patch
@@ -1,0 +1,9 @@
+diff --git a/index.js b/index.js
+index 27f19b757f7c1186b92c405a213bf0dd9b6cbe95..24315132970b6299c9c158ef5fb75b2e9c0e633d 100644
+--- a/index.js
++++ b/index.js
+@@ -1,3 +1,4 @@
++// patch
+ /*!
+  * is-number <https://github.com/jonschlinkert/is-number>
+  *

--- a/cli/integration_tests/prune/monorepo_with_root_dep/pnpm-lock.yaml
+++ b/cli/integration_tests/prune/monorepo_with_root_dep/pnpm-lock.yaml
@@ -1,5 +1,10 @@
 lockfileVersion: 5.4
 
+patchedDependencies:
+  is-number@7.0.0:
+    hash: 4fcx2ubzko3upkndnus4sjwpd4
+    path: patches/is-number@7.0.0.patch
+
 importers:
 
   .:
@@ -16,8 +21,10 @@ importers:
 
   apps/web:
     specifiers:
+      is-number: ^7.0.0
       shared: workspace:*
     dependencies:
+      is-number: 7.0.0_4fcx2ubzko3upkndnus4sjwpd4
       shared: link:../../packages/shared
 
   packages/shared:
@@ -25,3 +32,11 @@ importers:
 
   packages/util:
     specifiers: {}
+
+packages:
+
+  /is-number/7.0.0_4fcx2ubzko3upkndnus4sjwpd4:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+    dev: false
+    patched: true

--- a/cli/internal/prune/prune.go
+++ b/cli/internal/prune/prune.go
@@ -281,6 +281,15 @@ func (p *prune) prune(opts *turbostate.PrunePayload) error {
 			); err != nil {
 				return errors.Wrap(err, "Failed copying patch file")
 			}
+			if opts.Docker {
+				jsonDir := outDir.Join(turbopath.RelativeSystemPath("json"))
+				if err := fs.CopyFile(
+					&fs.LstatCachedFile{Path: p.base.RepoRoot.UntypedJoin(patch.ToString())},
+					patch.ToSystemPath().RestoreAnchor(jsonDir).ToStringDuringMigration(),
+				); err != nil {
+					return errors.Wrap(err, "Failed copying patch file")
+				}
+			}
 		}
 	} else {
 		if err := fs.CopyFile(


### PR DESCRIPTION
### Description

Implements #4289

Using the `--docker` flag with prune produces a `full` and `json` directory where the `json` directory only includes everything required to install dependencies. If a dependency is patched it makes sense to include the patch in the `json` directory as both the `package.json` and the lockfile reference the patch file.

### Testing Instructions

Added an integration test to verify that patches end up in the `json` output folder.
