### PR TITLE
ci: remove escaping of ! in filter argument to turbo run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -437,7 +437,7 @@ jobs:
 
       - name: Run tests
         run: |
-          turbo run check-types test --filter=...[${{ github.event.pull_request.base.sha || 'HEAD^1' }}] --filter="./packages/*" --filter="\!@vercel/*" --filter="\!turborepo-tests*" --color
+          turbo run check-types test --filter=...[${{ github.event.pull_request.base.sha || 'HEAD^1' }}] --filter="./packages/*" --filter="!@vercel/*" --filter="!turborepo-tests*" --color
 
   rust_prepare:
     name: Check rust crates

--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -113,7 +113,7 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           target: ${{ matrix.os.name }}
       - name: Run JS Package Tests
-        run: turbo run check-types test --filter="./packages/*" --filter="\!@vercel/*" --filter="\!turborepo-tests*" --color
+        run: turbo run check-types test --filter="./packages/*" --filter="!@vercel/*" --filter="!turborepo-tests*" --color
 
   build-go-darwin:
     name: "Build Go for macOS"


### PR DESCRIPTION
I needed this locally and _thought_ i needed it in CI also, but turns out the filter doesn't work with the escaping