### PR TITLE
Correct link to Customizing Turbopack

### DIFF
--- a/docs/pages/pack/docs/comparisons/webpack.mdx
+++ b/docs/pages/pack/docs/comparisons/webpack.mdx
@@ -63,4 +63,4 @@ In a 1,000 module application, Turbopack can react to file changes **<DocsBenchm
 
 webpack has an extraordinary collection of [plugins](https://webpack.js.org/plugins/) to customize its behavior. Composing plugins lets you create custom toolchains which can support a huge variety of bundler features.
 
-As of Next.js 13.2, Turbopack introduced a compatibility layer to support webpack's loaders and resolve aliases. See [Customizing Turbopack](features/customizing-turbopack) for how to configure them. In the future, we plan to make Turbopack just as extensible as webpack - though likely with an altered API.
+As of Next.js 13.2, Turbopack introduced a compatibility layer to support webpack's loaders and resolve aliases. See [Customizing Turbopack](../features/customizing-turbopack) for how to configure them. In the future, we plan to make Turbopack just as extensible as webpack - though likely with an altered API.


### PR DESCRIPTION
This page: https://turbo.build/pack/docs/comparisons/webpack, currently links to a 404 if you click on "Customizing Turbopack".