### PR TITLE
allow to see exports for non-enumerable properties

### DIFF
--- a/crates/turbopack-dev/js/src/runtime.js
+++ b/crates/turbopack-dev/js/src/runtime.js
@@ -165,6 +165,17 @@ function createGetter(obj, key) {
 }
 
 /**
+ * @param {any} obj
+ * @returns {any} prototype of the object
+ */
+const getProto = Object.getPrototypeOf
+  ? (obj) => Object.getPrototypeOf(obj)
+  : (obj) => obj.__proto__;
+
+/** Prototypes that are not expanded for exports */
+const LEAF_PROTOTYPES = [null, getProto({}), getProto([]), getProto(getProto)];
+
+/**
  * @param {Exports} raw
  * @param {EsmNamespaceObject} ns
  * @param {boolean} [allowExportDefault] false: will have the raw module as default export, true: will have the default property as default export
@@ -172,8 +183,15 @@ function createGetter(obj, key) {
 function interopEsm(raw, ns, allowExportDefault) {
   /** @type {Object.<string, () => any>} */
   const getters = { __proto__: null };
-  for (const key in raw) {
-    getters[key] = createGetter(raw, key);
+  for (
+    let current = raw;
+    (typeof current === "object" || typeof current === "function") &&
+    !LEAF_PROTOTYPES.includes(current);
+    current = getProto(current)
+  ) {
+    for (const key of Object.getOwnPropertyNames(current)) {
+      getters[key] = createGetter(raw, key);
+    }
   }
   if (!(allowExportDefault && "default" in getters)) {
     getters["default"] = () => raw;
@@ -273,11 +291,11 @@ function externalRequire(id, esm) {
     // compilation error.
     throw new Error(`Failed to load external module ${id}: ${err}`);
   }
-  if (!esm || raw.__esModule) {
+  if (!esm) {
     return raw;
   }
   const ns = {};
-  interopEsm(raw, ns, true);
+  interopEsm(raw, ns, raw.__esModule);
   return ns;
 }
 externalRequire.resolve = (name, opt) => {


### PR DESCRIPTION
### Description

enumerate all properties for namespace object creation.

This follows the webpack logic

test cases in https://github.com/vercel/next.js/pull/49106