### PR TITLE
Use global turbo install for smoke test

### DIFF
--- a/.github/workflows/pr-js-tests-filtered.yml
+++ b/.github/workflows/pr-js-tests-filtered.yml
@@ -46,7 +46,7 @@ jobs:
           ref: ${{ github.ref }}
           fetch-depth: ${{ steps.fetch-depth.outputs.depth  }}
 
-      - name: Build debug binary
+      - name: Build turborepo CLI from source
         uses: ./.github/actions/setup-turborepo-environment
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -234,7 +234,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: ./.github/actions/setup-turborepo-environment
+      - name: Build turborepo CLI from source
+        uses: ./.github/actions/setup-turborepo-environment
         with:
           target: ${{ matrix.os.name }}
           github-token: "${{ secrets.GITHUB_TOKEN }}"
@@ -255,7 +256,8 @@ jobs:
             runner: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ./.github/actions/setup-turborepo-environment
+      - name: Build turborepo CLI from source
+        uses: ./.github/actions/setup-turborepo-environment
         with:
           target: ${{ matrix.os.name }}
           github-token: "${{ secrets.GITHUB_TOKEN }}"
@@ -290,7 +292,8 @@ jobs:
             runner: windows-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ./.github/actions/setup-turborepo-environment
+      - name: Build turborepo CLI from source
+        uses: ./.github/actions/setup-turborepo-environment
         with:
           target: ${{ matrix.os.name }}
           github-token: "${{ secrets.GITHUB_TOKEN }}"
@@ -361,7 +364,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - uses: ./.github/actions/setup-turborepo-environment
+      - name: Build turborepo CLI from source
+        uses: ./.github/actions/setup-turborepo-environment
         with:
           target: ${{ matrix.os.name }}
           github-token: "${{ secrets.GITHUB_TOKEN }}"
@@ -1105,8 +1109,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-
-      - uses: ./.github/actions/setup-turborepo-environment
+      - name: Build turborepo CLI from source
+        uses: ./.github/actions/setup-turborepo-environment
         with:
           target: ubuntu
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/turborepo-release-step-2.yml
+++ b/.github/workflows/turborepo-release-step-2.yml
@@ -16,14 +16,13 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ inputs.release_branch }}
-      - uses: ./.github/actions/setup-node
-        with:
-          enable-corepack: false
-      - uses: ./.github/actions/setup-go
+      - name: Build debug binary
+        uses: ./.github/actions/setup-turborepo-environment
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-      - name: Test
-        run: pnpm -- turbo run test --filter=cli --color
+          target: ${{ matrix.os.name }}
+      - name: Run Unit Tests
+        run: turbo run test --filter=cli --color
 
   darwin:
     needs: [smoke-test]

--- a/.github/workflows/turborepo-release-step-2.yml
+++ b/.github/workflows/turborepo-release-step-2.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ inputs.release_branch }}
-      - name: Build debug binary
+      - name: Build turborepo CLI from source
         uses: ./.github/actions/setup-turborepo-environment
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Smaller change from the one in #4666. This avoids building turbo multiple times before running unit tests before a release