### PR TITLE
updated line height for banner text

### DIFF
--- a/docs/components/pages/landing/index.tsx
+++ b/docs/components/pages/landing/index.tsx
@@ -179,7 +179,7 @@ function LandingPage() {
       <main className="relative flex flex-col items-center justify-center w-full h-full  overflow-hidden [--geist-foreground:#fff] dark:[--geist-foreground:#000] [--gradient-stop-1:0px] [--gradient-stop-2:120px] sm:[--gradient-stop-1:0px] sm:[--gradient-stop-2:120px]">
         <Background />
         <FadeIn className="z-10 flex flex-col items-center justify-center w-full h-full">
-          <h1 className="mt-12 lg:!mt-20 mx-6 w-[300px] md:!w-full font-extrabold text-5xl lg:text-6xl leading-tight text-center mb-4 bg-clip-text text-transparent bg-gradient-to-b from-black/80 to-black dark:from-white dark:to-[#AAAAAA]">
+          <h1 className="mt-12 lg:!mt-20 mx-6 w-[300px] md:!w-full font-extrabold text-5xl lg:text-6xl  leading-tight xl:leading-snug text-center mb-4 bg-clip-text text-transparent bg-gradient-to-b from-black/80 to-black dark:from-white dark:to-[#AAAAAA]">
             Make Ship Happen
           </h1>
           <p className="mx-6 text-xl max-h-[112px] md:max-h-[96px] w-[315px] md:w-[660px] md:text-2xl font-space-grotesk text-center text-[#666666] dark:text-[#888888]">


### PR DESCRIPTION
### Description

Banner text for [turbo](https://turbo.build/) was truncated because of incorrect line height.
![image](https://user-images.githubusercontent.com/103115230/235620643-9dfa4d15-06d0-4a87-b945-d7f3929f2696.png)

Line height of banner text was increased to 1.375 (leading-snug) from 1.25 (leading-tight) solving the issue.
 result: 
![image](https://user-images.githubusercontent.com/103115230/235621152-2aefd629-43c2-452e-952c-963fc94eac0d.png)


### Testing Instructions
Not applicable.
