### PR TITLE
refactor(turbopack): deprecate single react_refresh options

### DIFF
--- a/crates/turbopack-cli/src/dev/web_entry_source.rs
+++ b/crates/turbopack-cli/src/dev/web_entry_source.rs
@@ -108,10 +108,17 @@ async fn get_client_module_options_context(
             .await?
             .is_found();
 
+    let enable_jsx = Some(
+        JsxTransformOptions {
+            react_refresh: enable_react_refresh,
+            ..Default::default()
+        }
+        .cell(),
+    );
+
     let module_options_context = ModuleOptionsContext {
-        enable_jsx: Some(JsxTransformOptions::default().cell()),
+        enable_jsx,
         enable_emotion: Some(EmotionTransformConfigVc::default()),
-        enable_react_refresh,
         enable_styled_components: Some(StyledComponentsTransformConfigVc::default()),
         enable_styled_jsx: true,
         enable_postcss_transform: Some(Default::default()),

--- a/crates/turbopack/src/module_options/mod.rs
+++ b/crates/turbopack/src/module_options/mod.rs
@@ -62,7 +62,6 @@ impl ModuleOptionsVc {
     ) -> Result<ModuleOptionsVc> {
         let ModuleOptionsContext {
             enable_jsx,
-            enable_react_refresh,
             enable_styled_jsx,
             ref enable_styled_components,
             enable_types,
@@ -139,7 +138,7 @@ impl ModuleOptionsVc {
             let jsx = enable_jsx.await?;
 
             transforms.push(EcmascriptInputTransform::React {
-                refresh: enable_react_refresh || jsx.react_refresh,
+                refresh: jsx.react_refresh,
                 import_source: OptionStringVc::cell(jsx.import_source.clone()),
                 runtime: OptionStringVc::cell(jsx.runtime.clone()),
             });

--- a/crates/turbopack/src/module_options/module_options_context.rs
+++ b/crates/turbopack/src/module_options/module_options_context.rs
@@ -134,8 +134,6 @@ pub struct ModuleOptionsContext {
     #[serde(default)]
     pub enable_emotion: Option<EmotionTransformConfigVc>,
     #[serde(default)]
-    pub enable_react_refresh: bool,
-    #[serde(default)]
     pub enable_styled_components: Option<StyledComponentsTransformConfigVc>,
     #[serde(default)]
     pub enable_styled_jsx: bool,


### PR DESCRIPTION
### Description

closes WEB-1049.

https://github.com/vercel/next.js/pull/49822 removes usage of the option itself, instead using jsxoptions.