### PR TITLE
refactor(ecmascript-plugins): encapsulate transform configs

### DIFF
--- a/crates/turbopack-cli/src/dev/web_entry_source.rs
+++ b/crates/turbopack-cli/src/dev/web_entry_source.rs
@@ -7,17 +7,14 @@ use turbo_tasks_fs::{FileSystem, FileSystemPathVc};
 use turbopack::{
     condition::ContextCondition,
     ecmascript::EcmascriptModuleAssetVc,
-    module_options::{
-        JsxTransformOptions, ModuleOptionsContext, ModuleOptionsContextVc,
-        StyledComponentsTransformConfigVc,
-    },
+    module_options::{JsxTransformOptions, ModuleOptionsContext, ModuleOptionsContextVc},
     resolve_options_context::{ResolveOptionsContext, ResolveOptionsContextVc},
     transition::TransitionsByNameVc,
     ModuleAssetContextVc,
 };
 use turbopack_cli_utils::runtime_entry::{RuntimeEntriesVc, RuntimeEntry};
 use turbopack_core::{
-    chunk::{ChunkableAsset, ChunkableAssetVc, ChunkingContext, ChunkingContextVc},
+    chunk::{ChunkableAssetVc, ChunkingContextVc},
     compile_time_defines,
     compile_time_info::{CompileTimeDefinesVc, CompileTimeInfo, CompileTimeInfoVc},
     context::AssetContextVc,
@@ -35,7 +32,9 @@ use turbopack_dev_server::{
     html::DevHtmlAssetVc,
     source::{asset_graph::AssetGraphContentSourceVc, ContentSourceVc},
 };
-use turbopack_ecmascript_plugins::transform::emotion::EmotionTransformConfigVc;
+use turbopack_ecmascript_plugins::transform::{
+    emotion::EmotionTransformConfigVc, styled_components::StyledComponentsTransformConfigVc,
+};
 use turbopack_node::execution_context::ExecutionContextVc;
 
 use crate::embed_js::embed_file_path;

--- a/crates/turbopack-ecmascript-plugins/src/transform/emotion.rs
+++ b/crates/turbopack-ecmascript-plugins/src/transform/emotion.rs
@@ -116,13 +116,3 @@ impl CustomTransformer for EmotionTransformer {
         Ok(())
     }
 }
-
-pub async fn build_emotion_transformer(
-    config: &Option<EmotionTransformConfigVc>,
-) -> Result<Option<Box<EmotionTransformer>>> {
-    Ok(if let Some(config) = config {
-        EmotionTransformer::new(&*config.await?).map(Box::new)
-    } else {
-        None
-    })
-}

--- a/crates/turbopack-tests/tests/snapshot.rs
+++ b/crates/turbopack-tests/tests/snapshot.rs
@@ -19,10 +19,10 @@ use turbo_tasks_fs::{
 use turbo_tasks_memory::MemoryBackend;
 use turbopack::{
     condition::ContextCondition,
-    ecmascript::EcmascriptModuleAssetVc,
+    ecmascript::{EcmascriptModuleAssetVc, TransformPluginVc},
     module_options::{
-        JsxTransformOptions, JsxTransformOptionsVc, ModuleOptionsContext,
-        StyledComponentsTransformConfigVc,
+        CustomEcmascriptTransformPlugins, CustomEcmascriptTransformPluginsVc, JsxTransformOptions,
+        JsxTransformOptionsVc, ModuleOptionsContext,
     },
     resolve_options_context::ResolveOptionsContext,
     transition::TransitionsByNameVc,
@@ -43,7 +43,10 @@ use turbopack_core::{
     source_asset::SourceAssetVc,
 };
 use turbopack_dev::DevChunkingContextVc;
-use turbopack_ecmascript_plugins::transform::emotion::EmotionTransformConfig;
+use turbopack_ecmascript_plugins::transform::{
+    emotion::{EmotionTransformConfig, EmotionTransformer},
+    styled_components::StyledComponentsTransformConfigVc,
+};
 use turbopack_env::ProcessEnvAssetVc;
 use turbopack_test_utils::snapshot::{diff, expected, matches_expected, snapshot_issues};
 
@@ -213,6 +216,18 @@ async fn run_test(resource: &str) -> Result<FileSystemPathVc> {
                 }
                 .cell(),
             )],
+            custom_ecma_transform_plugins: Some(CustomEcmascriptTransformPluginsVc::cell(
+                CustomEcmascriptTransformPlugins {
+                    source_transforms: vec![TransformPluginVc::cell(Box::new(
+                        EmotionTransformer::new(&EmotionTransformConfig {
+                            sourcemap: Some(false),
+                            ..Default::default()
+                        })
+                        .unwrap(),
+                    ))],
+                    output_transforms: vec![],
+                },
+            )),
             ..Default::default()
         }
         .into(),

--- a/crates/turbopack/src/module_options/mod.rs
+++ b/crates/turbopack/src/module_options/mod.rs
@@ -16,9 +16,7 @@ use turbopack_core::{
 use turbopack_css::{CssInputTransform, CssInputTransformsVc};
 use turbopack_ecmascript::{
     EcmascriptInputTransform, EcmascriptInputTransformsVc, EcmascriptOptions, SpecifiedModuleType,
-    TransformPluginVc,
 };
-use turbopack_ecmascript_plugins::transform::emotion::build_emotion_transformer;
 use turbopack_mdx::MdxTransformOptions;
 use turbopack_node::transforms::{postcss::PostCssTransformVc, webpack::WebpackLoadersVc};
 
@@ -64,7 +62,6 @@ impl ModuleOptionsVc {
     ) -> Result<ModuleOptionsVc> {
         let ModuleOptionsContext {
             enable_jsx,
-            ref enable_emotion,
             enable_react_refresh,
             enable_styled_jsx,
             ref enable_styled_components,
@@ -124,12 +121,6 @@ impl ModuleOptionsVc {
         // Styled JSX, there won't be JSX nodes for Styled JSX to transform.
         if enable_styled_jsx {
             transforms.push(EcmascriptInputTransform::StyledJsx);
-        }
-
-        if let Some(transformer) = build_emotion_transformer(enable_emotion).await? {
-            transforms.push(EcmascriptInputTransform::Plugin(TransformPluginVc::cell(
-                transformer,
-            )));
         }
 
         if let Some(enable_styled_components) = enable_styled_components {

--- a/crates/turbopack/src/module_options/module_options_context.rs
+++ b/crates/turbopack/src/module_options/module_options_context.rs
@@ -3,7 +3,9 @@ use serde::{Deserialize, Serialize};
 use turbo_tasks::trace::TraceRawVcs;
 use turbopack_core::{environment::EnvironmentVc, resolve::options::ImportMappingVc};
 use turbopack_ecmascript::{EcmascriptInputTransform, TransformPluginVc};
-use turbopack_ecmascript_plugins::transform::emotion::EmotionTransformConfigVc;
+use turbopack_ecmascript_plugins::transform::{
+    emotion::EmotionTransformConfigVc, styled_components::StyledComponentsTransformConfigVc,
+};
 use turbopack_node::{
     execution_context::ExecutionContextVc, transforms::webpack::WebpackLoaderConfigItemsVc,
 };
@@ -110,50 +112,6 @@ impl WebpackLoadersOptions {
 pub struct JsxTransformOptions {
     pub import_source: Option<String>,
     pub runtime: Option<String>,
-}
-
-#[turbo_tasks::value(transparent)]
-pub struct OptionStyledComponentsTransformConfig(Option<StyledComponentsTransformConfigVc>);
-
-#[turbo_tasks::value(shared)]
-#[derive(Clone, Debug)]
-#[serde(rename_all = "camelCase")]
-pub struct StyledComponentsTransformConfig {
-    pub display_name: bool,
-    pub ssr: bool,
-    pub file_name: bool,
-    pub top_level_import_paths: Vec<String>,
-    pub meaningless_file_names: Vec<String>,
-    pub css_prop: bool,
-    pub namespace: Option<String>,
-}
-
-impl Default for StyledComponentsTransformConfig {
-    fn default() -> Self {
-        StyledComponentsTransformConfig {
-            display_name: true,
-            ssr: true,
-            file_name: true,
-            top_level_import_paths: vec![],
-            meaningless_file_names: vec!["index".to_string()],
-            css_prop: true,
-            namespace: None,
-        }
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl StyledComponentsTransformConfigVc {
-    #[turbo_tasks::function]
-    pub fn default() -> Self {
-        Self::cell(Default::default())
-    }
-}
-
-impl Default for StyledComponentsTransformConfigVc {
-    fn default() -> Self {
-        Self::default()
-    }
 }
 
 /// Configuration options for the custom ecma transform to be applied.


### PR DESCRIPTION
### Description

Related with WEB-940.

Encapsulates config option to not leak swc-specific, as it can change anytime also leaking type means upstream caller need to import swc_* individually.