### PR TITLE
Record exit codes per task in a run

### DIFF
--- a/cli/integration_tests/basic_monorepo/dry_run.t
+++ b/cli/integration_tests/basic_monorepo/dry_run.t
@@ -20,14 +20,14 @@ Setup
     Global Files               = 1
     External Dependencies Hash = ccab0b28617f1f56
     Global Cache Key           = Buffalo buffalo Buffalo buffalo buffalo buffalo Buffalo buffalo
-    Root pipeline              = {"//#something":{"outputs":[],"cache":true,"dependsOn":[],"inputs":[],"outputMode":"full","env":[],"persistent":false},"build":{"outputs":[],"cache":true,"dependsOn":[],"inputs":[],"outputMode":"full","env":["NODE_ENV"],"persistent":false},"my-app#build":{"outputs":["apple.json","banana.txt"],"cache":true,"dependsOn":[],"inputs":[],"outputMode":"full","env":[],"persistent":false},"something":{"outputs":[],"cache":true,"dependsOn":[],"inputs":[],"outputMode":"full","env":[],"persistent":false}}
+    Root pipeline              = {"//#something":{"outputs":[],"cache":true,"dependsOn":[],"inputs":[],"outputMode":"full","env":[],"persistent":false},"build":{"outputs":[],"cache":true,"dependsOn":[],"inputs":[],"outputMode":"full","env":["NODE_ENV"],"persistent":false},"maybefails":{"outputs":[],"cache":true,"dependsOn":[],"inputs":[],"outputMode":"full","env":[],"persistent":false},"my-app#build":{"outputs":["apple.json","banana.txt"],"cache":true,"dependsOn":[],"inputs":[],"outputMode":"full","env":[],"persistent":false},"something":{"outputs":[],"cache":true,"dependsOn":[],"inputs":[],"outputMode":"full","env":[],"persistent":false}}
 
 # Part 3 are Tasks to Run, and we have to validate each task separately
   $ cat tmp-3.txt | grep "my-app#build" -A 15
   my-app#build
     Task                             = build                                                                                                                           
     Package                          = my-app                                                                                                                          
-    Hash                             = 45ec4e15c3dcf5c2                                                                                                                
+    Hash                             = 2f192ed93e20f940                                                                                                                
     Cached (Local)                   = false                                                                                                                           
     Cached (Remote)                  = false                                                                                                                           
     Directory                        = apps/my-app                                                                                                                     
@@ -45,7 +45,7 @@ Setup
   util#build
     Task                             = build                                                                                                            
     Package                          = util                                                                                                             
-    Hash                             = c36e55f947cd2d28                                                                                                 
+    Hash                             = af2ba2d52192ee45                                                                                                 
     Cached (Local)                   = false                                                                                                            
     Cached (Remote)                  = false                                                                                                            
     Directory                        = packages/util                                                                                                    

--- a/cli/integration_tests/basic_monorepo/dry_run_json.t
+++ b/cli/integration_tests/basic_monorepo/dry_run_json.t
@@ -37,6 +37,15 @@ Setup
         ],
         "persistent": false
       },
+      "maybefails": {
+        "outputs": [],
+        "cache": true,
+        "dependsOn": [],
+        "inputs": [],
+        "outputMode": "full",
+        "env": [],
+        "persistent": false
+      },
       "my-app#build": {
         "outputs": [
           "apple.json",
@@ -67,7 +76,7 @@ Setup
     "taskId": "my-app#build",
     "task": "build",
     "package": "my-app",
-    "hash": "45ec4e15c3dcf5c2",
+    "hash": "2f192ed93e20f940",
     "cacheState": {
       "local": false,
       "remote": false
@@ -96,7 +105,7 @@ Setup
       "persistent": false
     },
     "expandedInputs": {
-      "package.json": "f2a5d2525f3996a57680180a7cd9ad7310e4dec0"
+      "package.json": "6bcf57fd6ff30d1a6f40ad8d8d08e8b940fc7e3b"
     },
     "expandedOutputs": [],
     "framework": "<NO FRAMEWORK DETECTED>",
@@ -117,7 +126,7 @@ Setup
     "taskId": "util#build",
     "task": "build",
     "package": "util",
-    "hash": "c36e55f947cd2d28",
+    "hash": "af2ba2d52192ee45",
     "cacheState": {
       "local": false,
       "remote": false
@@ -142,7 +151,7 @@ Setup
       "persistent": false
     },
     "expandedInputs": {
-      "package.json": "8d3e121335e16dbd8d99c03522b892ec52416dda"
+      "package.json": "4d57bb28c9967640d812981198a743b3188f713e"
     },
     "expandedOutputs": [],
     "framework": "<NO FRAMEWORK DETECTED>",

--- a/cli/integration_tests/basic_monorepo/global_env.t
+++ b/cli/integration_tests/basic_monorepo/global_env.t
@@ -9,7 +9,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  util:build: cache miss, executing c36e55f947cd2d28
+  util:build: cache miss, executing af2ba2d52192ee45
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -20,7 +20,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  util:build: cache hit, suppressing output c36e55f947cd2d28
+  util:build: cache hit, suppressing output af2ba2d52192ee45
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total
@@ -31,7 +31,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  util:build: cache miss, executing dcdc86b6249b8fb8
+  util:build: cache miss, executing 17f686a212d7ddfa
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -42,7 +42,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  util:build: cache miss, executing a472b6a01f8c3855
+  util:build: cache miss, executing c3c2acfea2980d29
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -53,7 +53,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  util:build: cache miss, executing c2e4c4880597b0a3
+  util:build: cache miss, executing 533045e55589de0b
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total

--- a/cli/integration_tests/basic_monorepo/monorepo/apps/my-app/package.json
+++ b/cli/integration_tests/basic_monorepo/monorepo/apps/my-app/package.json
@@ -1,7 +1,8 @@
 {
   "name": "my-app",
   "scripts": {
-    "build": "echo 'building'"
+    "build": "echo 'building'",
+    "maybefails": "exit 4"
   },
   "dependencies": {
     "util": "*"

--- a/cli/integration_tests/basic_monorepo/monorepo/packages/util/package.json
+++ b/cli/integration_tests/basic_monorepo/monorepo/packages/util/package.json
@@ -1,6 +1,7 @@
 {
   "name": "util",
   "scripts": {
-    "build": "echo 'building'"
+    "build": "echo 'building'",
+    "maybefails": "echo 'did not fail'"
   }
 }

--- a/cli/integration_tests/basic_monorepo/monorepo/turbo.json
+++ b/cli/integration_tests/basic_monorepo/monorepo/turbo.json
@@ -13,6 +13,8 @@
     },
 
     "something": {},
-    "//#something": {}
+    "//#something": {},
+
+    "maybefails": {}
   }
 }

--- a/cli/integration_tests/basic_monorepo/run_summary.t
+++ b/cli/integration_tests/basic_monorepo/run_summary.t
@@ -33,7 +33,8 @@ Setup
     "startTime": [0-9]+, (re)
     "endTime": [0-9]+, (re)
     "status": "built",
-    "error": null
+    "error": null,
+    "exitCode": 0
   }
   $ cat $(/bin/ls .turbo/runs/*.json | head -n1) | jq '.tasks | map(select(.taskId == "my-app#build")) | .[0].commandArguments'
   [
@@ -45,7 +46,8 @@ Setup
     "startTime": [0-9]+, (re)
     "endTime": [0-9]+, (re)
     "status": "built",
-    "error": null
+    "error": null,
+    "exitCode": 0
   }
   $ cat $(/bin/ls .turbo/runs/*.json | head -n1) | jq '.tasks | map(select(.taskId == "my-app#build")) | .[0].hashOfExternalDependencies'
   "ccab0b28617f1f56"

--- a/cli/integration_tests/basic_monorepo/run_summary_fail.t
+++ b/cli/integration_tests/basic_monorepo/run_summary_fail.t
@@ -1,0 +1,29 @@
+Setup
+  $ . ${TESTDIR}/../setup.sh
+  $ . ${TESTDIR}/setup.sh $(pwd)
+
+  $ rm -rf .turbo/runs
+
+# Turbo exits early and doesn't generate run summaries on errors, so we need to use --continue for this test.
+The maybefails task fails for one workspace but not the other
+  $ TURBO_RUN_SUMMARY=true ${TURBO} run maybefails --continue > /dev/null
+
+# ExitCode here is 1, because npm will report all errors with exitCode 1
+  $ cat $(/bin/ls .turbo/runs/*.json | head -n1) | jq '.tasks | map(select(.taskId == "my-app#maybefails")) | .[0].execution'
+  {
+    "startTime": [0-9]+, (re)
+    "endTime": [0-9]+, (re)
+    "status": "buildFailed",
+    "error": {},
+    "exitCode": 1
+  }
+
+# This one has success exit code
+  $ cat $(/bin/ls .turbo/runs/*.json | head -n1) | jq '.tasks | map(select(.taskId == "util#maybefails")) | .[0].execution'
+  {
+    "startTime": [0-9]+, (re)
+    "endTime": [0-9]+, (re)
+    "status": "built",
+    "error": null,
+    "exitCode": 0
+  }

--- a/cli/integration_tests/basic_monorepo/run_summary_fail.t
+++ b/cli/integration_tests/basic_monorepo/run_summary_fail.t
@@ -7,6 +7,7 @@ Setup
 # Turbo exits early and doesn't generate run summaries on errors, so we need to use --continue for this test.
 The maybefails task fails for one workspace but not the other
   $ TURBO_RUN_SUMMARY=true ${TURBO} run maybefails --continue > /dev/null
+  my-app:maybefails: command finished with error, but continuing...
 
 # ExitCode here is 1, because npm will report all errors with exitCode 1
   $ cat $(/bin/ls .turbo/runs/*.json | head -n1) | jq '.tasks | map(select(.taskId == "my-app#maybefails")) | .[0].execution'

--- a/cli/integration_tests/basic_monorepo/verbosity.t
+++ b/cli/integration_tests/basic_monorepo/verbosity.t
@@ -8,7 +8,7 @@ Verbosity level 1
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  util:build: cache bypass, force executing c36e55f947cd2d28
+  util:build: cache bypass, force executing af2ba2d52192ee45
   util:build: 
   util:build: > build
   util:build: > echo 'building'
@@ -24,7 +24,7 @@ Verbosity level 1
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  util:build: cache bypass, force executing c36e55f947cd2d28
+  util:build: cache bypass, force executing af2ba2d52192ee45
   util:build: 
   util:build: > build
   util:build: > echo 'building'
@@ -48,15 +48,15 @@ Verbosity level 2
   [-0-9:.TWZ+]+ \[DEBUG] turbo: build tag: (go|rust) (re)
   [-0-9:.TWZ+]+ \[INFO]  turbo: skipping turbod since we appear to be in a non-interactive context (re)
   [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash env vars: vars=\["SOME_ENV_VAR", "VERCEL_ANALYTICS_ID"] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash: value=429dc909f3c08559 (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash: value=9278591ff41d3667 (re)
   [-0-9:.TWZ+]+ |[DEBUG] turbo: local cache folder: path="" (re)
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
   [-0-9:.TWZ+]+ \[DEBUG] turbo: task hash env vars for util:build: vars=\["NODE_ENV="] (re)
   [-0-9:.TWZ+]+ \[DEBUG] turbo.: start (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: task hash: value=c36e55f947cd2d28 (re)
-  util:build: cache bypass, force executing c36e55f947cd2d28
+  [-0-9:.TWZ+]+ \[DEBUG] turbo: task hash: value=af2ba2d52192ee45 (re)
+  util:build: cache bypass, force executing af2ba2d52192ee45
   util:build: 
   util:build: > build
   util:build: > echo 'building'
@@ -80,15 +80,15 @@ Verbosity level 2
   [-0-9:.TWZ+]+ \[DEBUG] turbo: build tag: (go|rust) (re)
   [-0-9:.TWZ+]+ \[INFO]  turbo: skipping turbod since we appear to be in a non-interactive context (re)
   [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash env vars: vars=\["SOME_ENV_VAR", "VERCEL_ANALYTICS_ID"] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash: value=429dc909f3c08559 (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash: value=9278591ff41d3667 (re)
   [-0-9:.TWZ+]+ \[DEBUG] turbo: local cache folder: path="" (re)
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
   [-0-9:.TWZ+]+ \[DEBUG] turbo: task hash env vars for util:build: vars=\["NODE_ENV="] (re)
   [-0-9:.TWZ+]+ \[DEBUG] turbo.: start (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: task hash: value=c36e55f947cd2d28 (re)
-  util:build: cache bypass, force executing c36e55f947cd2d28
+  [-0-9:.TWZ+]+ \[DEBUG] turbo: task hash: value=af2ba2d52192ee45 (re)
+  util:build: cache bypass, force executing af2ba2d52192ee45
   util:build: 
   util:build: > build
   util:build: > echo 'building'

--- a/cli/internal/run/real_run.go
+++ b/cli/internal/run/real_run.go
@@ -233,7 +233,7 @@ func (ec *execContext) exec(ctx gocontext.Context, packageTask *nodes.PackageTas
 		prefixedUI.Error(fmt.Sprintf("error fetching from cache: %s", err))
 	} else if hit {
 		ec.taskHashTracker.SetExpandedOutputs(packageTask.TaskID, taskCache.ExpandedOutputs)
-		// We only cache successful builds, so we can assume this is a successCode exit.
+		// We only cache successful executions, so we can assume this is a successCode exit.
 		tracer(runsummary.TargetCached, nil, &successCode)
 		return taskExecutionSummary, nil
 	}

--- a/cli/internal/runsummary/execution_summary.go
+++ b/cli/internal/runsummary/execution_summary.go
@@ -166,14 +166,14 @@ func (es *executionSummary) run(taskID string) (func(outcome executionEventName,
 			Duration: now.Sub(start),
 			Label:    taskID,
 			Status:   outcome,
+			// We'll assign this here regardless of whether it is nil, but we'll check for nil
+			// when we assign it to the taskExecutionSummary.
+			exitCode: exitCode,
 		}
 		if err != nil {
 			result.Err = fmt.Errorf("running %v failed: %w", taskID, err)
 		}
 
-		// We'll assign this here regardless of whether it is nil, but we'll check for nil
-		// when we assign it to the taskExecutionSummary.
-		result.exitCode = exitCode
 		// Ignore the return value here
 		es.add(result)
 	}

--- a/cli/internal/runsummary/execution_summary.go
+++ b/cli/internal/runsummary/execution_summary.go
@@ -26,6 +26,8 @@ type executionEvent struct {
 	Status executionEventName
 	// Error, only populated for failure statuses
 	Err error
+
+	exitCode *int
 }
 
 // executionEventName represents the status of a target when we log a build result.
@@ -64,21 +66,24 @@ type TaskExecutionSummary struct {
 	status   executionEventName // current status, updated during execution
 	err      error              // only populated for failure statuses
 	duration time.Duration      // updated during the task execution
+	exitCode *int               // pointer so we can distinguish between 0 and unknown.
 }
 
 // MarshalJSON munges the TaskExecutionSummary into a format we want
 // We'll use an anonmyous, private struct for this, so it's not confusingly duplicated
 func (ts *TaskExecutionSummary) MarshalJSON() ([]byte, error) {
 	serializable := struct {
-		Start  int64  `json:"startTime"`
-		End    int64  `json:"endTime"`
-		Status string `json:"status"`
-		Err    error  `json:"error"`
+		Start    int64  `json:"startTime"`
+		End      int64  `json:"endTime"`
+		Status   string `json:"status"`
+		Err      error  `json:"error"`
+		ExitCode *int   `json:"exitCode"`
 	}{
-		Start:  ts.startAt.UnixMilli(),
-		End:    ts.startAt.Add(ts.duration).UnixMilli(),
-		Status: ts.status.toString(),
-		Err:    ts.err,
+		Start:    ts.startAt.UnixMilli(),
+		End:      ts.startAt.Add(ts.duration).UnixMilli(),
+		Status:   ts.status.toString(),
+		Err:      ts.err,
+		ExitCode: ts.exitCode,
 	}
 
 	return json.Marshal(&serializable)
@@ -141,7 +146,7 @@ func newExecutionSummary(start time.Time, tracingProfile string) *executionSumma
 
 // Run starts the Execution of a single task. It returns a function that can
 // be used to update the state of a given taskID with the executionEventName enum
-func (es *executionSummary) run(taskID string) (func(outcome executionEventName, err error), *TaskExecutionSummary) {
+func (es *executionSummary) run(taskID string) (func(outcome executionEventName, err error, exitCode *int), *TaskExecutionSummary) {
 	start := time.Now()
 	taskExecutionSummary := es.add(&executionEvent{
 		Time:   start,
@@ -153,7 +158,7 @@ func (es *executionSummary) run(taskID string) (func(outcome executionEventName,
 
 	// This function can be called with an enum and an optional error to update
 	// the state of a given taskID.
-	tracerFn := func(outcome executionEventName, err error) {
+	tracerFn := func(outcome executionEventName, err error, exitCode *int) {
 		defer tracer.Done()
 		now := time.Now()
 		result := &executionEvent{
@@ -165,6 +170,10 @@ func (es *executionSummary) run(taskID string) (func(outcome executionEventName,
 		if err != nil {
 			result.Err = fmt.Errorf("running %v failed: %w", taskID, err)
 		}
+
+		// We'll assign this here regardless of whether it is nil, but we'll check for nil
+		// when we assign it to the taskExecutionSummary.
+		result.exitCode = exitCode
 		// Ignore the return value here
 		es.add(result)
 	}
@@ -191,6 +200,10 @@ func (es *executionSummary) add(event *executionEvent) *TaskExecutionSummary {
 	taskExecSummary.status = event.Status
 	taskExecSummary.err = event.Err
 	taskExecSummary.duration = event.Duration
+
+	if event.exitCode != nil {
+		taskExecSummary.exitCode = event.exitCode
+	}
 
 	switch {
 	case event.Status == TargetBuildFailed:

--- a/cli/internal/runsummary/run_summary.go
+++ b/cli/internal/runsummary/run_summary.go
@@ -117,7 +117,7 @@ func (rsm *Meta) Close(dir turbopath.AbsoluteSystemPath) {
 }
 
 // TrackTask makes it possible for the consumer to send information about the execution of a task.
-func (summary *RunSummary) TrackTask(taskID string) (func(outcome executionEventName, err error), *TaskExecutionSummary) {
+func (summary *RunSummary) TrackTask(taskID string) (func(outcome executionEventName, err error, exitCode *int), *TaskExecutionSummary) {
 	return summary.ExecutionSummary.run(taskID)
 }
 


### PR DESCRIPTION
This adds exitCodes per task when we know them. Currently, without the `--continue` flag, when a task fails, turbo exits without closing out the Run Summary. We will address this separately, but this lays the baseline for gathering successful and error codes when possible.