### PR TITLE
Remove second run of integration tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -258,11 +258,6 @@ jobs:
       - name: Integration Tests
         run: pnpm -- turbo run integration-tests --filter=cli
         env:
-          GO_TAG: go
-
-      - name: Integration Tests (with Rust FFI)
-        run: pnpm -- turbo run integration-tests --filter=cli
-        env:
           GO_TAG: rust
 
   go_e2e:


### PR DESCRIPTION
In d322f50be, we changed the GO_TAG to Rust, and have had a
few successful releases with it. We don't need to run tests with GO_TAG
set to Go.