### PR TITLE
oldGlobalHash can be named

### DIFF
--- a/cli/internal/run/global_hash.go
+++ b/cli/internal/run/global_hash.go
@@ -33,6 +33,17 @@ type GlobalHashable struct {
 	envMode              util.EnvMode
 }
 
+// This exists because the global hash used to have different fields. Changing
+// to a new struct layout changes the global hash. We can remove this converter
+// when we are going to have to update the global hash for something else.
+type oldGlobalHashable struct {
+	globalFileHashMap    map[turbopath.AnchoredUnixPath]string
+	rootExternalDepsHash string
+	envVars              env.EnvironmentVariablePairs
+	globalCacheKey       string
+	pipeline             fs.PristinePipeline
+}
+
 // calculateGlobalHashFromHashable returns a hash string from the globalHashable
 func calculateGlobalHashFromHashable(named GlobalHashable) (string, error) {
 	// When we aren't in infer mode, we can hash the whole object
@@ -47,39 +58,15 @@ func calculateGlobalHashFromHashable(named GlobalHashable) (string, error) {
 	}
 
 	// If we're in infer mode, and there is no global pass through config,
-	// we can use the old anonymous struct. this will be true for everyone not using the strict env
-	// feature, and we don't want to break their cache.
-	return fs.HashObject(getOldGlobalHashable(named))
-}
-
-// getOldGlobalHashable converts GlobalHashable into an anonymous struct.
-// This exists because the global hash was originally implemented with an anonymous
-// struct, and changing to a named struct changes the global hash (because the hash
-// is essentially a hash of `fmt.Sprint("%#v", thing)`, and the type is part of that string.
-// We keep this converter function around, because if we were to remove the anonymous
-// struct, it would change the global hash for everyone, invalidating EVERY TURBO CACHE ON THE PLANET!
-// We can remove this converter when we are going to have to update the global hash for something
-// else anyway.
-func getOldGlobalHashable(named GlobalHashable) struct {
-	globalFileHashMap    map[turbopath.AnchoredUnixPath]string
-	rootExternalDepsHash string
-	hashedSortedEnvPairs env.EnvironmentVariablePairs
-	globalCacheKey       string
-	pipeline             fs.PristinePipeline
-} {
-	return struct {
-		globalFileHashMap    map[turbopath.AnchoredUnixPath]string
-		rootExternalDepsHash string
-		hashedSortedEnvPairs env.EnvironmentVariablePairs
-		globalCacheKey       string
-		pipeline             fs.PristinePipeline
-	}{
+	// we need to use the old struct layout. This will be true for everyone
+	// not using the strict env feature and we don't want to break their cache.
+	return fs.HashObject(oldGlobalHashable{
 		globalFileHashMap:    named.globalFileHashMap,
 		rootExternalDepsHash: named.rootExternalDepsHash,
-		hashedSortedEnvPairs: named.envVars.All.ToHashable(),
+		envVars:              named.envVars.All.ToHashable(),
 		globalCacheKey:       named.globalCacheKey,
 		pipeline:             named.pipeline,
-	}
+	})
 }
 
 func calculateGlobalHash(


### PR DESCRIPTION
We currently use an anonymous struct for the `oldGlobalHash`` but that is unnecessary. The issue was that `&foo{}` and `foo{}` produce `&`-prefixed and non-`&`-prefixed outputs.

No behavior change, existing tests confirm no regression.