### PR TITLE
feat(ecmascript): support configurable styled component options

### DIFF
--- a/crates/turbopack-tests/tests/snapshot.rs
+++ b/crates/turbopack-tests/tests/snapshot.rs
@@ -22,6 +22,7 @@ use turbopack::{
     ecmascript::EcmascriptModuleAssetVc,
     module_options::{
         EmotionTransformConfig, JsxTransformOptions, JsxTransformOptionsVc, ModuleOptionsContext,
+        StyledComponentsTransformConfig, StyledComponentsTransformConfigVc,
     },
     resolve_options_context::ResolveOptionsContext,
     transition::TransitionsByNameVc,
@@ -199,7 +200,9 @@ async fn run_test(resource: &str) -> Result<FileSystemPathVc> {
                 sourcemap: Some(false),
                 ..Default::default()
             })),
-            enable_styled_components: true,
+            enable_styled_components: Some(StyledComponentsTransformConfigVc::cell(
+                Default::default(),
+            )),
             preset_env_versions: Some(env),
             rules: vec![(
                 ContextCondition::InDirectory("node_modules".to_string()),

--- a/crates/turbopack/src/module_options/mod.rs
+++ b/crates/turbopack/src/module_options/mod.rs
@@ -6,7 +6,7 @@ use anyhow::{Context, Result};
 pub use module_options_context::*;
 pub use module_rule::*;
 pub use rule_condition::*;
-use turbo_tasks::primitives::OptionStringVc;
+use turbo_tasks::primitives::{OptionStringVc, StringsVc};
 use turbo_tasks_fs::FileSystemPathVc;
 use turbopack_core::{
     reference_type::{ReferenceType, UrlReferenceSubType},
@@ -64,7 +64,7 @@ impl ModuleOptionsVc {
             ref enable_emotion,
             enable_react_refresh,
             enable_styled_jsx,
-            enable_styled_components,
+            ref enable_styled_components,
             enable_types,
             enable_tree_shaking,
             ref enable_typescript_transform,
@@ -113,8 +113,21 @@ impl ModuleOptionsVc {
                 },
             });
         }
-        if enable_styled_components {
-            transforms.push(EcmascriptInputTransform::StyledComponents);
+        if let Some(enable_styled_components) = enable_styled_components {
+            let styled_components_transform = &*enable_styled_components.await?;
+            transforms.push(EcmascriptInputTransform::StyledComponents {
+                display_name: styled_components_transform.display_name,
+                ssr: styled_components_transform.ssr,
+                file_name: styled_components_transform.file_name,
+                top_level_import_paths: StringsVc::cell(
+                    styled_components_transform.top_level_import_paths.clone(),
+                ),
+                meaningless_file_names: StringsVc::cell(
+                    styled_components_transform.meaningless_file_names.clone(),
+                ),
+                css_prop: styled_components_transform.css_prop,
+                namespace: OptionStringVc::cell(styled_components_transform.namespace.clone()),
+            });
         }
         if let Some(enable_jsx) = enable_jsx {
             let jsx = enable_jsx.await?;

--- a/crates/turbopack/src/module_options/module_options_context.rs
+++ b/crates/turbopack/src/module_options/module_options_context.rs
@@ -147,6 +147,50 @@ pub struct JsxTransformOptions {
     pub runtime: Option<String>,
 }
 
+#[turbo_tasks::value(transparent)]
+pub struct OptionStyledComponentsTransformConfig(Option<StyledComponentsTransformConfigVc>);
+
+#[turbo_tasks::value(shared)]
+#[derive(Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct StyledComponentsTransformConfig {
+    pub display_name: bool,
+    pub ssr: bool,
+    pub file_name: bool,
+    pub top_level_import_paths: Vec<String>,
+    pub meaningless_file_names: Vec<String>,
+    pub css_prop: bool,
+    pub namespace: Option<String>,
+}
+
+impl Default for StyledComponentsTransformConfig {
+    fn default() -> Self {
+        StyledComponentsTransformConfig {
+            display_name: true,
+            ssr: true,
+            file_name: true,
+            top_level_import_paths: vec![],
+            meaningless_file_names: vec!["index".to_string()],
+            css_prop: true,
+            namespace: None,
+        }
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl StyledComponentsTransformConfigVc {
+    #[turbo_tasks::function]
+    pub fn default() -> Self {
+        Self::cell(Default::default())
+    }
+}
+
+impl Default for StyledComponentsTransformConfigVc {
+    fn default() -> Self {
+        Self::default()
+    }
+}
+
 #[turbo_tasks::value(shared)]
 #[derive(Default, Clone)]
 pub struct ModuleOptionsContext {
@@ -157,7 +201,7 @@ pub struct ModuleOptionsContext {
     #[serde(default)]
     pub enable_react_refresh: bool,
     #[serde(default)]
-    pub enable_styled_components: bool,
+    pub enable_styled_components: Option<StyledComponentsTransformConfigVc>,
     #[serde(default)]
     pub enable_styled_jsx: bool,
     #[serde(default)]


### PR DESCRIPTION
### Description

WEB-670.

This PR expands config options for the styled components transform. However this is not a full fix yet, there are some additional failures in the test case need further investigations.

<!--
  ✍️ Write a short summary of your work.
  If necessary, include relevant screenshots.
-->

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
