### PR TITLE
Add ServerAddr ip/port methods

### DIFF
--- a/crates/turbopack-core/src/environment.rs
+++ b/crates/turbopack-core/src/environment.rs
@@ -25,6 +25,14 @@ impl ServerAddr {
         Self(Some(addr))
     }
 
+    pub fn ip(&self) -> Option<String> {
+        self.0.map(|addr| addr.ip().to_string())
+    }
+
+    pub fn port(&self) -> Option<u16> {
+        self.0.map(|addr| addr.port())
+    }
+
     pub fn to_string(&self) -> Result<String> {
         let addr = &self.0.context("expected some server address")?;
         let uri = if addr.ip().is_loopback() || addr.ip().is_unspecified() {


### PR DESCRIPTION
### Description

Two small methods that expose the ip/port of our `ServerAddr`. This is necessary for initializing the Next.js router, so that requests appear to be coming from the same correct for middleware requests.

### Testing Instructions

