### PR TITLE
fix(turborepo): Turbostate deserialization

### DIFF
--- a/cli/internal/turbostate/turbostate.go
+++ b/cli/internal/turbostate/turbostate.go
@@ -89,7 +89,7 @@ type ParsedArgsFromRust struct {
 
 // ExecutionState is the entire state of a turbo execution that is passed from the Rust shim.
 type ExecutionState struct {
-	APIClientConfig APIClientConfig    `json:"remote_config"`
+	APIClientConfig APIClientConfig    `json:"api_client_config"`
 	CLIArgs         ParsedArgsFromRust `json:"cli_args"`
 }
 

--- a/crates/turborepo-lib/src/execution_state.rs
+++ b/crates/turborepo-lib/src/execution_state.rs
@@ -29,7 +29,7 @@ impl<'a> TryFrom<&'a CommandBase> for ExecutionState<'a> {
         let client_config = base.client_config()?;
         let args = base.args();
 
-        let remote_config = APIClientConfig {
+        let api_client_config = APIClientConfig {
             token: user_config.token(),
             team_id: repo_config.team_id(),
             team_slug: repo_config.team_slug(),
@@ -39,7 +39,7 @@ impl<'a> TryFrom<&'a CommandBase> for ExecutionState<'a> {
         };
 
         Ok(ExecutionState {
-            api_client_config: remote_config,
+            api_client_config,
             cli_args: base.args(),
         })
     }

--- a/turborepo-tests/integration/tests/api-client-config.t
+++ b/turborepo-tests/integration/tests/api-client-config.t
@@ -3,7 +3,7 @@ Setup
   $ . ${TESTDIR}/_helpers/setup_monorepo.sh $(pwd)
 
 Run test run
-  $ ${TURBO} run build --__test-run | jq .remote_config
+  $ ${TURBO} run build --__test-run | jq .api_client_config
   {
     "token": null,
     "team_id": null,
@@ -14,29 +14,29 @@ Run test run
   }
 
 Run test run with api overloaded
-  $ ${TURBO} run build --__test-run --api http://localhost:8000 | jq .remote_config.api_url
+  $ ${TURBO} run build --__test-run --api http://localhost:8000 | jq .api_client_config.api_url
   null
 
 Run test run with token overloaded
-  $ ${TURBO} run build --__test-run --token 1234567890 | jq .remote_config.token
+  $ ${TURBO} run build --__test-run --token 1234567890 | jq .api_client_config.token
   "1234567890"
 
 Run test run with token overloaded from both TURBO_TOKEN and VERCEL_ARTIFACTS_TOKEN
-  $ TURBO_TOKEN=turbo VERCEL_ARTIFACTS_TOKEN=vercel ${TURBO} run build --__test-run | jq .remote_config.token
+  $ TURBO_TOKEN=turbo VERCEL_ARTIFACTS_TOKEN=vercel ${TURBO} run build --__test-run | jq .api_client_config.token
   "vercel"
 
 Run test run with team overloaded
-  $ ${TURBO} run build --__test-run --team vercel | jq .remote_config.team_slug
+  $ ${TURBO} run build --__test-run --team vercel | jq .api_client_config.team_slug
   "vercel"
 
 Run test run with team overloaded from both env and flag (flag should take precedence)
-  $ TURBO_TEAM=vercel ${TURBO} run build --__test-run --team turbo | jq .remote_config.team_slug
+  $ TURBO_TEAM=vercel ${TURBO} run build --__test-run --team turbo | jq .api_client_config.team_slug
   "turbo"
 
 Run test run with remote cache timeout env variable set
-  $ TURBO_REMOTE_CACHE_TIMEOUT=123 ${TURBO} run build --__test-run | jq .remote_config.timeout
+  $ TURBO_REMOTE_CACHE_TIMEOUT=123 ${TURBO} run build --__test-run | jq .api_client_config.timeout
   123
 
 Run test run with remote cache timeout from both env and flag (flag should take precedence)
-  $ TURBO_REMOTE_CACHE_TIMEOUT=123 ${TURBO} run build --__test-run --remote-cache-timeout 456 | jq .remote_config.timeout
+  $ TURBO_REMOTE_CACHE_TIMEOUT=123 ${TURBO} run build --__test-run --remote-cache-timeout 456 | jq .api_client_config.timeout
   456

--- a/turborepo-tests/integration/tests/api-client-config.t
+++ b/turborepo-tests/integration/tests/api-client-config.t
@@ -15,7 +15,7 @@ Run test run
 
 Run test run with api overloaded
   $ ${TURBO} run build --__test-run --api http://localhost:8000 | jq .api_client_config.api_url
-  null
+  "http://localhost:8000"
 
 Run test run with token overloaded
   $ ${TURBO} run build --__test-run --token 1234567890 | jq .api_client_config.token


### PR DESCRIPTION
### Description

Accidentally left the key as `remote_config` on the Go side instead of `api_client_config`

### Testing Instructions

Tested locally with ``.cram_env/bin/prysk --shell=`which bash` tests/api-client-config.t``