### PR TITLE
More fluent GraphTraversal API

### DIFF
--- a/crates/turbo-tasks/src/graph/graph_traversal.rs
+++ b/crates/turbo-tasks/src/graph/graph_traversal.rs
@@ -3,39 +3,54 @@ use std::{future::Future, pin::Pin};
 use anyhow::Result;
 use futures::{stream::FuturesUnordered, Stream};
 
-use super::{graph_store::GraphStore, with_future::With, Visit, VisitControlFlow};
+use super::{
+    graph_store::{GraphNode, GraphStore},
+    with_future::With,
+    SkipDuplicates, Visit, VisitControlFlow,
+};
 
 /// [`GraphTraversal`] is a utility type that can be used to traverse a graph of
 /// nodes, where each node can have a variable number of outgoing edges. The
 /// traversal is done in parallel, and the order of the nodes in the traversal
 /// result is determined by the [`GraphStore`] parameter.
-pub struct GraphTraversal<Store> {
-    _store: std::marker::PhantomData<Store>,
+pub trait GraphTraversal: GraphStore + Sized {
+    fn visit<RootEdgesIt, VisitImpl, Abort, Impl>(
+        self,
+        root_edges: RootEdgesIt,
+        visit: VisitImpl,
+    ) -> GraphTraversalFuture<Self, VisitImpl, Abort, Impl>
+    where
+        VisitImpl: Visit<Self::Node, Abort, Impl>,
+        RootEdgesIt: IntoIterator<Item = VisitImpl::Edge>;
+
+    fn skip_duplicates(self) -> SkipDuplicates<Self>;
 }
 
-impl<Store> GraphTraversal<Store> {
+impl<Store> GraphTraversal for Store
+where
+    Store: GraphStore,
+{
     /// Visits the graph starting from the given `roots`, and returns a future
     /// that will resolve to the traversal result.
-    pub fn visit<Node, RootEdgesIt, VisitImpl, Abort, Impl>(
+    fn visit<RootEdgesIt, VisitImpl, Abort, Impl>(
+        mut self,
         root_edges: RootEdgesIt,
         mut visit: VisitImpl,
-    ) -> GraphTraversalFuture<Node, Store, VisitImpl, Abort, Impl>
+    ) -> GraphTraversalFuture<Self, VisitImpl, Abort, Impl>
     where
-        Store: GraphStore<Node>,
-        VisitImpl: Visit<Node, Abort, Impl>,
+        VisitImpl: Visit<Self::Node, Abort, Impl>,
         RootEdgesIt: IntoIterator<Item = VisitImpl::Edge>,
     {
-        let mut store = Store::default();
         let futures = FuturesUnordered::new();
         for edge in root_edges {
             match visit.visit(edge) {
                 VisitControlFlow::Continue(node) => {
-                    if let Some((parent_handle, node_ref)) = store.insert(None, node) {
+                    if let Some((parent_handle, node_ref)) = self.insert(None, GraphNode(node)) {
                         futures.push(With::new(visit.edges(node_ref), parent_handle));
                     }
                 }
                 VisitControlFlow::Skip(node) => {
-                    store.insert(None, node);
+                    self.insert(None, GraphNode(node));
                 }
                 VisitControlFlow::Abort(abort) => {
                     return GraphTraversalFuture {
@@ -46,42 +61,46 @@ impl<Store> GraphTraversal<Store> {
         }
         GraphTraversalFuture {
             state: GraphTraversalState::Running(GraphTraversalRunningState {
-                store,
+                store: self,
                 futures,
                 visit,
             }),
         }
     }
+
+    fn skip_duplicates(self) -> SkipDuplicates<Self> {
+        SkipDuplicates::new(self)
+    }
 }
 
 /// A future that resolves to a [`GraphStore`] containing the result of a graph
 /// traversal.
-pub struct GraphTraversalFuture<Node, Store, VisitImpl, Abort, Impl>
+pub struct GraphTraversalFuture<Store, VisitImpl, Abort, Impl>
 where
-    Store: GraphStore<Node>,
-    VisitImpl: Visit<Node, Abort, Impl>,
+    Store: GraphStore,
+    VisitImpl: Visit<Store::Node, Abort, Impl>,
 {
-    state: GraphTraversalState<Node, Store, VisitImpl, Abort, Impl>,
+    state: GraphTraversalState<Store, VisitImpl, Abort, Impl>,
 }
 
 #[derive(Default)]
-enum GraphTraversalState<Node, Store, VisitImpl, Abort, Impl>
+enum GraphTraversalState<Store, VisitImpl, Abort, Impl>
 where
-    Store: GraphStore<Node>,
-    VisitImpl: Visit<Node, Abort, Impl>,
+    Store: GraphStore,
+    VisitImpl: Visit<Store::Node, Abort, Impl>,
 {
     #[default]
     Completed,
     Aborted {
         abort: Abort,
     },
-    Running(GraphTraversalRunningState<Node, Store, VisitImpl, Abort, Impl>),
+    Running(GraphTraversalRunningState<Store, VisitImpl, Abort, Impl>),
 }
 
-struct GraphTraversalRunningState<Node, Store, VisitImpl, Abort, Impl>
+struct GraphTraversalRunningState<Store, VisitImpl, Abort, Impl>
 where
-    Store: GraphStore<Node>,
-    VisitImpl: Visit<Node, Abort, Impl>,
+    Store: GraphStore,
+    VisitImpl: Visit<Store::Node, Abort, Impl>,
 {
     store: Store,
     futures: FuturesUnordered<With<VisitImpl::EdgesFuture, Store::Handle>>,
@@ -102,11 +121,10 @@ impl<Completed> GraphTraversalResult<Completed, !> {
     }
 }
 
-impl<Node, Store, VisitImpl, Abort, Impl> Future
-    for GraphTraversalFuture<Node, Store, VisitImpl, Abort, Impl>
+impl<Store, VisitImpl, Abort, Impl> Future for GraphTraversalFuture<Store, VisitImpl, Abort, Impl>
 where
-    Store: GraphStore<Node>,
-    VisitImpl: Visit<Node, Abort, Impl>,
+    Store: GraphStore,
+    VisitImpl: Visit<Store::Node, Abort, Impl>,
 {
     type Output = GraphTraversalResult<Result<Store>, Abort>;
 
@@ -132,8 +150,9 @@ where
                         for edge in edges {
                             match running.visit.visit(edge) {
                                 VisitControlFlow::Continue(node) => {
-                                    if let Some((node_handle, node_ref)) =
-                                        running.store.insert(Some(parent_handle.clone()), node)
+                                    if let Some((node_handle, node_ref)) = running
+                                        .store
+                                        .insert(Some(parent_handle.clone()), GraphNode(node))
                                     {
                                         running.futures.push(With::new(
                                             running.visit.edges(node_ref),
@@ -142,7 +161,9 @@ where
                                     }
                                 }
                                 VisitControlFlow::Skip(node) => {
-                                    running.store.insert(Some(parent_handle.clone()), node);
+                                    running
+                                        .store
+                                        .insert(Some(parent_handle.clone()), GraphNode(node));
                                 }
                                 VisitControlFlow::Abort(abort) => {
                                     break 'outer (

--- a/crates/turbo-tasks/src/graph/non_deterministic.rs
+++ b/crates/turbo-tasks/src/graph/non_deterministic.rs
@@ -1,4 +1,4 @@
-use super::graph_store::GraphStore;
+use super::graph_store::{GraphNode, GraphStore};
 
 /// A graph traversal that does not guarantee any particular order, and may not
 /// return the same order every time it is run.
@@ -8,19 +8,26 @@ pub struct NonDeterministic<T> {
 
 impl<T> Default for NonDeterministic<T> {
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T> NonDeterministic<T> {
+    pub fn new() -> Self {
         Self { output: Vec::new() }
     }
 }
 
-impl<T> GraphStore<T> for NonDeterministic<T> {
+impl<T> GraphStore for NonDeterministic<T> {
+    type Node = T;
     type Handle = ();
 
     fn insert(
         &mut self,
         _from_handle: Option<Self::Handle>,
-        node: T,
+        node: GraphNode<T>,
     ) -> Option<(Self::Handle, &T)> {
-        self.output.push(node);
+        self.output.push(node.into_node());
         Some(((), self.output.last().unwrap()))
     }
 }

--- a/crates/turbo-tasks/src/graph/reverse_topological.rs
+++ b/crates/turbo-tasks/src/graph/reverse_topological.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
-use super::graph_store::GraphStore;
+use super::graph_store::{GraphNode, GraphStore};
 
 /// A graph traversal that returns nodes in reverse topological order.
 pub struct ReverseTopological<T>
@@ -16,6 +16,15 @@ where
     T: Eq + std::hash::Hash + Clone,
 {
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T> ReverseTopological<T>
+where
+    T: Eq + std::hash::Hash + Clone,
+{
+    pub fn new() -> Self {
         Self {
             adjacency_map: HashMap::new(),
             roots: Vec::new(),
@@ -23,13 +32,14 @@ where
     }
 }
 
-impl<T> GraphStore<T> for ReverseTopological<T>
+impl<T> GraphStore for ReverseTopological<T>
 where
     T: Eq + std::hash::Hash + Clone,
 {
+    type Node = T;
     type Handle = T;
 
-    fn insert(&mut self, from_handle: Option<T>, node: T) -> Option<(Self::Handle, &T)> {
+    fn insert(&mut self, from_handle: Option<T>, node: GraphNode<T>) -> Option<(Self::Handle, &T)> {
         let vec = if let Some(from_handle) = from_handle {
             self.adjacency_map
                 .entry(from_handle)
@@ -38,8 +48,8 @@ where
             &mut self.roots
         };
 
-        vec.push(node.clone());
-        Some((node, vec.last().unwrap()))
+        vec.push(node.node().clone());
+        Some((node.into_node(), vec.last().unwrap()))
     }
 }
 

--- a/crates/turbopack-core/src/chunk/mod.rs
+++ b/crates/turbopack-core/src/chunk/mod.rs
@@ -562,10 +562,9 @@ where
         _phantom: PhantomData,
     };
 
-    let GraphTraversalResult::Completed(traversal_result) =
-        GraphTraversal::<ReverseTopological<_>>::visit(root_edges, visit).await else {
-            return Ok(None);
-        };
+    let GraphTraversalResult::Completed(traversal_result) = ReverseTopological::new().visit(root_edges, visit).await else {
+        return Ok(None);
+    };
 
     let graph_nodes: Vec<_> = traversal_result?.into_iter().collect();
 

--- a/crates/turbopack-node/src/lib.rs
+++ b/crates/turbopack-node/src/lib.rs
@@ -10,7 +10,7 @@ pub use node_entry::{
     NodeEntry, NodeEntryVc, NodeRenderingEntriesVc, NodeRenderingEntry, NodeRenderingEntryVc,
 };
 use turbo_tasks::{
-    graph::{GraphTraversal, ReverseTopological, SkipDuplicates},
+    graph::{GraphTraversal, ReverseTopological},
     CompletionVc, CompletionsVc, TryJoinIterExt, ValueToString,
 };
 use turbo_tasks_env::{ProcessEnv, ProcessEnvVc};
@@ -170,13 +170,12 @@ async fn separate_assets(
             .await
     };
 
-    let graph = GraphTraversal::<SkipDuplicates<ReverseTopological<Type>, _>>::visit(
-        once(Type::Internal(intermediate_asset)),
-        get_asset_children,
-    )
-    .await
-    .completed()?
-    .into_inner();
+    let graph = ReverseTopological::new()
+        .skip_duplicates()
+        .visit(once(Type::Internal(intermediate_asset)), get_asset_children)
+        .await
+        .completed()?
+        .into_inner();
 
     let mut internal_assets = IndexSet::new();
     let mut external_asset_entrypoints = IndexSet::new();


### PR DESCRIPTION
### Description

This PR refactors the API of `GraphTraversal` to be more fluent, and less magical. It should make it easier to use and understand. Had this in store from trying to debug a lifetime issue in another branch.

### Testing Instructions

Surface-level change.

Next.js PR: https://github.com/vercel/turbo/pulls/alexkirsz