### PR TITLE
Run Rust and JS package tests before publish

### DIFF
--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -113,7 +113,7 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           target: ${{ matrix.os.name }}
       - name: Run JS Package Tests
-        run: turbo run check-types test --filter=packages/ --color
+        run: turbo run check-types test --filter="./packages/*" --filter="\!@vercel/*" --color
 
   build-go-darwin:
     name: "Build Go for macOS"

--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -61,7 +61,8 @@ jobs:
     outputs:
       stage-branch: "${{ steps.stage.outputs.STAGE_BRANCH }}"
 
-  smoke-test:
+  go-smoke-test:
+    name: Go Unit Tests
     runs-on: ubuntu-latest
     needs: [stage]
     steps:
@@ -75,13 +76,49 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           target: ${{ matrix.os.name }}
-      - name: Run Unit Tests
+      - name: Run Go Unit Tests
         run: turbo run test --filter=cli --color
+
+  rust-smoke-test:
+    name: Rust Unit Tests
+    runs-on: ubuntu-latest
+    needs: [stage]
+    steps:
+      - name: Show Stage Commit
+        run: echo "${{ needs.stage.outputs.stage-branch }}"
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.stage.outputs.stage-branch }}
+      - name: Build turborepo CLI from source
+        uses: ./.github/actions/setup-turborepo-environment
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          target: ${{ matrix.os.name }}
+      - name: Run Rust Unit Tests
+        run: cargo tr-test
+
+  js-smoke-test:
+    name: JS Package Tests
+    runs-on: ubuntu-latest
+    needs: [stage]
+    steps:
+      - name: Show Stage Commit
+        run: echo "${{ needs.stage.outputs.stage-branch }}"
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.stage.outputs.stage-branch }}
+      - name: Build turborepo CLI from source
+        uses: ./.github/actions/setup-turborepo-environment
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          target: ${{ matrix.os.name }}
+      - name: Run JS Package Tests
+        run: turbo run check-types test --filter=packages/ --color
 
   build-go-darwin:
     name: "Build Go for macOS"
     runs-on: macos-latest
-    needs: [stage, smoke-test]
+    needs: [stage, go-smoke-test, rust-smoke-test, js-smoke-test]
     steps:
       - name: Show Stage Commit
         run: echo "${{ needs.stage.outputs.stage-branch }}"
@@ -118,7 +155,7 @@ jobs:
   build-go-cross:
     name: "Build Go for Windows and Linux"
     runs-on: ubuntu-latest
-    needs: [stage, smoke-test]
+    needs: [stage, go-smoke-test, rust-smoke-test, js-smoke-test]
     container:
       image: docker://ghcr.io/vercel/turbo-cross:v1.18.5
     steps:
@@ -165,7 +202,7 @@ jobs:
 
   build-rust:
     name: "Build Rust"
-    needs: [stage, smoke-test]
+    needs: [stage, go-smoke-test, rust-smoke-test, js-smoke-test]
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
If we're going to run smoke tests before, we should go all the way. Go unit tests won't catch issues with the JS packages, etc