### PR TITLE
Use pnpm in prepare script

### DIFF
--- a/.github/actions/turbopack-bump/package.json
+++ b/.github/actions/turbopack-bump/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "scripts": {
     "build": "ncc build src/index.ts -o dist --source-map --minify",
-    "prepare": "npm run build"
+    "prepare": "pnpm run build"
   },
   "dependencies": {
     "@actions/core": "^1.10.0",


### PR DESCRIPTION
Corepack throws an error when running pnpm install from the root of the monorepo, because the prepare script is run when you run install. Corepack does not allow using npm, because the root of the monorepo
has configured the packageManager to be pnpm.