### PR TITLE
Remove `THASH`

### DIFF
--- a/cli/internal/run/global_hash.go
+++ b/cli/internal/run/global_hash.go
@@ -127,7 +127,7 @@ func getGlobalHashInputs(
 	envVars := []string{}
 	envVars = append(envVars, envVarDependencies...)
 	envVars = append(envVars, _defaultEnvVars...)
-	globalHashableEnvVars, err := env.GetHashableEnvVars(envVars, []string{".*THASH.*"}, "")
+	globalHashableEnvVars, err := env.GetHashableEnvVars(envVars, nil, "")
 	if err != nil {
 		return GlobalHashableInputs{}, err
 	}

--- a/cli/internal/run/global_hash.go
+++ b/cli/internal/run/global_hash.go
@@ -3,10 +3,8 @@ package run
 import (
 	"fmt"
 	"path/filepath"
-	"strings"
 
 	"github.com/hashicorp/go-hclog"
-	"github.com/mitchellh/cli"
 	"github.com/vercel/turbo/cli/internal/env"
 	"github.com/vercel/turbo/cli/internal/fs"
 	"github.com/vercel/turbo/cli/internal/globby"
@@ -124,8 +122,6 @@ func getGlobalHashInputs(
 	envVarPassthroughs []string,
 	envMode util.EnvMode,
 	logger hclog.Logger,
-	ui cli.Ui,
-	isStructuredOutput bool,
 ) (GlobalHashableInputs, error) {
 	// Calculate env var dependencies
 	envVars := []string{}
@@ -134,14 +130,6 @@ func getGlobalHashInputs(
 	globalHashableEnvVars, err := env.GetHashableEnvVars(envVars, []string{".*THASH.*"}, "")
 	if err != nil {
 		return GlobalHashableInputs{}, err
-	}
-
-	// The only way we can add env vars into the hash via matching is via THASH,
-	// so we only do a simple check here for entries in `BySource.Matching`.
-	// If we enable globalEnv to accept wildcard characters, we'll need to update this
-	// check.
-	if !isStructuredOutput && len(globalHashableEnvVars.BySource.Matching) > 0 {
-		ui.Warn(fmt.Sprintf("[DEPRECATED] Using .*THASH.* to specify an environment variable for inclusion into the hash is deprecated. You specified: %s.", strings.Join(globalHashableEnvVars.BySource.Matching.Names(), ", ")))
 	}
 
 	logger.Debug("global hash env vars", "vars", globalHashableEnvVars.All.Names())

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -156,8 +156,6 @@ func (r *run) run(ctx gocontext.Context, targets []string) error {
 		return fmt.Errorf("failed to read package.json: %w", err)
 	}
 
-	isStructuredOutput := r.opts.runOpts.GraphDot || r.opts.runOpts.DryRunJSON
-
 	var pkgDepGraph *context.Context
 	if r.opts.runOpts.SinglePackage {
 		pkgDepGraph, err = context.SinglePackageGraph(r.base.RepoRoot, rootPackageJSON)
@@ -252,8 +250,6 @@ func (r *run) run(ctx gocontext.Context, targets []string) error {
 		turboJSON.GlobalPassthroughEnv,
 		r.opts.runOpts.EnvMode,
 		r.base.Logger,
-		r.base.UI,
-		isStructuredOutput,
 	)
 
 	if err != nil {

--- a/docs/pages/blog/turbo-1-1-0.mdx
+++ b/docs/pages/blog/turbo-1-1-0.mdx
@@ -82,7 +82,6 @@ You can now control `turbo`'s [cache fingerprinting (a.k.a. hashing)](/repo/docs
 - Including environment variables in a `dependsOn` in your `pipeline` definition prefixed by a `$` will impact the cache fingerprint on a per-task or per-package-task basis.
 - Including environment variables in `globalDependencies` list prefixed by a `$` will impact the cache fingerprint of _all_ tasks.
 - Including files or globs of files in `globalDependencies` will impact the cache fingerprint of _all_ tasks.
-- The value of any environment variable that includes `THASH` in its name will impact the cache fingerprint of _all_ tasks.
 
 ```jsonc
 {

--- a/docs/pages/repo/docs/core-concepts/caching.mdx
+++ b/docs/pages/repo/docs/core-concepts/caching.mdx
@@ -194,7 +194,6 @@ You can control `turbo`'s caching behavior based on
 the values of environment variables:
 
 - Including environment variables in the `env` key in your `pipeline` definition will impact the cache fingerprint on a per-task or per-workspace-task basis.
-- The value of any environment variable that includes `THASH` in its name will impact the cache fingerprint of _all_ tasks.
 
 ```jsonc
 {
@@ -432,7 +431,6 @@ By now, you're probably wondering how `turbo` decides what constitutes a cache h
 First, `turbo` constructs a hash of the current global state of the codebase:
 
 - The contents of any files that satisfy the glob patterns and any the values of environment variables listed in [`globalDependencies`](/repo/docs/reference/configuration#globalDependencies)
-- The sorted list environment variable key-value pairs that include `THASH` _anywhere_ in their names (e.g. `STRIPE_PUBLIC_THASH_SECRET_KEY`, but not `STRIPE_PUBLIC_KEY`)
 
 Then it adds more factors relevant to a given workspace's task:
 

--- a/turborepo-tests/integration/tests/global_env.t
+++ b/turborepo-tests/integration/tests/global_env.t
@@ -39,7 +39,6 @@ Setup
   
 # set env var with "THASH" and ensure cache miss
   $ SOMETHING_THASH_YES=hi ${TURBO} run build --filter=util --output-logs=hash-only
-  [DEPRECATED] Using .*THASH.* to specify an environment variable for inclusion into the hash is deprecated. You specified: SOMETHING_THASH_YES.
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
@@ -59,19 +58,4 @@ Setup
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
-  
-# THASH deprecation doesn't break --dry=json
-  $ SOMETHING_THASH_YES=hi ${TURBO} run build --filter=util --dry=json | jq -r '.tasks[0].environmentVariables.global[0]'
-  SOMETHING_THASH_YES=8f434346648f6b96df89dda901c5176b10a6d83961dd3c1ac88b59b2dc327aa4
-
-# THASH deprecation doesn't break --graph
-  $ SOMETHING_THASH_YES=hi ${TURBO} run build --filter=util --graph
-  
-  digraph {
-  \tcompound = "true" (esc)
-  \tnewrank = "true" (esc)
-  \tsubgraph "root" { (esc)
-  \t\t"[root] util#build" -> "[root] ___ROOT___" (esc)
-  \t} (esc)
-  }
   

--- a/turborepo-tests/integration/tests/global_env.t
+++ b/turborepo-tests/integration/tests/global_env.t
@@ -37,17 +37,6 @@ Setup
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
-# set env var with "THASH" and ensure cache miss
-  $ SOMETHING_THASH_YES=hi ${TURBO} run build --filter=util --output-logs=hash-only
-  \xe2\x80\xa2 Packages in scope: util (esc)
-  \xe2\x80\xa2 Running build in 1 packages (esc)
-  \xe2\x80\xa2 Remote caching disabled (esc)
-  util:build: cache miss, executing c3c2acfea2980d29
-  
-   Tasks:    1 successful, 1 total
-  Cached:    0 cached, 1 total
-    Time:\s*[\.0-9]+m?s  (re)
-  
 # set vercel analytics env var and ensure cache miss
   $ VERCEL_ANALYTICS_ID=hi ${TURBO} run build --filter=util --output-logs=hash-only
   \xe2\x80\xa2 Packages in scope: util (esc)


### PR DESCRIPTION
After 1.9 as a deprecation period (and having heard no user feedback as to being an integral part of their workflow) this removes `THASH`.

Related: #4526