### PR TITLE
Use `SharedError` for body streaming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7749,7 +7749,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_qs",
- "thiserror",
  "tokio",
  "tokio-stream",
  "tokio-util",

--- a/crates/turbopack-dev-server/Cargo.toml
+++ b/crates/turbopack-dev-server/Cargo.toml
@@ -24,7 +24,6 @@ pin-project-lite = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_qs = { workspace = true }
-thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = "0.1.9"
 tokio-util = { workspace = true }

--- a/crates/turbopack-dev-server/src/source/mod.rs
+++ b/crates/turbopack-dev-server/src/source/mod.rs
@@ -236,7 +236,7 @@ pub struct ContentSourceData {
 pub type BodyChunk = Result<Bytes, SharedError>;
 
 /// A request body.
-#[turbo_tasks::value(shared, serialization = "none")]
+#[turbo_tasks::value(shared)]
 #[derive(Default, Clone, Debug)]
 pub struct Body {
     #[turbo_tasks(trace_ignore)]

--- a/crates/turbopack-dev-server/src/source/mod.rs
+++ b/crates/turbopack-dev-server/src/source/mod.rs
@@ -18,8 +18,7 @@ use std::collections::BTreeSet;
 use anyhow::Result;
 use futures::stream::Stream as StreamTrait;
 use serde::{Deserialize, Serialize};
-use thiserror::Error;
-use turbo_tasks::{trace::TraceRawVcs, Value};
+use turbo_tasks::{trace::TraceRawVcs, util::SharedError, Value};
 use turbo_tasks_bytes::{Bytes, Stream, StreamRead};
 use turbo_tasks_fs::FileSystemPathVc;
 use turbopack_core::version::VersionedContentVc;
@@ -38,38 +37,6 @@ pub struct ProxyResult {
     pub headers: Vec<(String, String)>,
     /// The body to return.
     pub body: Body,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Error)]
-#[error("{err}")]
-pub struct BodyError {
-    err: String,
-}
-
-impl BodyError {
-    pub fn new(err: String) -> Self {
-        BodyError { err }
-    }
-}
-
-impl From<&str> for BodyError {
-    fn from(err: &str) -> Self {
-        BodyError {
-            err: err.to_string(),
-        }
-    }
-}
-
-impl From<String> for BodyError {
-    fn from(err: String) -> Self {
-        BodyError { err }
-    }
-}
-
-impl From<anyhow::Error> for BodyError {
-    fn from(value: anyhow::Error) -> Self {
-        value.to_string().into()
-    }
 }
 
 /// The return value of a content source when getting a path. A specificity is
@@ -266,9 +233,10 @@ pub struct ContentSourceData {
     pub cache_buster: u64,
 }
 
-pub type BodyChunk = Result<Bytes, BodyError>;
+pub type BodyChunk = Result<Bytes, SharedError>;
+
 /// A request body.
-#[turbo_tasks::value(shared)]
+#[turbo_tasks::value(shared, serialization = "none")]
 #[derive(Default, Clone, Debug)]
 pub struct Body {
     #[turbo_tasks(trace_ignore)]

--- a/crates/turbopack-node/src/evaluate.rs
+++ b/crates/turbopack-node/src/evaluate.rs
@@ -91,7 +91,7 @@ struct JavaScriptStreamSender {
     get: Box<dyn Fn() -> UnboundedSender<Result<Bytes, SharedError>> + Send + Sync>,
 }
 
-#[turbo_tasks::value(transparent, eq = "manual", cell = "new", serialization = "none")]
+#[turbo_tasks::value(transparent)]
 #[derive(Clone, Debug)]
 pub struct JavaScriptEvaluation(#[turbo_tasks(trace_ignore)] JavaScriptStream);
 

--- a/crates/turbopack-node/src/render/render_proxy.rs
+++ b/crates/turbopack-node/src/render/render_proxy.rs
@@ -136,7 +136,7 @@ struct RenderStreamSender {
     get: Box<dyn Fn() -> UnboundedSender<RenderItemResult> + Send + Sync>,
 }
 
-#[turbo_tasks::value(transparent, eq = "manual", cell = "new", serialization = "none")]
+#[turbo_tasks::value(transparent)]
 struct RenderStream(#[turbo_tasks(trace_ignore)] Stream<RenderItemResult>);
 
 #[turbo_tasks::function]

--- a/crates/turbopack-node/src/render/render_proxy.rs
+++ b/crates/turbopack-node/src/render/render_proxy.rs
@@ -10,7 +10,7 @@ use turbo_tasks_bytes::{Bytes, Stream};
 use turbo_tasks_env::ProcessEnvVc;
 use turbo_tasks_fs::FileSystemPathVc;
 use turbopack_core::{chunk::ChunkingContextVc, error::PrettyPrintError};
-use turbopack_dev_server::source::{Body, BodyError, BodyVc, ProxyResult, ProxyResultVc};
+use turbopack_dev_server::source::{Body, BodyVc, ProxyResult, ProxyResultVc};
 use turbopack_ecmascript::{chunk::EcmascriptChunkPlaceablesVc, EcmascriptModuleAssetVc};
 
 use super::{
@@ -68,11 +68,11 @@ pub async fn render_proxy(
 
     let body = Body::from_stream(stream.map(|item| match item {
         Ok(RenderItem::BodyChunk(b)) => Ok(b),
-        Ok(v) => Err(BodyError::new(format!("unexpected render item: {:#?}", v))),
-        Err(e) => Err(BodyError::new(format!(
-            "error streaming proxied contents: {}",
-            e
+        Ok(v) => Err(SharedError::new(anyhow!(
+            "unexpected render item: {:#?}",
+            v
         ))),
+        Err(e) => Err(e),
     }));
     let result = ProxyResult {
         status: data.status,

--- a/crates/turbopack-node/src/render/render_proxy.rs
+++ b/crates/turbopack-node/src/render/render_proxy.rs
@@ -131,7 +131,7 @@ enum RenderItem {
 type RenderItemResult = Result<RenderItem, SharedError>;
 
 #[turbo_tasks::value(eq = "manual", cell = "new", serialization = "none")]
-pub struct RenderStreamSender {
+struct RenderStreamSender {
     #[turbo_tasks(trace_ignore, debug_ignore)]
     get: Box<dyn Fn() -> UnboundedSender<RenderItemResult> + Send + Sync>,
 }

--- a/crates/turbopack-node/src/render/render_static.rs
+++ b/crates/turbopack-node/src/render/render_static.rs
@@ -16,7 +16,7 @@ use turbopack_core::{
 };
 use turbopack_dev_server::{
     html::DevHtmlAssetVc,
-    source::{Body, BodyError, HeaderListVc, RewriteBuilder, RewriteVc},
+    source::{Body, HeaderListVc, RewriteBuilder, RewriteVc},
 };
 use turbopack_ecmascript::{chunk::EcmascriptChunkPlaceablesVc, EcmascriptModuleAssetVc};
 
@@ -107,11 +107,11 @@ pub async fn render_static(
         RenderItem::Headers(data) => {
             let body = stream.map(|item| match item {
                 Ok(RenderItem::BodyChunk(b)) => Ok(b),
-                Ok(v) => Err(BodyError::new(format!("unexpected render item: {:#?}", v))),
-                Err(e) => Err(BodyError::new(format!(
-                    "error streaming proxied contents: {}",
-                    e
+                Ok(v) => Err(SharedError::new(anyhow!(
+                    "unexpected render item: {:#?}",
+                    v
                 ))),
+                Err(e) => Err(e),
             });
             StaticResult::StreamedContent {
                 status: data.status,

--- a/crates/turbopack-node/src/render/render_static.rs
+++ b/crates/turbopack-node/src/render/render_static.rs
@@ -185,7 +185,7 @@ struct RenderStreamSender {
     get: Box<dyn Fn() -> UnboundedSender<RenderItemResult> + Send + Sync>,
 }
 
-#[turbo_tasks::value(transparent, eq = "manual", cell = "new", serialization = "none")]
+#[turbo_tasks::value(transparent)]
 struct RenderStream(#[turbo_tasks(trace_ignore)] Stream<RenderItemResult>);
 
 #[turbo_tasks::function]

--- a/crates/turbopack-node/src/render/render_static.rs
+++ b/crates/turbopack-node/src/render/render_static.rs
@@ -180,7 +180,7 @@ enum RenderItem {
 type RenderItemResult = Result<RenderItem, SharedError>;
 
 #[turbo_tasks::value(eq = "manual", cell = "new", serialization = "none")]
-pub struct RenderStreamSender {
+struct RenderStreamSender {
     #[turbo_tasks(trace_ignore, debug_ignore)]
     get: Box<dyn Fn() -> UnboundedSender<RenderItemResult> + Send + Sync>,
 }


### PR DESCRIPTION
Follow up to https://github.com/vercel/turbo/pull/4329, this removes `BodyError` (which was just a simple `String` and not an `Error`) and switches to `SharedError`.

I've implemented a basic `PartialEq` and `Serialization` for `SharedError` so that it doesn't infect everything that uses `Body`.