### PR TITLE
fix: set repoRoot on http cache so cache can be restored

### DIFF
--- a/cli/internal/cache/cache.go
+++ b/cli/internal/cache/cache.go
@@ -129,7 +129,7 @@ func newSyncCache(opts Opts, repoRoot turbopath.AbsoluteSystemPath, client clien
 	}
 
 	if useHTTPCache {
-		implementation := newHTTPCache(opts, client, recorder)
+		implementation := newHTTPCache(opts, client, recorder, repoRoot)
 		cacheImplementations = append(cacheImplementations, implementation)
 	}
 

--- a/cli/internal/cache/cache_http.go
+++ b/cli/internal/cache/cache_http.go
@@ -267,12 +267,13 @@ func (cache *httpCache) CleanAll() {
 
 func (cache *httpCache) Shutdown() {}
 
-func newHTTPCache(opts Opts, client client, recorder analytics.Recorder) *httpCache {
+func newHTTPCache(opts Opts, client client, recorder analytics.Recorder, repoRoot turbopath.AbsoluteSystemPath) *httpCache {
 	return &httpCache{
 		writable:       true,
 		client:         client,
 		requestLimiter: make(limiter, 20),
 		recorder:       recorder,
+		repoRoot:       repoRoot,
 		signerVerifier: &ArtifactSignatureAuthentication{
 			// TODO(Gaspar): this should use RemoteCacheOptions.TeamId once we start
 			// enforcing team restrictions for repositories.


### PR DESCRIPTION
The http cache requires a repoRoot so it can restore downloaded tar files to the right place. Without this path, it fails to proceed causing cache misses downstream, even though the artifact is downloaded from the remote cache.

I think this is caused by #4634 and a default case that isn't handled anymore. It doesn't reproduce in 1.9.4, but does 1.9.5, so it should have relatively low impact.