### PR TITLE
ci: Reinstate cargo sweep

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -21,10 +21,6 @@ inputs:
     description: "Determiners whether the cache should be saved. If `false`, the cache is only restored."
     required: false
     default: "false"
-  install-cargo-sweep:
-    description: "Whether to install cargo-sweep"
-    required: false
-    default: true
 
 runs:
   using: "composite"
@@ -69,11 +65,9 @@ runs:
         save-if: ${{ github.ref == 'refs/heads/main' && inputs.save-cache || 'false' }}
 
     - name: "Install cargo-sweep"
-      if: ${{ inputs.install-cargo-sweep == 'true' }}
       uses: baptiste0928/cargo-install@v1
       with:
         crate: cargo-sweep
 
     - name: "Run cargo-sweep"
-      if: ${{ inputs.install-cargo-sweep == 'true' }}
       uses: ./.github/actions/cargo-sweep

--- a/.github/actions/setup-turborepo-environment/action.yml
+++ b/.github/actions/setup-turborepo-environment/action.yml
@@ -38,7 +38,6 @@ runs:
         shared-cache-key: turborepo-debug-build
         cache-key: ${{ inputs.target }}
         save-cache: true
-        install-cargo-sweep: false
 
     - name: Install Turbo globally
       shell: bash


### PR DESCRIPTION
In #4644 I had disabled cargo-sweep from running for turborepo workflows, but I implemented the `if` incorrectly. In #4969 I was forced to fix it, because somehow the workflow parsing was failing (although it could totally have been a red herring that it was failing on that). 

I'm reinstating the cargo-sweep here because

- I never actually removed it
- @ForsakenHarmony had doubts about whether it was even worthwhile to remove (and again, I may have been misunderstanding what I was looking at that made me think we should remove it)