### PR TITLE
chore: Remove release flag from turborepo-ffi build

### DIFF
--- a/cli/Makefile
+++ b/cli/Makefile
@@ -42,7 +42,7 @@ turborepo-ffi-install: turborepo-ffi turborepo-ffi-copy-bindings
 
 .PHONY: turborepo-ffi
 turborepo-ffi:
-	cd ../crates/turborepo-ffi && cargo build --release --target-dir ./target
+	cd ../crates/turborepo-ffi && cargo build --target-dir ./target
 
 .PHONY: turborepo-ffi-copy-bindings
 turborepo-ffi-copy-bindings:

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -38,7 +38,7 @@ go-turbo$(EXT): $(GENERATED_FILES) $(SRC_FILES) go.mod turborepo-ffi-install
 
 .PHONY: turborepo-ffi-install
 turborepo-ffi-install: turborepo-ffi turborepo-ffi-copy-bindings
-	cp ../crates/turborepo-ffi/target/release/libturborepo_ffi.a ./internal/ffi/libturborepo_ffi_$(GOOS)_$(GOARCH).a
+	cp ../crates/turborepo-ffi/target/debug/libturborepo_ffi.a ./internal/ffi/libturborepo_ffi_$(GOOS)_$(GOARCH).a
 
 .PHONY: turborepo-ffi
 turborepo-ffi:


### PR DESCRIPTION
### Description

We build turborepo-ffi on release mode currently for our development. This slows down compilation speeds, so I switched us to dev mode.

### Testing Instructions

Existing tests and CI should work.
