### PR TITLE
Port RecursiveCopy to Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8905,8 +8905,20 @@ dependencies = [
  "prost",
  "prost-build",
  "thiserror",
+ "turbopath",
+ "turborepo-fs",
  "turborepo-lockfiles",
  "turborepo-scm",
+]
+
+[[package]]
+name = "turborepo-fs"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "tempfile",
+ "turbopath",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ members = [
   "crates/turborepo",
   "crates/turborepo-api-client",
   "crates/turborepo-ffi",
+  "crates/turborepo-fs",
   "crates/turborepo-lib",
   "crates/turborepo-lockfiles",
   "crates/turborepo-scm",
@@ -147,6 +148,7 @@ turbopath = { path = "crates/turbopath" }
 turborepo = { path = "crates/turborepo" }
 turborepo-api-client = { path = "crates/turborepo-api-client" }
 turborepo-ffi = { path = "crates/turborepo-ffi" }
+turborepo-fs = { path = "crates/turborepo-fs" }
 turborepo-lib = { path = "crates/turborepo-lib" }
 turborepo-lockfiles = { path = "crates/turborepo-lockfiles" }
 turborepo-scm = { path = "crates/turborepo-scm" }

--- a/cli/internal/ffi/bindings.h
+++ b/cli/internal/ffi/bindings.h
@@ -16,6 +16,8 @@ struct Buffer changed_files(struct Buffer buffer);
 
 struct Buffer previous_content(struct Buffer buffer);
 
+struct Buffer recursive_copy(struct Buffer buffer);
+
 struct Buffer transitive_closure(struct Buffer buf);
 
 struct Buffer subgraph(struct Buffer buf);

--- a/cli/internal/ffi/ffi.go
+++ b/cli/internal/ffi/ffi.go
@@ -264,12 +264,34 @@ func Patches(content []byte, packageManager string) []string {
 	if err := Unmarshal(resBuf, resp.ProtoReflect().Interface()); err != nil {
 		panic(err)
 	}
-
 	if err := resp.GetError(); err != "" {
 		panic(err)
 	}
 
 	return resp.GetPatches().GetPatches()
+}
+
+// RecursiveCopy copies src and its contents to dst
+func RecursiveCopy(src string, dst string) error {
+	req := ffi_proto.RecursiveCopyRequest{
+		Src: src,
+		Dst: dst,
+	}
+	reqBuf := Marshal(&req)
+	resBuf := C.recursive_copy(reqBuf)
+	reqBuf.Free()
+
+	resp := ffi_proto.RecursiveCopyResponse{}
+	if err := Unmarshal(resBuf, resp.ProtoReflect().Interface()); err != nil {
+		panic(err)
+	}
+	// Error is optional, so a nil value means no error was set
+	// GetError() papers over the difference and returns the zero
+	// value if it isn't set, so we need to check the value directly.
+	if resp.Error != nil {
+		return errors.New(*resp.Error)
+	}
+	return nil
 }
 
 // GlobalChange checks if there are any differences between lockfiles that would completely invalidate

--- a/cli/internal/ffi/proto/messages.pb.go
+++ b/cli/internal/ffi/proto/messages.pb.go
@@ -1560,6 +1560,108 @@ func (x *GlobalChangeResponse) GetGlobalChange() bool {
 	return false
 }
 
+type RecursiveCopyRequest struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Src string `protobuf:"bytes,1,opt,name=src,proto3" json:"src,omitempty"`
+	Dst string `protobuf:"bytes,2,opt,name=dst,proto3" json:"dst,omitempty"`
+}
+
+func (x *RecursiveCopyRequest) Reset() {
+	*x = RecursiveCopyRequest{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_turborepo_ffi_messages_proto_msgTypes[24]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *RecursiveCopyRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RecursiveCopyRequest) ProtoMessage() {}
+
+func (x *RecursiveCopyRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_turborepo_ffi_messages_proto_msgTypes[24]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RecursiveCopyRequest.ProtoReflect.Descriptor instead.
+func (*RecursiveCopyRequest) Descriptor() ([]byte, []int) {
+	return file_turborepo_ffi_messages_proto_rawDescGZIP(), []int{24}
+}
+
+func (x *RecursiveCopyRequest) GetSrc() string {
+	if x != nil {
+		return x.Src
+	}
+	return ""
+}
+
+func (x *RecursiveCopyRequest) GetDst() string {
+	if x != nil {
+		return x.Dst
+	}
+	return ""
+}
+
+type RecursiveCopyResponse struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Error *string `protobuf:"bytes,1,opt,name=error,proto3,oneof" json:"error,omitempty"`
+}
+
+func (x *RecursiveCopyResponse) Reset() {
+	*x = RecursiveCopyResponse{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_turborepo_ffi_messages_proto_msgTypes[25]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *RecursiveCopyResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RecursiveCopyResponse) ProtoMessage() {}
+
+func (x *RecursiveCopyResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_turborepo_ffi_messages_proto_msgTypes[25]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RecursiveCopyResponse.ProtoReflect.Descriptor instead.
+func (*RecursiveCopyResponse) Descriptor() ([]byte, []int) {
+	return file_turborepo_ffi_messages_proto_rawDescGZIP(), []int{25}
+}
+
+func (x *RecursiveCopyResponse) GetError() string {
+	if x != nil && x.Error != nil {
+		return *x.Error
+	}
+	return ""
+}
+
 var File_turborepo_ffi_messages_proto protoreflect.FileDescriptor
 
 var file_turborepo_ffi_messages_proto_rawDesc = []byte{
@@ -1733,11 +1835,18 @@ var file_turborepo_ffi_messages_proto_rawDesc = []byte{
 	0x47, 0x6c, 0x6f, 0x62, 0x61, 0x6c, 0x43, 0x68, 0x61, 0x6e, 0x67, 0x65, 0x52, 0x65, 0x73, 0x70,
 	0x6f, 0x6e, 0x73, 0x65, 0x12, 0x23, 0x0a, 0x0d, 0x67, 0x6c, 0x6f, 0x62, 0x61, 0x6c, 0x5f, 0x63,
 	0x68, 0x61, 0x6e, 0x67, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x08, 0x52, 0x0c, 0x67, 0x6c, 0x6f,
-	0x62, 0x61, 0x6c, 0x43, 0x68, 0x61, 0x6e, 0x67, 0x65, 0x2a, 0x24, 0x0a, 0x0e, 0x50, 0x61, 0x63,
-	0x6b, 0x61, 0x67, 0x65, 0x4d, 0x61, 0x6e, 0x61, 0x67, 0x65, 0x72, 0x12, 0x07, 0x0a, 0x03, 0x4e,
-	0x50, 0x4d, 0x10, 0x00, 0x12, 0x09, 0x0a, 0x05, 0x42, 0x45, 0x52, 0x52, 0x59, 0x10, 0x01, 0x42,
-	0x0b, 0x5a, 0x09, 0x66, 0x66, 0x69, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x06, 0x70, 0x72,
-	0x6f, 0x74, 0x6f, 0x33,
+	0x62, 0x61, 0x6c, 0x43, 0x68, 0x61, 0x6e, 0x67, 0x65, 0x22, 0x3a, 0x0a, 0x14, 0x52, 0x65, 0x63,
+	0x75, 0x72, 0x73, 0x69, 0x76, 0x65, 0x43, 0x6f, 0x70, 0x79, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73,
+	0x74, 0x12, 0x10, 0x0a, 0x03, 0x73, 0x72, 0x63, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x03,
+	0x73, 0x72, 0x63, 0x12, 0x10, 0x0a, 0x03, 0x64, 0x73, 0x74, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09,
+	0x52, 0x03, 0x64, 0x73, 0x74, 0x22, 0x3c, 0x0a, 0x15, 0x52, 0x65, 0x63, 0x75, 0x72, 0x73, 0x69,
+	0x76, 0x65, 0x43, 0x6f, 0x70, 0x79, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x19,
+	0x0a, 0x05, 0x65, 0x72, 0x72, 0x6f, 0x72, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x48, 0x00, 0x52,
+	0x05, 0x65, 0x72, 0x72, 0x6f, 0x72, 0x88, 0x01, 0x01, 0x42, 0x08, 0x0a, 0x06, 0x5f, 0x65, 0x72,
+	0x72, 0x6f, 0x72, 0x2a, 0x24, 0x0a, 0x0e, 0x50, 0x61, 0x63, 0x6b, 0x61, 0x67, 0x65, 0x4d, 0x61,
+	0x6e, 0x61, 0x67, 0x65, 0x72, 0x12, 0x07, 0x0a, 0x03, 0x4e, 0x50, 0x4d, 0x10, 0x00, 0x12, 0x09,
+	0x0a, 0x05, 0x42, 0x45, 0x52, 0x52, 0x59, 0x10, 0x01, 0x42, 0x0b, 0x5a, 0x09, 0x66, 0x66, 0x69,
+	0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
 }
 
 var (
@@ -1753,7 +1862,7 @@ func file_turborepo_ffi_messages_proto_rawDescGZIP() []byte {
 }
 
 var file_turborepo_ffi_messages_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_turborepo_ffi_messages_proto_msgTypes = make([]protoimpl.MessageInfo, 27)
+var file_turborepo_ffi_messages_proto_msgTypes = make([]protoimpl.MessageInfo, 29)
 var file_turborepo_ffi_messages_proto_goTypes = []interface{}{
 	(PackageManager)(0),            // 0: PackageManager
 	(*TurboDataDirResp)(nil),       // 1: TurboDataDirResp
@@ -1780,20 +1889,22 @@ var file_turborepo_ffi_messages_proto_goTypes = []interface{}{
 	(*Patches)(nil),                // 22: Patches
 	(*GlobalChangeRequest)(nil),    // 23: GlobalChangeRequest
 	(*GlobalChangeResponse)(nil),   // 24: GlobalChangeResponse
-	nil,                            // 25: WorkspaceDependencies.DependenciesEntry
-	nil,                            // 26: TransitiveDepsRequest.WorkspacesEntry
-	nil,                            // 27: AdditionalBerryData.ResolutionsEntry
+	(*RecursiveCopyRequest)(nil),   // 25: RecursiveCopyRequest
+	(*RecursiveCopyResponse)(nil),  // 26: RecursiveCopyResponse
+	nil,                            // 27: WorkspaceDependencies.DependenciesEntry
+	nil,                            // 28: TransitiveDepsRequest.WorkspacesEntry
+	nil,                            // 29: AdditionalBerryData.ResolutionsEntry
 }
 var file_turborepo_ffi_messages_proto_depIdxs = []int32{
 	4,  // 0: GlobResp.files:type_name -> GlobRespList
 	7,  // 1: ChangedFilesResp.files:type_name -> ChangedFilesList
 	10, // 2: PackageDependencyList.list:type_name -> PackageDependency
-	25, // 3: WorkspaceDependencies.dependencies:type_name -> WorkspaceDependencies.DependenciesEntry
+	27, // 3: WorkspaceDependencies.dependencies:type_name -> WorkspaceDependencies.DependenciesEntry
 	0,  // 4: TransitiveDepsRequest.package_manager:type_name -> PackageManager
-	26, // 5: TransitiveDepsRequest.workspaces:type_name -> TransitiveDepsRequest.WorkspacesEntry
+	28, // 5: TransitiveDepsRequest.workspaces:type_name -> TransitiveDepsRequest.WorkspacesEntry
 	15, // 6: TransitiveDepsRequest.resolutions:type_name -> AdditionalBerryData
 	12, // 7: TransitiveDepsResponse.dependencies:type_name -> WorkspaceDependencies
-	27, // 8: AdditionalBerryData.resolutions:type_name -> AdditionalBerryData.ResolutionsEntry
+	29, // 8: AdditionalBerryData.resolutions:type_name -> AdditionalBerryData.ResolutionsEntry
 	16, // 9: LockfilePackageList.list:type_name -> LockfilePackage
 	0,  // 10: SubgraphRequest.package_manager:type_name -> PackageManager
 	15, // 11: SubgraphRequest.resolutions:type_name -> AdditionalBerryData
@@ -2103,6 +2214,30 @@ func file_turborepo_ffi_messages_proto_init() {
 				return nil
 			}
 		}
+		file_turborepo_ffi_messages_proto_msgTypes[24].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*RecursiveCopyRequest); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_turborepo_ffi_messages_proto_msgTypes[25].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*RecursiveCopyResponse); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
 	}
 	file_turborepo_ffi_messages_proto_msgTypes[2].OneofWrappers = []interface{}{
 		(*GlobResp_Files)(nil),
@@ -2131,13 +2266,14 @@ func file_turborepo_ffi_messages_proto_init() {
 		(*PatchesResponse_Patches)(nil),
 		(*PatchesResponse_Error)(nil),
 	}
+	file_turborepo_ffi_messages_proto_msgTypes[25].OneofWrappers = []interface{}{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_turborepo_ffi_messages_proto_rawDesc,
 			NumEnums:      1,
-			NumMessages:   27,
+			NumMessages:   29,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/cli/internal/fs/copy_file.go
+++ b/cli/internal/fs/copy_file.go
@@ -6,39 +6,9 @@ package fs
 import (
 	"errors"
 	"os"
-	"path/filepath"
 
 	"github.com/karrick/godirwalk"
-	"github.com/vercel/turbo/cli/internal/turbopath"
 )
-
-// RecursiveCopy copies either a single file or a directory.
-// 'mode' is the mode of the destination file.
-func RecursiveCopy(from turbopath.AbsoluteSystemPath, to turbopath.AbsoluteSystemPath) error {
-	// Verified all callers are passing in absolute paths for from (and to)
-	statedFrom := LstatCachedFile{Path: from}
-	fromType, err := statedFrom.GetType()
-	if err != nil {
-		return err
-	}
-
-	if fromType.IsDir() {
-		return WalkMode(statedFrom.Path.ToStringDuringMigration(), func(name string, isDir bool, fileType os.FileMode) error {
-			dest := filepath.Join(to.ToStringDuringMigration(), name[len(statedFrom.Path.ToString()):])
-			// name is absolute, (originates from godirwalk)
-			src := LstatCachedFile{Path: UnsafeToAbsoluteSystemPath(name), fileType: &fileType}
-			if isDir {
-				mode, err := src.GetMode()
-				if err != nil {
-					return err
-				}
-				return os.MkdirAll(dest, mode)
-			}
-			return CopyFile(&src, dest)
-		})
-	}
-	return CopyFile(&statedFrom, to.ToStringDuringMigration())
-}
 
 // Walk implements an equivalent to filepath.Walk.
 // It's implemented over github.com/karrick/godirwalk but the provided interface doesn't use that

--- a/cli/internal/fs/copy_file_test.go
+++ b/cli/internal/fs/copy_file_test.go
@@ -138,10 +138,10 @@ func TestRecursiveCopy(t *testing.T) {
 	circlePath := filepath.Join(childDir, "circle")
 	assert.NilError(t, os.Symlink(filepath.FromSlash("../child"), circlePath), "Symlink")
 
-	err = RecursiveCopy(src.Path(), dst.Path())
+	err = RecursiveCopy(turbopath.AbsoluteSystemPathFromUpstream(src.Path()), turbopath.AbsoluteSystemPathFromUpstream(dst.Path()))
 	assert.NilError(t, err, "RecursiveCopy")
 	// For ensure multiple times copy will not broken
-	err = RecursiveCopy(src.Path(), dst.Path())
+	err = RecursiveCopy(turbopath.AbsoluteSystemPathFromUpstream(src.Path()), turbopath.AbsoluteSystemPathFromUpstream(dst.Path()))
 	assert.NilError(t, err, "RecursiveCopy")
 
 	dstChildDir := filepath.Join(dst.Path(), "child")

--- a/cli/internal/fs/recursive_copy_go.go
+++ b/cli/internal/fs/recursive_copy_go.go
@@ -1,0 +1,38 @@
+//go:build go || !rust
+// +build go !rust
+
+package fs
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/vercel/turbo/cli/internal/turbopath"
+)
+
+// RecursiveCopy copies either a single file or a directory.
+func RecursiveCopy(from turbopath.AbsoluteSystemPath, to turbopath.AbsoluteSystemPath) error {
+	// Verified all callers are passing in absolute paths for from (and to)
+	statedFrom := LstatCachedFile{Path: from}
+	fromType, err := statedFrom.GetType()
+	if err != nil {
+		return err
+	}
+
+	if fromType.IsDir() {
+		return WalkMode(statedFrom.Path.ToStringDuringMigration(), func(name string, isDir bool, fileType os.FileMode) error {
+			dest := filepath.Join(to.ToStringDuringMigration(), name[len(statedFrom.Path.ToString()):])
+			// name is absolute, (originates from godirwalk)
+			src := LstatCachedFile{Path: UnsafeToAbsoluteSystemPath(name), fileType: &fileType}
+			if isDir {
+				mode, err := src.GetMode()
+				if err != nil {
+					return err
+				}
+				return os.MkdirAll(dest, mode)
+			}
+			return CopyFile(&src, dest)
+		})
+	}
+	return CopyFile(&statedFrom, to.ToStringDuringMigration())
+}

--- a/cli/internal/fs/recursive_copy_rust.go
+++ b/cli/internal/fs/recursive_copy_rust.go
@@ -1,0 +1,14 @@
+//go:build rust
+// +build rust
+
+package fs
+
+import (
+	"github.com/vercel/turbo/cli/internal/ffi"
+	"github.com/vercel/turbo/cli/internal/turbopath"
+)
+
+// RecursiveCopy copies either a single file or a directory.
+func RecursiveCopy(from turbopath.AbsoluteSystemPath, to turbopath.AbsoluteSystemPath) error {
+	return ffi.RecursiveCopy(from.ToString(), to.ToString())
+}

--- a/cli/internal/prune/prune.go
+++ b/cli/internal/prune/prune.go
@@ -151,7 +151,7 @@ func (p *prune) prune(opts *turbostate.PrunePayload) error {
 			return errors.Wrapf(err, "failed to create folder %s for %v", targetDir, internalDep)
 		}
 
-		if err := fs.RecursiveCopy(ctx.WorkspaceInfos.PackageJSONs[internalDep].Dir.ToStringDuringMigration(), targetDir.ToStringDuringMigration()); err != nil {
+		if err := fs.RecursiveCopy(ctx.WorkspaceInfos.PackageJSONs[internalDep].Dir.RestoreAnchor(p.base.RepoRoot), targetDir); err != nil {
 			return errors.Wrapf(err, "failed to copy %v into %v", internalDep, targetDir)
 		}
 		if opts.Docker {
@@ -159,7 +159,7 @@ func (p *prune) prune(opts *turbostate.PrunePayload) error {
 			if err := jsonDir.EnsureDir(); err != nil {
 				return errors.Wrapf(err, "failed to create folder %v for %v", jsonDir, internalDep)
 			}
-			if err := fs.RecursiveCopy(ctx.WorkspaceInfos.PackageJSONs[internalDep].PackageJSONPath.ToStringDuringMigration(), jsonDir.ToStringDuringMigration()); err != nil {
+			if err := fs.RecursiveCopy(ctx.WorkspaceInfos.PackageJSONs[internalDep].PackageJSONPath.RestoreAnchor(p.base.RepoRoot), jsonDir); err != nil {
 				return errors.Wrapf(err, "failed to copy %v into %v", internalDep, jsonDir)
 			}
 		}

--- a/crates/turbopath/src/absolute_system_path_buf.rs
+++ b/crates/turbopath/src/absolute_system_path_buf.rs
@@ -61,6 +61,10 @@ impl AbsoluteSystemPathBuf {
         Ok(AbsoluteSystemPathBuf(system_path))
     }
 
+    pub fn new_unchecked(raw: impl Into<PathBuf>) -> Self {
+        Self(raw.into())
+    }
+
     /// Anchors `path` at `self`.
     ///
     /// # Arguments

--- a/crates/turbopath/src/absolute_system_path_buf.rs
+++ b/crates/turbopath/src/absolute_system_path_buf.rs
@@ -61,10 +61,6 @@ impl AbsoluteSystemPathBuf {
         Ok(AbsoluteSystemPathBuf(system_path))
     }
 
-    pub fn new_unchecked(raw: impl Into<PathBuf>) -> Self {
-        Self(raw.into())
-    }
-
     /// Anchors `path` at `self`.
     ///
     /// # Arguments

--- a/crates/turbopath/src/lib.rs
+++ b/crates/turbopath/src/lib.rs
@@ -5,17 +5,36 @@ mod anchored_system_path_buf;
 mod relative_system_path_buf;
 mod relative_unix_path_buf;
 
-use std::path::{Path, PathBuf};
+use std::{
+    io,
+    path::{Path, PathBuf},
+};
 
 pub use absolute_system_path_buf::AbsoluteSystemPathBuf;
 pub use anchored_system_path_buf::AnchoredSystemPathBuf;
 use path_slash::{PathBufExt, PathExt};
 pub use relative_system_path_buf::RelativeSystemPathBuf;
 pub use relative_unix_path_buf::RelativeUnixPathBuf;
-use thiserror::Error;
+
+#[derive(Debug, thiserror::Error)]
+pub enum PathError {
+    #[error("Path validation failed: {0}")]
+    PathValidationError(#[from] PathValidationError),
+    #[error("IO Error {0}")]
+    IO(#[from] io::Error),
+}
+
+impl PathError {
+    pub fn is_io_error(&self, kind: io::ErrorKind) -> bool {
+        match self {
+            PathError::IO(err) => err.kind() == kind,
+            _ => false,
+        }
+    }
+}
 
 // Custom error type for path validation errors
-#[derive(Debug, Error)]
+#[derive(Debug, thiserror::Error)]
 pub enum PathValidationError {
     #[error("Path is non-UTF-8: {0}")]
     InvalidUnicode(PathBuf),

--- a/crates/turborepo-ffi/Cargo.toml
+++ b/crates/turborepo-ffi/Cargo.toml
@@ -11,6 +11,8 @@ crate-type = ["staticlib"]
 directories = "4.0.1"
 prost = "0.11.6"
 thiserror = { workspace = true }
+turbopath = { workspace = true }
+turborepo-fs = { workspace = true }
 turborepo-lockfiles = { workspace = true }
 turborepo-scm = { workspace = true }
 

--- a/crates/turborepo-ffi/messages.proto
+++ b/crates/turborepo-ffi/messages.proto
@@ -140,3 +140,12 @@ message GlobalChangeRequest {
 message GlobalChangeResponse {
   bool global_change = 1;
 }
+
+message RecursiveCopyRequest {
+  string src = 1;
+  string dst = 2;
+}
+
+message RecursiveCopyResponse {
+  optional string error = 1;
+}

--- a/crates/turborepo-ffi/src/lib.rs
+++ b/crates/turborepo-ffi/src/lib.rs
@@ -134,10 +134,28 @@ pub extern "C" fn recursive_copy(buffer: Buffer) -> Buffer {
             return resp.into();
         }
     };
-    let response = match turborepo_fs::recursive_copy(
-        &AbsoluteSystemPathBuf::new_unchecked(req.src),
-        &AbsoluteSystemPathBuf::new_unchecked(req.dst),
-    ) {
+
+    let src = match AbsoluteSystemPathBuf::new(req.src) {
+        Ok(src) => src,
+        Err(e) => {
+            let response = proto::RecursiveCopyResponse {
+                error: Some(e.to_string()),
+            };
+            return response.into();
+        }
+    };
+
+    let dst = match AbsoluteSystemPathBuf::new(req.dst) {
+        Ok(dst) => dst,
+        Err(e) => {
+            let response = proto::RecursiveCopyResponse {
+                error: Some(e.to_string()),
+            };
+            return response.into();
+        }
+    };
+
+    let response = match turborepo_fs::recursive_copy(&src, &dst) {
         Ok(()) => proto::RecursiveCopyResponse { error: None },
         Err(e) => proto::RecursiveCopyResponse {
             error: Some(e.to_string()),

--- a/crates/turborepo-fs/Cargo.toml
+++ b/crates/turborepo-fs/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "turborepo-fs"
+version = "0.1.0"
+license = "MPL-2.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = { workspace = true }
+turbopath = { workspace = true }
+walkdir = "2.3.3"
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/turborepo-fs/src/lib.rs
+++ b/crates/turborepo-fs/src/lib.rs
@@ -1,0 +1,250 @@
+use std::fs::{self, DirBuilder, Metadata};
+
+use anyhow::Result;
+use turbopath::{AbsoluteSystemPathBuf, AnchoredSystemPathBuf};
+use walkdir::WalkDir;
+
+pub fn recursive_copy(src: &AbsoluteSystemPathBuf, dst: &AbsoluteSystemPathBuf) -> Result<()> {
+    let src_metadata = src.metadata()?;
+    if src_metadata.is_dir() {
+        let walker = WalkDir::new(src.as_path()).follow_links(false);
+        for entry in walker.into_iter() {
+            match entry {
+                Err(e) => {
+                    if let Some(_) = e.io_error() {
+                        // Matches go behavior where we translate path errors
+                        // into skipping the path we're currently walking
+                        continue;
+                    } else {
+                        return Err(e.into());
+                    }
+                }
+                Ok(entry) => {
+                    let path = AbsoluteSystemPathBuf::new(entry.path())?;
+                    let file_type = entry.file_type();
+                    // currently we support symlinked files, but not symlinked directories:
+                    // For copying, we Mkdir and bail if we encounter a symlink to a directoy
+                    // For finding packages, we enumerate the symlink, but don't follow inside
+                    // Note that we also don't currently copy broken symlinks
+                    let is_dir_or_symlink_to_dir = if file_type.is_dir() {
+                        true
+                    } else if file_type.is_symlink() {
+                        if let Ok(metadata) = path.stat() {
+                            metadata.is_dir()
+                        } else {
+                            // If we have a broken link, skip this entry
+                            continue;
+                        }
+                    } else {
+                        false
+                    };
+
+                    let suffix = AnchoredSystemPathBuf::new(src, &path)?;
+                    let target = dst.resolve(&suffix);
+                    if is_dir_or_symlink_to_dir {
+                        let src_metadata = entry.metadata()?;
+                        make_dir_copy(&target, &src_metadata)?;
+                    } else {
+                        copy_file_with_type(&path, file_type, &target)?;
+                    }
+                }
+            }
+        }
+        Ok(())
+    } else {
+        copy_file_with_type(src, src_metadata.file_type(), dst)
+    }
+}
+
+fn make_dir_copy(dir: &AbsoluteSystemPathBuf, src_metadata: &Metadata) -> Result<()> {
+    let mut builder = DirBuilder::new();
+    #[cfg(not(windows))]
+    {
+        use std::os::unix::{fs::DirBuilderExt, prelude::MetadataExt};
+        builder.mode(src_metadata.mode());
+    }
+    builder.recursive(true);
+    builder.create(dir.as_path())?;
+    Ok(())
+}
+
+pub fn copy_file(from: &AbsoluteSystemPathBuf, to: &AbsoluteSystemPathBuf) -> Result<()> {
+    let metadata = from.metadata()?;
+    copy_file_with_type(from, metadata.file_type(), to)
+}
+
+fn copy_file_with_type(
+    from: &AbsoluteSystemPathBuf,
+    from_type: fs::FileType,
+    to: &AbsoluteSystemPathBuf,
+) -> Result<()> {
+    if from_type.is_symlink() {
+        let target = from.read_symlink()?;
+        to.ensure_dir()?;
+        if to.metadata().is_ok() {
+            to.remove()?;
+        }
+        to.symlink_to_file(&target)?;
+        Ok(())
+    } else {
+        to.ensure_dir()?;
+        fs::copy(from.as_path(), to.as_path())?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{io, path::Path};
+
+    use turbopath::PathError;
+
+    use super::*;
+
+    fn tmp_dir() -> Result<(tempfile::TempDir, AbsoluteSystemPathBuf)> {
+        let tmp_dir = tempfile::tempdir()?;
+        let dir = AbsoluteSystemPathBuf::new(tmp_dir.path().to_path_buf())?;
+        Ok((tmp_dir, dir))
+    }
+
+    #[test]
+    fn test_copy_missing_file() -> Result<()> {
+        let (_src_tmp, src_dir) = tmp_dir()?;
+        let src_file = src_dir.join_literal("src");
+
+        let (_dst_tmp, dst_dir) = tmp_dir()?;
+        let dst_file = dst_dir.join_literal("dest");
+
+        let err = copy_file(&src_file, &dst_file).unwrap_err();
+        let err = err.downcast::<PathError>()?;
+        assert_eq!(err.is_io_error(io::ErrorKind::NotFound), true);
+        Ok(())
+    }
+
+    #[test]
+    fn test_basic_copy_file() -> Result<()> {
+        let (_src_tmp, src_dir) = tmp_dir()?;
+        let src_file = src_dir.join_literal("src");
+
+        let (_dst_tmp, dst_dir) = tmp_dir()?;
+        let dst_file = dst_dir.join_literal("dest");
+
+        // src exists, dst doesn't
+        src_file.create_with_contents("src")?;
+
+        copy_file(&src_file, &dst_file)?;
+        assert_file_matches(&src_file, &dst_file);
+        Ok(())
+    }
+
+    #[test]
+    fn test_symlinks() -> Result<()> {
+        let (_src_tmp, src_dir) = tmp_dir()?;
+        let src_symlink = src_dir.join_literal("symlink");
+
+        let (_target_tmp, target_dir) = tmp_dir()?;
+        let src_target = target_dir.join_literal("target");
+
+        let (_dst_tmp, dst_dir) = tmp_dir()?;
+        let dst_file = dst_dir.join_literal("dest");
+
+        // create symlink target
+        src_target.create_with_contents("target")?;
+        src_symlink.symlink_to_file(src_target.as_path())?;
+
+        copy_file(&src_symlink, &dst_file)?;
+        assert_target_matches(&dst_file, &src_target);
+        Ok(())
+    }
+
+    #[test]
+    fn test_copy_file_with_perms() -> Result<()> {
+        let (_src_tmp, src_dir) = tmp_dir()?;
+        let src_file = src_dir.join_literal("src");
+
+        let (_dst_tmp, dst_dir) = tmp_dir()?;
+        let dst_file = dst_dir.join_literal("dest");
+
+        // src exists, dst doesn't
+        src_file.create_with_contents("src")?;
+        src_file.set_readonly()?;
+
+        copy_file(&src_file, &dst_file)?;
+        assert_file_matches(&src_file, &dst_file);
+        assert_eq!(dst_file.is_readonly()?, true);
+        Ok(())
+    }
+
+    #[test]
+    fn test_recursive_copy() -> Result<()> {
+        // Directory layout:
+        //
+        // <src>/
+        //   b
+        //   child/
+        //     a
+        //     link -> ../b
+        //     broken -> missing
+        //     circle -> ../child
+        let (_src_tmp, src_dir) = tmp_dir()?;
+        let child_dir = src_dir.join_literal("child");
+        let a_path = child_dir.join_literal("a");
+        a_path.ensure_dir()?;
+        a_path.create_with_contents("hello")?;
+
+        let b_path = src_dir.join_literal("b");
+        b_path.create_with_contents("bFile")?;
+
+        let link_path = child_dir.join_literal("link");
+        link_path.symlink_to_file("../b")?;
+
+        let broken_link_path = child_dir.join_literal("broken");
+        broken_link_path.symlink_to_file("missing")?;
+
+        let circle_path = child_dir.join_literal("circle");
+        circle_path.symlink_to_dir("../child")?;
+
+        let (_dst_tmp, dst_dir) = tmp_dir()?;
+
+        recursive_copy(&src_dir, &dst_dir)?;
+
+        // Ensure double copy doesn't error
+        recursive_copy(&src_dir, &dst_dir)?;
+
+        let dst_child_path = dst_dir.join_literal("child");
+        let dst_a_path = dst_child_path.join_literal("a");
+        assert_file_matches(&a_path, &dst_a_path);
+
+        let dst_b_path = dst_dir.join_literal("b");
+        assert_file_matches(&b_path, &dst_b_path);
+
+        let dst_link_path = dst_child_path.join_literal("link");
+        assert_target_matches(&dst_link_path, "../b");
+
+        let dst_broken_path = dst_child_path.join_literal("broken");
+        assert_eq!(dst_broken_path.as_path().exists(), false);
+
+        // Currently, we convert symlink-to-directory to empty-directory
+        // This is very likely not ideal behavior, but leaving this test here to verify
+        // that it is what we expect at this point in time.
+        let dst_circle_path = dst_child_path.join_literal("circle");
+        let dst_circle_metadata = dst_circle_path.metadata()?;
+        assert_eq!(dst_circle_metadata.is_dir(), true);
+
+        let num_files = fs::read_dir(dst_circle_path.as_path())?.into_iter().count();
+        assert_eq!(num_files, 0);
+
+        Ok(())
+    }
+
+    fn assert_file_matches(a: &AbsoluteSystemPathBuf, b: &AbsoluteSystemPathBuf) {
+        let a_contents = fs::read_to_string(a.as_path()).unwrap();
+        let b_contents = fs::read_to_string(b.as_path()).unwrap();
+        assert_eq!(a_contents, b_contents);
+    }
+
+    fn assert_target_matches<P: AsRef<Path>>(link: &AbsoluteSystemPathBuf, expected: P) {
+        let path = link.read_symlink().unwrap();
+        assert_eq!(path.as_path(), expected.as_ref());
+    }
+}


### PR DESCRIPTION
### Description

 - Ports `RecursiveCopy` to rust and wires it up.
 - Ports `CopyFile` to rust but only uses it internally within `recursive_copy`. It is available for later though.

### Testing Instructions

Ported `copy_file_test.go` to Rust, which includes the test for `RecursiveCopy`. To Go test also continues to pass against the rust implementation.
Existing `prune` integration tests pass

### Review Notes 
The commits are:
 1. Tweaks to Go to ensure we always have absolute system paths
 2. Rust implementation
 3. FFI wiring

It's possible I've missed specifying a new crate in some location, please let me know.

Note the new methods on `AbsoluteSystemPathBuf`. These are an example of the kinds of things that will let us spot and flag uses of things like `fs::Open` and `fs::Metadata` in other pieces of code. 

Also note that our existing `RecursiveCopy` has some weird behavior: symlinks to directories get turned into empty folders and broken symlinks are not copied at all. I've reproduced these quirks so that we can fix them on purpose rather than bury them in the porting effort.
