### PR TITLE
fix(create-turbo): Add --fix-lockfile for pnpm install

### DIFF
--- a/packages/turbo-workspaces/src/install.ts
+++ b/packages/turbo-workspaces/src/install.ts
@@ -40,7 +40,7 @@ export const PACKAGE_MANAGERS: Record<
       name: "pnpm",
       template: "pnpm",
       command: "pnpm",
-      installArgs: ["install"],
+      installArgs: ["install", "--fix-lockfile"],
       version: "latest",
       executable: "pnpm dlx",
       semver: ">=7",


### PR DESCRIPTION
If:
- `create-turbo` is run in an environment detected as CI,
- using `pnpm`, and
- the `pnpm` version is newer than the lockfile that we ship.

The installation step will fail because `pnpm` makes `--frozen-lockfile` the default on CI.

To address this, `create-turbo` should call `pnpm install --fix-lockfile`, which will succeed in a CI environment.