### PR TITLE
no longer opt-in to kqueue on macos

### DIFF
--- a/crates/globwatch/Cargo.toml
+++ b/crates/globwatch/Cargo.toml
@@ -10,10 +10,7 @@ futures = { version = "0.3.26" }
 glob-match = "0.2.1"
 itertools.workspace = true
 merge-streams = "0.1.2"
-notify = { version = "5.1.0", default-features = false, features = [
-  "macos_fsevent",
-  "fsevent-sys",
-] }
+notify = "5.1"
 notify-debouncer-mini = { version = "0.2.1", default-features = false }
 pin-project = "1.0.12"
 stop-token = "0.7.0"

--- a/crates/turborepo-lib/Cargo.toml
+++ b/crates/turborepo-lib/Cargo.toml
@@ -55,9 +55,7 @@ indicatif = { workspace = true }
 itertools = "0.10.5"
 lazy_static = { workspace = true }
 libc = "0.2.140"
-notify = { version = "5.1.0", default-features = false, features = [
-  "macos_kqueue",
-] }
+notify = "5.1"
 pidlock = { path = "../pidlock" }
 prost = "0.11.6"
 reqwest = { workspace = true, default_features = false, features = ["json"] }


### PR DESCRIPTION
kqueue performance is pretty awful, and fsevent is the default, so this PR removes that feature and uses fsevent on macOS instead.

This does not totally resolve the perf issues, but does at least prevent it from using 100% cpu for multiple minutes while it registers handlers. Smarter glob-watching and request timeouts are coming in a separate PR.
