### PR TITLE
ci: Stop building Go code twice

### DIFF
--- a/cli/Makefile
+++ b/cli/Makefile
@@ -28,7 +28,7 @@ SRC_FILES = $(shell find . -name "*.go" | grep -v "_test.go")
 GENERATED_FILES = internal/turbodprotocol/turbod.pb.go internal/turbodprotocol/turbod_grpc.pb.go
 
 turbo: go-turbo$(EXT)
-	cargo build --manifest-path ../crates/turborepo/Cargo.toml
+	SKIP_GO_BUILD=true cargo build -p turbo
 
 turbo-prod: go-turbo$(EXT)
 	cargo build --release --manifest-path ../crates/turborepo/Cargo.toml

--- a/crates/turborepo/build.rs
+++ b/crates/turborepo/build.rs
@@ -2,6 +2,9 @@ use std::{env, fs, path::PathBuf, process::Command};
 
 fn main() {
     println!("cargo:rerun-if-changed=../../cli");
+    if env::var("SKIP_GO_BUILD").is_ok() {
+        return;
+    }
     let profile = env::var("PROFILE").unwrap();
     let is_ci_release =
         &profile == "release" && matches!(env::var("RELEASE_TURBO_CLI"), Ok(v) if v == "true");


### PR DESCRIPTION
### Description

When we use the makefile, we build the Go code, then build the Rust code, but the Rust code in turn builds the Go code again.

This PR stops that by passing an environment variable `SKIP_GO_BUILD` that prevents the Rust from building the Go code.

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
