### PR TITLE
Simplify goroutine setup for async task requests

### DIFF
--- a/cli/internal/run/dry_run.go
+++ b/cli/internal/run/dry_run.go
@@ -90,7 +90,7 @@ func DryRun(
 
 	// The exitCode isn't really used by the Run Summary Close() method for dry runs
 	// but we pass in a successful value to match Real Runs.
-	return summary.Close(0, g.WorkspaceInfos)
+	return summary.Close(ctx, 0, g.WorkspaceInfos)
 }
 
 func populateCacheState(turboCache cache.Cache, taskSummaries []*runsummary.TaskSummary) {

--- a/cli/internal/run/real_run.go
+++ b/cli/internal/run/real_run.go
@@ -174,7 +174,7 @@ func RealRun(
 		}
 	}
 
-	if err := runSummary.Close(exitCode, g.WorkspaceInfos); err != nil {
+	if err := runSummary.Close(ctx, exitCode, g.WorkspaceInfos); err != nil {
 		// We don't need to throw an error, but we can warn on this.
 		// Note: this method doesn't actually return an error for Real Runs at the time of writing.
 		base.UI.Info(fmt.Sprintf("Failed to close Run Summary %v", err))

--- a/cli/internal/runsummary/run_summary.go
+++ b/cli/internal/runsummary/run_summary.go
@@ -120,7 +120,7 @@ func NewRunSummary(
 	}
 
 	rsm.spacesClient = newSpacesClient(spaceID, apiClient, ui)
-	rsm.spacesClient.start()
+	go rsm.spacesClient.start()
 	rsm.spacesClient.createRun(&rsm)
 
 	return rsm

--- a/cli/internal/runsummary/spaces.go
+++ b/cli/internal/runsummary/spaces.go
@@ -191,10 +191,6 @@ func (c *spacesClient) createRun(rsm *Meta) {
 		// handler for when the request finishes. We set the response into a struct on the client
 		// because we need the run ID and URL from the server later.
 		onDone: func(req *spaceRequest, response []byte) {
-			if response == nil {
-				return
-			}
-
 			if err := json.Unmarshal(response, c.run); err != nil {
 				c.errors = append(c.errors, req.error(fmt.Sprintf("Error unmarshaling response: %s", err)))
 			}

--- a/cli/internal/runsummary/spaces.go
+++ b/cli/internal/runsummary/spaces.go
@@ -191,9 +191,6 @@ func (c *spacesClient) createRun(rsm *Meta) {
 		// handler for when the request finishes. We set the response into a struct on the client
 		// because we need the run ID and URL from the server later.
 		onDone: func(req *spaceRequest, response []byte) {
-			// close the run.created channel, because all other requests are blocked on it
-			close(c.run.created)
-
 			if response == nil {
 				return
 			}
@@ -201,6 +198,9 @@ func (c *spacesClient) createRun(rsm *Meta) {
 			if err := json.Unmarshal(response, c.run); err != nil {
 				c.errors = append(c.errors, req.error(fmt.Sprintf("Error unmarshaling response: %s", err)))
 			}
+
+			// close the run.created channel, because all other requests are blocked on it
+			close(c.run.created)
 		},
 	})
 }


### PR DESCRIPTION
This change works, but I see that the total execution time jumps from ~500ms to ~2s though (both FULL TURBO). I can share the test I'm using (in front). 

The execution time shouldn't change by much, because execution is closed off _before_ the `wg.Wait()`, so I don't think this diff is the best either