### PR TITLE
fix(turbo/gen): fix generate name arg

### DIFF
--- a/packages/turbo-gen/src/commands/generate/prompts.ts
+++ b/packages/turbo-gen/src/commands/generate/prompts.ts
@@ -1,5 +1,6 @@
 import inquirer from "inquirer";
 import type { Generator } from "../../utils/plop";
+import { logger } from "@turbo/utils";
 
 export async function customGenerators({
   generators,
@@ -8,15 +9,19 @@ export async function customGenerators({
   generators: Array<Generator | inquirer.Separator>;
   generator?: string;
 }) {
-  if (
-    generator &&
-    generators.find(
-      (g) => !(g instanceof inquirer.Separator) && g.name === generator
-    )
-  ) {
-    return {
-      selectedGenerator: generator,
-    };
+  if (generator) {
+    if (
+      generators.find(
+        (g) => !(g instanceof inquirer.Separator) && g.name === generator
+      )
+    ) {
+      return {
+        selectedGenerator: generator,
+      };
+    }
+
+    logger.warn(`Generator "${generator}" not found`);
+    console.log();
   }
 
   const generatorAnswer = await inquirer.prompt<{
@@ -24,8 +29,6 @@ export async function customGenerators({
   }>({
     type: "list",
     name: "selectedGenerator",
-    default: generator,
-    when: !generator,
     message: `Select generator to run`,
     choices: generators.map((gen) => {
       if (gen instanceof inquirer.Separator) {

--- a/packages/turbo-gen/src/commands/raw/index.ts
+++ b/packages/turbo-gen/src/commands/raw/index.ts
@@ -3,7 +3,7 @@ import { generate, type CustomGeneratorOptions } from "../generate";
 import { convertCase } from "@turbo/utils";
 
 interface MinimalOptions {
-  generator?: string;
+  generatorName?: string;
   [arg: string]: any;
 }
 
@@ -25,8 +25,8 @@ export async function raw(command: string, options: { json: string }) {
       await add(incomingOptions as TurboGeneratorOptions);
       break;
     case "generate":
-      const { generator } = incomingOptions;
-      await generate(generator, incomingOptions as CustomGeneratorOptions);
+      const { generatorName } = incomingOptions;
+      await generate(generatorName, incomingOptions as CustomGeneratorOptions);
       break;
     default:
       console.error(


### PR DESCRIPTION
### Description

Fix a bug with passing a generator name arg directly. Also add a better error message and fallback when a generate name is passed directly and it doesn't exist. 

