### PR TITLE
ci: Remove test script from package that has no tests

### DIFF
--- a/packages/turbo-gen/package.json
+++ b/packages/turbo-gen/package.json
@@ -16,7 +16,6 @@
   "types": "dist/types.d.ts",
   "scripts": {
     "build": "tsup",
-    "test": "jest",
     "lint": "eslint src/**/*.ts",
     "check-types": "tsc --noEmit"
   },


### PR DESCRIPTION
This fails the smoke test before publish because `jest` exits with `1` when there are no tests.