### PR TITLE
fix(turbo-utils): package manager available

### DIFF
--- a/packages/turbo-utils/src/managers.ts
+++ b/packages/turbo-utils/src/managers.ts
@@ -37,7 +37,7 @@ async function getVersion(
 async function getAvailablePackageManagers(): Promise<
   Record<PackageManager, PackageManagerAvailable>
 > {
-  const [yarn, pnpm, npm] = await Promise.all([
+  const [yarn, npm, pnpm] = await Promise.all([
     getVersion("yarnpkg"),
     getVersion("npm"),
     getVersion("pnpm"),


### PR DESCRIPTION
### Description

Fixes incorrect yarn / pnpm / npm available check.

