### PR TITLE
exclude turborepo from turbopack bench tests

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -8,11 +8,12 @@ linker = "rust-lld"
 xtask = "run --package xtask --"
 tr-build = "build -p turbo"
 tr-run = "run -p turbo"
-tr-test = "test -p turborepo-lib -p turborepo-scm -p turborepo-lockfiles -p turbopath -p turborepo-api-client -p vercel-api-mock --features rustls-tls"
+tr-test = "test -p turborepo-* -p turbopath -p vercel-api-mock --features rustls-tls"
 tr-check = "check -p turbo -p vercel-api-mock"
 # Builds all test code to check for compiler errors before running
-tp-pre-test = "nextest run --no-run --workspace --release --exclude turbo --exclude turborepo-ffi --exclude turborepo-lib --exclude turborepo-scm --exclude turbopath --exclude turborepo-lockfiles --exclude turborepo-api-client --exclude vercel-api-mock"
-tp-test = "nextest run --workspace --release --no-fail-fast --exclude turbo --exclude turborepo-ffi --exclude turborepo-lib --exclude turborepo-scm --exclude turbopath --exclude turborepo-lockfiles --exclude turborepo-api-client --exclude vercel-api-mock"
+tp-pre-test = "nextest run --no-run --workspace --release --exclude turbo --exclude turborepo-* --exclude turbopath --exclude vercel-api-mock"
+tp-test = "nextest run --workspace --release --no-fail-fast --exclude turbo --exclude turborepo-* --exclude turbopath --exclude vercel-api-mock"
+tp-bench-test = "test --benches --workspace --release --no-fail-fast --exclude turbopack-bench --exclude turbo --exclude turborepo-* --exclude turbopath --exclude vercel-api-mock"
 
 [target.'cfg(all())']
 rustflags = ["--cfg", "tokio_unstable", "-Csymbol-mangling-version=v0", "-Aclippy::too_many_arguments"]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -751,12 +751,12 @@ jobs:
       - name: Build benchmarks for tests
         timeout-minutes: 120
         run: |
-          cargo test --benches --release --workspace --exclude turbopack-bench --no-run
+          cargo tp-bench-test --no-run
 
       - name: Run cargo test on benchmarks
         timeout-minutes: 120
         run: |
-          cargo test --benches --release --workspace --exclude turbopack-bench
+          cargo tp-bench-test
 
       - name: Build benchmarks for tests for other bundlers
         if: needs.determine_jobs.outputs.turbopack_bench == 'true'


### PR DESCRIPTION
### Description

avoid running benchmark tests for turborepo when testing turbopack