### PR TITLE
fix(turbo-binding): disable custom alloc default features

### DIFF
--- a/crates/turbo-binding/Cargo.toml
+++ b/crates/turbo-binding/Cargo.toml
@@ -155,7 +155,7 @@ auto-hash-map = { optional = true, workspace = true }
 swc-ast-explorer = { optional = true, workspace = true }
 
 node-file-trace = { optional = true, workspace = true }
-turbo-malloc = { optional = true, workspace = true }
+turbo-malloc = { optional = true, workspace = true, default-features = false }
 turbo-tasks = { optional = true, workspace = true }
 turbo-tasks-build = { optional = true, workspace = true }
 turbo-tasks-bytes = { optional = true, workspace = true }


### PR DESCRIPTION
### Description

Enabling default will merge into all of next-swc for the unsupported platforms.