### PR TITLE
feat(turbopack): initial mdxRs next.config.js support

### DIFF
--- a/crates/turbopack-mdx/src/lib.rs
+++ b/crates/turbopack-mdx/src/lib.rs
@@ -2,10 +2,7 @@
 
 use anyhow::{anyhow, Result};
 use mdxjs::{compile, Options};
-use turbo_tasks::{
-    primitives::{OptionStringVc, StringVc},
-    Value,
-};
+use turbo_tasks::{primitives::StringVc, Value};
 use turbo_tasks_fs::{rope::Rope, File, FileContent, FileSystemPathVc};
 use turbopack_core::{
     asset::{Asset, AssetContent, AssetContentVc, AssetVc},
@@ -36,14 +33,13 @@ fn modifier() -> StringVc {
 
 /// Subset of mdxjs::Options to allow to inherit turbopack's jsx-related configs
 /// into mdxjs.
-#[turbo_tasks::value(serialization = "auto_for_input")]
-#[derive(PartialOrd, Ord, Hash, Debug, Copy, Clone)]
+#[turbo_tasks::value(shared)]
+#[derive(PartialOrd, Ord, Hash, Debug, Clone)]
 pub struct MdxTransformOptions {
     pub development: bool,
     pub preserve_jsx: bool,
-    pub jsx_runtime: OptionStringVc,
-    pub jsx_import_source: OptionStringVc,
-    pub filepath: Option<FileSystemPathVc>,
+    pub jsx_runtime: Option<String>,
+    pub jsx_import_source: Option<String>,
 }
 
 impl Default for MdxTransformOptions {
@@ -51,10 +47,23 @@ impl Default for MdxTransformOptions {
         Self {
             development: true,
             preserve_jsx: false,
-            jsx_runtime: OptionStringVc::cell(None),
-            jsx_import_source: OptionStringVc::cell(None),
-            filepath: None,
+            jsx_runtime: None,
+            jsx_import_source: None,
         }
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl MdxTransformOptionsVc {
+    #[turbo_tasks::function]
+    pub fn default() -> Self {
+        Self::cell(Default::default())
+    }
+}
+
+impl Default for MdxTransformOptionsVc {
+    fn default() -> Self {
+        Self::default()
     }
 }
 
@@ -64,7 +73,7 @@ pub struct MdxModuleAsset {
     source: AssetVc,
     context: AssetContextVc,
     transforms: EcmascriptInputTransformsVc,
-    options: MdxTransformOptions,
+    options: MdxTransformOptionsVc,
 }
 
 /// MDX components should be treated as normal j|tsx components to analyze
@@ -77,7 +86,7 @@ async fn into_ecmascript_module_asset(
 ) -> Result<EcmascriptModuleAssetVc> {
     let content = current_context.content();
     let this = current_context.await?;
-    let transform_options = this.options;
+    let transform_options = this.options.await?;
 
     let AssetContent::File(file) = &*content.await? else {
         anyhow::bail!("Unexpected mdx asset content");
@@ -87,7 +96,7 @@ async fn into_ecmascript_module_asset(
         anyhow::bail!("Not able to read mdx file content");
     };
 
-    let jsx_runtime = if let Some(runtime) = &*transform_options.jsx_runtime.await? {
+    let jsx_runtime = if let Some(runtime) = &transform_options.jsx_runtime {
         match runtime.as_str() {
             "automatic" => Some(mdxjs::JsxRuntime::Automatic),
             "classic" => Some(mdxjs::JsxRuntime::Classic),
@@ -97,25 +106,20 @@ async fn into_ecmascript_module_asset(
         None
     };
 
-    let filepath = if let Some(filepath) = transform_options.filepath {
-        Some(filepath.await?.path.clone())
-    } else {
-        None
-    };
-
     let options = Options {
         development: transform_options.development,
         jsx: transform_options.preserve_jsx, // true means 'preserve' jsx syntax.
         jsx_runtime,
-        jsx_import_source: transform_options.jsx_import_source.await?.clone_value(),
-        filepath,
+        jsx_import_source: transform_options
+            .jsx_import_source
+            .as_ref()
+            .map(|s| s.into()),
+        filepath: Some(this.source.ident().path().await?.to_string()),
         ..Default::default()
     };
     // TODO: upstream mdx currently bubbles error as string
     let mdx_jsx_component =
         compile(&file.content().to_str()?, &options).map_err(|e| anyhow!("{}", e))?;
-
-    println!("MDX JSX: {:#?} {}", options, mdx_jsx_component);
 
     let source = VirtualAssetVc::new_with_ident(
         this.source.ident(),
@@ -138,13 +142,13 @@ impl MdxModuleAssetVc {
         source: AssetVc,
         context: AssetContextVc,
         transforms: EcmascriptInputTransformsVc,
-        options: Value<MdxTransformOptions>,
+        options: MdxTransformOptionsVc,
     ) -> Self {
         Self::cell(MdxModuleAsset {
             source,
             context,
             transforms,
-            options: options.into_value(),
+            options,
         })
     }
 

--- a/crates/turbopack/src/lib.rs
+++ b/crates/turbopack/src/lib.rs
@@ -176,7 +176,7 @@ async fn apply_module_type(
         ModuleType::Mdx {
             transforms,
             options,
-        } => MdxModuleAssetVc::new(source, context.into(), *transforms, (*options).into()).into(),
+        } => MdxModuleAssetVc::new(source, context.into(), *transforms, *options).into(),
         ModuleType::Custom(_) => todo!(),
     })
 }

--- a/crates/turbopack/src/lib.rs
+++ b/crates/turbopack/src/lib.rs
@@ -173,9 +173,10 @@ async fn apply_module_type(
             ModuleCssModuleAssetVc::new(source, context.into(), *transforms).into()
         }
         ModuleType::Static => StaticModuleAssetVc::new(source, context.into()).into(),
-        ModuleType::Mdx(transforms) => {
-            MdxModuleAssetVc::new(source, context.into(), *transforms).into()
-        }
+        ModuleType::Mdx {
+            transforms,
+            options,
+        } => MdxModuleAssetVc::new(source, context.into(), *transforms, (*options).into()).into(),
         ModuleType::Custom(_) => todo!(),
     })
 }

--- a/crates/turbopack/src/module_options/mod.rs
+++ b/crates/turbopack/src/module_options/mod.rs
@@ -351,21 +351,18 @@ impl ModuleOptionsVc {
         if enable_mdx || enable_mdx_rs {
             let (jsx_runtime, jsx_import_source) = if let Some(enable_jsx) = enable_jsx {
                 let jsx = enable_jsx.await?;
-                (
-                    OptionStringVc::cell(jsx.runtime.clone()),
-                    OptionStringVc::cell(jsx.import_source.clone()),
-                )
+                (jsx.runtime.clone(), jsx.import_source.clone())
             } else {
-                (OptionStringVc::cell(None), OptionStringVc::cell(None))
+                (None, None)
             };
 
-            let mdx_transform_options = MdxTransformOptions {
+            let mdx_transform_options = (MdxTransformOptions {
                 development: true,
                 preserve_jsx: false,
                 jsx_runtime,
                 jsx_import_source,
-                filepath: Some(path),
-            };
+            })
+            .cell();
 
             rules.push(ModuleRule::new(
                 ModuleRuleCondition::any(vec![

--- a/crates/turbopack/src/module_options/mod.rs
+++ b/crates/turbopack/src/module_options/mod.rs
@@ -17,6 +17,7 @@ use turbopack_css::{CssInputTransform, CssInputTransformsVc};
 use turbopack_ecmascript::{
     EcmascriptInputTransform, EcmascriptInputTransformsVc, EcmascriptOptions,
 };
+use turbopack_mdx::MdxTransformOptions;
 use turbopack_node::transforms::{postcss::PostCssTransformVc, webpack::WebpackLoadersVc};
 
 use crate::evaluate_context::node_evaluate_asset_context;
@@ -70,6 +71,7 @@ impl ModuleOptionsVc {
             ref enable_typescript_transform,
             ref decorators,
             enable_mdx,
+            enable_mdx_rs,
             ref enable_postcss_transform,
             ref enable_webpack_loaders,
             preset_env_versions,
@@ -131,6 +133,7 @@ impl ModuleOptionsVc {
         }
         if let Some(enable_jsx) = enable_jsx {
             let jsx = enable_jsx.await?;
+
             transforms.push(EcmascriptInputTransform::React {
                 refresh: enable_react_refresh,
                 import_source: OptionStringVc::cell(jsx.import_source.clone()),
@@ -345,12 +348,34 @@ impl ModuleOptionsVc {
             ),
         ];
 
-        if enable_mdx {
+        if enable_mdx || enable_mdx_rs {
+            let (jsx_runtime, jsx_import_source) = if let Some(enable_jsx) = enable_jsx {
+                let jsx = enable_jsx.await?;
+                (
+                    OptionStringVc::cell(jsx.runtime.clone()),
+                    OptionStringVc::cell(jsx.import_source.clone()),
+                )
+            } else {
+                (OptionStringVc::cell(None), OptionStringVc::cell(None))
+            };
+
+            let mdx_transform_options = MdxTransformOptions {
+                development: true,
+                preserve_jsx: false,
+                jsx_runtime,
+                jsx_import_source,
+                filepath: Some(path),
+            };
+
             rules.push(ModuleRule::new(
-                ModuleRuleCondition::ResourcePathEndsWith(".mdx".to_string()),
-                vec![ModuleRuleEffect::ModuleType(ModuleType::Mdx(
-                    mdx_transforms,
-                ))],
+                ModuleRuleCondition::any(vec![
+                    ModuleRuleCondition::ResourcePathEndsWith(".md".to_string()),
+                    ModuleRuleCondition::ResourcePathEndsWith(".mdx".to_string()),
+                ]),
+                vec![ModuleRuleEffect::ModuleType(ModuleType::Mdx {
+                    transforms: mdx_transforms,
+                    options: mdx_transform_options,
+                })],
             ));
         }
 

--- a/crates/turbopack/src/module_options/module_options_context.rs
+++ b/crates/turbopack/src/module_options/module_options_context.rs
@@ -216,6 +216,10 @@ pub struct ModuleOptionsContext {
     pub decorators: Option<DecoratorsOptionsVc>,
     #[serde(default)]
     pub enable_mdx: bool,
+    // [Note]: currently mdx, and mdx_rs have different configuration entrypoint from next.config.js,
+    // however we might want to unify them in the future.
+    #[serde(default)]
+    pub enable_mdx_rs: bool,
     #[serde(default)]
     pub preset_env_versions: Option<EnvironmentVc>,
     #[serde(default)]

--- a/crates/turbopack/src/module_options/module_rule.rs
+++ b/crates/turbopack/src/module_options/module_rule.rs
@@ -7,7 +7,7 @@ use turbopack_core::{
 };
 use turbopack_css::CssInputTransformsVc;
 use turbopack_ecmascript::{EcmascriptInputTransformsVc, EcmascriptOptions};
-use turbopack_mdx::MdxTransformOptions;
+use turbopack_mdx::MdxTransformOptionsVc;
 
 use super::ModuleRuleCondition;
 
@@ -60,8 +60,7 @@ pub enum ModuleType {
     Raw,
     Mdx {
         transforms: EcmascriptInputTransformsVc,
-        #[turbo_tasks(trace_ignore)]
-        options: MdxTransformOptions,
+        options: MdxTransformOptionsVc,
     },
     Css(CssInputTransformsVc),
     CssModule(CssInputTransformsVc),

--- a/crates/turbopack/src/module_options/module_rule.rs
+++ b/crates/turbopack/src/module_options/module_rule.rs
@@ -7,6 +7,7 @@ use turbopack_core::{
 };
 use turbopack_css::CssInputTransformsVc;
 use turbopack_ecmascript::{EcmascriptInputTransformsVc, EcmascriptOptions};
+use turbopack_mdx::MdxTransformOptions;
 
 use super::ModuleRuleCondition;
 
@@ -57,7 +58,11 @@ pub enum ModuleType {
     TypescriptDeclaration(EcmascriptInputTransformsVc),
     Json,
     Raw,
-    Mdx(EcmascriptInputTransformsVc),
+    Mdx {
+        transforms: EcmascriptInputTransformsVc,
+        #[turbo_tasks(trace_ignore)]
+        options: MdxTransformOptions,
+    },
     Css(CssInputTransformsVc),
     CssModule(CssInputTransformsVc),
     Static,


### PR DESCRIPTION
### Description

Related with WEB-488.

This PR enables `mdxRs` configuration option from next.config.js's `experimental`. When it is enabled, it allows to transform `.md` and `.mdx` with mdx compiler with inheriting any existing jsx transform options to align with other jsx components transform options.

Currently while there are mdx / mdxRs config, both shares same transform (mdxrs). It may need to be either 1. consolidate options in next.config.js or 2. support js-based mdx correctly in turbopack, but something to consider later.

Lastly, with `Runtime::Classic` unlike existing test cases in next.js this transform will fail with `React is not defined` runtime error. Manually adding import to react works, however it's unclear if turbopack supposed to auto-inject those importsource or not. For now, make minimal piece working first.