### PR TITLE
make the invalidation reason easier to read

### DIFF
--- a/crates/turbo-tasks-fs/src/invalidation.rs
+++ b/crates/turbo-tasks-fs/src/invalidation.rs
@@ -35,7 +35,7 @@ impl InvalidationReasonKind for WatchChangeKind {
     ) -> std::fmt::Result {
         write!(
             f,
-            "{} files changed (e. g. {})",
+            "{} files changed ({}, ...)",
             reasons.len(),
             reasons[0]
                 .as_any()

--- a/crates/turbopack-dev-server/src/invalidation.rs
+++ b/crates/turbopack-dev-server/src/invalidation.rs
@@ -42,7 +42,7 @@ impl InvalidationReasonKind for ServerRequestKind {
             .unwrap();
         write!(
             f,
-            "{} requests (e. g. {} {})",
+            "{} requests ({} {}, ...)",
             reasons.len(),
             example.method,
             example.uri.path()


### PR DESCRIPTION
### Description

before:

```
event - 141 requests (e. g. GET /api/exp) 22s
```

after:

```
event - 141 requests (GET /api/exp, ...) 22s
```