### PR TITLE
errors lead to consistent exit code in issue detail

### DIFF
--- a/crates/turbopack-node/js/src/ipc/index.ts
+++ b/crates/turbopack-node/js/src/ipc/index.ts
@@ -134,8 +134,9 @@ function createIpc<TIncoming, TOutgoing>(
         });
       } catch (err) {
         // ignore and exit anyway
+        process.exit(1);
       }
-      process.exit(1);
+      process.exit(0);
     },
   };
 }

--- a/crates/turbopack-node/src/render/issue.rs
+++ b/crates/turbopack-node/src/render/issue.rs
@@ -38,7 +38,9 @@ impl Issue for RenderingIssue {
         let mut details = vec![];
 
         if let Some(status) = self.status {
-            details.push(format!("Node.js exit code: {status}"));
+            if status != 0 {
+                details.push(format!("Node.js exit code: {status}"));
+            }
         }
 
         Ok(StringVc::cell(details.join("\n")))


### PR DESCRIPTION
### Description

issue snapshots are flaky due to alternating issue detail with exist code or not.

It's a race condition between process exit after sending error and process killing after receiving error.