### PR TITLE
Refactor/request timeouts

### DIFF
--- a/crates/globwatch/examples/cancel.rs
+++ b/crates/globwatch/examples/cancel.rs
@@ -32,8 +32,7 @@ async fn main() {
             tokio::time::sleep(Duration::from_secs(1)).await;
             config
                 .exclude(&PathBuf::try_from(".").unwrap(), "globwatch/src/**")
-                .await
-                .unwrap();
+                .await;
             tokio::time::sleep(Duration::from_secs(1)).await;
         }
 

--- a/crates/globwatch/src/lib.rs
+++ b/crates/globwatch/src/lib.rs
@@ -205,19 +205,6 @@ pub enum WatcherCommand {
     Flush(oneshot::Sender<()>),
 }
 
-/// A change to the watcher configuration.
-///
-/// This is used to communicate changes to the watcher
-/// from other threads. Can optionally contain the span
-/// that the change was made in, for tracing purposes.
-#[derive(Debug)]
-pub enum WatcherChange {
-    /// Register a glob to be included by the watcher.
-    Include(String, Option<Id>),
-    /// Register a glob to be excluded by the watcher.
-    Exclude(String, Option<Id>),
-}
-
 /// A sender for watcher configuration changes.
 #[derive(Debug, Clone)]
 pub struct WatchConfig<T: Watcher> {

--- a/crates/globwatch/src/lib.rs
+++ b/crates/globwatch/src/lib.rs
@@ -36,7 +36,7 @@ pub use notify::{Error, Event, Watcher};
 pub use stop_token::{stream::StreamExt, StopSource, StopToken, TimedOutError};
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tokio_stream::wrappers::UnboundedReceiverStream;
-use tracing::{event, span, trace, warn, Id, Level};
+use tracing::{event, span, trace, warn, Level};
 
 /// A wrapper around notify that allows for glob-based watching.
 #[derive(Debug)]
@@ -273,7 +273,7 @@ impl<T: Watcher> WatchConfig<T> {
 
     /// Register a glob to be excluded by the watcher.
     #[tracing::instrument(skip(self))]
-    pub async fn exclude(&self, relative_to: &Path, glob: &str) -> Result<(), ConfigError> {
+    pub async fn exclude(&self, relative_to: &Path, glob: &str) {
         trace!("excluding {:?}", glob);
 
         for p in glob_to_paths(&glob).iter().map(|p| relative_to.join(p)) {
@@ -284,7 +284,6 @@ impl<T: Watcher> WatchConfig<T> {
                 .unwatch(&p)
                 .ok();
         }
-        Ok(())
     }
 
     /// Await a full filesystem flush from the watcher.

--- a/crates/turborepo-lib/src/daemon/connector.rs
+++ b/crates/turborepo-lib/src/daemon/connector.rs
@@ -195,6 +195,7 @@ impl DaemonConnector {
         // note, this endpoint is just a dummy. the actual path is passed in
         Endpoint::try_from("http://[::]:50051")
             .expect("this is a valid uri")
+            .timeout(Duration::from_secs(1))
             .connect_with_connector(tower::service_fn(make_service))
             .await
             .map(TurbodClient::new)

--- a/crates/turborepo-lib/src/globwatcher/mod.rs
+++ b/crates/turborepo-lib/src/globwatcher/mod.rs
@@ -107,10 +107,7 @@ impl<T: Watcher> HashGlobWatcher<T> {
             };
 
             for glob in globs_to_exclude {
-                self.config
-                    .exclude(self.relative_to.as_path(), &glob)
-                    .await
-                    .unwrap();
+                self.config.exclude(self.relative_to.as_path(), &glob).await;
             }
         }
     }
@@ -266,10 +263,11 @@ fn populate_hash_globs<'a>(
 
         for hash in hash_status.iter() {
             let globs = match hash_globs.get_mut(hash).filter(|globs| {
-                !globs
-                    .exclude
-                    .iter()
-                    .any(|f| glob_match::glob_match(f, path.to_str().unwrap()))
+                !globs.exclude.iter().any(|f| {
+                    path.to_str()
+                        .map(|s| glob_match::glob_match(f, s))
+                        .unwrap_or(false) // invalid utf8 cannot be matched
+                })
             }) {
                 Some(globs) => globs,
                 None => {


### PR DESCRIPTION
### Description

This PR sets maximum limits on request times to the daemon and within the daemon to prevent hanging. With this PR, performance is still degraded compared to a fully functioning daemon however enabling the daemon will not block builds.
