### PR TITLE
create-turbo: automatic git configuration.

### DIFF
--- a/packages/create-turbo/__tests__/git.test.ts
+++ b/packages/create-turbo/__tests__/git.test.ts
@@ -140,8 +140,7 @@ describe("git", () => {
       const calls = [
         "git init",
         "git checkout -b main",
-        "git add -A",
-        'git commit -m "test commit"',
+        'git commit --author="Turbobot <turbobot@vercel.com>" -am "test commit"',
       ];
       expect(mockExecSync).toHaveBeenCalledTimes(calls.length + 2);
       calls.forEach((call) => {
@@ -195,11 +194,7 @@ describe("git", () => {
       const result = tryGitInit(root, "test commit");
       expect(result).toBe(false);
 
-      const calls: string[] = [
-        GIT_REPO_COMMAND,
-        HG_REPO_COMMAND,
-        "git init"
-      ];
+      const calls: string[] = [GIT_REPO_COMMAND, HG_REPO_COMMAND, "git init"];
 
       expect(mockExecSync).toHaveBeenCalledTimes(calls.length);
       calls.forEach((call) => {
@@ -234,7 +229,7 @@ describe("git", () => {
       const calls = [
         "git init",
         "git checkout -b main",
-        "git add -A",
+        'git commit --author="Turbobot <turbobot@vercel.com>" -am "test commit"',
       ];
 
       expect(mockExecSync).toHaveBeenCalledTimes(calls.length + 2);

--- a/packages/create-turbo/__tests__/git.test.ts
+++ b/packages/create-turbo/__tests__/git.test.ts
@@ -124,7 +124,6 @@ describe("git", () => {
       const { root } = useFixture({ fixture: `git` });
       const mockExecSync = jest
         .spyOn(childProcess, "execSync")
-        .mockReturnValueOnce("git version 2.38.1")
         .mockImplementationOnce(() => {
           throw new Error(
             "fatal: not a git repository (or any of the parent directories): .git"
@@ -139,7 +138,6 @@ describe("git", () => {
       expect(result).toBe(true);
 
       const calls = [
-        "git --version",
         "git init",
         "git checkout -b main",
         "git add -A",
@@ -160,16 +158,15 @@ describe("git", () => {
       });
       const mockExecSync = jest
         .spyOn(childProcess, "execSync")
-        .mockReturnValueOnce("git version 2.38.1")
         .mockReturnValueOnce("true")
         .mockReturnValue("success");
 
       const result = tryGitInit(root, "test commit");
       expect(result).toBe(false);
 
-      const calls = ["git --version"];
+      const calls: string[] = [];
 
-      // 1 call for git --version, 1 call for isInGitRepository
+      // 1 call for isInGitRepository
       expect(mockExecSync).toHaveBeenCalledTimes(calls.length + 1);
       calls.forEach((call) => {
         expect(mockExecSync).toHaveBeenCalledWith(call, {
@@ -184,13 +181,25 @@ describe("git", () => {
       const mockExecSync = jest
         .spyOn(childProcess, "execSync")
         .mockImplementationOnce(() => {
-          throw new Error("fatal: unknown command git");
+          throw new Error(
+            "fatal: not a git repository (or any of the parent directories): .git"
+          );
+        })
+        .mockImplementationOnce(() => {
+          throw new Error("abort: no repository found (.hg not found)");
+        })
+        .mockImplementationOnce(() => {
+          throw new Error("fatal: 128");
         });
 
       const result = tryGitInit(root, "test commit");
       expect(result).toBe(false);
 
-      const calls = ["git --version"];
+      const calls: string[] = [
+        GIT_REPO_COMMAND,
+        HG_REPO_COMMAND,
+        "git init"
+      ];
 
       expect(mockExecSync).toHaveBeenCalledTimes(calls.length);
       calls.forEach((call) => {
@@ -205,7 +214,6 @@ describe("git", () => {
       const { root } = useFixture({ fixture: `git` });
       const mockExecSync = jest
         .spyOn(childProcess, "execSync")
-        .mockReturnValueOnce("git version 2.38.1")
         .mockImplementationOnce(() => {
           throw new Error(
             "fatal: not a git repository (or any of the parent directories): .git"
@@ -224,7 +232,6 @@ describe("git", () => {
       expect(result).toBe(false);
 
       const calls = [
-        "git --version",
         "git init",
         "git checkout -b main",
         "git add -A",

--- a/packages/create-turbo/src/utils/git.ts
+++ b/packages/create-turbo/src/utils/git.ts
@@ -51,7 +51,6 @@ export function isInMercurialRepository(): boolean {
 export function tryGitInit(root: string, message: string): boolean {
   let didInit = false;
   try {
-    execSync("git --version", { stdio: "ignore" });
     if (isInGitRepository() || isInMercurialRepository()) {
       return false;
     }

--- a/packages/create-turbo/src/utils/git.ts
+++ b/packages/create-turbo/src/utils/git.ts
@@ -60,10 +60,7 @@ export function tryGitInit(root: string, message: string): boolean {
 
     execSync("git checkout -b main", { stdio: "ignore" });
 
-    execSync("git add -A", { stdio: "ignore" });
-    execSync(`git commit -m "${message}"`, {
-      stdio: "ignore",
-    });
+    gitCommit(message);
     return true;
   } catch (err) {
     if (didInit) {
@@ -77,12 +74,18 @@ export function tryGitInit(root: string, message: string): boolean {
 
 export function tryGitCommit(message: string): boolean {
   try {
-    execSync("git add -A", { stdio: "ignore" });
-    execSync(`git commit -m "${message}"`, {
-      stdio: "ignore",
-    });
+    gitCommit(message);
     return true;
   } catch (err) {
     return false;
   }
+}
+
+function gitCommit(message: string) {
+  execSync(
+    `git commit --author="Turbobot <turbobot@vercel.com>" -am "${message}"`,
+    {
+      stdio: "ignore",
+    }
+  );
 }


### PR DESCRIPTION
Not all environments where `create-turbo` is run will have a preconfigured `git` config. This ensures that we always have an author config for the initial commit.

It also reduces the number of processes executed to reduce the chances of intermittent failures.