### PR TITLE
chore: pipe through root package json to lockfile parsing

### DIFF
--- a/cli/internal/context/context.go
+++ b/cli/internal/context/context.go
@@ -179,7 +179,7 @@ func BuildPackageGraph(repoRoot turbopath.AbsoluteSystemPath, rootPackageJSON *f
 	}
 	c.PackageManager = packageManager
 
-	if lockfile, err := c.PackageManager.ReadLockfile(repoRoot); err != nil {
+	if lockfile, err := c.PackageManager.ReadLockfile(repoRoot, rootPackageJSON); err != nil {
 		warnings.append(err)
 	} else {
 		c.Lockfile = lockfile

--- a/cli/internal/packagemanager/berry.go
+++ b/cli/internal/packagemanager/berry.go
@@ -113,7 +113,7 @@ var nodejsBerry = PackageManager{
 		return true, nil
 	},
 
-	UnmarshalLockfile: func(contents []byte) (lockfile.Lockfile, error) {
+	UnmarshalLockfile: func(_rootPackageJSON *fs.PackageJSON, contents []byte) (lockfile.Lockfile, error) {
 		return lockfile.DecodeBerryLockfile(contents)
 	},
 

--- a/cli/internal/packagemanager/npm.go
+++ b/cli/internal/packagemanager/npm.go
@@ -53,7 +53,7 @@ var nodejsNpm = PackageManager{
 		return true, nil
 	},
 
-	UnmarshalLockfile: func(contents []byte) (lockfile.Lockfile, error) {
+	UnmarshalLockfile: func(_rootPackageJSON *fs.PackageJSON, contents []byte) (lockfile.Lockfile, error) {
 		return lockfile.DecodeNpmLockfile(contents)
 	},
 }

--- a/cli/internal/packagemanager/packagemanager.go
+++ b/cli/internal/packagemanager/packagemanager.go
@@ -61,7 +61,7 @@ type PackageManager struct {
 	detect func(projectDirectory turbopath.AbsoluteSystemPath, packageManager *PackageManager) (bool, error)
 
 	// Read a lockfile for a given package manager
-	UnmarshalLockfile func(contents []byte) (lockfile.Lockfile, error)
+	UnmarshalLockfile func(rootPackageJSON *fs.PackageJSON, contents []byte) (lockfile.Lockfile, error)
 
 	// Prune the given pkgJSON to only include references to the given patches
 	prunePatches func(pkgJSON *fs.PackageJSON, patches []turbopath.AnchoredUnixPath) error
@@ -173,7 +173,7 @@ func (pm PackageManager) CanPrune(projectDirectory turbopath.AbsoluteSystemPath)
 }
 
 // ReadLockfile will read the applicable lockfile into memory
-func (pm PackageManager) ReadLockfile(projectDirectory turbopath.AbsoluteSystemPath) (lockfile.Lockfile, error) {
+func (pm PackageManager) ReadLockfile(projectDirectory turbopath.AbsoluteSystemPath, rootPackageJSON *fs.PackageJSON) (lockfile.Lockfile, error) {
 	if pm.UnmarshalLockfile == nil {
 		return nil, nil
 	}
@@ -181,7 +181,7 @@ func (pm PackageManager) ReadLockfile(projectDirectory turbopath.AbsoluteSystemP
 	if err != nil {
 		return nil, fmt.Errorf("reading %s: %w", pm.Lockfile, err)
 	}
-	lf, err := pm.UnmarshalLockfile(contents)
+	lf, err := pm.UnmarshalLockfile(rootPackageJSON, contents)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error in %v", pm.Lockfile)
 	}

--- a/cli/internal/packagemanager/pnpm.go
+++ b/cli/internal/packagemanager/pnpm.go
@@ -117,7 +117,7 @@ var nodejsPnpm = PackageManager{
 		return true, nil
 	},
 
-	UnmarshalLockfile: func(contents []byte) (lockfile.Lockfile, error) {
+	UnmarshalLockfile: func(_rootPackageJSON *fs.PackageJSON, contents []byte) (lockfile.Lockfile, error) {
 		return lockfile.DecodePnpmLockfile(contents)
 	},
 

--- a/cli/internal/packagemanager/pnpm6.go
+++ b/cli/internal/packagemanager/pnpm6.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/Masterminds/semver"
+	"github.com/vercel/turbo/cli/internal/fs"
 	"github.com/vercel/turbo/cli/internal/lockfile"
 	"github.com/vercel/turbo/cli/internal/turbopath"
 )
@@ -56,7 +57,7 @@ var nodejsPnpm6 = PackageManager{
 		return true, nil
 	},
 
-	UnmarshalLockfile: func(contents []byte) (lockfile.Lockfile, error) {
+	UnmarshalLockfile: func(_rootPackageJSON *fs.PackageJSON, contents []byte) (lockfile.Lockfile, error) {
 		return lockfile.DecodePnpmLockfile(contents)
 	},
 }

--- a/cli/internal/packagemanager/yarn.go
+++ b/cli/internal/packagemanager/yarn.go
@@ -110,7 +110,7 @@ var nodejsYarn = PackageManager{
 		return packageManager.Matches(packageManager.Slug, strings.TrimSpace(string(out)))
 	},
 
-	UnmarshalLockfile: func(contents []byte) (lockfile.Lockfile, error) {
+	UnmarshalLockfile: func(_rootPackageJSON *fs.PackageJSON, contents []byte) (lockfile.Lockfile, error) {
 		return lockfile.DecodeYarnLockfile(contents)
 	},
 }

--- a/cli/internal/scope/scope.go
+++ b/cli/internal/scope/scope.go
@@ -262,7 +262,7 @@ func getChangesFromLockfile(scm scm.SCM, ctx *context.Context, changedFiles []st
 		// unable to reconstruct old lockfile, assume everything changed
 		return nil, true
 	}
-	prevLockfile, err := ctx.PackageManager.UnmarshalLockfile(prevContents)
+	prevLockfile, err := ctx.PackageManager.UnmarshalLockfile(ctx.WorkspaceInfos.PackageJSONs[util.RootPkgName], prevContents)
 	if err != nil {
 		// unable to parse old lockfile, assume everything changed
 		return nil, true

--- a/cli/internal/scope/scope_test.go
+++ b/cli/internal/scope/scope_test.go
@@ -507,7 +507,7 @@ func TestResolvePackages(t *testing.T) {
 			for _, path := range systemSeparatorChanged {
 				scm.contents[path] = nil
 			}
-			readLockfile := func(contents []byte) (lockfile.Lockfile, error) {
+			readLockfile := func(_rootPackageJSON *fs.PackageJSON, content []byte) (lockfile.Lockfile, error) {
 				return tc.prevLockfile, nil
 			}
 			pkgs, isAllPackages, err := ResolvePackages(&Opts{


### PR DESCRIPTION
### Description

In order to properly support prune support for the [yarn `resolutions` field](https://yarnpkg.com/configuration/manifest/#resolutions), we need to have access to the `resolutions` field when we construct the lockfile object. This PR simply adds the root package json as an argument to all lockfile parsing methods.

### Testing Instructions

Existing unit and integration tests pass.
