### PR TITLE
Leave pathname formatting up to the caller

### DIFF
--- a/crates/turbo-tasks-fs/src/lib.rs
+++ b/crates/turbo-tasks-fs/src/lib.rs
@@ -872,6 +872,9 @@ impl FileSystemPath {
         self.path.is_empty()
     }
 
+    /// Returns the path of `inner` relative to `self`.
+    ///
+    /// Note: this method always strips the leading `/` from the result.
     pub fn get_path_to<'a>(&self, inner: &'a FileSystemPath) -> Option<&'a str> {
         if self.fs != inner.fs {
             return None;

--- a/crates/turbopack-node/src/render/rendered_source.rs
+++ b/crates/turbopack-node/src/render/rendered_source.rs
@@ -226,14 +226,14 @@ impl GetContentSourceContent for NodeRenderGetContentResult {
                 url: url.clone(),
                 raw_query: raw_query.clone(),
                 raw_headers: raw_headers.clone(),
-                path: format!("/{}", source.pathname.await?),
+                path: source.pathname.await?.clone_value(),
                 data: Some(self.render_data.await?),
             }
             .cell(),
         )
         .issue_context(
             entry.module.ident().path(),
-            format!("server-side rendering /{}", source.pathname.await?),
+            format!("server-side rendering {}", source.pathname.await?),
         )
         .await?;
         Ok(match *result.await? {


### PR DESCRIPTION
### Description

Next.js code calling into `create_node_rendered_source` doesn't always format the pathname with a leading `/`.

This PR removes all assumptions about the pathname from `turbopack-node` and leaves the formatting up to the caller.

### Testing Instructions

N/A

Corresponding Next.js PR: https://github.com/vercel/next.js/pull/49085

link WEB-366