### PR TITLE
build(turbo-binding): export turbopack_dev

### DIFF
--- a/crates/turbo-binding/src/lib.rs
+++ b/crates/turbo-binding/src/lib.rs
@@ -62,6 +62,8 @@ pub mod turbopack {
     pub use turbopack_create_test_app as create_test_app;
     #[cfg(feature = "__turbopack_css")]
     pub use turbopack_css as css;
+    #[cfg(feature = "__turbopack_dev")]
+    pub use turbopack_dev as dev;
     #[cfg(feature = "__turbopack_dev_server")]
     pub use turbopack_dev_server as dev_server;
     #[cfg(feature = "__turbopack_ecmascript")]


### PR DESCRIPTION
### Description

Minor fix from previous PR, actually exposes turbopack_dev.