### PR TITLE
feat(cli): generators what -> type + cmd change

### DIFF
--- a/crates/turborepo-lib/src/cli.rs
+++ b/crates/turborepo-lib/src/cli.rs
@@ -338,8 +338,8 @@ pub struct GenerateWorkspaceArgs {
     #[clap(short = 'd', long)]
     pub destination: Option<String>,
     /// The type of workspace to create
-    #[clap(short = 'w', long)]
-    pub what: Option<String>,
+    #[clap(short = 't', long)]
+    pub r#type: Option<String>,
     /// The root of your repository (default: directory with root turbo.json)
     #[clap(short = 'r', long)]
     pub root: Option<String>,

--- a/crates/turborepo-lib/src/commands/generate.rs
+++ b/crates/turborepo-lib/src/commands/generate.rs
@@ -50,16 +50,16 @@ pub fn run(
         Some(command) => {
             if let GenerateCommand::Workspace(workspace_args) = command {
                 let raw_args = serde_json::to_string(&workspace_args)?;
-                call_turbo_gen("add", tag, &raw_args)?;
+                call_turbo_gen("workspace", tag, &raw_args)?;
             } else {
                 let raw_args = serde_json::to_string(&args)?;
-                call_turbo_gen("generate", tag, &raw_args)?;
+                call_turbo_gen("run", tag, &raw_args)?;
             }
         }
         // if no subcommand was passed, run the generate command as default
         None => {
             let raw_args = serde_json::to_string(&args)?;
-            call_turbo_gen("generate", tag, &raw_args)?;
+            call_turbo_gen("run", tag, &raw_args)?;
         }
     };
 


### PR DESCRIPTION
### Description

Minor change to rename the what option. Will have an accompanying PR in turbo-gen. Requested by both @NicholasLYang and @anthonyshew, and now that the argument is "workspace" instead of "add" it makes a lot of sense. 