### PR TITLE
Increase timeout length for e2e tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -269,7 +269,7 @@ jobs:
     name: Go E2E Tests
     needs: determine_jobs
     if: needs.determine_jobs.outputs.go_e2e == 'true'
-    timeout-minutes: 30
+    timeout-minutes: 60
     runs-on: ${{ matrix.os.runner }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
We're regularly seeing e2e tests time out especially in Windows. Doubling the timeout length, even though the real fix here is to make them faster. The bulk of the time is compiling turborepo / ffi, so moving more quickly towards full Rust port will alleviate these pains.