### PR TITLE
Skip integration,e2e,examples tests in JS tests workflow

### DIFF
--- a/.github/workflows/pr-js-tests-filtered.yml
+++ b/.github/workflows/pr-js-tests-filtered.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Run tests
         run: |
-          turbo run check-types test --filter=...[${{ github.event.pull_request.base.sha || 'HEAD^1' }}] --filter=!cli --color
+          turbo run check-types test --filter=...[${{ github.event.pull_request.base.sha || 'HEAD^1' }}] --filter=!cli --filter=!turborepo-tests* --color
 
   cleanup:
     name: Cleanup


### PR DESCRIPTION
I noticed integration tests failing #4773 when it shouldn't have run those tests in the first place. 

Ideally we should combine all our tests into just `turbo test` and have it use the cache for the right things, but we aren't quite there yet.