### PR TITLE
feat(turbopack): allow to detect ending path with contextcondition

### DIFF
--- a/crates/turbopack/src/condition.rs
+++ b/crates/turbopack/src/condition.rs
@@ -9,6 +9,7 @@ pub enum ContextCondition {
     All(Vec<ContextCondition>),
     Any(Vec<ContextCondition>),
     Not(Box<ContextCondition>),
+    PathEndsWith(String),
     InDirectory(String),
     InPath(FileSystemPathVc),
 }
@@ -58,6 +59,7 @@ impl ContextCondition {
                     || context.path.ends_with(&format!("/{dir}"))
                     || context.path == *dir
             }
+            ContextCondition::PathEndsWith(end) => context.path.ends_with(end),
         }
     }
 }


### PR DESCRIPTION
### Description

WEB-1003

This PR mimic ruleCondition's PathEndsWith (https://github.com/vercel/turbo/blob/910bc39abc68d6271113c983a1479934a045d16c/crates/turbopack/src/module_options/rule_condition.rs#L19) into ContextCondition, let contextcondition allows to detect specific file / extension / etcs ends with given string.

This tries to allow to transpiling non-ecma resources under node_modules (i.e `import 'tailwind/tailwind.css'`), current contextcondition restricts transpiling _any_ imports under node_modules and result to ignoring those imports.