### PR TITLE
ci(workflow): apply latest turbopack when build next-swc

### DIFF
--- a/.github/workflows/daily-nextjs-integration-test.yml
+++ b/.github/workflows/daily-nextjs-integration-test.yml
@@ -26,7 +26,7 @@ jobs:
     uses: ./.github/workflows/nextjs-integration-test.yml
     with:
       diff_base: "none"
-      version: ${{ inputs.version }}
+      version: ${{ inputs.version || 'canary' }}
       skip_post_to_slack: ${{ github.event_name != 'schedule' && inputs.post_to_slack != true }}
 
   # Upload test results to branch.

--- a/.github/workflows/setup-nextjs-build.yml
+++ b/.github/workflows/setup-nextjs-build.yml
@@ -13,6 +13,8 @@ jobs:
   build_nextjs:
     name: Build Next.js for the turbopack integration test
     runs-on: ubuntu-latest-16-core-oss
+    outputs:
+      output1: ${{ steps.build-next-swc-turbopack-patch.outputs.success }}
     env:
       # pnpm version should match to what upstream next.js uses
       PNPM_VERSION: 7.24.3
@@ -77,11 +79,35 @@ jobs:
           npm i -g pnpm@$PNPM_VERSION && pnpm --version
           pnpm install --loglevel error
 
-      - name: Build next.js volume
+      - name: Build next-swc with latest turbopack
+        id: build-next-swc-turbopack-patch
+        continue-on-error: true
         run: |
-          # Build next.js, next-swc
+          export TURBOPACK_REMOTE="https://github.com/vercel/turbo"
+          # Apply patches to the cargo to the latest turbopack's sha.
+          # Basic recipe to apply patch to cargo via cli looks like this:
+          # cargo check --config 'patch."https://github.com/vercel/turbo".$PKG_NAME.git="https://github.com/vercel/turbo.git?rev=$SHA"'
+          # Careful to preserve quote to allow dot expression can access git url based property key.
+          export BINDING=$(printf 'patch.\\"%s\\".%s.git=\\"%s?rev=%s\\"' "$TURBOPACK_REMOTE" "turbo-binding" "$TURBOPACK_REMOTE" "$GITHUB_SHA")
+          export TASKS=$(printf 'patch.\\"%s\\".%s.git=\\"%s?rev=%s\\"' "$TURBOPACK_REMOTE" "turbo-tasks" "$TURBOPACK_REMOTE" "$GITHUB_SHA")
+          export TASKS_FS=$(printf 'patch.\\"%s\\".%s.git=\\"%s?rev=%s\\"' "$TURBOPACK_REMOTE" "turbo-tasks-fs" "$TURBOPACK_REMOTE" "$GITHUB_SHA")
+
+          echo "Trying to build next-swc with turbopack $GITHUB_SHA"
+          echo "success=false" >> $GITHUB_OUTPUT
+          hyperfine --min-runs 1 --show-output 'pnpm run --filter=@next/swc build-native --features plugin,rustls-tls,__internal_nextjs_integration_test --release --cargo-flags="--config $BINDING --config $TASKS --config $TASKS_FS"'
+          echo "success=true" >> $GITHUB_OUTPUT
+          echo "Successfully built next-swc with turbopack $GITHUB_SHA"
+
+      - name: Build next-swc
+        if: steps.build-next-swc-turbopack-patch.outputs.success != true
+        run: |
+          echo "Looks like we could not apply latest turbopack to next-swc. Trying to build next-swc with published turbopack. This might happen when there is a breaking changes in turbopack, and next.js is not yet updated."
+          hyperfine --min-runs 1 --show-output 'pnpm run --filter=@next/swc build-native --features plugin,rustls-tls,__internal_nextjs_integration_test --release'
+          echo "Successfully built next-swc with published turbopack"
+
+      - name: Build next.js
+        run: |
           pnpm run build
-          hyperfine --min-runs 1 --style nocolor 'pnpm run --filter=@next/swc build-native --features plugin,rustls-tls,__internal_nextjs_integration_test --release --cargo-flags="--message-format short --quiet"'
           strip packages/next-swc/native/next-swc.*.node
           ls -al packages/next-swc/native
           # Reduce the size of the cache bit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -547,9 +547,7 @@ jobs:
           export TASKS_FS=$(printf 'patch."%s".%s.git="%s?rev=%s"' "$TURBOPACK_REMOTE" "turbo-tasks-fs" "$TURBOPACK_REMOTE" "$GITHUB_SHA")
 
           cd packages/next-swc
-          cargo check --config $BINDING --config $TASKS --config $TASKS_FS --message-format short --quiet && \
-          cargo check --config $BINDING --config $TASKS --config $TASKS_FS -p next-swc-napi --features plugin,rustls-tls --message-format short --quiet && \
-          cargo check --config $BINDING --config $TASKS --config $TASKS_FS -p next-dev --no-default-features --features cli,custom_allocator,rustls-tls,__internal_nextjs_integration_test --message-format short --quiet &> cargo_output.log
+          cargo check --config $BINDING --config $TASKS --config $TASKS_FS --all -p next-swc-api -p next-dev --no-default-features --features cli,custom_allocator,rustls-tls,__internal_nextjs_integration_test --message-format short --quiet &> cargo_output.log
 
       - name: Post logs if there are errors
         run: |


### PR DESCRIPTION
### Description

- closes WEB-763.

This PR expands current daily integration setup to apply local patch to the turbopack when build `next-swc`. This'll allow to run integartion against latest TOT where possible.

Since we expect there are breaking changes makes incompatible build with next-* codes in next.js to the turbopack, workflow falls back to building normal next-swc with latest published turbopack if build fails for any reason. We do not have fine grained way to determine if build fails due to incompatiblity or other reason - simply falls back as soon as build fails.