### PR TITLE
improve commonjs esm interop and node ESM

### DIFF
--- a/crates/turbopack-dev/js/src/runtime.js
+++ b/crates/turbopack-dev/js/src/runtime.js
@@ -16,7 +16,7 @@
 /** @typedef {import('../types').SourceType.Parent} SourceTypeParent */
 /** @typedef {import('../types').SourceType.Update} SourceTypeUpdate */
 /** @typedef {import('../types').Exports} Exports */
-/** @typedef {import('../types').EsmInteropNamespace} EsmInteropNamespace */
+/** @typedef {import('../types').EsmNamespaceObject} EsmNamespaceObject */
 /** @typedef {import('../types').RequireContext} RequireContext */
 /** @typedef {import('../types').RequireContextMap} RequireContextMap */
 
@@ -119,6 +119,16 @@ function esm(exports, getters) {
 }
 
 /**
+ * Makes the module an ESM with exports
+ *
+ * @param {Module} module
+ * @param {Record<string, () => any>} getters
+ */
+function makeEsm(module, getters) {
+  esm((module.namespaceObject = module.exports), getters);
+}
+
+/**
  * Adds the getters to the exports object
  *
  * @param {Exports} exports
@@ -148,8 +158,8 @@ function createGetter(obj, key) {
 
 /**
  * @param {Exports} raw
- * @param {EsmInteropNamespace} ns
- * @param {boolean} [allowExportDefault]
+ * @param {EsmNamespaceObject} ns
+ * @param {boolean} [allowExportDefault] false: will have the raw module as default export, true: will have the default property as default export
  */
 function interopEsm(raw, ns, allowExportDefault) {
   /** @type {Object.<string, () => any>} */
@@ -166,17 +176,15 @@ function interopEsm(raw, ns, allowExportDefault) {
 /**
  * @param {Module} sourceModule
  * @param {ModuleId} id
- * @param {boolean} allowExportDefault
- * @returns {EsmInteropNamespace}
+ * @returns {EsmNamespaceObject}
  */
-function esmImport(sourceModule, id, allowExportDefault) {
+function esmImport(sourceModule, id) {
   const module = getOrInstantiateModuleFromParent(id, sourceModule);
   if (module.error) throw module.error;
+  if (module.namespaceObject) return module.namespaceObject;
   const raw = module.exports;
-  if (raw.__esModule) return raw;
-  if (module.interopNamespace) return module.interopNamespace;
-  const ns = (module.interopNamespace = {});
-  interopEsm(raw, ns, allowExportDefault);
+  const ns = (module.namespaceObject = {});
+  interopEsm(raw, ns, raw.__esModule);
   return ns;
 }
 
@@ -244,7 +252,7 @@ function requireContext(sourceModule, map) {
 /**
  * @param {ModuleId} id
  * @param {boolean} esm
- * @returns {Exports | EsmInteropNamespace}
+ * @returns {Exports | EsmNamespaceObject}
  */
 function externalRequire(id, esm) {
   let raw;
@@ -427,7 +435,7 @@ function instantiateModule(id, source) {
     id,
     parents: undefined,
     children: [],
-    interopNamespace: undefined,
+    namespaceObject: undefined,
     hot,
   };
   moduleCache[id] = module;
@@ -456,7 +464,7 @@ function instantiateModule(id, source) {
         x: externalRequire,
         f: requireContext.bind(null, module),
         i: esmImport.bind(null, module),
-        s: esm.bind(null, module.exports),
+        s: makeEsm.bind(null, module),
         j: cjs.bind(null, module.exports),
         v: exportValue.bind(null, module),
         m: module,
@@ -473,9 +481,9 @@ function instantiateModule(id, source) {
   });
 
   module.loaded = true;
-  if (module.interopNamespace) {
+  if (module.namespaceObject && module.exports !== module.namespaceObject) {
     // in case of a circular dependency: cjs1 -> esm2 -> cjs1
-    interopEsm(module.exports, module.interopNamespace);
+    interopEsm(module.exports, module.namespaceObject);
   }
 
   return module;

--- a/crates/turbopack-dev/js/types/index.d.ts
+++ b/crates/turbopack-dev/js/types/index.d.ts
@@ -49,7 +49,7 @@ interface Module {
   hot?: Hot;
   children: ModuleId[];
   parents: ModuleId[];
-  interopNamespace?: EsmInteropNamespace;
+  namespaceObject?: EsmNamespaceObject;
 }
 
 enum SourceType {
@@ -99,16 +99,16 @@ type RequireContextMap = Record<
 >;
 
 interface RequireContext {
-  (moduleId: ModuleId): Exports | EsmInteropNamespace;
+  (moduleId: ModuleId): Exports | EsmNamespaceObject;
   keys(): ModuleId[];
   resolve(moduleId: ModuleId): ModuleId;
 }
 
-export type EsmInteropNamespace = Record<string, any>;
+export type EsmNamespaceObject = Record<string, any>;
 type EsmImport = (
   moduleId: ModuleId,
   allowExportDefault: boolean
-) => EsmInteropNamespace;
+) => EsmNamespaceObject;
 type EsmExport = (exportGetters: Record<string, () => any>) => void;
 type ExportValue = (value: any) => void;
 

--- a/crates/turbopack-ecmascript/src/lib.rs
+++ b/crates/turbopack-ecmascript/src/lib.rs
@@ -84,6 +84,15 @@ use crate::{
 };
 
 #[turbo_tasks::value(serialization = "auto_for_input")]
+#[derive(PartialOrd, Ord, Hash, Debug, Clone, Copy, Default)]
+pub enum SpecifiedModuleType {
+    #[default]
+    Automatic,
+    CommonJs,
+    EcmaScript,
+}
+
+#[turbo_tasks::value(serialization = "auto_for_input")]
 #[derive(PartialOrd, Ord, Hash, Debug, Default, Copy, Clone)]
 pub struct EcmascriptOptions {
     /// module is split into smaller module parts which can be selectively
@@ -91,6 +100,8 @@ pub struct EcmascriptOptions {
     pub split_into_parts: bool,
     /// imports will import parts of modules
     pub import_parts: bool,
+    /// module is forced to a specific type (happens e. g. for .cjs and .mjs)
+    pub specified_module_type: SpecifiedModuleType,
 }
 
 #[turbo_tasks::value(serialization = "auto_for_input")]

--- a/crates/turbopack-ecmascript/src/references/esm/export.rs
+++ b/crates/turbopack-ecmascript/src/references/esm/export.rs
@@ -69,8 +69,9 @@ async fn expand_star_exports(root_asset: EcmascriptChunkPlaceableVc) -> Result<E
                 category: StringVc::cell("analyze".to_string()),
                 message: StringVc::cell(format!(
                     "export * used with module {} which has no exports\nTypescript only: Did you \
-                     want to export only types with `export type {{ ... }} from \"...\"`?",
-                    // TODO recommend export type * from "..." once https://github.com/microsoft/TypeScript/issues/37238 is implemented
+                     want to export only types with `export type * from \"...\"`?\nNote: Using \
+                     `export type` is more efficient than `export *` as it won't emit any runtime \
+                     code.",
                     asset.ident().to_string().await?
                 )),
                 source_ident: asset.ident(),

--- a/crates/turbopack-ecmascript/src/references/type_issue.rs
+++ b/crates/turbopack-ecmascript/src/references/type_issue.rs
@@ -1,0 +1,85 @@
+use turbo_tasks::primitives::StringVc;
+use turbo_tasks_fs::FileSystemPathVc;
+use turbopack_core::issue::{Issue, IssueSeverity, IssueSeverityVc, IssueVc};
+
+use crate::SpecifiedModuleType;
+
+#[turbo_tasks::value(shared)]
+pub struct SpecifiedModuleTypeIssue {
+    pub path: FileSystemPathVc,
+    pub specified_type: SpecifiedModuleType,
+}
+
+#[turbo_tasks::value_impl]
+impl Issue for SpecifiedModuleTypeIssue {
+    #[turbo_tasks::function]
+    fn context(&self) -> FileSystemPathVc {
+        self.path
+    }
+
+    #[turbo_tasks::function]
+    fn title(&self) -> StringVc {
+        match self.specified_type {
+            SpecifiedModuleType::CommonJs => StringVc::cell(
+                "Specified module format (CommonJs) is not matching the module format of the \
+                 source code (EcmaScript Modules)"
+                    .to_string(),
+            ),
+            SpecifiedModuleType::EcmaScript => StringVc::cell(
+                "Specified module format (EcmaScript Modules) is not matching the module format \
+                 of the source code (CommonJs)"
+                    .to_string(),
+            ),
+            SpecifiedModuleType::Automatic => StringVc::cell(
+                "Specified module format is not matching the module format of the source code"
+                    .to_string(),
+            ),
+        }
+    }
+
+    #[turbo_tasks::function]
+    fn description(&self) -> StringVc {
+        match self.specified_type {
+            SpecifiedModuleType::CommonJs => StringVc::cell(
+                "The CommonJs module format was specified in the package.json that is affecting \
+                 this source file or by using an special extension, but Ecmascript import/export \
+                 syntax is used in the source code.\nThe module was automatically converted to an \
+                 EcmaScript module, but that is in conflict with the specified module format. \
+                 Either change the \"type\" field in the package.json or replace EcmaScript \
+                 import/export syntax with CommonJs syntas in the source file.\nIn some cases \
+                 EcmaScript import/export syntax is added by an transform and isn't actually part \
+                 of the source code. In these cases revisit transformation options to inject the \
+                 correct syntax."
+                    .to_string(),
+            ),
+            SpecifiedModuleType::EcmaScript => StringVc::cell(
+                "The EcmaScript module format was specified in the package.json that is affecting \
+                 this source file or by using an special extension, but it looks like that \
+                 CommonJs syntax is used in the source code.\nExports made by CommonJs syntax \
+                 will lead to a runtime error, since the module is in EcmaScript mode. Either \
+                 change the \"type\" field in the package.json or replace CommonJs syntax with \
+                 EcmaScript import/export syntax in the source file."
+                    .to_string(),
+            ),
+            SpecifiedModuleType::Automatic => StringVc::cell(
+                "The module format specified in the package.json file is not matching the module \
+                 format of the source code."
+                    .to_string(),
+            ),
+        }
+    }
+
+    #[turbo_tasks::function]
+    fn severity(&self) -> IssueSeverityVc {
+        match self.specified_type {
+            SpecifiedModuleType::CommonJs => IssueSeverity::Error.cell(),
+            SpecifiedModuleType::EcmaScript => IssueSeverity::Warning.cell(),
+            SpecifiedModuleType::Automatic => IssueSeverity::Hint.cell(),
+        }
+    }
+
+    #[turbo_tasks::function]
+    fn category(&self) -> StringVc {
+        StringVc::cell("module type".to_string())
+    }
+}

--- a/crates/turbopack/src/lib.rs
+++ b/crates/turbopack/src/lib.rs
@@ -127,30 +127,39 @@ async fn apply_module_type(
 
             base.into()
         }
-        ModuleType::Typescript(transforms) => EcmascriptModuleAssetVc::new(
+        ModuleType::Typescript {
+            transforms,
+            options,
+        } => EcmascriptModuleAssetVc::new(
             source,
             context.into(),
             Value::new(EcmascriptModuleAssetType::Typescript),
             *transforms,
-            Value::new(Default::default()),
+            Value::new(*options),
             context.compile_time_info(),
         )
         .into(),
-        ModuleType::TypescriptWithTypes(transforms) => EcmascriptModuleAssetVc::new(
+        ModuleType::TypescriptWithTypes {
+            transforms,
+            options,
+        } => EcmascriptModuleAssetVc::new(
             source,
             context.with_types_resolving_enabled().into(),
             Value::new(EcmascriptModuleAssetType::TypescriptWithTypes),
             *transforms,
-            Value::new(Default::default()),
+            Value::new(*options),
             context.compile_time_info(),
         )
         .into(),
-        ModuleType::TypescriptDeclaration(transforms) => EcmascriptModuleAssetVc::new(
+        ModuleType::TypescriptDeclaration {
+            transforms,
+            options,
+        } => EcmascriptModuleAssetVc::new(
             source,
             context.with_types_resolving_enabled().into(),
             Value::new(EcmascriptModuleAssetType::TypescriptDeclaration),
             *transforms,
-            Value::new(Default::default()),
+            Value::new(*options),
             context.compile_time_info(),
         )
         .into(),
@@ -293,16 +302,20 @@ impl ModuleAssetContextVc {
                                     transforms: transforms.extend(*additional_transforms),
                                     options,
                                 }),
-                                Some(ModuleType::Typescript(transforms)) => {
-                                    Some(ModuleType::Typescript(
-                                        transforms.extend(*additional_transforms),
-                                    ))
-                                }
-                                Some(ModuleType::TypescriptWithTypes(transforms)) => {
-                                    Some(ModuleType::TypescriptWithTypes(
-                                        transforms.extend(*additional_transforms),
-                                    ))
-                                }
+                                Some(ModuleType::Typescript {
+                                    transforms,
+                                    options,
+                                }) => Some(ModuleType::Typescript {
+                                    transforms: transforms.extend(*additional_transforms),
+                                    options,
+                                }),
+                                Some(ModuleType::TypescriptWithTypes {
+                                    transforms,
+                                    options,
+                                }) => Some(ModuleType::TypescriptWithTypes {
+                                    transforms: transforms.extend(*additional_transforms),
+                                    options,
+                                }),
                                 Some(module_type) => {
                                     ModuleIssue {
                                         ident,

--- a/crates/turbopack/src/module_options/module_rule.rs
+++ b/crates/turbopack/src/module_options/module_rule.rs
@@ -54,9 +54,21 @@ pub enum ModuleType {
         #[turbo_tasks(trace_ignore)]
         options: EcmascriptOptions,
     },
-    Typescript(EcmascriptInputTransformsVc),
-    TypescriptWithTypes(EcmascriptInputTransformsVc),
-    TypescriptDeclaration(EcmascriptInputTransformsVc),
+    Typescript {
+        transforms: EcmascriptInputTransformsVc,
+        #[turbo_tasks(trace_ignore)]
+        options: EcmascriptOptions,
+    },
+    TypescriptWithTypes {
+        transforms: EcmascriptInputTransformsVc,
+        #[turbo_tasks(trace_ignore)]
+        options: EcmascriptOptions,
+    },
+    TypescriptDeclaration {
+        transforms: EcmascriptInputTransformsVc,
+        #[turbo_tasks(trace_ignore)]
+        options: EcmascriptOptions,
+    },
     Json,
     Raw,
     Mdx {


### PR DESCRIPTION
### Description

* generate a default export when import faux modules
* detect specified module type and follow that
* emit errors/warnings when using non-matching syntax

next.js test case: https://github.com/vercel/next.js/pull/48940
