### PR TITLE
Remove --serial from the docs.

### DIFF
--- a/docs/pages/repo/docs/reference/command-line-reference.mdx
+++ b/docs/pages/repo/docs/reference/command-line-reference.mdx
@@ -432,19 +432,6 @@ turbo run lint --scope="@example/**"
 turbo run dev --scope="@example/a" --scope="@example/b" --no-cache --no-deps
 ```
 
-#### `--serial`
-
-<Callout type="error">
-  `serial` is deprecated in `0.5.3`.Please use
-  [`--concurrency=1`](#--concurrency) instead.
-</Callout>
-
-Executes all tasks serially (i.e. one-at-a-time).
-
-```sh
-turbo run build --serial
-```
-
 #### `--since`
 
 <Callout type="error">


### PR DESCRIPTION
`--serial` was never ported to Go and doesn't exist.