### PR TITLE
fix: turborepo unused code lints

### DIFF
--- a/crates/globwatch/src/lib.rs
+++ b/crates/globwatch/src/lib.rs
@@ -36,7 +36,7 @@ pub use notify::{Error, Event, Watcher};
 pub use stop_token::{stream::StreamExt, StopSource, StopToken, TimedOutError};
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tokio_stream::wrappers::UnboundedReceiverStream;
-use tracing::{event, span, trace, warn, Id, Level, Span};
+use tracing::{event, span, trace, warn, Id, Level};
 
 /// A wrapper around notify that allows for glob-based watching.
 #[derive(Debug)]

--- a/crates/turborepo-lib/src/daemon/bump_timeout.rs
+++ b/crates/turborepo-lib/src/daemon/bump_timeout.rs
@@ -32,10 +32,12 @@ impl BumpTimeout {
         Duration::from_millis(self.deadline.load(Ordering::Relaxed))
     }
 
+    #[allow(dead_code)]
     pub fn deadline(&self) -> Instant {
         self.start + self.duration()
     }
 
+    #[allow(dead_code)]
     pub fn elapsed(&self) -> Duration {
         self.start.elapsed()
     }

--- a/crates/turborepo-lib/src/daemon/endpoint.rs
+++ b/crates/turborepo-lib/src/daemon/endpoint.rs
@@ -1,6 +1,6 @@
 use std::sync::{atomic::AtomicBool, Arc};
 #[cfg(windows)]
-use std::{atomic::Ordering, io::ErrorKind, time::Duration};
+use std::{io::ErrorKind, sync::atomic::Ordering, time::Duration};
 
 use futures::Stream;
 use tokio::io::{AsyncRead, AsyncWrite};

--- a/crates/turborepo-lib/src/daemon/endpoint.rs
+++ b/crates/turborepo-lib/src/daemon/endpoint.rs
@@ -1,11 +1,6 @@
-use std::{
-    io::ErrorKind,
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc,
-    },
-    time::Duration,
-};
+use std::sync::{atomic::AtomicBool, Arc};
+#[cfg(windows)]
+use std::{atomic::Ordering, io::ErrorKind, time::Duration};
 
 use futures::Stream;
 use tokio::io::{AsyncRead, AsyncWrite};
@@ -21,6 +16,7 @@ pub enum SocketOpenError {
     LockError(#[from] pidlock::PidlockError),
 }
 
+#[cfg(windows)]
 const WINDOWS_POLL_DURATION: Duration = Duration::from_millis(1);
 
 /// Gets a stream of incoming connections from a Unix socket.
@@ -31,7 +27,7 @@ const WINDOWS_POLL_DURATION: Duration = Duration::from_millis(1);
 ///       code path to shut down the non-blocking polling
 pub async fn open_socket(
     path: AbsoluteSystemPathBuf,
-    running: Arc<AtomicBool>,
+    #[allow(unused)] running: Arc<AtomicBool>,
 ) -> Result<
     (
         pidlock::Pidlock,


### PR DESCRIPTION
### Description

Mostly gating constants and imports behind `#[cfg(windows)]`.

One question for @arlyon is if we should delete the two methods on `BumpTimeout` that appear unused. I did a search and I didn't find any uses in the codebase, but wasn't sure if these will be used in some future PR.

### Testing Instructions

Windows still builds on CI
