### PR TITLE
Invoke turborepo tests via global turbo

### DIFF
--- a/.github/actions/setup-turborepo-environment/action.yml
+++ b/.github/actions/setup-turborepo-environment/action.yml
@@ -26,4 +26,6 @@ runs:
         cache-key: ${{ inputs.target }}
         save-cache: true
         install-cargo-sweep: false
-    - run: npm i -g turbo@canary
+    - name: Install Turbo globally
+      shell: bash
+      run: npm i -g turbo@canary

--- a/.github/actions/setup-turborepo-environment/action.yml
+++ b/.github/actions/setup-turborepo-environment/action.yml
@@ -26,5 +26,4 @@ runs:
         cache-key: ${{ inputs.target }}
         save-cache: true
         install-cargo-sweep: false
-    - name: "Install global turbo"
-      run: npm i -g turbo@canary
+    - run: npm i -g turbo@canary

--- a/.github/actions/setup-turborepo-environment/action.yml
+++ b/.github/actions/setup-turborepo-environment/action.yml
@@ -26,3 +26,5 @@ runs:
         cache-key: ${{ inputs.target }}
         save-cache: true
         install-cargo-sweep: false
+    - name: "Install global turbo"
+      run: npm i -g turbo@canary

--- a/.github/workflows/pr-js-tests-filtered.yml
+++ b/.github/workflows/pr-js-tests-filtered.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Run tests
         run: |
-          pnpm -- turbo run check-types test --filter=...[${{ github.event.pull_request.base.sha || 'HEAD^1' }}] --filter=!cli --color
+          turbo run check-types test --filter=...[${{ github.event.pull_request.base.sha || 'HEAD^1' }}] --filter=!cli --color
 
   cleanup:
     name: Cleanup

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -239,7 +239,7 @@ jobs:
           target: ${{ matrix.os.name }}
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      - run: pnpm -- turbo run test --filter=cli --color
+      - run: turbo run test --filter=cli --color
 
   go_integration:
     name: Go Integration Tests
@@ -268,7 +268,7 @@ jobs:
           key: prysk-venv-${{ matrix.os.name }}
 
       - name: Integration Tests
-        run: pnpm test -- --filter=turborepo-tests-integration
+        run: turbo run test --filter=turborepo-tests-integration
         env:
           GO_TAG: rust
 
@@ -296,7 +296,7 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: E2E Tests
-        run: pnpm -- turbo run test --filter=turborepo-tests-e2e
+        run: turbo run test --filter=turborepo-tests-e2e
 
   go_examples:
     name: Go Cli Examples
@@ -394,7 +394,7 @@ jobs:
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
           TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
           TURBO_REMOTE_ONLY: true
-        run: pnpm -- turbo run test --filter="turborepo-tests-examples" -- "${{ matrix.example }}" "${{ matrix.manager }}"
+        run: turbo run test --filter="turborepo-tests-examples" -- "${{ matrix.example }}" "${{ matrix.manager }}"
 
   rust_prepare:
     name: Check rust crates
@@ -1115,7 +1115,7 @@ jobs:
         # This is the syntax for running the `//#lint` task specifically in turbo.json
         # It runs the taplo check on taplo.toml, and prettier check across the whole repo.
         # TODO: run prettier in individual workspaces instead of globally.
-        run: pnpm -- turbo run lint --filter=//
+        run: turbo run lint --filter=//
 
   final:
     name: Ok

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,9 @@ brew install moreutils jq zstd # (moreutils is for sponge)
 
 #### Go Tests
 
-From the root directory, you can run:
+First: `npm install -g turbo`.
+
+Then from the root directory, you can run:
 
 - Go unit tests
   ```bash

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "build": "turbo run build --filter=docs",
+    "build": "pnpm -- turbo run build --filter=docs",
     "build:turbo": "pnpm run --filter=cli build",
     "build:ts": "tsc -b tsconfig.project.json",
     "check:prettier": "prettier -c .",
@@ -12,7 +12,9 @@
     "format:prettier": "prettier -w .",
     "format:rs": "cargo fmt --all",
     "format:toml": "taplo format",
-    "docs": "turbo run dev --filter=docs --no-cache",
+    "turbo": "pnpm run build:turbo && node turbow.js",
+    "turbo-prebuilt": "node turbow.js",
+    "docs": "pnpm -- turbo run dev --filter=docs --no-cache",
     "prepare": "husky install",
     "test": "turbo run test"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "build": "pnpm -- turbo run build --filter=docs",
+    "build": "turbo run build --filter=docs",
     "build:turbo": "pnpm run --filter=cli build",
     "build:ts": "tsc -b tsconfig.project.json",
     "check:prettier": "prettier -c .",
@@ -12,11 +12,9 @@
     "format:prettier": "prettier -w .",
     "format:rs": "cargo fmt --all",
     "format:toml": "taplo format",
-    "turbo": "pnpm run build:turbo && node turbow.js",
-    "turbo-prebuilt": "node turbow.js",
-    "docs": "pnpm -- turbo run dev --filter=docs --no-cache",
+    "docs": "turbo run dev --filter=docs --no-cache",
     "prepare": "husky install",
-    "test": "pnpm -- turbo run test"
+    "test": "turbo run test"
   },
   "devDependencies": {
     "@taplo/cli": "^0.5.2",

--- a/turbo.json
+++ b/turbo.json
@@ -3,7 +3,7 @@
   "pipeline": {
     "test": {
       "outputs": ["coverage/**/*"],
-      "dependsOn": ["^build"]
+      "dependsOn": ["cli#build", "^build"]
     },
 
     // lint tasks

--- a/turborepo-tests/e2e/turbo.json
+++ b/turborepo-tests/e2e/turbo.json
@@ -2,7 +2,6 @@
   "extends": ["//"],
   "pipeline": {
     "test": {
-      "dependsOn": ["cli#build"],
       "output": []
     }
   }

--- a/turborepo-tests/e2e/turbo.json
+++ b/turborepo-tests/e2e/turbo.json
@@ -2,9 +2,7 @@
   "extends": ["//"],
   "pipeline": {
     "test": {
-      // TODO: we should have this depend on cli#build, but we first need to change
-      // how these tests are invoked.
-      "dependsOn": [],
+      "dependsOn": ["cli#build"],
       "output": []
     }
   }

--- a/turborepo-tests/examples/turbo.json
+++ b/turborepo-tests/examples/turbo.json
@@ -7,7 +7,7 @@
       "dependsOn": ["^topo"]
     },
     "test": {
-      "dependsOn": ["cli#build", "topo"],
+      "dependsOn": ["topo"],
       "outputs": []
     }
   }

--- a/turborepo-tests/integration/turbo.json
+++ b/turborepo-tests/integration/turbo.json
@@ -7,7 +7,7 @@
       "dependsOn": ["^topo"]
     },
     "test": {
-      "dependsOn": ["topo"],
+      "dependsOn": ["cli#build", "topo"],
       "env": ["GO_TAG"]
     }
   }

--- a/turborepo-tests/integration/turbo.json
+++ b/turborepo-tests/integration/turbo.json
@@ -7,7 +7,7 @@
       "dependsOn": ["^topo"]
     },
     "test": {
-      "dependsOn": ["cli#build", "topo"],
+      "dependsOn": ["topo"],
       "env": ["GO_TAG"]
     }
   }


### PR DESCRIPTION
This reduces the number of turbo builds to one, as a dependency of running tests.

this also means we may actually be able to turn on remote caching in GitHub CI and make it faster. 

The important caveat is that we have to use a published version of turbo to kick off test runs. I think this is generally a good thing because it means we use what our customers use and we become *real* customers of our own tool.

The tests themselves will continue to exercise the locally built code. (except in the case of examples tests which use the installed version in each example)

smoke tests that run post publish are not affected as they test a combination of global and local installs.