### PR TITLE
Minimum Node Version

### DIFF
--- a/docs/pages/repo/docs/installing.mdx
+++ b/docs/pages/repo/docs/installing.mdx
@@ -14,6 +14,9 @@ import { Tabs, Tab } from '../../../components/Tabs'
 - Linux 64-bit, ARM 64-bit
 - Windows 64-bit, ARM 64-bit
 
+Minimum Requirements
+- Node 18
+
 <Callout>
   Note: Linux builds of `turbo` link against `glibc`. For Alpine Docker environments, you will need to ensure libc6-compat is installed as well, via `RUN apk add --no-cache libc6-compat`
 </Callout>


### PR DESCRIPTION
### Description

![SCR-20230324-g3z](https://user-images.githubusercontent.com/22017882/227611501-a06d642e-ee32-4c69-8a72-995d4c7087d4.png)
Module resolution fails on Node 16
### Testing Instructions
1. Switch to node 16 and run `npm run dev`
2. Upgrade to node 18 and the error goes away
