### PR TITLE
Fix hang up when loading duplicated CSS module chunks

### DIFF
--- a/crates/turbopack-dev/js/src/runtime.dom.js
+++ b/crates/turbopack-dev/js/src/runtime.dom.js
@@ -18,15 +18,8 @@ let BACKEND;
 
       for (const otherChunkData of params.otherChunks) {
         const otherChunkPath = getChunkPath(otherChunkData);
-        if (otherChunkPath.endsWith(".css")) {
-          // Mark all CSS chunks within the same chunk group as this chunk as loaded.
-          // They are just injected as <link> tag and have to way to communicate completion.
-          const cssResolver = getOrCreateResolver(otherChunkPath);
-          cssResolver.resolve();
-        } else if (otherChunkPath.endsWith(".js")) {
-          // Chunk might have started loading, so we want to avoid triggering another load.
-          getOrCreateResolver(otherChunkPath);
-        }
+        // Chunk might have started loading, so we want to avoid triggering another load.
+        getOrCreateResolver(otherChunkPath);
       }
 
       // This waits for chunks to be loaded, but also marks included items as available.
@@ -169,12 +162,20 @@ let BACKEND;
       return resolver.promise;
     }
 
-    // We don't need to load chunks references from runtime code, as they're already
-    // present in the DOM.
-    // However, we need to wait for them to register themselves within `registerChunk`
-    // before we can start instantiating runtime modules, hence the absense of
-    // `resolver.resolve()` in this branch.
     if (source.type === SourceTypeRuntime) {
+      // We don't need to load chunks references from runtime code, as they're already
+      // present in the DOM.
+
+      if (chunkPath.endsWith(".css")) {
+        // CSS chunks do not register themselves, and as such must be marked as
+        // loaded instantly.
+        resolver.resolve();
+      }
+
+      // We need to wait for JS chunks to register themselves within `registerChunk`
+      // before we can start instantiating runtime modules, hence the absence of
+      // `resolver.resolve()` in this branch.
+
       return resolver.promise;
     }
 

--- a/crates/turbopack-tests/tests/snapshot/basic/async_chunk/output/crates_turbopack-tests_tests_snapshot_basic_async_chunk_input_index_0d348e.js
+++ b/crates/turbopack-tests/tests/snapshot/basic/async_chunk/output/crates_turbopack-tests_tests_snapshot_basic_async_chunk_input_index_0d348e.js
@@ -1532,15 +1532,8 @@ let BACKEND;
 
       for (const otherChunkData of params.otherChunks) {
         const otherChunkPath = getChunkPath(otherChunkData);
-        if (otherChunkPath.endsWith(".css")) {
-          // Mark all CSS chunks within the same chunk group as this chunk as loaded.
-          // They are just injected as <link> tag and have to way to communicate completion.
-          const cssResolver = getOrCreateResolver(otherChunkPath);
-          cssResolver.resolve();
-        } else if (otherChunkPath.endsWith(".js")) {
-          // Chunk might have started loading, so we want to avoid triggering another load.
-          getOrCreateResolver(otherChunkPath);
-        }
+        // Chunk might have started loading, so we want to avoid triggering another load.
+        getOrCreateResolver(otherChunkPath);
       }
 
       // This waits for chunks to be loaded, but also marks included items as available.
@@ -1683,12 +1676,20 @@ let BACKEND;
       return resolver.promise;
     }
 
-    // We don't need to load chunks references from runtime code, as they're already
-    // present in the DOM.
-    // However, we need to wait for them to register themselves within `registerChunk`
-    // before we can start instantiating runtime modules, hence the absense of
-    // `resolver.resolve()` in this branch.
     if (source.type === SourceTypeRuntime) {
+      // We don't need to load chunks references from runtime code, as they're already
+      // present in the DOM.
+
+      if (chunkPath.endsWith(".css")) {
+        // CSS chunks do not register themselves, and as such must be marked as
+        // loaded instantly.
+        resolver.resolve();
+      }
+
+      // We need to wait for JS chunks to register themselves within `registerChunk`
+      // before we can start instantiating runtime modules, hence the absence of
+      // `resolver.resolve()` in this branch.
+
       return resolver.promise;
     }
 

--- a/crates/turbopack-tests/tests/snapshot/basic/chunked/output/crates_turbopack-tests_tests_snapshot_basic_chunked_input_index_e77e9f.js
+++ b/crates/turbopack-tests/tests/snapshot/basic/chunked/output/crates_turbopack-tests_tests_snapshot_basic_chunked_input_index_e77e9f.js
@@ -1532,15 +1532,8 @@ let BACKEND;
 
       for (const otherChunkData of params.otherChunks) {
         const otherChunkPath = getChunkPath(otherChunkData);
-        if (otherChunkPath.endsWith(".css")) {
-          // Mark all CSS chunks within the same chunk group as this chunk as loaded.
-          // They are just injected as <link> tag and have to way to communicate completion.
-          const cssResolver = getOrCreateResolver(otherChunkPath);
-          cssResolver.resolve();
-        } else if (otherChunkPath.endsWith(".js")) {
-          // Chunk might have started loading, so we want to avoid triggering another load.
-          getOrCreateResolver(otherChunkPath);
-        }
+        // Chunk might have started loading, so we want to avoid triggering another load.
+        getOrCreateResolver(otherChunkPath);
       }
 
       // This waits for chunks to be loaded, but also marks included items as available.
@@ -1683,12 +1676,20 @@ let BACKEND;
       return resolver.promise;
     }
 
-    // We don't need to load chunks references from runtime code, as they're already
-    // present in the DOM.
-    // However, we need to wait for them to register themselves within `registerChunk`
-    // before we can start instantiating runtime modules, hence the absense of
-    // `resolver.resolve()` in this branch.
     if (source.type === SourceTypeRuntime) {
+      // We don't need to load chunks references from runtime code, as they're already
+      // present in the DOM.
+
+      if (chunkPath.endsWith(".css")) {
+        // CSS chunks do not register themselves, and as such must be marked as
+        // loaded instantly.
+        resolver.resolve();
+      }
+
+      // We need to wait for JS chunks to register themselves within `registerChunk`
+      // before we can start instantiating runtime modules, hence the absence of
+      // `resolver.resolve()` in this branch.
+
       return resolver.promise;
     }
 

--- a/crates/turbopack-tests/tests/snapshot/basic/shebang/output/crates_turbopack-tests_tests_snapshot_basic_shebang_input_index_b1f0c2.js
+++ b/crates/turbopack-tests/tests/snapshot/basic/shebang/output/crates_turbopack-tests_tests_snapshot_basic_shebang_input_index_b1f0c2.js
@@ -1532,15 +1532,8 @@ let BACKEND;
 
       for (const otherChunkData of params.otherChunks) {
         const otherChunkPath = getChunkPath(otherChunkData);
-        if (otherChunkPath.endsWith(".css")) {
-          // Mark all CSS chunks within the same chunk group as this chunk as loaded.
-          // They are just injected as <link> tag and have to way to communicate completion.
-          const cssResolver = getOrCreateResolver(otherChunkPath);
-          cssResolver.resolve();
-        } else if (otherChunkPath.endsWith(".js")) {
-          // Chunk might have started loading, so we want to avoid triggering another load.
-          getOrCreateResolver(otherChunkPath);
-        }
+        // Chunk might have started loading, so we want to avoid triggering another load.
+        getOrCreateResolver(otherChunkPath);
       }
 
       // This waits for chunks to be loaded, but also marks included items as available.
@@ -1683,12 +1676,20 @@ let BACKEND;
       return resolver.promise;
     }
 
-    // We don't need to load chunks references from runtime code, as they're already
-    // present in the DOM.
-    // However, we need to wait for them to register themselves within `registerChunk`
-    // before we can start instantiating runtime modules, hence the absense of
-    // `resolver.resolve()` in this branch.
     if (source.type === SourceTypeRuntime) {
+      // We don't need to load chunks references from runtime code, as they're already
+      // present in the DOM.
+
+      if (chunkPath.endsWith(".css")) {
+        // CSS chunks do not register themselves, and as such must be marked as
+        // loaded instantly.
+        resolver.resolve();
+      }
+
+      // We need to wait for JS chunks to register themselves within `registerChunk`
+      // before we can start instantiating runtime modules, hence the absence of
+      // `resolver.resolve()` in this branch.
+
       return resolver.promise;
     }
 

--- a/crates/turbopack-tests/tests/snapshot/comptime/define/output/crates_turbopack-tests_tests_snapshot_comptime_define_input_index_6b0d2b.js
+++ b/crates/turbopack-tests/tests/snapshot/comptime/define/output/crates_turbopack-tests_tests_snapshot_comptime_define_input_index_6b0d2b.js
@@ -1532,15 +1532,8 @@ let BACKEND;
 
       for (const otherChunkData of params.otherChunks) {
         const otherChunkPath = getChunkPath(otherChunkData);
-        if (otherChunkPath.endsWith(".css")) {
-          // Mark all CSS chunks within the same chunk group as this chunk as loaded.
-          // They are just injected as <link> tag and have to way to communicate completion.
-          const cssResolver = getOrCreateResolver(otherChunkPath);
-          cssResolver.resolve();
-        } else if (otherChunkPath.endsWith(".js")) {
-          // Chunk might have started loading, so we want to avoid triggering another load.
-          getOrCreateResolver(otherChunkPath);
-        }
+        // Chunk might have started loading, so we want to avoid triggering another load.
+        getOrCreateResolver(otherChunkPath);
       }
 
       // This waits for chunks to be loaded, but also marks included items as available.
@@ -1683,12 +1676,20 @@ let BACKEND;
       return resolver.promise;
     }
 
-    // We don't need to load chunks references from runtime code, as they're already
-    // present in the DOM.
-    // However, we need to wait for them to register themselves within `registerChunk`
-    // before we can start instantiating runtime modules, hence the absense of
-    // `resolver.resolve()` in this branch.
     if (source.type === SourceTypeRuntime) {
+      // We don't need to load chunks references from runtime code, as they're already
+      // present in the DOM.
+
+      if (chunkPath.endsWith(".css")) {
+        // CSS chunks do not register themselves, and as such must be marked as
+        // loaded instantly.
+        resolver.resolve();
+      }
+
+      // We need to wait for JS chunks to register themselves within `registerChunk`
+      // before we can start instantiating runtime modules, hence the absence of
+      // `resolver.resolve()` in this branch.
+
       return resolver.promise;
     }
 

--- a/crates/turbopack-tests/tests/snapshot/css/absolute-uri-import/output/crates_turbopack-tests_tests_snapshot_css_absolute-uri-import_input_index_fa9a30.js
+++ b/crates/turbopack-tests/tests/snapshot/css/absolute-uri-import/output/crates_turbopack-tests_tests_snapshot_css_absolute-uri-import_input_index_fa9a30.js
@@ -1532,15 +1532,8 @@ let BACKEND;
 
       for (const otherChunkData of params.otherChunks) {
         const otherChunkPath = getChunkPath(otherChunkData);
-        if (otherChunkPath.endsWith(".css")) {
-          // Mark all CSS chunks within the same chunk group as this chunk as loaded.
-          // They are just injected as <link> tag and have to way to communicate completion.
-          const cssResolver = getOrCreateResolver(otherChunkPath);
-          cssResolver.resolve();
-        } else if (otherChunkPath.endsWith(".js")) {
-          // Chunk might have started loading, so we want to avoid triggering another load.
-          getOrCreateResolver(otherChunkPath);
-        }
+        // Chunk might have started loading, so we want to avoid triggering another load.
+        getOrCreateResolver(otherChunkPath);
       }
 
       // This waits for chunks to be loaded, but also marks included items as available.
@@ -1683,12 +1676,20 @@ let BACKEND;
       return resolver.promise;
     }
 
-    // We don't need to load chunks references from runtime code, as they're already
-    // present in the DOM.
-    // However, we need to wait for them to register themselves within `registerChunk`
-    // before we can start instantiating runtime modules, hence the absense of
-    // `resolver.resolve()` in this branch.
     if (source.type === SourceTypeRuntime) {
+      // We don't need to load chunks references from runtime code, as they're already
+      // present in the DOM.
+
+      if (chunkPath.endsWith(".css")) {
+        // CSS chunks do not register themselves, and as such must be marked as
+        // loaded instantly.
+        resolver.resolve();
+      }
+
+      // We need to wait for JS chunks to register themselves within `registerChunk`
+      // before we can start instantiating runtime modules, hence the absence of
+      // `resolver.resolve()` in this branch.
+
       return resolver.promise;
     }
 

--- a/crates/turbopack-tests/tests/snapshot/css/css/output/crates_turbopack-tests_tests_snapshot_css_css_input_index_37a138.js
+++ b/crates/turbopack-tests/tests/snapshot/css/css/output/crates_turbopack-tests_tests_snapshot_css_css_input_index_37a138.js
@@ -1532,15 +1532,8 @@ let BACKEND;
 
       for (const otherChunkData of params.otherChunks) {
         const otherChunkPath = getChunkPath(otherChunkData);
-        if (otherChunkPath.endsWith(".css")) {
-          // Mark all CSS chunks within the same chunk group as this chunk as loaded.
-          // They are just injected as <link> tag and have to way to communicate completion.
-          const cssResolver = getOrCreateResolver(otherChunkPath);
-          cssResolver.resolve();
-        } else if (otherChunkPath.endsWith(".js")) {
-          // Chunk might have started loading, so we want to avoid triggering another load.
-          getOrCreateResolver(otherChunkPath);
-        }
+        // Chunk might have started loading, so we want to avoid triggering another load.
+        getOrCreateResolver(otherChunkPath);
       }
 
       // This waits for chunks to be loaded, but also marks included items as available.
@@ -1683,12 +1676,20 @@ let BACKEND;
       return resolver.promise;
     }
 
-    // We don't need to load chunks references from runtime code, as they're already
-    // present in the DOM.
-    // However, we need to wait for them to register themselves within `registerChunk`
-    // before we can start instantiating runtime modules, hence the absense of
-    // `resolver.resolve()` in this branch.
     if (source.type === SourceTypeRuntime) {
+      // We don't need to load chunks references from runtime code, as they're already
+      // present in the DOM.
+
+      if (chunkPath.endsWith(".css")) {
+        // CSS chunks do not register themselves, and as such must be marked as
+        // loaded instantly.
+        resolver.resolve();
+      }
+
+      // We need to wait for JS chunks to register themselves within `registerChunk`
+      // before we can start instantiating runtime modules, hence the absence of
+      // `resolver.resolve()` in this branch.
+
       return resolver.promise;
     }
 

--- a/crates/turbopack-tests/tests/snapshot/emotion/emotion/output/crates_turbopack-tests_tests_snapshot_emotion_emotion_input_index_b080c4.js
+++ b/crates/turbopack-tests/tests/snapshot/emotion/emotion/output/crates_turbopack-tests_tests_snapshot_emotion_emotion_input_index_b080c4.js
@@ -1532,15 +1532,8 @@ let BACKEND;
 
       for (const otherChunkData of params.otherChunks) {
         const otherChunkPath = getChunkPath(otherChunkData);
-        if (otherChunkPath.endsWith(".css")) {
-          // Mark all CSS chunks within the same chunk group as this chunk as loaded.
-          // They are just injected as <link> tag and have to way to communicate completion.
-          const cssResolver = getOrCreateResolver(otherChunkPath);
-          cssResolver.resolve();
-        } else if (otherChunkPath.endsWith(".js")) {
-          // Chunk might have started loading, so we want to avoid triggering another load.
-          getOrCreateResolver(otherChunkPath);
-        }
+        // Chunk might have started loading, so we want to avoid triggering another load.
+        getOrCreateResolver(otherChunkPath);
       }
 
       // This waits for chunks to be loaded, but also marks included items as available.
@@ -1683,12 +1676,20 @@ let BACKEND;
       return resolver.promise;
     }
 
-    // We don't need to load chunks references from runtime code, as they're already
-    // present in the DOM.
-    // However, we need to wait for them to register themselves within `registerChunk`
-    // before we can start instantiating runtime modules, hence the absense of
-    // `resolver.resolve()` in this branch.
     if (source.type === SourceTypeRuntime) {
+      // We don't need to load chunks references from runtime code, as they're already
+      // present in the DOM.
+
+      if (chunkPath.endsWith(".css")) {
+        // CSS chunks do not register themselves, and as such must be marked as
+        // loaded instantly.
+        resolver.resolve();
+      }
+
+      // We need to wait for JS chunks to register themselves within `registerChunk`
+      // before we can start instantiating runtime modules, hence the absence of
+      // `resolver.resolve()` in this branch.
+
       return resolver.promise;
     }
 

--- a/crates/turbopack-tests/tests/snapshot/env/env/output/crates_turbopack-tests_tests_snapshot_env_env_input_index_29a23f.js
+++ b/crates/turbopack-tests/tests/snapshot/env/env/output/crates_turbopack-tests_tests_snapshot_env_env_input_index_29a23f.js
@@ -1532,15 +1532,8 @@ let BACKEND;
 
       for (const otherChunkData of params.otherChunks) {
         const otherChunkPath = getChunkPath(otherChunkData);
-        if (otherChunkPath.endsWith(".css")) {
-          // Mark all CSS chunks within the same chunk group as this chunk as loaded.
-          // They are just injected as <link> tag and have to way to communicate completion.
-          const cssResolver = getOrCreateResolver(otherChunkPath);
-          cssResolver.resolve();
-        } else if (otherChunkPath.endsWith(".js")) {
-          // Chunk might have started loading, so we want to avoid triggering another load.
-          getOrCreateResolver(otherChunkPath);
-        }
+        // Chunk might have started loading, so we want to avoid triggering another load.
+        getOrCreateResolver(otherChunkPath);
       }
 
       // This waits for chunks to be loaded, but also marks included items as available.
@@ -1683,12 +1676,20 @@ let BACKEND;
       return resolver.promise;
     }
 
-    // We don't need to load chunks references from runtime code, as they're already
-    // present in the DOM.
-    // However, we need to wait for them to register themselves within `registerChunk`
-    // before we can start instantiating runtime modules, hence the absense of
-    // `resolver.resolve()` in this branch.
     if (source.type === SourceTypeRuntime) {
+      // We don't need to load chunks references from runtime code, as they're already
+      // present in the DOM.
+
+      if (chunkPath.endsWith(".css")) {
+        // CSS chunks do not register themselves, and as such must be marked as
+        // loaded instantly.
+        resolver.resolve();
+      }
+
+      // We need to wait for JS chunks to register themselves within `registerChunk`
+      // before we can start instantiating runtime modules, hence the absence of
+      // `resolver.resolve()` in this branch.
+
       return resolver.promise;
     }
 

--- a/crates/turbopack-tests/tests/snapshot/evaluated_entrry/runtime_entry/output/a587c_tests_snapshot_evaluated_entrry_runtime_entry_input_index_f59cc7.js
+++ b/crates/turbopack-tests/tests/snapshot/evaluated_entrry/runtime_entry/output/a587c_tests_snapshot_evaluated_entrry_runtime_entry_input_index_f59cc7.js
@@ -1532,15 +1532,8 @@ let BACKEND;
 
       for (const otherChunkData of params.otherChunks) {
         const otherChunkPath = getChunkPath(otherChunkData);
-        if (otherChunkPath.endsWith(".css")) {
-          // Mark all CSS chunks within the same chunk group as this chunk as loaded.
-          // They are just injected as <link> tag and have to way to communicate completion.
-          const cssResolver = getOrCreateResolver(otherChunkPath);
-          cssResolver.resolve();
-        } else if (otherChunkPath.endsWith(".js")) {
-          // Chunk might have started loading, so we want to avoid triggering another load.
-          getOrCreateResolver(otherChunkPath);
-        }
+        // Chunk might have started loading, so we want to avoid triggering another load.
+        getOrCreateResolver(otherChunkPath);
       }
 
       // This waits for chunks to be loaded, but also marks included items as available.
@@ -1683,12 +1676,20 @@ let BACKEND;
       return resolver.promise;
     }
 
-    // We don't need to load chunks references from runtime code, as they're already
-    // present in the DOM.
-    // However, we need to wait for them to register themselves within `registerChunk`
-    // before we can start instantiating runtime modules, hence the absense of
-    // `resolver.resolve()` in this branch.
     if (source.type === SourceTypeRuntime) {
+      // We don't need to load chunks references from runtime code, as they're already
+      // present in the DOM.
+
+      if (chunkPath.endsWith(".css")) {
+        // CSS chunks do not register themselves, and as such must be marked as
+        // loaded instantly.
+        resolver.resolve();
+      }
+
+      // We need to wait for JS chunks to register themselves within `registerChunk`
+      // before we can start instantiating runtime modules, hence the absence of
+      // `resolver.resolve()` in this branch.
+
       return resolver.promise;
     }
 

--- a/crates/turbopack-tests/tests/snapshot/example/example/output/crates_turbopack-tests_tests_snapshot_example_example_input_index_78b6bf.js
+++ b/crates/turbopack-tests/tests/snapshot/example/example/output/crates_turbopack-tests_tests_snapshot_example_example_input_index_78b6bf.js
@@ -1532,15 +1532,8 @@ let BACKEND;
 
       for (const otherChunkData of params.otherChunks) {
         const otherChunkPath = getChunkPath(otherChunkData);
-        if (otherChunkPath.endsWith(".css")) {
-          // Mark all CSS chunks within the same chunk group as this chunk as loaded.
-          // They are just injected as <link> tag and have to way to communicate completion.
-          const cssResolver = getOrCreateResolver(otherChunkPath);
-          cssResolver.resolve();
-        } else if (otherChunkPath.endsWith(".js")) {
-          // Chunk might have started loading, so we want to avoid triggering another load.
-          getOrCreateResolver(otherChunkPath);
-        }
+        // Chunk might have started loading, so we want to avoid triggering another load.
+        getOrCreateResolver(otherChunkPath);
       }
 
       // This waits for chunks to be loaded, but also marks included items as available.
@@ -1683,12 +1676,20 @@ let BACKEND;
       return resolver.promise;
     }
 
-    // We don't need to load chunks references from runtime code, as they're already
-    // present in the DOM.
-    // However, we need to wait for them to register themselves within `registerChunk`
-    // before we can start instantiating runtime modules, hence the absense of
-    // `resolver.resolve()` in this branch.
     if (source.type === SourceTypeRuntime) {
+      // We don't need to load chunks references from runtime code, as they're already
+      // present in the DOM.
+
+      if (chunkPath.endsWith(".css")) {
+        // CSS chunks do not register themselves, and as such must be marked as
+        // loaded instantly.
+        resolver.resolve();
+      }
+
+      // We need to wait for JS chunks to register themselves within `registerChunk`
+      // before we can start instantiating runtime modules, hence the absence of
+      // `resolver.resolve()` in this branch.
+
       return resolver.promise;
     }
 

--- a/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/output/crates_turbopack-tests_tests_snapshot_export-alls_cjs-2_input_index_289ae7.js
+++ b/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/output/crates_turbopack-tests_tests_snapshot_export-alls_cjs-2_input_index_289ae7.js
@@ -1532,15 +1532,8 @@ let BACKEND;
 
       for (const otherChunkData of params.otherChunks) {
         const otherChunkPath = getChunkPath(otherChunkData);
-        if (otherChunkPath.endsWith(".css")) {
-          // Mark all CSS chunks within the same chunk group as this chunk as loaded.
-          // They are just injected as <link> tag and have to way to communicate completion.
-          const cssResolver = getOrCreateResolver(otherChunkPath);
-          cssResolver.resolve();
-        } else if (otherChunkPath.endsWith(".js")) {
-          // Chunk might have started loading, so we want to avoid triggering another load.
-          getOrCreateResolver(otherChunkPath);
-        }
+        // Chunk might have started loading, so we want to avoid triggering another load.
+        getOrCreateResolver(otherChunkPath);
       }
 
       // This waits for chunks to be loaded, but also marks included items as available.
@@ -1683,12 +1676,20 @@ let BACKEND;
       return resolver.promise;
     }
 
-    // We don't need to load chunks references from runtime code, as they're already
-    // present in the DOM.
-    // However, we need to wait for them to register themselves within `registerChunk`
-    // before we can start instantiating runtime modules, hence the absense of
-    // `resolver.resolve()` in this branch.
     if (source.type === SourceTypeRuntime) {
+      // We don't need to load chunks references from runtime code, as they're already
+      // present in the DOM.
+
+      if (chunkPath.endsWith(".css")) {
+        // CSS chunks do not register themselves, and as such must be marked as
+        // loaded instantly.
+        resolver.resolve();
+      }
+
+      // We need to wait for JS chunks to register themselves within `registerChunk`
+      // before we can start instantiating runtime modules, hence the absence of
+      // `resolver.resolve()` in this branch.
+
       return resolver.promise;
     }
 

--- a/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/output/crates_turbopack-tests_tests_snapshot_export-alls_cjs-script_input_index_3e96b7.js
+++ b/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/output/crates_turbopack-tests_tests_snapshot_export-alls_cjs-script_input_index_3e96b7.js
@@ -1532,15 +1532,8 @@ let BACKEND;
 
       for (const otherChunkData of params.otherChunks) {
         const otherChunkPath = getChunkPath(otherChunkData);
-        if (otherChunkPath.endsWith(".css")) {
-          // Mark all CSS chunks within the same chunk group as this chunk as loaded.
-          // They are just injected as <link> tag and have to way to communicate completion.
-          const cssResolver = getOrCreateResolver(otherChunkPath);
-          cssResolver.resolve();
-        } else if (otherChunkPath.endsWith(".js")) {
-          // Chunk might have started loading, so we want to avoid triggering another load.
-          getOrCreateResolver(otherChunkPath);
-        }
+        // Chunk might have started loading, so we want to avoid triggering another load.
+        getOrCreateResolver(otherChunkPath);
       }
 
       // This waits for chunks to be loaded, but also marks included items as available.
@@ -1683,12 +1676,20 @@ let BACKEND;
       return resolver.promise;
     }
 
-    // We don't need to load chunks references from runtime code, as they're already
-    // present in the DOM.
-    // However, we need to wait for them to register themselves within `registerChunk`
-    // before we can start instantiating runtime modules, hence the absense of
-    // `resolver.resolve()` in this branch.
     if (source.type === SourceTypeRuntime) {
+      // We don't need to load chunks references from runtime code, as they're already
+      // present in the DOM.
+
+      if (chunkPath.endsWith(".css")) {
+        // CSS chunks do not register themselves, and as such must be marked as
+        // loaded instantly.
+        resolver.resolve();
+      }
+
+      // We need to wait for JS chunks to register themselves within `registerChunk`
+      // before we can start instantiating runtime modules, hence the absence of
+      // `resolver.resolve()` in this branch.
+
       return resolver.promise;
     }
 

--- a/crates/turbopack-tests/tests/snapshot/import-meta/cjs/output/crates_turbopack-tests_tests_snapshot_import-meta_cjs_input_index_537553.js
+++ b/crates/turbopack-tests/tests/snapshot/import-meta/cjs/output/crates_turbopack-tests_tests_snapshot_import-meta_cjs_input_index_537553.js
@@ -1532,15 +1532,8 @@ let BACKEND;
 
       for (const otherChunkData of params.otherChunks) {
         const otherChunkPath = getChunkPath(otherChunkData);
-        if (otherChunkPath.endsWith(".css")) {
-          // Mark all CSS chunks within the same chunk group as this chunk as loaded.
-          // They are just injected as <link> tag and have to way to communicate completion.
-          const cssResolver = getOrCreateResolver(otherChunkPath);
-          cssResolver.resolve();
-        } else if (otherChunkPath.endsWith(".js")) {
-          // Chunk might have started loading, so we want to avoid triggering another load.
-          getOrCreateResolver(otherChunkPath);
-        }
+        // Chunk might have started loading, so we want to avoid triggering another load.
+        getOrCreateResolver(otherChunkPath);
       }
 
       // This waits for chunks to be loaded, but also marks included items as available.
@@ -1683,12 +1676,20 @@ let BACKEND;
       return resolver.promise;
     }
 
-    // We don't need to load chunks references from runtime code, as they're already
-    // present in the DOM.
-    // However, we need to wait for them to register themselves within `registerChunk`
-    // before we can start instantiating runtime modules, hence the absense of
-    // `resolver.resolve()` in this branch.
     if (source.type === SourceTypeRuntime) {
+      // We don't need to load chunks references from runtime code, as they're already
+      // present in the DOM.
+
+      if (chunkPath.endsWith(".css")) {
+        // CSS chunks do not register themselves, and as such must be marked as
+        // loaded instantly.
+        resolver.resolve();
+      }
+
+      // We need to wait for JS chunks to register themselves within `registerChunk`
+      // before we can start instantiating runtime modules, hence the absence of
+      // `resolver.resolve()` in this branch.
+
       return resolver.promise;
     }
 

--- a/crates/turbopack-tests/tests/snapshot/import-meta/esm-multiple/output/79fb1_turbopack-tests_tests_snapshot_import-meta_esm-multiple_input_index_c00392.js
+++ b/crates/turbopack-tests/tests/snapshot/import-meta/esm-multiple/output/79fb1_turbopack-tests_tests_snapshot_import-meta_esm-multiple_input_index_c00392.js
@@ -1532,15 +1532,8 @@ let BACKEND;
 
       for (const otherChunkData of params.otherChunks) {
         const otherChunkPath = getChunkPath(otherChunkData);
-        if (otherChunkPath.endsWith(".css")) {
-          // Mark all CSS chunks within the same chunk group as this chunk as loaded.
-          // They are just injected as <link> tag and have to way to communicate completion.
-          const cssResolver = getOrCreateResolver(otherChunkPath);
-          cssResolver.resolve();
-        } else if (otherChunkPath.endsWith(".js")) {
-          // Chunk might have started loading, so we want to avoid triggering another load.
-          getOrCreateResolver(otherChunkPath);
-        }
+        // Chunk might have started loading, so we want to avoid triggering another load.
+        getOrCreateResolver(otherChunkPath);
       }
 
       // This waits for chunks to be loaded, but also marks included items as available.
@@ -1683,12 +1676,20 @@ let BACKEND;
       return resolver.promise;
     }
 
-    // We don't need to load chunks references from runtime code, as they're already
-    // present in the DOM.
-    // However, we need to wait for them to register themselves within `registerChunk`
-    // before we can start instantiating runtime modules, hence the absense of
-    // `resolver.resolve()` in this branch.
     if (source.type === SourceTypeRuntime) {
+      // We don't need to load chunks references from runtime code, as they're already
+      // present in the DOM.
+
+      if (chunkPath.endsWith(".css")) {
+        // CSS chunks do not register themselves, and as such must be marked as
+        // loaded instantly.
+        resolver.resolve();
+      }
+
+      // We need to wait for JS chunks to register themselves within `registerChunk`
+      // before we can start instantiating runtime modules, hence the absence of
+      // `resolver.resolve()` in this branch.
+
       return resolver.promise;
     }
 

--- a/crates/turbopack-tests/tests/snapshot/import-meta/esm-mutable/output/crates_turbopack-tests_tests_snapshot_import-meta_esm-mutable_input_index_6c9201.js
+++ b/crates/turbopack-tests/tests/snapshot/import-meta/esm-mutable/output/crates_turbopack-tests_tests_snapshot_import-meta_esm-mutable_input_index_6c9201.js
@@ -1532,15 +1532,8 @@ let BACKEND;
 
       for (const otherChunkData of params.otherChunks) {
         const otherChunkPath = getChunkPath(otherChunkData);
-        if (otherChunkPath.endsWith(".css")) {
-          // Mark all CSS chunks within the same chunk group as this chunk as loaded.
-          // They are just injected as <link> tag and have to way to communicate completion.
-          const cssResolver = getOrCreateResolver(otherChunkPath);
-          cssResolver.resolve();
-        } else if (otherChunkPath.endsWith(".js")) {
-          // Chunk might have started loading, so we want to avoid triggering another load.
-          getOrCreateResolver(otherChunkPath);
-        }
+        // Chunk might have started loading, so we want to avoid triggering another load.
+        getOrCreateResolver(otherChunkPath);
       }
 
       // This waits for chunks to be loaded, but also marks included items as available.
@@ -1683,12 +1676,20 @@ let BACKEND;
       return resolver.promise;
     }
 
-    // We don't need to load chunks references from runtime code, as they're already
-    // present in the DOM.
-    // However, we need to wait for them to register themselves within `registerChunk`
-    // before we can start instantiating runtime modules, hence the absense of
-    // `resolver.resolve()` in this branch.
     if (source.type === SourceTypeRuntime) {
+      // We don't need to load chunks references from runtime code, as they're already
+      // present in the DOM.
+
+      if (chunkPath.endsWith(".css")) {
+        // CSS chunks do not register themselves, and as such must be marked as
+        // loaded instantly.
+        resolver.resolve();
+      }
+
+      // We need to wait for JS chunks to register themselves within `registerChunk`
+      // before we can start instantiating runtime modules, hence the absence of
+      // `resolver.resolve()` in this branch.
+
       return resolver.promise;
     }
 

--- a/crates/turbopack-tests/tests/snapshot/import-meta/esm-object/output/crates_turbopack-tests_tests_snapshot_import-meta_esm-object_input_index_6fcf7d.js
+++ b/crates/turbopack-tests/tests/snapshot/import-meta/esm-object/output/crates_turbopack-tests_tests_snapshot_import-meta_esm-object_input_index_6fcf7d.js
@@ -1532,15 +1532,8 @@ let BACKEND;
 
       for (const otherChunkData of params.otherChunks) {
         const otherChunkPath = getChunkPath(otherChunkData);
-        if (otherChunkPath.endsWith(".css")) {
-          // Mark all CSS chunks within the same chunk group as this chunk as loaded.
-          // They are just injected as <link> tag and have to way to communicate completion.
-          const cssResolver = getOrCreateResolver(otherChunkPath);
-          cssResolver.resolve();
-        } else if (otherChunkPath.endsWith(".js")) {
-          // Chunk might have started loading, so we want to avoid triggering another load.
-          getOrCreateResolver(otherChunkPath);
-        }
+        // Chunk might have started loading, so we want to avoid triggering another load.
+        getOrCreateResolver(otherChunkPath);
       }
 
       // This waits for chunks to be loaded, but also marks included items as available.
@@ -1683,12 +1676,20 @@ let BACKEND;
       return resolver.promise;
     }
 
-    // We don't need to load chunks references from runtime code, as they're already
-    // present in the DOM.
-    // However, we need to wait for them to register themselves within `registerChunk`
-    // before we can start instantiating runtime modules, hence the absense of
-    // `resolver.resolve()` in this branch.
     if (source.type === SourceTypeRuntime) {
+      // We don't need to load chunks references from runtime code, as they're already
+      // present in the DOM.
+
+      if (chunkPath.endsWith(".css")) {
+        // CSS chunks do not register themselves, and as such must be marked as
+        // loaded instantly.
+        resolver.resolve();
+      }
+
+      // We need to wait for JS chunks to register themselves within `registerChunk`
+      // before we can start instantiating runtime modules, hence the absence of
+      // `resolver.resolve()` in this branch.
+
       return resolver.promise;
     }
 

--- a/crates/turbopack-tests/tests/snapshot/import-meta/esm/output/crates_turbopack-tests_tests_snapshot_import-meta_esm_input_index_c4c88a.js
+++ b/crates/turbopack-tests/tests/snapshot/import-meta/esm/output/crates_turbopack-tests_tests_snapshot_import-meta_esm_input_index_c4c88a.js
@@ -1532,15 +1532,8 @@ let BACKEND;
 
       for (const otherChunkData of params.otherChunks) {
         const otherChunkPath = getChunkPath(otherChunkData);
-        if (otherChunkPath.endsWith(".css")) {
-          // Mark all CSS chunks within the same chunk group as this chunk as loaded.
-          // They are just injected as <link> tag and have to way to communicate completion.
-          const cssResolver = getOrCreateResolver(otherChunkPath);
-          cssResolver.resolve();
-        } else if (otherChunkPath.endsWith(".js")) {
-          // Chunk might have started loading, so we want to avoid triggering another load.
-          getOrCreateResolver(otherChunkPath);
-        }
+        // Chunk might have started loading, so we want to avoid triggering another load.
+        getOrCreateResolver(otherChunkPath);
       }
 
       // This waits for chunks to be loaded, but also marks included items as available.
@@ -1683,12 +1676,20 @@ let BACKEND;
       return resolver.promise;
     }
 
-    // We don't need to load chunks references from runtime code, as they're already
-    // present in the DOM.
-    // However, we need to wait for them to register themselves within `registerChunk`
-    // before we can start instantiating runtime modules, hence the absense of
-    // `resolver.resolve()` in this branch.
     if (source.type === SourceTypeRuntime) {
+      // We don't need to load chunks references from runtime code, as they're already
+      // present in the DOM.
+
+      if (chunkPath.endsWith(".css")) {
+        // CSS chunks do not register themselves, and as such must be marked as
+        // loaded instantly.
+        resolver.resolve();
+      }
+
+      // We need to wait for JS chunks to register themselves within `registerChunk`
+      // before we can start instantiating runtime modules, hence the absence of
+      // `resolver.resolve()` in this branch.
+
       return resolver.promise;
     }
 

--- a/crates/turbopack-tests/tests/snapshot/import-meta/url/output/crates_turbopack-tests_tests_snapshot_import-meta_url_input_index_988b57.js
+++ b/crates/turbopack-tests/tests/snapshot/import-meta/url/output/crates_turbopack-tests_tests_snapshot_import-meta_url_input_index_988b57.js
@@ -1532,15 +1532,8 @@ let BACKEND;
 
       for (const otherChunkData of params.otherChunks) {
         const otherChunkPath = getChunkPath(otherChunkData);
-        if (otherChunkPath.endsWith(".css")) {
-          // Mark all CSS chunks within the same chunk group as this chunk as loaded.
-          // They are just injected as <link> tag and have to way to communicate completion.
-          const cssResolver = getOrCreateResolver(otherChunkPath);
-          cssResolver.resolve();
-        } else if (otherChunkPath.endsWith(".js")) {
-          // Chunk might have started loading, so we want to avoid triggering another load.
-          getOrCreateResolver(otherChunkPath);
-        }
+        // Chunk might have started loading, so we want to avoid triggering another load.
+        getOrCreateResolver(otherChunkPath);
       }
 
       // This waits for chunks to be loaded, but also marks included items as available.
@@ -1683,12 +1676,20 @@ let BACKEND;
       return resolver.promise;
     }
 
-    // We don't need to load chunks references from runtime code, as they're already
-    // present in the DOM.
-    // However, we need to wait for them to register themselves within `registerChunk`
-    // before we can start instantiating runtime modules, hence the absense of
-    // `resolver.resolve()` in this branch.
     if (source.type === SourceTypeRuntime) {
+      // We don't need to load chunks references from runtime code, as they're already
+      // present in the DOM.
+
+      if (chunkPath.endsWith(".css")) {
+        // CSS chunks do not register themselves, and as such must be marked as
+        // loaded instantly.
+        resolver.resolve();
+      }
+
+      // We need to wait for JS chunks to register themselves within `registerChunk`
+      // before we can start instantiating runtime modules, hence the absence of
+      // `resolver.resolve()` in this branch.
+
       return resolver.promise;
     }
 

--- a/crates/turbopack-tests/tests/snapshot/imports/dynamic/output/crates_turbopack-tests_tests_snapshot_imports_dynamic_input_index_45c162.js
+++ b/crates/turbopack-tests/tests/snapshot/imports/dynamic/output/crates_turbopack-tests_tests_snapshot_imports_dynamic_input_index_45c162.js
@@ -1532,15 +1532,8 @@ let BACKEND;
 
       for (const otherChunkData of params.otherChunks) {
         const otherChunkPath = getChunkPath(otherChunkData);
-        if (otherChunkPath.endsWith(".css")) {
-          // Mark all CSS chunks within the same chunk group as this chunk as loaded.
-          // They are just injected as <link> tag and have to way to communicate completion.
-          const cssResolver = getOrCreateResolver(otherChunkPath);
-          cssResolver.resolve();
-        } else if (otherChunkPath.endsWith(".js")) {
-          // Chunk might have started loading, so we want to avoid triggering another load.
-          getOrCreateResolver(otherChunkPath);
-        }
+        // Chunk might have started loading, so we want to avoid triggering another load.
+        getOrCreateResolver(otherChunkPath);
       }
 
       // This waits for chunks to be loaded, but also marks included items as available.
@@ -1683,12 +1676,20 @@ let BACKEND;
       return resolver.promise;
     }
 
-    // We don't need to load chunks references from runtime code, as they're already
-    // present in the DOM.
-    // However, we need to wait for them to register themselves within `registerChunk`
-    // before we can start instantiating runtime modules, hence the absense of
-    // `resolver.resolve()` in this branch.
     if (source.type === SourceTypeRuntime) {
+      // We don't need to load chunks references from runtime code, as they're already
+      // present in the DOM.
+
+      if (chunkPath.endsWith(".css")) {
+        // CSS chunks do not register themselves, and as such must be marked as
+        // loaded instantly.
+        resolver.resolve();
+      }
+
+      // We need to wait for JS chunks to register themselves within `registerChunk`
+      // before we can start instantiating runtime modules, hence the absence of
+      // `resolver.resolve()` in this branch.
+
       return resolver.promise;
     }
 

--- a/crates/turbopack-tests/tests/snapshot/imports/json/output/crates_turbopack-tests_tests_snapshot_imports_json_input_index_961ae2.js
+++ b/crates/turbopack-tests/tests/snapshot/imports/json/output/crates_turbopack-tests_tests_snapshot_imports_json_input_index_961ae2.js
@@ -1532,15 +1532,8 @@ let BACKEND;
 
       for (const otherChunkData of params.otherChunks) {
         const otherChunkPath = getChunkPath(otherChunkData);
-        if (otherChunkPath.endsWith(".css")) {
-          // Mark all CSS chunks within the same chunk group as this chunk as loaded.
-          // They are just injected as <link> tag and have to way to communicate completion.
-          const cssResolver = getOrCreateResolver(otherChunkPath);
-          cssResolver.resolve();
-        } else if (otherChunkPath.endsWith(".js")) {
-          // Chunk might have started loading, so we want to avoid triggering another load.
-          getOrCreateResolver(otherChunkPath);
-        }
+        // Chunk might have started loading, so we want to avoid triggering another load.
+        getOrCreateResolver(otherChunkPath);
       }
 
       // This waits for chunks to be loaded, but also marks included items as available.
@@ -1683,12 +1676,20 @@ let BACKEND;
       return resolver.promise;
     }
 
-    // We don't need to load chunks references from runtime code, as they're already
-    // present in the DOM.
-    // However, we need to wait for them to register themselves within `registerChunk`
-    // before we can start instantiating runtime modules, hence the absense of
-    // `resolver.resolve()` in this branch.
     if (source.type === SourceTypeRuntime) {
+      // We don't need to load chunks references from runtime code, as they're already
+      // present in the DOM.
+
+      if (chunkPath.endsWith(".css")) {
+        // CSS chunks do not register themselves, and as such must be marked as
+        // loaded instantly.
+        resolver.resolve();
+      }
+
+      // We need to wait for JS chunks to register themselves within `registerChunk`
+      // before we can start instantiating runtime modules, hence the absence of
+      // `resolver.resolve()` in this branch.
+
       return resolver.promise;
     }
 

--- a/crates/turbopack-tests/tests/snapshot/imports/resolve_error_cjs/output/79fb1_turbopack-tests_tests_snapshot_imports_resolve_error_cjs_input_index_f8412b.js
+++ b/crates/turbopack-tests/tests/snapshot/imports/resolve_error_cjs/output/79fb1_turbopack-tests_tests_snapshot_imports_resolve_error_cjs_input_index_f8412b.js
@@ -1532,15 +1532,8 @@ let BACKEND;
 
       for (const otherChunkData of params.otherChunks) {
         const otherChunkPath = getChunkPath(otherChunkData);
-        if (otherChunkPath.endsWith(".css")) {
-          // Mark all CSS chunks within the same chunk group as this chunk as loaded.
-          // They are just injected as <link> tag and have to way to communicate completion.
-          const cssResolver = getOrCreateResolver(otherChunkPath);
-          cssResolver.resolve();
-        } else if (otherChunkPath.endsWith(".js")) {
-          // Chunk might have started loading, so we want to avoid triggering another load.
-          getOrCreateResolver(otherChunkPath);
-        }
+        // Chunk might have started loading, so we want to avoid triggering another load.
+        getOrCreateResolver(otherChunkPath);
       }
 
       // This waits for chunks to be loaded, but also marks included items as available.
@@ -1683,12 +1676,20 @@ let BACKEND;
       return resolver.promise;
     }
 
-    // We don't need to load chunks references from runtime code, as they're already
-    // present in the DOM.
-    // However, we need to wait for them to register themselves within `registerChunk`
-    // before we can start instantiating runtime modules, hence the absense of
-    // `resolver.resolve()` in this branch.
     if (source.type === SourceTypeRuntime) {
+      // We don't need to load chunks references from runtime code, as they're already
+      // present in the DOM.
+
+      if (chunkPath.endsWith(".css")) {
+        // CSS chunks do not register themselves, and as such must be marked as
+        // loaded instantly.
+        resolver.resolve();
+      }
+
+      // We need to wait for JS chunks to register themselves within `registerChunk`
+      // before we can start instantiating runtime modules, hence the absence of
+      // `resolver.resolve()` in this branch.
+
       return resolver.promise;
     }
 

--- a/crates/turbopack-tests/tests/snapshot/imports/resolve_error_esm/output/79fb1_turbopack-tests_tests_snapshot_imports_resolve_error_esm_input_index_0b3e45.js
+++ b/crates/turbopack-tests/tests/snapshot/imports/resolve_error_esm/output/79fb1_turbopack-tests_tests_snapshot_imports_resolve_error_esm_input_index_0b3e45.js
@@ -1532,15 +1532,8 @@ let BACKEND;
 
       for (const otherChunkData of params.otherChunks) {
         const otherChunkPath = getChunkPath(otherChunkData);
-        if (otherChunkPath.endsWith(".css")) {
-          // Mark all CSS chunks within the same chunk group as this chunk as loaded.
-          // They are just injected as <link> tag and have to way to communicate completion.
-          const cssResolver = getOrCreateResolver(otherChunkPath);
-          cssResolver.resolve();
-        } else if (otherChunkPath.endsWith(".js")) {
-          // Chunk might have started loading, so we want to avoid triggering another load.
-          getOrCreateResolver(otherChunkPath);
-        }
+        // Chunk might have started loading, so we want to avoid triggering another load.
+        getOrCreateResolver(otherChunkPath);
       }
 
       // This waits for chunks to be loaded, but also marks included items as available.
@@ -1683,12 +1676,20 @@ let BACKEND;
       return resolver.promise;
     }
 
-    // We don't need to load chunks references from runtime code, as they're already
-    // present in the DOM.
-    // However, we need to wait for them to register themselves within `registerChunk`
-    // before we can start instantiating runtime modules, hence the absense of
-    // `resolver.resolve()` in this branch.
     if (source.type === SourceTypeRuntime) {
+      // We don't need to load chunks references from runtime code, as they're already
+      // present in the DOM.
+
+      if (chunkPath.endsWith(".css")) {
+        // CSS chunks do not register themselves, and as such must be marked as
+        // loaded instantly.
+        resolver.resolve();
+      }
+
+      // We need to wait for JS chunks to register themselves within `registerChunk`
+      // before we can start instantiating runtime modules, hence the absence of
+      // `resolver.resolve()` in this branch.
+
       return resolver.promise;
     }
 

--- a/crates/turbopack-tests/tests/snapshot/imports/static-and-dynamic/output/79fb1_turbopack-tests_tests_snapshot_imports_static-and-dynamic_input_index_ec8693.js
+++ b/crates/turbopack-tests/tests/snapshot/imports/static-and-dynamic/output/79fb1_turbopack-tests_tests_snapshot_imports_static-and-dynamic_input_index_ec8693.js
@@ -1532,15 +1532,8 @@ let BACKEND;
 
       for (const otherChunkData of params.otherChunks) {
         const otherChunkPath = getChunkPath(otherChunkData);
-        if (otherChunkPath.endsWith(".css")) {
-          // Mark all CSS chunks within the same chunk group as this chunk as loaded.
-          // They are just injected as <link> tag and have to way to communicate completion.
-          const cssResolver = getOrCreateResolver(otherChunkPath);
-          cssResolver.resolve();
-        } else if (otherChunkPath.endsWith(".js")) {
-          // Chunk might have started loading, so we want to avoid triggering another load.
-          getOrCreateResolver(otherChunkPath);
-        }
+        // Chunk might have started loading, so we want to avoid triggering another load.
+        getOrCreateResolver(otherChunkPath);
       }
 
       // This waits for chunks to be loaded, but also marks included items as available.
@@ -1683,12 +1676,20 @@ let BACKEND;
       return resolver.promise;
     }
 
-    // We don't need to load chunks references from runtime code, as they're already
-    // present in the DOM.
-    // However, we need to wait for them to register themselves within `registerChunk`
-    // before we can start instantiating runtime modules, hence the absense of
-    // `resolver.resolve()` in this branch.
     if (source.type === SourceTypeRuntime) {
+      // We don't need to load chunks references from runtime code, as they're already
+      // present in the DOM.
+
+      if (chunkPath.endsWith(".css")) {
+        // CSS chunks do not register themselves, and as such must be marked as
+        // loaded instantly.
+        resolver.resolve();
+      }
+
+      // We need to wait for JS chunks to register themselves within `registerChunk`
+      // before we can start instantiating runtime modules, hence the absence of
+      // `resolver.resolve()` in this branch.
+
       return resolver.promise;
     }
 

--- a/crates/turbopack-tests/tests/snapshot/imports/static/output/crates_turbopack-tests_tests_snapshot_imports_static_input_index_885269.js
+++ b/crates/turbopack-tests/tests/snapshot/imports/static/output/crates_turbopack-tests_tests_snapshot_imports_static_input_index_885269.js
@@ -1532,15 +1532,8 @@ let BACKEND;
 
       for (const otherChunkData of params.otherChunks) {
         const otherChunkPath = getChunkPath(otherChunkData);
-        if (otherChunkPath.endsWith(".css")) {
-          // Mark all CSS chunks within the same chunk group as this chunk as loaded.
-          // They are just injected as <link> tag and have to way to communicate completion.
-          const cssResolver = getOrCreateResolver(otherChunkPath);
-          cssResolver.resolve();
-        } else if (otherChunkPath.endsWith(".js")) {
-          // Chunk might have started loading, so we want to avoid triggering another load.
-          getOrCreateResolver(otherChunkPath);
-        }
+        // Chunk might have started loading, so we want to avoid triggering another load.
+        getOrCreateResolver(otherChunkPath);
       }
 
       // This waits for chunks to be loaded, but also marks included items as available.
@@ -1683,12 +1676,20 @@ let BACKEND;
       return resolver.promise;
     }
 
-    // We don't need to load chunks references from runtime code, as they're already
-    // present in the DOM.
-    // However, we need to wait for them to register themselves within `registerChunk`
-    // before we can start instantiating runtime modules, hence the absense of
-    // `resolver.resolve()` in this branch.
     if (source.type === SourceTypeRuntime) {
+      // We don't need to load chunks references from runtime code, as they're already
+      // present in the DOM.
+
+      if (chunkPath.endsWith(".css")) {
+        // CSS chunks do not register themselves, and as such must be marked as
+        // loaded instantly.
+        resolver.resolve();
+      }
+
+      // We need to wait for JS chunks to register themselves within `registerChunk`
+      // before we can start instantiating runtime modules, hence the absence of
+      // `resolver.resolve()` in this branch.
+
       return resolver.promise;
     }
 

--- a/crates/turbopack-tests/tests/snapshot/node/node_protocol_external/output/79fb1_turbopack-tests_tests_snapshot_node_node_protocol_external_input_index_667edf.js
+++ b/crates/turbopack-tests/tests/snapshot/node/node_protocol_external/output/79fb1_turbopack-tests_tests_snapshot_node_node_protocol_external_input_index_667edf.js
@@ -1532,15 +1532,8 @@ let BACKEND;
 
       for (const otherChunkData of params.otherChunks) {
         const otherChunkPath = getChunkPath(otherChunkData);
-        if (otherChunkPath.endsWith(".css")) {
-          // Mark all CSS chunks within the same chunk group as this chunk as loaded.
-          // They are just injected as <link> tag and have to way to communicate completion.
-          const cssResolver = getOrCreateResolver(otherChunkPath);
-          cssResolver.resolve();
-        } else if (otherChunkPath.endsWith(".js")) {
-          // Chunk might have started loading, so we want to avoid triggering another load.
-          getOrCreateResolver(otherChunkPath);
-        }
+        // Chunk might have started loading, so we want to avoid triggering another load.
+        getOrCreateResolver(otherChunkPath);
       }
 
       // This waits for chunks to be loaded, but also marks included items as available.
@@ -1683,12 +1676,20 @@ let BACKEND;
       return resolver.promise;
     }
 
-    // We don't need to load chunks references from runtime code, as they're already
-    // present in the DOM.
-    // However, we need to wait for them to register themselves within `registerChunk`
-    // before we can start instantiating runtime modules, hence the absense of
-    // `resolver.resolve()` in this branch.
     if (source.type === SourceTypeRuntime) {
+      // We don't need to load chunks references from runtime code, as they're already
+      // present in the DOM.
+
+      if (chunkPath.endsWith(".css")) {
+        // CSS chunks do not register themselves, and as such must be marked as
+        // loaded instantly.
+        resolver.resolve();
+      }
+
+      // We need to wait for JS chunks to register themselves within `registerChunk`
+      // before we can start instantiating runtime modules, hence the absence of
+      // `resolver.resolve()` in this branch.
+
       return resolver.promise;
     }
 

--- a/crates/turbopack-tests/tests/snapshot/styled_components/styled_components/output/a587c_tests_snapshot_styled_components_styled_components_input_index_afc482.js
+++ b/crates/turbopack-tests/tests/snapshot/styled_components/styled_components/output/a587c_tests_snapshot_styled_components_styled_components_input_index_afc482.js
@@ -1532,15 +1532,8 @@ let BACKEND;
 
       for (const otherChunkData of params.otherChunks) {
         const otherChunkPath = getChunkPath(otherChunkData);
-        if (otherChunkPath.endsWith(".css")) {
-          // Mark all CSS chunks within the same chunk group as this chunk as loaded.
-          // They are just injected as <link> tag and have to way to communicate completion.
-          const cssResolver = getOrCreateResolver(otherChunkPath);
-          cssResolver.resolve();
-        } else if (otherChunkPath.endsWith(".js")) {
-          // Chunk might have started loading, so we want to avoid triggering another load.
-          getOrCreateResolver(otherChunkPath);
-        }
+        // Chunk might have started loading, so we want to avoid triggering another load.
+        getOrCreateResolver(otherChunkPath);
       }
 
       // This waits for chunks to be loaded, but also marks included items as available.
@@ -1683,12 +1676,20 @@ let BACKEND;
       return resolver.promise;
     }
 
-    // We don't need to load chunks references from runtime code, as they're already
-    // present in the DOM.
-    // However, we need to wait for them to register themselves within `registerChunk`
-    // before we can start instantiating runtime modules, hence the absense of
-    // `resolver.resolve()` in this branch.
     if (source.type === SourceTypeRuntime) {
+      // We don't need to load chunks references from runtime code, as they're already
+      // present in the DOM.
+
+      if (chunkPath.endsWith(".css")) {
+        // CSS chunks do not register themselves, and as such must be marked as
+        // loaded instantly.
+        resolver.resolve();
+      }
+
+      // We need to wait for JS chunks to register themselves within `registerChunk`
+      // before we can start instantiating runtime modules, hence the absence of
+      // `resolver.resolve()` in this branch.
+
       return resolver.promise;
     }
 

--- a/crates/turbopack-tests/tests/snapshot/swc_transforms/mono_transforms/output/a587c_tests_snapshot_swc_transforms_mono_transforms_input_packages_app_index_4a3d65.js
+++ b/crates/turbopack-tests/tests/snapshot/swc_transforms/mono_transforms/output/a587c_tests_snapshot_swc_transforms_mono_transforms_input_packages_app_index_4a3d65.js
@@ -1532,15 +1532,8 @@ let BACKEND;
 
       for (const otherChunkData of params.otherChunks) {
         const otherChunkPath = getChunkPath(otherChunkData);
-        if (otherChunkPath.endsWith(".css")) {
-          // Mark all CSS chunks within the same chunk group as this chunk as loaded.
-          // They are just injected as <link> tag and have to way to communicate completion.
-          const cssResolver = getOrCreateResolver(otherChunkPath);
-          cssResolver.resolve();
-        } else if (otherChunkPath.endsWith(".js")) {
-          // Chunk might have started loading, so we want to avoid triggering another load.
-          getOrCreateResolver(otherChunkPath);
-        }
+        // Chunk might have started loading, so we want to avoid triggering another load.
+        getOrCreateResolver(otherChunkPath);
       }
 
       // This waits for chunks to be loaded, but also marks included items as available.
@@ -1683,12 +1676,20 @@ let BACKEND;
       return resolver.promise;
     }
 
-    // We don't need to load chunks references from runtime code, as they're already
-    // present in the DOM.
-    // However, we need to wait for them to register themselves within `registerChunk`
-    // before we can start instantiating runtime modules, hence the absense of
-    // `resolver.resolve()` in this branch.
     if (source.type === SourceTypeRuntime) {
+      // We don't need to load chunks references from runtime code, as they're already
+      // present in the DOM.
+
+      if (chunkPath.endsWith(".css")) {
+        // CSS chunks do not register themselves, and as such must be marked as
+        // loaded instantly.
+        resolver.resolve();
+      }
+
+      // We need to wait for JS chunks to register themselves within `registerChunk`
+      // before we can start instantiating runtime modules, hence the absence of
+      // `resolver.resolve()` in this branch.
+
       return resolver.promise;
     }
 

--- a/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/output/79fb1_turbopack-tests_tests_snapshot_swc_transforms_preset_env_input_index_9dcfd0.js
+++ b/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env/output/79fb1_turbopack-tests_tests_snapshot_swc_transforms_preset_env_input_index_9dcfd0.js
@@ -1532,15 +1532,8 @@ let BACKEND;
 
       for (const otherChunkData of params.otherChunks) {
         const otherChunkPath = getChunkPath(otherChunkData);
-        if (otherChunkPath.endsWith(".css")) {
-          // Mark all CSS chunks within the same chunk group as this chunk as loaded.
-          // They are just injected as <link> tag and have to way to communicate completion.
-          const cssResolver = getOrCreateResolver(otherChunkPath);
-          cssResolver.resolve();
-        } else if (otherChunkPath.endsWith(".js")) {
-          // Chunk might have started loading, so we want to avoid triggering another load.
-          getOrCreateResolver(otherChunkPath);
-        }
+        // Chunk might have started loading, so we want to avoid triggering another load.
+        getOrCreateResolver(otherChunkPath);
       }
 
       // This waits for chunks to be loaded, but also marks included items as available.
@@ -1683,12 +1676,20 @@ let BACKEND;
       return resolver.promise;
     }
 
-    // We don't need to load chunks references from runtime code, as they're already
-    // present in the DOM.
-    // However, we need to wait for them to register themselves within `registerChunk`
-    // before we can start instantiating runtime modules, hence the absense of
-    // `resolver.resolve()` in this branch.
     if (source.type === SourceTypeRuntime) {
+      // We don't need to load chunks references from runtime code, as they're already
+      // present in the DOM.
+
+      if (chunkPath.endsWith(".css")) {
+        // CSS chunks do not register themselves, and as such must be marked as
+        // loaded instantly.
+        resolver.resolve();
+      }
+
+      // We need to wait for JS chunks to register themselves within `registerChunk`
+      // before we can start instantiating runtime modules, hence the absence of
+      // `resolver.resolve()` in this branch.
+
       return resolver.promise;
     }
 

--- a/crates/turbopack-tests/tests/snapshot/typescript/jsconfig-baseurl/output/79fb1_turbopack-tests_tests_snapshot_typescript_jsconfig-baseurl_input_index_8f1e58.js
+++ b/crates/turbopack-tests/tests/snapshot/typescript/jsconfig-baseurl/output/79fb1_turbopack-tests_tests_snapshot_typescript_jsconfig-baseurl_input_index_8f1e58.js
@@ -1532,15 +1532,8 @@ let BACKEND;
 
       for (const otherChunkData of params.otherChunks) {
         const otherChunkPath = getChunkPath(otherChunkData);
-        if (otherChunkPath.endsWith(".css")) {
-          // Mark all CSS chunks within the same chunk group as this chunk as loaded.
-          // They are just injected as <link> tag and have to way to communicate completion.
-          const cssResolver = getOrCreateResolver(otherChunkPath);
-          cssResolver.resolve();
-        } else if (otherChunkPath.endsWith(".js")) {
-          // Chunk might have started loading, so we want to avoid triggering another load.
-          getOrCreateResolver(otherChunkPath);
-        }
+        // Chunk might have started loading, so we want to avoid triggering another load.
+        getOrCreateResolver(otherChunkPath);
       }
 
       // This waits for chunks to be loaded, but also marks included items as available.
@@ -1683,12 +1676,20 @@ let BACKEND;
       return resolver.promise;
     }
 
-    // We don't need to load chunks references from runtime code, as they're already
-    // present in the DOM.
-    // However, we need to wait for them to register themselves within `registerChunk`
-    // before we can start instantiating runtime modules, hence the absense of
-    // `resolver.resolve()` in this branch.
     if (source.type === SourceTypeRuntime) {
+      // We don't need to load chunks references from runtime code, as they're already
+      // present in the DOM.
+
+      if (chunkPath.endsWith(".css")) {
+        // CSS chunks do not register themselves, and as such must be marked as
+        // loaded instantly.
+        resolver.resolve();
+      }
+
+      // We need to wait for JS chunks to register themselves within `registerChunk`
+      // before we can start instantiating runtime modules, hence the absence of
+      // `resolver.resolve()` in this branch.
+
       return resolver.promise;
     }
 

--- a/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-baseurl/output/a587c_tests_snapshot_typescript_tsconfig-baseurl_input_index.ts_0aa04e._.js
+++ b/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-baseurl/output/a587c_tests_snapshot_typescript_tsconfig-baseurl_input_index.ts_0aa04e._.js
@@ -1532,15 +1532,8 @@ let BACKEND;
 
       for (const otherChunkData of params.otherChunks) {
         const otherChunkPath = getChunkPath(otherChunkData);
-        if (otherChunkPath.endsWith(".css")) {
-          // Mark all CSS chunks within the same chunk group as this chunk as loaded.
-          // They are just injected as <link> tag and have to way to communicate completion.
-          const cssResolver = getOrCreateResolver(otherChunkPath);
-          cssResolver.resolve();
-        } else if (otherChunkPath.endsWith(".js")) {
-          // Chunk might have started loading, so we want to avoid triggering another load.
-          getOrCreateResolver(otherChunkPath);
-        }
+        // Chunk might have started loading, so we want to avoid triggering another load.
+        getOrCreateResolver(otherChunkPath);
       }
 
       // This waits for chunks to be loaded, but also marks included items as available.
@@ -1683,12 +1676,20 @@ let BACKEND;
       return resolver.promise;
     }
 
-    // We don't need to load chunks references from runtime code, as they're already
-    // present in the DOM.
-    // However, we need to wait for them to register themselves within `registerChunk`
-    // before we can start instantiating runtime modules, hence the absense of
-    // `resolver.resolve()` in this branch.
     if (source.type === SourceTypeRuntime) {
+      // We don't need to load chunks references from runtime code, as they're already
+      // present in the DOM.
+
+      if (chunkPath.endsWith(".css")) {
+        // CSS chunks do not register themselves, and as such must be marked as
+        // loaded instantly.
+        resolver.resolve();
+      }
+
+      // We need to wait for JS chunks to register themselves within `registerChunk`
+      // before we can start instantiating runtime modules, hence the absence of
+      // `resolver.resolve()` in this branch.
+
       return resolver.promise;
     }
 

--- a/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-module-full-path/output/8562f_snapshot_typescript_tsconfig-extends-module-full-path_input_index.ts_a751eb._.js
+++ b/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-module-full-path/output/8562f_snapshot_typescript_tsconfig-extends-module-full-path_input_index.ts_a751eb._.js
@@ -1532,15 +1532,8 @@ let BACKEND;
 
       for (const otherChunkData of params.otherChunks) {
         const otherChunkPath = getChunkPath(otherChunkData);
-        if (otherChunkPath.endsWith(".css")) {
-          // Mark all CSS chunks within the same chunk group as this chunk as loaded.
-          // They are just injected as <link> tag and have to way to communicate completion.
-          const cssResolver = getOrCreateResolver(otherChunkPath);
-          cssResolver.resolve();
-        } else if (otherChunkPath.endsWith(".js")) {
-          // Chunk might have started loading, so we want to avoid triggering another load.
-          getOrCreateResolver(otherChunkPath);
-        }
+        // Chunk might have started loading, so we want to avoid triggering another load.
+        getOrCreateResolver(otherChunkPath);
       }
 
       // This waits for chunks to be loaded, but also marks included items as available.
@@ -1683,12 +1676,20 @@ let BACKEND;
       return resolver.promise;
     }
 
-    // We don't need to load chunks references from runtime code, as they're already
-    // present in the DOM.
-    // However, we need to wait for them to register themselves within `registerChunk`
-    // before we can start instantiating runtime modules, hence the absense of
-    // `resolver.resolve()` in this branch.
     if (source.type === SourceTypeRuntime) {
+      // We don't need to load chunks references from runtime code, as they're already
+      // present in the DOM.
+
+      if (chunkPath.endsWith(".css")) {
+        // CSS chunks do not register themselves, and as such must be marked as
+        // loaded instantly.
+        resolver.resolve();
+      }
+
+      // We need to wait for JS chunks to register themselves within `registerChunk`
+      // before we can start instantiating runtime modules, hence the absence of
+      // `resolver.resolve()` in this branch.
+
       return resolver.promise;
     }
 

--- a/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-module/output/a587c_tests_snapshot_typescript_tsconfig-extends-module_input_index.ts_a662d4._.js
+++ b/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-module/output/a587c_tests_snapshot_typescript_tsconfig-extends-module_input_index.ts_a662d4._.js
@@ -1532,15 +1532,8 @@ let BACKEND;
 
       for (const otherChunkData of params.otherChunks) {
         const otherChunkPath = getChunkPath(otherChunkData);
-        if (otherChunkPath.endsWith(".css")) {
-          // Mark all CSS chunks within the same chunk group as this chunk as loaded.
-          // They are just injected as <link> tag and have to way to communicate completion.
-          const cssResolver = getOrCreateResolver(otherChunkPath);
-          cssResolver.resolve();
-        } else if (otherChunkPath.endsWith(".js")) {
-          // Chunk might have started loading, so we want to avoid triggering another load.
-          getOrCreateResolver(otherChunkPath);
-        }
+        // Chunk might have started loading, so we want to avoid triggering another load.
+        getOrCreateResolver(otherChunkPath);
       }
 
       // This waits for chunks to be loaded, but also marks included items as available.
@@ -1683,12 +1676,20 @@ let BACKEND;
       return resolver.promise;
     }
 
-    // We don't need to load chunks references from runtime code, as they're already
-    // present in the DOM.
-    // However, we need to wait for them to register themselves within `registerChunk`
-    // before we can start instantiating runtime modules, hence the absense of
-    // `resolver.resolve()` in this branch.
     if (source.type === SourceTypeRuntime) {
+      // We don't need to load chunks references from runtime code, as they're already
+      // present in the DOM.
+
+      if (chunkPath.endsWith(".css")) {
+        // CSS chunks do not register themselves, and as such must be marked as
+        // loaded instantly.
+        resolver.resolve();
+      }
+
+      // We need to wait for JS chunks to register themselves within `registerChunk`
+      // before we can start instantiating runtime modules, hence the absence of
+      // `resolver.resolve()` in this branch.
+
       return resolver.promise;
     }
 

--- a/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-relative-dir/output/a587c_tests_snapshot_typescript_tsconfig-extends-relative-dir_input_index.ts_be3d7b._.js
+++ b/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-relative-dir/output/a587c_tests_snapshot_typescript_tsconfig-extends-relative-dir_input_index.ts_be3d7b._.js
@@ -1532,15 +1532,8 @@ let BACKEND;
 
       for (const otherChunkData of params.otherChunks) {
         const otherChunkPath = getChunkPath(otherChunkData);
-        if (otherChunkPath.endsWith(".css")) {
-          // Mark all CSS chunks within the same chunk group as this chunk as loaded.
-          // They are just injected as <link> tag and have to way to communicate completion.
-          const cssResolver = getOrCreateResolver(otherChunkPath);
-          cssResolver.resolve();
-        } else if (otherChunkPath.endsWith(".js")) {
-          // Chunk might have started loading, so we want to avoid triggering another load.
-          getOrCreateResolver(otherChunkPath);
-        }
+        // Chunk might have started loading, so we want to avoid triggering another load.
+        getOrCreateResolver(otherChunkPath);
       }
 
       // This waits for chunks to be loaded, but also marks included items as available.
@@ -1683,12 +1676,20 @@ let BACKEND;
       return resolver.promise;
     }
 
-    // We don't need to load chunks references from runtime code, as they're already
-    // present in the DOM.
-    // However, we need to wait for them to register themselves within `registerChunk`
-    // before we can start instantiating runtime modules, hence the absense of
-    // `resolver.resolve()` in this branch.
     if (source.type === SourceTypeRuntime) {
+      // We don't need to load chunks references from runtime code, as they're already
+      // present in the DOM.
+
+      if (chunkPath.endsWith(".css")) {
+        // CSS chunks do not register themselves, and as such must be marked as
+        // loaded instantly.
+        resolver.resolve();
+      }
+
+      // We need to wait for JS chunks to register themselves within `registerChunk`
+      // before we can start instantiating runtime modules, hence the absence of
+      // `resolver.resolve()` in this branch.
+
       return resolver.promise;
     }
 

--- a/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-without-ext/output/a587c_tests_snapshot_typescript_tsconfig-extends-without-ext_input_index.ts_38aae8._.js
+++ b/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends-without-ext/output/a587c_tests_snapshot_typescript_tsconfig-extends-without-ext_input_index.ts_38aae8._.js
@@ -1532,15 +1532,8 @@ let BACKEND;
 
       for (const otherChunkData of params.otherChunks) {
         const otherChunkPath = getChunkPath(otherChunkData);
-        if (otherChunkPath.endsWith(".css")) {
-          // Mark all CSS chunks within the same chunk group as this chunk as loaded.
-          // They are just injected as <link> tag and have to way to communicate completion.
-          const cssResolver = getOrCreateResolver(otherChunkPath);
-          cssResolver.resolve();
-        } else if (otherChunkPath.endsWith(".js")) {
-          // Chunk might have started loading, so we want to avoid triggering another load.
-          getOrCreateResolver(otherChunkPath);
-        }
+        // Chunk might have started loading, so we want to avoid triggering another load.
+        getOrCreateResolver(otherChunkPath);
       }
 
       // This waits for chunks to be loaded, but also marks included items as available.
@@ -1683,12 +1676,20 @@ let BACKEND;
       return resolver.promise;
     }
 
-    // We don't need to load chunks references from runtime code, as they're already
-    // present in the DOM.
-    // However, we need to wait for them to register themselves within `registerChunk`
-    // before we can start instantiating runtime modules, hence the absense of
-    // `resolver.resolve()` in this branch.
     if (source.type === SourceTypeRuntime) {
+      // We don't need to load chunks references from runtime code, as they're already
+      // present in the DOM.
+
+      if (chunkPath.endsWith(".css")) {
+        // CSS chunks do not register themselves, and as such must be marked as
+        // loaded instantly.
+        resolver.resolve();
+      }
+
+      // We need to wait for JS chunks to register themselves within `registerChunk`
+      // before we can start instantiating runtime modules, hence the absence of
+      // `resolver.resolve()` in this branch.
+
       return resolver.promise;
     }
 

--- a/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends/output/a587c_tests_snapshot_typescript_tsconfig-extends_input_index.ts_18c083._.js
+++ b/crates/turbopack-tests/tests/snapshot/typescript/tsconfig-extends/output/a587c_tests_snapshot_typescript_tsconfig-extends_input_index.ts_18c083._.js
@@ -1532,15 +1532,8 @@ let BACKEND;
 
       for (const otherChunkData of params.otherChunks) {
         const otherChunkPath = getChunkPath(otherChunkData);
-        if (otherChunkPath.endsWith(".css")) {
-          // Mark all CSS chunks within the same chunk group as this chunk as loaded.
-          // They are just injected as <link> tag and have to way to communicate completion.
-          const cssResolver = getOrCreateResolver(otherChunkPath);
-          cssResolver.resolve();
-        } else if (otherChunkPath.endsWith(".js")) {
-          // Chunk might have started loading, so we want to avoid triggering another load.
-          getOrCreateResolver(otherChunkPath);
-        }
+        // Chunk might have started loading, so we want to avoid triggering another load.
+        getOrCreateResolver(otherChunkPath);
       }
 
       // This waits for chunks to be loaded, but also marks included items as available.
@@ -1683,12 +1676,20 @@ let BACKEND;
       return resolver.promise;
     }
 
-    // We don't need to load chunks references from runtime code, as they're already
-    // present in the DOM.
-    // However, we need to wait for them to register themselves within `registerChunk`
-    // before we can start instantiating runtime modules, hence the absense of
-    // `resolver.resolve()` in this branch.
     if (source.type === SourceTypeRuntime) {
+      // We don't need to load chunks references from runtime code, as they're already
+      // present in the DOM.
+
+      if (chunkPath.endsWith(".css")) {
+        // CSS chunks do not register themselves, and as such must be marked as
+        // loaded instantly.
+        resolver.resolve();
+      }
+
+      // We need to wait for JS chunks to register themselves within `registerChunk`
+      // before we can start instantiating runtime modules, hence the absence of
+      // `resolver.resolve()` in this branch.
+
       return resolver.promise;
     }
 


### PR DESCRIPTION
### Description

I identified this issue when authoring a test for PostCSS. Here's how it goes:

1. CSS chunk 1 loads with module chunk A and source = runtime. This marks chunk A as an available module chunk. The promise for A is the same promise as for CSS chunk 1, which is resolved in registerChunk because chunk 1 is part of the chunk group of the initial JS chunk.

2. CSS chunk 2 loads with module chunks A and B. Since A is already available, we run into a different branch, where we only try to load B. However, since we're still using source = runtime, we don't actually attempt to load B and instead return a promise to the resolver of B. But B isn't part of the chunk group of the initial JS chunk, so it is never resolved.

This hangs up the runtime entirely and breaks page hydration.

Instead, we move the "automatically resolving CSS chunks when source = Runtime" from `registerChunk` (which wasn't quite correct either as far as I can tell) into `loadChunk`, which solves this issue.

### Testing Instructions

I don't know if it's worth having a test case just for this, but this will technically be covered under the PostCSS test case in https://github.com/vercel/next.js/pull/49463.
link WEB-1023