### PR TITLE
fix(turborepo): Fixed test by killing process when test is done

### DIFF
--- a/crates/turborepo-lib/src/daemon/endpoint.rs
+++ b/crates/turborepo-lib/src/daemon/endpoint.rs
@@ -222,7 +222,7 @@ mod test {
         #[cfg(not(windows))]
         let node_bin = "node";
 
-        let child = Command::new(node_bin).spawn().unwrap();
+        let mut child = Command::new(node_bin).spawn().unwrap();
         pid_path
             .create_with_contents(format!("{}", child.id()).as_ref())
             .unwrap();
@@ -236,5 +236,7 @@ mod test {
         } else {
             panic!("expected an error")
         }
+
+        child.kill().unwrap();
     }
 }


### PR DESCRIPTION
### Description

Noticed node errors when running tests. I suspect it's because this node process isn't properly killed on test exit.

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
