### PR TITLE
Disable cargo-sweep install when setting up turborepo environment

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -4,7 +4,6 @@ inputs:
   target:
     description: "Compilation target"
     required: true
-
   targets:
     description: "Comma-separated list of target triples to install for this toolchain"
     required: false
@@ -22,6 +21,10 @@ inputs:
     description: "Determiners whether the cache should be saved. If `false`, the cache is only restored."
     required: false
     default: "false"
+  install-cargo-sweep:
+    description: "Whether to install cargo-sweep"
+    required: false
+    default: true
 
 runs:
   using: "composite"

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -69,7 +69,7 @@ runs:
         save-if: ${{ github.ref == 'refs/heads/main' && inputs.save-cache || 'false' }}
 
     - name: "Install cargo-sweep"
-      if: ${{ inputs.install-cargo-swee }} == "true"
+      if: ${{ inputs.install-cargo-sweep }} == "true"
       uses: baptiste0928/cargo-install@v1
       with:
         crate: cargo-sweep

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -69,9 +69,11 @@ runs:
         save-if: ${{ github.ref == 'refs/heads/main' && inputs.save-cache || 'false' }}
 
     - name: "Install cargo-sweep"
+      if: ${{ inputs.install-cargo-swee }} == "true"
       uses: baptiste0928/cargo-install@v1
       with:
         crate: cargo-sweep
 
     - name: "Run cargo-sweep"
+      if: ${{ inputs.install-cargo-sweep }} == "true"
       uses: ./.github/actions/cargo-sweep

--- a/.github/actions/setup-turborepo-environment/action.yml
+++ b/.github/actions/setup-turborepo-environment/action.yml
@@ -25,3 +25,4 @@ runs:
         shared-cache-key: turborepo-debug-build
         cache-key: ${{ inputs.target }}
         save-cache: true
+        install-cargo-sweep: false


### PR DESCRIPTION
This is very slow and affects turborepo test suites