### PR TITLE
allow to create stress test for client components

### DIFF
--- a/crates/turbopack-create-test-app/src/main.rs
+++ b/crates/turbopack-create-test-app/src/main.rs
@@ -34,6 +34,10 @@ struct Args {
     /// How to communicate changes to the consumer (none | hook | component)
     #[clap(long, default_value = "none")]
     effect_mode: EffectMode,
+
+    /// Make leaf modules client components for app dir
+    #[clap(long, default_value_t = false)]
+    leaf_client_components: bool,
 }
 
 fn main() -> Result<()> {
@@ -53,6 +57,7 @@ fn main() -> Result<()> {
                 None
             },
             effect_mode: args.effect_mode,
+            leaf_client_components: args.leaf_client_components,
         }
         .build()?
         .path()

--- a/crates/turbopack-create-test-app/src/test_app_builder.rs
+++ b/crates/turbopack-create-test-app/src/test_app_builder.rs
@@ -76,6 +76,7 @@ pub struct TestAppBuilder {
     pub flatness: usize,
     pub package_json: Option<PackageJsonConfig>,
     pub effect_mode: EffectMode,
+    pub leaf_client_components: bool,
 }
 
 impl Default for TestAppBuilder {
@@ -88,6 +89,7 @@ impl Default for TestAppBuilder {
             flatness: 5,
             package_json: Some(Default::default()),
             effect_mode: EffectMode::Hook,
+            leaf_client_components: false,
         }
     }
 }
@@ -172,10 +174,17 @@ impl TestAppBuilder {
                 || (!queue.is_empty()
                     && (queue.len() + remaining_modules) % (self.flatness + 1) == 0);
             if leaf {
+                let maybe_use_client = if self.leaf_client_components {
+                    r#""use client";"#
+                } else {
+                    ""
+                };
                 write_file(
                     &format!("leaf file {}", file.display()),
                     &file,
                     formatdoc! {r#"
+                        {maybe_use_client}
+
                         {setup_imports}
 
                         {SETUP_EFFECT_PROPS}


### PR DESCRIPTION
### Description

adds `--leaf-client-components` to the test app generator to make all leaf components client components and allow to stress test an app with many client components