### PR TITLE
Make find_up use os.ReadDir

### DIFF
--- a/cli/internal/turbopath/find_up.go
+++ b/cli/internal/turbopath/find_up.go
@@ -1,17 +1,12 @@
 package turbopath
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
 
-type readDir func(string) ([]os.FileInfo, error)
-
-var defaultReadDir readDir = ioutil.ReadDir
-
-func hasFile(name, dir string, readdir readDir) (bool, error) {
-	files, err := readdir(dir)
+func hasFile(name, dir string) (bool, error) {
+	files, err := os.ReadDir(dir)
 
 	if err != nil {
 		return false, err
@@ -26,9 +21,9 @@ func hasFile(name, dir string, readdir readDir) (bool, error) {
 	return false, nil
 }
 
-func findupFrom(name, dir string, readdir readDir) (string, error) {
+func findupFrom(name, dir string) (string, error) {
 	for {
-		found, err := hasFile(name, dir, readdir)
+		found, err := hasFile(name, dir)
 
 		if err != nil {
 			return "", err
@@ -48,8 +43,8 @@ func findupFrom(name, dir string, readdir readDir) (string, error) {
 	}
 }
 
-// Recursively find a file by walking up parents in the file tree
+// FindupFrom Recursively finds a file by walking up parents in the file tree
 // starting from a specific directory.
 func FindupFrom(name, dir string) (string, error) {
-	return findupFrom(name, dir, defaultReadDir)
+	return findupFrom(name, dir)
 }


### PR DESCRIPTION
`ioutil.ReadDir` amazingly calls `os.Open` on every single file in a folder. This makes it likely to trigger spurious permission errors for things we don't care about.

This change switches to use `os.ReadDir` which operates on `fs.DirEntry`s instead. Tests pre-existing in `AbsoluteSystemPath` and still pass.

Closes #4563