### PR TITLE
allow to mark tasks as finished 

### DIFF
--- a/crates/turbo-tasks-memory/src/memory_backend.rs
+++ b/crates/turbo-tasks-memory/src/memory_backend.rs
@@ -691,6 +691,14 @@ impl Backend for MemoryBackend {
         self.connect_task_child(parent_task, task, turbo_tasks);
     }
 
+    fn mark_own_task_as_finished(
+        &self,
+        task: TaskId,
+        _turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackend>,
+    ) {
+        self.with_task(task, |task| task.mark_as_finished(self))
+    }
+
     fn create_transient_task(
         &self,
         task_type: TransientTaskType,

--- a/crates/turbo-tasks-testing/src/lib.rs
+++ b/crates/turbo-tasks-testing/src/lib.rs
@@ -219,6 +219,10 @@ impl TurboTasksApi for VcStorage {
     fn connect_task(&self, _task: TaskId) {
         // no-op
     }
+
+    fn mark_own_task_as_finished(&self, _task: TaskId) {
+        // no-op
+    }
 }
 
 impl VcStorage {

--- a/crates/turbo-tasks/src/backend.rs
+++ b/crates/turbo-tasks/src/backend.rs
@@ -338,6 +338,14 @@ pub trait Backend: Sync + Send {
         turbo_tasks: &dyn TurboTasksBackendApi<Self>,
     );
 
+    fn mark_own_task_as_finished(
+        &self,
+        _task: TaskId,
+        _turbo_tasks: &dyn TurboTasksBackendApi<Self>,
+    ) {
+        // Do nothing by default
+    }
+
     fn create_transient_task(
         &self,
         task_type: TransientTaskType,

--- a/crates/turbo-tasks/src/lib.rs
+++ b/crates/turbo-tasks/src/lib.rs
@@ -79,9 +79,10 @@ pub use invalidation::{
 };
 pub use join_iter_ext::{JoinIterExt, TryJoinIterExt};
 pub use manager::{
-    dynamic_call, emit, get_invalidator, mark_stateful, run_once, run_once_with_reason,
-    spawn_blocking, spawn_thread, trait_call, turbo_tasks, Invalidator, StatsType, TaskIdProvider,
-    TurboTasks, TurboTasksApi, TurboTasksBackendApi, TurboTasksCallApi, Unused, UpdateInfo,
+    dynamic_call, emit, get_invalidator, mark_finished, mark_stateful, run_once,
+    run_once_with_reason, spawn_blocking, spawn_thread, trait_call, turbo_tasks, Invalidator,
+    StatsType, TaskIdProvider, TurboTasks, TurboTasksApi, TurboTasksBackendApi, TurboTasksCallApi,
+    Unused, UpdateInfo,
 };
 pub use native_function::{NativeFunction, NativeFunctionVc};
 pub use nothing::{Nothing, NothingVc};

--- a/crates/turbopack-node/src/evaluate.rs
+++ b/crates/turbopack-node/src/evaluate.rs
@@ -12,6 +12,7 @@ use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use turbo_tasks::{
+    mark_finished,
     primitives::{JsonValueVc, StringVc},
     util::SharedError,
     CompletionVc, RawVc, TryJoinIterExt, Value, ValueToString,
@@ -311,6 +312,7 @@ async fn compute_evaluate_stream(
     args: Vec<JsonValueVc>,
     sender: JavaScriptStreamSenderVc,
 ) {
+    mark_finished();
     let Ok(sender) = sender.await else {
         // Impossible to handle the error in a good way.
         return;

--- a/crates/turbopack-node/src/evaluate.rs
+++ b/crates/turbopack-node/src/evaluate.rs
@@ -380,6 +380,9 @@ async fn compute_evaluate_stream(
         if sender.send(value).await.is_err() {
             return;
         }
+        if sender.flush().await.is_err() {
+            return;
+        }
     }
 }
 


### PR DESCRIPTION
### Description

this allows to exclude them from strongly consistency

mark evaluate stream as finished to allow to return early from strongly consitent reads
