### PR TITLE
Allow passing arbitrary data to static/proxy renders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8384,6 +8384,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_regex",
+ "serde_test",
  "stable_deref_trait",
  "thiserror",
  "tokio",

--- a/crates/turbo-tasks/Cargo.toml
+++ b/crates/turbo-tasks/Cargo.toml
@@ -39,5 +39,8 @@ tokio = { workspace = true, features = ["full"] }
 turbo-tasks-hash = { workspace = true }
 turbo-tasks-macros = { workspace = true }
 
+[dev-dependencies]
+serde_test = "1.0.157"
+
 [build-dependencies]
 turbo-tasks-build = { workspace = true }

--- a/crates/turbo-tasks/src/primitives.rs
+++ b/crates/turbo-tasks/src/primitives.rs
@@ -2,6 +2,7 @@ use std::ops::Deref;
 
 use anyhow::Result;
 use auto_hash_map::AutoSet;
+use turbo_tasks::debug::ValueDebugFormat;
 
 use crate::{self as turbo_tasks, RawVc, ValueToString, ValueToStringVc};
 
@@ -56,8 +57,9 @@ pub struct Usize(usize);
 #[turbo_tasks::value(transparent)]
 pub struct RawVcSet(AutoSet<RawVc>);
 
+#[derive(ValueDebugFormat)]
 #[turbo_tasks::value(transparent)]
-pub struct JsonValue(serde_json::Value);
+pub struct JsonValue(pub serde_json::Value);
 
 #[turbo_tasks::value_impl]
 impl ValueToString for JsonValue {

--- a/crates/turbo-tasks/src/read_ref.rs
+++ b/crates/turbo-tasks/src/read_ref.rs
@@ -131,18 +131,17 @@ impl<T, U: Serialize> Serialize for ReadRef<T, U> {
     }
 }
 
-impl<'de, T, U: Deserialize<'de>> Deserialize<'de> for ReadRef<T, U> {
+impl<'de, T: Deserialize<'de>, U> Deserialize<'de> for ReadRef<T, U> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
-        let value = Arc::new(U::deserialize(deserializer)?);
-        let inner = unsafe { transmute(value) };
-        Ok(Self(inner, PhantomData))
+        let value = T::deserialize(deserializer)?;
+        Ok(Self(Arc::new(value), PhantomData))
     }
 }
 
-impl<T, U> ReadRef<T, U> {
+impl<T> ReadRef<T, T> {
     pub fn new(arc: Arc<T>) -> Self {
         Self(arc, PhantomData)
     }

--- a/crates/turbopack-node/src/render/mod.rs
+++ b/crates/turbopack-node/src/render/mod.rs
@@ -1,5 +1,6 @@
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
 
 use crate::{route_matcher::Param, ResponseHeaders, StructuredError};
 
@@ -19,6 +20,7 @@ pub struct RenderData {
     raw_query: String,
     raw_headers: Vec<(String, String)>,
     path: String,
+    data: Option<JsonValue>,
 }
 
 #[derive(Serialize)]

--- a/crates/turbopack-node/src/render/mod.rs
+++ b/crates/turbopack-node/src/render/mod.rs
@@ -1,6 +1,6 @@
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
-use serde_json::Value as JsonValue;
+use turbo_tasks::primitives::JsonValueReadRef;
 
 use crate::{route_matcher::Param, ResponseHeaders, StructuredError};
 
@@ -20,7 +20,7 @@ pub struct RenderData {
     raw_query: String,
     raw_headers: Vec<(String, String)>,
     path: String,
-    data: Option<JsonValue>,
+    data: Option<JsonValueReadRef>,
 }
 
 #[derive(Serialize)]

--- a/crates/turbopack-node/src/render/node_api_source.rs
+++ b/crates/turbopack-node/src/render/node_api_source.rs
@@ -1,6 +1,9 @@
 use anyhow::{anyhow, Result};
 use indexmap::IndexSet;
-use turbo_tasks::{primitives::StringVc, Value};
+use turbo_tasks::{
+    primitives::{JsonValueVc, StringVc},
+    Value,
+};
 use turbo_tasks_env::ProcessEnvVc;
 use turbo_tasks_fs::FileSystemPathVc;
 use turbopack_core::introspect::{
@@ -29,6 +32,7 @@ pub fn create_node_api_source(
     route_match: RouteMatcherVc,
     pathname: StringVc,
     entry: NodeEntryVc,
+    render_data: JsonValueVc,
 ) -> ContentSourceVc {
     NodeApiContentSource {
         cwd,
@@ -38,6 +42,7 @@ pub fn create_node_api_source(
         pathname,
         route_match,
         entry,
+        render_data,
     }
     .cell()
     .into()
@@ -58,6 +63,7 @@ pub struct NodeApiContentSource {
     pathname: StringVc,
     route_match: RouteMatcherVc,
     entry: NodeEntryVc,
+    render_data: JsonValueVc,
 }
 
 #[turbo_tasks::value_impl]
@@ -82,6 +88,7 @@ impl ContentSource for NodeApiContentSource {
                 specificity: this.specificity,
                 get_content: NodeApiGetContentResult {
                     source: self_vc,
+                    render_data: this.render_data,
                     path: path.to_string(),
                 }
                 .cell()
@@ -96,6 +103,7 @@ impl ContentSource for NodeApiContentSource {
 #[turbo_tasks::value]
 struct NodeApiGetContentResult {
     source: NodeApiContentSourceVc,
+    render_data: JsonValueVc,
     path: String,
 }
 
@@ -148,6 +156,7 @@ impl GetContentSourceContent for NodeApiGetContentResult {
                 raw_query: raw_query.clone(),
                 raw_headers: raw_headers.clone(),
                 path: format!("/{}", self.path),
+                data: Some(self.render_data.await?.clone_value()),
             }
             .cell(),
             *body,

--- a/crates/turbopack-node/src/render/node_api_source.rs
+++ b/crates/turbopack-node/src/render/node_api_source.rs
@@ -156,7 +156,7 @@ impl GetContentSourceContent for NodeApiGetContentResult {
                 raw_query: raw_query.clone(),
                 raw_headers: raw_headers.clone(),
                 path: format!("/{}", self.path),
-                data: Some(self.render_data.await?.clone_value()),
+                data: Some(self.render_data.await?),
             }
             .cell(),
             *body,

--- a/crates/turbopack-node/src/render/rendered_source.rs
+++ b/crates/turbopack-node/src/render/rendered_source.rs
@@ -1,6 +1,9 @@
 use anyhow::{anyhow, Result};
 use indexmap::IndexSet;
-use turbo_tasks::{primitives::StringVc, Value};
+use turbo_tasks::{
+    primitives::{JsonValueVc, StringVc},
+    Value,
+};
 use turbo_tasks_env::ProcessEnvVc;
 use turbo_tasks_fs::FileSystemPathVc;
 use turbopack_core::{
@@ -51,6 +54,7 @@ pub fn create_node_rendered_source(
     pathname: StringVc,
     entry: NodeEntryVc,
     fallback_page: DevHtmlAssetVc,
+    render_data: JsonValueVc,
 ) -> ContentSourceVc {
     let source = NodeRenderContentSource {
         cwd,
@@ -61,6 +65,7 @@ pub fn create_node_rendered_source(
         pathname,
         entry,
         fallback_page,
+        render_data,
     }
     .cell();
     ConditionalContentSourceVc::new(
@@ -85,6 +90,7 @@ pub struct NodeRenderContentSource {
     pathname: StringVc,
     entry: NodeEntryVc,
     fallback_page: DevHtmlAssetVc,
+    render_data: JsonValueVc,
 }
 
 #[turbo_tasks::value_impl]
@@ -154,6 +160,7 @@ impl ContentSource for NodeRenderContentSource {
                 specificity: this.specificity,
                 get_content: NodeRenderGetContentResult {
                     source: self_vc,
+                    render_data: this.render_data,
                     path: path.to_string(),
                 }
                 .cell()
@@ -168,6 +175,7 @@ impl ContentSource for NodeRenderContentSource {
 #[turbo_tasks::value]
 struct NodeRenderGetContentResult {
     source: NodeRenderContentSourceVc,
+    render_data: JsonValueVc,
     path: String,
 }
 
@@ -219,6 +227,7 @@ impl GetContentSourceContent for NodeRenderGetContentResult {
                 raw_query: raw_query.clone(),
                 raw_headers: raw_headers.clone(),
                 path: format!("/{}", source.pathname.await?),
+                data: Some(self.render_data.await?.clone_value()),
             }
             .cell(),
         )

--- a/crates/turbopack-node/src/render/rendered_source.rs
+++ b/crates/turbopack-node/src/render/rendered_source.rs
@@ -227,7 +227,7 @@ impl GetContentSourceContent for NodeRenderGetContentResult {
                 raw_query: raw_query.clone(),
                 raw_headers: raw_headers.clone(),
                 path: format!("/{}", source.pathname.await?),
-                data: Some(self.render_data.await?.clone_value()),
+                data: Some(self.render_data.await?),
             }
             .cell(),
         )


### PR DESCRIPTION
This adds an arbitrary `serde_json::Value` data field to our generic rendering code, allowing us to pass down the `NextConfig.output` field (and anything else we want) to the Node.js renderer.

Re: WEB-842