### PR TITLE
feature(turborepo): AbsoluteSystemPath

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9149,6 +9149,7 @@ dependencies = [
 name = "turbopath"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "bstr",
  "path-slash",
  "serde",

--- a/crates/turbopath/Cargo.toml
+++ b/crates/turbopath/Cargo.toml
@@ -12,3 +12,6 @@ path-slash = "0.2.1"
 # TODO: Make this a crate feature
 serde = { workspace = true }
 thiserror = { workspace = true }
+
+[dev-dependencies]
+anyhow = { workspace = true }

--- a/crates/turbopath/src/absolute_system_path.rs
+++ b/crates/turbopath/src/absolute_system_path.rs
@@ -1,0 +1,199 @@
+#[cfg(not(windows))]
+use std::os::unix::fs::symlink as symlink_file;
+#[cfg(not(windows))]
+use std::os::unix::fs::symlink as symlink_dir;
+#[cfg(windows)]
+use std::os::windows::fs::{symlink_dir, symlink_file};
+use std::{
+    borrow::Cow,
+    fmt, fs,
+    fs::Metadata,
+    io,
+    path::{Path, PathBuf},
+};
+
+use path_slash::CowExt;
+
+use crate::{
+    AbsoluteSystemPathBuf, AnchoredSystemPathBuf, IntoSystem, PathError, PathValidationError,
+    RelativeSystemPathBuf, RelativeUnixPath,
+};
+
+pub struct AbsoluteSystemPath(Path);
+
+impl ToOwned for AbsoluteSystemPath {
+    type Owned = AbsoluteSystemPathBuf;
+
+    fn to_owned(&self) -> Self::Owned {
+        AbsoluteSystemPathBuf(self.0.to_owned())
+    }
+}
+
+impl AsRef<AbsoluteSystemPath> for AbsoluteSystemPath {
+    fn as_ref(&self) -> &AbsoluteSystemPath {
+        self
+    }
+}
+
+impl fmt::Display for AbsoluteSystemPath {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.display().fmt(f)
+    }
+}
+
+impl AsRef<Path> for AbsoluteSystemPath {
+    fn as_ref(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl AbsoluteSystemPath {
+    /// Creates a path that is known to be absolute and a system path.
+    /// If either of these conditions are not met, we error.
+    /// Does *not* do automatic conversion like `AbsoluteSystemPathBuf::new`
+    /// does
+    ///
+    /// # Arguments
+    ///
+    /// * `value`: The path to convert to an absolute system path
+    ///
+    /// returns: Result<&AbsoluteSystemPath, PathError>
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use turbopath::AbsoluteSystemPath;
+    /// #[cfg(unix)]
+    /// {
+    ///   assert!(AbsoluteSystemPath::new("/foo/bar").is_ok());
+    ///   assert!(AbsoluteSystemPath::new("foo/bar").is_err());
+    ///   assert!(AbsoluteSystemPath::new("C:\\foo\\bar").is_err());
+    /// }
+    ///
+    /// #[cfg(windows)]
+    /// {
+    ///   assert!(AbsoluteSystemPath::new("C:\\foo\\bar").is_ok());
+    ///   assert!(AbsoluteSystemPath::new("foo\\bar").is_err());
+    ///   assert!(AbsoluteSystemPath::new("/foo/bar").is_err());
+    /// }
+    /// ```
+    pub fn new<P: AsRef<Path> + ?Sized>(value: &P) -> Result<&Self, PathError> {
+        let path = value.as_ref();
+        if path.is_relative() {
+            return Err(PathValidationError::NotAbsolute(path.to_owned()).into());
+        }
+        let path_str = path.to_str().ok_or_else(|| {
+            PathError::PathValidationError(PathValidationError::InvalidUnicode(path.to_owned()))
+        })?;
+
+        let system_path = Cow::from_slash(path_str);
+
+        match system_path {
+            Cow::Owned(path) => {
+                Err(PathValidationError::NotSystem(path.to_string_lossy().to_string()).into())
+            }
+            Cow::Borrowed(path) => {
+                let path = Path::new(path);
+                // copied from stdlib path.rs: relies on the representation of
+                // AbsoluteSystemPath being just a Path, the same way Path relies on
+                // just being an OsStr
+                let absolute_system_path = unsafe { &*(path as *const Path as *const Self) };
+                Ok(absolute_system_path)
+            }
+        }
+    }
+
+    pub fn as_path(&self) -> &Path {
+        &self.0
+    }
+
+    pub fn join_relative(&self, path: &RelativeSystemPathBuf) -> AbsoluteSystemPathBuf {
+        let path = self.0.join(path.as_path());
+        AbsoluteSystemPathBuf(path)
+    }
+
+    pub fn join_literal(&self, segment: &str) -> AbsoluteSystemPathBuf {
+        AbsoluteSystemPathBuf(self.0.join(segment))
+    }
+
+    pub fn join_unix_path(
+        &self,
+        unix_path: &RelativeUnixPath,
+    ) -> Result<AbsoluteSystemPathBuf, PathError> {
+        let tail = unix_path.to_system_path()?;
+        Ok(AbsoluteSystemPathBuf(self.0.join(tail.as_path())))
+    }
+
+    pub fn anchor(&self, path: &AbsoluteSystemPath) -> Result<AnchoredSystemPathBuf, PathError> {
+        AnchoredSystemPathBuf::new(self, path)
+    }
+
+    pub fn ensure_dir(&self) -> Result<(), io::Error> {
+        if let Some(parent) = self.0.parent() {
+            fs::create_dir_all(parent)
+        } else {
+            Ok(())
+        }
+    }
+
+    pub fn symlink_to_file<P: AsRef<Path>>(&self, to: P) -> Result<(), PathError> {
+        let system_path = to.as_ref();
+        let system_path = system_path.into_system()?;
+        symlink_file(system_path, &self.0)?;
+        Ok(())
+    }
+
+    pub fn symlink_to_dir<P: AsRef<Path>>(&self, to: P) -> Result<(), PathError> {
+        let system_path = to.as_ref();
+        let system_path = system_path.into_system()?;
+        symlink_dir(&system_path, &self.0)?;
+        Ok(())
+    }
+
+    pub fn resolve(&self, path: &AnchoredSystemPathBuf) -> AbsoluteSystemPathBuf {
+        let path = self.0.join(path.as_path());
+        AbsoluteSystemPathBuf(path)
+    }
+
+    // note that this is *not* lstat. If this is a symlink, it
+    // will return metadata for the target.
+    pub fn stat(&self) -> Result<Metadata, PathError> {
+        Ok(fs::metadata(&self.0)?)
+    }
+
+    pub fn symlink_metadata(&self) -> Result<Metadata, PathError> {
+        Ok(fs::symlink_metadata(&self.0)?)
+    }
+
+    pub fn read_link(&self) -> Result<PathBuf, io::Error> {
+        fs::read_link(&self.0)
+    }
+
+    pub fn remove_file(&self) -> Result<(), io::Error> {
+        fs::remove_file(&self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Result;
+
+    use super::*;
+
+    #[test]
+    fn test_create_absolute_path() -> Result<()> {
+        #[cfg(unix)]
+        {
+            let absolute_path = AbsoluteSystemPath::new("/foo/bar")?;
+            assert_eq!(absolute_path.to_string(), "/foo/bar");
+        }
+
+        #[cfg(windows)]
+        {
+            let absolute_path = AbsoluteSystemPath::new(r"C:\foo\bar")?;
+            assert_eq!(absolute_path.to_string(), r"C:\foo\bar");
+        }
+
+        Ok(())
+    }
+}

--- a/crates/turbopath/src/anchored_system_path_buf.rs
+++ b/crates/turbopath/src/anchored_system_path_buf.rs
@@ -2,9 +2,7 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    AbsoluteSystemPathBuf, IntoSystem, PathError, PathValidationError, RelativeUnixPathBuf,
-};
+use crate::{AbsoluteSystemPath, IntoSystem, PathError, PathValidationError, RelativeUnixPathBuf};
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Serialize, Deserialize)]
 pub struct AnchoredSystemPathBuf(PathBuf);
@@ -24,9 +22,11 @@ impl TryFrom<&Path> for AnchoredSystemPathBuf {
 
 impl AnchoredSystemPathBuf {
     pub fn new(
-        root: &AbsoluteSystemPathBuf,
-        path: &AbsoluteSystemPathBuf,
+        root: impl AsRef<AbsoluteSystemPath>,
+        path: impl AsRef<AbsoluteSystemPath>,
     ) -> Result<Self, PathError> {
+        let root = root.as_ref();
+        let path = path.as_ref();
         let stripped_path = path
             .as_path()
             .strip_prefix(root.as_path())

--- a/crates/turbopath/src/lib.rs
+++ b/crates/turbopath/src/lib.rs
@@ -1,5 +1,32 @@
 #![feature(assert_matches)]
 
+/// Turborepo's path handling library
+/// Defines distinct path types for the different usecases of paths in turborepo
+///
+/// - `AbsoluteSystemPath(Buf)`: a path that is absolute and uses the system's
+///   path separator. Used for interacting with the filesystem
+/// - `RelativeSystemPath(Buf)`: a path that is relative and uses the system's
+///   path separator. Mostly used for appending onto `AbsoluteSystemPaths`.
+/// - `RelativeUnixPath(Buf)`: a path that is relative and uses the unix path
+///   separator. Used when saving to a cache as a platform-independent path.
+/// - `AnchoredSystemPath(Buf)`: a path that is relative to a specific directory
+///   and uses the system's path separator. Used for handling files relative to
+///   the repository root.
+///
+/// As in `std::path`, there are `Path` and `PathBuf` variants of each path
+/// type, that indicate whether the path is borrowed or owned.
+///
+/// When initializing a path type, it is highly recommended that you use a
+/// method that validates the path. This will ensure that the path is in the
+/// correct format. For the -Buf variants, the `new` method will validate that
+/// the path is either absolute or relative, and then convert it to either
+/// system or unix. For the non-Buf variants, the `new` method will *only*
+/// validate and not convert (this is because conversion requires allocation).
+///
+/// The only case where initializing a path type without validation is
+/// recommended is inside turbopath itself. But that unchecked initialization
+/// should be considered unsafe
+mod absolute_system_path;
 mod absolute_system_path_buf;
 mod anchored_system_path_buf;
 mod relative_system_path_buf;
@@ -11,6 +38,7 @@ use std::{
     path::{Path, PathBuf, StripPrefixError},
 };
 
+pub use absolute_system_path::AbsoluteSystemPath;
 pub use absolute_system_path_buf::AbsoluteSystemPathBuf;
 pub use anchored_system_path_buf::AnchoredSystemPathBuf;
 use path_slash::{PathBufExt, PathExt};
@@ -58,6 +86,8 @@ pub enum PathValidationError {
     NotParent(String, String),
     #[error("Path {0} is not a unix path")]
     NotUnix(String),
+    #[error("Path {0} is not a system path")]
+    NotSystem(String),
     #[error("{0} is not a prefix for {1}")]
     PrefixError(String, String),
 }

--- a/crates/turborepo-ffi/src/lib.rs
+++ b/crates/turborepo-ffi/src/lib.rs
@@ -155,7 +155,7 @@ pub extern "C" fn recursive_copy(buffer: Buffer) -> Buffer {
         }
     };
 
-    let response = match turborepo_fs::recursive_copy(&src, &dst) {
+    let response = match turborepo_fs::recursive_copy(src, dst) {
         Ok(()) => proto::RecursiveCopyResponse { error: None },
         Err(e) => proto::RecursiveCopyResponse {
             error: Some(e.to_string()),

--- a/crates/turborepo-fs/src/lib.rs
+++ b/crates/turborepo-fs/src/lib.rs
@@ -1,17 +1,22 @@
 use std::fs::{self, DirBuilder, Metadata};
 
 use anyhow::Result;
-use turbopath::{AbsoluteSystemPathBuf, AnchoredSystemPathBuf};
+use turbopath::{AbsoluteSystemPath, AnchoredSystemPathBuf};
 use walkdir::WalkDir;
 
-pub fn recursive_copy(src: &AbsoluteSystemPathBuf, dst: &AbsoluteSystemPathBuf) -> Result<()> {
-    let src_metadata = src.metadata()?;
+pub fn recursive_copy(
+    src: impl AsRef<AbsoluteSystemPath>,
+    dst: impl AsRef<AbsoluteSystemPath>,
+) -> Result<()> {
+    let src = src.as_ref();
+    let dst = dst.as_ref();
+    let src_metadata = src.symlink_metadata()?;
     if src_metadata.is_dir() {
         let walker = WalkDir::new(src.as_path()).follow_links(false);
         for entry in walker.into_iter() {
             match entry {
                 Err(e) => {
-                    if let Some(_) = e.io_error() {
+                    if e.io_error().is_some() {
                         // Matches go behavior where we translate path errors
                         // into skipping the path we're currently walking
                         continue;
@@ -20,7 +25,8 @@ pub fn recursive_copy(src: &AbsoluteSystemPathBuf, dst: &AbsoluteSystemPathBuf) 
                     }
                 }
                 Ok(entry) => {
-                    let path = AbsoluteSystemPathBuf::new(entry.path())?;
+                    let path = entry.path();
+                    let path = AbsoluteSystemPath::new(path)?;
                     let file_type = entry.file_type();
                     // currently we support symlinked files, but not symlinked directories:
                     // For copying, we Mkdir and bail if we encounter a symlink to a directoy
@@ -56,7 +62,8 @@ pub fn recursive_copy(src: &AbsoluteSystemPathBuf, dst: &AbsoluteSystemPathBuf) 
     }
 }
 
-fn make_dir_copy(dir: &AbsoluteSystemPathBuf, src_metadata: &Metadata) -> Result<()> {
+fn make_dir_copy(dir: impl AsRef<AbsoluteSystemPath>, src_metadata: &Metadata) -> Result<()> {
+    let dir = dir.as_ref();
     let mut builder = DirBuilder::new();
     #[cfg(not(windows))]
     {
@@ -68,23 +75,29 @@ fn make_dir_copy(dir: &AbsoluteSystemPathBuf, src_metadata: &Metadata) -> Result
     Ok(())
 }
 
-pub fn copy_file(from: &AbsoluteSystemPathBuf, to: &AbsoluteSystemPathBuf) -> Result<()> {
-    let metadata = from.metadata()?;
+pub fn copy_file(
+    from: impl AsRef<AbsoluteSystemPath>,
+    to: impl AsRef<AbsoluteSystemPath>,
+) -> Result<()> {
+    let from = from.as_ref();
+    let metadata = from.symlink_metadata()?;
     copy_file_with_type(from, metadata.file_type(), to)
 }
 
 fn copy_file_with_type(
-    from: &AbsoluteSystemPathBuf,
+    from: impl AsRef<AbsoluteSystemPath>,
     from_type: fs::FileType,
-    to: &AbsoluteSystemPathBuf,
+    to: impl AsRef<AbsoluteSystemPath>,
 ) -> Result<()> {
+    let from = from.as_ref();
+    let to = to.as_ref();
     if from_type.is_symlink() {
-        let target = from.read_symlink()?;
+        let target = from.read_link()?;
         to.ensure_dir()?;
-        if to.metadata().is_ok() {
-            to.remove()?;
+        if to.symlink_metadata().is_ok() {
+            to.remove_file()?;
         }
-        to.symlink_to_file(&target)?;
+        to.symlink_to_file(target)?;
         Ok(())
     } else {
         to.ensure_dir()?;
@@ -97,13 +110,13 @@ fn copy_file_with_type(
 mod tests {
     use std::{io, path::Path};
 
-    use turbopath::PathError;
+    use turbopath::{AbsoluteSystemPathBuf, PathError};
 
     use super::*;
 
-    fn tmp_dir() -> Result<(tempfile::TempDir, AbsoluteSystemPathBuf)> {
+    fn tmp_dir<'a>() -> Result<(tempfile::TempDir, AbsoluteSystemPathBuf)> {
         let tmp_dir = tempfile::tempdir()?;
-        let dir = AbsoluteSystemPathBuf::new(tmp_dir.path().to_path_buf())?;
+        let dir = AbsoluteSystemPathBuf::new(tmp_dir.path())?;
         Ok((tmp_dir, dir))
     }
 
@@ -115,7 +128,7 @@ mod tests {
         let (_dst_tmp, dst_dir) = tmp_dir()?;
         let dst_file = dst_dir.join_literal("dest");
 
-        let err = copy_file(&src_file, &dst_file).unwrap_err();
+        let err = copy_file(src_file, dst_file).unwrap_err();
         let err = err.downcast::<PathError>()?;
         assert_eq!(err.is_io_error(io::ErrorKind::NotFound), true);
         Ok(())
@@ -228,7 +241,7 @@ mod tests {
         // This is very likely not ideal behavior, but leaving this test here to verify
         // that it is what we expect at this point in time.
         let dst_circle_path = dst_child_path.join_literal("circle");
-        let dst_circle_metadata = dst_circle_path.metadata()?;
+        let dst_circle_metadata = fs::symlink_metadata(&dst_circle_path)?;
         assert_eq!(dst_circle_metadata.is_dir(), true);
 
         let num_files = fs::read_dir(dst_circle_path.as_path())?.into_iter().count();
@@ -237,14 +250,17 @@ mod tests {
         Ok(())
     }
 
-    fn assert_file_matches(a: &AbsoluteSystemPathBuf, b: &AbsoluteSystemPathBuf) {
+    fn assert_file_matches(a: impl AsRef<AbsoluteSystemPath>, b: impl AsRef<AbsoluteSystemPath>) {
+        let a = a.as_ref();
+        let b = b.as_ref();
         let a_contents = fs::read_to_string(a.as_path()).unwrap();
         let b_contents = fs::read_to_string(b.as_path()).unwrap();
         assert_eq!(a_contents, b_contents);
     }
 
-    fn assert_target_matches<P: AsRef<Path>>(link: &AbsoluteSystemPathBuf, expected: P) {
-        let path = link.read_symlink().unwrap();
+    fn assert_target_matches(link: impl AsRef<AbsoluteSystemPath>, expected: impl AsRef<Path>) {
+        let link = link.as_ref();
+        let path = link.read_link().unwrap();
         assert_eq!(path.as_path(), expected.as_ref());
     }
 }

--- a/crates/turborepo-lib/src/commands/mod.rs
+++ b/crates/turborepo-lib/src/commands/mod.rs
@@ -1,3 +1,5 @@
+use std::borrow::Borrow;
+
 use anyhow::Result;
 use sha2::{Digest, Sha256};
 use tokio::sync::OnceCell;
@@ -49,7 +51,7 @@ impl CommandBase {
     }
 
     fn create_repo_config(&self) -> Result<()> {
-        let repo_config_path = get_repo_config_path(&self.repo_root);
+        let repo_config_path = get_repo_config_path(self.repo_root.borrow());
 
         let repo_config = RepoConfigLoader::new(repo_config_path)
             .with_api(self.args.api.clone())
@@ -67,7 +69,7 @@ impl CommandBase {
     // currently do not have any commands that delete the repo config file
     // and then attempt to read from it.
     pub fn delete_repo_config_file(&mut self) -> Result<()> {
-        let repo_config_path = get_repo_config_path(&self.repo_root);
+        let repo_config_path = get_repo_config_path(self.repo_root.borrow());
         if repo_config_path.exists() {
             std::fs::remove_file(repo_config_path)?;
         }

--- a/crates/turborepo-lib/src/config/repo.rs
+++ b/crates/turborepo-lib/src/config/repo.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, env};
 use anyhow::Result;
 use config::Config;
 use serde::{Deserialize, Serialize};
-use turbopath::{AbsoluteSystemPathBuf, RelativeSystemPathBuf};
+use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, RelativeSystemPathBuf};
 
 use super::{write_to_disk, MappedEnvironment};
 
@@ -78,9 +78,9 @@ impl RepoConfig {
     }
 }
 
-pub fn get_repo_config_path(repo_root: &AbsoluteSystemPathBuf) -> AbsoluteSystemPathBuf {
+pub fn get_repo_config_path(repo_root: &AbsoluteSystemPath) -> AbsoluteSystemPathBuf {
     let config = RelativeSystemPathBuf::new(".turbo/config.json").expect("is relative");
-    repo_root.join_relative(config)
+    repo_root.join_relative(&config)
 }
 
 impl RepoConfigLoader {

--- a/crates/turborepo-lib/src/execution_state.rs
+++ b/crates/turborepo-lib/src/execution_state.rs
@@ -1,6 +1,6 @@
 use serde::Serialize;
 use tracing::trace;
-use turbopath::{AbsoluteSystemPathBuf, RelativeSystemPathBuf};
+use turbopath::RelativeSystemPathBuf;
 
 use crate::{
     cli::Args, commands::CommandBase, package_json::PackageJson, package_manager::PackageManager,
@@ -29,10 +29,11 @@ impl<'a> TryFrom<&'a CommandBase> for ExecutionState<'a> {
     type Error = anyhow::Error;
 
     fn try_from(base: &'a CommandBase) -> Result<Self, Self::Error> {
-        let root_package_json = PackageJson::load(&AbsoluteSystemPathBuf::new(
-            base.repo_root
+        let root_package_json = PackageJson::load(
+            &base
+                .repo_root
                 .join_relative(RelativeSystemPathBuf::new("package.json")?),
-        )?)
+        )
         .ok();
 
         let package_manager =


### PR DESCRIPTION
### Description

In the process of porting cache stuff, I started needing an `AbsoluteSystemPath` so I wouldn't have to clone paths too much.

This PR creates that type and implements a conversion from it to `AbsoluteSystemPathBuf` as `ToOwned` and vice versa for `Borrowed`. It also changes any usage of `&AbsoluteSystemPathBuf` to `&AbsoluteSystemPath`.

There's also some renaming and moving of functions to match `std::path`

### Testing Instructions

I added a test for creating an `AbsoluteSystemPath`