### PR TITLE
chore: Add profiles to cargo using aliases

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,6 +6,13 @@ linker = "rust-lld"
 
 [alias]
 xtask = "run --package xtask --"
+tr-build = "build -p turbo"
+tr-run = "run -p turbo"
+tr-test = "test -p turborepo-lib -p turborepo-scm -p turborepo-lockfiles -p turbopath -p turborepo-api-client --features rustls-tls"
+tr-check = "check -p turbo"
+# Builds all test code to check for compiler errors before running
+tp-pre-test = "nextest run --no-run --workspace --release --exclude turbo --exclude turborepo-ffi --exclude turborepo-lib --exclude turborepo-scm --exclude turbopath --exclude turborepo-lockfiles --exclude turborepo-api-client"
+tp-test = "nextest run --workspace --release --no-fail-fast --exclude turbo --exclude turborepo-ffi --exclude turborepo-lib --exclude turborepo-scm --exclude turbopath --exclude turborepo-lockfiles --exclude turborepo-api-client"
 
 [target.'cfg(all())']
 rustflags = ["--cfg", "tokio_unstable", "-Csymbol-mangling-version=v0", "-Aclippy::too_many_arguments"]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -608,7 +608,7 @@ jobs:
         timeout-minutes: 120
         # We exclude turbo as it requires linking Go and all logic resides in turborepo-lib
         run: |
-          cargo test -p turborepo-lib -p turborepo-scm -p turborepo-lockfiles -p turbopath -p turborepo-api-client --features rustls-tls
+          cargo tr-test
 
   turbopack_rust_test1:
     needs: [determine_jobs, rust_prepare]
@@ -641,12 +641,11 @@ jobs:
       - name: Build nextest
         timeout-minutes: 120
         run: |
-          cargo nextest run --no-run --workspace --release --exclude turbo --exclude turborepo-ffi --exclude turborepo-lib --exclude turborepo-scm --exclude turbopath --exclude turborepo-lockfiles --exclude turborepo-api-client
-
+          cargo tp-pre-test
       - name: Run nextest
         timeout-minutes: 120
         run: |
-          cargo nextest run --workspace --release --no-fail-fast --exclude turbo --exclude turborepo-ffi --exclude turborepo-lib --exclude turborepo-scm --exclude turbopath --exclude turborepo-lockfiles --exclude turborepo-api-client
+          cargo tp-test
 
   turbopack_rust_test2:
     needs: [determine_jobs, rust_prepare]
@@ -703,15 +702,15 @@ jobs:
 
       - name: Build nextest
         timeout-minutes: 120
-        # We exclude turbo as it requires linking Go and all logic resides in turborepo-lib
         run: |
-          cargo nextest run --no-run --workspace --release --exclude turbo --exclude turborepo-ffi --exclude turborepo-lib --exclude turborepo-scm --exclude turbopath --exclude turborepo-lockfiles --exclude turborepo-api-client
+          cargo tp-pre-test
+
 
       - name: Run nextest
         timeout-minutes: 120
-        # We exclude turbo as it requires linking Go and all logic resides in turborepo-lib
         run: |
-          cargo nextest run --workspace --release --no-fail-fast --exclude turbo --exclude turborepo-ffi --exclude turborepo-lib --exclude turborepo-scm --exclude turbopath --exclude turborepo-lockfiles --exclude turborepo-api-client
+          cargo tp-test
+
 
   turbopack_rust_test_bench1:
     needs: [determine_jobs, rust_prepare]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -705,12 +705,10 @@ jobs:
         run: |
           cargo tp-pre-test
 
-
       - name: Run nextest
         timeout-minutes: 120
         run: |
           cargo tp-test
-
 
   turbopack_rust_test_bench1:
     needs: [determine_jobs, rust_prepare]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -188,8 +188,8 @@ For instance, if we were adding a `turborepo-foo` crate, we would add the follow
 ```
 
 The crate must also be explicitly excluded from build commands
-for Turbopack and included in build commands for Turborepo. 
-To do so, add a `--exclude turborepo-foo` flag to the Turbopack commands in 
+for Turbopack and included in build commands for Turborepo.
+To do so, add a `--exclude turborepo-foo` flag to the Turbopack commands in
 `.cargo/config.toml` such as `tp-test`, and add an `-p turborepo-foo` to the Turborepo
 commands such as `tr-test`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -188,9 +188,10 @@ For instance, if we were adding a `turborepo-foo` crate, we would add the follow
 ```
 
 The crate must also be explicitly excluded from build commands
-when building Turbopack. To do so, add a `--exclude turbopack-foo`
-flag to the build command. Search through `test.yml` and add this
-flag to all cargo commands that already exclude `turborepo-lib`.
+for Turbopack and included in build commands for Turborepo. 
+To do so, add a `--exclude turborepo-foo` flag to the Turbopack commands in 
+`.cargo/config.toml` such as `tp-test`, and add an `-p turborepo-foo` to the Turborepo
+commands such as `tr-test`.
 
 Finally, the crate must be added to the Turborepo section of CODEOWNERS:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7819,6 +7819,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "turbopath"
+version = "0.1.0"
+dependencies = [
+ "path-slash",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "turborepo-api-client"
 version = "0.1.0"
 dependencies = [
@@ -7828,15 +7837,6 @@ dependencies = [
  "rustc_version_runtime",
  "serde",
  "tokio",
-]
-
-[[package]]
-name = "turbopath"
-version = "0.1.0"
-dependencies = [
- "path-slash",
- "serde",
- "thiserror",
 ]
 
 [[package]]
@@ -7910,8 +7910,8 @@ dependencies = [
  "tonic-build",
  "tower",
  "turbo-updater",
- "turborepo-api-client",
  "turbopath",
+ "turborepo-api-client",
  "uds_windows",
  "url",
  "webbrowser",


### PR DESCRIPTION
### Description

Some of the cargo commands in test.yml were getting unwieldy. Plus it's useful to have a simple command to run for testing turborepo code versus turbopack code.

### Testing Instructions

Existing test.yml code should verify that it works.
