### PR TITLE
Fix(Docs): Turbo customization docs broken link

### DIFF
--- a/docs/pages/pack/docs/comparisons/webpack.mdx
+++ b/docs/pages/pack/docs/comparisons/webpack.mdx
@@ -63,4 +63,4 @@ In a 1,000 module application, Turbopack can react to file changes **<DocsBenchm
 
 webpack has an extraordinary collection of [plugins](https://webpack.js.org/plugins/) to customize its behavior. Composing plugins lets you create custom toolchains which can support a huge variety of bundler features.
 
-As of Next.js 13.2, Turbopack introduced a compatibility layer to support webpack's loaders and resolve aliases. See [Customizing Turbopack](features/customizing-turbopack) for how to configure them. In the future, we plan to make Turbopack just as extensible as webpack - though likely with an altered API.
+As of Next.js 13.2, Turbopack introduced a compatibility layer to support webpack's loaders and resolve aliases. See [Customizing Turbopack](/pack/docs/features/customizing-turbopack) for how to configure them. In the future, we plan to make Turbopack just as extensible as webpack - though likely with an altered API.


### PR DESCRIPTION
### Description
While browsing `TurboPack` documentations here https://turbo.build/pack/docs/comparisons/webpack,
The last paragraph which talks about compatibility layer, there's a link that points to https://turbo.build/pack/docs/comparisons/features/customizing-turbopack, and that page shows 404.

It's been moved to https://turbo.build/pack/docs/features/customizing-turbopack.

  


### Testing Instructions
Visit https://turbo.build/pack/docs/comparisons/webpack, scroll down to the last paragraph and click on the link titled `Customizing Turbopack`, it'll lead to a 404 

This PR fixes that link  
