### PR TITLE
chore: add turborepo-lockfiles to turborepo code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -38,6 +38,7 @@ pnpm-lock.yaml
 /crates/turborepo-api-client @vercel/turbo-oss
 /crates/turborepo-ffi @vercel/turbo-oss
 /crates/turborepo-lib @vercel/turbo-oss
+/crates/turborepo-lockfiles @vercel/turbo-oss
 /crates/turborepo-scm @vercel/turbo-oss
 /crates/turbo-updater @vercel/turbo-oss
 


### PR DESCRIPTION
### Description

As noted in #4516 this crate needs to get tagged as being owned by @vercel/turbo-oss 
