### PR TITLE
Fix plex.tv showcase url

### DIFF
--- a/docs/components/clients/users.ts
+++ b/docs/components/clients/users.ts
@@ -241,7 +241,7 @@ export const users: Array<TurboUser> = [
   {
     caption: "Plex",
     image: "/images/logos/plex.svg",
-    infoLink: "https://www.plex.com/",
+    infoLink: "https://www.plex.tv/",
     pinned: true,
   },
   {


### PR DESCRIPTION
### Description

Was looking at the showcase page on the docs and found that the plex link led to some random manufacturing platform (https://plex.com). This fixes it to redirect to https://plex.tv.
