### PR TITLE
chore: add underlying error to lockfile error messages

### DIFF
--- a/crates/turborepo-ffi/src/lockfile.rs
+++ b/crates/turborepo-ffi/src/lockfile.rs
@@ -23,7 +23,7 @@ impl From<Package> for proto::LockfilePackage {
 enum Error {
     #[error("error performing lockfile operation: {0}")]
     Lockfile(#[from] turborepo_lockfiles::Error),
-    #[error("error decoding protobuf")]
+    #[error("error decoding protobuf: {0}")]
     Protobuf(#[from] prost::DecodeError),
     #[error(transparent)]
     BerryParse(#[from] turborepo_lockfiles::BerryError),

--- a/crates/turborepo-lockfiles/src/berry/mod.rs
+++ b/crates/turborepo-lockfiles/src/berry/mod.rs
@@ -21,13 +21,13 @@ use super::Lockfile;
 
 #[derive(Debug, Error)]
 pub enum Error {
-    #[error("unable to parse")]
+    #[error("unable to parse yaml: {0}")]
     Parse(#[from] serde_yaml::Error),
-    #[error("unable to parse")]
+    #[error("unable to parse identifier: {0}")]
     Identifiers(#[from] identifiers::Error),
     #[error("unable to find original package in patch locator {0}")]
     PatchMissingOriginalLocator(Locator<'static>),
-    #[error("unable to parse resolutions field")]
+    #[error("unable to parse resolutions field: {0}")]
     Resolutions(#[from] resolution::Error),
     #[error("unable to find entry for {0}")]
     MissingPackageForLocator(Locator<'static>),

--- a/crates/turborepo-lockfiles/src/berry/resolution.rs
+++ b/crates/turborepo-lockfiles/src/berry/resolution.rs
@@ -15,7 +15,7 @@ fn tag_regex() -> &'static Regex {
 
 #[derive(Debug, Error)]
 pub enum Error {
-    #[error("unable to parse")]
+    #[error("unable to parse: {0}")]
     // Boxed due to this enum variant being much larger than the others
     Pest(#[from] Box<pest::error::Error<Rule>>),
     #[error("unexpected end of input")]

--- a/crates/turborepo-lockfiles/src/error.rs
+++ b/crates/turborepo-lockfiles/src/error.rs
@@ -8,7 +8,7 @@ pub enum Error {
     MissingPackage(String),
     #[error("Missing version from non-workspace package: '{0}'")]
     MissingVersion(String),
-    #[error("Unable to convert from json")]
+    #[error("Unable to convert from json: {0}")]
     JsonError(#[from] serde_json::Error),
     #[error("Turbo doesn't support npm lockfiles without a 'packages' field")]
     UnsupportedNpmVersion,


### PR DESCRIPTION
### Description

Noticed that I didn't include the underlying error in some of the lockfile error variants. This PR adds underlying errors to the error message to all variants where applicable.

### Testing Instructions

`rustc`
