### PR TITLE
Increase timeout for Go Unit Tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -229,7 +229,7 @@ jobs:
     name: Go Unit Tests
     needs: determine_jobs
     if: needs.determine_jobs.outputs.go == 'true'
-    timeout-minutes: 30
+    timeout-minutes: 45
     runs-on: ${{ matrix.os.runner }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
These tests keep timing out on Windows, hoping
that bumping will help reduce failed PRs.