### PR TITLE
refactor(turbopack): consolidate jsx fast refresh

### DIFF
--- a/crates/turbopack/src/module_options/mod.rs
+++ b/crates/turbopack/src/module_options/mod.rs
@@ -139,7 +139,7 @@ impl ModuleOptionsVc {
             let jsx = enable_jsx.await?;
 
             transforms.push(EcmascriptInputTransform::React {
-                refresh: enable_react_refresh,
+                refresh: enable_react_refresh || jsx.react_refresh,
                 import_source: OptionStringVc::cell(jsx.import_source.clone()),
                 runtime: OptionStringVc::cell(jsx.runtime.clone()),
             });

--- a/crates/turbopack/src/module_options/module_options_context.rs
+++ b/crates/turbopack/src/module_options/module_options_context.rs
@@ -106,10 +106,10 @@ impl WebpackLoadersOptions {
     }
 }
 
-// [TODO]: should enabled_react_refresh belong to this options?
 #[turbo_tasks::value(shared)]
 #[derive(Default, Clone, Debug)]
 pub struct JsxTransformOptions {
+    pub react_refresh: bool,
     pub import_source: Option<String>,
     pub runtime: Option<String>,
 }


### PR DESCRIPTION
### Description

WEB-940

Minor refactoring to consolidate react related options.

Next.js still uses old `enable_react_refresh`, will migrate once this changes land.