### PR TITLE
refactor(ecmsacript): remove custom transform cloned return

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8910,7 +8910,11 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "indexmap",
+ "modularize_imports",
  "serde",
+ "styled_components",
+ "styled_jsx",
  "swc_core",
  "swc_emotion",
  "swc_relay",

--- a/crates/turbopack-ecmascript-plugins/Cargo.toml
+++ b/crates/turbopack-ecmascript-plugins/Cargo.toml
@@ -23,6 +23,8 @@ turbo-tasks-fs = { workspace = true }
 turbopack-ecmascript = { workspace = true }
 
 modularize_imports = { workspace = true }
+styled_components = { workspace = true }
+styled_jsx = { workspace = true }
 swc_core = { workspace = true, features = ["ecma_ast", "ecma_visit", "common"] }
 swc_emotion = { workspace = true }
 swc_relay = { workspace = true }

--- a/crates/turbopack-ecmascript-plugins/Cargo.toml
+++ b/crates/turbopack-ecmascript-plugins/Cargo.toml
@@ -15,12 +15,14 @@ transform_emotion = []
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
+indexmap = { workspace = true }
 serde = { workspace = true }
 
 turbo-tasks = { workspace = true }
 turbo-tasks-fs = { workspace = true }
 turbopack-ecmascript = { workspace = true }
 
+modularize_imports = { workspace = true }
 swc_core = { workspace = true, features = ["ecma_ast", "ecma_visit", "common"] }
 swc_emotion = { workspace = true }
 swc_relay = { workspace = true }

--- a/crates/turbopack-ecmascript-plugins/src/transform/directives/client.rs
+++ b/crates/turbopack-ecmascript-plugins/src/transform/directives/client.rs
@@ -1,0 +1,37 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use swc_core::ecma::{ast::Program, transforms::base::resolver, visit::VisitMutWith};
+use turbo_tasks::primitives::StringVc;
+use turbopack_ecmascript::{CustomTransformer, TransformContext};
+
+use super::{is_client_module, server_to_client_proxy::create_proxy_module};
+
+#[derive(Debug)]
+pub struct ClientDirectiveTransformer {
+    transition_name: StringVc,
+}
+
+impl ClientDirectiveTransformer {
+    pub fn new(transition_name: &StringVc) -> Self {
+        Self {
+            transition_name: transition_name.clone(),
+        }
+    }
+}
+
+#[async_trait]
+impl CustomTransformer for ClientDirectiveTransformer {
+    async fn transform(&self, program: &mut Program, ctx: &TransformContext<'_>) -> Result<()> {
+        if is_client_module(program) {
+            let transition_name = &*self.transition_name.await?;
+            *program = create_proxy_module(transition_name, &format!("./{}", ctx.file_name_str));
+            program.visit_mut_with(&mut resolver(
+                ctx.unresolved_mark,
+                ctx.top_level_mark,
+                false,
+            ));
+        }
+
+        Ok(())
+    }
+}

--- a/crates/turbopack-ecmascript-plugins/src/transform/directives/mod.rs
+++ b/crates/turbopack-ecmascript-plugins/src/transform/directives/mod.rs
@@ -1,0 +1,39 @@
+use swc_core::ecma::ast::{Lit, Program};
+
+pub mod client;
+pub mod server;
+mod server_to_client_proxy;
+
+macro_rules! has_directive {
+    ($stmts:expr, $name:literal) => {
+        $stmts
+            .map(|item| {
+                if let Lit::Str(str) = item?.as_expr()?.expr.as_lit()? {
+                    Some(str)
+                } else {
+                    None
+                }
+            })
+            .take_while(Option::is_some)
+            .map(Option::unwrap)
+            .any(|s| &*s.value == $name)
+    };
+}
+
+fn is_client_module(program: &Program) -> bool {
+    match program {
+        Program::Module(m) => {
+            has_directive!(m.body.iter().map(|item| item.as_stmt()), "use client")
+        }
+        Program::Script(s) => has_directive!(s.body.iter().map(Some), "use client"),
+    }
+}
+
+fn is_server_module(program: &Program) -> bool {
+    match program {
+        Program::Module(m) => {
+            has_directive!(m.body.iter().map(|item| item.as_stmt()), "use server")
+        }
+        Program::Script(s) => has_directive!(s.body.iter().map(Some), "use server"),
+    }
+}

--- a/crates/turbopack-ecmascript-plugins/src/transform/directives/server.rs
+++ b/crates/turbopack-ecmascript-plugins/src/transform/directives/server.rs
@@ -1,0 +1,42 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use swc_core::{
+    ecma::ast::{ModuleItem, Program},
+    quote,
+};
+use turbopack_ecmascript::{CustomTransformer, TransformContext, UnsupportedServerActionIssue};
+
+use super::is_server_module;
+
+#[derive(Debug)]
+pub struct ServerDirectiveTransformer;
+
+impl ServerDirectiveTransformer {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl CustomTransformer for ServerDirectiveTransformer {
+    async fn transform(&self, program: &mut Program, ctx: &TransformContext<'_>) -> Result<()> {
+        if is_server_module(program) {
+            let stmt = quote!(
+                "throw new Error('Server actions (\"use server\") are not yet supported in \
+                 Turbopack');" as Stmt
+            );
+            match program {
+                Program::Module(m) => m.body = vec![ModuleItem::Stmt(stmt)],
+                Program::Script(s) => s.body = vec![stmt],
+            }
+            UnsupportedServerActionIssue {
+                context: ctx.file_path,
+            }
+            .cell()
+            .as_issue()
+            .emit();
+        }
+
+        Ok(())
+    }
+}

--- a/crates/turbopack-ecmascript-plugins/src/transform/directives/server_to_client_proxy.rs
+++ b/crates/turbopack-ecmascript-plugins/src/transform/directives/server_to_client_proxy.rs
@@ -10,10 +10,8 @@ use swc_core::{
     },
     quote,
 };
+use turbopack_ecmascript::TURBOPACK_HELPER;
 
-use crate::references::TURBOPACK_HELPER;
-
-#[deprecated(note = "use Client/ServerDirectiveTransformer instead")]
 pub fn create_proxy_module(transition_name: &str, target_import: &str) -> Program {
     let ident = private_ident!("createProxy");
     Program::Module(Module {

--- a/crates/turbopack-ecmascript-plugins/src/transform/emotion.rs
+++ b/crates/turbopack-ecmascript-plugins/src/transform/emotion.rs
@@ -94,11 +94,7 @@ impl EmotionTransformer {
 
 #[async_trait]
 impl CustomTransformer for EmotionTransformer {
-    async fn transform(
-        &self,
-        program: &mut Program,
-        ctx: &TransformContext<'_>,
-    ) -> Result<Option<Program>> {
+    async fn transform(&self, program: &mut Program, ctx: &TransformContext<'_>) -> Result<()> {
         #[cfg(feature = "transform_emotion")]
         {
             let p = std::mem::replace(program, Program::Module(Module::dummy()));
@@ -117,7 +113,7 @@ impl CustomTransformer for EmotionTransformer {
             ));
         }
 
-        Ok(None)
+        Ok(())
     }
 }
 

--- a/crates/turbopack-ecmascript-plugins/src/transform/mod.rs
+++ b/crates/turbopack-ecmascript-plugins/src/transform/mod.rs
@@ -1,2 +1,3 @@
 pub mod emotion;
+pub mod modularize_imports;
 pub mod relay;

--- a/crates/turbopack-ecmascript-plugins/src/transform/mod.rs
+++ b/crates/turbopack-ecmascript-plugins/src/transform/mod.rs
@@ -1,3 +1,4 @@
+pub mod directives;
 pub mod emotion;
 pub mod modularize_imports;
 pub mod relay;

--- a/crates/turbopack-ecmascript-plugins/src/transform/mod.rs
+++ b/crates/turbopack-ecmascript-plugins/src/transform/mod.rs
@@ -1,3 +1,5 @@
 pub mod emotion;
 pub mod modularize_imports;
 pub mod relay;
+pub mod styled_components;
+pub mod styled_jsx;

--- a/crates/turbopack-ecmascript-plugins/src/transform/modularize_imports.rs
+++ b/crates/turbopack-ecmascript-plugins/src/transform/modularize_imports.rs
@@ -1,0 +1,63 @@
+use std::collections::HashMap;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use indexmap::IndexMap;
+use modularize_imports::{modularize_imports, Config, PackageConfig};
+use serde::{Deserialize, Serialize};
+use swc_core::{
+    common::util::take::Take,
+    ecma::{
+        ast::{Module, Program},
+        visit::FoldWith,
+    },
+};
+use turbo_tasks::trace::TraceRawVcs;
+use turbopack_ecmascript::{CustomTransformer, TransformContext};
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize, TraceRawVcs)]
+#[serde(rename_all = "camelCase")]
+pub struct ModularizeImportPackageConfig {
+    pub transform: String,
+    #[serde(default)]
+    pub prevent_full_import: bool,
+    #[serde(default)]
+    pub skip_default_conversion: bool,
+}
+
+#[derive(Debug)]
+pub struct ModularizeImportsTransformer {
+    packages: HashMap<String, PackageConfig>,
+}
+
+impl ModularizeImportsTransformer {
+    pub fn new(packages: &IndexMap<String, ModularizeImportPackageConfig>) -> Self {
+        Self {
+            packages: packages
+                .iter()
+                .map(|(k, v)| {
+                    (
+                        k.clone(),
+                        PackageConfig {
+                            transform: v.transform.clone(),
+                            prevent_full_import: v.prevent_full_import,
+                            skip_default_conversion: v.skip_default_conversion,
+                        },
+                    )
+                })
+                .collect(),
+        }
+    }
+}
+
+#[async_trait]
+impl CustomTransformer for ModularizeImportsTransformer {
+    async fn transform(&self, program: &mut Program, _ctx: &TransformContext<'_>) -> Result<()> {
+        let p = std::mem::replace(program, Program::Module(Module::dummy()));
+        *program = p.fold_with(&mut modularize_imports(Config {
+            packages: self.packages.clone(),
+        }));
+
+        Ok(())
+    }
+}

--- a/crates/turbopack-ecmascript-plugins/src/transform/relay.rs
+++ b/crates/turbopack-ecmascript-plugins/src/transform/relay.rs
@@ -24,11 +24,7 @@ impl RelayTransformer {
 
 #[async_trait]
 impl CustomTransformer for RelayTransformer {
-    async fn transform(
-        &self,
-        program: &mut Program,
-        ctx: &TransformContext<'_>,
-    ) -> Result<Option<Program>> {
+    async fn transform(&self, program: &mut Program, ctx: &TransformContext<'_>) -> Result<()> {
         // If user supplied artifact_directory, it should be resolvable already.
         // Otherwise, supply default relative path (./__generated__)
         let (root, config) = if self.config.artifact_directory.is_some() {
@@ -52,6 +48,6 @@ impl CustomTransformer for RelayTransformer {
             Some(ctx.unresolved_mark),
         ));
 
-        Ok(None)
+        Ok(())
     }
 }

--- a/crates/turbopack-ecmascript-plugins/src/transform/styled_components.rs
+++ b/crates/turbopack-ecmascript-plugins/src/transform/styled_components.rs
@@ -1,0 +1,33 @@
+use std::path::PathBuf;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use swc_core::{
+    common::FileName,
+    ecma::{ast::Program, visit::VisitMutWith},
+};
+use turbopack_ecmascript::{CustomTransformer, TransformContext};
+
+#[derive(Debug)]
+pub struct StyledComponentsTransformer {
+    config: styled_components::Config,
+}
+
+impl StyledComponentsTransformer {
+    pub fn new(config: styled_components::Config) -> Self {
+        Self { config }
+    }
+}
+
+#[async_trait]
+impl CustomTransformer for StyledComponentsTransformer {
+    async fn transform(&self, program: &mut Program, ctx: &TransformContext<'_>) -> Result<()> {
+        program.visit_mut_with(&mut styled_components::styled_components(
+            FileName::Real(PathBuf::from(ctx.file_path_str)),
+            ctx.file_name_hash,
+            self.config.clone(),
+        ));
+
+        Ok(())
+    }
+}

--- a/crates/turbopack-ecmascript-plugins/src/transform/styled_jsx.rs
+++ b/crates/turbopack-ecmascript-plugins/src/transform/styled_jsx.rs
@@ -1,0 +1,33 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use swc_core::{
+    common::{util::take::Take, FileName},
+    ecma::{
+        ast::{Module, Program},
+        visit::FoldWith,
+    },
+};
+use turbopack_ecmascript::{CustomTransformer, TransformContext};
+
+#[derive(Debug)]
+pub struct StyledJsxTransformer;
+
+impl StyledJsxTransformer {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl CustomTransformer for StyledJsxTransformer {
+    async fn transform(&self, program: &mut Program, ctx: &TransformContext<'_>) -> Result<()> {
+        let p = std::mem::replace(program, Program::Module(Module::dummy()));
+        *program = p.fold_with(&mut styled_jsx::visitor::styled_jsx(
+            ctx.source_map.clone(),
+            // styled_jsx don't really use that in a relevant way
+            FileName::Anon,
+        ));
+
+        Ok(())
+    }
+}

--- a/crates/turbopack-ecmascript/src/lib.rs
+++ b/crates/turbopack-ecmascript/src/lib.rs
@@ -22,7 +22,6 @@ pub mod tree_shake;
 pub mod typescript;
 pub mod utils;
 pub mod webpack;
-
 use anyhow::Result;
 use chunk::{
     EcmascriptChunkItem, EcmascriptChunkItemVc, EcmascriptChunkPlaceablesVc, EcmascriptChunkVc,
@@ -34,6 +33,7 @@ use parse::{parse, ParseResult};
 pub use parse::{ParseResultSourceMap, ParseResultSourceMapVc};
 use path_visitor::ApplyVisitors;
 use references::AnalyzeEcmascriptModuleResult;
+pub use references::TURBOPACK_HELPER;
 use swc_core::{
     common::GLOBALS,
     ecma::{
@@ -44,7 +44,7 @@ use swc_core::{
 pub use transform::{
     CustomTransformer, EcmascriptInputTransform, EcmascriptInputTransformsVc,
     OptionTransformPlugin, OptionTransformPluginVc, TransformContext, TransformPlugin,
-    TransformPluginVc,
+    TransformPluginVc, UnsupportedServerActionIssue,
 };
 use turbo_tasks::{
     primitives::StringVc, trace::TraceRawVcs, RawVc, ReadRef, TryJoinIterExt, Value, ValueToString,

--- a/crates/turbopack-ecmascript/src/transform/mod.rs
+++ b/crates/turbopack-ecmascript/src/transform/mod.rs
@@ -80,11 +80,7 @@ pub enum EcmascriptInputTransform {
 /// transformer to run over all ECMAScript files imported in the graph.
 #[async_trait]
 pub trait CustomTransformer: Debug {
-    async fn transform(
-        &self,
-        program: &mut Program,
-        ctx: &TransformContext<'_>,
-    ) -> Result<Option<Program>>;
+    async fn transform(&self, program: &mut Program, ctx: &TransformContext<'_>) -> Result<()>;
 }
 
 /// A wrapper around a TransformPlugin instance, allowing it to operate with
@@ -110,11 +106,7 @@ impl Default for OptionTransformPluginVc {
 
 #[async_trait]
 impl CustomTransformer for TransformPlugin {
-    async fn transform(
-        &self,
-        program: &mut Program,
-        ctx: &TransformContext<'_>,
-    ) -> Result<Option<Program>> {
+    async fn transform(&self, program: &mut Program, ctx: &TransformContext<'_>) -> Result<()> {
         self.0.transform(program, ctx).await
     }
 }
@@ -343,9 +335,7 @@ impl EcmascriptInputTransform {
                 }
             }
             EcmascriptInputTransform::Plugin(transform) => {
-                if let Some(output) = transform.await?.transform(program, ctx).await? {
-                    *program = output;
-                }
+                transform.await?.transform(program, ctx).await?
             }
         }
         Ok(())

--- a/crates/turbopack-ecmascript/src/transform/mod.rs
+++ b/crates/turbopack-ecmascript/src/transform/mod.rs
@@ -311,6 +311,7 @@ impl EcmascriptInputTransform {
                     inject_helpers(unresolved_mark)
                 ));
             }
+            // [TODO]: WEB-940 - use ClientDirectiveTransformer in next-swc
             EcmascriptInputTransform::ClientDirective(transition_name) => {
                 if is_client_module(program) {
                     let transition_name = &*transition_name.await?;
@@ -318,6 +319,7 @@ impl EcmascriptInputTransform {
                     program.visit_mut_with(&mut resolver(unresolved_mark, top_level_mark, false));
                 }
             }
+            // [TODO]: WEB-940 - use ServerDirectiveTransformer in next-swc
             EcmascriptInputTransform::ServerDirective(_transition_name) => {
                 if is_server_module(program) {
                     let stmt = quote!(


### PR DESCRIPTION
### Description

Part 1 for WEB-1024.

PR refactors custom transformer signature to not allow to return cloned instance. Also moves out few non-core transforms into plugins, so next.js turbopack can use it.

Next.js changes: https://github.com/vercel/next.js/pull/49560