### PR TITLE
Fix basic example to update on dependency changes

### DIFF
--- a/examples/basic/turbo.json
+++ b/examples/basic/turbo.json
@@ -3,6 +3,7 @@
   "globalDependencies": ["**/.env.*local"],
   "pipeline": {
     "build": {
+      "dependsOn": ["^build"],
       "outputs": [".next/**", "!.next/cache/**"]
     },
     "lint": {},


### PR DESCRIPTION
By default, if you change one of the packages in the basic example, the caches for the apps don't invalidate. This is a common issue people run into so we want a good default in place.