### PR TITLE
ci: Remove Rust/Go toolchain for examples tests

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -69,11 +69,11 @@ runs:
         save-if: ${{ github.ref == 'refs/heads/main' && inputs.save-cache || 'false' }}
 
     - name: "Install cargo-sweep"
-      if: ${{ inputs.install-cargo-sweep }} == "true"
+      if: ${{ inputs.install-cargo-sweep == 'true' }}
       uses: baptiste0928/cargo-install@v1
       with:
         crate: cargo-sweep
 
     - name: "Run cargo-sweep"
-      if: ${{ inputs.install-cargo-sweep }} == "true"
+      if: ${{ inputs.install-cargo-sweep == 'true' }}
       uses: ./.github/actions/cargo-sweep

--- a/.github/actions/setup-turborepo-environment/action.yml
+++ b/.github/actions/setup-turborepo-environment/action.yml
@@ -7,6 +7,17 @@ inputs:
   github-token:
     description: "GitHub token. You can pass secrets.GITHUB_TOKEN"
     required: true
+  setup-rust:
+    description: "Install Rust toolchain to build Turborepo"
+    required: false
+    type: boolean
+    default: true
+  setup-go:
+    description: "Install Go toolchain to build Turborepo"
+    required: false
+    type: boolean
+    default: true
+
 runs:
   using: "composite"
   steps:
@@ -14,11 +25,13 @@ runs:
       uses: ./.github/actions/setup-node
 
     - name: "Setup Go"
+      if: inputs.setup-go == 'true'
       uses: ./.github/actions/setup-go
       with:
         github-token: ${{ inputs.github-token }}
 
     - name: "Setup Rust"
+      if: inputs.setup-rust == 'true'
       uses: ./.github/actions/setup-rust
       with:
         target: ${{ inputs.target }}
@@ -26,6 +39,7 @@ runs:
         cache-key: ${{ inputs.target }}
         save-cache: true
         install-cargo-sweep: false
+
     - name: Install Turbo globally
       shell: bash
       run: npm i -g turbo@canary

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -361,11 +361,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      # Note: the setup-node action inside this is somehow required for
+      # the node setup below this step. Not sure why.
       - uses: ./.github/actions/setup-turborepo-environment
         with:
           target: ${{ matrix.os.name }}
           github-token: "${{ secrets.GITHUB_TOKEN }}"
+          setup-rust: false
+          setup-go: false
 
+      # TODO: .github/actions/setup-node is pretty similar to the following
+      # steps (Setup Pnpm, pnpm cache, corepack, setup node), but it didn't
+      # work out of box. We should take another stab at it later.
       - name: Setup Pnpm
         uses: pnpm/action-setup@v2.2.4
         with:


### PR DESCRIPTION
Examples tests do not use a local build of Turborepo, so we do not need the toolchain for that. 

