### PR TITLE
Log the location of the summary file in the execution summary

### DIFF
--- a/cli/integration_tests/basic_monorepo/run_summary/discovery.t
+++ b/cli/integration_tests/basic_monorepo/run_summary/discovery.t
@@ -1,0 +1,21 @@
+Setup
+  $ . ${TESTDIR}/../../setup.sh
+  $ . ${TESTDIR}/../setup.sh $(pwd)
+  $ rm -rf .turbo/runs
+
+  $ ${TURBO} run build --summarize=true --filter=my-app
+  \xe2\x80\xa2 Packages in scope: my-app (esc)
+  \xe2\x80\xa2 Running build in 1 packages (esc)
+  \xe2\x80\xa2 Remote caching disabled (esc)
+  my-app:build: cache miss, executing 2f192ed93e20f940
+  my-app:build: 
+  my-app:build: > build
+  my-app:build: > echo 'building'
+  my-app:build: 
+  my-app:build: building
+  
+    Tasks:    1 successful, 1 total
+   Cached:    0 cached, 1 total
+     Time:\s*[\.0-9]+m?s  (re)
+  Summary:    .turbo/runs/[a-zA-Z0-9]+.json (re)
+  

--- a/cli/integration_tests/basic_monorepo/run_summary/discovery.t
+++ b/cli/integration_tests/basic_monorepo/run_summary/discovery.t
@@ -17,5 +17,5 @@ Setup
     Tasks:    1 successful, 1 total
    Cached:    0 cached, 1 total
      Time:\s*[\.0-9]+m?s  (re)
-  Summary:    .turbo/runs/[a-zA-Z0-9]+.json (re)
+  Summary:    .+\.turbo\/runs\/[a-zA-Z0-9]+.json (re)
   

--- a/cli/internal/run/real_run.go
+++ b/cli/internal/run/real_run.go
@@ -167,7 +167,7 @@ func RealRun(
 		}
 	}
 
-	runSummary.Close(exitCode, base.RepoRoot)
+	runSummary.Close(exitCode)
 
 	if exitCode != 0 {
 		return &process.ChildExit{

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -352,6 +352,7 @@ func (r *run) run(ctx gocontext.Context, targets []string) error {
 	summary := runsummary.NewRunSummary(
 		startAt,
 		r.base.UI,
+		r.base.RepoRoot,
 		rs.Opts.runOpts.singlePackage,
 		rs.Opts.runOpts.profile,
 		r.base.TurboVersion,

--- a/cli/internal/runsummary/format_execution_summary.go
+++ b/cli/internal/runsummary/format_execution_summary.go
@@ -40,21 +40,24 @@ func (rsm *Meta) printExecutionSummary() {
 	ui.Output("")    // Clear the line
 	spacer := "    " // 4 chars
 
-	// We'll start with some default lines
-	lines := []string{
-		util.Sprintf("${BOLD} Tasks:${BOLD_GREEN}%s%v successful${RESET}${GRAY}, %v total${RESET}", spacer, successful, attempted),
-		util.Sprintf("${BOLD}Cached:%s%v cached${RESET}${GRAY}, %v total${RESET}", spacer, cached, attempted),
-		util.Sprintf("${BOLD}  Time:%s%v${RESET} %v${RESET}", spacer, duration, maybeFullTurbo),
-	}
+	var lines []string
 
-	// If we have a run summary file, add that in. We have to do some whitespace adjusting, so just
-	// duplicate the lines above instead of using some fancy tabbibg/spacing mechanism.
+	// The only difference between these two branches is that when there is a run summary
+	// we print the path to that file and we adjust the whitespace in the printed text so it aligns.
+	// We could just always align to account for the summary line, but that would require a whole
+	// bunch of test output assertions to change.
 	if rsm.getPath().FileExists() {
 		lines = []string{
 			util.Sprintf("${BOLD}  Tasks:${BOLD_GREEN}%s%v successful${RESET}${GRAY}, %v total${RESET}", spacer, successful, attempted),
 			util.Sprintf("${BOLD} Cached:%s%v cached${RESET}${GRAY}, %v total${RESET}", spacer, cached, attempted),
 			util.Sprintf("${BOLD}   Time:%s%v${RESET} %v${RESET}", spacer, duration, maybeFullTurbo),
 			util.Sprintf("${BOLD}Summary:%s%s${RESET}", spacer, rsm.getPath()),
+		}
+	} else {
+		lines = []string{
+			util.Sprintf("${BOLD} Tasks:${BOLD_GREEN}%s%v successful${RESET}${GRAY}, %v total${RESET}", spacer, successful, attempted),
+			util.Sprintf("${BOLD}Cached:%s%v cached${RESET}${GRAY}, %v total${RESET}", spacer, cached, attempted),
+			util.Sprintf("${BOLD}  Time:%s%v${RESET} %v${RESET}", spacer, duration, maybeFullTurbo),
 		}
 	}
 

--- a/cli/internal/runsummary/format_execution_summary.go
+++ b/cli/internal/runsummary/format_execution_summary.go
@@ -42,20 +42,19 @@ func (rsm *Meta) printExecutionSummary() {
 
 	// We'll start with some default lines
 	lines := []string{
-		util.Sprintf("${BOLD} Tasks:${BOLD_GREEN}%s%v successful${RESET}${GRAY}, %v total${RESET}", spacer, success, attempted),
+		util.Sprintf("${BOLD} Tasks:${BOLD_GREEN}%s%v successful${RESET}${GRAY}, %v total${RESET}", spacer, successful, attempted),
 		util.Sprintf("${BOLD}Cached:%s%v cached${RESET}${GRAY}, %v total${RESET}", spacer, cached, attempted),
 		util.Sprintf("${BOLD}  Time:%s%v${RESET} %v${RESET}", spacer, duration, maybeFullTurbo),
 	}
 
-	// If we have a run summary file and we can get  a
+	// If we have a run summary file, add that in. We have to do some whitespace adjusting, so just
+	// duplicate the lines above instead of using some fancy tabbibg/spacing mechanism.
 	if rsm.getPath().FileExists() {
-		if relativePath, err := rsm.repoRoot.PathTo(rsm.getPath()); err == nil {
-			lines = []string{
-				util.Sprintf("${BOLD}  Tasks:${BOLD_GREEN}%s%v successful${RESET}${GRAY}, %v total${RESET}", spacer, successful, attempted),
-				util.Sprintf("${BOLD} Cached:%s%v cached${RESET}${GRAY}, %v total${RESET}", spacer, cached, attempted),
-				util.Sprintf("${BOLD}   Time:%s%v${RESET} %v${RESET}", spacer, duration, maybeFullTurbo),
-				util.Sprintf("${BOLD}Summary:%s%s${RESET}", spacer, relativePath),
-			}
+		lines = []string{
+			util.Sprintf("${BOLD}  Tasks:${BOLD_GREEN}%s%v successful${RESET}${GRAY}, %v total${RESET}", spacer, successful, attempted),
+			util.Sprintf("${BOLD} Cached:%s%v cached${RESET}${GRAY}, %v total${RESET}", spacer, cached, attempted),
+			util.Sprintf("${BOLD}   Time:%s%v${RESET} %v${RESET}", spacer, duration, maybeFullTurbo),
+			util.Sprintf("${BOLD}Summary:%s%s${RESET}", spacer, rsm.getPath()),
 		}
 	}
 

--- a/cli/internal/runsummary/format_execution_summary.go
+++ b/cli/internal/runsummary/format_execution_summary.go
@@ -55,9 +55,9 @@ func (rsm *Meta) printExecutionSummary() {
 		}
 	} else {
 		lines = []string{
-			util.Sprintf("${BOLD} Tasks:${BOLD_GREEN}%s%v successful${RESET}${GRAY}, %v total${RESET}", spacer, successful, attempted),
-			util.Sprintf("${BOLD}Cached:%s%v cached${RESET}${GRAY}, %v total${RESET}", spacer, cached, attempted),
-			util.Sprintf("${BOLD}  Time:%s%v${RESET} %v${RESET}", spacer, duration, maybeFullTurbo),
+			util.Sprintf("${BOLD} Tasks:${BOLD_GREEN}    %v successful${RESET}${GRAY}, %v total${RESET}", successful, attempted),
+			util.Sprintf("${BOLD}Cached:    %v cached${RESET}${GRAY}, %v total${RESET}", cached, attempted),
+			util.Sprintf("${BOLD}  Time:    %v${RESET} %v${RESET}", duration, maybeFullTurbo),
 		}
 	}
 

--- a/cli/internal/runsummary/format_execution_summary.go
+++ b/cli/internal/runsummary/format_execution_summary.go
@@ -37,11 +37,32 @@ func (rsm *Meta) printExecutionSummary() {
 		ui.Warn("No tasks were executed as part of this run.")
 	}
 
-	ui.Output("") // Clear the line
+	ui.Output("")    // Clear the line
+	spacer := "    " // 4 chars
 
-	// The whitespaces in the string are to align the UI in a nice way.
-	ui.Output(util.Sprintf("${BOLD} Tasks:${BOLD_GREEN}    %v successful${RESET}${GRAY}, %v total${RESET}", successful, attempted))
-	ui.Output(util.Sprintf("${BOLD}Cached:    %v cached${RESET}${GRAY}, %v total${RESET}", cached, attempted))
-	ui.Output(util.Sprintf("${BOLD}  Time:    %v${RESET} %v${RESET}", duration, maybeFullTurbo))
+	// We'll start with some default lines
+	lines := []string{
+		util.Sprintf("${BOLD} Tasks:${BOLD_GREEN}%s%v successful${RESET}${GRAY}, %v total${RESET}", spacer, success, attempted),
+		util.Sprintf("${BOLD}Cached:%s%v cached${RESET}${GRAY}, %v total${RESET}", spacer, cached, attempted),
+		util.Sprintf("${BOLD}  Time:%s%v${RESET} %v${RESET}", spacer, duration, maybeFullTurbo),
+	}
+
+	// If we have a run summary file and we can get  a
+	if rsm.getPath().FileExists() {
+		if relativePath, err := rsm.repoRoot.PathTo(rsm.getPath()); err == nil {
+			lines = []string{
+				util.Sprintf("${BOLD}  Tasks:${BOLD_GREEN}%s%v successful${RESET}${GRAY}, %v total${RESET}", spacer, successful, attempted),
+				util.Sprintf("${BOLD} Cached:%s%v cached${RESET}${GRAY}, %v total${RESET}", spacer, cached, attempted),
+				util.Sprintf("${BOLD}   Time:%s%v${RESET} %v${RESET}", spacer, duration, maybeFullTurbo),
+				util.Sprintf("${BOLD}Summary:%s%s${RESET}", spacer, relativePath),
+			}
+		}
+	}
+
+	// Print the real thing
+	for _, line := range lines {
+		ui.Output(line)
+	}
+
 	ui.Output("")
 }

--- a/cli/internal/runsummary/run_summary.go
+++ b/cli/internal/runsummary/run_summary.go
@@ -31,6 +31,7 @@ const tasksEndpoint = "/v0/spaces/%s/runs/%s/tasks"
 type Meta struct {
 	RunSummary    *RunSummary
 	ui            cli.Ui
+	repoRoot      turbopath.AbsoluteSystemPath // used to write run summary
 	singlePackage bool
 	shouldSave    bool
 	apiClient     *client.APIClient
@@ -59,6 +60,7 @@ type singlePackageRunSummary struct {
 func NewRunSummary(
 	startAt time.Time,
 	terminal cli.Ui,
+	repoRoot turbopath.AbsoluteSystemPath,
 	singlePackage bool,
 	profile string,
 	turboVersion string,
@@ -81,6 +83,7 @@ func NewRunSummary(
 			GlobalHashSummary: globalHashSummary,
 		},
 		ui:            terminal,
+		repoRoot:      repoRoot,
 		singlePackage: singlePackage,
 		shouldSave:    shouldSave,
 		apiClient:     apiClient,
@@ -88,8 +91,16 @@ func NewRunSummary(
 	}
 }
 
+// getPath returns a path to where the runSummary is written.
+// The returned path will always be relative to the dir passsed in.
+// We don't do a lot of validation, so `../../` paths are allowed.
+func (rsm *Meta) getPath() turbopath.AbsoluteSystemPath {
+	filename := fmt.Sprintf("%s.json", rsm.RunSummary.ID)
+	return rsm.repoRoot.UntypedJoin(filepath.Join(".turbo", "runs"), filename)
+}
+
 // Close wraps up the RunSummary at the end of a `turbo run`.
-func (rsm *Meta) Close(exitCode int, dir turbopath.AbsoluteSystemPath) {
+func (rsm *Meta) Close(exitCode int) {
 	rsm.RunSummary.ExecutionSummary.exitCode = exitCode
 	rsm.RunSummary.ExecutionSummary.endedAt = time.Now()
 
@@ -102,19 +113,24 @@ func (rsm *Meta) Close(exitCode int, dir turbopath.AbsoluteSystemPath) {
 	// are all the same thng, we should use a strategy similar to cache save/upload to
 	// do this in parallel.
 
+	// Otherwise, attempt to save the summary
+	// Warn on the error, but we don't need to throw an error
+	if rsm.shouldSave {
+		if err := rsm.save(); err != nil {
+			rsm.ui.Warn(fmt.Sprintf("Error writing run summary: %v", err))
+		}
+	}
+
 	rsm.printExecutionSummary()
 
 	if rsm.shouldSave {
-		if err := rsm.save(dir); err != nil {
-			rsm.ui.Warn(fmt.Sprintf("Error writing run summary: %v", err))
-		}
-
 		if rsm.spaceID != "" && rsm.apiClient.IsLinked() {
 			if err := rsm.record(); err != nil {
 				rsm.ui.Warn(fmt.Sprintf("Error recording Run to Vercel: %v", err))
 			}
 		}
 	}
+
 }
 
 // TrackTask makes it possible for the consumer to send information about the execution of a task.
@@ -123,7 +139,7 @@ func (summary *RunSummary) TrackTask(taskID string) (func(outcome executionEvent
 }
 
 // Save saves the run summary to a file
-func (rsm *Meta) save(dir turbopath.AbsoluteSystemPath) error {
+func (rsm *Meta) save() error {
 	json, err := rsm.FormatJSON()
 	if err != nil {
 		return err
@@ -131,10 +147,7 @@ func (rsm *Meta) save(dir turbopath.AbsoluteSystemPath) error {
 
 	// summaryPath will always be relative to the dir passsed in.
 	// We don't do a lot of validation, so `../../` paths are allowed
-	summaryPath := dir.UntypedJoin(
-		filepath.Join(".turbo", "runs"),
-		fmt.Sprintf("%s.json", rsm.RunSummary.ID),
-	)
+	summaryPath := rsm.getPath()
 
 	if err := summaryPath.EnsureDir(); err != nil {
 		return err


### PR DESCRIPTION
With and without the Run summary:

<img width="252" alt="CleanShot 2023-03-29 at 11 24 59@2x" src="https://user-images.githubusercontent.com/490968/228632921-689077b9-ab78-4367-a073-e07d21c8bc89.png">

<img width="806" alt="CleanShot 2023-03-29 at 12 49 11@2x" src="https://user-images.githubusercontent.com/490968/228651391-6f132065-89fa-4124-98a6-949e97eb96da.png">