### PR TITLE
remove box_syntax

### DIFF
--- a/crates/turbo-tasks-fs/src/lib.rs
+++ b/crates/turbo-tasks-fs/src/lib.rs
@@ -3,7 +3,6 @@
 #![feature(min_specialization)]
 #![feature(iter_advance_by)]
 #![feature(io_error_more)]
-#![feature(box_syntax)]
 #![feature(round_char_boundary)]
 
 pub mod attach;
@@ -1684,7 +1683,7 @@ impl FileContent {
                 match serde_path_to_error::deserialize(de) {
                     Ok(data) => FileJsonContent::Content(data),
                     Err(e) => FileJsonContent::Unparseable(
-                        box UnparseableJson::from_serde_path_to_error(e),
+                        Box::new(UnparseableJson::from_serde_path_to_error(e)),
                     ),
                 }
             }
@@ -1709,10 +1708,10 @@ impl FileContent {
                             "text content doesn't contain any json data",
                         ),
                     },
-                    Err(e) => FileJsonContent::Unparseable(box UnparseableJson::from_jsonc_error(
+                    Err(e) => FileJsonContent::Unparseable(Box::new(UnparseableJson::from_jsonc_error(
                         e,
                         string.as_ref(),
-                    )),
+                    ))),
                 },
                 Err(_) => FileJsonContent::unparseable("binary is not valid utf-8 text"),
             },

--- a/crates/turbo-tasks-memory/src/lib.rs
+++ b/crates/turbo-tasks-memory/src/lib.rs
@@ -1,6 +1,5 @@
 #![feature(hash_drain_filter)]
 #![feature(option_get_or_insert_default)]
-#![feature(box_syntax)]
 #![feature(type_alias_impl_trait)]
 #![feature(lint_reasons)]
 #![feature(box_patterns)]

--- a/crates/turbo-tasks-memory/src/task.rs
+++ b/crates/turbo-tasks-memory/src/task.rs
@@ -528,10 +528,10 @@ impl Task {
         Self {
             id,
             ty,
-            state: RwLock::new(TaskMetaState::Full(box TaskState::new(
+            state: RwLock::new(TaskMetaState::Full(Box::new(TaskState::new(
                 description,
                 stats_type,
-            ))),
+            )))),
         }
     }
 
@@ -546,11 +546,11 @@ impl Task {
         Self {
             id,
             ty,
-            state: RwLock::new(TaskMetaState::Full(box TaskState::new_scheduled_in_scope(
+            state: RwLock::new(TaskMetaState::Full(Box::new(TaskState::new_scheduled_in_scope(
                 description,
                 scope,
                 stats_type,
-            ))),
+            )))),
         }
     }
 
@@ -565,11 +565,11 @@ impl Task {
         Self {
             id,
             ty,
-            state: RwLock::new(TaskMetaState::Full(box TaskState::new_scheduled_in_scope(
+            state: RwLock::new(TaskMetaState::Full(Box::new(TaskState::new_scheduled_in_scope(
                 description,
                 scope,
                 stats_type,
-            ))),
+            )))),
         }
     }
 
@@ -579,18 +579,18 @@ impl Task {
         trait_type_id: TraitTypeId,
         stats_type: StatsType,
     ) -> Self {
-        let ty = TaskType::ReadScopeCollectibles(box ReadScopeCollectiblesTaskType {
+        let ty = TaskType::ReadScopeCollectibles(Box::new(ReadScopeCollectiblesTaskType {
             scope: target_scope,
             trait_type: trait_type_id,
-        });
+        }));
         let description = Self::get_event_description_static(id, &ty);
         Self {
             id,
             ty,
-            state: RwLock::new(TaskMetaState::Full(box TaskState::new(
+            state: RwLock::new(TaskMetaState::Full(Box::new(TaskState::new(
                 description,
                 stats_type,
-            ))),
+            )))),
         }
     }
 
@@ -601,19 +601,19 @@ impl Task {
         trait_type_id: TraitTypeId,
         stats_type: StatsType,
     ) -> Self {
-        let ty = TaskType::ReadTaskCollectibles(box ReadTaskCollectiblesTaskType {
+        let ty = TaskType::ReadTaskCollectibles(Box::new(ReadTaskCollectiblesTaskType {
             task: target_task,
             trait_type: trait_type_id,
-        });
+        }));
         let description = Self::get_event_description_static(id, &ty);
         Self {
             id,
             ty,
-            state: RwLock::new(TaskMetaState::Full(box TaskState::new_root_scoped(
+            state: RwLock::new(TaskMetaState::Full(Box::new(TaskState::new_root_scoped(
                 description,
                 scope,
                 stats_type,
-            ))),
+            )))),
         }
     }
 
@@ -2787,7 +2787,7 @@ impl Task {
         if unset {
             *state = TaskMetaState::Unloaded(UnloadedTaskState { stats_type });
         } else {
-            *state = TaskMetaState::Partial(box PartialTaskState { scopes, stats_type });
+            *state = TaskMetaState::Partial(Box::new(PartialTaskState { scopes, stats_type }));
         }
         drop(state);
 

--- a/crates/turbo-tasks-memory/src/task/meta_state.rs
+++ b/crates/turbo-tasks-memory/src/task/meta_state.rs
@@ -187,7 +187,7 @@ impl<'a> TaskMetaStateWriteGuard<'a> {
                 )
                 .into_partial()
                 .unwrap();
-                *guard = TaskMetaState::Full(box partial.into_full(task.get_event_description()));
+                *guard = TaskMetaState::Full(Box::new(partial.into_full(task.get_event_description())));
             }
             TaskMetaState::Unloaded(_) => {
                 let unloaded = replace(
@@ -199,7 +199,7 @@ impl<'a> TaskMetaStateWriteGuard<'a> {
                 )
                 .into_unloaded()
                 .unwrap();
-                *guard = TaskMetaState::Full(box unloaded.into_full(task.get_event_description()));
+                *guard = TaskMetaState::Full(Box::new(unloaded.into_full(task.get_event_description())));
             }
         }
         WriteGuard::new(guard, TaskMetaState::as_full, TaskMetaState::as_full_mut)
@@ -228,7 +228,7 @@ impl<'a> TaskMetaStateWriteGuard<'a> {
                 )
                 .into_unloaded()
                 .unwrap();
-                *guard = TaskMetaState::Partial(box unloaded.into_partial());
+                *guard = TaskMetaState::Partial(Box::new(unloaded.into_partial()));
                 TaskMetaStateWriteGuard::Partial(WriteGuard::new(
                     guard,
                     TaskMetaState::as_partial,

--- a/crates/turbo-tasks-testing/src/lib.rs
+++ b/crates/turbo-tasks-testing/src/lib.rs
@@ -1,6 +1,5 @@
 //! Testing utilities and macros for turbo-tasks and applications based on it.
 
-#![feature(box_syntax)]
 
 mod macros;
 pub mod retry;

--- a/crates/turbo-tasks/src/lib.rs
+++ b/crates/turbo-tasks/src/lib.rs
@@ -28,7 +28,6 @@
 #![feature(hash_drain_filter)]
 #![deny(unsafe_op_in_unsafe_fn)]
 #![feature(result_flattening)]
-#![feature(box_syntax)]
 #![feature(error_generic_member_access)]
 #![feature(provide_any)]
 #![feature(new_uninit)]

--- a/crates/turbopack-css/src/lib.rs
+++ b/crates/turbopack-css/src/lib.rs
@@ -1,6 +1,5 @@
 #![feature(min_specialization)]
 #![feature(box_patterns)]
-#![feature(box_syntax)]
 #![feature(iter_intersperse)]
 #![feature(int_roundings)]
 

--- a/crates/turbopack-ecmascript/src/analyzer/builtin.rs
+++ b/crates/turbopack-ecmascript/src/analyzer/builtin.rs
@@ -74,7 +74,7 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
                 *value = JsValue::alternatives(
                     take(alts)
                         .into_iter()
-                        .map(|alt| JsValue::member(box alt, prop.clone()))
+                        .map(|alt| JsValue::member(Box::new(alt), prop.clone()))
                         .collect(),
                 );
                 true
@@ -87,7 +87,7 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
             } => {
                 fn items_to_alternatives(items: &mut Vec<JsValue>, prop: &mut JsValue) -> JsValue {
                     items.push(JsValue::unknown(
-                        JsValue::member(box JsValue::array(Vec::new()), box take(prop)),
+                        JsValue::member(Box::new(JsValue::array(Vec::new())), Box::new(take(prop))),
                         "unknown array prototype methods or values",
                     ));
                     JsValue::alternatives(take(items))
@@ -105,7 +105,7 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
                                 true
                             } else {
                                 *value = JsValue::unknown(
-                                    JsValue::member(box take(obj), box take(prop)),
+                                    JsValue::member(Box::new(take(obj)), Box::new(take(prop))),
                                     "invalid index",
                                 );
                                 true
@@ -127,7 +127,7 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
                         *value = JsValue::alternatives(
                             take(alts)
                                 .into_iter()
-                                .map(|alt| JsValue::member(box obj.clone(), box alt))
+                                .map(|alt| JsValue::member(Box::new(obj.clone()), Box::new(alt)))
                                 .collect(),
                         );
                         true
@@ -160,7 +160,7 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
                             ObjectPart::Spread(_) => {
                                 values.push(JsValue::unknown(
                                     JsValue::member(
-                                        box JsValue::object(vec![take(part)]),
+                                        Box::new(JsValue::object(vec![take(part)])),
                                         prop.clone(),
                                     ),
                                     "spreaded object",
@@ -170,7 +170,7 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
                     }
                     if include_unknown {
                         values.push(JsValue::unknown(
-                            JsValue::member(box JsValue::object(Vec::new()), box take(prop)),
+                            JsValue::member(Box::new(JsValue::object(Vec::new())), Box::new(take(prop))),
                             "unknown object prototype methods or values",
                         ));
                     }
@@ -262,7 +262,7 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
                         *value = JsValue::alternatives(
                             take(alts)
                                 .into_iter()
-                                .map(|alt| JsValue::member(box obj.clone(), box alt))
+                                .map(|alt| JsValue::member(Box::new(obj.clone()), Box::new(alt)))
                                 .collect(),
                         );
                         true
@@ -336,7 +336,7 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
                                             .enumerate()
                                             .map(|(i, item)| {
                                                 JsValue::call(
-                                                    box func.clone(),
+                                                    Box::new(func.clone()),
                                                     vec![
                                                         item,
                                                         JsValue::Constant(ConstantValue::Num(
@@ -361,7 +361,7 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
                         take(alts)
                             .into_iter()
                             .map(|alt| {
-                                JsValue::member_call(box alt, box prop.clone(), args.clone())
+                                JsValue::member_call(Box::new(alt), Box::new(prop.clone()), args.clone())
                             })
                             .collect(),
                     );
@@ -372,7 +372,7 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
             // without special handling, we convert it into a normal call like
             // `(obj.prop)(arg1, arg2, ...)`
             *value = JsValue::call(
-                box JsValue::member(box take(obj), box take(prop)),
+                Box::new(JsValue::member(Box::new(take(obj)), Box::new(take(prop)))),
                 take(args),
             );
             true
@@ -383,7 +383,7 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
             *value = JsValue::alternatives(
                 take(alts)
                     .into_iter()
-                    .map(|alt| JsValue::call(box alt, args.clone()))
+                    .map(|alt| JsValue::call(Box::new(alt), args.clone()))
                     .collect(),
             );
             true

--- a/crates/turbopack-ecmascript/src/analyzer/graph.rs
+++ b/crates/turbopack-ecmascript/src/analyzer/graph.rs
@@ -343,7 +343,7 @@ impl EvalContext {
             }) => {
                 let arg = self.eval(arg);
 
-                JsValue::logical_not(box arg)
+                JsValue::logical_not(Box::new(arg))
             }
 
             Expr::Bin(BinExpr {
@@ -474,7 +474,7 @@ impl EvalContext {
                 ..
             }) => {
                 let obj = self.eval(obj);
-                JsValue::member(box obj, box prop.sym.clone().into())
+                JsValue::member(Box::new(obj), Box::new(prop.sym.clone().into()))
             }
 
             Expr::Member(MemberExpr {
@@ -484,7 +484,7 @@ impl EvalContext {
             }) => {
                 let obj = self.eval(obj);
                 let prop = self.eval(&computed.expr);
-                JsValue::member(box obj, box prop)
+                JsValue::member(Box::new(obj), Box::new(prop))
             }
 
             Expr::Call(CallExpr {
@@ -499,8 +499,8 @@ impl EvalContext {
 
                 let args = args.iter().map(|arg| self.eval(&arg.expr)).collect();
                 if let Expr::Member(MemberExpr { obj, prop, .. }) = unparen(callee) {
-                    let obj = box self.eval(obj);
-                    let prop = box match prop {
+                    let obj = Box::new(self.eval(obj));
+                    let prop = Box::new(match prop {
                         // TODO avoid clone
                         MemberProp::Ident(i) => i.sym.clone().into(),
                         MemberProp::PrivateName(_) => {
@@ -509,10 +509,10 @@ impl EvalContext {
                             );
                         }
                         MemberProp::Computed(ComputedPropName { expr, .. }) => self.eval(expr),
-                    };
+                    });
                     JsValue::member_call(obj, prop, args)
                 } else {
-                    let callee = box self.eval(callee);
+                    let callee = Box::new(self.eval(callee));
 
                     JsValue::call(callee, args)
                 }
@@ -529,7 +529,7 @@ impl EvalContext {
                 }
                 let args = args.iter().map(|arg| self.eval(&arg.expr)).collect();
 
-                let callee = box JsValue::FreeVar(js_word!("import"));
+                let callee = Box::new(JsValue::FreeVar(js_word!("import")));
 
                 JsValue::call(callee, args)
             }
@@ -928,9 +928,9 @@ impl Analyzer<'_> {
         let values = self.cur_fn_return_values.take().unwrap();
 
         match values.len() {
-            0 => box JsValue::FreeVar(js_word!("undefined")),
-            1 => box values.into_iter().next().unwrap(),
-            _ => box JsValue::alternatives(values),
+            0 => Box::new(JsValue::FreeVar(js_word!("undefined"))),
+            1 => Box::new(values.into_iter().next().unwrap()),
+            _ => Box::new(JsValue::alternatives(values)),
         }
     }
 }
@@ -1302,7 +1302,7 @@ impl VisitAstPath for Analyzer<'_> {
                 expr.visit_children_with_path(self, ast_path);
                 let return_value = self.eval_context.eval(inner_expr);
 
-                let fn_val = JsValue::function(self.cur_fn_ident, box return_value);
+                let fn_val = JsValue::function(self.cur_fn_ident, Box::new(return_value));
                 self.cur_fn_ident = old_ident;
                 fn_val
             }
@@ -1407,10 +1407,10 @@ impl VisitAstPath for Analyzer<'_> {
                         ast_path.with(AstParentNodeRef::Pat(pat, PatField::Array), |ast_path| {
                             for (idx, elem) in arr.elems.iter().enumerate() {
                                 self.current_value = Some(JsValue::member(
-                                    box value.clone(),
-                                    box JsValue::Constant(ConstantValue::Num(ConstantNumber(
+                                    Box::new(value.clone()),
+                                    Box::new(JsValue::Constant(ConstantValue::Num(ConstantNumber(
                                         idx as f64,
-                                    ))),
+                                    )))),
                                 ));
                                 ast_path.with(
                                     AstParentNodeRef::ArrayPat(arr, ArrayPatField::Elems(idx)),
@@ -1609,7 +1609,7 @@ impl<'a> Analyzer<'a> {
         } else {
             self.add_effect(Effect::Conditional {
                 condition,
-                kind: box cond_kind,
+                kind: Box::new(cond_kind),
                 ast_path: as_parent_path_with(ast_path, ast_kind),
                 span,
                 in_try: is_in_try(ast_path),
@@ -1645,8 +1645,8 @@ impl<'a> Analyzer<'a> {
                                         },
                                     );
                                     self.current_value = Some(JsValue::member(
-                                        box current_value.clone(),
-                                        box key_value,
+                                        Box::new(current_value.clone()),
+                                        Box::new(key_value),
                                     ));
                                     ast_path.with(
                                         AstParentNodeRef::KeyValuePatProp(
@@ -1681,15 +1681,15 @@ impl<'a> Analyzer<'a> {
                                             let value = self.eval_context.eval(value);
                                             JsValue::alternatives(vec![
                                                 JsValue::member(
-                                                    box current_value.clone(),
-                                                    box key_value,
+                                                    Box::new(current_value.clone()),
+                                                    Box::new(key_value),
                                                 ),
                                                 value,
                                             ])
                                         } else {
                                             JsValue::member(
-                                                box current_value.clone(),
-                                                box key_value,
+                                                Box::new(current_value.clone()),
+                                                Box::new(key_value),
                                             )
                                         },
                                     );

--- a/crates/turbopack-ecmascript/src/analyzer/imports.rs
+++ b/crates/turbopack-ecmascript/src/analyzer/imports.rs
@@ -124,11 +124,11 @@ impl ImportMap {
         if let Some((i, i_sym)) = self.imports.get(id) {
             let r = &self.references[*i];
             return Some(JsValue::member(
-                box JsValue::Module(ModuleValue {
+                Box::new(JsValue::Module(ModuleValue {
                     module: r.module_path.clone(),
                     annotations: r.annotations.clone(),
-                }),
-                box i_sym.clone().into(),
+                })),
+                Box::new(i_sym.clone().into()),
             ));
         }
         if let Some(i) = self.namespace_imports.get(id) {

--- a/crates/turbopack-ecmascript/src/analyzer/linker.rs
+++ b/crates/turbopack-ecmascript/src/analyzer/linker.rs
@@ -147,7 +147,7 @@ where
                     }
                     total_nodes += 1;
                     done.push(JsValue::unknown(
-                        JsValue::call(box JsValue::function(func_ident, return_value), args),
+                        JsValue::call(Box::new(JsValue::function(func_ident, return_value)), args),
                         "recursive function call",
                     ));
                 }

--- a/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -722,36 +722,36 @@ impl JsValue {
     pub fn equal(a: JsValue, b: JsValue) -> Self {
         Self::Binary(
             1 + a.total_nodes() + b.total_nodes(),
-            box a,
+            Box::new(a),
             BinaryOperator::Equal,
-            box b,
+            Box::new(b),
         )
     }
 
     pub fn not_equal(a: JsValue, b: JsValue) -> Self {
         Self::Binary(
             1 + a.total_nodes() + b.total_nodes(),
-            box a,
+            Box::new(a),
             BinaryOperator::NotEqual,
-            box b,
+            Box::new(b),
         )
     }
 
     pub fn strict_equal(a: JsValue, b: JsValue) -> Self {
         Self::Binary(
             1 + a.total_nodes() + b.total_nodes(),
-            box a,
+            Box::new(a),
             BinaryOperator::StrictEqual,
-            box b,
+            Box::new(b),
         )
     }
 
     pub fn strict_not_equal(a: JsValue, b: JsValue) -> Self {
         Self::Binary(
             1 + a.total_nodes() + b.total_nodes(),
-            box a,
+            Box::new(a),
             BinaryOperator::StrictNotEqual,
-            box b,
+            Box::new(b),
         )
     }
 
@@ -3363,7 +3363,7 @@ mod tests {
                                 let new_args = handle_args(args, &mut queue, &var_graph, i).await;
                                 resolved.push((
                                     format!("{parent} -> {i} call"),
-                                    JsValue::call(box func, new_args),
+                                    JsValue::call(Box::new(func), new_args),
                                 ));
                             }
                             Effect::FreeVar { var, .. } => {
@@ -3377,7 +3377,7 @@ mod tests {
                                 let new_args = handle_args(args, &mut queue, &var_graph, i).await;
                                 resolved.push((
                                     format!("{parent} -> {i} member call"),
-                                    JsValue::member_call(box obj, box prop, new_args),
+                                    JsValue::member_call(Box::new(obj), Box::new(prop), new_args),
                                 ));
                             }
                             _ => {}

--- a/crates/turbopack-ecmascript/src/analyzer/well_known.rs
+++ b/crates/turbopack-ecmascript/src/analyzer/well_known.rs
@@ -57,7 +57,7 @@ pub async fn well_known_function_call(
         WellKnownFunctionKind::PathDirname => path_dirname(args),
         WellKnownFunctionKind::PathResolve(cwd) => path_resolve(*cwd, args),
         WellKnownFunctionKind::Import => JsValue::unknown(
-            JsValue::call(box JsValue::WellKnownFunction(kind), args),
+            JsValue::call(Box::new(JsValue::WellKnownFunction(kind)), args),
             "import() is not supported",
         ),
         WellKnownFunctionKind::Require => require(args),
@@ -90,7 +90,7 @@ pub async fn well_known_function_call(
                 cwd.clone().into()
             } else {
                 JsValue::unknown(
-                    JsValue::call(box JsValue::WellKnownFunction(kind), args),
+                    JsValue::call(Box::new(JsValue::WellKnownFunction(kind)), args),
                     "process.cwd is not specified in the environment",
                 )
             }
@@ -111,7 +111,7 @@ pub async fn well_known_function_call(
         }
 
         _ => JsValue::unknown(
-            JsValue::call(box JsValue::WellKnownFunction(kind), args),
+            JsValue::call(Box::new(JsValue::WellKnownFunction(kind)), args),
             "unsupported function",
         ),
     })
@@ -138,7 +138,7 @@ pub fn object_assign(args: Vec<JsValue>) -> JsValue {
         } else {
             JsValue::unknown(
                 JsValue::call(
-                    box JsValue::WellKnownFunction(WellKnownFunctionKind::ObjectAssign),
+                    Box::new(JsValue::WellKnownFunction(WellKnownFunctionKind::ObjectAssign)),
                     vec![],
                 ),
                 "empty arguments for Object.assign",
@@ -147,7 +147,7 @@ pub fn object_assign(args: Vec<JsValue>) -> JsValue {
     } else {
         JsValue::unknown(
             JsValue::call(
-                box JsValue::WellKnownFunction(WellKnownFunctionKind::ObjectAssign),
+                Box::new(JsValue::WellKnownFunction(WellKnownFunctionKind::ObjectAssign)),
                 args,
             ),
             "only const object assign is supported",
@@ -302,7 +302,7 @@ pub fn path_dirname(mut args: Vec<JsValue>) -> JsValue {
     }
     JsValue::unknown(
         JsValue::call(
-            box JsValue::WellKnownFunction(WellKnownFunctionKind::PathDirname),
+            Box::new(JsValue::WellKnownFunction(WellKnownFunctionKind::PathDirname)),
             args,
         ),
         "path.dirname with unsupported arguments",
@@ -319,7 +319,7 @@ pub fn require(args: Vec<JsValue>) -> JsValue {
         } else {
             JsValue::unknown(
                 JsValue::call(
-                    box JsValue::WellKnownFunction(WellKnownFunctionKind::Require),
+                    Box::new(JsValue::WellKnownFunction(WellKnownFunctionKind::Require)),
                     args,
                 ),
                 "only constant argument is supported",
@@ -328,7 +328,7 @@ pub fn require(args: Vec<JsValue>) -> JsValue {
     } else {
         JsValue::unknown(
             JsValue::call(
-                box JsValue::WellKnownFunction(WellKnownFunctionKind::Require),
+                Box::new(JsValue::WellKnownFunction(WellKnownFunctionKind::Require)),
                 args,
             ),
             "only a single argument is supported",
@@ -344,7 +344,7 @@ pub async fn require_context_require(
     if args.is_empty() {
         return Ok(JsValue::unknown(
             JsValue::call(
-                box JsValue::WellKnownFunction(WellKnownFunctionKind::RequireContextRequire(val)),
+                Box::new(JsValue::WellKnownFunction(WellKnownFunctionKind::RequireContextRequire(val))),
                 args,
             ),
             "require.context(...).require() requires an argument specifying the module path",
@@ -354,7 +354,7 @@ pub async fn require_context_require(
     let Some(s) = args[0].as_str() else {
         return Ok(JsValue::unknown(
             JsValue::call(
-                box JsValue::WellKnownFunction(WellKnownFunctionKind::RequireContextRequire(val)),
+                Box::new(JsValue::WellKnownFunction(WellKnownFunctionKind::RequireContextRequire(val))),
                 args,
             ),
             "require.context(...).require() only accepts a single, constant string argument",
@@ -365,7 +365,7 @@ pub async fn require_context_require(
     let Some(m) = map.get(s) else {
        return Ok(JsValue::unknown(
            JsValue::call(
-               box JsValue::WellKnownFunction(WellKnownFunctionKind::RequireContextRequire(val)),
+               Box::new(JsValue::WellKnownFunction(WellKnownFunctionKind::RequireContextRequire(val))),
                args,
            ),
            "require.context(...).require() can only be called with an argument that's in the context",
@@ -389,9 +389,9 @@ pub async fn require_context_require_keys(
     } else {
         JsValue::unknown(
             JsValue::call(
-                box JsValue::WellKnownFunction(WellKnownFunctionKind::RequireContextRequireKeys(
+                Box::new(JsValue::WellKnownFunction(WellKnownFunctionKind::RequireContextRequireKeys(
                     val,
-                )),
+                ))),
                 args,
             ),
             "require.context(...).keys() does not accept arguments",
@@ -407,9 +407,9 @@ pub async fn require_context_require_resolve(
     if args.len() != 1 {
         return Ok(JsValue::unknown(
             JsValue::call(
-                box JsValue::WellKnownFunction(
+                Box::new(JsValue::WellKnownFunction(
                     WellKnownFunctionKind::RequireContextRequireResolve(val),
-                ),
+                )),
                 args,
             ),
             "require.context(...).resolve() only accepts a single, constant string argument",
@@ -419,9 +419,9 @@ pub async fn require_context_require_resolve(
     let Some(s) = args[0].as_str() else {
         return Ok(JsValue::unknown(
             JsValue::call(
-                box JsValue::WellKnownFunction(
+                Box::new(JsValue::WellKnownFunction(
                     WellKnownFunctionKind::RequireContextRequireResolve(val),
-                ),
+                )),
                 args,
             ),
             "require.context(...).resolve() only accepts a single, constant string argument",
@@ -432,9 +432,9 @@ pub async fn require_context_require_resolve(
     let Some(m) = map.get(s) else {
         return Ok(JsValue::unknown(
             JsValue::call(
-                box JsValue::WellKnownFunction(
+                Box::new(JsValue::WellKnownFunction(
                     WellKnownFunctionKind::RequireContextRequireResolve(val),
-                ),
+                )),
                 args,
             ),
             "require.context(...).resolve() can only be called with an argument that's in the context",
@@ -452,7 +452,7 @@ pub fn path_to_file_url(args: Vec<JsValue>) -> JsValue {
                 .unwrap_or_else(|_| {
                     JsValue::unknown(
                         JsValue::call(
-                            box JsValue::WellKnownFunction(WellKnownFunctionKind::PathToFileUrl),
+                            Box::new(JsValue::WellKnownFunction(WellKnownFunctionKind::PathToFileUrl)),
                             args,
                         ),
                         "url not parseable: path is relative or has an invalid prefix",
@@ -461,7 +461,7 @@ pub fn path_to_file_url(args: Vec<JsValue>) -> JsValue {
         } else {
             JsValue::unknown(
                 JsValue::call(
-                    box JsValue::WellKnownFunction(WellKnownFunctionKind::PathToFileUrl),
+                    Box::new(JsValue::WellKnownFunction(WellKnownFunctionKind::PathToFileUrl)),
                     args,
                 ),
                 "only constant argument is supported",
@@ -470,7 +470,7 @@ pub fn path_to_file_url(args: Vec<JsValue>) -> JsValue {
     } else {
         JsValue::unknown(
             JsValue::call(
-                box JsValue::WellKnownFunction(WellKnownFunctionKind::PathToFileUrl),
+                Box::new(JsValue::WellKnownFunction(WellKnownFunctionKind::PathToFileUrl)),
                 args,
             ),
             "only a single argument is supported",
@@ -504,7 +504,7 @@ pub fn well_known_function_member(kind: WellKnownFunctionKind, prop: JsValue) ->
         #[allow(unreachable_patterns)]
         (kind, _) => {
             return (
-                JsValue::member(box JsValue::WellKnownFunction(kind), box prop),
+                JsValue::member(Box::new(JsValue::WellKnownFunction(kind)), Box::new(prop)),
                 false,
             )
         }
@@ -541,7 +541,7 @@ pub async fn well_known_object_member(
         #[allow(unreachable_patterns)]
         _ => {
             return Ok((
-                JsValue::member(box JsValue::WellKnownObject(kind), box prop),
+                JsValue::member(Box::new(JsValue::WellKnownObject(kind)), Box::new(prop)),
                 false,
             ))
         }
@@ -554,8 +554,8 @@ fn global_object(prop: JsValue) -> JsValue {
         Some("assign") => JsValue::WellKnownFunction(WellKnownFunctionKind::ObjectAssign),
         _ => JsValue::unknown(
             JsValue::member(
-                box JsValue::WellKnownObject(WellKnownObjectKind::GlobalObject),
-                box prop,
+                Box::new(JsValue::WellKnownObject(WellKnownObjectKind::GlobalObject)),
+                Box::new(prop),
             ),
             "unsupported property on global Object",
         ),
@@ -568,15 +568,15 @@ pub fn path_module_member(kind: WellKnownObjectKind, prop: JsValue) -> JsValue {
         (.., Some("dirname")) => JsValue::WellKnownFunction(WellKnownFunctionKind::PathDirname),
         (.., Some("resolve")) => {
             // cwd is added while resolving in refernces.rs
-            JsValue::WellKnownFunction(WellKnownFunctionKind::PathResolve(box JsValue::from("")))
+            JsValue::WellKnownFunction(WellKnownFunctionKind::PathResolve(Box::new(JsValue::from(""))))
         }
         (WellKnownObjectKind::PathModule, Some("default")) => {
             JsValue::WellKnownObject(WellKnownObjectKind::PathModuleDefault)
         }
         _ => JsValue::unknown(
             JsValue::member(
-                box JsValue::WellKnownObject(WellKnownObjectKind::PathModule),
-                box prop,
+                Box::new(JsValue::WellKnownObject(WellKnownObjectKind::PathModule)),
+                Box::new(prop),
             ),
             "unsupported property on Node.js path module",
         ),
@@ -606,8 +606,8 @@ pub fn fs_module_member(kind: WellKnownObjectKind, prop: JsValue) -> JsValue {
     }
     JsValue::unknown(
         JsValue::member(
-            box JsValue::WellKnownObject(WellKnownObjectKind::FsModule),
-            box prop,
+            Box::new(JsValue::WellKnownObject(WellKnownObjectKind::FsModule)),
+            Box::new(prop),
         ),
         "unsupported property on Node.js fs module",
     )
@@ -623,8 +623,8 @@ pub fn url_module_member(kind: WellKnownObjectKind, prop: JsValue) -> JsValue {
         }
         _ => JsValue::unknown(
             JsValue::member(
-                box JsValue::WellKnownObject(WellKnownObjectKind::UrlModule),
-                box prop,
+                Box::new(JsValue::WellKnownObject(WellKnownObjectKind::UrlModule)),
+                Box::new(prop),
             ),
             "unsupported property on Node.js url module",
         ),
@@ -645,8 +645,8 @@ pub fn child_process_module_member(kind: WellKnownObjectKind, prop: JsValue) -> 
         }
         _ => JsValue::unknown(
             JsValue::member(
-                box JsValue::WellKnownObject(WellKnownObjectKind::ChildProcess),
-                box prop,
+                Box::new(JsValue::WellKnownObject(WellKnownObjectKind::ChildProcess)),
+                Box::new(prop),
             ),
             "unsupported property on Node.js child_process module",
         ),
@@ -663,8 +663,8 @@ fn os_module_member(kind: WellKnownObjectKind, prop: JsValue) -> JsValue {
         }
         _ => JsValue::unknown(
             JsValue::member(
-                box JsValue::WellKnownObject(WellKnownObjectKind::OsModule),
-                box prop,
+                Box::new(JsValue::WellKnownObject(WellKnownObjectKind::OsModule)),
+                Box::new(prop),
             ),
             "unsupported property on Node.js os module",
         ),
@@ -694,8 +694,8 @@ async fn node_process_member(
         Some("env") => JsValue::WellKnownObject(WellKnownObjectKind::NodeProcessEnv),
         _ => JsValue::unknown(
             JsValue::member(
-                box JsValue::WellKnownObject(WellKnownObjectKind::NodeProcess),
-                box prop,
+                Box::new(JsValue::WellKnownObject(WellKnownObjectKind::NodeProcess)),
+                Box::new(prop),
             ),
             "unsupported property on Node.js process object",
         ),
@@ -707,8 +707,8 @@ fn node_pre_gyp(prop: JsValue) -> JsValue {
         Some("find") => JsValue::WellKnownFunction(WellKnownFunctionKind::NodePreGypFind),
         _ => JsValue::unknown(
             JsValue::member(
-                box JsValue::WellKnownObject(WellKnownObjectKind::NodePreGyp),
-                box prop,
+                Box::new(JsValue::WellKnownObject(WellKnownObjectKind::NodePreGyp)),
+                Box::new(prop),
             ),
             "unsupported property on @mapbox/node-pre-gyp module",
         ),
@@ -720,8 +720,8 @@ fn express(prop: JsValue) -> JsValue {
         Some("set") => JsValue::WellKnownFunction(WellKnownFunctionKind::NodeExpressSet),
         _ => JsValue::unknown(
             JsValue::member(
-                box JsValue::WellKnownObject(WellKnownObjectKind::NodeExpressApp),
-                box prop,
+                Box::new(JsValue::WellKnownObject(WellKnownObjectKind::NodeExpressApp)),
+                Box::new(prop),
             ),
             "unsupported property on require('express')() object",
         ),
@@ -735,8 +735,8 @@ fn protobuf_loader(prop: JsValue) -> JsValue {
         }
         _ => JsValue::unknown(
             JsValue::member(
-                box JsValue::WellKnownObject(WellKnownObjectKind::NodeProtobufLoader),
-                box prop,
+                Box::new(JsValue::WellKnownObject(WellKnownObjectKind::NodeProtobufLoader)),
+                Box::new(prop),
             ),
             "unsupported property on require('@grpc/proto-loader') object",
         ),

--- a/crates/turbopack-ecmascript/src/code_gen.rs
+++ b/crates/turbopack-ecmascript/src/code_gen.rs
@@ -87,7 +87,7 @@ macro_rules! create_visitor {
             for Box<Visitor<T>>
         {
             fn create<'a>(&'a self) -> Box<dyn swc_core::ecma::visit::VisitMut + Send + Sync + 'a> {
-                box &**self
+                Box::new(&**self)
             }
         }
 
@@ -101,9 +101,9 @@ macro_rules! create_visitor {
 
         (
             $ast_path,
-            box box Visitor {
+            Box::new(Box::new(Visitor {
                 $name: move |$arg: &mut swc_core::ecma::ast::$ty| $b,
-            } as Box<dyn $crate::code_gen::VisitorFactory>,
+            })) as Box<dyn $crate::code_gen::VisitorFactory>,
         )
     }};
     (visit_mut_program($arg:ident: &mut Program) $b:block) => {{
@@ -115,7 +115,7 @@ macro_rules! create_visitor {
             for Box<Visitor<T>>
         {
             fn create<'a>(&'a self) -> Box<dyn swc_core::ecma::visit::VisitMut + Send + Sync + 'a> {
-                box &**self
+                Box::new(&**self)
             }
         }
 
@@ -129,9 +129,9 @@ macro_rules! create_visitor {
 
         (
             Vec::new(),
-            box box Visitor {
+            Box::new(Box::new(Visitor {
                 visit_mut_program: move |$arg: &mut swc_core::ecma::ast::Program| $b,
-            } as Box<dyn $crate::code_gen::VisitorFactory>,
+            })) as Box<dyn $crate::code_gen::VisitorFactory>,
         )
     }};
 }

--- a/crates/turbopack-ecmascript/src/lib.rs
+++ b/crates/turbopack-ecmascript/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(box_syntax)]
 #![feature(box_patterns)]
 #![feature(min_specialization)]
 #![feature(iter_intersperse)]

--- a/crates/turbopack-ecmascript/src/parse.rs
+++ b/crates/turbopack-ecmascript/src/parse.rs
@@ -196,11 +196,11 @@ async fn parse_content(
     let handler = Handler::with_emitter(
         true,
         false,
-        box IssueEmitter {
+        Box::new(IssueEmitter {
             source,
             source_map: source_map.clone(),
             title: Some("Parsing ecmascript source code failed".to_string()),
-        },
+        }),
     );
     let globals = Arc::new(Globals::new());
     let globals_ref = &globals;

--- a/crates/turbopack-ecmascript/src/path_visitor.rs
+++ b/crates/turbopack-ecmascript/src/path_visitor.rs
@@ -190,7 +190,7 @@ mod tests {
 
     impl VisitorFactory for Box<StrReplacer<'_>> {
         fn create<'a>(&'a self) -> Box<dyn VisitMut + Send + Sync + 'a> {
-            box &**self
+            Box::new(&**self)
         }
     }
 
@@ -202,7 +202,7 @@ mod tests {
     }
 
     fn replacer(from: &'static str, to: &'static str) -> impl VisitorFactory {
-        box StrReplacer { from, to }
+        Box::new(StrReplacer { from, to })
     }
 
     fn to_js(m: &Module, cm: &Arc<SourceMap>) -> String {

--- a/crates/turbopack-ecmascript/src/references/amd.rs
+++ b/crates/turbopack-ecmascript/src/references/amd.rs
@@ -251,7 +251,7 @@ fn transform_amd_factory(
             let f = private_ident!("f");
             let call_f = Expr::Call(CallExpr {
                 args: deps,
-                callee: Callee::Expr(box Expr::Ident(f.clone())),
+                callee: Callee::Expr(Box::new(Expr::Ident(f.clone()))),
                 span: DUMMY_SP,
                 type_args: None,
             });
@@ -274,12 +274,12 @@ fn transform_amd_factory(
                 "r => r !== undefined && __turbopack_export_value__(r)"
             ));
             args.push(ExprOrSpread {
-                expr: box Expr::Call(CallExpr {
+                expr: Box::new(Expr::Call(CallExpr {
                     args: deps,
                     callee: Callee::Expr(factory),
                     span: DUMMY_SP,
                     type_args: None,
-                }),
+                })),
                 spread: None,
             });
         }

--- a/crates/turbopack-ecmascript/src/references/cjs.rs
+++ b/crates/turbopack-ecmascript/src/references/cjs.rs
@@ -175,20 +175,20 @@ impl CodeGenerateable for CjsRequireAssetReference {
                 visitors.push(
                     create_visitor!(exact path, visit_mut_call_expr(call_expr: &mut CallExpr) {
                         call_expr.callee = Callee::Expr(
-                            box Expr::Ident(Ident::new(
+                            Box::new(Expr::Ident(Ident::new(
                                 if pm.is_internal_import() {
                                     "__turbopack_require__"
                                 } else {
                                     "__turbopack_external_require__"
                                 }.into(), DUMMY_SP
-                            ))
+                            )))
                         );
                         let old_args = std::mem::take(&mut call_expr.args);
                         let expr = match old_args.into_iter().next() {
                             Some(ExprOrSpread { expr, spread: None }) => pm.apply(*expr),
                             _ => pm.create(),
                         };
-                        call_expr.args.push(ExprOrSpread { spread: None, expr: box expr });
+                        call_expr.args.push(ExprOrSpread { spread: None, expr: Box::new(expr) });
                     }),
                 );
             }

--- a/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -288,7 +288,7 @@ pub(crate) fn insert_hoisted_stmt(program: &mut Program, stmt: Stmt) {
                 body.insert(
                     0,
                     ModuleItem::Stmt(Stmt::Expr(ExprStmt {
-                        expr: box Expr::Lit(Lit::Str((*ESM_HOISTING_LOCATION).into())),
+                        expr: Box::new(Expr::Lit(Lit::Str((*ESM_HOISTING_LOCATION).into()))),
                         span: DUMMY_SP,
                     })),
                 );
@@ -313,7 +313,7 @@ pub(crate) fn insert_hoisted_stmt(program: &mut Program, stmt: Stmt) {
                 body.insert(
                     0,
                     Stmt::Expr(ExprStmt {
-                        expr: box Expr::Lit(Lit::Str((*ESM_HOISTING_LOCATION).into())),
+                        expr: Box::new(Expr::Lit(Lit::Str((*ESM_HOISTING_LOCATION).into()))),
                         span: DUMMY_SP,
                     }),
                 );

--- a/crates/turbopack-ecmascript/src/references/esm/binding.rs
+++ b/crates/turbopack-ecmascript/src/references/esm/binding.rs
@@ -58,14 +58,14 @@ impl CodeGenerateable for EsmBinding {
             if let Some(export) = export {
                 Expr::Member(MemberExpr {
                     span: DUMMY_SP,
-                    obj: box Expr::Ident(Ident::new(imported_module.into(), DUMMY_SP)),
+                    obj: Box::new(Expr::Ident(Ident::new(imported_module.into(), DUMMY_SP))),
                     prop: MemberProp::Computed(ComputedPropName {
                         span: DUMMY_SP,
-                        expr: box Expr::Lit(Lit::Str(Str {
+                        expr: Box::new(Expr::Lit(Lit::Str(Str {
                             span: DUMMY_SP,
                             value: export.into(),
                             raw: None,
-                        })),
+                        }))),
                     }),
                 })
             } else {
@@ -99,7 +99,7 @@ impl CodeGenerateable for EsmBinding {
                             if let Prop::Shorthand(ident) = prop {
                                 // TODO: Merge with the above condition when https://rust-lang.github.io/rfcs/2497-if-let-chains.html lands.
                                 if let Some(imported_ident) = imported_module.as_deref() {
-                                    *prop = Prop::KeyValue(KeyValueProp { key: PropName::Ident(ident.clone()), value: box make_expr(imported_ident, this.export.as_deref())});
+                                    *prop = Prop::KeyValue(KeyValueProp { key: PropName::Ident(ident.clone()), value: Box::new(make_expr(imported_ident, this.export.as_deref()))});
                                 }
                             }
                         }),

--- a/crates/turbopack-ecmascript/src/references/esm/dynamic.rs
+++ b/crates/turbopack-ecmascript/src/references/esm/dynamic.rs
@@ -179,7 +179,7 @@ impl CodeGenerateableWithAvailabilityInfo for EsmAsyncAssetReference {
                         ];
                     } else {
                         call_expr.args = vec![
-                            ExprOrSpread { spread: None, expr: box expr }
+                            ExprOrSpread { spread: None, expr: Box::new(expr) }
                         ]
                     }
                 })

--- a/crates/turbopack-ecmascript/src/references/esm/export.rs
+++ b/crates/turbopack-ecmascript/src/references/esm/export.rs
@@ -191,14 +191,14 @@ impl CodeGenerateable for EsmExports {
                             "(() => $expr)" as Expr,
                             expr: Expr = Expr::Member(MemberExpr {
                                 span: DUMMY_SP,
-                                obj: box Expr::Ident(Ident::new(ident.into(), DUMMY_SP)),
+                                obj: Box::new(Expr::Ident(Ident::new(ident.into(), DUMMY_SP))),
                                 prop: MemberProp::Computed(ComputedPropName {
                                     span: DUMMY_SP,
-                                    expr: box Expr::Lit(Lit::Str(Str {
+                                    expr: Box::new(Expr::Lit(Lit::Str(Str {
                                         span: DUMMY_SP,
                                         value: (name as &str).into(),
                                         raw: None,
-                                    }))
+                                    })))
                                 })
                             })
                         )
@@ -215,14 +215,14 @@ impl CodeGenerateable for EsmExports {
                 }
             };
             if let Some(expr) = expr {
-                props.push(PropOrSpread::Prop(box Prop::KeyValue(KeyValueProp {
+                props.push(PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {
                     key: PropName::Str(Str {
                         span: DUMMY_SP,
                         value: exported.as_ref().into(),
                         raw: None,
                     }),
-                    value: box expr,
-                })));
+                    value: Box::new(expr),
+                }))));
             }
         }
         let getters = Expr::Object(ObjectLit {

--- a/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/crates/turbopack-ecmascript/src/references/mod.rs
@@ -382,11 +382,11 @@ pub(crate) async fn analyze_ecmascript_module(
             let handler = Handler::with_emitter(
                 true,
                 false,
-                box IssueEmitter {
+                Box::new(IssueEmitter {
                     source,
                     source_map: source_map.clone(),
                     title: None,
-                },
+                }),
             );
             let var_graph = HANDLER.set(&handler, || {
                 GLOBALS.set(globals, || create_graph(program, eval_context))
@@ -801,11 +801,11 @@ pub(crate) async fn analyze_ecmascript_module(
                         let linked_func_call = state
                             .link_value(
                                 JsValue::call(
-                                    box JsValue::WellKnownFunction(
+                                    Box::new(JsValue::WellKnownFunction(
                                         WellKnownFunctionKind::PathResolve(
-                                            box parent_path.path.as_str().into(),
+                                            Box::new(parent_path.path.as_str().into()),
                                         ),
-                                    ),
+                                    )),
                                     args.clone(),
                                 ),
                                 in_try,
@@ -832,7 +832,7 @@ pub(crate) async fn analyze_ecmascript_module(
                         let linked_func_call = state
                             .link_value(
                                 JsValue::call(
-                                    box JsValue::WellKnownFunction(WellKnownFunctionKind::PathJoin),
+                                    Box::new(JsValue::WellKnownFunction(WellKnownFunctionKind::PathJoin)),
                                     args.clone(),
                                 ),
                                 in_try,
@@ -861,7 +861,7 @@ pub(crate) async fn analyze_ecmascript_module(
                             let pat = js_value_to_pattern(&args[0]);
                             if pat.is_match("node") && args.len() >= 2 {
                                 let first_arg =
-                                    JsValue::member(box args[1].clone(), box 0_f64.into());
+                                    JsValue::member(Box::new(args[1].clone()), Box::new(0_f64.into()));
                                 let first_arg = state.link_value(first_arg, in_try).await?;
                                 let pat = js_value_to_pattern(&first_arg);
                                 if !pat.has_constant_parts() {
@@ -1062,9 +1062,9 @@ pub(crate) async fn analyze_ecmascript_module(
                                                 let linked_func_call = state
                                                     .link_value(
                                                         JsValue::call(
-                                                            box JsValue::WellKnownFunction(
+                                                            Box::new(JsValue::WellKnownFunction(
                                                                 WellKnownFunctionKind::PathJoin,
-                                                            ),
+                                                            )),
                                                             vec![
                                                                 JsValue::FreeVar(
                                                                     "__dirname".into(),
@@ -1125,9 +1125,9 @@ pub(crate) async fn analyze_ecmascript_module(
                                 let linked_func_call = state
                                     .link_value(
                                         JsValue::call(
-                                            box JsValue::WellKnownFunction(
+                                            Box::new(JsValue::WellKnownFunction(
                                                 WellKnownFunctionKind::PathJoin,
-                                            ),
+                                            )),
                                             vec![
                                                 JsValue::FreeVar("__dirname".into()),
                                                 p.into(),
@@ -1565,7 +1565,7 @@ pub(crate) async fn analyze_ecmascript_module(
                                 }
 
                                 let func = analysis_state
-                                    .link_value(JsValue::member(box obj.clone(), box prop), in_try)
+                                    .link_value(JsValue::member(Box::new(obj.clone()), Box::new(prop)), in_try)
                                     .await?;
 
                                 handle_call(
@@ -2029,7 +2029,7 @@ async fn require_resolve_visitor(
         match values.len() {
             0 => JsValue::unknown(
                 JsValue::call(
-                    box JsValue::WellKnownFunction(WellKnownFunctionKind::RequireResolve),
+                    Box::new(JsValue::WellKnownFunction(WellKnownFunctionKind::RequireResolve)),
                     args,
                 ),
                 "unresolveable request",
@@ -2040,7 +2040,7 @@ async fn require_resolve_visitor(
     } else {
         JsValue::unknown(
             JsValue::call(
-                box JsValue::WellKnownFunction(WellKnownFunctionKind::RequireResolve),
+                Box::new(JsValue::WellKnownFunction(WellKnownFunctionKind::RequireResolve)),
                 args,
             ),
             "only a single argument is supported",
@@ -2058,7 +2058,7 @@ async fn require_context_visitor(
         Err(err) => {
             return Ok(JsValue::unknown(
                 JsValue::call(
-                    box JsValue::WellKnownFunction(WellKnownFunctionKind::RequireContext),
+                    Box::new(JsValue::WellKnownFunction(WellKnownFunctionKind::RequireContext)),
                     args,
                 ),
                 PrettyPrintError(&err).to_string(),

--- a/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -464,7 +464,7 @@ impl EcmascriptChunkItem for RequireContextChunkItem {
 
             context_map
                 .props
-                .push(PropOrSpread::Prop(box Prop::KeyValue(prop)));
+                .push(PropOrSpread::Prop(Box::new(Prop::KeyValue(prop))));
         }
 
         let expr = quote_expr!(

--- a/crates/turbopack-ecmascript/src/transform/server_to_client_proxy.rs
+++ b/crates/turbopack-ecmascript/src/transform/server_to_client_proxy.rs
@@ -18,11 +18,11 @@ pub fn create_proxy_module(transition_name: &str, target_import: &str) -> Progra
     Program::Module(Module {
         body: vec![
             ModuleItem::Stmt(Stmt::Expr(ExprStmt {
-                expr: box Expr::Lit(Lit::Str(Str {
+                expr: Box::new(Expr::Lit(Lit::Str(Str {
                     value: format!("TURBOPACK {{ transition: {transition_name} }}").into(),
                     raw: None,
                     span: DUMMY_SP,
-                })),
+                }))),
                 span: DUMMY_SP,
             })),
             ModuleItem::ModuleDecl(ModuleDecl::Import(ImportDecl {
@@ -30,15 +30,15 @@ pub fn create_proxy_module(transition_name: &str, target_import: &str) -> Progra
                     local: ident.clone(),
                     span: DUMMY_SP,
                 })],
-                src: box target_import.into(),
+                src: Box::new(target_import.into()),
                 type_only: false,
-                asserts: Some(box ObjectLit {
+                asserts: Some(Box::new(ObjectLit {
                     span: DUMMY_SP,
-                    props: vec![PropOrSpread::Prop(box Prop::KeyValue(KeyValueProp {
+                    props: vec![PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {
                         key: PropName::Ident(Ident::new(TURBOPACK_HELPER.into(), DUMMY_SP)),
-                        value: box Expr::Lit(true.into()),
-                    }))],
-                }),
+                        value: Box::new(Expr::Lit(true.into())),
+                    })))],
+                })),
                 span: DUMMY_SP,
             })),
             ModuleItem::Stmt(quote!(

--- a/crates/turbopack-ecmascript/src/tree_shake/graph.rs
+++ b/crates/turbopack-ecmascript/src/tree_shake/graph.rs
@@ -296,9 +296,9 @@ impl DepGraph {
                     .push(ModuleItem::ModuleDecl(ModuleDecl::Import(ImportDecl {
                         span: DUMMY_SP,
                         specifiers,
-                        src: box uri_of_module.clone().into(),
+                        src: Box::new(uri_of_module.clone().into()),
                         type_only: false,
-                        asserts: Some(box create_turbopack_chunk_id_assert(dep)),
+                        asserts: Some(Box::new(create_turbopack_chunk_id_assert(dep))),
                     })));
             }
 
@@ -312,10 +312,10 @@ impl DepGraph {
                 // Emit `export { foo }`
                 for var in data.write_vars.iter() {
                     if required_vars.remove(var) {
-                        let assertion_prop = PropOrSpread::Prop(box Prop::KeyValue(KeyValueProp {
+                        let assertion_prop = PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {
                             key: quote_ident!("__turbopack_var__").into(),
-                            value: box true.into(),
-                        }));
+                            value: Box::new(true.into()),
+                        })));
 
                         chunk
                             .body
@@ -332,10 +332,10 @@ impl DepGraph {
                                     )],
                                     src: None,
                                     type_only: false,
-                                    asserts: Some(box ObjectLit {
+                                    asserts: Some(Box::new(ObjectLit {
                                         span: DUMMY_SP,
                                         props: vec![assertion_prop],
-                                    }),
+                                    })),
                                 },
                             )));
                     }
@@ -826,10 +826,10 @@ const ASSERT_CHUNK_KEY: &str = "__turbopack_chunk__";
 fn create_turbopack_chunk_id_assert(dep: u32) -> ObjectLit {
     ObjectLit {
         span: DUMMY_SP,
-        props: vec![PropOrSpread::Prop(box Prop::KeyValue(KeyValueProp {
+        props: vec![PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {
             key: PropName::Ident(Ident::new(ASSERT_CHUNK_KEY.into(), DUMMY_SP)),
             value: (dep as f64).into(),
-        }))],
+        })))],
     }
 }
 

--- a/crates/turbopack-ecmascript/src/webpack/references.rs
+++ b/crates/turbopack-ecmascript/src/webpack/references.rs
@@ -46,11 +46,11 @@ pub async fn module_references(
             let handler = Handler::with_emitter(
                 true,
                 false,
-                box IssueEmitter {
+                Box::new(IssueEmitter {
                     source,
                     source_map: source_map.clone(),
                     title: Some("Parsing webpack bundle failed".to_string()),
-                },
+                }),
             );
             HANDLER.set(&handler, || {
                 program.visit_with(&mut visitor);

--- a/crates/turbopack/src/lib.rs
+++ b/crates/turbopack/src/lib.rs
@@ -1,5 +1,4 @@
 #![feature(box_patterns)]
-#![feature(box_syntax)]
 #![feature(trivial_bounds)]
 #![feature(min_specialization)]
 #![feature(map_try_insert)]


### PR DESCRIPTION


### Description

Box syntax removed in https://github.com/rust-lang/rust/pull/108471

Removed all `#![features(box_syntax)]` and ran `cargo fix --broken-code` to replace all previous box_patterns uses of `box` with `Box::new()`.

### Testing Instructions

No testing needed. 