### PR TITLE
test: fix berry roundtrip test on 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 crates/turbopack-tests/tests/snapshot/**/output/** linguist-generated=true
+crates/turborepo-lockfiles/fixtures/*.lock eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 crates/turbopack-tests/tests/snapshot/**/output/** linguist-generated=true
-crates/turborepo-lockfiles/fixtures/*.lock eol=lf
+crates/turborepo-lockfiles/fixtures/*.lock text eol=lf


### PR DESCRIPTION
### Description

We were incorrectly using CRLF on Windows for the berry lockfile fixtures. This PR configures git to always use `lf` for the berry lockfile fixtures.

### Testing Instructions

- Checkout this branch on Windows
- `rm -r crates/turborepo-lockfiles/fixtures`
- `git restore crates/turborepo-lockfiles/fixtures`
- `cargo tr-test` now passes
