### PR TITLE
Cleanup "started server on" message

### DIFF
--- a/crates/turbopack-cli/src/dev/mod.rs
+++ b/crates/turbopack-cli/src/dev/mod.rs
@@ -398,10 +398,9 @@ pub async fn start_server(args: &DevArguments) -> Result<()> {
     {
         let index_uri = ServerAddr::new(server.addr).to_string()?;
         println!(
-            "{} - started server on {}:{}, url: {}",
+            "{} - started server on {}, url: {}",
             "ready".green(),
-            server.addr.ip(),
-            server.addr.port(),
+            server.addr,
             index_uri
         );
         if !args.no_open {


### PR DESCRIPTION
We bind to an IPv6 unspecified address (`::`), which makes the old message say "started server on :::3000", and that's kinda ugly. The new message will say "[::]:3000".