### PR TITLE
Allow the dev server socket to be reused immediately

### DIFF
--- a/crates/turbopack-dev-server/src/lib.rs
+++ b/crates/turbopack-dev-server/src/lib.rs
@@ -110,6 +110,8 @@ impl DevServer {
         // Allow the socket to be reused immediately after closing. This ensures that
         // the dev server can be restarted on the same address without a buffer time for
         // the OS to release the socket.
+        // https://docs.microsoft.com/en-us/windows/win32/winsock/using-so-reuseaddr-and-so-exclusiveaddruse
+        #[cfg(not(windows))]
         let _ = socket.set_reuse_address(true);
         if matches!(addr, SocketAddr::V6(_)) {
             // When possible bind to v4 and v6, otherwise ignore the error

--- a/crates/turbopack-dev-server/src/lib.rs
+++ b/crates/turbopack-dev-server/src/lib.rs
@@ -107,6 +107,10 @@ impl DevServer {
         // real TCP listener, see if it bound, and get its bound address.
         let socket = Socket::new(Domain::for_address(addr), Type::STREAM, Some(Protocol::TCP))
             .context("unable to create socket")?;
+        // Allow the socket to be reused immediately after closing. This ensures that
+        // the dev server can be restarted on the same address without a buffer time for
+        // the OS to release the socket.
+        let _ = socket.set_reuse_address(true);
         if matches!(addr, SocketAddr::V6(_)) {
             // When possible bind to v4 and v6, otherwise ignore the error
             let _ = socket.set_only_v6(false);


### PR DESCRIPTION
### Description

This avoids running into "Address already in use (os error 48)" when restarting the dev server in quick succession.
