### PR TITLE
Fix typos in example tsconfig' readme

### DIFF
--- a/examples/with-create-react-app/packages/tsconfig/README.md
+++ b/examples/with-create-react-app/packages/tsconfig/README.md
@@ -1,3 +1,3 @@
 # `tsconfig`
 
-This is the Turborepo shared `tsconfig.json` from which all sother `tsconfig.json`'s inherit from. Making changes to this may have unintended consequences.
+This is the Turborepo shared `tsconfig.json` from which all others `tsconfig.json`s inherit from. Making changes to this may have unintended consequences.


### PR DESCRIPTION
### Description
A simple typo fix in a README.md file of the examples folder.
