### PR TITLE
Hack to get correct log file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9138,6 +9138,7 @@ dependencies = [
  "tempfile",
  "test-case",
  "thiserror",
+ "time 0.3.20",
  "tiny-gradient",
  "tokio",
  "tokio-stream",

--- a/crates/turborepo-lib/Cargo.toml
+++ b/crates/turborepo-lib/Cargo.toml
@@ -68,6 +68,7 @@ sha2 = "0.10.6"
 shared_child = "1.0.0"
 sysinfo = "0.27.7"
 thiserror = "1.0.38"
+time = "0.3.20"
 tiny-gradient = { workspace = true }
 tokio = { workspace = true, features = ["full", "time"] }
 tokio-stream = { version = "0.1.12", features = ["net"] }

--- a/crates/turborepo-lib/src/daemon/client.rs
+++ b/crates/turborepo-lib/src/daemon/client.rs
@@ -152,6 +152,9 @@ pub enum DaemonError {
 
     #[error("unable to display output: {0}")]
     DisplayError(#[from] serde_json::Error),
+
+    #[error("unable to construct log file name: {0}")]
+    InvalidLogFile(#[from] time::Error),
 }
 
 impl From<Status> for DaemonError {


### PR DESCRIPTION
### Description

Match the logic in `tracing_appender::Rotation::DAILY` to generate the correct log filename to report in `turbo daemon status`. This is kind of a hack, but there did not appear to be an easy way to grab this value.

### Testing Instructions

Tested manually