### PR TITLE
docs(prisma): add required version field in example

### DIFF
--- a/docs/pages/repo/docs/handbook/tools/prisma.mdx
+++ b/docs/pages/repo/docs/handbook/tools/prisma.mdx
@@ -27,6 +27,7 @@ Create a new folder called `database` inside packages with a `package.json` insi
 ```json filename="packages/database/package.json"
 {
   "name": "database",
+  "version": "0.0.0",
   "dependencies": {
     "@prisma/client": "latest"
   },


### PR DESCRIPTION
### Description

When we follow instructions of this page https://turbo.build/repo/docs/handbook/tools/prisma, we got the following error : 
```
yarn install
yarn install v1.22.19
warning package.json: No license field
warning Missing version in workspace at "/xxxxx/packages/database", ignoring.
[1/4] 🔍  Resolving packages...
success Already up-to-date.
✨  Done in 0.12s.       
```

I just have added the required `version` field to have reproductible steps when we add a Prisma package on our monorepository.

### Testing Instructions

No test required
