### PR TITLE
chore: Remove cli#build dependency on all tests everywhere

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -3,7 +3,10 @@
   "pipeline": {
     "test": {
       "outputs": ["coverage/**/*"],
-      "dependsOn": ["cli#build", "^build"]
+
+      // ^build is generically set here, we haven't fully enumerated which workspaces
+      // actually need to build before running tests.
+      "dependsOn": ["^build"]
     },
 
     // lint tasks

--- a/turborepo-tests/e2e/turbo.json
+++ b/turborepo-tests/e2e/turbo.json
@@ -2,6 +2,7 @@
   "extends": ["//"],
   "pipeline": {
     "test": {
+      "dependsOn": ["cli#build", "^build"],
       "output": []
     }
   }


### PR DESCRIPTION
JS package tests don't need to build the turbo CLI before running. Rather than disabling in those workspaces, we can limit cli#build to e2e-style tests for the CLI itself
