### PR TITLE
chore: Disallows unknown fields in JSON sent by Rust.

### DIFF
--- a/cli/cmd/turbo/main.go
+++ b/cli/cmd/turbo/main.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/vercel/turbo/cli/internal/cmd"
 	"github.com/vercel/turbo/cli/internal/turbostate"
@@ -17,7 +18,10 @@ func main() {
 
 	executionStateString := os.Args[1]
 	var executionState turbostate.ExecutionState
-	err := json.Unmarshal([]byte(executionStateString), &executionState)
+	decoder := json.NewDecoder(strings.NewReader(executionStateString))
+	decoder.DisallowUnknownFields()
+
+	err := decoder.Decode(&executionState)
 	if err != nil {
 		fmt.Printf("Error unmarshalling execution state: %v\n Execution state string: %v\n", err, executionStateString)
 		os.Exit(1)

--- a/crates/turborepo-lib/src/cli.rs
+++ b/crates/turborepo-lib/src/cli.rs
@@ -67,6 +67,7 @@ pub enum EnvMode {
 #[clap(arg_required_else_help = true)]
 pub struct Args {
     #[clap(long, global = true)]
+    #[serde(skip)]
     pub version: bool,
     #[clap(long, global = true)]
     #[serde(skip)]
@@ -75,6 +76,7 @@ pub struct Args {
     pub skip_infer: bool,
     /// Disable the turbo update notification
     #[clap(long, global = true)]
+    #[serde(skip)]
     pub no_update_notifier: bool,
     /// Override the endpoint for API calls
     #[clap(long, global = true, value_parser)]
@@ -116,12 +118,16 @@ pub struct Args {
     /// verbosity
     #[clap(flatten)]
     pub verbosity: Verbosity,
-    #[clap(long, global = true, hide = true)]
     /// Force a check for a new version of turbo
+    #[clap(long, global = true, hide = true)]
+    #[serde(skip)]
     pub check_for_update: bool,
     #[clap(long = "__test-run", global = true, hide = true)]
     pub test_run: bool,
     #[clap(flatten, next_help_heading = "Run Arguments")]
+    // We don't serialize this because by the time we're calling
+    // Go, we've moved it to the command field as a Command::Run
+    #[serde(skip)]
     pub run_args: Option<RunArgs>,
     #[clap(subcommand)]
     pub command: Option<Command>,
@@ -209,8 +215,8 @@ impl Args {
                 process::exit(0);
             }
         };
-        // --version flag doesn't work with ignore_errors in clap, so we have to handle
-        // it manually
+        // We have to override the --version flag because we use `get_version`
+        // instead of a hard-coded version or the crate version
         if clap_args.version {
             println!("{}", get_version());
             process::exit(0);


### PR DESCRIPTION
### Description

We've gotten bitten by field names being out of sync (#4712). To prevent this from happening, we error on any unknown fields sent to the Go side.

### Testing Instructions

Existing tests cover this. I already discovered a few fields we don't need to send over
