### PR TITLE
feat(contextcondition): support InPath contextcondition

### DIFF
--- a/crates/turbopack/Cargo.toml
+++ b/crates/turbopack/Cargo.toml
@@ -16,6 +16,7 @@ bench_against_node_nft = []
 [dependencies]
 anyhow = { workspace = true }
 async-recursion = "1.0.2"
+futures = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }
 lazy_static = { workspace = true }
 regex = { workspace = true }

--- a/crates/turbopack/src/module_options/mod.rs
+++ b/crates/turbopack/src/module_options/mod.rs
@@ -7,7 +7,7 @@ pub use module_options_context::*;
 pub use module_rule::*;
 pub use rule_condition::*;
 use turbo_tasks::primitives::{OptionStringVc, StringsVc};
-use turbo_tasks_fs::FileSystemPathVc;
+use turbo_tasks_fs::{FileSystem, FileSystemPathVc};
 use turbopack_core::{
     reference_type::{ReferenceType, UrlReferenceSubType},
     resolve::options::{ImportMap, ImportMapVc, ImportMapping, ImportMappingVc},
@@ -84,8 +84,9 @@ impl ModuleOptionsVc {
         } = *context.await?;
         if !rules.is_empty() {
             let path_value = path.await?;
+
             for (condition, new_context) in rules.iter() {
-                if condition.matches(&path_value) {
+                if condition.matches(&path_value).await {
                     return Ok(ModuleOptionsVc::new(path, *new_context));
                 }
             }

--- a/crates/turbopack/src/resolve.rs
+++ b/crates/turbopack/src/resolve.rs
@@ -235,7 +235,7 @@ pub async fn resolve_options(
     if !options_context_value.rules.is_empty() {
         let context_value = &*context.await?;
         for (condition, new_options_context) in options_context_value.rules.iter() {
-            if condition.matches(context_value) {
+            if condition.matches(context_value).await {
                 return Ok(resolve_options(context, *new_options_context));
             }
         }


### PR DESCRIPTION
### Description

Attempt to close WEB-862.

Currently turbopack in next-swc applies all of moduleoptionscontext into any kind of internal assets. Current available contextcondition (`ContextCondition::InDirectory`) does not gives enough context to determine where it comes from, makes non trivial to determine if given context need to be treated differently. 

~I'm trying to workaround by supplying addtional context for the filesystemkind, and caller can use it for creating a new contextcondition. In case of turbopack, I assume any embedded assets in the binary won't be an external / user's. Next-swc will assign a new condition like https://github.com/vercel/next.js/compare/canary...client-context-embedded-fs#diff-92086db0c6bc192f76dab5d612a562df8fddffea05244c1c00d58e7288879e11R213-R214.~

~Still bit unsure if this is a legit apporach or would be better way to go. PR is for the POC + further improvement based on the feedback.~

Per review suggestion, this PR now supports `InPath(FileSystemVc)` as new condition instead.