### PR TITLE
vdbg! macro

### DIFF
--- a/crates/turbo-tasks-testing/src/lib.rs
+++ b/crates/turbo-tasks-testing/src/lib.rs
@@ -221,6 +221,13 @@ impl TurboTasksApi for VcStorage {
     fn mark_own_task_as_finished(&self, _task: TaskId) {
         // no-op
     }
+
+    fn detached(
+        &self,
+        _f: std::pin::Pin<Box<dyn Future<Output = Result<()>> + Send + 'static>>,
+    ) -> std::pin::Pin<Box<dyn Future<Output = Result<()>> + Send + 'static>> {
+        unimplemented!()
+    }
 }
 
 impl VcStorage {

--- a/crates/turbo-tasks/src/debug/mod.rs
+++ b/crates/turbo-tasks/src/debug/mod.rs
@@ -7,6 +7,7 @@ use crate::{self as turbo_tasks};
 
 #[doc(hidden)]
 pub mod internal;
+mod vdbg;
 
 use internal::PassthroughDebug;
 

--- a/crates/turbo-tasks/src/debug/vdbg.rs
+++ b/crates/turbo-tasks/src/debug/vdbg.rs
@@ -1,0 +1,43 @@
+// NOTE(alexkirsz) Implementation and comments are based on the `dbg!` macro
+// from the Rust standard library.
+/// This macro supports the same syntax as `dbg!` but will also work for
+/// `turbo_tasks` `Vc` types.
+#[macro_export]
+macro_rules! vdbg {
+    // NOTE: We cannot use `concat!` to make a static string as a format argument
+    // of `eprintln!` because `file!` could contain a `{` or
+    // `$val` expression could be a block (`{ .. }`), in which case the `eprintln!`
+    // will be malformed.
+    () => {
+        eprintln!("[{}:{}]", file!(), line!())
+    };
+    ($val:expr ; depth = $depth:expr) => {
+        // Use of `match` here is intentional because it affects the lifetimes
+        // of temporaries - https://stackoverflow.com/a/48732525/1063961
+        match $val {
+            tmp => {
+                $crate::macro_helpers::spawn_detached(async move {
+                    use $crate::debug::ValueDebugFormat;
+                    eprintln!(
+                        "[{}:{}] {} = {}",
+                        file!(),
+                        line!(),
+                        stringify!($val),
+                        (&tmp).value_debug_format($depth).try_to_string().await?,
+                    );
+                    Ok(())
+                });
+                tmp
+            }
+        }
+    };
+    ($($val:expr),+ ; depth = $depth:expr) => {
+        ($(vdbg!($val ; depth = $depth)),+,)
+    };
+    ($val:expr $(,)?) => {
+        vdbg!($val ; depth = usize::MAX)
+    };
+    ($($val:expr),+ $(,)?) => {
+        ($(vdbg!($val)),+,)
+    };
+}

--- a/crates/turbo-tasks/src/debug/vdbg.rs
+++ b/crates/turbo-tasks/src/debug/vdbg.rs
@@ -1,7 +1,11 @@
 // NOTE(alexkirsz) Implementation and comments are based on the `dbg!` macro
 // from the Rust standard library.
-/// This macro supports the same syntax as `dbg!` but will also work for
-/// `turbo_tasks` `Vc` types.
+/// This macro supports the same syntax as `dbg!`, but also supports
+/// pretty-printing `Vc` types.
+///
+/// Beware: this macro should only be used for debugging purposes. Its behavior
+/// around dependency tracking is not well-defined and could lead to unexpected
+/// results.
 #[macro_export]
 macro_rules! vdbg {
     // NOTE: We cannot use `concat!` to make a static string as a format argument

--- a/crates/turbo-tasks/src/lib.rs
+++ b/crates/turbo-tasks/src/lib.rs
@@ -104,7 +104,7 @@ pub use value_type::{
 pub mod macro_helpers {
     pub use once_cell::sync::{Lazy, OnceCell};
 
-    pub use super::manager::find_cell_by_type;
+    pub use super::manager::{find_cell_by_type, spawn_detached};
 }
 
 pub mod test_helpers {

--- a/crates/turbo-tasks/src/manager.rs
+++ b/crates/turbo-tasks/src/manager.rs
@@ -990,16 +990,14 @@ impl<B: Backend + 'static> TurboTasksApi for TurboTasks<B> {
         &self,
         f: Pin<Box<dyn Future<Output = Result<()>> + Send + 'static>>,
     ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'static>> {
-        Box::pin(
-            TURBO_TASKS.scope(
-                turbo_tasks(),
-                CURRENT_TASK_ID.scope(
-                    CURRENT_TASK_ID.with(|id| *id),
-                    self.backend
-                        .execution_scope(CURRENT_TASK_ID.with(|id| *id), f),
-                ),
+        let current_task_id = CURRENT_TASK_ID.get();
+        Box::pin(TURBO_TASKS.scope(
+            turbo_tasks(),
+            CURRENT_TASK_ID.scope(
+                current_task_id,
+                self.backend.execution_scope(current_task_id, f),
             ),
-        )
+        ))
     }
 }
 

--- a/crates/turbo-tasks/src/manager.rs
+++ b/crates/turbo-tasks/src/manager.rs
@@ -1322,6 +1322,10 @@ pub fn with_turbo_tasks_for_testing<T>(
     )
 }
 
+/// Spawns the given future within the context of the current task.
+///
+/// Beware: this method is not safe to use in production code. It is only
+/// intended for use in tests and for debugging purposes.
 pub fn spawn_detached(f: impl Future<Output = Result<()>> + Send + 'static) {
     tokio::spawn(turbo_tasks().detached(Box::pin(f)));
 }


### PR DESCRIPTION
### Description

The `vdbg!` macro works the same way as the `dbg!` macro, with the additional benefit of automatically calling `ValueDebugFormat` implementations.

This means that you can do:

```rust
vdbg!(42, asset_ident_vc);
vdbg!(42, asset_ident_vc; depth = 1);
```

and the macro will print out

```rust
[src/main.rs:10] 42 = 42
[src/main.rs:10] some_vc = AssetIdent {
    path: FileSystemPath {
        fs: FileSystem(DiskFileSystem {
            name: "project",
            root: "...",
        }),
        path: "...",
    },
    query: None,
    fragment: None,
    assets: [],
    modifiers: [],
    part: None,
}
```

```rust
[src/main.rs:10] 42 = 42
[src/main.rs:10] asset_ident_vc = AssetIdent {
    path: FileSystemPath,
    query: core::option::Option<turbo_tasks::primitives::StringVc>,
    fragment: core::option::Option<turbo_tasks::primitives::StringVc>,
    assets: alloc::vec::Vec<(turbo_tasks::primitives::StringVc, turbopack_core::ident::AssetIdentVc)>,
    modifiers: alloc::vec::Vec<turbo_tasks::primitives::StringVc>,
    part: core::option::Option<turbopack_core::resolve::ModulePartVc>,
}
```

This is an ergonomic improvement over having to call `.dbg()` or `.dbg_depth()` manually in four major ways:
1. No need to be in an async context and call `.await?`: the macro will spawn a task on its own. This means that it is no longer necessary to convert a `turbo_tasks::function` to async just to debug one of its arguments.
2. No need to import the `turbo_tasks::debug::ValueDebug` trait. You can call `turbo_tasks::vdbg!(...)` directly, of `vdbg!(...)` if you have it imported already.
3. No need to call `eprintln!` or `dbg!`: `vdbg!` calls `eprintln!` directly under the hood, with the same format as `dbg!`.
4. It's just one macro, with support for the `depth` argument baked in.

### Testing Instructions

N/A
link WEB-520