### PR TITLE
remove circular dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7669,7 +7669,6 @@ dependencies = [
  "tungstenite 0.17.3",
  "turbo-tasks",
  "turbo-tasks-testing",
- "turbopack-cli",
  "turbopack-create-test-app",
  "url",
  "webbrowser",

--- a/crates/turbopack-bench/Cargo.toml
+++ b/crates/turbopack-bench/Cargo.toml
@@ -37,7 +37,6 @@ tokio = { workspace = true, features = ["full"] }
 tungstenite = { workspace = true }
 turbo-tasks = { workspace = true }
 turbo-tasks-testing = { workspace = true }
-turbopack-cli = { workspace = true }
 turbopack-create-test-app = { workspace = true }
 url = { workspace = true }
 webbrowser = { workspace = true }


### PR DESCRIPTION
### Description

rust-analyzer seem to be unhappy about this circular dependency and in fact we don't need this dependency anyway