### PR TITLE
handle module evaluation errors in the runtime correctly

### DIFF
--- a/crates/turbopack-dev/js/types/index.d.ts
+++ b/crates/turbopack-dev/js/types/index.d.ts
@@ -25,6 +25,7 @@ export type ChunkRegistration = [
 
 interface Module {
   exports: Exports;
+  error: Error | undefined;
   loaded: boolean;
   id: ModuleId;
   hot?: Hot;

--- a/crates/turbopack-tests/tests/snapshot/basic/async_chunk/output/crates_turbopack-tests_tests_snapshot_basic_async_chunk_input_index_0d348e.js
+++ b/crates/turbopack-tests/tests/snapshot/basic/async_chunk/output/crates_turbopack-tests_tests_snapshot_basic_async_chunk_input_index_0d348e.js
@@ -175,6 +175,7 @@ function interopEsm(raw, ns, allowExportDefault) {
  */
 function esmImport(sourceModule, id, allowExportDefault) {
   const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
   const raw = module.exports;
   if (raw.__esModule) return raw;
   if (module.interopNamespace) return module.interopNamespace;
@@ -189,7 +190,9 @@ function esmImport(sourceModule, id, allowExportDefault) {
  * @returns {Exports}
  */
 function commonJsRequire(sourceModule, id) {
-  return getOrInstantiateModuleFromParent(id, sourceModule).exports;
+  const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
+  return module.exports;
 }
 
 function externalRequire(id, esm) {
@@ -285,6 +288,7 @@ function instantiateModule(id, source) {
   /** @type {Module} */
   const module = {
     exports: {},
+    error: undefined,
     loaded: false,
     id,
     parents: undefined,
@@ -311,21 +315,25 @@ function instantiateModule(id, source) {
   }
 
   runModuleExecutionHooks(module, () => {
-    moduleFactory.call(module.exports, {
-      e: module.exports,
-      r: commonJsRequire.bind(null, module),
-      x: externalRequire,
-      i: esmImport.bind(null, module),
-      s: esm.bind(null, module.exports),
-      j: cjs.bind(null, module.exports),
-      v: exportValue.bind(null, module),
-      m: module,
-      c: moduleCache,
-      l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
-      k: registerChunkList,
-      g: globalThis,
-      __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
-    });
+    try {
+      moduleFactory.call(module.exports, {
+        e: module.exports,
+        r: commonJsRequire.bind(null, module),
+        x: externalRequire,
+        i: esmImport.bind(null, module),
+        s: esm.bind(null, module.exports),
+        j: cjs.bind(null, module.exports),
+        v: exportValue.bind(null, module),
+        m: module,
+        c: moduleCache,
+        l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
+        k: registerChunkList,
+        g: globalThis,
+        __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
+      });
+    } catch (error) {
+      module.error = error;
+    }
   });
 
   module.loaded = true;

--- a/crates/turbopack-tests/tests/snapshot/basic/chunked/output/crates_turbopack-tests_tests_snapshot_basic_chunked_input_index_e77e9f.js
+++ b/crates/turbopack-tests/tests/snapshot/basic/chunked/output/crates_turbopack-tests_tests_snapshot_basic_chunked_input_index_e77e9f.js
@@ -175,6 +175,7 @@ function interopEsm(raw, ns, allowExportDefault) {
  */
 function esmImport(sourceModule, id, allowExportDefault) {
   const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
   const raw = module.exports;
   if (raw.__esModule) return raw;
   if (module.interopNamespace) return module.interopNamespace;
@@ -189,7 +190,9 @@ function esmImport(sourceModule, id, allowExportDefault) {
  * @returns {Exports}
  */
 function commonJsRequire(sourceModule, id) {
-  return getOrInstantiateModuleFromParent(id, sourceModule).exports;
+  const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
+  return module.exports;
 }
 
 function externalRequire(id, esm) {
@@ -285,6 +288,7 @@ function instantiateModule(id, source) {
   /** @type {Module} */
   const module = {
     exports: {},
+    error: undefined,
     loaded: false,
     id,
     parents: undefined,
@@ -311,21 +315,25 @@ function instantiateModule(id, source) {
   }
 
   runModuleExecutionHooks(module, () => {
-    moduleFactory.call(module.exports, {
-      e: module.exports,
-      r: commonJsRequire.bind(null, module),
-      x: externalRequire,
-      i: esmImport.bind(null, module),
-      s: esm.bind(null, module.exports),
-      j: cjs.bind(null, module.exports),
-      v: exportValue.bind(null, module),
-      m: module,
-      c: moduleCache,
-      l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
-      k: registerChunkList,
-      g: globalThis,
-      __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
-    });
+    try {
+      moduleFactory.call(module.exports, {
+        e: module.exports,
+        r: commonJsRequire.bind(null, module),
+        x: externalRequire,
+        i: esmImport.bind(null, module),
+        s: esm.bind(null, module.exports),
+        j: cjs.bind(null, module.exports),
+        v: exportValue.bind(null, module),
+        m: module,
+        c: moduleCache,
+        l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
+        k: registerChunkList,
+        g: globalThis,
+        __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
+      });
+    } catch (error) {
+      module.error = error;
+    }
   });
 
   module.loaded = true;

--- a/crates/turbopack-tests/tests/snapshot/basic/shebang/output/crates_turbopack-tests_tests_snapshot_basic_shebang_input_index_b1f0c2.js
+++ b/crates/turbopack-tests/tests/snapshot/basic/shebang/output/crates_turbopack-tests_tests_snapshot_basic_shebang_input_index_b1f0c2.js
@@ -175,6 +175,7 @@ function interopEsm(raw, ns, allowExportDefault) {
  */
 function esmImport(sourceModule, id, allowExportDefault) {
   const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
   const raw = module.exports;
   if (raw.__esModule) return raw;
   if (module.interopNamespace) return module.interopNamespace;
@@ -189,7 +190,9 @@ function esmImport(sourceModule, id, allowExportDefault) {
  * @returns {Exports}
  */
 function commonJsRequire(sourceModule, id) {
-  return getOrInstantiateModuleFromParent(id, sourceModule).exports;
+  const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
+  return module.exports;
 }
 
 function externalRequire(id, esm) {
@@ -285,6 +288,7 @@ function instantiateModule(id, source) {
   /** @type {Module} */
   const module = {
     exports: {},
+    error: undefined,
     loaded: false,
     id,
     parents: undefined,
@@ -311,21 +315,25 @@ function instantiateModule(id, source) {
   }
 
   runModuleExecutionHooks(module, () => {
-    moduleFactory.call(module.exports, {
-      e: module.exports,
-      r: commonJsRequire.bind(null, module),
-      x: externalRequire,
-      i: esmImport.bind(null, module),
-      s: esm.bind(null, module.exports),
-      j: cjs.bind(null, module.exports),
-      v: exportValue.bind(null, module),
-      m: module,
-      c: moduleCache,
-      l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
-      k: registerChunkList,
-      g: globalThis,
-      __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
-    });
+    try {
+      moduleFactory.call(module.exports, {
+        e: module.exports,
+        r: commonJsRequire.bind(null, module),
+        x: externalRequire,
+        i: esmImport.bind(null, module),
+        s: esm.bind(null, module.exports),
+        j: cjs.bind(null, module.exports),
+        v: exportValue.bind(null, module),
+        m: module,
+        c: moduleCache,
+        l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
+        k: registerChunkList,
+        g: globalThis,
+        __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
+      });
+    } catch (error) {
+      module.error = error;
+    }
   });
 
   module.loaded = true;

--- a/crates/turbopack-tests/tests/snapshot/comptime/define/output/crates_turbopack-tests_tests_snapshot_comptime_define_input_index_6b0d2b.js
+++ b/crates/turbopack-tests/tests/snapshot/comptime/define/output/crates_turbopack-tests_tests_snapshot_comptime_define_input_index_6b0d2b.js
@@ -175,6 +175,7 @@ function interopEsm(raw, ns, allowExportDefault) {
  */
 function esmImport(sourceModule, id, allowExportDefault) {
   const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
   const raw = module.exports;
   if (raw.__esModule) return raw;
   if (module.interopNamespace) return module.interopNamespace;
@@ -189,7 +190,9 @@ function esmImport(sourceModule, id, allowExportDefault) {
  * @returns {Exports}
  */
 function commonJsRequire(sourceModule, id) {
-  return getOrInstantiateModuleFromParent(id, sourceModule).exports;
+  const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
+  return module.exports;
 }
 
 function externalRequire(id, esm) {
@@ -285,6 +288,7 @@ function instantiateModule(id, source) {
   /** @type {Module} */
   const module = {
     exports: {},
+    error: undefined,
     loaded: false,
     id,
     parents: undefined,
@@ -311,21 +315,25 @@ function instantiateModule(id, source) {
   }
 
   runModuleExecutionHooks(module, () => {
-    moduleFactory.call(module.exports, {
-      e: module.exports,
-      r: commonJsRequire.bind(null, module),
-      x: externalRequire,
-      i: esmImport.bind(null, module),
-      s: esm.bind(null, module.exports),
-      j: cjs.bind(null, module.exports),
-      v: exportValue.bind(null, module),
-      m: module,
-      c: moduleCache,
-      l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
-      k: registerChunkList,
-      g: globalThis,
-      __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
-    });
+    try {
+      moduleFactory.call(module.exports, {
+        e: module.exports,
+        r: commonJsRequire.bind(null, module),
+        x: externalRequire,
+        i: esmImport.bind(null, module),
+        s: esm.bind(null, module.exports),
+        j: cjs.bind(null, module.exports),
+        v: exportValue.bind(null, module),
+        m: module,
+        c: moduleCache,
+        l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
+        k: registerChunkList,
+        g: globalThis,
+        __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
+      });
+    } catch (error) {
+      module.error = error;
+    }
   });
 
   module.loaded = true;

--- a/crates/turbopack-tests/tests/snapshot/css/absolute-uri-import/output/crates_turbopack-tests_tests_snapshot_css_absolute-uri-import_input_index_082e10.js
+++ b/crates/turbopack-tests/tests/snapshot/css/absolute-uri-import/output/crates_turbopack-tests_tests_snapshot_css_absolute-uri-import_input_index_082e10.js
@@ -175,6 +175,7 @@ function interopEsm(raw, ns, allowExportDefault) {
  */
 function esmImport(sourceModule, id, allowExportDefault) {
   const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
   const raw = module.exports;
   if (raw.__esModule) return raw;
   if (module.interopNamespace) return module.interopNamespace;
@@ -189,7 +190,9 @@ function esmImport(sourceModule, id, allowExportDefault) {
  * @returns {Exports}
  */
 function commonJsRequire(sourceModule, id) {
-  return getOrInstantiateModuleFromParent(id, sourceModule).exports;
+  const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
+  return module.exports;
 }
 
 function externalRequire(id, esm) {
@@ -285,6 +288,7 @@ function instantiateModule(id, source) {
   /** @type {Module} */
   const module = {
     exports: {},
+    error: undefined,
     loaded: false,
     id,
     parents: undefined,
@@ -311,21 +315,25 @@ function instantiateModule(id, source) {
   }
 
   runModuleExecutionHooks(module, () => {
-    moduleFactory.call(module.exports, {
-      e: module.exports,
-      r: commonJsRequire.bind(null, module),
-      x: externalRequire,
-      i: esmImport.bind(null, module),
-      s: esm.bind(null, module.exports),
-      j: cjs.bind(null, module.exports),
-      v: exportValue.bind(null, module),
-      m: module,
-      c: moduleCache,
-      l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
-      k: registerChunkList,
-      g: globalThis,
-      __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
-    });
+    try {
+      moduleFactory.call(module.exports, {
+        e: module.exports,
+        r: commonJsRequire.bind(null, module),
+        x: externalRequire,
+        i: esmImport.bind(null, module),
+        s: esm.bind(null, module.exports),
+        j: cjs.bind(null, module.exports),
+        v: exportValue.bind(null, module),
+        m: module,
+        c: moduleCache,
+        l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
+        k: registerChunkList,
+        g: globalThis,
+        __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
+      });
+    } catch (error) {
+      module.error = error;
+    }
   });
 
   module.loaded = true;

--- a/crates/turbopack-tests/tests/snapshot/css/css/output/crates_turbopack-tests_tests_snapshot_css_css_input_index_2081e1.js
+++ b/crates/turbopack-tests/tests/snapshot/css/css/output/crates_turbopack-tests_tests_snapshot_css_css_input_index_2081e1.js
@@ -175,6 +175,7 @@ function interopEsm(raw, ns, allowExportDefault) {
  */
 function esmImport(sourceModule, id, allowExportDefault) {
   const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
   const raw = module.exports;
   if (raw.__esModule) return raw;
   if (module.interopNamespace) return module.interopNamespace;
@@ -189,7 +190,9 @@ function esmImport(sourceModule, id, allowExportDefault) {
  * @returns {Exports}
  */
 function commonJsRequire(sourceModule, id) {
-  return getOrInstantiateModuleFromParent(id, sourceModule).exports;
+  const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
+  return module.exports;
 }
 
 function externalRequire(id, esm) {
@@ -285,6 +288,7 @@ function instantiateModule(id, source) {
   /** @type {Module} */
   const module = {
     exports: {},
+    error: undefined,
     loaded: false,
     id,
     parents: undefined,
@@ -311,21 +315,25 @@ function instantiateModule(id, source) {
   }
 
   runModuleExecutionHooks(module, () => {
-    moduleFactory.call(module.exports, {
-      e: module.exports,
-      r: commonJsRequire.bind(null, module),
-      x: externalRequire,
-      i: esmImport.bind(null, module),
-      s: esm.bind(null, module.exports),
-      j: cjs.bind(null, module.exports),
-      v: exportValue.bind(null, module),
-      m: module,
-      c: moduleCache,
-      l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
-      k: registerChunkList,
-      g: globalThis,
-      __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
-    });
+    try {
+      moduleFactory.call(module.exports, {
+        e: module.exports,
+        r: commonJsRequire.bind(null, module),
+        x: externalRequire,
+        i: esmImport.bind(null, module),
+        s: esm.bind(null, module.exports),
+        j: cjs.bind(null, module.exports),
+        v: exportValue.bind(null, module),
+        m: module,
+        c: moduleCache,
+        l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
+        k: registerChunkList,
+        g: globalThis,
+        __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
+      });
+    } catch (error) {
+      module.error = error;
+    }
   });
 
   module.loaded = true;

--- a/crates/turbopack-tests/tests/snapshot/emotion/emotion/output/crates_turbopack-tests_tests_snapshot_emotion_emotion_input_index_b080c4.js
+++ b/crates/turbopack-tests/tests/snapshot/emotion/emotion/output/crates_turbopack-tests_tests_snapshot_emotion_emotion_input_index_b080c4.js
@@ -175,6 +175,7 @@ function interopEsm(raw, ns, allowExportDefault) {
  */
 function esmImport(sourceModule, id, allowExportDefault) {
   const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
   const raw = module.exports;
   if (raw.__esModule) return raw;
   if (module.interopNamespace) return module.interopNamespace;
@@ -189,7 +190,9 @@ function esmImport(sourceModule, id, allowExportDefault) {
  * @returns {Exports}
  */
 function commonJsRequire(sourceModule, id) {
-  return getOrInstantiateModuleFromParent(id, sourceModule).exports;
+  const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
+  return module.exports;
 }
 
 function externalRequire(id, esm) {
@@ -285,6 +288,7 @@ function instantiateModule(id, source) {
   /** @type {Module} */
   const module = {
     exports: {},
+    error: undefined,
     loaded: false,
     id,
     parents: undefined,
@@ -311,21 +315,25 @@ function instantiateModule(id, source) {
   }
 
   runModuleExecutionHooks(module, () => {
-    moduleFactory.call(module.exports, {
-      e: module.exports,
-      r: commonJsRequire.bind(null, module),
-      x: externalRequire,
-      i: esmImport.bind(null, module),
-      s: esm.bind(null, module.exports),
-      j: cjs.bind(null, module.exports),
-      v: exportValue.bind(null, module),
-      m: module,
-      c: moduleCache,
-      l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
-      k: registerChunkList,
-      g: globalThis,
-      __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
-    });
+    try {
+      moduleFactory.call(module.exports, {
+        e: module.exports,
+        r: commonJsRequire.bind(null, module),
+        x: externalRequire,
+        i: esmImport.bind(null, module),
+        s: esm.bind(null, module.exports),
+        j: cjs.bind(null, module.exports),
+        v: exportValue.bind(null, module),
+        m: module,
+        c: moduleCache,
+        l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
+        k: registerChunkList,
+        g: globalThis,
+        __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
+      });
+    } catch (error) {
+      module.error = error;
+    }
   });
 
   module.loaded = true;

--- a/crates/turbopack-tests/tests/snapshot/env/env/output/crates_turbopack-tests_tests_snapshot_env_env_input_index_29a23f.js
+++ b/crates/turbopack-tests/tests/snapshot/env/env/output/crates_turbopack-tests_tests_snapshot_env_env_input_index_29a23f.js
@@ -175,6 +175,7 @@ function interopEsm(raw, ns, allowExportDefault) {
  */
 function esmImport(sourceModule, id, allowExportDefault) {
   const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
   const raw = module.exports;
   if (raw.__esModule) return raw;
   if (module.interopNamespace) return module.interopNamespace;
@@ -189,7 +190,9 @@ function esmImport(sourceModule, id, allowExportDefault) {
  * @returns {Exports}
  */
 function commonJsRequire(sourceModule, id) {
-  return getOrInstantiateModuleFromParent(id, sourceModule).exports;
+  const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
+  return module.exports;
 }
 
 function externalRequire(id, esm) {
@@ -285,6 +288,7 @@ function instantiateModule(id, source) {
   /** @type {Module} */
   const module = {
     exports: {},
+    error: undefined,
     loaded: false,
     id,
     parents: undefined,
@@ -311,21 +315,25 @@ function instantiateModule(id, source) {
   }
 
   runModuleExecutionHooks(module, () => {
-    moduleFactory.call(module.exports, {
-      e: module.exports,
-      r: commonJsRequire.bind(null, module),
-      x: externalRequire,
-      i: esmImport.bind(null, module),
-      s: esm.bind(null, module.exports),
-      j: cjs.bind(null, module.exports),
-      v: exportValue.bind(null, module),
-      m: module,
-      c: moduleCache,
-      l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
-      k: registerChunkList,
-      g: globalThis,
-      __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
-    });
+    try {
+      moduleFactory.call(module.exports, {
+        e: module.exports,
+        r: commonJsRequire.bind(null, module),
+        x: externalRequire,
+        i: esmImport.bind(null, module),
+        s: esm.bind(null, module.exports),
+        j: cjs.bind(null, module.exports),
+        v: exportValue.bind(null, module),
+        m: module,
+        c: moduleCache,
+        l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
+        k: registerChunkList,
+        g: globalThis,
+        __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
+      });
+    } catch (error) {
+      module.error = error;
+    }
   });
 
   module.loaded = true;

--- a/crates/turbopack-tests/tests/snapshot/evaluated_entrry/runtime_entry/output/a587c_tests_snapshot_evaluated_entrry_runtime_entry_input_index_f59cc7.js
+++ b/crates/turbopack-tests/tests/snapshot/evaluated_entrry/runtime_entry/output/a587c_tests_snapshot_evaluated_entrry_runtime_entry_input_index_f59cc7.js
@@ -175,6 +175,7 @@ function interopEsm(raw, ns, allowExportDefault) {
  */
 function esmImport(sourceModule, id, allowExportDefault) {
   const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
   const raw = module.exports;
   if (raw.__esModule) return raw;
   if (module.interopNamespace) return module.interopNamespace;
@@ -189,7 +190,9 @@ function esmImport(sourceModule, id, allowExportDefault) {
  * @returns {Exports}
  */
 function commonJsRequire(sourceModule, id) {
-  return getOrInstantiateModuleFromParent(id, sourceModule).exports;
+  const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
+  return module.exports;
 }
 
 function externalRequire(id, esm) {
@@ -285,6 +288,7 @@ function instantiateModule(id, source) {
   /** @type {Module} */
   const module = {
     exports: {},
+    error: undefined,
     loaded: false,
     id,
     parents: undefined,
@@ -311,21 +315,25 @@ function instantiateModule(id, source) {
   }
 
   runModuleExecutionHooks(module, () => {
-    moduleFactory.call(module.exports, {
-      e: module.exports,
-      r: commonJsRequire.bind(null, module),
-      x: externalRequire,
-      i: esmImport.bind(null, module),
-      s: esm.bind(null, module.exports),
-      j: cjs.bind(null, module.exports),
-      v: exportValue.bind(null, module),
-      m: module,
-      c: moduleCache,
-      l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
-      k: registerChunkList,
-      g: globalThis,
-      __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
-    });
+    try {
+      moduleFactory.call(module.exports, {
+        e: module.exports,
+        r: commonJsRequire.bind(null, module),
+        x: externalRequire,
+        i: esmImport.bind(null, module),
+        s: esm.bind(null, module.exports),
+        j: cjs.bind(null, module.exports),
+        v: exportValue.bind(null, module),
+        m: module,
+        c: moduleCache,
+        l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
+        k: registerChunkList,
+        g: globalThis,
+        __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
+      });
+    } catch (error) {
+      module.error = error;
+    }
   });
 
   module.loaded = true;

--- a/crates/turbopack-tests/tests/snapshot/example/example/output/crates_turbopack-tests_tests_snapshot_example_example_input_index_78b6bf.js
+++ b/crates/turbopack-tests/tests/snapshot/example/example/output/crates_turbopack-tests_tests_snapshot_example_example_input_index_78b6bf.js
@@ -175,6 +175,7 @@ function interopEsm(raw, ns, allowExportDefault) {
  */
 function esmImport(sourceModule, id, allowExportDefault) {
   const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
   const raw = module.exports;
   if (raw.__esModule) return raw;
   if (module.interopNamespace) return module.interopNamespace;
@@ -189,7 +190,9 @@ function esmImport(sourceModule, id, allowExportDefault) {
  * @returns {Exports}
  */
 function commonJsRequire(sourceModule, id) {
-  return getOrInstantiateModuleFromParent(id, sourceModule).exports;
+  const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
+  return module.exports;
 }
 
 function externalRequire(id, esm) {
@@ -285,6 +288,7 @@ function instantiateModule(id, source) {
   /** @type {Module} */
   const module = {
     exports: {},
+    error: undefined,
     loaded: false,
     id,
     parents: undefined,
@@ -311,21 +315,25 @@ function instantiateModule(id, source) {
   }
 
   runModuleExecutionHooks(module, () => {
-    moduleFactory.call(module.exports, {
-      e: module.exports,
-      r: commonJsRequire.bind(null, module),
-      x: externalRequire,
-      i: esmImport.bind(null, module),
-      s: esm.bind(null, module.exports),
-      j: cjs.bind(null, module.exports),
-      v: exportValue.bind(null, module),
-      m: module,
-      c: moduleCache,
-      l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
-      k: registerChunkList,
-      g: globalThis,
-      __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
-    });
+    try {
+      moduleFactory.call(module.exports, {
+        e: module.exports,
+        r: commonJsRequire.bind(null, module),
+        x: externalRequire,
+        i: esmImport.bind(null, module),
+        s: esm.bind(null, module.exports),
+        j: cjs.bind(null, module.exports),
+        v: exportValue.bind(null, module),
+        m: module,
+        c: moduleCache,
+        l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
+        k: registerChunkList,
+        g: globalThis,
+        __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
+      });
+    } catch (error) {
+      module.error = error;
+    }
   });
 
   module.loaded = true;

--- a/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/output/crates_turbopack-tests_tests_snapshot_export-alls_cjs-2_input_index_289ae7.js
+++ b/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/output/crates_turbopack-tests_tests_snapshot_export-alls_cjs-2_input_index_289ae7.js
@@ -175,6 +175,7 @@ function interopEsm(raw, ns, allowExportDefault) {
  */
 function esmImport(sourceModule, id, allowExportDefault) {
   const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
   const raw = module.exports;
   if (raw.__esModule) return raw;
   if (module.interopNamespace) return module.interopNamespace;
@@ -189,7 +190,9 @@ function esmImport(sourceModule, id, allowExportDefault) {
  * @returns {Exports}
  */
 function commonJsRequire(sourceModule, id) {
-  return getOrInstantiateModuleFromParent(id, sourceModule).exports;
+  const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
+  return module.exports;
 }
 
 function externalRequire(id, esm) {
@@ -285,6 +288,7 @@ function instantiateModule(id, source) {
   /** @type {Module} */
   const module = {
     exports: {},
+    error: undefined,
     loaded: false,
     id,
     parents: undefined,
@@ -311,21 +315,25 @@ function instantiateModule(id, source) {
   }
 
   runModuleExecutionHooks(module, () => {
-    moduleFactory.call(module.exports, {
-      e: module.exports,
-      r: commonJsRequire.bind(null, module),
-      x: externalRequire,
-      i: esmImport.bind(null, module),
-      s: esm.bind(null, module.exports),
-      j: cjs.bind(null, module.exports),
-      v: exportValue.bind(null, module),
-      m: module,
-      c: moduleCache,
-      l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
-      k: registerChunkList,
-      g: globalThis,
-      __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
-    });
+    try {
+      moduleFactory.call(module.exports, {
+        e: module.exports,
+        r: commonJsRequire.bind(null, module),
+        x: externalRequire,
+        i: esmImport.bind(null, module),
+        s: esm.bind(null, module.exports),
+        j: cjs.bind(null, module.exports),
+        v: exportValue.bind(null, module),
+        m: module,
+        c: moduleCache,
+        l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
+        k: registerChunkList,
+        g: globalThis,
+        __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
+      });
+    } catch (error) {
+      module.error = error;
+    }
   });
 
   module.loaded = true;

--- a/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/output/crates_turbopack-tests_tests_snapshot_export-alls_cjs-script_input_index_3e96b7.js
+++ b/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/output/crates_turbopack-tests_tests_snapshot_export-alls_cjs-script_input_index_3e96b7.js
@@ -175,6 +175,7 @@ function interopEsm(raw, ns, allowExportDefault) {
  */
 function esmImport(sourceModule, id, allowExportDefault) {
   const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
   const raw = module.exports;
   if (raw.__esModule) return raw;
   if (module.interopNamespace) return module.interopNamespace;
@@ -189,7 +190,9 @@ function esmImport(sourceModule, id, allowExportDefault) {
  * @returns {Exports}
  */
 function commonJsRequire(sourceModule, id) {
-  return getOrInstantiateModuleFromParent(id, sourceModule).exports;
+  const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
+  return module.exports;
 }
 
 function externalRequire(id, esm) {
@@ -285,6 +288,7 @@ function instantiateModule(id, source) {
   /** @type {Module} */
   const module = {
     exports: {},
+    error: undefined,
     loaded: false,
     id,
     parents: undefined,
@@ -311,21 +315,25 @@ function instantiateModule(id, source) {
   }
 
   runModuleExecutionHooks(module, () => {
-    moduleFactory.call(module.exports, {
-      e: module.exports,
-      r: commonJsRequire.bind(null, module),
-      x: externalRequire,
-      i: esmImport.bind(null, module),
-      s: esm.bind(null, module.exports),
-      j: cjs.bind(null, module.exports),
-      v: exportValue.bind(null, module),
-      m: module,
-      c: moduleCache,
-      l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
-      k: registerChunkList,
-      g: globalThis,
-      __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
-    });
+    try {
+      moduleFactory.call(module.exports, {
+        e: module.exports,
+        r: commonJsRequire.bind(null, module),
+        x: externalRequire,
+        i: esmImport.bind(null, module),
+        s: esm.bind(null, module.exports),
+        j: cjs.bind(null, module.exports),
+        v: exportValue.bind(null, module),
+        m: module,
+        c: moduleCache,
+        l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
+        k: registerChunkList,
+        g: globalThis,
+        __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
+      });
+    } catch (error) {
+      module.error = error;
+    }
   });
 
   module.loaded = true;

--- a/crates/turbopack-tests/tests/snapshot/import-meta/cjs/output/crates_turbopack-tests_tests_snapshot_import-meta_cjs_input_index_537553.js
+++ b/crates/turbopack-tests/tests/snapshot/import-meta/cjs/output/crates_turbopack-tests_tests_snapshot_import-meta_cjs_input_index_537553.js
@@ -175,6 +175,7 @@ function interopEsm(raw, ns, allowExportDefault) {
  */
 function esmImport(sourceModule, id, allowExportDefault) {
   const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
   const raw = module.exports;
   if (raw.__esModule) return raw;
   if (module.interopNamespace) return module.interopNamespace;
@@ -189,7 +190,9 @@ function esmImport(sourceModule, id, allowExportDefault) {
  * @returns {Exports}
  */
 function commonJsRequire(sourceModule, id) {
-  return getOrInstantiateModuleFromParent(id, sourceModule).exports;
+  const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
+  return module.exports;
 }
 
 function externalRequire(id, esm) {
@@ -285,6 +288,7 @@ function instantiateModule(id, source) {
   /** @type {Module} */
   const module = {
     exports: {},
+    error: undefined,
     loaded: false,
     id,
     parents: undefined,
@@ -311,21 +315,25 @@ function instantiateModule(id, source) {
   }
 
   runModuleExecutionHooks(module, () => {
-    moduleFactory.call(module.exports, {
-      e: module.exports,
-      r: commonJsRequire.bind(null, module),
-      x: externalRequire,
-      i: esmImport.bind(null, module),
-      s: esm.bind(null, module.exports),
-      j: cjs.bind(null, module.exports),
-      v: exportValue.bind(null, module),
-      m: module,
-      c: moduleCache,
-      l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
-      k: registerChunkList,
-      g: globalThis,
-      __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
-    });
+    try {
+      moduleFactory.call(module.exports, {
+        e: module.exports,
+        r: commonJsRequire.bind(null, module),
+        x: externalRequire,
+        i: esmImport.bind(null, module),
+        s: esm.bind(null, module.exports),
+        j: cjs.bind(null, module.exports),
+        v: exportValue.bind(null, module),
+        m: module,
+        c: moduleCache,
+        l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
+        k: registerChunkList,
+        g: globalThis,
+        __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
+      });
+    } catch (error) {
+      module.error = error;
+    }
   });
 
   module.loaded = true;

--- a/crates/turbopack-tests/tests/snapshot/import-meta/esm-multiple/output/79fb1_turbopack-tests_tests_snapshot_import-meta_esm-multiple_input_index_c00392.js
+++ b/crates/turbopack-tests/tests/snapshot/import-meta/esm-multiple/output/79fb1_turbopack-tests_tests_snapshot_import-meta_esm-multiple_input_index_c00392.js
@@ -175,6 +175,7 @@ function interopEsm(raw, ns, allowExportDefault) {
  */
 function esmImport(sourceModule, id, allowExportDefault) {
   const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
   const raw = module.exports;
   if (raw.__esModule) return raw;
   if (module.interopNamespace) return module.interopNamespace;
@@ -189,7 +190,9 @@ function esmImport(sourceModule, id, allowExportDefault) {
  * @returns {Exports}
  */
 function commonJsRequire(sourceModule, id) {
-  return getOrInstantiateModuleFromParent(id, sourceModule).exports;
+  const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
+  return module.exports;
 }
 
 function externalRequire(id, esm) {
@@ -285,6 +288,7 @@ function instantiateModule(id, source) {
   /** @type {Module} */
   const module = {
     exports: {},
+    error: undefined,
     loaded: false,
     id,
     parents: undefined,
@@ -311,21 +315,25 @@ function instantiateModule(id, source) {
   }
 
   runModuleExecutionHooks(module, () => {
-    moduleFactory.call(module.exports, {
-      e: module.exports,
-      r: commonJsRequire.bind(null, module),
-      x: externalRequire,
-      i: esmImport.bind(null, module),
-      s: esm.bind(null, module.exports),
-      j: cjs.bind(null, module.exports),
-      v: exportValue.bind(null, module),
-      m: module,
-      c: moduleCache,
-      l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
-      k: registerChunkList,
-      g: globalThis,
-      __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
-    });
+    try {
+      moduleFactory.call(module.exports, {
+        e: module.exports,
+        r: commonJsRequire.bind(null, module),
+        x: externalRequire,
+        i: esmImport.bind(null, module),
+        s: esm.bind(null, module.exports),
+        j: cjs.bind(null, module.exports),
+        v: exportValue.bind(null, module),
+        m: module,
+        c: moduleCache,
+        l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
+        k: registerChunkList,
+        g: globalThis,
+        __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
+      });
+    } catch (error) {
+      module.error = error;
+    }
   });
 
   module.loaded = true;

--- a/crates/turbopack-tests/tests/snapshot/import-meta/esm-mutable/output/crates_turbopack-tests_tests_snapshot_import-meta_esm-mutable_input_index_6c9201.js
+++ b/crates/turbopack-tests/tests/snapshot/import-meta/esm-mutable/output/crates_turbopack-tests_tests_snapshot_import-meta_esm-mutable_input_index_6c9201.js
@@ -175,6 +175,7 @@ function interopEsm(raw, ns, allowExportDefault) {
  */
 function esmImport(sourceModule, id, allowExportDefault) {
   const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
   const raw = module.exports;
   if (raw.__esModule) return raw;
   if (module.interopNamespace) return module.interopNamespace;
@@ -189,7 +190,9 @@ function esmImport(sourceModule, id, allowExportDefault) {
  * @returns {Exports}
  */
 function commonJsRequire(sourceModule, id) {
-  return getOrInstantiateModuleFromParent(id, sourceModule).exports;
+  const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
+  return module.exports;
 }
 
 function externalRequire(id, esm) {
@@ -285,6 +288,7 @@ function instantiateModule(id, source) {
   /** @type {Module} */
   const module = {
     exports: {},
+    error: undefined,
     loaded: false,
     id,
     parents: undefined,
@@ -311,21 +315,25 @@ function instantiateModule(id, source) {
   }
 
   runModuleExecutionHooks(module, () => {
-    moduleFactory.call(module.exports, {
-      e: module.exports,
-      r: commonJsRequire.bind(null, module),
-      x: externalRequire,
-      i: esmImport.bind(null, module),
-      s: esm.bind(null, module.exports),
-      j: cjs.bind(null, module.exports),
-      v: exportValue.bind(null, module),
-      m: module,
-      c: moduleCache,
-      l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
-      k: registerChunkList,
-      g: globalThis,
-      __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
-    });
+    try {
+      moduleFactory.call(module.exports, {
+        e: module.exports,
+        r: commonJsRequire.bind(null, module),
+        x: externalRequire,
+        i: esmImport.bind(null, module),
+        s: esm.bind(null, module.exports),
+        j: cjs.bind(null, module.exports),
+        v: exportValue.bind(null, module),
+        m: module,
+        c: moduleCache,
+        l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
+        k: registerChunkList,
+        g: globalThis,
+        __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
+      });
+    } catch (error) {
+      module.error = error;
+    }
   });
 
   module.loaded = true;

--- a/crates/turbopack-tests/tests/snapshot/import-meta/esm-object/output/crates_turbopack-tests_tests_snapshot_import-meta_esm-object_input_index_6fcf7d.js
+++ b/crates/turbopack-tests/tests/snapshot/import-meta/esm-object/output/crates_turbopack-tests_tests_snapshot_import-meta_esm-object_input_index_6fcf7d.js
@@ -175,6 +175,7 @@ function interopEsm(raw, ns, allowExportDefault) {
  */
 function esmImport(sourceModule, id, allowExportDefault) {
   const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
   const raw = module.exports;
   if (raw.__esModule) return raw;
   if (module.interopNamespace) return module.interopNamespace;
@@ -189,7 +190,9 @@ function esmImport(sourceModule, id, allowExportDefault) {
  * @returns {Exports}
  */
 function commonJsRequire(sourceModule, id) {
-  return getOrInstantiateModuleFromParent(id, sourceModule).exports;
+  const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
+  return module.exports;
 }
 
 function externalRequire(id, esm) {
@@ -285,6 +288,7 @@ function instantiateModule(id, source) {
   /** @type {Module} */
   const module = {
     exports: {},
+    error: undefined,
     loaded: false,
     id,
     parents: undefined,
@@ -311,21 +315,25 @@ function instantiateModule(id, source) {
   }
 
   runModuleExecutionHooks(module, () => {
-    moduleFactory.call(module.exports, {
-      e: module.exports,
-      r: commonJsRequire.bind(null, module),
-      x: externalRequire,
-      i: esmImport.bind(null, module),
-      s: esm.bind(null, module.exports),
-      j: cjs.bind(null, module.exports),
-      v: exportValue.bind(null, module),
-      m: module,
-      c: moduleCache,
-      l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
-      k: registerChunkList,
-      g: globalThis,
-      __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
-    });
+    try {
+      moduleFactory.call(module.exports, {
+        e: module.exports,
+        r: commonJsRequire.bind(null, module),
+        x: externalRequire,
+        i: esmImport.bind(null, module),
+        s: esm.bind(null, module.exports),
+        j: cjs.bind(null, module.exports),
+        v: exportValue.bind(null, module),
+        m: module,
+        c: moduleCache,
+        l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
+        k: registerChunkList,
+        g: globalThis,
+        __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
+      });
+    } catch (error) {
+      module.error = error;
+    }
   });
 
   module.loaded = true;

--- a/crates/turbopack-tests/tests/snapshot/import-meta/esm/output/crates_turbopack-tests_tests_snapshot_import-meta_esm_input_index_c4c88a.js
+++ b/crates/turbopack-tests/tests/snapshot/import-meta/esm/output/crates_turbopack-tests_tests_snapshot_import-meta_esm_input_index_c4c88a.js
@@ -175,6 +175,7 @@ function interopEsm(raw, ns, allowExportDefault) {
  */
 function esmImport(sourceModule, id, allowExportDefault) {
   const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
   const raw = module.exports;
   if (raw.__esModule) return raw;
   if (module.interopNamespace) return module.interopNamespace;
@@ -189,7 +190,9 @@ function esmImport(sourceModule, id, allowExportDefault) {
  * @returns {Exports}
  */
 function commonJsRequire(sourceModule, id) {
-  return getOrInstantiateModuleFromParent(id, sourceModule).exports;
+  const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
+  return module.exports;
 }
 
 function externalRequire(id, esm) {
@@ -285,6 +288,7 @@ function instantiateModule(id, source) {
   /** @type {Module} */
   const module = {
     exports: {},
+    error: undefined,
     loaded: false,
     id,
     parents: undefined,
@@ -311,21 +315,25 @@ function instantiateModule(id, source) {
   }
 
   runModuleExecutionHooks(module, () => {
-    moduleFactory.call(module.exports, {
-      e: module.exports,
-      r: commonJsRequire.bind(null, module),
-      x: externalRequire,
-      i: esmImport.bind(null, module),
-      s: esm.bind(null, module.exports),
-      j: cjs.bind(null, module.exports),
-      v: exportValue.bind(null, module),
-      m: module,
-      c: moduleCache,
-      l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
-      k: registerChunkList,
-      g: globalThis,
-      __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
-    });
+    try {
+      moduleFactory.call(module.exports, {
+        e: module.exports,
+        r: commonJsRequire.bind(null, module),
+        x: externalRequire,
+        i: esmImport.bind(null, module),
+        s: esm.bind(null, module.exports),
+        j: cjs.bind(null, module.exports),
+        v: exportValue.bind(null, module),
+        m: module,
+        c: moduleCache,
+        l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
+        k: registerChunkList,
+        g: globalThis,
+        __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
+      });
+    } catch (error) {
+      module.error = error;
+    }
   });
 
   module.loaded = true;

--- a/crates/turbopack-tests/tests/snapshot/import-meta/url/output/crates_turbopack-tests_tests_snapshot_import-meta_url_input_index_988b57.js
+++ b/crates/turbopack-tests/tests/snapshot/import-meta/url/output/crates_turbopack-tests_tests_snapshot_import-meta_url_input_index_988b57.js
@@ -175,6 +175,7 @@ function interopEsm(raw, ns, allowExportDefault) {
  */
 function esmImport(sourceModule, id, allowExportDefault) {
   const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
   const raw = module.exports;
   if (raw.__esModule) return raw;
   if (module.interopNamespace) return module.interopNamespace;
@@ -189,7 +190,9 @@ function esmImport(sourceModule, id, allowExportDefault) {
  * @returns {Exports}
  */
 function commonJsRequire(sourceModule, id) {
-  return getOrInstantiateModuleFromParent(id, sourceModule).exports;
+  const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
+  return module.exports;
 }
 
 function externalRequire(id, esm) {
@@ -285,6 +288,7 @@ function instantiateModule(id, source) {
   /** @type {Module} */
   const module = {
     exports: {},
+    error: undefined,
     loaded: false,
     id,
     parents: undefined,
@@ -311,21 +315,25 @@ function instantiateModule(id, source) {
   }
 
   runModuleExecutionHooks(module, () => {
-    moduleFactory.call(module.exports, {
-      e: module.exports,
-      r: commonJsRequire.bind(null, module),
-      x: externalRequire,
-      i: esmImport.bind(null, module),
-      s: esm.bind(null, module.exports),
-      j: cjs.bind(null, module.exports),
-      v: exportValue.bind(null, module),
-      m: module,
-      c: moduleCache,
-      l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
-      k: registerChunkList,
-      g: globalThis,
-      __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
-    });
+    try {
+      moduleFactory.call(module.exports, {
+        e: module.exports,
+        r: commonJsRequire.bind(null, module),
+        x: externalRequire,
+        i: esmImport.bind(null, module),
+        s: esm.bind(null, module.exports),
+        j: cjs.bind(null, module.exports),
+        v: exportValue.bind(null, module),
+        m: module,
+        c: moduleCache,
+        l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
+        k: registerChunkList,
+        g: globalThis,
+        __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
+      });
+    } catch (error) {
+      module.error = error;
+    }
   });
 
   module.loaded = true;

--- a/crates/turbopack-tests/tests/snapshot/imports/dynamic/output/crates_turbopack-tests_tests_snapshot_imports_dynamic_input_index_45c162.js
+++ b/crates/turbopack-tests/tests/snapshot/imports/dynamic/output/crates_turbopack-tests_tests_snapshot_imports_dynamic_input_index_45c162.js
@@ -175,6 +175,7 @@ function interopEsm(raw, ns, allowExportDefault) {
  */
 function esmImport(sourceModule, id, allowExportDefault) {
   const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
   const raw = module.exports;
   if (raw.__esModule) return raw;
   if (module.interopNamespace) return module.interopNamespace;
@@ -189,7 +190,9 @@ function esmImport(sourceModule, id, allowExportDefault) {
  * @returns {Exports}
  */
 function commonJsRequire(sourceModule, id) {
-  return getOrInstantiateModuleFromParent(id, sourceModule).exports;
+  const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
+  return module.exports;
 }
 
 function externalRequire(id, esm) {
@@ -285,6 +288,7 @@ function instantiateModule(id, source) {
   /** @type {Module} */
   const module = {
     exports: {},
+    error: undefined,
     loaded: false,
     id,
     parents: undefined,
@@ -311,21 +315,25 @@ function instantiateModule(id, source) {
   }
 
   runModuleExecutionHooks(module, () => {
-    moduleFactory.call(module.exports, {
-      e: module.exports,
-      r: commonJsRequire.bind(null, module),
-      x: externalRequire,
-      i: esmImport.bind(null, module),
-      s: esm.bind(null, module.exports),
-      j: cjs.bind(null, module.exports),
-      v: exportValue.bind(null, module),
-      m: module,
-      c: moduleCache,
-      l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
-      k: registerChunkList,
-      g: globalThis,
-      __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
-    });
+    try {
+      moduleFactory.call(module.exports, {
+        e: module.exports,
+        r: commonJsRequire.bind(null, module),
+        x: externalRequire,
+        i: esmImport.bind(null, module),
+        s: esm.bind(null, module.exports),
+        j: cjs.bind(null, module.exports),
+        v: exportValue.bind(null, module),
+        m: module,
+        c: moduleCache,
+        l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
+        k: registerChunkList,
+        g: globalThis,
+        __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
+      });
+    } catch (error) {
+      module.error = error;
+    }
   });
 
   module.loaded = true;

--- a/crates/turbopack-tests/tests/snapshot/imports/json/output/crates_turbopack-tests_tests_snapshot_imports_json_input_index_961ae2.js
+++ b/crates/turbopack-tests/tests/snapshot/imports/json/output/crates_turbopack-tests_tests_snapshot_imports_json_input_index_961ae2.js
@@ -175,6 +175,7 @@ function interopEsm(raw, ns, allowExportDefault) {
  */
 function esmImport(sourceModule, id, allowExportDefault) {
   const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
   const raw = module.exports;
   if (raw.__esModule) return raw;
   if (module.interopNamespace) return module.interopNamespace;
@@ -189,7 +190,9 @@ function esmImport(sourceModule, id, allowExportDefault) {
  * @returns {Exports}
  */
 function commonJsRequire(sourceModule, id) {
-  return getOrInstantiateModuleFromParent(id, sourceModule).exports;
+  const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
+  return module.exports;
 }
 
 function externalRequire(id, esm) {
@@ -285,6 +288,7 @@ function instantiateModule(id, source) {
   /** @type {Module} */
   const module = {
     exports: {},
+    error: undefined,
     loaded: false,
     id,
     parents: undefined,
@@ -311,21 +315,25 @@ function instantiateModule(id, source) {
   }
 
   runModuleExecutionHooks(module, () => {
-    moduleFactory.call(module.exports, {
-      e: module.exports,
-      r: commonJsRequire.bind(null, module),
-      x: externalRequire,
-      i: esmImport.bind(null, module),
-      s: esm.bind(null, module.exports),
-      j: cjs.bind(null, module.exports),
-      v: exportValue.bind(null, module),
-      m: module,
-      c: moduleCache,
-      l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
-      k: registerChunkList,
-      g: globalThis,
-      __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
-    });
+    try {
+      moduleFactory.call(module.exports, {
+        e: module.exports,
+        r: commonJsRequire.bind(null, module),
+        x: externalRequire,
+        i: esmImport.bind(null, module),
+        s: esm.bind(null, module.exports),
+        j: cjs.bind(null, module.exports),
+        v: exportValue.bind(null, module),
+        m: module,
+        c: moduleCache,
+        l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
+        k: registerChunkList,
+        g: globalThis,
+        __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
+      });
+    } catch (error) {
+      module.error = error;
+    }
   });
 
   module.loaded = true;

--- a/crates/turbopack-tests/tests/snapshot/imports/resolve_error_cjs/output/79fb1_turbopack-tests_tests_snapshot_imports_resolve_error_cjs_input_index_f8412b.js
+++ b/crates/turbopack-tests/tests/snapshot/imports/resolve_error_cjs/output/79fb1_turbopack-tests_tests_snapshot_imports_resolve_error_cjs_input_index_f8412b.js
@@ -175,6 +175,7 @@ function interopEsm(raw, ns, allowExportDefault) {
  */
 function esmImport(sourceModule, id, allowExportDefault) {
   const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
   const raw = module.exports;
   if (raw.__esModule) return raw;
   if (module.interopNamespace) return module.interopNamespace;
@@ -189,7 +190,9 @@ function esmImport(sourceModule, id, allowExportDefault) {
  * @returns {Exports}
  */
 function commonJsRequire(sourceModule, id) {
-  return getOrInstantiateModuleFromParent(id, sourceModule).exports;
+  const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
+  return module.exports;
 }
 
 function externalRequire(id, esm) {
@@ -285,6 +288,7 @@ function instantiateModule(id, source) {
   /** @type {Module} */
   const module = {
     exports: {},
+    error: undefined,
     loaded: false,
     id,
     parents: undefined,
@@ -311,21 +315,25 @@ function instantiateModule(id, source) {
   }
 
   runModuleExecutionHooks(module, () => {
-    moduleFactory.call(module.exports, {
-      e: module.exports,
-      r: commonJsRequire.bind(null, module),
-      x: externalRequire,
-      i: esmImport.bind(null, module),
-      s: esm.bind(null, module.exports),
-      j: cjs.bind(null, module.exports),
-      v: exportValue.bind(null, module),
-      m: module,
-      c: moduleCache,
-      l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
-      k: registerChunkList,
-      g: globalThis,
-      __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
-    });
+    try {
+      moduleFactory.call(module.exports, {
+        e: module.exports,
+        r: commonJsRequire.bind(null, module),
+        x: externalRequire,
+        i: esmImport.bind(null, module),
+        s: esm.bind(null, module.exports),
+        j: cjs.bind(null, module.exports),
+        v: exportValue.bind(null, module),
+        m: module,
+        c: moduleCache,
+        l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
+        k: registerChunkList,
+        g: globalThis,
+        __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
+      });
+    } catch (error) {
+      module.error = error;
+    }
   });
 
   module.loaded = true;

--- a/crates/turbopack-tests/tests/snapshot/imports/resolve_error_esm/output/79fb1_turbopack-tests_tests_snapshot_imports_resolve_error_esm_input_index_0b3e45.js
+++ b/crates/turbopack-tests/tests/snapshot/imports/resolve_error_esm/output/79fb1_turbopack-tests_tests_snapshot_imports_resolve_error_esm_input_index_0b3e45.js
@@ -175,6 +175,7 @@ function interopEsm(raw, ns, allowExportDefault) {
  */
 function esmImport(sourceModule, id, allowExportDefault) {
   const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
   const raw = module.exports;
   if (raw.__esModule) return raw;
   if (module.interopNamespace) return module.interopNamespace;
@@ -189,7 +190,9 @@ function esmImport(sourceModule, id, allowExportDefault) {
  * @returns {Exports}
  */
 function commonJsRequire(sourceModule, id) {
-  return getOrInstantiateModuleFromParent(id, sourceModule).exports;
+  const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
+  return module.exports;
 }
 
 function externalRequire(id, esm) {
@@ -285,6 +288,7 @@ function instantiateModule(id, source) {
   /** @type {Module} */
   const module = {
     exports: {},
+    error: undefined,
     loaded: false,
     id,
     parents: undefined,
@@ -311,21 +315,25 @@ function instantiateModule(id, source) {
   }
 
   runModuleExecutionHooks(module, () => {
-    moduleFactory.call(module.exports, {
-      e: module.exports,
-      r: commonJsRequire.bind(null, module),
-      x: externalRequire,
-      i: esmImport.bind(null, module),
-      s: esm.bind(null, module.exports),
-      j: cjs.bind(null, module.exports),
-      v: exportValue.bind(null, module),
-      m: module,
-      c: moduleCache,
-      l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
-      k: registerChunkList,
-      g: globalThis,
-      __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
-    });
+    try {
+      moduleFactory.call(module.exports, {
+        e: module.exports,
+        r: commonJsRequire.bind(null, module),
+        x: externalRequire,
+        i: esmImport.bind(null, module),
+        s: esm.bind(null, module.exports),
+        j: cjs.bind(null, module.exports),
+        v: exportValue.bind(null, module),
+        m: module,
+        c: moduleCache,
+        l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
+        k: registerChunkList,
+        g: globalThis,
+        __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
+      });
+    } catch (error) {
+      module.error = error;
+    }
   });
 
   module.loaded = true;

--- a/crates/turbopack-tests/tests/snapshot/imports/static-and-dynamic/output/79fb1_turbopack-tests_tests_snapshot_imports_static-and-dynamic_input_index_ec8693.js
+++ b/crates/turbopack-tests/tests/snapshot/imports/static-and-dynamic/output/79fb1_turbopack-tests_tests_snapshot_imports_static-and-dynamic_input_index_ec8693.js
@@ -175,6 +175,7 @@ function interopEsm(raw, ns, allowExportDefault) {
  */
 function esmImport(sourceModule, id, allowExportDefault) {
   const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
   const raw = module.exports;
   if (raw.__esModule) return raw;
   if (module.interopNamespace) return module.interopNamespace;
@@ -189,7 +190,9 @@ function esmImport(sourceModule, id, allowExportDefault) {
  * @returns {Exports}
  */
 function commonJsRequire(sourceModule, id) {
-  return getOrInstantiateModuleFromParent(id, sourceModule).exports;
+  const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
+  return module.exports;
 }
 
 function externalRequire(id, esm) {
@@ -285,6 +288,7 @@ function instantiateModule(id, source) {
   /** @type {Module} */
   const module = {
     exports: {},
+    error: undefined,
     loaded: false,
     id,
     parents: undefined,
@@ -311,21 +315,25 @@ function instantiateModule(id, source) {
   }
 
   runModuleExecutionHooks(module, () => {
-    moduleFactory.call(module.exports, {
-      e: module.exports,
-      r: commonJsRequire.bind(null, module),
-      x: externalRequire,
-      i: esmImport.bind(null, module),
-      s: esm.bind(null, module.exports),
-      j: cjs.bind(null, module.exports),
-      v: exportValue.bind(null, module),
-      m: module,
-      c: moduleCache,
-      l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
-      k: registerChunkList,
-      g: globalThis,
-      __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
-    });
+    try {
+      moduleFactory.call(module.exports, {
+        e: module.exports,
+        r: commonJsRequire.bind(null, module),
+        x: externalRequire,
+        i: esmImport.bind(null, module),
+        s: esm.bind(null, module.exports),
+        j: cjs.bind(null, module.exports),
+        v: exportValue.bind(null, module),
+        m: module,
+        c: moduleCache,
+        l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
+        k: registerChunkList,
+        g: globalThis,
+        __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
+      });
+    } catch (error) {
+      module.error = error;
+    }
   });
 
   module.loaded = true;

--- a/crates/turbopack-tests/tests/snapshot/imports/static/output/crates_turbopack-tests_tests_snapshot_imports_static_input_index_885269.js
+++ b/crates/turbopack-tests/tests/snapshot/imports/static/output/crates_turbopack-tests_tests_snapshot_imports_static_input_index_885269.js
@@ -175,6 +175,7 @@ function interopEsm(raw, ns, allowExportDefault) {
  */
 function esmImport(sourceModule, id, allowExportDefault) {
   const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
   const raw = module.exports;
   if (raw.__esModule) return raw;
   if (module.interopNamespace) return module.interopNamespace;
@@ -189,7 +190,9 @@ function esmImport(sourceModule, id, allowExportDefault) {
  * @returns {Exports}
  */
 function commonJsRequire(sourceModule, id) {
-  return getOrInstantiateModuleFromParent(id, sourceModule).exports;
+  const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
+  return module.exports;
 }
 
 function externalRequire(id, esm) {
@@ -285,6 +288,7 @@ function instantiateModule(id, source) {
   /** @type {Module} */
   const module = {
     exports: {},
+    error: undefined,
     loaded: false,
     id,
     parents: undefined,
@@ -311,21 +315,25 @@ function instantiateModule(id, source) {
   }
 
   runModuleExecutionHooks(module, () => {
-    moduleFactory.call(module.exports, {
-      e: module.exports,
-      r: commonJsRequire.bind(null, module),
-      x: externalRequire,
-      i: esmImport.bind(null, module),
-      s: esm.bind(null, module.exports),
-      j: cjs.bind(null, module.exports),
-      v: exportValue.bind(null, module),
-      m: module,
-      c: moduleCache,
-      l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
-      k: registerChunkList,
-      g: globalThis,
-      __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
-    });
+    try {
+      moduleFactory.call(module.exports, {
+        e: module.exports,
+        r: commonJsRequire.bind(null, module),
+        x: externalRequire,
+        i: esmImport.bind(null, module),
+        s: esm.bind(null, module.exports),
+        j: cjs.bind(null, module.exports),
+        v: exportValue.bind(null, module),
+        m: module,
+        c: moduleCache,
+        l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
+        k: registerChunkList,
+        g: globalThis,
+        __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
+      });
+    } catch (error) {
+      module.error = error;
+    }
   });
 
   module.loaded = true;

--- a/crates/turbopack-tests/tests/snapshot/node/node_protocol_external/output/79fb1_turbopack-tests_tests_snapshot_node_node_protocol_external_input_index_667edf.js
+++ b/crates/turbopack-tests/tests/snapshot/node/node_protocol_external/output/79fb1_turbopack-tests_tests_snapshot_node_node_protocol_external_input_index_667edf.js
@@ -175,6 +175,7 @@ function interopEsm(raw, ns, allowExportDefault) {
  */
 function esmImport(sourceModule, id, allowExportDefault) {
   const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
   const raw = module.exports;
   if (raw.__esModule) return raw;
   if (module.interopNamespace) return module.interopNamespace;
@@ -189,7 +190,9 @@ function esmImport(sourceModule, id, allowExportDefault) {
  * @returns {Exports}
  */
 function commonJsRequire(sourceModule, id) {
-  return getOrInstantiateModuleFromParent(id, sourceModule).exports;
+  const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
+  return module.exports;
 }
 
 function externalRequire(id, esm) {
@@ -285,6 +288,7 @@ function instantiateModule(id, source) {
   /** @type {Module} */
   const module = {
     exports: {},
+    error: undefined,
     loaded: false,
     id,
     parents: undefined,
@@ -311,21 +315,25 @@ function instantiateModule(id, source) {
   }
 
   runModuleExecutionHooks(module, () => {
-    moduleFactory.call(module.exports, {
-      e: module.exports,
-      r: commonJsRequire.bind(null, module),
-      x: externalRequire,
-      i: esmImport.bind(null, module),
-      s: esm.bind(null, module.exports),
-      j: cjs.bind(null, module.exports),
-      v: exportValue.bind(null, module),
-      m: module,
-      c: moduleCache,
-      l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
-      k: registerChunkList,
-      g: globalThis,
-      __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
-    });
+    try {
+      moduleFactory.call(module.exports, {
+        e: module.exports,
+        r: commonJsRequire.bind(null, module),
+        x: externalRequire,
+        i: esmImport.bind(null, module),
+        s: esm.bind(null, module.exports),
+        j: cjs.bind(null, module.exports),
+        v: exportValue.bind(null, module),
+        m: module,
+        c: moduleCache,
+        l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
+        k: registerChunkList,
+        g: globalThis,
+        __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
+      });
+    } catch (error) {
+      module.error = error;
+    }
   });
 
   module.loaded = true;

--- a/crates/turbopack-tests/tests/snapshot/styled_components/styled_components/output/a587c_tests_snapshot_styled_components_styled_components_input_index_afc482.js
+++ b/crates/turbopack-tests/tests/snapshot/styled_components/styled_components/output/a587c_tests_snapshot_styled_components_styled_components_input_index_afc482.js
@@ -175,6 +175,7 @@ function interopEsm(raw, ns, allowExportDefault) {
  */
 function esmImport(sourceModule, id, allowExportDefault) {
   const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
   const raw = module.exports;
   if (raw.__esModule) return raw;
   if (module.interopNamespace) return module.interopNamespace;
@@ -189,7 +190,9 @@ function esmImport(sourceModule, id, allowExportDefault) {
  * @returns {Exports}
  */
 function commonJsRequire(sourceModule, id) {
-  return getOrInstantiateModuleFromParent(id, sourceModule).exports;
+  const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
+  return module.exports;
 }
 
 function externalRequire(id, esm) {
@@ -285,6 +288,7 @@ function instantiateModule(id, source) {
   /** @type {Module} */
   const module = {
     exports: {},
+    error: undefined,
     loaded: false,
     id,
     parents: undefined,
@@ -311,21 +315,25 @@ function instantiateModule(id, source) {
   }
 
   runModuleExecutionHooks(module, () => {
-    moduleFactory.call(module.exports, {
-      e: module.exports,
-      r: commonJsRequire.bind(null, module),
-      x: externalRequire,
-      i: esmImport.bind(null, module),
-      s: esm.bind(null, module.exports),
-      j: cjs.bind(null, module.exports),
-      v: exportValue.bind(null, module),
-      m: module,
-      c: moduleCache,
-      l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
-      k: registerChunkList,
-      g: globalThis,
-      __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
-    });
+    try {
+      moduleFactory.call(module.exports, {
+        e: module.exports,
+        r: commonJsRequire.bind(null, module),
+        x: externalRequire,
+        i: esmImport.bind(null, module),
+        s: esm.bind(null, module.exports),
+        j: cjs.bind(null, module.exports),
+        v: exportValue.bind(null, module),
+        m: module,
+        c: moduleCache,
+        l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
+        k: registerChunkList,
+        g: globalThis,
+        __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
+      });
+    } catch (error) {
+      module.error = error;
+    }
   });
 
   module.loaded = true;

--- a/crates/turbopack-tests/tests/snapshot/swc_transforms/mono_transforms/output/a587c_tests_snapshot_swc_transforms_mono_transforms_input_packages_app_index_4a3d65.js
+++ b/crates/turbopack-tests/tests/snapshot/swc_transforms/mono_transforms/output/a587c_tests_snapshot_swc_transforms_mono_transforms_input_packages_app_index_4a3d65.js
@@ -175,6 +175,7 @@ function interopEsm(raw, ns, allowExportDefault) {
  */
 function esmImport(sourceModule, id, allowExportDefault) {
   const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
   const raw = module.exports;
   if (raw.__esModule) return raw;
   if (module.interopNamespace) return module.interopNamespace;
@@ -189,7 +190,9 @@ function esmImport(sourceModule, id, allowExportDefault) {
  * @returns {Exports}
  */
 function commonJsRequire(sourceModule, id) {
-  return getOrInstantiateModuleFromParent(id, sourceModule).exports;
+  const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
+  return module.exports;
 }
 
 function externalRequire(id, esm) {
@@ -285,6 +288,7 @@ function instantiateModule(id, source) {
   /** @type {Module} */
   const module = {
     exports: {},
+    error: undefined,
     loaded: false,
     id,
     parents: undefined,
@@ -311,21 +315,25 @@ function instantiateModule(id, source) {
   }
 
   runModuleExecutionHooks(module, () => {
-    moduleFactory.call(module.exports, {
-      e: module.exports,
-      r: commonJsRequire.bind(null, module),
-      x: externalRequire,
-      i: esmImport.bind(null, module),
-      s: esm.bind(null, module.exports),
-      j: cjs.bind(null, module.exports),
-      v: exportValue.bind(null, module),
-      m: module,
-      c: moduleCache,
-      l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
-      k: registerChunkList,
-      g: globalThis,
-      __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
-    });
+    try {
+      moduleFactory.call(module.exports, {
+        e: module.exports,
+        r: commonJsRequire.bind(null, module),
+        x: externalRequire,
+        i: esmImport.bind(null, module),
+        s: esm.bind(null, module.exports),
+        j: cjs.bind(null, module.exports),
+        v: exportValue.bind(null, module),
+        m: module,
+        c: moduleCache,
+        l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
+        k: registerChunkList,
+        g: globalThis,
+        __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
+      });
+    } catch (error) {
+      module.error = error;
+    }
   });
 
   module.loaded = true;

--- a/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/output/79fb1_turbopack-tests_tests_snapshot_swc_transforms_preset_env_input_index_e2f660.js
+++ b/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/output/79fb1_turbopack-tests_tests_snapshot_swc_transforms_preset_env_input_index_e2f660.js
@@ -175,6 +175,7 @@ function interopEsm(raw, ns, allowExportDefault) {
  */
 function esmImport(sourceModule, id, allowExportDefault) {
   const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
   const raw = module.exports;
   if (raw.__esModule) return raw;
   if (module.interopNamespace) return module.interopNamespace;
@@ -189,7 +190,9 @@ function esmImport(sourceModule, id, allowExportDefault) {
  * @returns {Exports}
  */
 function commonJsRequire(sourceModule, id) {
-  return getOrInstantiateModuleFromParent(id, sourceModule).exports;
+  const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
+  return module.exports;
 }
 
 function externalRequire(id, esm) {
@@ -285,6 +288,7 @@ function instantiateModule(id, source) {
   /** @type {Module} */
   const module = {
     exports: {},
+    error: undefined,
     loaded: false,
     id,
     parents: undefined,
@@ -311,21 +315,25 @@ function instantiateModule(id, source) {
   }
 
   runModuleExecutionHooks(module, () => {
-    moduleFactory.call(module.exports, {
-      e: module.exports,
-      r: commonJsRequire.bind(null, module),
-      x: externalRequire,
-      i: esmImport.bind(null, module),
-      s: esm.bind(null, module.exports),
-      j: cjs.bind(null, module.exports),
-      v: exportValue.bind(null, module),
-      m: module,
-      c: moduleCache,
-      l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
-      k: registerChunkList,
-      g: globalThis,
-      __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
-    });
+    try {
+      moduleFactory.call(module.exports, {
+        e: module.exports,
+        r: commonJsRequire.bind(null, module),
+        x: externalRequire,
+        i: esmImport.bind(null, module),
+        s: esm.bind(null, module.exports),
+        j: cjs.bind(null, module.exports),
+        v: exportValue.bind(null, module),
+        m: module,
+        c: moduleCache,
+        l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
+        k: registerChunkList,
+        g: globalThis,
+        __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
+      });
+    } catch (error) {
+      module.error = error;
+    }
   });
 
   module.loaded = true;

--- a/crates/turbopack-tests/tests/snapshot/typescript/jsconfig-baseurl/output/79fb1_turbopack-tests_tests_snapshot_typescript_jsconfig-baseurl_input_index_8f1e58.js
+++ b/crates/turbopack-tests/tests/snapshot/typescript/jsconfig-baseurl/output/79fb1_turbopack-tests_tests_snapshot_typescript_jsconfig-baseurl_input_index_8f1e58.js
@@ -175,6 +175,7 @@ function interopEsm(raw, ns, allowExportDefault) {
  */
 function esmImport(sourceModule, id, allowExportDefault) {
   const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
   const raw = module.exports;
   if (raw.__esModule) return raw;
   if (module.interopNamespace) return module.interopNamespace;
@@ -189,7 +190,9 @@ function esmImport(sourceModule, id, allowExportDefault) {
  * @returns {Exports}
  */
 function commonJsRequire(sourceModule, id) {
-  return getOrInstantiateModuleFromParent(id, sourceModule).exports;
+  const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
+  return module.exports;
 }
 
 function externalRequire(id, esm) {
@@ -285,6 +288,7 @@ function instantiateModule(id, source) {
   /** @type {Module} */
   const module = {
     exports: {},
+    error: undefined,
     loaded: false,
     id,
     parents: undefined,
@@ -311,21 +315,25 @@ function instantiateModule(id, source) {
   }
 
   runModuleExecutionHooks(module, () => {
-    moduleFactory.call(module.exports, {
-      e: module.exports,
-      r: commonJsRequire.bind(null, module),
-      x: externalRequire,
-      i: esmImport.bind(null, module),
-      s: esm.bind(null, module.exports),
-      j: cjs.bind(null, module.exports),
-      v: exportValue.bind(null, module),
-      m: module,
-      c: moduleCache,
-      l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
-      k: registerChunkList,
-      g: globalThis,
-      __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
-    });
+    try {
+      moduleFactory.call(module.exports, {
+        e: module.exports,
+        r: commonJsRequire.bind(null, module),
+        x: externalRequire,
+        i: esmImport.bind(null, module),
+        s: esm.bind(null, module.exports),
+        j: cjs.bind(null, module.exports),
+        v: exportValue.bind(null, module),
+        m: module,
+        c: moduleCache,
+        l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
+        k: registerChunkList,
+        g: globalThis,
+        __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
+      });
+    } catch (error) {
+      module.error = error;
+    }
   });
 
   module.loaded = true;

--- a/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-baseurl/output/a587c_tests_snapshot_typescript_tsconfig-baseurl_input_index.ts_0aa04e._.js
+++ b/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-baseurl/output/a587c_tests_snapshot_typescript_tsconfig-baseurl_input_index.ts_0aa04e._.js
@@ -175,6 +175,7 @@ function interopEsm(raw, ns, allowExportDefault) {
  */
 function esmImport(sourceModule, id, allowExportDefault) {
   const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
   const raw = module.exports;
   if (raw.__esModule) return raw;
   if (module.interopNamespace) return module.interopNamespace;
@@ -189,7 +190,9 @@ function esmImport(sourceModule, id, allowExportDefault) {
  * @returns {Exports}
  */
 function commonJsRequire(sourceModule, id) {
-  return getOrInstantiateModuleFromParent(id, sourceModule).exports;
+  const module = getOrInstantiateModuleFromParent(id, sourceModule);
+  if (module.error) throw module.error;
+  return module.exports;
 }
 
 function externalRequire(id, esm) {
@@ -285,6 +288,7 @@ function instantiateModule(id, source) {
   /** @type {Module} */
   const module = {
     exports: {},
+    error: undefined,
     loaded: false,
     id,
     parents: undefined,
@@ -311,21 +315,25 @@ function instantiateModule(id, source) {
   }
 
   runModuleExecutionHooks(module, () => {
-    moduleFactory.call(module.exports, {
-      e: module.exports,
-      r: commonJsRequire.bind(null, module),
-      x: externalRequire,
-      i: esmImport.bind(null, module),
-      s: esm.bind(null, module.exports),
-      j: cjs.bind(null, module.exports),
-      v: exportValue.bind(null, module),
-      m: module,
-      c: moduleCache,
-      l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
-      k: registerChunkList,
-      g: globalThis,
-      __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
-    });
+    try {
+      moduleFactory.call(module.exports, {
+        e: module.exports,
+        r: commonJsRequire.bind(null, module),
+        x: externalRequire,
+        i: esmImport.bind(null, module),
+        s: esm.bind(null, module.exports),
+        j: cjs.bind(null, module.exports),
+        v: exportValue.bind(null, module),
+        m: module,
+        c: moduleCache,
+        l: loadChunk.bind(null, { type: SourceTypeParent, parentId: id }),
+        k: registerChunkList,
+        g: globalThis,
+        __dirname: module.id.replace(/(^|\/)[\/]+$/, ""),
+      });
+    } catch (error) {
+      module.error = error;
+    }
   });
 
   module.loaded = true;


### PR DESCRIPTION
### Description

Caches the module evaluation error

```
try {
  // when throwing on the first try
  require("module")
} catch {
  // it should throw on the second try too
  require("module")
}
```
