### PR TITLE
Save task duration correctly

### DIFF
--- a/cli/integration_tests/cache_state.t
+++ b/cli/integration_tests/cache_state.t
@@ -13,8 +13,20 @@ Run a build to get a local cache.
     Time:\s+[.0-9]+m?s  (re)
   
 
-Validate cache state according to dry-run
-  $ ${TURBO} run build --dry=json | jq '.tasks | map(select(.taskId == "my-app#build")) | .[0].cache'
+Do a dry run so we can see the state of the cache
+  $ ${TURBO} run build --dry=json > dry.json
+
+Get the hash of the my-app#build task, so we can inspect the cache
+  $ HASH=$(cat dry.json | jq -r '.tasks | map(select(.taskId == "my-app#build")) | .[0].hash')
+  $ duration=$(cat "node_modules/.cache/turbo/$HASH-meta.json" | jq .duration)
+check that it exists
+  $ echo $duration
+  [0-9]+ (re)
+should not be 0
+  $ test $duration != 0
+
+Validate that local cache is true in dry run
+  $ cat dry.json | jq '.tasks | map(select(.taskId == "my-app#build")) | .[0].cache'
   {
     "local": true,
     "remote": false

--- a/cli/internal/run/real_run.go
+++ b/cli/internal/run/real_run.go
@@ -407,7 +407,7 @@ func (ec *execContext) exec(ctx gocontext.Context, packageTask *nodes.PackageTas
 	if err := closeOutputs(); err != nil {
 		ec.logError("", err)
 	} else {
-		if err = taskCache.SaveOutputs(ctx, progressLogger, prefixedUI, int(taskExecutionSummary.Duration.Milliseconds())); err != nil {
+		if err = taskCache.SaveOutputs(ctx, progressLogger, prefixedUI, int(taskExecutionSummary.Duration)); err != nil {
 			ec.logError("", fmt.Errorf("error caching output: %w", err))
 		} else {
 			ec.taskHashTracker.SetExpandedOutputs(packageTask.TaskID, taskCache.ExpandedOutputs)

--- a/cli/internal/run/real_run.go
+++ b/cli/internal/run/real_run.go
@@ -403,11 +403,14 @@ func (ec *execContext) exec(ctx gocontext.Context, packageTask *nodes.PackageTas
 		return taskExecutionSummary, err
 	}
 
+	// Add another timestamp into the tracer, so we have an accurate timestamp for how long the task took.
+	tracer(runsummary.TargetExecuted, nil, nil)
+
 	// Close off our outputs and cache them
 	if err := closeOutputs(); err != nil {
 		ec.logError("", err)
 	} else {
-		if err = taskCache.SaveOutputs(ctx, progressLogger, prefixedUI, int(taskExecutionSummary.Duration)); err != nil {
+		if err = taskCache.SaveOutputs(ctx, progressLogger, prefixedUI, int(taskExecutionSummary.Duration.Milliseconds())); err != nil {
 			ec.logError("", fmt.Errorf("error caching output: %w", err))
 		} else {
 			ec.taskHashTracker.SetExpandedOutputs(packageTask.TaskID, taskCache.ExpandedOutputs)

--- a/cli/internal/runsummary/execution_summary.go
+++ b/cli/internal/runsummary/execution_summary.go
@@ -39,6 +39,7 @@ const (
 	targetInitialized executionEventName = iota
 	TargetBuilding
 	TargetBuildStopped
+	TargetExecuted
 	TargetBuilt
 	TargetCached
 	TargetBuildFailed
@@ -52,6 +53,8 @@ func (en executionEventName) toString() string {
 		return "building"
 	case TargetBuildStopped:
 		return "buildStopped"
+	case TargetExecuted:
+		return "executed"
 	case TargetBuilt:
 		return "built"
 	case TargetCached:


### PR DESCRIPTION
This is a regression from #4342, which went out in [v1.8.6](https://github.com/vercel/turbo/releases/tag/v1.8.6). 

The bug is the `tracer()` updates duration every time you call it, and we hadn't called it after task execution. I'm adding a new state to get this timestamp. We cannot use `TargetBuilt` because we don't want to capture that state until _after_ cache is saved, and, conversely, we don't want to include the time to save the cache in the task duration.

⚠️ **Automerge is enabled**, only ✅ if you're comfortable merging!