### PR TITLE
Revert "ci: Remove go/rust toolchain from JS package tests (#4993)"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -441,8 +441,6 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           target: ${{ matrix.os.name }}
-          setup-go: false
-          setup-rust: false
 
       - name: Run tests
         run: |


### PR DESCRIPTION
This reverts commit b95ebaaf2588b67b2bb243936143cf3771fa0eae.