### PR TITLE
Bind to IPv6 and IPv4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3055,9 +3055,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.140"
+version = "0.2.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
 
 [[package]]
 name = "libgit2-sys"
@@ -7821,6 +7821,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_qs",
+ "socket2",
  "tokio",
  "tokio-stream",
  "tokio-util",

--- a/crates/turbopack-dev-server/Cargo.toml
+++ b/crates/turbopack-dev-server/Cargo.toml
@@ -24,6 +24,7 @@ pin-project-lite = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_qs = { workspace = true }
+socket2 = "0.4.9"
 tokio = { workspace = true }
 tokio-stream = "0.1.9"
 tokio-util = { workspace = true }

--- a/crates/turbopack-dev-server/src/lib.rs
+++ b/crates/turbopack-dev-server/src/lib.rs
@@ -24,6 +24,7 @@ use hyper::{
     service::{make_service_fn, service_fn},
     Request, Response, Server,
 };
+use socket2::{Domain, Protocol, Socket, Type};
 use turbo_tasks::{
     run_once_with_reason, trace::TraceRawVcs, util::FormatDuration, CollectiblesSource, RawVc,
     TransientInstance, TransientValue, TurboTasksApi,
@@ -104,12 +105,17 @@ impl DevServer {
         // because the OS will remap that to an actual free port, and we need to know
         // that port before we build the request handler. So we need to construct a
         // real TCP listener, see if it bound, and get its bound address.
-        let listener = TcpListener::bind(addr).context("not able to bind address")?;
-        let addr = listener
+        let socket = Socket::new(Domain::for_address(addr), Type::STREAM, Some(Protocol::TCP))
+            .context("unable to create socket")?;
+        socket
+            .set_only_v6(false)
+            .context("unable to set socket to not only IPv6")?;
+        socket.bind(&addr).context("not able to bind address")?;
+        let addr = socket
             .local_addr()
             .context("not able to get bound address")?;
 
-        let server = Server::from_tcp(listener).context("Not able to start server")?;
+        let server = Server::from_tcp(socket.into()).context("Not able to start server")?;
         Ok(DevServerBuilder { addr, server })
     }
 }

--- a/crates/turbopack-dev-server/src/lib.rs
+++ b/crates/turbopack-dev-server/src/lib.rs
@@ -110,13 +110,19 @@ impl DevServer {
         socket
             .set_only_v6(false)
             .context("unable to set socket to not only IPv6")?;
-        socket.bind(&addr).context("not able to bind address")?;
-        let addr = socket
+        socket
+            .bind(&addr.into())
+            .context("not able to bind address")?;
+
+        let listener: TcpListener = socket.into();
+        let addr = listener
             .local_addr()
             .context("not able to get bound address")?;
-
-        let server = Server::from_tcp(socket.into()).context("Not able to start server")?;
-        Ok(DevServerBuilder { addr, server })
+        let server = Server::from_tcp(listener).context("Not able to start server")?;
+        Ok(DevServerBuilder {
+            addr: addr.into(),
+            server,
+        })
     }
 }
 

--- a/crates/turbopack-dev-server/src/lib.rs
+++ b/crates/turbopack-dev-server/src/lib.rs
@@ -107,9 +107,10 @@ impl DevServer {
         // real TCP listener, see if it bound, and get its bound address.
         let socket = Socket::new(Domain::for_address(addr), Type::STREAM, Some(Protocol::TCP))
             .context("unable to create socket")?;
-        socket
-            .set_only_v6(false)
-            .context("unable to set socket to not only IPv6")?;
+        if matches!(addr, SocketAddr::V6(_)) {
+            // When possible bind to v4 and v6, otherwise ignore the error
+            let _ = socket.set_only_v6(false);
+        }
         socket
             .bind(&addr.into())
             .context("not able to bind address")?;


### PR DESCRIPTION
### Description

The std api doesn't allow to control the `IPV6_ONLY` flag for sockets and it defaults to true.
But we want to bind to both IPv6 and IPv4.
