### PR TITLE
feat: Print failed tasks at the bottom of the run

### DIFF
--- a/cli/internal/runsummary/format_execution_summary.go
+++ b/cli/internal/runsummary/format_execution_summary.go
@@ -1,7 +1,9 @@
 package runsummary
 
 import (
+	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/fatih/color"
@@ -16,6 +18,7 @@ func (rsm *Meta) printExecutionSummary() {
 
 	attempted := summary.ExecutionSummary.attempted
 	successful := summary.ExecutionSummary.cached + summary.ExecutionSummary.success
+	failed := rsm.RunSummary.getFailedTasks() // Note: ExecutionSummary.failure exists, but we need the task names
 	cached := summary.ExecutionSummary.cached
 	// TODO: can we use a method on ExecutionSummary here?
 	duration := time.Since(summary.ExecutionSummary.startedAt).Truncate(time.Millisecond)
@@ -32,39 +35,57 @@ func (rsm *Meta) printExecutionSummary() {
 		}
 	}
 
+	lineData := []summaryLine{
+		{header: "Tasks", trailer: util.Sprintf("${BOLD_GREEN}%v successful${RESET}${GRAY}, %v total", successful, attempted)},
+		{header: "Cached", trailer: util.Sprintf("%v cached${RESET}${GRAY}, %v total", cached, attempted)},
+		{header: "Time", trailer: util.Sprintf("%v${RESET} %v", duration, maybeFullTurbo)},
+	}
+
+	if rsm.getPath().FileExists() {
+		l := summaryLine{header: "Summary", trailer: util.Sprintf("%s", rsm.getPath())}
+		lineData = append(lineData, l)
+	}
+
+	if len(failed) > 0 {
+		formatted := []string{}
+		for _, t := range failed {
+			formatted = append(formatted, util.Sprintf("${BOLD_RED}%s${RESET}", t.TaskID))
+		}
+		l := summaryLine{header: "Failed", trailer: strings.Join(formatted, ", ")}
+		lineData = append(lineData, l)
+	}
+
+	// Some info we need for left padding
+	maxlength := 0
+	for _, sl := range lineData {
+		if len(sl.header) > maxlength {
+			maxlength = len(sl.header)
+		}
+	}
+
+	lines := []string{}
+	for _, sl := range lineData {
+		paddedHeader := fmt.Sprintf("%*s", maxlength, sl.header)
+		line := util.Sprintf("${BOLD}%s:    %s${RESET}", paddedHeader, sl.trailer)
+		lines = append(lines, line)
+	}
+
+	// Print the lines to terminal
 	if attempted == 0 {
 		ui.Output("") // Clear the line
 		ui.Warn("No tasks were executed as part of this run.")
 	}
 
-	ui.Output("")    // Clear the line
-	spacer := "    " // 4 chars
+	ui.Output("") // Clear the line
 
-	var lines []string
-
-	// The only difference between these two branches is that when there is a run summary
-	// we print the path to that file and we adjust the whitespace in the printed text so it aligns.
-	// We could just always align to account for the summary line, but that would require a whole
-	// bunch of test output assertions to change.
-	if rsm.getPath().FileExists() {
-		lines = []string{
-			util.Sprintf("${BOLD}  Tasks:${BOLD_GREEN}%s%v successful${RESET}${GRAY}, %v total${RESET}", spacer, successful, attempted),
-			util.Sprintf("${BOLD} Cached:%s%v cached${RESET}${GRAY}, %v total${RESET}", spacer, cached, attempted),
-			util.Sprintf("${BOLD}   Time:%s%v${RESET} %v${RESET}", spacer, duration, maybeFullTurbo),
-			util.Sprintf("${BOLD}Summary:%s%s${RESET}", spacer, rsm.getPath()),
-		}
-	} else {
-		lines = []string{
-			util.Sprintf("${BOLD} Tasks:${BOLD_GREEN}%s%v successful${RESET}${GRAY}, %v total${RESET}", spacer, successful, attempted),
-			util.Sprintf("${BOLD}Cached:%s%v cached${RESET}${GRAY}, %v total${RESET}", spacer, cached, attempted),
-			util.Sprintf("${BOLD}  Time:%s%v${RESET} %v${RESET}", spacer, duration, maybeFullTurbo),
-		}
-	}
-
-	// Print the real thing
 	for _, line := range lines {
 		ui.Output(line)
 	}
 
 	ui.Output("")
+}
+
+type summaryLine struct {
+	header  string
+	trailer string
 }

--- a/cli/internal/runsummary/format_execution_summary.go
+++ b/cli/internal/runsummary/format_execution_summary.go
@@ -3,6 +3,7 @@ package runsummary
 import (
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -51,6 +52,7 @@ func (rsm *Meta) printExecutionSummary() {
 		for _, t := range failed {
 			formatted = append(formatted, util.Sprintf("${BOLD_RED}%s${RESET}", t.TaskID))
 		}
+		sort.Strings(formatted) // To make the order deterministic
 		l := summaryLine{header: "Failed", trailer: strings.Join(formatted, ", ")}
 		lineData = append(lineData, l)
 	}

--- a/cli/internal/runsummary/run_summary.go
+++ b/cli/internal/runsummary/run_summary.go
@@ -230,6 +230,17 @@ func (summary *RunSummary) TrackTask(taskID string) (func(outcome executionEvent
 	return summary.ExecutionSummary.run(taskID)
 }
 
+func (summary *RunSummary) getFailedTasks() []*TaskSummary {
+	failed := []*TaskSummary{}
+
+	for _, t := range summary.Tasks {
+		if *t.Execution.exitCode != 0 {
+			failed = append(failed, t)
+		}
+	}
+	return failed
+}
+
 // Save saves the run summary to a file
 func (rsm *Meta) save() error {
 	json, err := rsm.FormatJSON()

--- a/turborepo-tests/integration/tests/continue.t
+++ b/turborepo-tests/integration/tests/continue.t
@@ -82,7 +82,7 @@ Run with --continue
    Tasks:    1 successful, 3 total
   Cached:    0 cached, 3 total
     Time:\s*[\.0-9]+m?s  (re)
-  Failed:    some-lib#build, other-app#build
+  Failed:    other-app#build, some-lib#build
   
    ERROR  run failed: command  exited (1)
   [1]

--- a/turborepo-tests/integration/tests/continue.t
+++ b/turborepo-tests/integration/tests/continue.t
@@ -21,6 +21,7 @@ Run without --continue
    Tasks:    0 successful, 1 total
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
+  Failed:    some-lib#build
   
    ERROR  run failed: command  exited (1)
   [1]
@@ -45,6 +46,7 @@ Run without --continue, and with only errors.
    Tasks:    0 successful, 1 total
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
+  Failed:    some-lib#build
   
    ERROR  run failed: command  exited (1)
   [1]
@@ -80,6 +82,7 @@ Run with --continue
    Tasks:    1 successful, 3 total
   Cached:    0 cached, 3 total
     Time:\s*[\.0-9]+m?s  (re)
+  Failed:    some-lib#build, other-app#build
   
    ERROR  run failed: command  exited (1)
   [1]

--- a/turborepo-tests/integration/tests/errors-only.t
+++ b/turborepo-tests/integration/tests/errors-only.t
@@ -54,6 +54,7 @@ Setup
    Tasks:    0 successful, 1 total
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
+  Failed:    app-a#builderror
   
    ERROR  run failed: command  exited (1)
   [1]
@@ -83,6 +84,7 @@ Setup
    Tasks:    0 successful, 1 total
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
+  Failed:    app-a#builderror2
   
    ERROR  run failed: command  exited (1)
   [1]

--- a/turborepo-tests/integration/tests/one_script_error.t
+++ b/turborepo-tests/integration/tests/one_script_error.t
@@ -29,6 +29,7 @@ Note that npm reports any failed script as exit code 1, even though we "exit 2"
    Tasks:    1 successful, 2 total
   Cached:    0 cached, 2 total
     Time:\s*[\.0-9]+m?s  (re)
+  Failed:    my-app#error
   
    ERROR  run failed: command  exited (1)
   [1]
@@ -59,6 +60,7 @@ Make sure error isn't cached
    Tasks:    1 successful, 2 total
   Cached:    1 cached, 2 total
     Time:\s*[\.0-9]+m?s  (re)
+  Failed:    my-app#error
   
    ERROR  run failed: command  exited (1)
   [1]
@@ -95,6 +97,7 @@ Make sure error code isn't swallowed with continue
    Tasks:    2 successful, 3 total
   Cached:    1 cached, 3 total
     Time:\s*[\.0-9]+m?s  (re)
+  Failed:    my-app#error
   
    ERROR  run failed: command  exited (1)
   [1]


### PR DESCRIPTION
This adds a line to the bottom of the run listing the tasks that failed. Note that if `--continue` is not passed, the output is non-deterministic since a different task could fail each run. 

Example:

<img width="301" alt="CleanShot 2023-05-16 at 14 10 21@2x" src="https://github.com/vercel/turbo/assets/490968/2eb09c99-3807-4f60-b1d9-626d1fece9c6">
