### PR TITLE
Configure React development flag, inherit NODE_ENV from execution context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8667,6 +8667,7 @@ dependencies = [
  "tokio",
  "turbo-tasks",
  "turbo-tasks-build",
+ "turbo-tasks-env",
  "turbo-tasks-fs",
  "turbo-tasks-malloc",
  "turbo-tasks-memory",

--- a/crates/turbopack-ecmascript/src/transform/mod.rs
+++ b/crates/turbopack-ecmascript/src/transform/mod.rs
@@ -31,6 +31,8 @@ pub enum EcmascriptInputTransform {
     PresetEnv(EnvironmentVc),
     React {
         #[serde(default)]
+        development: bool,
+        #[serde(default)]
         refresh: bool,
         // swc.jsc.transform.react.importSource
         import_source: OptionStringVc,
@@ -143,6 +145,7 @@ impl EcmascriptInputTransform {
         } = ctx;
         match self {
             EcmascriptInputTransform::React {
+                development,
                 refresh,
                 import_source,
                 runtime,
@@ -165,7 +168,7 @@ impl EcmascriptInputTransform {
 
                 let config = Options {
                     runtime: Some(runtime),
-                    development: Some(true),
+                    development: Some(*development),
                     import_source: import_source.await?.clone_value(),
                     refresh: if *refresh {
                         Some(swc_core::ecma::transforms::react::RefreshOptions {

--- a/crates/turbopack-tests/tests/snapshot.rs
+++ b/crates/turbopack-tests/tests/snapshot.rs
@@ -199,6 +199,7 @@ async fn run_test(resource: &str) -> Result<FileSystemPathVc> {
         compile_time_info,
         ModuleOptionsContext {
             enable_jsx: Some(JsxTransformOptionsVc::cell(JsxTransformOptions {
+                development: true,
                 ..Default::default()
             })),
             enable_emotion: Some(EmotionTransformConfig::cell(EmotionTransformConfig {

--- a/crates/turbopack/Cargo.toml
+++ b/crates/turbopack/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = { workspace = true }
 tokio = { workspace = true }
 
 turbo-tasks = { workspace = true }
+turbo-tasks-env = { workspace = true }
 turbo-tasks-fs = { workspace = true }
 turbopack-core = { workspace = true }
 turbopack-css = { workspace = true }

--- a/crates/turbopack/src/evaluate_context.rs
+++ b/crates/turbopack/src/evaluate_context.rs
@@ -8,6 +8,7 @@ use turbopack_core::{
     environment::{EnvironmentIntention, EnvironmentVc, ExecutionEnvironment, NodeJsEnvironment},
     resolve::options::{ImportMap, ImportMapVc, ImportMapping},
 };
+use turbopack_node::execution_context::ExecutionContextVc;
 
 use crate::{
     module_options::ModuleOptionsContext, resolve_options_context::ResolveOptionsContext,
@@ -26,7 +27,7 @@ pub fn node_build_environment() -> EnvironmentVc {
 
 #[turbo_tasks::function]
 pub async fn node_evaluate_asset_context(
-    project_path: FileSystemPathVc,
+    execution_context: ExecutionContextVc,
     import_map: Option<ImportMapVc>,
     transitions: Option<TransitionsByNameVc>,
 ) -> Result<AssetContextVc> {
@@ -44,13 +45,18 @@ pub async fn node_evaluate_asset_context(
         .cell(),
     );
     let import_map = import_map.cell();
+    let node_env = if let Some(node_env) = &*execution_context.env().read("NODE_ENV").await? {
+        node_env.clone()
+    } else {
+        "development".to_string()
+    };
     Ok(ModuleAssetContextVc::new(
         transitions.unwrap_or_else(|| TransitionsByNameVc::cell(Default::default())),
         CompileTimeInfo::builder(node_build_environment())
             .defines(
                 compile_time_defines!(
                     process.turbopack = true,
-                    process.env.NODE_ENV = "development",
+                    process.env.NODE_ENV = node_env.clone(),
                 )
                 .cell(),
             )
@@ -65,7 +71,7 @@ pub async fn node_evaluate_asset_context(
             enable_node_modules: Some(project_path.root().resolve().await?),
             enable_node_externals: true,
             enable_node_native_modules: true,
-            custom_conditions: vec!["development".to_string(), "node".to_string()],
+            custom_conditions: vec![node_env, "node".to_string()],
             import_map: Some(import_map),
             ..Default::default()
         }

--- a/crates/turbopack/src/evaluate_context.rs
+++ b/crates/turbopack/src/evaluate_context.rs
@@ -68,7 +68,7 @@ pub async fn node_evaluate_asset_context(
         .cell(),
         ResolveOptionsContext {
             enable_typescript: true,
-            enable_node_modules: Some(project_path.root().resolve().await?),
+            enable_node_modules: Some(execution_context.project_path().root().resolve().await?),
             enable_node_externals: true,
             enable_node_native_modules: true,
             custom_conditions: vec![node_env, "node".to_string()],

--- a/crates/turbopack/src/evaluate_context.rs
+++ b/crates/turbopack/src/evaluate_context.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use turbo_tasks::Value;
-use turbo_tasks_fs::{FileSystem, FileSystemPathVc};
+use turbo_tasks_env::ProcessEnv;
+use turbo_tasks_fs::FileSystem;
 use turbopack_core::{
     compile_time_defines,
     compile_time_info::CompileTimeInfo,

--- a/crates/turbopack/src/module_options/mod.rs
+++ b/crates/turbopack/src/module_options/mod.rs
@@ -138,6 +138,7 @@ impl ModuleOptionsVc {
             let jsx = enable_jsx.await?;
 
             transforms.push(EcmascriptInputTransform::React {
+                development: jsx.development,
                 refresh: jsx.react_refresh,
                 import_source: OptionStringVc::cell(jsx.import_source.clone()),
                 runtime: OptionStringVc::cell(jsx.runtime.clone()),

--- a/crates/turbopack/src/module_options/mod.rs
+++ b/crates/turbopack/src/module_options/mod.rs
@@ -258,7 +258,7 @@ impl ModuleOptionsVc {
                         Some(ModuleRuleEffect::SourceTransforms(
                             SourceTransformsVc::cell(vec![PostCssTransformVc::new(
                                 node_evaluate_asset_context(
-                                    execution_context.project_path(),
+                                    execution_context,
                                     Some(import_map),
                                     None,
                                 ),
@@ -473,7 +473,7 @@ impl ModuleOptionsVc {
                         ModuleRuleEffect::SourceTransforms(SourceTransformsVc::cell(vec![
                             WebpackLoadersVc::new(
                                 node_evaluate_asset_context(
-                                    execution_context.project_path(),
+                                    execution_context,
                                     Some(import_map),
                                     None,
                                 ),

--- a/crates/turbopack/src/module_options/module_options_context.rs
+++ b/crates/turbopack/src/module_options/module_options_context.rs
@@ -109,6 +109,7 @@ impl WebpackLoadersOptions {
 #[turbo_tasks::value(shared)]
 #[derive(Default, Clone, Debug)]
 pub struct JsxTransformOptions {
+    pub development: bool,
     pub react_refresh: bool,
     pub import_source: Option<String>,
     pub runtime: Option<String>,


### PR DESCRIPTION
### Description

This PR allows Turbopack users to configure the `development` flag from the SWC React transform. This is used in https://github.com/vercel/next.js/pull/49852.

This PR also makes the Node.js evaluation asset context inherit its NODE_ENV from the execution context.

### Testing Instructions

N/A