### PR TITLE
Remove smoke test before publish

### DIFF
--- a/.github/workflows/turborepo-release-step-2.yml
+++ b/.github/workflows/turborepo-release-step-2.yml
@@ -10,22 +10,7 @@ on:
         description: "Staging branch to run release from"
 
 jobs:
-  smoke-test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ inputs.release_branch }}
-      - name: Build turborepo CLI from source
-        uses: ./.github/actions/setup-turborepo-environment
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-          target: ${{ matrix.os.name }}
-      - name: Run Integration Tests
-        run: turbo run test --filter=turborepo-tests-integration
-
   darwin:
-    needs: [smoke-test]
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
@@ -59,7 +44,6 @@ jobs:
 
   # compiles linux and windows in a container
   cross:
-    needs: [smoke-test]
     runs-on: ubuntu-latest
     container:
       image: docker://ghcr.io/vercel/turbo-cross:v1.18.5

--- a/.github/workflows/turborepo-release-step-2.yml
+++ b/.github/workflows/turborepo-release-step-2.yml
@@ -21,8 +21,8 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           target: ${{ matrix.os.name }}
-      - name: Run Unit Tests
-        run: turbo run test --filter=cli --color
+      - name: Run Integration Tests
+        run: turbo run test --filter=turborepo-tests-integration
 
   darwin:
     needs: [smoke-test]


### PR DESCRIPTION
I'm not sure there's much value in running unit tests before a release and it takes about 10 minutes to run this step (e.g. https://github.com/vercel/turbo/actions/runs/4761979875) 

If we really think they can catch bugs before release, but have two arguments against:

1. We are actively writing fewer unit tests in Go as we port to Rust, so the value of these diminishes over time
2. From other parts of our team process, we expect that "`main` is always shippable". If this is true and we have the right checks in place to make sure this is true, then a smoke test before release seems unnecessary,.

The argument for keeping _some_ kind of smoke test is that multiple merges to main that are independently tested may end up breaking each other. I think this is valid reasoning, but at a cost of 10 minutes, I'm not sure it's worth the cost. 

#### Alternatives

- Keep smoke tests for patch/minor/major releases, but omit them for canary
- Instead of running the test suite, just run `make` and see if the code compiles
- Run integration tests instead of unit tests before release
- Reduce babysitting for releases, so an extra 10 minutes does not feel expensive (we are effectively waiting for full Rust port before we do this)