### PR TITLE
Remove fallback to configured git user

### DIFF
--- a/cli/internal/runsummary/run_summary.go
+++ b/cli/internal/runsummary/run_summary.go
@@ -14,7 +14,6 @@ import (
 	"github.com/vercel/turbo/cli/internal/ci"
 	"github.com/vercel/turbo/cli/internal/client"
 	"github.com/vercel/turbo/cli/internal/env"
-	"github.com/vercel/turbo/cli/internal/scm"
 	"github.com/vercel/turbo/cli/internal/spinner"
 	"github.com/vercel/turbo/cli/internal/turbopath"
 	"github.com/vercel/turbo/cli/internal/util"
@@ -342,10 +341,6 @@ func getUser(envVars env.EnvironmentVariableMap, dir turbopath.AbsoluteSystemPat
 	if ci.IsCi() {
 		vendor := ci.Info()
 		username = envVars[vendor.UsernameEnvVar]
-	}
-
-	if username == "" {
-		username = scm.GetCurrentUser(dir)
 	}
 
 	return username

--- a/cli/internal/scm/scm.go
+++ b/cli/internal/scm/scm.go
@@ -78,17 +78,3 @@ func GetCurrentSha(dir turbopath.AbsoluteSystemPath) string {
 	}
 	return strings.TrimRight(string(out), "\n")
 }
-
-// GetCurrentUser returns the local user.name
-// We do not specify a --local or --global flag so it should
-// resolve the value the same way git does when creating a commit.
-func GetCurrentUser(dir turbopath.AbsoluteSystemPath) string {
-	cmd := exec.Command("git", []string{"config", "user.name"}...)
-	cmd.Dir = dir.ToString()
-
-	out, err := cmd.Output()
-	if err != nil {
-		return ""
-	}
-	return strings.TrimRight(string(out), "\n")
-}


### PR DESCRIPTION
When we don't have a known CI environment variable we can rely on the token that is used to submit the Run to associate the user. The backend already handles this case
