### PR TITLE
More robust vdbg! macro

### DIFF
--- a/crates/turbo-tasks/src/manager.rs
+++ b/crates/turbo-tasks/src/manager.rs
@@ -995,7 +995,10 @@ impl<B: Backend + 'static> TurboTasksApi for TurboTasks<B> {
             turbo_tasks(),
             CURRENT_TASK_ID.scope(
                 current_task_id,
-                self.backend.execution_scope(current_task_id, f),
+                CELL_COUNTERS.scope(
+                    Default::default(),
+                    self.backend.execution_scope(current_task_id, f),
+                ),
             ),
         ))
     }


### PR DESCRIPTION
### Description

I ran into a couple of issues with the vdbg! macro:
* The macro tries to move its parameters within an async block, which requires everything that's moved to be both `Copy` and `'static` to work properly. This would break when trying to pass `&obj.property`, where the reference doesn't have a `'static` lifetime. Instead, I'm adding the requirement on parameters to impl `ToOwned` so we can ensure the `'static` lifetime, and creating an owned version of the parameter to move into the future.
* The `CELL_COUNTERS` thread local could be unset when calling `.value_debug_format().try_to_string()`, which would panic the thread.
