### PR TITLE
Synthesize a command for a Run

### DIFF
--- a/cli/integration_tests/single_package/run-summary.t
+++ b/cli/integration_tests/single_package/run-summary.t
@@ -20,9 +20,11 @@ Check
   [
     "attempted",
     "cached",
+    "command",
     "endTime",
     "exitCode",
     "failed",
+    "repoPath",
     "startTime",
     "success"
   ]

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -30,18 +30,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-var _cmdLong = `
-Run tasks across projects in your monorepo.
-
-By default, turbo executes tasks in topological order (i.e.
-dependencies first) and then caches the results. Re-running commands for
-tasks already in the cache will skip re-execution and immediately move
-artifacts from the cache into the correct output folders (as if the task
-occurred again).
-
-Arguments passed after '--' will be passed through to the named tasks.
-`
-
 // ExecuteRun executes the run command
 func ExecuteRun(ctx gocontext.Context, helper *cmdutil.Helper, signalWatcher *signals.Watcher, args *turbostate.ParsedArgsFromRust) error {
 	base, err := helper.GetCmdBase(args)

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -73,7 +73,9 @@ func optsFromArgs(args *turbostate.ParsedArgsFromRust) (*Opts, error) {
 
 	opts := getDefaultOptions()
 	// aliases := make(map[string]string)
-	scope.OptsFromArgs(&opts.scopeOpts, args)
+	if err := scope.OptsFromArgs(&opts.scopeOpts, args); err != nil {
+		return nil, err
+	}
 
 	// Cache flags
 	opts.clientOpts.Timeout = args.RemoteCacheTimeout
@@ -358,6 +360,7 @@ func (r *run) run(ctx gocontext.Context, targets []string) error {
 		startAt,
 		r.base.UI,
 		r.base.RepoRoot,
+		rs.Opts.scopeOpts.PackageInferenceRoot,
 		r.base.TurboVersion,
 		r.base.APIClient,
 		rs.Opts.runOpts,
@@ -369,6 +372,7 @@ func (r *run) run(ctx gocontext.Context, targets []string) error {
 			globalHashable.globalCacheKey,
 			globalHashable.pipeline,
 		),
+		rs.Opts.SynthesizeCommand(rs.Targets),
 	)
 
 	// Dry Run

--- a/cli/internal/run/run_spec.go
+++ b/cli/internal/run/run_spec.go
@@ -3,6 +3,8 @@
 package run
 
 import (
+	"strings"
+
 	"github.com/vercel/turbo/cli/internal/cache"
 	"github.com/vercel/turbo/cli/internal/client"
 	"github.com/vercel/turbo/cli/internal/runcache"
@@ -43,6 +45,36 @@ type Opts struct {
 	clientOpts   client.Opts
 	runcacheOpts runcache.Opts
 	scopeOpts    scope.Opts
+}
+
+// SynthesizeCommand produces a command that produces an equivalent set of packages, tasks,
+// and task arguments to what the current set of opts selects.
+func (o *Opts) SynthesizeCommand(tasks []string) string {
+	cmd := "turbo run"
+	cmd += " " + strings.Join(tasks, " ")
+	for _, filterPattern := range o.scopeOpts.FilterPatterns {
+		cmd += " --filter=" + filterPattern
+	}
+	for _, filterPattern := range o.scopeOpts.LegacyFilter.AsFilterPatterns() {
+		cmd += " --filter=" + filterPattern
+	}
+	if o.runOpts.Parallel {
+		cmd += " --parallel"
+	}
+	if o.runOpts.ContinueOnError {
+		cmd += " --continue"
+	}
+	if o.runOpts.DryRun {
+		if o.runOpts.DryRunJSON {
+			cmd += " --dry=json"
+		} else {
+			cmd += " --dry"
+		}
+	}
+	if len(o.runOpts.PassThroughArgs) > 0 {
+		cmd += " -- " + strings.Join(o.runOpts.PassThroughArgs, " ")
+	}
+	return cmd
 }
 
 // getDefaultOptions returns the default set of Opts for every run

--- a/cli/internal/run/run_spec_test.go
+++ b/cli/internal/run/run_spec_test.go
@@ -1,0 +1,107 @@
+package run
+
+import (
+	"testing"
+
+	"github.com/vercel/turbo/cli/internal/scope"
+	"github.com/vercel/turbo/cli/internal/util"
+)
+
+func TestSynthesizeCommand(t *testing.T) {
+	testCases := []struct {
+		filterPatterns  []string
+		legacyFilter    scope.LegacyFilter
+		passThroughArgs []string
+		parallel        bool
+		continueOnError bool
+		dryRun          bool
+		dryRunJSON      bool
+		tasks           []string
+		expected        string
+	}{
+		{
+			filterPatterns: []string{"my-app"},
+			tasks:          []string{"build"},
+			expected:       "turbo run build --filter=my-app",
+		},
+		{
+			filterPatterns:  []string{"my-app"},
+			tasks:           []string{"build"},
+			passThroughArgs: []string{"-v", "--foo=bar"},
+			expected:        "turbo run build --filter=my-app -- -v --foo=bar",
+		},
+		{
+			legacyFilter: scope.LegacyFilter{
+				Entrypoints:    []string{"my-app"},
+				SkipDependents: true,
+			},
+			tasks:           []string{"build"},
+			passThroughArgs: []string{"-v", "--foo=bar"},
+			expected:        "turbo run build --filter=my-app -- -v --foo=bar",
+		},
+		{
+			legacyFilter: scope.LegacyFilter{
+				Entrypoints:    []string{"my-app"},
+				SkipDependents: true,
+			},
+			filterPatterns:  []string{"other-app"},
+			tasks:           []string{"build"},
+			passThroughArgs: []string{"-v", "--foo=bar"},
+			expected:        "turbo run build --filter=other-app --filter=my-app -- -v --foo=bar",
+		},
+		{
+			legacyFilter: scope.LegacyFilter{
+				Entrypoints:         []string{"my-app"},
+				IncludeDependencies: true,
+				Since:               "some-ref",
+			},
+			filterPatterns: []string{"other-app"},
+			tasks:          []string{"build"},
+			expected:       "turbo run build --filter=other-app --filter=...my-app...[some-ref]...",
+		},
+		{
+			filterPatterns:  []string{"my-app"},
+			tasks:           []string{"build"},
+			parallel:        true,
+			continueOnError: true,
+			expected:        "turbo run build --filter=my-app --parallel --continue",
+		},
+		{
+			filterPatterns: []string{"my-app"},
+			tasks:          []string{"build"},
+			dryRun:         true,
+			expected:       "turbo run build --filter=my-app --dry",
+		},
+		{
+			filterPatterns: []string{"my-app"},
+			tasks:          []string{"build"},
+			dryRun:         true,
+			dryRunJSON:     true,
+			expected:       "turbo run build --filter=my-app --dry=json",
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.expected, func(t *testing.T) {
+			o := Opts{
+				scopeOpts: scope.Opts{
+					FilterPatterns: testCase.filterPatterns,
+					LegacyFilter:   testCase.legacyFilter,
+				},
+				runOpts: util.RunOpts{
+					PassThroughArgs: testCase.passThroughArgs,
+					Parallel:        testCase.parallel,
+					ContinueOnError: testCase.continueOnError,
+					DryRun:          testCase.dryRun,
+					DryRunJSON:      testCase.dryRunJSON,
+				},
+			}
+			cmd := o.SynthesizeCommand(testCase.tasks)
+			if cmd != testCase.expected {
+				t.Errorf("SynthesizeCommand() got %v, want %v", cmd, testCase.expected)
+			}
+		})
+	}
+
+}

--- a/cli/internal/runsummary/run_summary.go
+++ b/cli/internal/runsummary/run_summary.go
@@ -89,7 +89,7 @@ func NewRunSummary(
 		}
 	}
 
-	executionSummary := newExecutionSummary(startAt, profile)
+	executionSummary := newExecutionSummary(synthesizedCommand, repoPath, startAt, profile)
 
 	return Meta{
 		RunSummary: &RunSummary{

--- a/cli/internal/runsummary/run_summary.go
+++ b/cli/internal/runsummary/run_summary.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
-	"strings"
 	"sync"
 	"time"
 
@@ -41,14 +40,16 @@ const (
 // Meta is a wrapper around the serializable RunSummary, with some extra information
 // about the Run and references to other things that we need.
 type Meta struct {
-	RunSummary    *RunSummary
-	ui            cli.Ui
-	repoRoot      turbopath.AbsoluteSystemPath // used to write run summary
-	singlePackage bool
-	shouldSave    bool
-	apiClient     *client.APIClient
-	spaceID       string
-	runType       runType
+	RunSummary         *RunSummary
+	ui                 cli.Ui
+	repoRoot           turbopath.AbsoluteSystemPath // used to write run summary
+	repoPath           turbopath.RelativeSystemPath
+	singlePackage      bool
+	shouldSave         bool
+	apiClient          *client.APIClient
+	spaceID            string
+	runType            runType
+	synthesizedCommand string
 }
 
 // RunSummary contains a summary of what happens in the `turbo run` command and why.
@@ -67,11 +68,13 @@ func NewRunSummary(
 	startAt time.Time,
 	ui cli.Ui,
 	repoRoot turbopath.AbsoluteSystemPath,
+	repoPath turbopath.RelativeSystemPath,
 	turboVersion string,
 	apiClient *client.APIClient,
 	runOpts util.RunOpts,
 	packages []string,
 	globalHashSummary *GlobalHashSummary,
+	synthesizedCommand string,
 ) Meta {
 	singlePackage := runOpts.SinglePackage
 	profile := runOpts.Profile
@@ -98,13 +101,14 @@ func NewRunSummary(
 			Tasks:             []*TaskSummary{},
 			GlobalHashSummary: globalHashSummary,
 		},
-		ui:            ui,
-		runType:       runType,
-		repoRoot:      repoRoot,
-		singlePackage: singlePackage,
-		shouldSave:    shouldSave,
-		apiClient:     apiClient,
-		spaceID:       spaceID,
+		ui:                 ui,
+		runType:            runType,
+		repoRoot:           repoRoot,
+		singlePackage:      singlePackage,
+		shouldSave:         shouldSave,
+		apiClient:          apiClient,
+		spaceID:            spaceID,
+		synthesizedCommand: synthesizedCommand,
 	}
 }
 
@@ -181,16 +185,6 @@ func (summary *RunSummary) TrackTask(taskID string) (func(outcome executionEvent
 	return summary.ExecutionSummary.run(taskID)
 }
 
-// command returns a best guess command for the entire Run.
-// TODO: we should thread this through from the entry point rather than make it up
-func (summary *RunSummary) command() string {
-	taskNames := make(util.Set, len(summary.Tasks))
-	for _, task := range summary.Tasks {
-		taskNames.Add(task.Task)
-	}
-	return fmt.Sprintf("turbo run %s", strings.Join(taskNames.UnsafeListOfStrings(), " "))
-}
-
 // Save saves the run summary to a file
 func (rsm *Meta) save() error {
 	json, err := rsm.FormatJSON()
@@ -219,7 +213,7 @@ func (rsm *Meta) record() []error {
 	// can happen when the Run actually starts, so we can send updates to Vercel as the tasks progress.
 	runsURL := fmt.Sprintf(runsEndpoint, rsm.spaceID)
 	var runID string
-	payload := newVercelRunCreatePayload(rsm.RunSummary)
+	payload := rsm.newVercelRunCreatePayload()
 	if startPayload, err := json.Marshal(payload); err == nil {
 		if resp, err := rsm.apiClient.JSONPost(runsURL, startPayload); err != nil {
 			errs = append(errs, err)

--- a/cli/internal/runsummary/vercel.go
+++ b/cli/internal/runsummary/vercel.go
@@ -13,10 +13,10 @@ type vercelRunPayload struct {
 	ID string `json:"vercelId,omitempty"`
 
 	// StartTime is when this run was started
-	StartTime int `json:"startTime,omitempty"`
+	StartTime int64 `json:"startTime,omitempty"`
 
 	// EndTime is when this run ended. We will never be submitting start and endtime at the same time.
-	EndTime int `json:"endTime,omitempty"`
+	EndTime int64 `json:"endTime,omitempty"`
 
 	// Status is
 	Status string `json:"status,omitempty"`
@@ -29,6 +29,10 @@ type vercelRunPayload struct {
 
 	// The command that kicked off the turbo run
 	Command string `json:"command,omitempty"`
+
+	// RepositoryPath is the relative directory from the turborepo root to where
+	// the command was invoked.
+	RepositoryPath string `json:"repositoryPath,omitempty"`
 
 	// Context is the host on which this Run was executed (e.g. Vercel)
 	Context string `json:"context,omitempty"`
@@ -49,31 +53,32 @@ type vercelTask struct {
 	Name         string            `json:"name,omitempty"`
 	Workspace    string            `json:"workspace,omitempty"`
 	Hash         string            `json:"hash,omitempty"`
-	StartTime    int               `json:"startTime,omitempty"`
-	EndTime      int               `json:"endTime,omitempty"`
+	StartTime    int64             `json:"startTime,omitempty"`
+	EndTime      int64             `json:"endTime,omitempty"`
 	Cache        vercelCacheStatus `json:"cache,omitempty"`
 	ExitCode     int               `json:"exitCode,omitempty"`
 	Dependencies []string          `json:"dependencies,omitempty"`
 	Dependents   []string          `json:"dependents,omitempty"`
 }
 
-func newVercelRunCreatePayload(runsummary *RunSummary) *vercelRunPayload {
-	startTime := int(runsummary.ExecutionSummary.startedAt.UnixMilli())
-	var context = "LOCAL"
+func (rsm *Meta) newVercelRunCreatePayload() *vercelRunPayload {
+	startTime := rsm.RunSummary.ExecutionSummary.startedAt.UnixMilli()
+	context := "LOCAL"
 	if name := ci.Constant(); name != "" {
 		context = name
 	}
 	return &vercelRunPayload{
-		StartTime: startTime,
-		Status:    "running",
-		Command:   runsummary.command(),
-		Type:      "TURBO",
-		Context:   context,
+		StartTime:      startTime,
+		Status:         "running",
+		Command:        rsm.synthesizedCommand,
+		RepositoryPath: rsm.repoPath.ToString(),
+		Type:           "TURBO",
+		Context:        context,
 	}
 }
 
 func newVercelDonePayload(runsummary *RunSummary) *vercelRunPayload {
-	endTime := int(runsummary.ExecutionSummary.endedAt.UnixMilli())
+	endTime := runsummary.ExecutionSummary.endedAt.UnixMilli()
 	return &vercelRunPayload{
 		Status:   "completed",
 		EndTime:  endTime,
@@ -90,8 +95,8 @@ func newVercelTaskPayload(taskSummary *TaskSummary) *vercelTask {
 		status = "HIT"
 	}
 
-	startTime := int(taskSummary.Execution.startAt.UnixMilli())
-	endTime := int(taskSummary.Execution.endTime().UnixMilli())
+	startTime := taskSummary.Execution.startAt.UnixMilli()
+	endTime := taskSummary.Execution.endTime().UnixMilli()
 
 	return &vercelTask{
 		Key:       taskSummary.TaskID,

--- a/cli/internal/scope/scope.go
+++ b/cli/internal/scope/scope.go
@@ -55,7 +55,7 @@ type Opts struct {
 	// Patterns are the filter patterns supplied to --filter on the commandline
 	FilterPatterns []string
 
-	PackageInferenceRoot string
+	PackageInferenceRoot turbopath.RelativeSystemPath
 }
 
 var (
@@ -70,17 +70,35 @@ match any filter will be included.`
 in the root directory. Includes turbo.json, root package.json, and the root lockfile by default.`
 )
 
+// normalize package inference path. We compare against "" in several places, so maintain
+// that behavior. In a post-rust-port world, this should more properly be an Option
+func resolvePackageInferencePath(raw string) (turbopath.RelativeSystemPath, error) {
+	pkgInferenceRoot, err := turbopath.CheckedToRelativeSystemPath(raw)
+	if err != nil {
+		return "", errors.Wrapf(err, "invalid package inference root %v", raw)
+	}
+	if pkgInferenceRoot == "." {
+		return "", nil
+	}
+	return pkgInferenceRoot, nil
+}
+
 // OptsFromArgs adds the settings relevant to this package to the given Opts
-func OptsFromArgs(opts *Opts, args *turbostate.ParsedArgsFromRust) {
+func OptsFromArgs(opts *Opts, args *turbostate.ParsedArgsFromRust) error {
 	opts.FilterPatterns = args.Command.Run.Filter
 	opts.IgnorePatterns = args.Command.Run.Ignore
 	opts.GlobalDepPatterns = args.Command.Run.GlobalDeps
-	opts.PackageInferenceRoot = args.Command.Run.PkgInferenceRoot
+	pkgInferenceRoot, err := resolvePackageInferencePath(args.Command.Run.PkgInferenceRoot)
+	if err != nil {
+		return err
+	}
+	opts.PackageInferenceRoot = pkgInferenceRoot
 	addLegacyFlagsFromArgs(&opts.LegacyFilter, args)
+	return nil
 }
 
-// asFilterPatterns normalizes legacy selectors to filter syntax
-func (l *LegacyFilter) asFilterPatterns() []string {
+// AsFilterPatterns normalizes legacy selectors to filter syntax
+func (l *LegacyFilter) AsFilterPatterns() []string {
 	var patterns []string
 	prefix := ""
 	if !l.SkipDependents {
@@ -131,7 +149,7 @@ func ResolvePackages(opts *Opts, repoRoot turbopath.AbsoluteSystemPath, scm scm.
 		PackagesChangedInRange: opts.getPackageChangeFunc(scm, repoRoot, ctx),
 	}
 	filterPatterns := opts.FilterPatterns
-	legacyFilterPatterns := opts.LegacyFilter.asFilterPatterns()
+	legacyFilterPatterns := opts.LegacyFilter.AsFilterPatterns()
 	filterPatterns = append(filterPatterns, legacyFilterPatterns...)
 	isAllPackages := len(filterPatterns) == 0 && opts.PackageInferenceRoot == ""
 	filteredPkgs, err := filterResolver.GetPackagesFromPatterns(filterPatterns)
@@ -149,14 +167,10 @@ func ResolvePackages(opts *Opts, repoRoot turbopath.AbsoluteSystemPath, scm scm.
 	return filteredPkgs, isAllPackages, nil
 }
 
-func calculateInference(repoRoot turbopath.AbsoluteSystemPath, rawPkgInferenceDir string, packageInfos workspace.Catalog, logger hclog.Logger) (*scope_filter.PackageInference, error) {
-	if rawPkgInferenceDir == "" {
+func calculateInference(repoRoot turbopath.AbsoluteSystemPath, pkgInferencePath turbopath.RelativeSystemPath, packageInfos workspace.Catalog, logger hclog.Logger) (*scope_filter.PackageInference, error) {
+	if pkgInferencePath == "" {
 		// No inference specified, no need to calculate anything
 		return nil, nil
-	}
-	pkgInferencePath, err := turbopath.CheckedToRelativeSystemPath(rawPkgInferenceDir)
-	if err != nil {
-		return nil, err
 	}
 	logger.Debug(fmt.Sprintf("Using %v as a basis for selecting packages", pkgInferencePath))
 	fullInferencePath := repoRoot.Join(pkgInferencePath)

--- a/cli/internal/scope/scope_test.go
+++ b/cli/internal/scope/scope_test.go
@@ -510,6 +510,10 @@ func TestResolvePackages(t *testing.T) {
 			readLockfile := func(_rootPackageJSON *fs.PackageJSON, content []byte) (lockfile.Lockfile, error) {
 				return tc.prevLockfile, nil
 			}
+			pkgInferenceRoot, err := resolvePackageInferencePath(tc.inferPkgPath)
+			if err != nil {
+				t.Errorf("bad inference path (%v): %v", tc.inferPkgPath, err)
+			}
 			pkgs, isAllPackages, err := ResolvePackages(&Opts{
 				LegacyFilter: LegacyFilter{
 					Entrypoints:         tc.scope,
@@ -519,7 +523,7 @@ func TestResolvePackages(t *testing.T) {
 				},
 				IgnorePatterns:       []string{tc.ignore},
 				GlobalDepPatterns:    tc.globalDeps,
-				PackageInferenceRoot: tc.inferPkgPath,
+				PackageInferenceRoot: pkgInferenceRoot,
 			}, root, scm, &context.Context{
 				WorkspaceInfos: workspaceInfos,
 				WorkspaceNames: packageNames,


### PR DESCRIPTION
 - Switches `pkgInferencePath` to be a `RelativeSystemPath` (note "" token for not set)
 - Records `repositoryPath` in Run Payload
 - Switches timestamps over to `int64` since they milliseconds
 - Synthesizes a plausible command to produce an identical set of tasks and packages to execute

Note merge base is #4495 

### Testing Instructions

Added a new test for command syntheses
