### PR TITLE
ci: simplify filter for running JS tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -444,7 +444,7 @@ jobs:
 
       - name: Run tests
         run: |
-          turbo run check-types test --filter=...[${{ github.event.pull_request.base.sha || 'HEAD^1' }}] --filter="./packages/*" --filter="!@vercel/*" --filter="!turborepo-tests*" --color
+          turbo run check-types test --filter=...[${{ github.event.pull_request.base.sha || 'HEAD^1' }}] --filter="./packages/*" --color
 
   rust_prepare:
     name: Check rust crates

--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -113,7 +113,7 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           target: ${{ matrix.os.name }}
       - name: Run JS Package Tests
-        run: turbo run check-types test --filter="./packages/*" --filter="!@vercel/*" --filter="!turborepo-tests*" --color
+        run: turbo run check-types test --filter="./packages/*" --color
 
   build-go-darwin:
     name: "Build Go for macOS"


### PR DESCRIPTION
Using ! syntax seems to create a union set between the filters and catches many more tests than we want to run in this case. Using `./packages` works better, because even though it includes packages that the turborepo team does not own, the filter by changed workspaces should exclude them. Even if it doesn't, it's ok to run all JS package tests without accounting for code ownership.
