### PR TITLE
Implement Streaming Static/Proxy Rendering

### DIFF
--- a/crates/turbopack-node/src/lib.rs
+++ b/crates/turbopack-node/src/lib.rs
@@ -278,6 +278,7 @@ pub async fn get_intermediate_asset(
     .into())
 }
 
+#[derive(Clone, Debug)]
 #[turbo_tasks::value(shared)]
 pub struct ResponseHeaders {
     pub status: u16,

--- a/crates/turbopack-node/src/render/mod.rs
+++ b/crates/turbopack-node/src/render/mod.rs
@@ -7,7 +7,8 @@ use turbopack_core::asset::AssetVc;
 use turbopack_dev_server::source::Body;
 
 use crate::{
-    pool::NodeJsOperation, route_matcher::Param, trace_stack, ResponseHeaders, StructuredError,
+    pool::NodeJsOperation, route_matcher::Param, source_map::trace_stack, ResponseHeaders,
+    StructuredError,
 };
 
 pub(crate) mod error_page;
@@ -79,6 +80,7 @@ pub(crate) fn stream_body_chunks(
     mut operation: NodeJsOperation,
     intermediate_asset: AssetVc,
     intermediate_output_path: FileSystemPathVc,
+    project_dir: FileSystemPathVc,
 ) -> Body {
     let chunks = Stream::new_open(
         vec![],
@@ -104,7 +106,7 @@ pub(crate) fn stream_body_chunks(
                     RenderBodyChunks::BodyEnd => break,
                     RenderBodyChunks::Error(error) => {
                         let trace =
-                            trace_stack(error, intermediate_asset, intermediate_output_path).await;
+                            trace_stack(error, intermediate_asset, intermediate_output_path, project_dir).await;
                         let e = trace.map_or_else(Into::into, Into::into);
                         yield Err(e);
                         break;

--- a/crates/turbopack-node/src/render/mod.rs
+++ b/crates/turbopack-node/src/render/mod.rs
@@ -1,7 +1,14 @@
+use async_stream::stream as generator;
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
+use turbo_tasks_bytes::Stream;
+use turbo_tasks_fs::FileSystemPathVc;
+use turbopack_core::asset::AssetVc;
+use turbopack_dev_server::source::Body;
 
-use crate::{route_matcher::Param, ResponseHeaders, StructuredError};
+use crate::{
+    pool::NodeJsOperation, route_matcher::Param, trace_stack, ResponseHeaders, StructuredError,
+};
 
 pub(crate) mod error_page;
 pub mod issue;
@@ -39,8 +46,6 @@ enum RenderProxyOutgoingMessage<'a> {
 #[serde(tag = "type", rename_all = "camelCase")]
 enum RenderProxyIncomingMessage {
     Headers { data: ResponseHeaders },
-    BodyChunk { data: Vec<u8> },
-    BodyEnd,
     Error(StructuredError),
 }
 
@@ -53,8 +58,60 @@ enum RenderStaticIncomingMessage {
         headers: Vec<(String, String)>,
         body: String,
     },
+    Headers {
+        data: ResponseHeaders,
+    },
     Rewrite {
         path: String,
     },
     Error(StructuredError),
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "type", rename_all = "camelCase")]
+enum RenderBodyChunks {
+    BodyChunk { data: Vec<u8> },
+    BodyEnd,
+    Error(StructuredError),
+}
+
+pub(crate) fn stream_body_chunks(
+    mut operation: NodeJsOperation,
+    intermediate_asset: AssetVc,
+    intermediate_output_path: FileSystemPathVc,
+) -> Body {
+    let chunks = Stream::new_open(
+        vec![],
+        Box::pin(generator! {
+            macro_rules! tri {
+                ($exp:expr) => {
+                    match $exp {
+                        Ok(v) => v,
+                        Err(e) => {
+                            operation.disallow_reuse();
+                            yield Err(e.into());
+                            return;
+                        }
+                    }
+                }
+            }
+
+            loop {
+                match tri!(operation.recv().await) {
+                    RenderBodyChunks::BodyChunk { data } => {
+                        yield Ok(data.into());
+                    }
+                    RenderBodyChunks::BodyEnd => break,
+                    RenderBodyChunks::Error(error) => {
+                        let trace =
+                            trace_stack(error, intermediate_asset, intermediate_output_path).await;
+                        let e = trace.map_or_else(Into::into, Into::into);
+                        yield Err(e);
+                        break;
+                    }
+                }
+            }
+        }),
+    );
+    Body::from_stream(chunks.read())
 }

--- a/crates/turbopack-node/src/render/mod.rs
+++ b/crates/turbopack-node/src/render/mod.rs
@@ -43,10 +43,12 @@ enum RenderProxyOutgoingMessage<'a> {
     BodyEnd,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 #[serde(tag = "type", rename_all = "camelCase")]
 enum RenderProxyIncomingMessage {
     Headers { data: ResponseHeaders },
+    BodyChunk { data: Vec<u8> },
+    BodyEnd,
     Error(StructuredError),
 }
 

--- a/crates/turbopack-node/src/render/mod.rs
+++ b/crates/turbopack-node/src/render/mod.rs
@@ -39,7 +39,8 @@ enum RenderProxyOutgoingMessage<'a> {
 #[serde(tag = "type", rename_all = "camelCase")]
 enum RenderProxyIncomingMessage {
     Headers { data: ResponseHeaders },
-    Body { data: Vec<u8> },
+    BodyChunk { data: Vec<u8> },
+    BodyEnd,
     Error(StructuredError),
 }
 

--- a/crates/turbopack-node/src/render/render_proxy.rs
+++ b/crates/turbopack-node/src/render/render_proxy.rs
@@ -1,19 +1,27 @@
-use anyhow::{bail, Result};
-use futures::StreamExt;
-use turbo_tasks::primitives::StringVc;
+use anyhow::{anyhow, bail, Result};
+use async_stream::try_stream as generator;
+use futures::{
+    channel::mpsc::{unbounded, UnboundedSender},
+    pin_mut, SinkExt, StreamExt,
+};
+use parking_lot::Mutex;
+use turbo_tasks::{mark_finished, primitives::StringVc, util::SharedError, RawVc};
+use turbo_tasks_bytes::{Bytes, Stream};
 use turbo_tasks_env::ProcessEnvVc;
 use turbo_tasks_fs::FileSystemPathVc;
 use turbopack_core::{asset::AssetVc, chunk::ChunkingContextVc, error::PrettyPrintError};
-use turbopack_dev_server::source::{BodyVc, ProxyResult, ProxyResultVc};
+use turbopack_dev_server::source::{Body, BodyError, BodyVc, ProxyResult, ProxyResultVc};
 use turbopack_ecmascript::{chunk::EcmascriptChunkPlaceablesVc, EcmascriptModuleAssetVc};
 
 use super::{
-    issue::RenderingIssue, stream_body_chunks, RenderDataVc, RenderProxyIncomingMessage,
-    RenderProxyOutgoingMessage, ResponseHeaders,
+    issue::RenderingIssue, RenderDataVc, RenderProxyIncomingMessage, RenderProxyOutgoingMessage,
+    ResponseHeaders,
 };
 use crate::{
-    get_intermediate_asset, get_renderer_pool, pool::NodeJsOperation,
-    render::error_page::error_html, source_map::trace_stack,
+    get_intermediate_asset, get_renderer_pool,
+    pool::{NodeJsOperation, NodeJsPoolVc},
+    render::error_page::error_html,
+    source_map::trace_stack,
 };
 
 /// Renders a module as static HTML in a node.js process.
@@ -44,87 +52,48 @@ pub async fn render_proxy(
         output_root,
         project_dir,
         /* debug */ false,
-    )
-    .await?;
+    );
 
-    let mut operation = match pool.operation().await {
-        Ok(operation) => operation,
-        Err(err) => {
-            let (status, body) = proxy_error(path, err, None).await?;
-            return Ok(proxy_error_result(status, body));
-        }
-    };
-
-    let (status, headers) = match start_proxy_operation(
-        &mut operation,
+    let render = render_stream(
+        pool,
         data,
         body,
         intermediate_asset,
         intermediate_output_path,
         project_dir,
+        path,
     )
-    .await
-    {
-        Ok(v) => v,
-        Err(err) => {
-            let (status, body) = proxy_error(path, err, Some(operation)).await?;
-            return Ok(proxy_error_result(status, body));
+    .await?;
+
+    let mut stream = render.read();
+    let first = match stream.next().await {
+        Some(Ok(f)) => f,
+        _ => {
+            // If an Error was received first, then it would have been
+            // transformed into a proxy err error response.
+            bail!("did not receive response from render");
         }
     };
 
-    Ok(ProxyResult {
-        status,
-        headers,
-        body: stream_body_chunks(
-            operation,
-            intermediate_asset,
-            intermediate_output_path,
-            project_dir,
-        ),
-    }
-    .cell())
-}
+    let RenderItem::Headers(data) = first else {
+        bail!("did not receive headers from render");
+    };
 
-async fn start_proxy_operation(
-    operation: &mut NodeJsOperation,
-    data: RenderDataVc,
-    body: BodyVc,
-    intermediate_asset: AssetVc,
-    intermediate_output_path: FileSystemPathVc,
-    project_dir: FileSystemPathVc,
-) -> Result<(u16, Vec<(String, String)>)> {
-    let data = data.await?;
-    // First, send the render data.
-    operation
-        .send(RenderProxyOutgoingMessage::Headers { data: &data })
-        .await?;
+    let body = Body::from_stream(stream.map(|item| match item {
+        Ok(RenderItem::BodyChunk(b)) => Ok(b),
+        Ok(v) => Err(BodyError::new(format!("unexpected render item: {:#?}", v))),
+        Err(e) => Err(BodyError::new(format!(
+            "error streaming proxied contents: {}",
+            e
+        ))),
+    }));
+    let result = ProxyResult {
+        status: data.status,
+        headers: data.headers,
+        body,
+    };
 
-    let mut body = body.await?.read();
-    // Then, send the binary body in chunks.
-    while let Some(data) = body.next().await {
-        operation
-            .send(RenderProxyOutgoingMessage::BodyChunk { data: &data? })
-            .await?;
-    }
-
-    operation.send(RenderProxyOutgoingMessage::BodyEnd).await?;
-
-    match operation.recv().await? {
-        RenderProxyIncomingMessage::Headers {
-            data: ResponseHeaders { status, headers },
-        } => Ok((status, headers)),
-        RenderProxyIncomingMessage::Error(error) => {
-            bail!(
-                trace_stack(
-                    error,
-                    intermediate_asset,
-                    intermediate_output_path,
-                    project_dir
-                )
-                .await?
-            )
-        }
-    }
+    Ok(result.cell())
 }
 
 async fn proxy_error(
@@ -165,14 +134,164 @@ async fn proxy_error(
     Ok((status_code, body))
 }
 
-fn proxy_error_result(status: u16, body: String) -> ProxyResultVc {
-    ProxyResult {
-        status,
-        headers: vec![(
-            "content-type".to_string(),
-            "text/html; charset=utf-8".to_string(),
-        )],
-        body: body.clone().into(),
+#[derive(Clone, Debug)]
+#[turbo_tasks::value]
+enum RenderItem {
+    Headers(ResponseHeaders),
+    BodyChunk(Bytes),
+}
+
+type RenderItemResult = Result<RenderItem, SharedError>;
+
+#[turbo_tasks::value(eq = "manual", cell = "new", serialization = "none")]
+pub struct RenderStreamSender {
+    #[turbo_tasks(trace_ignore, debug_ignore)]
+    get: Box<dyn Fn() -> UnboundedSender<RenderItemResult> + Send + Sync>,
+}
+
+#[turbo_tasks::value(transparent, eq = "manual", cell = "new", serialization = "none")]
+struct RenderStream(#[turbo_tasks(trace_ignore)] Stream<RenderItemResult>);
+
+#[turbo_tasks::function]
+fn render_stream(
+    pool: NodeJsPoolVc,
+    data: RenderDataVc,
+    body: BodyVc,
+    intermediate_asset: AssetVc,
+    intermediate_output_path: FileSystemPathVc,
+    project_dir: FileSystemPathVc,
+    error_path: FileSystemPathVc,
+) -> RenderStreamVc {
+    // Note the following code uses some hacks to create a child task that produces
+    // a stream that is returned by this task.
+
+    // We create a new cell in this task, which will be updated from the
+    // [render_stream_internal] task.
+    let cell = turbo_tasks::macro_helpers::find_cell_by_type(*RENDERSTREAM_VALUE_TYPE_ID);
+
+    // We initialize the cell with a stream that is open, but has no values.
+    // The first [render_stream_internal] pipe call will pick up that stream.
+    let (sender, receiver) = unbounded();
+    cell.update_shared(RenderStream(Stream::new_open(vec![], Box::new(receiver))));
+    let initial = Mutex::new(Some(sender));
+
+    // run the evaluation as side effect
+    render_stream_internal(
+        pool,
+        data,
+        body,
+        intermediate_asset,
+        intermediate_output_path,
+        project_dir,
+        error_path,
+        RenderStreamSender {
+            get: Box::new(move || {
+                if let Some(sender) = initial.lock().take() {
+                    sender
+                } else {
+                    // In cases when only [render_stream_internal] is (re)executed, we need to
+                    // update the old stream with a new value.
+                    let (sender, receiver) = unbounded();
+                    cell.update_shared(RenderStream(Stream::new_open(vec![], Box::new(receiver))));
+                    sender
+                }
+            }),
+        }
+        .cell(),
+    );
+
+    let raw: RawVc = cell.into();
+    raw.into()
+}
+
+#[turbo_tasks::function]
+async fn render_stream_internal(
+    pool: NodeJsPoolVc,
+    data: RenderDataVc,
+    body: BodyVc,
+    intermediate_asset: AssetVc,
+    intermediate_output_path: FileSystemPathVc,
+    project_dir: FileSystemPathVc,
+    error_path: FileSystemPathVc,
+    sender: RenderStreamSenderVc,
+) {
+    mark_finished();
+    let Ok(sender) = sender.await else {
+        // Impossible to handle the error in a good way.
+        return;
+    };
+
+    let stream = generator! {
+        let data = data.await?;
+        let pool = pool.await?;
+        let mut operation = pool.operation().await?;
+
+        // First, send the render data.
+        operation
+            .send(RenderProxyOutgoingMessage::Headers { data: &data })
+            .await?;
+        // Then, send the binary body in chunks.
+        let mut body = body.await?.read();
+        while let Some(data) = body.next().await {
+            operation
+                .send(RenderProxyOutgoingMessage::BodyChunk { data: &data.unwrap() })
+                .await?;
+        }
+        operation.send(RenderProxyOutgoingMessage::BodyEnd).await?;
+
+        match operation.recv().await? {
+            RenderProxyIncomingMessage::Headers { data } => yield RenderItem::Headers(data),
+            RenderProxyIncomingMessage::Error(error) => {
+                // If we don't get headers, then something is very wrong. Instead, we send down a
+                // 500 proxy error as if it were the proper result.
+                let trace = trace_stack(
+                    error,
+                    intermediate_asset,
+                    intermediate_output_path,
+                    project_dir
+                )
+                .await?;
+                let (status, body) =  proxy_error(error_path, anyhow!("error rendering: {}", trace), Some(operation)).await?;
+                yield RenderItem::Headers(ResponseHeaders {
+                    status,
+                    headers: vec![(
+                        "content-type".to_string(),
+                        "text/html; charset=utf-8".to_string(),
+                    )],
+                });
+                yield RenderItem::BodyChunk(body.into());
+                return;
+            }
+            v => Err(anyhow!("unexpected message during rendering: {:#?}", v))?,
+        };
+
+        loop {
+            match operation.recv().await? {
+                RenderProxyIncomingMessage::BodyChunk { data } => {
+                    yield RenderItem::BodyChunk(data.into());
+                }
+                RenderProxyIncomingMessage::BodyEnd => break,
+                RenderProxyIncomingMessage::Error(error) => {
+                    // We have already started to send a result, so we can't change the
+                    // headers/body to a proxy error.
+                    operation.disallow_reuse();
+                    let trace =
+                        trace_stack(error, intermediate_asset, intermediate_output_path, project_dir).await?;
+                    Err(anyhow!("error during streaming render: {}", trace))?;
+                }
+                v => Err(anyhow!("unexpected message during rendering: {:#?}", v))?,
+            }
+        }
+    };
+
+    let mut sender = (sender.get)();
+    pin_mut!(stream);
+    while let Some(value) = stream.next().await {
+        if sender.send(value).await.is_err() {
+            return;
+        }
+        if sender.flush().await.is_err() {
+            return;
+        }
     }
-    .cell()
 }

--- a/crates/turbopack-node/src/render/render_proxy.rs
+++ b/crates/turbopack-node/src/render/render_proxy.rs
@@ -75,7 +75,12 @@ pub async fn render_proxy(
     Ok(ProxyResult {
         status,
         headers,
-        body: stream_body_chunks(operation, intermediate_asset, intermediate_output_path),
+        body: stream_body_chunks(
+            operation,
+            intermediate_asset,
+            intermediate_output_path,
+            project_dir,
+        ),
     }
     .cell())
 }

--- a/crates/turbopack-node/src/render/render_proxy.rs
+++ b/crates/turbopack-node/src/render/render_proxy.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, bail, Result};
 use async_stream::try_stream as generator;
 use futures::{
     channel::mpsc::{unbounded, UnboundedSender},
-    pin_mut, SinkExt, StreamExt,
+    pin_mut, SinkExt, StreamExt, TryStreamExt,
 };
 use parking_lot::Mutex;
 use turbo_tasks::{mark_finished, primitives::StringVc, util::SharedError, RawVc};
@@ -53,9 +53,9 @@ pub async fn render_proxy(
     .await?;
 
     let mut stream = render.read();
-    let first = match stream.next().await {
-        Some(Ok(f)) => f,
-        _ => {
+    let first = match stream.try_next().await? {
+        Some(f) => f,
+        None => {
             // If an Error was received first, then it would have been
             // transformed into a proxy err error response.
             bail!("did not receive response from render");

--- a/crates/turbopack-node/src/render/render_static.rs
+++ b/crates/turbopack-node/src/render/render_static.rs
@@ -1,27 +1,37 @@
-use anyhow::{anyhow, Context, Result};
-use turbo_tasks::primitives::StringVc;
+use anyhow::{anyhow, bail, Context, Result};
+use async_stream::try_stream as generator;
+use futures::{
+    channel::mpsc::{unbounded, UnboundedSender},
+    pin_mut, SinkExt, StreamExt,
+};
+use parking_lot::Mutex;
+use turbo_tasks::{mark_finished, primitives::StringVc, util::SharedError, RawVc};
+use turbo_tasks_bytes::{Bytes, Stream};
 use turbo_tasks_env::ProcessEnvVc;
 use turbo_tasks_fs::{File, FileContent, FileSystemPathVc};
 use turbopack_core::{
-    asset::{Asset, AssetContentVc},
+    asset::{Asset, AssetContentVc, AssetVc},
     chunk::ChunkingContextVc,
     error::PrettyPrintError,
 };
 use turbopack_dev_server::{
     html::DevHtmlAssetVc,
-    source::{Body, HeaderListVc, RewriteBuilder, RewriteVc},
+    source::{Body, BodyError, HeaderListVc, RewriteBuilder, RewriteVc},
 };
 use turbopack_ecmascript::{chunk::EcmascriptChunkPlaceablesVc, EcmascriptModuleAssetVc};
 
 use super::{
-    issue::RenderingIssue, stream_body_chunks, RenderDataVc, RenderStaticIncomingMessage,
-    RenderStaticOutgoingMessage,
+    issue::RenderingIssue, RenderDataVc, RenderStaticIncomingMessage, RenderStaticOutgoingMessage,
 };
 use crate::{
-    get_intermediate_asset, get_renderer_pool, pool::NodeJsOperation,
-    render::error_page::error_html_body, source_map::trace_stack,
+    get_intermediate_asset, get_renderer_pool,
+    pool::{NodeJsOperation, NodeJsPoolVc},
+    render::error_page::error_html_body,
+    source_map::trace_stack,
+    ResponseHeaders,
 };
 
+#[derive(Clone, Debug)]
 #[turbo_tasks::value]
 pub enum StaticResult {
     Content {
@@ -83,72 +93,47 @@ pub async fn render_static(
         project_dir,
         /* debug */ false,
     );
-    // Read this strongly consistent, since we don't want to run inconsistent
-    // node.js code.
-    let pool = renderer_pool.strongly_consistent().await?;
-    let mut operation = match pool.operation().await {
-        Ok(operation) => operation,
-        Err(err) => {
-            return Ok(StaticResultVc::content(
-                static_error(path, err, None, fallback_page).await?,
-                500,
-                HeaderListVc::empty(),
-            ))
+
+    let render = render_stream(
+        renderer_pool,
+        data,
+        intermediate_asset,
+        intermediate_output_path,
+        project_dir,
+        path,
+        fallback_page,
+    )
+    .await?;
+
+    let mut stream = render.read();
+    let first = match stream.next().await {
+        Some(Ok(f)) => f,
+        _ => {
+            // If an Error was received first, then it would have been
+            // transformed into a proxy err error response.
+            bail!("did not receive response from render");
         }
     };
 
-    let data = data.await?;
-
-    operation
-        .send(RenderStaticOutgoingMessage::Headers { data: &data })
-        .await
-        .context("sending headers to node.js process")?;
-
-    let first = operation
-        .recv()
-        .await
-        .context("receiving from node.js process")?;
-
     Ok(match first {
-        RenderStaticIncomingMessage::Rewrite { path } => {
-            StaticResultVc::rewrite(RewriteBuilder::new(path).build())
-        }
-        RenderStaticIncomingMessage::Response {
-            status_code,
-            headers,
-            body,
-        } => StaticResultVc::content(
-            FileContent::Content(File::from(body)).into(),
-            status_code,
-            HeaderListVc::cell(headers),
-        ),
-        RenderStaticIncomingMessage::Error(error) => {
-            let trace = trace_stack(
-                error,
-                intermediate_asset,
-                intermediate_output_path,
-                project_dir,
-            )
-            .await?;
-            StaticResultVc::content(
-                static_error(path, anyhow!(trace), Some(operation), fallback_page).await?,
-                500,
-                HeaderListVc::empty(),
-            )
-        }
-        RenderStaticIncomingMessage::Headers { data } => {
+        RenderItem::Response(response) => response,
+        RenderItem::Headers(data) => {
+            let body = stream.map(|item| match item {
+                Ok(RenderItem::BodyChunk(b)) => Ok(b),
+                Ok(v) => Err(BodyError::new(format!("unexpected render item: {:#?}", v))),
+                Err(e) => Err(BodyError::new(format!(
+                    "error streaming proxied contents: {}",
+                    e
+                ))),
+            });
             StaticResult::StreamedContent {
                 status: data.status,
                 headers: HeaderListVc::cell(data.headers),
-                body: stream_body_chunks(
-                    operation,
-                    intermediate_asset,
-                    intermediate_output_path,
-                    project_dir,
-                ),
+                body: Body::from_stream(body),
             }
+            .cell()
         }
-        .cell(),
+        v => bail!("unexpected render item: {:#?}", v),
     })
 }
 
@@ -195,4 +180,177 @@ async fn static_error(
     let html = fallback_page.with_body(body);
 
     Ok(html.content())
+}
+
+#[derive(Clone, Debug)]
+#[turbo_tasks::value]
+enum RenderItem {
+    Response(StaticResultVc),
+    Headers(ResponseHeaders),
+    BodyChunk(Bytes),
+}
+
+type RenderItemResult = Result<RenderItem, SharedError>;
+
+#[turbo_tasks::value(eq = "manual", cell = "new", serialization = "none")]
+pub struct RenderStreamSender {
+    #[turbo_tasks(trace_ignore, debug_ignore)]
+    get: Box<dyn Fn() -> UnboundedSender<RenderItemResult> + Send + Sync>,
+}
+
+#[turbo_tasks::value(transparent, eq = "manual", cell = "new", serialization = "none")]
+struct RenderStream(#[turbo_tasks(trace_ignore)] Stream<RenderItemResult>);
+
+#[turbo_tasks::function]
+fn render_stream(
+    pool: NodeJsPoolVc,
+    data: RenderDataVc,
+    intermediate_asset: AssetVc,
+    intermediate_output_path: FileSystemPathVc,
+    project_dir: FileSystemPathVc,
+    error_path: FileSystemPathVc,
+    fallback_page: DevHtmlAssetVc,
+) -> RenderStreamVc {
+    // Note the following code uses some hacks to create a child task that produces
+    // a stream that is returned by this task.
+
+    // We create a new cell in this task, which will be updated from the
+    // [render_stream_internal] task.
+    let cell = turbo_tasks::macro_helpers::find_cell_by_type(*RENDERSTREAM_VALUE_TYPE_ID);
+
+    // We initialize the cell with a stream that is open, but has no values.
+    // The first [render_stream_internal] pipe call will pick up that stream.
+    let (sender, receiver) = unbounded();
+    cell.update_shared(RenderStream(Stream::new_open(vec![], Box::new(receiver))));
+    let initial = Mutex::new(Some(sender));
+
+    // run the evaluation as side effect
+    render_stream_internal(
+        pool,
+        data,
+        intermediate_asset,
+        intermediate_output_path,
+        project_dir,
+        error_path,
+        fallback_page,
+        RenderStreamSender {
+            get: Box::new(move || {
+                if let Some(sender) = initial.lock().take() {
+                    sender
+                } else {
+                    // In cases when only [render_stream_internal] is (re)executed, we need to
+                    // update the old stream with a new value.
+                    let (sender, receiver) = unbounded();
+                    cell.update_shared(RenderStream(Stream::new_open(vec![], Box::new(receiver))));
+                    sender
+                }
+            }),
+        }
+        .cell(),
+    );
+
+    let raw: RawVc = cell.into();
+    raw.into()
+}
+
+#[turbo_tasks::function]
+async fn render_stream_internal(
+    pool: NodeJsPoolVc,
+    data: RenderDataVc,
+    intermediate_asset: AssetVc,
+    intermediate_output_path: FileSystemPathVc,
+    project_dir: FileSystemPathVc,
+    error_path: FileSystemPathVc,
+    fallback_page: DevHtmlAssetVc,
+    sender: RenderStreamSenderVc,
+) {
+    mark_finished();
+    let Ok(sender) = sender.await else {
+        // Impossible to handle the error in a good way.
+        return;
+    };
+
+    let stream = generator! {
+        let data = data.await?;
+        // Read this strongly consistent, since we don't want to run inconsistent
+        // node.js code.
+        let pool = pool.strongly_consistent().await?;
+        let mut operation = pool.operation().await?;
+
+        operation
+            .send(RenderStaticOutgoingMessage::Headers { data: &data })
+            .await
+            .context("sending headers to node.js process")?;
+
+        match operation.recv().await? {
+            RenderStaticIncomingMessage::Headers { data } => yield RenderItem::Headers(data),
+            RenderStaticIncomingMessage::Rewrite { path } => {
+                yield RenderItem::Response(StaticResultVc::rewrite(RewriteBuilder::new(path).build()));
+                return;
+            }
+            RenderStaticIncomingMessage::Response {
+                status_code,
+                headers,
+                body,
+            } => {
+                yield RenderItem::Response(StaticResultVc::content(
+                    FileContent::Content(File::from(body)).into(),
+                    status_code,
+                    HeaderListVc::cell(headers),
+                ));
+                return;
+            }
+            RenderStaticIncomingMessage::Error(error) => {
+                // If we don't get headers, then something is very wrong. Instead, we send down a
+                // 500 proxy error as if it were the proper result.
+                let trace = trace_stack(
+                    error,
+                    intermediate_asset,
+                    intermediate_output_path,
+                    project_dir,
+                )
+                .await?;
+                yield RenderItem::Response(
+                    StaticResultVc::content(
+                        static_error(error_path, anyhow!(trace), Some(operation), fallback_page).await?,
+                        500,
+                        HeaderListVc::empty(),
+                    )
+                );
+                return;
+            }
+            v => Err(anyhow!("unexpected message during rendering: {:#?}", v))?,
+        };
+
+        // If we get here, then the first message was a Headers. Now we need to stream out the body
+        // chunks.
+        loop {
+            match operation.recv().await? {
+                RenderStaticIncomingMessage::BodyChunk { data } => {
+                    yield RenderItem::BodyChunk(data.into());
+                }
+                RenderStaticIncomingMessage::BodyEnd => break,
+                RenderStaticIncomingMessage::Error(error) => {
+                    // We have already started to send a result, so we can't change the
+                    // headers/body to a proxy error.
+                    operation.disallow_reuse();
+                    let trace =
+                        trace_stack(error, intermediate_asset, intermediate_output_path, project_dir).await?;
+                    Err(anyhow!("error during streaming render: {}", trace))?;
+                }
+                v => Err(anyhow!("unexpected message during rendering: {:#?}", v))?,
+            }
+        }
+    };
+
+    let mut sender = (sender.get)();
+    pin_mut!(stream);
+    while let Some(value) = stream.next().await {
+        if sender.send(value).await.is_err() {
+            return;
+        }
+        if sender.flush().await.is_err() {
+            return;
+        }
+    }
 }

--- a/crates/turbopack-node/src/render/render_static.rs
+++ b/crates/turbopack-node/src/render/render_static.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{anyhow, Context, Result};
 use turbo_tasks::primitives::StringVc;
 use turbo_tasks_env::ProcessEnvVc;
 use turbo_tasks_fs::{File, FileContent, FileSystemPathVc};
@@ -140,7 +140,12 @@ pub async fn render_static(
             StaticResult::StreamedContent {
                 status: data.status,
                 headers: HeaderListVc::cell(data.headers),
-                body: stream_body_chunks(operation, intermediate_asset, intermediate_output_path),
+                body: stream_body_chunks(
+                    operation,
+                    intermediate_asset,
+                    intermediate_output_path,
+                    project_dir,
+                ),
             }
         }
         .cell(),

--- a/crates/turbopack-node/src/render/rendered_source.rs
+++ b/crates/turbopack-node/src/render/rendered_source.rs
@@ -21,7 +21,7 @@ use turbopack_dev_server::{
         specificity::SpecificityVc,
         ContentSource, ContentSourceContent, ContentSourceContentVc, ContentSourceData,
         ContentSourceDataVary, ContentSourceDataVaryVc, ContentSourceResult, ContentSourceResultVc,
-        ContentSourceVc, GetContentSourceContent, GetContentSourceContentVc,
+        ContentSourceVc, GetContentSourceContent, GetContentSourceContentVc, ProxyResult,
     },
 };
 use turbopack_ecmascript::chunk::EcmascriptChunkPlaceablesVc;
@@ -237,6 +237,19 @@ impl GetContentSourceContent for NodeRenderGetContentResult {
                 status_code,
                 headers,
             } => ContentSourceContentVc::static_with_headers(content.into(), status_code, headers),
+            StaticResult::StreamedContent {
+                status,
+                headers,
+                ref body,
+            } => ContentSourceContent::HttpProxy(
+                ProxyResult {
+                    status,
+                    headers: headers.await?.clone_value(),
+                    body: body.clone(),
+                }
+                .cell(),
+            )
+            .cell(),
             StaticResult::Rewrite(rewrite) => ContentSourceContent::Rewrite(rewrite).cell(),
         })
     }


### PR DESCRIPTION
### Description

Implements streaming rendering for static/proxy renders (I don't know why they're called static or proxy…) using an initial `Headers` message, N `BodyChunk` messages, and a final `BodyEnd` message.

Updating proxy rendering was very easy. It already implemented separate messages for header and body, but it buffered the full body before sending the full contents. But static rendering was a little more difficult, it has multiple paths that are immediately ready with a full body that I didn't want to break apart. So I kept the `Response` message for a full response that transforms into a `ContentSourceContent::Static`, and implemented a new enum type for streaming responses into a `ContentSourceContent::HttpProxy`.

These is some weirdness with different data types on the `headers` field of a `ContentSourceContent::Static`'s `StaticContent` and a `ContentSourceContent::HttpProxy`'s `ProxyResultVc`. One is a `HeaderListVc` and the other is a `Vec<(String, String)>` (and really should be a `HeadersList`), but I'm leaving this for a follow up.


### Testing Instructions

Paired Next.js PR: https://github.com/vercel/next.js/pull/47476

Re: WEB-27