### PR TITLE
fix: correctly deserialize npm packages in lockfile

### DIFF
--- a/crates/turborepo-lockfiles/src/npm.rs
+++ b/crates/turborepo-lockfiles/src/npm.rs
@@ -24,6 +24,7 @@ pub struct NpmLockfile {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
 struct NpmPackage {
     version: Option<String>,
     resolved: Option<String>,
@@ -321,6 +322,17 @@ mod test {
                     "node_modules/require-from-string",
                     "node_modules/table/node_modules/json-schema-traverse",
                     "node_modules/uri-js",
+                ],
+            ),
+            (
+                "node_modules/turbo",
+                vec![
+                    "node_modules/turbo-darwin-64",
+                    "node_modules/turbo-darwin-arm64",
+                    "node_modules/turbo-linux-64",
+                    "node_modules/turbo-linux-arm64",
+                    "node_modules/turbo-windows-64",
+                    "node_modules/turbo-windows-arm64",
                 ],
             ),
         ];


### PR DESCRIPTION
### Description

Fixes #4365

1.8.6 was our first release with the Rust npm lockfile implementation. It wasn't correctly deserializing `optionalDependencies` so they were ending up in the `other` field which isn't used for lockfile analysis.

### Testing Instructions

Added failing unit test. Can also verify that pruning a project that depends on `turbo` now includes all of the possible binaries.
fix WEB-806 ([link](https://linear.app/vercel/issue/WEB-806))