### PR TITLE
fix(turbo-binding): disable default custom alloc features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ swc_relay = { version = "0.1.0" }
 testing = { version = "0.31.31" }
 
 auto-hash-map = { path = "crates/auto-hash-map" }
-node-file-trace = { path = "crates/node-file-trace" }
+node-file-trace = { path = "crates/node-file-trace", default-features = false }
 swc-ast-explorer = { path = "crates/swc-ast-explorer" }
 turbo-malloc = { path = "crates/turbo-malloc", default-features = false }
 turbo-tasks = { path = "crates/turbo-tasks" }

--- a/crates/turbo-binding/Cargo.toml
+++ b/crates/turbo-binding/Cargo.toml
@@ -122,6 +122,10 @@ __turbopack_tests = ["__turbopack", "turbopack-tests"]
 __features = []
 __feature_mdx_rs = ["__features", "mdxjs/serializable"]
 __feature_node_file_trace = ["__features", "node-file-trace/node-api"]
+__feature_node_file_trace_cli = ["node-file-trace/cli"]
+__feature_node_file_trace_custom_allocator = [
+  "node-file-trace/custom_allocator",
+]
 __feature_auto_hash_map = ["__features", "auto-hash-map"]
 __feature_swc_ast_explorer = ["__features", "swc-ast-explorer"]
 

--- a/crates/turbopack/Cargo.toml
+++ b/crates/turbopack/Cargo.toml
@@ -43,7 +43,7 @@ futures = { workspace = true }
 rstest = { workspace = true }
 rstest_reuse = "0.5.0"
 tokio = { workspace = true }
-turbo-malloc = { workspace = true }
+turbo-malloc = { workspace = true, default-features = false }
 turbo-tasks-memory = { workspace = true }
 
 [build-dependencies]


### PR DESCRIPTION
### Description

Partially resolves WEB-736

Same as https://github.com/vercel/turbo/pull/4355, minor update to not to merge custom alloc features by default.