### PR TITLE
Exclude turborepo-tests from JS tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -455,7 +455,7 @@ jobs:
 
       - name: Run tests
         run: |
-          turbo run check-types test --filter=...[${{ github.event.pull_request.base.sha || 'HEAD^1' }}] --filter="./packages/*" --filter="\!@vercel/*" --color
+          turbo check-types test -F=...[${{ github.event.pull_request.base.sha || 'HEAD^1' }}] -F="./packages/*" -F="\!@vercel/*" -F="\!turborepo-tests*" --color
 
   rust_prepare:
     name: Check rust crates

--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -113,7 +113,7 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           target: ${{ matrix.os.name }}
       - name: Run JS Package Tests
-        run: turbo run check-types test --filter="./packages/*" --filter="\!@vercel/*" --color
+        run: turbo check-types test -F="./packages/*" -F="\!@vercel/*" -F="\!turborepo-tests*" --color
 
   build-go-darwin:
     name: "Build Go for macOS"


### PR DESCRIPTION
Not sure why, but these tests are getting caught in the filters as they are now
