### PR TITLE
Minimum requirements

### DIFF
--- a/docs/pages/repo/docs/installing.mdx
+++ b/docs/pages/repo/docs/installing.mdx
@@ -15,7 +15,7 @@ import { Tabs, Tab } from '../../../components/Tabs'
 - Windows 64-bit, ARM 64-bit
 
 Minimum Requirements
-- Node 18
+- NPM 7([read about npm workspaces](https://docs.npmjs.com/cli/v7/using-npm/workspaces))
 
 <Callout>
   Note: Linux builds of `turbo` link against `glibc`. For Alpine Docker environments, you will need to ensure libc6-compat is installed as well, via `RUN apk add --no-cache libc6-compat`

--- a/docs/pages/repo/docs/installing.mdx
+++ b/docs/pages/repo/docs/installing.mdx
@@ -14,6 +14,9 @@ import { Tabs, Tab } from '../../../components/Tabs'
 - Linux 64-bit, ARM 64-bit
 - Windows 64-bit, ARM 64-bit
 
+Minimum Requirements
+- Node 18
+
 <Callout>
   Note: Linux builds of `turbo` link against `glibc`. For Alpine Docker environments, you will need to ensure libc6-compat is installed as well, via `RUN apk add --no-cache libc6-compat`
 </Callout>


### PR DESCRIPTION
### Description

I spent a lot of time trying to get turbo working and concluded turbo requires NPM V7 because thats when workspaces were introduced.

### Testing Instructions

1. Downgrade to NPM 6 and run `turbo build` after `npm i`

- errors about missing packages will appear

2. Upgrade and the errors go away