### PR TITLE
refactor: Move transforms and compile time info into `EcmascriptOption`

### DIFF
--- a/crates/turbopack-core/src/context.rs
+++ b/crates/turbopack-core/src/context.rs
@@ -14,6 +14,8 @@ use crate::{
 /// type (e. g. from SourceAsset to ModuleAsset).
 #[turbo_tasks::value_trait]
 pub trait AssetContext {
+    // TODO: Remove this.
+    // https://github.com/vercel/turbo/pull/4596#discussion_r1168245809
     fn compile_time_info(&self) -> CompileTimeInfoVc;
     fn resolve_options(
         &self,

--- a/crates/turbopack-ecmascript/src/lib.rs
+++ b/crates/turbopack-ecmascript/src/lib.rs
@@ -130,9 +130,7 @@ pub struct EcmascriptModuleAsset {
     pub source: AssetVc,
     pub context: AssetContextVc,
     pub ty: EcmascriptModuleAssetType,
-    pub transforms: EcmascriptInputTransformsVc,
     pub options: EcmascriptOptions,
-    pub compile_time_info: CompileTimeInfoVc,
     pub inner_assets: Option<InnerAssetsVc>,
     #[turbo_tasks(debug_ignore)]
     #[serde(skip)]
@@ -150,17 +148,13 @@ impl EcmascriptModuleAssetVc {
         source: AssetVc,
         context: AssetContextVc,
         ty: Value<EcmascriptModuleAssetType>,
-        transforms: EcmascriptInputTransformsVc,
         options: Value<EcmascriptOptions>,
-        compile_time_info: CompileTimeInfoVc,
     ) -> Self {
         Self::cell(EcmascriptModuleAsset {
             source,
             context,
             ty: ty.into_value(),
-            transforms,
             options: options.into_value(),
-            compile_time_info,
             inner_assets: None,
             last_successful_analysis: Default::default(),
         })
@@ -171,18 +165,14 @@ impl EcmascriptModuleAssetVc {
         source: AssetVc,
         context: AssetContextVc,
         ty: Value<EcmascriptModuleAssetType>,
-        transforms: EcmascriptInputTransformsVc,
         options: Value<EcmascriptOptions>,
-        compile_time_info: CompileTimeInfoVc,
         inner_assets: InnerAssetsVc,
     ) -> Self {
         Self::cell(EcmascriptModuleAsset {
             source,
             context,
             ty: ty.into_value(),
-            transforms,
             options: options.into_value(),
-            compile_time_info,
             inner_assets: Some(inner_assets),
             last_successful_analysis: Default::default(),
         })

--- a/crates/turbopack-ecmascript/src/lib.rs
+++ b/crates/turbopack-ecmascript/src/lib.rs
@@ -84,13 +84,17 @@ use crate::{
 };
 
 #[turbo_tasks::value(serialization = "auto_for_input")]
-#[derive(PartialOrd, Ord, Hash, Debug, Default, Copy, Clone)]
+#[derive(PartialOrd, Ord, Hash, Debug, Copy, Clone)]
 pub struct EcmascriptOptions {
     /// module is split into smaller module parts which can be selectively
     /// imported
     pub split_into_parts: bool,
     /// imports will import parts of modules
     pub import_parts: bool,
+
+    pub transforms: EcmascriptInputTransformsVc,
+
+    pub compile_time_info: CompileTimeInfoVc,
 }
 
 #[turbo_tasks::value(serialization = "auto_for_input")]

--- a/crates/turbopack-ecmascript/src/lib.rs
+++ b/crates/turbopack-ecmascript/src/lib.rs
@@ -194,9 +194,7 @@ impl EcmascriptModuleAssetVc {
             this.source,
             self.as_resolve_origin(),
             Value::new(this.ty),
-            this.transforms,
             Value::new(this.options),
-            this.compile_time_info,
             None,
         ))
     }
@@ -238,7 +236,11 @@ impl EcmascriptModuleAssetVc {
     #[turbo_tasks::function]
     pub async fn parse(self) -> Result<ParseResultVc> {
         let this = self.await?;
-        Ok(parse(this.source, Value::new(this.ty), this.transforms))
+        Ok(parse(
+            this.source,
+            Value::new(this.ty),
+            this.options.transforms,
+        ))
     }
 }
 
@@ -381,7 +383,11 @@ impl EcmascriptChunkItem for ModuleChunkItem {
         };
 
         let module = this.module.await?;
-        let parsed = parse(module.source, Value::new(module.ty), module.transforms);
+        let parsed = parse(
+            module.source,
+            Value::new(module.ty),
+            module.options.transforms,
+        );
 
         Ok(gen_content(
             this.context.into(),

--- a/crates/turbopack-ecmascript/src/lib.rs
+++ b/crates/turbopack-ecmascript/src/lib.rs
@@ -94,7 +94,7 @@ pub struct EcmascriptOptions {
 
     pub transforms: EcmascriptInputTransformsVc,
 
-    pub compile_time_info: CompileTimeInfoVc,
+    pub compile_time_info: Option<CompileTimeInfoVc>,
 }
 
 #[turbo_tasks::value(serialization = "auto_for_input")]

--- a/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/crates/turbopack-ecmascript/src/references/mod.rs
@@ -479,7 +479,7 @@ pub(crate) async fn analyze_ecmascript_module(
             // Check if it was a webpack entry
             if let Some((request, span)) = webpack_runtime {
                 let request = RequestVc::parse(Value::new(request.into()));
-                let runtime = resolve_as_webpack_runtime(origin, request, transforms);
+                let runtime = resolve_as_webpack_runtime(origin, request, options.transforms);
                 match &*runtime.await? {
                     WebpackRuntime::Webpack5 { .. } => {
                         ignore_effect_span = Some(span);
@@ -488,7 +488,7 @@ pub(crate) async fn analyze_ecmascript_module(
                                 origin,
                                 request,
                                 runtime,
-                                transforms,
+                                transforms: options.transforms,
                             }
                             .cell(),
                         );
@@ -497,7 +497,7 @@ pub(crate) async fn analyze_ecmascript_module(
                                 WebpackEntryAssetReference {
                                     source,
                                     runtime,
-                                    transforms,
+                                    transforms: options.transforms,
                                 }
                                 .cell(),
                             );
@@ -507,7 +507,7 @@ pub(crate) async fn analyze_ecmascript_module(
                                 WebpackChunkAssetReference {
                                     chunk_id: chunk,
                                     runtime,
-                                    transforms,
+                                    transforms: options.transforms,
                                 }
                                 .cell(),
                             );
@@ -1361,7 +1361,7 @@ pub(crate) async fn analyze_ecmascript_module(
                 handler: &handler,
                 source,
                 origin,
-                compile_time_info,
+                compile_time_info: options.compile_time_info,
                 var_graph: &var_graph,
                 fun_args_values: Mutex::new(HashMap::<u32, Vec<JsValue>>::new()),
                 first_import_meta: true,
@@ -1664,7 +1664,7 @@ pub(crate) async fn analyze_ecmascript_module(
                                 analysis.add_reference(UrlAssetReferenceVc::new(
                                     origin,
                                     RequestVc::parse(Value::new(pat)),
-                                    compile_time_info.environment().rendering(),
+                                    options.compile_time_info.environment().rendering(),
                                     AstPathVc::cell(ast_path),
                                     IssueSourceVc::from_byte_offset(
                                         source,

--- a/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/crates/turbopack-ecmascript/src/references/mod.rs
@@ -1361,7 +1361,7 @@ pub(crate) async fn analyze_ecmascript_module(
                 handler: &handler,
                 source,
                 origin,
-                compile_time_info: options.compile_time_info,
+                compile_time_info: options.compile_time_info.unwrap(),
                 var_graph: &var_graph,
                 fun_args_values: Mutex::new(HashMap::<u32, Vec<JsValue>>::new()),
                 first_import_meta: true,
@@ -1664,7 +1664,12 @@ pub(crate) async fn analyze_ecmascript_module(
                                 analysis.add_reference(UrlAssetReferenceVc::new(
                                     origin,
                                     RequestVc::parse(Value::new(pat)),
-                                    options.compile_time_info.environment().rendering(),
+                                    options
+                                        .compile_time_info
+                                        .as_ref()
+                                        .unwrap()
+                                        .environment()
+                                        .rendering(),
                                     AstPathVc::cell(ast_path),
                                     IssueSourceVc::from_byte_offset(
                                         source,

--- a/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/crates/turbopack-ecmascript/src/references/mod.rs
@@ -269,9 +269,7 @@ pub(crate) async fn analyze_ecmascript_module(
     source: AssetVc,
     origin: ResolveOriginVc,
     ty: Value<EcmascriptModuleAssetType>,
-    transforms: EcmascriptInputTransformsVc,
     options: Value<EcmascriptOptions>,
-    compile_time_info: CompileTimeInfoVc,
     part: Option<ModulePartVc>,
 ) -> Result<AnalyzeEcmascriptModuleResultVc> {
     let mut analysis = AnalyzeEcmascriptModuleResultBuilder::new();
@@ -285,11 +283,11 @@ pub(crate) async fn analyze_ecmascript_module(
     };
 
     let parsed = if let Some(part) = part {
-        let parsed = parse(source, ty, transforms);
+        let parsed = parse(source, ty, options.transforms);
         let split_data = split(path, parsed);
         part_of_module(split_data, part)
     } else {
-        parse(source, ty, transforms)
+        parse(source, ty, options.transforms)
     };
 
     match &*find_context_file(path.parent(), package_json()).await? {

--- a/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -164,9 +164,7 @@ async fn analyze(
         module.source,
         full_module.as_resolve_origin(),
         Value::new(module.ty),
-        module.transforms,
         Value::new(module.options),
-        module.compile_time_info,
         Some(part),
     ))
 }

--- a/crates/turbopack-mdx/src/lib.rs
+++ b/crates/turbopack-mdx/src/lib.rs
@@ -23,7 +23,7 @@ use turbopack_ecmascript::{
         EcmascriptChunkingContextVc, EcmascriptExports, EcmascriptExportsVc,
     },
     AnalyzeEcmascriptModuleResultVc, EcmascriptInputTransformsVc, EcmascriptModuleAssetType,
-    EcmascriptModuleAssetVc,
+    EcmascriptModuleAssetVc, EcmascriptOptions,
 };
 
 #[turbo_tasks::function]
@@ -129,9 +129,12 @@ async fn into_ecmascript_module_asset(
         source.into(),
         this.context,
         Value::new(EcmascriptModuleAssetType::Typescript),
-        this.transforms,
-        Value::new(Default::default()),
-        this.context.compile_time_info(),
+        Value::new(EcmascriptOptions {
+            split_into_parts: false,
+            import_parts: false,
+            transforms: this.transforms,
+            compile_time_info: this.context.compile_time_info(),
+        }),
     ))
 }
 

--- a/crates/turbopack-mdx/src/lib.rs
+++ b/crates/turbopack-mdx/src/lib.rs
@@ -133,7 +133,7 @@ async fn into_ecmascript_module_asset(
             split_into_parts: false,
             import_parts: false,
             transforms: this.transforms,
-            compile_time_info: this.context.compile_time_info(),
+            compile_time_info: Some(this.context.compile_time_info()),
         }),
     ))
 }

--- a/crates/turbopack-node/src/evaluate.rs
+++ b/crates/turbopack-node/src/evaluate.rs
@@ -33,7 +33,7 @@ use turbopack_core::{
 };
 use turbopack_ecmascript::{
     EcmascriptInputTransform, EcmascriptInputTransformsVc, EcmascriptModuleAssetType,
-    EcmascriptModuleAssetVc, InnerAssetsVc,
+    EcmascriptModuleAssetVc, EcmascriptOptions, InnerAssetsVc,
 };
 
 use crate::{
@@ -112,11 +112,16 @@ pub async fn get_evaluate_pool(
         SourceAssetVc::new(embed_file_path("ipc/evaluate.ts")).into(),
         context,
         Value::new(EcmascriptModuleAssetType::Typescript),
-        EcmascriptInputTransformsVc::cell(vec![EcmascriptInputTransform::TypeScript {
-            use_define_for_class_fields: false,
-        }]),
-        Value::new(Default::default()),
-        context.compile_time_info(),
+        Value::new(EcmascriptOptions {
+            split_into_parts: false,
+            import_parts: false,
+            transforms: EcmascriptInputTransformsVc::cell(vec![
+                EcmascriptInputTransform::TypeScript {
+                    use_define_for_class_fields: false,
+                },
+            ]),
+            compile_time_info: context.compile_time_info(),
+        }),
     )
     .as_asset();
 
@@ -142,11 +147,16 @@ pub async fn get_evaluate_pool(
         .into(),
         context,
         Value::new(EcmascriptModuleAssetType::Typescript),
-        EcmascriptInputTransformsVc::cell(vec![EcmascriptInputTransform::TypeScript {
-            use_define_for_class_fields: false,
-        }]),
-        Value::new(Default::default()),
-        context.compile_time_info(),
+        Value::new(EcmascriptOptions {
+            split_into_parts: false,
+            import_parts: false,
+            transforms: EcmascriptInputTransformsVc::cell(vec![
+                EcmascriptInputTransform::TypeScript {
+                    use_define_for_class_fields: false,
+                },
+            ]),
+            compile_time_info: context.compile_time_info(),
+        }),
         InnerAssetsVc::cell(indexmap! {
             "INNER".to_string() => module_asset,
             "RUNTIME".to_string() => runtime_asset
@@ -162,11 +172,16 @@ pub async fn get_evaluate_pool(
             SourceAssetVc::new(embed_file_path("globals.ts")).into(),
             context,
             Value::new(EcmascriptModuleAssetType::Typescript),
-            EcmascriptInputTransformsVc::cell(vec![EcmascriptInputTransform::TypeScript {
-                use_define_for_class_fields: false,
-            }]),
-            Value::new(Default::default()),
-            context.compile_time_info(),
+            Value::new(EcmascriptOptions {
+                split_into_parts: false,
+                import_parts: false,
+                transforms: EcmascriptInputTransformsVc::cell(vec![
+                    EcmascriptInputTransform::TypeScript {
+                        use_define_for_class_fields: false,
+                    },
+                ]),
+                compile_time_info: context.compile_time_info(),
+            }),
         )
         .as_evaluatable_asset();
 

--- a/crates/turbopack-node/src/evaluate.rs
+++ b/crates/turbopack-node/src/evaluate.rs
@@ -120,7 +120,7 @@ pub async fn get_evaluate_pool(
                     use_define_for_class_fields: false,
                 },
             ]),
-            compile_time_info: context.compile_time_info(),
+            compile_time_info: Some(context.compile_time_info()),
         }),
     )
     .as_asset();
@@ -155,7 +155,7 @@ pub async fn get_evaluate_pool(
                     use_define_for_class_fields: false,
                 },
             ]),
-            compile_time_info: context.compile_time_info(),
+            compile_time_info: Some(context.compile_time_info()),
         }),
         InnerAssetsVc::cell(indexmap! {
             "INNER".to_string() => module_asset,
@@ -180,7 +180,7 @@ pub async fn get_evaluate_pool(
                         use_define_for_class_fields: false,
                     },
                 ]),
-                compile_time_info: context.compile_time_info(),
+                compile_time_info: Some(context.compile_time_info()),
             }),
         )
         .as_evaluatable_asset();

--- a/crates/turbopack-node/src/transforms/postcss.rs
+++ b/crates/turbopack-node/src/transforms/postcss.rs
@@ -23,7 +23,7 @@ use turbopack_core::{
 };
 use turbopack_ecmascript::{
     EcmascriptInputTransform, EcmascriptInputTransformsVc, EcmascriptModuleAssetType,
-    EcmascriptModuleAssetVc, InnerAssetsVc,
+    EcmascriptModuleAssetVc, EcmascriptOptions, InnerAssetsVc,
 };
 
 use super::util::{emitted_assets_to_virtual_assets, EmittedAsset};
@@ -151,9 +151,12 @@ async fn extra_configs(
                             SourceAssetVc::new(path).into(),
                             context,
                             Value::new(EcmascriptModuleAssetType::Ecmascript),
-                            EcmascriptInputTransformsVc::cell(vec![]),
-                            Value::new(Default::default()),
-                            context.compile_time_info(),
+                            Value::new(EcmascriptOptions {
+                                split_into_parts: false,
+                                import_parts: false,
+                                transforms: EcmascriptInputTransformsVc::cell(vec![]),
+                                compile_time_info: context.compile_time_info(),
+                            }),
                         )
                         .into(),
                     )
@@ -184,11 +187,16 @@ fn postcss_executor(context: AssetContextVc, postcss_config_path: FileSystemPath
         .into(),
         context,
         Value::new(EcmascriptModuleAssetType::Typescript),
-        EcmascriptInputTransformsVc::cell(vec![EcmascriptInputTransform::TypeScript {
-            use_define_for_class_fields: false,
-        }]),
-        Value::new(Default::default()),
-        context.compile_time_info(),
+        Value::new(EcmascriptOptions {
+            split_into_parts: false,
+            import_parts: false,
+            transforms: EcmascriptInputTransformsVc::cell(vec![
+                EcmascriptInputTransform::TypeScript {
+                    use_define_for_class_fields: false,
+                },
+            ]),
+            compile_time_info: context.compile_time_info(),
+        }),
         InnerAssetsVc::cell(indexmap! {
             "CONFIG".to_string() => config_asset
         }),

--- a/crates/turbopack-node/src/transforms/postcss.rs
+++ b/crates/turbopack-node/src/transforms/postcss.rs
@@ -155,7 +155,7 @@ async fn extra_configs(
                                 split_into_parts: false,
                                 import_parts: false,
                                 transforms: EcmascriptInputTransformsVc::cell(vec![]),
-                                compile_time_info: context.compile_time_info(),
+                                compile_time_info: Some(context.compile_time_info()),
                             }),
                         )
                         .into(),
@@ -195,7 +195,7 @@ fn postcss_executor(context: AssetContextVc, postcss_config_path: FileSystemPath
                     use_define_for_class_fields: false,
                 },
             ]),
-            compile_time_info: context.compile_time_info(),
+            compile_time_info: Some(context.compile_time_info()),
         }),
         InnerAssetsVc::cell(indexmap! {
             "CONFIG".to_string() => config_asset

--- a/crates/turbopack-node/src/transforms/webpack.rs
+++ b/crates/turbopack-node/src/transforms/webpack.rs
@@ -14,7 +14,7 @@ use turbopack_core::{
 };
 use turbopack_ecmascript::{
     EcmascriptInputTransform, EcmascriptInputTransformsVc, EcmascriptModuleAssetType,
-    EcmascriptModuleAssetVc,
+    EcmascriptModuleAssetVc, EcmascriptOptions,
 };
 
 use super::util::{emitted_assets_to_virtual_assets, EmittedAsset};
@@ -121,11 +121,16 @@ fn webpack_loaders_executor(context: AssetContextVc) -> AssetVc {
         SourceAssetVc::new(embed_file_path("transforms/webpack-loaders.ts")).into(),
         context,
         Value::new(EcmascriptModuleAssetType::Typescript),
-        EcmascriptInputTransformsVc::cell(vec![EcmascriptInputTransform::TypeScript {
-            use_define_for_class_fields: false,
-        }]),
-        Value::new(Default::default()),
-        context.compile_time_info(),
+        Value::new(EcmascriptOptions {
+            split_into_parts: false,
+            import_parts: false,
+            transforms: EcmascriptInputTransformsVc::cell(vec![
+                EcmascriptInputTransform::TypeScript {
+                    use_define_for_class_fields: false,
+                },
+            ]),
+            compile_time_info: context.compile_time_info(),
+        }),
     )
     .into()
 }

--- a/crates/turbopack-node/src/transforms/webpack.rs
+++ b/crates/turbopack-node/src/transforms/webpack.rs
@@ -129,7 +129,7 @@ fn webpack_loaders_executor(context: AssetContextVc) -> AssetVc {
                     use_define_for_class_fields: false,
                 },
             ]),
-            compile_time_info: context.compile_time_info(),
+            compile_time_info: Some(context.compile_time_info()),
         }),
     )
     .into()

--- a/crates/turbopack/src/lib.rs
+++ b/crates/turbopack/src/lib.rs
@@ -127,34 +127,28 @@ async fn apply_module_type(
             context.into(),
             Value::new(EcmascriptModuleAssetType::Typescript),
             Value::new(EcmascriptOptions {
-                split_into_parts: false,
-                import_parts: false,
-                transforms: *transforms,
                 compile_time_info: context.compile_time_info(),
+                ..options.clone()
             }),
         )
         .into(),
-        ModuleType::TypescriptWithTypes(transforms) => EcmascriptModuleAssetVc::new(
+        ModuleType::TypescriptWithTypes { options } => EcmascriptModuleAssetVc::new(
             source,
             context.with_types_resolving_enabled().into(),
             Value::new(EcmascriptModuleAssetType::TypescriptWithTypes),
             Value::new(EcmascriptOptions {
-                split_into_parts: false,
-                import_parts: false,
-                transforms: *transforms,
                 compile_time_info: context.compile_time_info(),
+                ..options.clone()
             }),
         )
         .into(),
-        ModuleType::TypescriptDeclaration(transforms) => EcmascriptModuleAssetVc::new(
+        ModuleType::TypescriptDeclaration { options } => EcmascriptModuleAssetVc::new(
             source,
             context.with_types_resolving_enabled().into(),
             Value::new(EcmascriptModuleAssetType::TypescriptDeclaration),
             Value::new(EcmascriptOptions {
-                split_into_parts: false,
-                import_parts: false,
-                transforms: *transforms,
                 compile_time_info: context.compile_time_info(),
+                ..options.clone()
             }),
         )
         .into(),
@@ -290,22 +284,20 @@ impl ModuleAssetContextVc {
                         }
                         ModuleRuleEffect::AddEcmascriptTransforms(additional_transforms) => {
                             current_module_type = match current_module_type {
-                                Some(ModuleType::Ecmascript {
-                                    transforms,
-                                    options,
-                                }) => Some(ModuleType::Ecmascript {
-                                    transforms: transforms.extend(*additional_transforms),
-                                    options,
-                                }),
-                                Some(ModuleType::Typescript(transforms)) => {
-                                    Some(ModuleType::Typescript(
-                                        transforms.extend(*additional_transforms),
-                                    ))
+                                Some(ModuleType::Ecmascript { mut options }) => {
+                                    options.transforms =
+                                        options.transforms.extend(*additional_transforms);
+                                    Some(ModuleType::Ecmascript { options })
                                 }
-                                Some(ModuleType::TypescriptWithTypes(transforms)) => {
-                                    Some(ModuleType::TypescriptWithTypes(
-                                        transforms.extend(*additional_transforms),
-                                    ))
+                                Some(ModuleType::Typescript { mut options }) => {
+                                    options.transforms =
+                                        options.transforms.extend(*additional_transforms);
+                                    Some(ModuleType::Typescript { options })
+                                }
+                                Some(ModuleType::TypescriptWithTypes { mut options }) => {
+                                    options.transforms =
+                                        options.transforms.extend(*additional_transforms);
+                                    Some(ModuleType::TypescriptWithTypes { options })
                                 }
                                 Some(module_type) => {
                                     ModuleIssue {

--- a/crates/turbopack/src/lib.rs
+++ b/crates/turbopack/src/lib.rs
@@ -127,7 +127,7 @@ async fn apply_module_type(
             context.into(),
             Value::new(EcmascriptModuleAssetType::Typescript),
             Value::new(EcmascriptOptions {
-                compile_time_info: context.compile_time_info(),
+                compile_time_info: Some(context.compile_time_info()),
                 ..options.clone()
             }),
         )
@@ -137,7 +137,7 @@ async fn apply_module_type(
             context.with_types_resolving_enabled().into(),
             Value::new(EcmascriptModuleAssetType::TypescriptWithTypes),
             Value::new(EcmascriptOptions {
-                compile_time_info: context.compile_time_info(),
+                compile_time_info: Some(context.compile_time_info()),
                 ..options.clone()
             }),
         )
@@ -147,7 +147,7 @@ async fn apply_module_type(
             context.with_types_resolving_enabled().into(),
             Value::new(EcmascriptModuleAssetType::TypescriptDeclaration),
             Value::new(EcmascriptOptions {
-                compile_time_info: context.compile_time_info(),
+                compile_time_info: Some(context.compile_time_info()),
                 ..options.clone()
             }),
         )

--- a/crates/turbopack/src/lib.rs
+++ b/crates/turbopack/src/lib.rs
@@ -104,10 +104,7 @@ async fn apply_module_type(
     part: Option<ModulePartVc>,
 ) -> Result<AssetVc> {
     Ok(match &*module_type.await? {
-        ModuleType::Ecmascript {
-            transforms,
-            options,
-        } => {
+        ModuleType::Ecmascript { options } => {
             let base = EcmascriptModuleAssetVc::new(
                 source,
                 context.into(),
@@ -125,7 +122,7 @@ async fn apply_module_type(
 
             base.into()
         }
-        ModuleType::Typescript(transforms) => EcmascriptModuleAssetVc::new(
+        ModuleType::Typescript { options } => EcmascriptModuleAssetVc::new(
             source,
             context.into(),
             Value::new(EcmascriptModuleAssetType::Typescript),

--- a/crates/turbopack/src/lib.rs
+++ b/crates/turbopack/src/lib.rs
@@ -17,7 +17,7 @@ use css::{CssModuleAssetVc, ModuleCssModuleAssetVc};
 use ecmascript::{
     tree_shake::asset::EcmascriptModulePartAssetVc,
     typescript::resolve::TypescriptTypesAssetReferenceVc, EcmascriptModuleAssetType,
-    EcmascriptModuleAssetVc,
+    EcmascriptModuleAssetVc, EcmascriptOptions,
 };
 use graph::{aggregate, AggregatedGraphNodeContent, AggregatedGraphVc};
 use module_options::{
@@ -112,9 +112,7 @@ async fn apply_module_type(
                 source,
                 context.into(),
                 Value::new(EcmascriptModuleAssetType::Ecmascript),
-                *transforms,
                 Value::new(*options),
-                context.compile_time_info(),
             );
 
             if options.split_into_parts {
@@ -131,27 +129,36 @@ async fn apply_module_type(
             source,
             context.into(),
             Value::new(EcmascriptModuleAssetType::Typescript),
-            *transforms,
-            Value::new(Default::default()),
-            context.compile_time_info(),
+            Value::new(EcmascriptOptions {
+                split_into_parts: false,
+                import_parts: false,
+                transforms: *transforms,
+                compile_time_info: context.compile_time_info(),
+            }),
         )
         .into(),
         ModuleType::TypescriptWithTypes(transforms) => EcmascriptModuleAssetVc::new(
             source,
             context.with_types_resolving_enabled().into(),
             Value::new(EcmascriptModuleAssetType::TypescriptWithTypes),
-            *transforms,
-            Value::new(Default::default()),
-            context.compile_time_info(),
+            Value::new(EcmascriptOptions {
+                split_into_parts: false,
+                import_parts: false,
+                transforms: *transforms,
+                compile_time_info: context.compile_time_info(),
+            }),
         )
         .into(),
         ModuleType::TypescriptDeclaration(transforms) => EcmascriptModuleAssetVc::new(
             source,
             context.with_types_resolving_enabled().into(),
             Value::new(EcmascriptModuleAssetType::TypescriptDeclaration),
-            *transforms,
-            Value::new(Default::default()),
-            context.compile_time_info(),
+            Value::new(EcmascriptOptions {
+                split_into_parts: false,
+                import_parts: false,
+                transforms: *transforms,
+                compile_time_info: context.compile_time_info(),
+            }),
         )
         .into(),
         ModuleType::Json => JsonModuleAssetVc::new(source).into(),

--- a/crates/turbopack/src/module_options/mod.rs
+++ b/crates/turbopack/src/module_options/mod.rs
@@ -133,11 +133,6 @@ impl ModuleOptionsVc {
             });
         }
 
-        let ecmascript_options = EcmascriptOptions {
-            split_into_parts: enable_tree_shaking,
-            import_parts: enable_tree_shaking,
-        };
-
         if let Some(env) = preset_env_versions {
             transforms.push(EcmascriptInputTransform::PresetEnv(env));
         }
@@ -222,6 +217,13 @@ impl ModuleOptionsVc {
             .chain(transforms.iter().cloned())
             .collect(),
         );
+
+        let ecmascript_options = EcmascriptOptions {
+            split_into_parts: enable_tree_shaking,
+            import_parts: enable_tree_shaking,
+            transforms: app_transforms,
+            compile_time_info,
+        };
 
         let mut rules = vec![
             ModuleRule::new(

--- a/crates/turbopack/src/module_options/mod.rs
+++ b/crates/turbopack/src/module_options/mod.rs
@@ -81,6 +81,7 @@ impl ModuleOptionsVc {
             ref custom_rules,
             execution_context,
             ref rules,
+            compile_time_info,
             ..
         } = *context.await?;
         if !rules.is_empty() {

--- a/crates/turbopack/src/module_options/mod.rs
+++ b/crates/turbopack/src/module_options/mod.rs
@@ -299,15 +299,30 @@ impl ModuleOptionsVc {
                     ModuleRuleCondition::ResourcePathEndsWith(".tsx".to_string()),
                 ]),
                 vec![if enable_types {
-                    ModuleRuleEffect::ModuleType(ModuleType::TypescriptWithTypes(ts_app_transforms))
+                    ModuleRuleEffect::ModuleType(ModuleType::TypescriptWithTypes {
+                        options: EcmascriptOptions {
+                            transforms: ts_app_transforms,
+                            ..ecmascript_options.clone()
+                        },
+                    })
                 } else {
-                    ModuleRuleEffect::ModuleType(ModuleType::Typescript(ts_app_transforms))
+                    ModuleRuleEffect::ModuleType(ModuleType::Typescript {
+                        options: EcmascriptOptions {
+                            transforms: ts_app_transforms,
+                            ..ecmascript_options.clone()
+                        },
+                    })
                 }],
             ),
             ModuleRule::new(
                 ModuleRuleCondition::ResourcePathEndsWith(".d.ts".to_string()),
                 vec![ModuleRuleEffect::ModuleType(
-                    ModuleType::TypescriptDeclaration(vendor_transforms),
+                    ModuleType::TypescriptDeclaration {
+                        options: EcmascriptOptions {
+                            transforms: vendor_transforms,
+                            ..ecmascript_options.clone()
+                        },
+                    },
                 )],
             ),
             ModuleRule::new(

--- a/crates/turbopack/src/module_options/mod.rs
+++ b/crates/turbopack/src/module_options/mod.rs
@@ -278,21 +278,18 @@ impl ModuleOptionsVc {
                     ModuleRuleCondition::ResourcePathEndsWith(".jsx".to_string()),
                 ]),
                 vec![ModuleRuleEffect::ModuleType(ModuleType::Ecmascript {
-                    transforms: app_transforms,
                     options: ecmascript_options.clone(),
                 })],
             ),
             ModuleRule::new(
                 ModuleRuleCondition::ResourcePathEndsWith(".mjs".to_string()),
                 vec![ModuleRuleEffect::ModuleType(ModuleType::Ecmascript {
-                    transforms: app_transforms,
                     options: ecmascript_options.clone(),
                 })],
             ),
             ModuleRule::new(
                 ModuleRuleCondition::ResourcePathEndsWith(".cjs".to_string()),
                 vec![ModuleRuleEffect::ModuleType(ModuleType::Ecmascript {
-                    transforms: app_transforms,
                     options: ecmascript_options.clone(),
                 })],
             ),
@@ -331,8 +328,10 @@ impl ModuleOptionsVc {
             ModuleRule::new(
                 ModuleRuleCondition::ResourcePathHasNoExtension,
                 vec![ModuleRuleEffect::ModuleType(ModuleType::Ecmascript {
-                    transforms: vendor_transforms,
-                    options: ecmascript_options.clone(),
+                    options: EcmascriptOptions {
+                        transforms: vendor_transforms,
+                        ..ecmascript_options.clone()
+                    },
                 })],
             ),
             ModuleRule::new(
@@ -390,7 +389,6 @@ impl ModuleOptionsVc {
                     ]),
                     vec![
                         ModuleRuleEffect::ModuleType(ModuleType::Ecmascript {
-                            transforms: app_transforms,
                             options: ecmascript_options.clone(),
                         }),
                         ModuleRuleEffect::SourceTransforms(SourceTransformsVc::cell(vec![

--- a/crates/turbopack/src/module_options/module_options_context.rs
+++ b/crates/turbopack/src/module_options/module_options_context.rs
@@ -1,7 +1,10 @@
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use turbo_tasks::trace::TraceRawVcs;
-use turbopack_core::{environment::EnvironmentVc, resolve::options::ImportMappingVc};
+use turbopack_core::{
+    compile_time_info::CompileTimeInfoVc, environment::EnvironmentVc,
+    resolve::options::ImportMappingVc,
+};
 use turbopack_ecmascript::EcmascriptInputTransform;
 use turbopack_ecmascript_plugins::transform::emotion::EmotionTransformConfigVc;
 use turbopack_node::{

--- a/crates/turbopack/src/module_options/module_options_context.rs
+++ b/crates/turbopack/src/module_options/module_options_context.rs
@@ -204,6 +204,8 @@ pub struct ModuleOptionsContext {
     pub placeholder_for_future_extensions: (),
     #[serde(default)]
     pub enable_tree_shaking: bool,
+
+    pub compile_time_info: CompileTimeInfoVc,
 }
 
 #[turbo_tasks::value_impl]

--- a/crates/turbopack/src/module_options/module_options_context.rs
+++ b/crates/turbopack/src/module_options/module_options_context.rs
@@ -208,7 +208,8 @@ pub struct ModuleOptionsContext {
     #[serde(default)]
     pub enable_tree_shaking: bool,
 
-    pub compile_time_info: CompileTimeInfoVc,
+    #[serde(default)]
+    pub compile_time_info: Option<CompileTimeInfoVc>,
 }
 
 #[turbo_tasks::value_impl]

--- a/crates/turbopack/src/module_options/module_rule.rs
+++ b/crates/turbopack/src/module_options/module_rule.rs
@@ -50,13 +50,17 @@ pub enum ModuleRuleEffect {
 #[derive(PartialOrd, Ord, Hash, Debug, Copy, Clone)]
 pub enum ModuleType {
     Ecmascript {
-        transforms: EcmascriptInputTransformsVc,
-        #[turbo_tasks(trace_ignore)]
         options: EcmascriptOptions,
     },
-    Typescript(EcmascriptInputTransformsVc),
-    TypescriptWithTypes(EcmascriptInputTransformsVc),
-    TypescriptDeclaration(EcmascriptInputTransformsVc),
+    Typescript {
+        options: EcmascriptOptions,
+    },
+    TypescriptWithTypes {
+        options: EcmascriptOptions,
+    },
+    TypescriptDeclaration {
+        options: EcmascriptOptions,
+    },
     Json,
     Raw,
     Mdx {


### PR DESCRIPTION
### Description

This PR reflects feedback from #3338. (https://github.com/vercel/turbo/pull/3338#discussion_r1138234264)

 - Closes WEB-726
 - Next.js counterpart: https://github.com/vercel/next.js/pull/48512

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
