### PR TITLE
cli: internal: ffi: Fix missing library

### DIFF
--- a/cli/internal/ffi/ffi.go
+++ b/cli/internal/ffi/ffi.go
@@ -11,8 +11,8 @@ package ffi
 // #cgo darwin,amd64 LDFLAGS:  -L${SRCDIR} -lturborepo_ffi_darwin_amd64  -lz -liconv
 // #cgo linux,arm64,staticbinary LDFLAGS:   -L${SRCDIR} -lturborepo_ffi_linux_arm64 -lunwind
 // #cgo linux,amd64,staticbinary LDFLAGS:   -L${SRCDIR} -lturborepo_ffi_linux_amd64 -lunwind
-// #cgo linux,arm64,!staticbinary LDFLAGS:   -L${SRCDIR} -lturborepo_ffi_linux_arm64 -lz
-// #cgo linux,amd64,!staticbinary LDFLAGS:   -L${SRCDIR} -lturborepo_ffi_linux_amd64 -lz
+// #cgo linux,arm64,!staticbinary LDFLAGS:   -L${SRCDIR} -lturborepo_ffi_linux_arm64 -lz -lgit2
+// #cgo linux,amd64,!staticbinary LDFLAGS:   -L${SRCDIR} -lturborepo_ffi_linux_amd64 -lz -lgit2
 // #cgo windows,amd64 LDFLAGS: -L${SRCDIR} -lturborepo_ffi_windows_amd64 -lole32 -lbcrypt -lws2_32 -luserenv
 import "C"
 


### PR DESCRIPTION
### Description

On building `turbo` on archlinux, the following errors occurs:

```sh
$ cargo build --frozen --release -p turborepo-ffi
$ cargo build --frozen --release -p turbo
...snip...
  /usr/bin/ld: /home/shohei/pkgbuilds/turbo/src/turbo-1.8.5/cli/internal/ffi/libturborepo_ffi_linux_amd64.a(git2-c77affaa1e7e43cb.git2.dccd2a89-cgu.13.rcgu.o): in function `git2::remote_callbacks::credentials_cb::{closure#0}::{closure#2}':
  /home/shohei/.cargo/registry/src/index.crates.io-6f17d22bba15001f/git2-0.16.1/src/remote_callbacks.rs:293: undefined reference to `git_error_set_str'
  ...snip...
```

I assume that `go-turbo` requires libgit2 from the errors.

### Environment
distro: archlinux
rust: 1.70.0-nightly

### Testing Instructions

I tested according to https://github.com/vercel/turbo/blob/main/CONTRIBUTING.md#building-turborepo.

```sh
$ cargo install cargo-nextest
$ pnpm install
$ cargo nextest run
...snip...
     Summary [   0.630s] 120/314 tests run: 93 passed, 27 failed, 0 skipped
        FAIL [   0.346s] turbopack::node-file-trace node_file_trace_memory::case_001_analytics_node
        FAIL [   0.428s] turbopack::node-file-trace node_file_trace_memory::case_003_apollo
        FAIL [   0.397s] turbopack::node-file-trace node_file_trace_memory::case_004_argon2
        FAIL [   0.424s] turbopack::node-file-trace node_file_trace_memory::case_005_auth0
        FAIL [   0.414s] turbopack::node-file-trace node_file_trace_memory::case_006_aws_sdk
        FAIL [   0.421s] turbopack::node-file-trace node_file_trace_memory::case_007_axios
        FAIL [   0.408s] turbopack::node-file-trace node_file_trace_memory::case_008_azure_cosmos
        FAIL [   0.370s] turbopack::node-file-trace node_file_trace_memory::case_009_azure_storage
        FAIL [   0.407s] turbopack::node-file-trace node_file_trace_memory::case_010_bcrypt
        FAIL [   0.448s] turbopack::node-file-trace node_file_trace_memory::case_011_better_sqlite3
        FAIL [   0.446s] turbopack::node-file-trace node_file_trace_memory::case_012_bindings_failure
        FAIL [   0.379s] turbopack::node-file-trace node_file_trace_memory::case_013_browserify_middleware
        FAIL [   0.395s] turbopack::node-file-trace node_file_trace_memory::case_014_bugsnag_js
        FAIL [   0.384s] turbopack::node-file-trace node_file_trace_memory::case_017_camaro
        FAIL [   0.436s] turbopack::node-file-trace node_file_trace_memory::case_018_canvas
        FAIL [   0.467s] turbopack::node-file-trace node_file_trace_memory::case_019_chromeless
        FAIL [   0.455s] turbopack::node-file-trace node_file_trace_memory::case_020_core_js
        FAIL [   0.412s] turbopack::node-file-trace node_file_trace_memory::case_021_cosmosdb_query
        FAIL [   0.334s] turbopack::node-file-trace node_file_trace_memory::case_022_cowsay
        FAIL [   0.399s] turbopack::node-file-trace node_file_trace_memory::case_024_dynamic_in_package
        FAIL [   0.382s] turbopack::node-file-trace node_file_trace_memory::case_027_es_get_iterator
        FAIL [   0.416s] turbopack::node-file-trace node_file_trace_memory::case_028_esbuild
        FAIL [   0.486s] turbopack::node-file-trace node_file_trace_memory::case_029_esm
        FAIL [   0.418s] turbopack::node-file-trace node_file_trace_memory::case_030_express_consolidate
        FAIL [   0.425s] turbopack::node-file-trace node_file_trace_memory::case_031_express_template_engine
        FAIL [   0.433s] turbopack::node-file-trace node_file_trace_memory::case_032_express_template_pug
        FAIL [   0.260s] turbopack::node-file-trace node_file_trace_memory::case_033_express
error: test run failed
```
