### PR TITLE
fix(create-turbo): correct package manager selection

### DIFF
--- a/packages/create-turbo/src/commands/create/prompts.ts
+++ b/packages/create-turbo/src/commands/create/prompts.ts
@@ -100,9 +100,12 @@ export async function packageManager({
     choices: ["npm", "pnpm", "yarn"].map((p) => ({
       name: p,
       value: p,
-      disabled: availablePackageManagers?.[p as PackageManager]?.available
-        ? false
-        : `not installed`,
+      // npm should always be available
+      disabled:
+        p !== "npm" ||
+        availablePackageManagers?.[p as PackageManager]?.available
+          ? false
+          : `not installed`,
     })),
   });
 

--- a/packages/turbo-utils/src/managers.ts
+++ b/packages/turbo-utils/src/managers.ts
@@ -15,7 +15,13 @@ async function getVersion(
     env: { COREPACK_ENABLE_STRICT: "0" },
   };
 
+  let available = false;
   try {
+    const userAgent = process.env.npm_config_user_agent;
+    if (userAgent && userAgent.startsWith(packageManager)) {
+      available = true;
+    }
+
     const result = await execa(packageManager, ["--version"], execOptions);
     return {
       available: true,
@@ -23,7 +29,7 @@ async function getVersion(
     };
   } catch (e) {
     return {
-      available: false,
+      available,
     };
   }
 }


### PR DESCRIPTION
### Description

Fixes https://github.com/vercel/turbo/issues/4556

Restores the previous detection logic used by create-turbo. 

