### PR TITLE
fix(docs): Change `secrets.TURBO_TEAM` to `vars.TURBO_TEAM`

### DIFF
--- a/docs/pages/repo/docs/ci/github-actions.mdx
+++ b/docs/pages/repo/docs/ci/github-actions.mdx
@@ -62,7 +62,7 @@ Create file called `.github/workflows/ci.yml` in your repository with the follow
           # To use Remote Caching, uncomment the next lines and follow the steps below.
           # env:
           #  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-          #  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+          #  TURBO_TEAM: ${{ vars.TURBO_TEAM }}
           #  TURBO_REMOTE_ONLY: true
 
           steps:
@@ -106,7 +106,7 @@ Create file called `.github/workflows/ci.yml` in your repository with the follow
           # To use Remote Caching, uncomment the next lines and follow the steps below.
           # env:
           #  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-          #  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+          #  TURBO_TEAM: ${{ vars.TURBO_TEAM }}
 
           steps:
             - name: Check out code
@@ -149,7 +149,7 @@ Create file called `.github/workflows/ci.yml` in your repository with the follow
           # To use Remote Caching, uncomment the next lines and follow the steps below.
           # env:
           #  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-          #  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+          #  TURBO_TEAM: ${{ vars.TURBO_TEAM }}
 
           steps:
             - name: Check out code
@@ -223,7 +223,7 @@ jobs:
     # To use Turborepo Remote Caching, set the following environment variables for the job.
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
 
     steps:
       - name: Check out code


### PR DESCRIPTION
### Description

In the [CI Docs for GitHub Actions](https://turbo.build/repo/docs/ci/github-actions) there are instructions to use a repository variable for the `TURBO_TEAM`.

> Using a repository variable rather than a secret will keep Github Actions from censoring your team name in the log output.

In current documentation, the GitHub Action yml instructs using `secrets.TURBO_TEAM`:
```yml
env:
  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
```

In this case, the log output will be:
```
  env:
    TURBO_TOKEN: ***
    TURBO_TEAM:
```

Meaning `TURBO_TEAM` has an empty string.

This PR changes `secrets.TURBO_TEAM` to `vars.TURBO_TEAM` in the docs.
This change will lead to correct behavior in the log:
```
  env:
    TURBO_TOKEN: ***
    TURBO_TEAM: my_team_id
```

[Reference for `vars` context](https://docs.github.com/en/actions/learn-github-actions/variables#using-the-vars-context-to-access-configuration-variable-values)

### Testing Instructions
Configure the remote cache, invoke GitHub Action, and check the logs.