### PR TITLE
Allow for dropped updates in the benchmarks

### DIFF
--- a/crates/turbopack-bench/src/bundlers/mod.rs
+++ b/crates/turbopack-bench/src/bundlers/mod.rs
@@ -1,4 +1,4 @@
-use std::{path::Path, process::Child};
+use std::{path::Path, process::Child, time::Duration};
 
 use anyhow::Result;
 
@@ -56,6 +56,20 @@ pub trait Bundler {
         Ok(())
     }
     fn start_server(&self, test_dir: &Path) -> Result<(Child, String)>;
+
+    /// The maximum amount of time to wait for HMR during the setup and warmup
+    /// phase.
+    fn max_init_update_timeout(&self, _module_count: usize) -> Duration {
+        Duration::from_secs(60)
+    }
+
+    /// The maximum amount of time to wait for HMR during the actual benchmark.
+    /// This is a lot shorter than the init timeout because we expect
+    /// updates to generally happen quickly, and we don't want to wait for a
+    /// long time when an update is dropped.
+    fn max_update_timeout(&self, _module_count: usize) -> Duration {
+        Duration::from_secs(5)
+    }
 }
 
 pub fn get_bundlers() -> Vec<Box<dyn Bundler>> {

--- a/crates/turbopack-bench/src/bundlers/nextjs/mod.rs
+++ b/crates/turbopack-bench/src/bundlers/nextjs/mod.rs
@@ -129,7 +129,7 @@ impl Bundler for NextJs {
         match (self.render_type, self.turbo) {
             (RenderType::ServerSidePrerendered, true) => Duration::from_millis(500),
             // Arbitrary default timeout that seems to work well for Next.js Webpack
-            _ => Duration::from_millis(500 + (module_count as f64 / 2.0).ceil() as u64),
+            _ => Duration::from_millis(5000 + (module_count as f64 / 2.0).ceil() as u64),
         }
     }
 }

--- a/crates/turbopack-bench/src/bundlers/nextjs/mod.rs
+++ b/crates/turbopack-bench/src/bundlers/nextjs/mod.rs
@@ -2,6 +2,7 @@ use std::{
     fs,
     path::Path,
     process::{Child, Command, Stdio},
+    time::Duration,
 };
 
 use anyhow::{anyhow, Context, Result};
@@ -122,6 +123,14 @@ impl Bundler for NextJs {
         .ok_or_else(|| anyhow!("failed to find devserver address"))?;
 
         Ok((proc, format!("{addr}/page")))
+    }
+
+    fn max_update_timeout(&self, module_count: usize) -> std::time::Duration {
+        match (self.render_type, self.turbo) {
+            (RenderType::ServerSidePrerendered, true) => Duration::from_millis(500),
+            // Arbitrary default timeout that seems to work well for Next.js Webpack
+            _ => Duration::from_millis(500 + (module_count as f64 / 2.0).ceil() as u64),
+        }
     }
 }
 

--- a/crates/turbopack-bench/src/lib.rs
+++ b/crates/turbopack-bench/src/lib.rs
@@ -33,7 +33,14 @@ use crate::{bundlers::Bundler, util::PageGuard};
 pub mod bundlers;
 pub mod util;
 
-const MAX_UPDATE_TIMEOUT: Duration = Duration::from_secs(60);
+/// The maximum amount of time to wait for HMR during the setup and warmup
+/// phase.
+const MAX_INIT_UPDATE_TIMEOUT: Duration = Duration::from_secs(60);
+/// The maximum amount of time to wait for HMR during the actual benchmark. This
+/// is a lot shorter than the init timeout because we expect updates to
+/// generally happen quickly, and we don't want to wait for a long time when an
+/// update is dropped.
+const MAX_UPDATE_TIMEOUT: Duration = Duration::from_secs(5);
 
 pub fn bench_startup(c: &mut Criterion, bundlers: &[Box<dyn Bundler>]) {
     let mut g = c.benchmark_group("bench_startup");
@@ -226,7 +233,7 @@ fn bench_hmr_internal(
                                         }
                                         Err(e) => {
                                             exponential_duration *= 2;
-                                            if exponential_duration > MAX_UPDATE_TIMEOUT {
+                                            if exponential_duration > MAX_INIT_UPDATE_TIMEOUT {
                                                 return Err(
                                                     e.context("failed to make warmup change")
                                                 );
@@ -237,8 +244,10 @@ fn bench_hmr_internal(
 
                                 // Once we know the HMR server is connected, we make a few warmup
                                 // changes.
-                                for _ in 0..hmr_warmup {
-                                    make_change(
+                                let mut hmr_warmup_iter = 0;
+                                let mut hmr_warmup_dropped = 0;
+                                while hmr_warmup_iter < hmr_warmup {
+                                    match make_change(
                                         &modules[0].0,
                                         bundler,
                                         &mut guard,
@@ -246,7 +255,23 @@ fn bench_hmr_internal(
                                         MAX_UPDATE_TIMEOUT,
                                         &WallTime,
                                     )
-                                    .await?;
+                                    .await
+                                    {
+                                        Err(_) => {
+                                            // We don't care about dropped updates during warmup.
+                                            hmr_warmup_dropped += 1;
+
+                                            if hmr_warmup_dropped >= hmr_warmup {
+                                                return Err(anyhow!(
+                                                    "failed to make warmup change {} times",
+                                                    hmr_warmup_dropped
+                                                ));
+                                            }
+                                        }
+                                        Ok(_) => {
+                                            hmr_warmup_iter += 1;
+                                        }
+                                    }
                                 }
 
                                 Ok(guard)
@@ -255,9 +280,11 @@ fn bench_hmr_internal(
                                 let module_picker = Arc::clone(module_picker);
                                 async move {
                                     let mut value = m.zero();
-                                    for iter in 0..iters {
+                                    let mut dropped = 0;
+                                    let mut iter = 0;
+                                    while iter < iters {
                                         let module = module_picker.pick();
-                                        let duration = make_change(
+                                        let duration = match make_change(
                                             module,
                                             bundler,
                                             &mut guard,
@@ -265,16 +292,33 @@ fn bench_hmr_internal(
                                             MAX_UPDATE_TIMEOUT,
                                             &m,
                                         )
-                                        .await?;
+                                        .await
+                                        {
+                                            Err(_) => {
+                                                // Some bundlers (e.g. Turbopack and Vite) can drop
+                                                // updates under certain conditions. We don't want
+                                                // to crash or stop the benchmark
+                                                // because of this. Instead, we keep going and
+                                                // report the number of dropped updates at the end.
+                                                dropped += 1;
+                                                continue;
+                                            }
+                                            Ok(duration) => duration,
+                                        };
                                         value = m.add(&value, &duration);
 
-                                        let i: u64 = iter + 1;
-                                        if verbose && i != iters && i.count_ones() == 1 {
+                                        iter += 1;
+                                        if verbose && iter != iters && iter.count_ones() == 1 {
                                             eprint!(
-                                                " [{:?} {:?}/{}]",
+                                                " [{:?} {:?}/{}{}]",
                                                 duration,
-                                                FormatDuration(value / (i as u32)),
-                                                i
+                                                FormatDuration(value / (iter as u32)),
+                                                iter,
+                                                if dropped > 0 {
+                                                    format!(" ({} dropped)", dropped)
+                                                } else {
+                                                    "".to_string()
+                                                }
                                             );
                                         }
                                     }

--- a/crates/turbopack-cli/benches/bundler.rs
+++ b/crates/turbopack-cli/benches/bundler.rs
@@ -1,6 +1,7 @@
 use std::{
     path::Path,
     process::{Child, Command, Stdio},
+    time::Duration,
 };
 
 use anyhow::{anyhow, Context, Result};
@@ -74,5 +75,9 @@ impl Bundler for Turbopack {
         .ok_or_else(|| anyhow!("failed to find devserver address"))?;
 
         Ok((proc, addr))
+    }
+
+    fn max_update_timeout(&self, _module_count: usize) -> std::time::Duration {
+        Duration::from_millis(500)
     }
 }


### PR DESCRIPTION
### Description

This improves the reliability of HMR benchmarks for bundlers that can drop updates (Vite, Turbopack). Before, an update being dropped meant the whole benchmark was canceled.

### Testing Instructions

Running the benchmarks