### PR TITLE
chore(turborepo): Make rustls the default feature for turborepo-lib

### DIFF
--- a/crates/turborepo-lib/Cargo.toml
+++ b/crates/turborepo-lib/Cargo.toml
@@ -7,6 +7,7 @@ license = "MPL-2.0"
 [features]
 # Allows configuring a specific tls backend for reqwest.
 # See top level Cargo.toml for more details.
+default = ["rustls-tls"]
 native-tls = ["turborepo-api-client/native-tls", "turbo-updater/native-tls"]
 rustls-tls = ["turborepo-api-client/rustls-tls", "turbo-updater/rustls-tls"]
 


### PR DESCRIPTION
### Description

I got sick of getting the same "no TLS feature" error message, so decided to switch on rustls by default. Will need @vercel/web-tooling approval that we can do this

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
