### PR TITLE
chore: make node version less strict for gatsby example

### DIFF
--- a/examples/with-gatsby/package.json
+++ b/examples/with-gatsby/package.json
@@ -18,7 +18,7 @@
     "turbo": "latest"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=16.0.0"
   },
   "dependencies": {},
   "packageManager": "pnpm@7.29.1"


### PR DESCRIPTION
node 18 was added as a requirement in #4233 when this example was created,
but our CI runs examples tests with node 16 at the moment, which adds an
extra output warning. We can easily workaround that, but in this case, the [gatsby
starter template][1] does not have this requirement and none of our other examples do
either, although [`with-docker` requires >14][2], and the [`kitchen-sink` remix app requires > 14][3]).

This makes our examples at least consistent with _our_ CI. We have a task to generally update everything
to Node 18 where we _could_ add these requirements uniform. 

An alternative is to just remove this `engines`, but it's probably good practice to recommend a minimum
of Node 16.

[1]: https://github.com/gatsbyjs/gatsby-starter-hello-world/blob/master/package.json
[2]: https://github.com/vercel/turbo/blob/717e8c335ce5d277ac6841ae74b0b6051af1c743/examples/with-docker/package.json#L25
[3]: https://github.com/vercel/turbo/blob/717e8c335ce5d277ac6841ae74b0b6051af1c743/examples/kitchen-sink/apps/blog/package.json#L30