### PR TITLE
refactor: Change Itemstatus signature to include TimeSaved metric

### DIFF
--- a/cli/internal/cache/async_cache.go
+++ b/cli/internal/cache/async_cache.go
@@ -50,7 +50,7 @@ func (c *asyncCache) Put(anchor turbopath.AbsoluteSystemPath, key string, durati
 	return nil
 }
 
-func (c *asyncCache) Fetch(anchor turbopath.AbsoluteSystemPath, key string, files []string) (ItemStatus, []turbopath.AnchoredSystemPath, int, error) {
+func (c *asyncCache) Fetch(anchor turbopath.AbsoluteSystemPath, key string, files []string) (ItemStatus, []turbopath.AnchoredSystemPath, error) {
 	return c.realCache.Fetch(anchor, key, files)
 }
 

--- a/cli/internal/cache/cache.go
+++ b/cli/internal/cache/cache.go
@@ -20,7 +20,7 @@ import (
 type Cache interface {
 	// Fetch returns true if there is a cache it. It is expected to move files
 	// into their correct position as a side effect
-	Fetch(anchor turbopath.AbsoluteSystemPath, hash string, files []string) (ItemStatus, []turbopath.AnchoredSystemPath, int, error)
+	Fetch(anchor turbopath.AbsoluteSystemPath, hash string, files []string) (ItemStatus, []turbopath.AnchoredSystemPath, error)
 	Exists(hash string) ItemStatus
 	// Put caches files for a given hash
 	Put(anchor turbopath.AbsoluteSystemPath, hash string, duration int, files []turbopath.AnchoredSystemPath) error
@@ -32,8 +32,35 @@ type Cache interface {
 // ItemStatus holds whether artifacts exists for a given hash on local
 // and/or remote caching server
 type ItemStatus struct {
-	Local  bool `json:"local"`
-	Remote bool `json:"remote"`
+	Hit       bool
+	Source    string // only relevant if Hit is true
+	TimeSaved int    // will be 0 if Hit is false
+}
+
+// NewCacheMiss returns an ItemStatus with the fields set to indicate a cache miss
+func NewCacheMiss() ItemStatus {
+	return ItemStatus{
+		Source:    CacheSourceNone,
+		Hit:       false,
+		TimeSaved: 0,
+	}
+}
+
+// NewFSTaskCacheStatus returns an ItemStatus with the fields set to indicate a local cache hit
+func NewFSTaskCacheStatus(hit bool, timeSaved int) ItemStatus {
+	return ItemStatus{
+		Source:    CacheSourceFS,
+		Hit:       hit,
+		TimeSaved: timeSaved,
+	}
+}
+
+func newRemoteTaskCacheStatus(hit bool, timeSaved int) ItemStatus {
+	return ItemStatus{
+		Source:    CacheSourceRemote,
+		Hit:       hit,
+		TimeSaved: timeSaved,
+	}
 }
 
 const (
@@ -41,6 +68,8 @@ const (
 	CacheSourceFS = "LOCAL"
 	// CacheSourceRemote is a constant to indicate remote cache hit
 	CacheSourceRemote = "REMOTE"
+	// CacheSourceNone is an empty string because there is no source for a cache miss
+	CacheSourceNone = ""
 	// CacheEventHit is a constant to indicate a cache hit
 	CacheEventHit = "HIT"
 	// CacheEventMiss is a constant to indicate a cache miss
@@ -240,7 +269,7 @@ func (mplex *cacheMultiplexer) removeCache(removal *cacheRemoval) {
 	}
 }
 
-func (mplex *cacheMultiplexer) Fetch(anchor turbopath.AbsoluteSystemPath, key string, files []string) (ItemStatus, []turbopath.AnchoredSystemPath, int, error) {
+func (mplex *cacheMultiplexer) Fetch(anchor turbopath.AbsoluteSystemPath, key string, files []string) (ItemStatus, []turbopath.AnchoredSystemPath, error) {
 	// Make a shallow copy of the caches, since storeUntil can call removeCache
 	mplex.mu.RLock()
 	caches := make([]Cache, len(mplex.caches))
@@ -248,15 +277,15 @@ func (mplex *cacheMultiplexer) Fetch(anchor turbopath.AbsoluteSystemPath, key st
 	mplex.mu.RUnlock()
 
 	// We need to return a composite cache status from multiple caches
-	// Initialize the empty struct so we can assign values to it. This is similar
+	// Start with a cache miss, and we will assign values to it. This is similar
 	// to how the Exists() method works.
-	combinedCacheState := ItemStatus{}
+	combinedCacheState := NewCacheMiss()
 
 	// Retrieve from caches sequentially; if we did them simultaneously we could
 	// easily write the same file from two goroutines at once.
 	for i, cache := range caches {
-		itemStatus, actualFiles, duration, err := cache.Fetch(anchor, key, files)
-		ok := itemStatus.Local || itemStatus.Remote
+		itemStatus, actualFiles, err := cache.Fetch(anchor, key, files)
+		ok := itemStatus.Hit
 
 		if err != nil {
 			cd := &util.CacheDisabledError{}
@@ -271,28 +300,36 @@ func (mplex *cacheMultiplexer) Fetch(anchor turbopath.AbsoluteSystemPath, key st
 			// the operation. Future work that plumbs UI / Logging into the cache system
 			// should probably log this at least.
 		}
+
 		if ok {
 			// Store this into other caches. We can ignore errors here because we know
 			// we have previously successfully stored in a higher-priority cache, and so the overall
 			// result is a success at fetching. Storing in lower-priority caches is an optimization.
-			_ = mplex.storeUntil(anchor, key, duration, actualFiles, i)
+			_ = mplex.storeUntil(anchor, key, itemStatus.TimeSaved, actualFiles, i)
 
 			// If another cache had already set this to true, we don't need to set it again from this cache
-			combinedCacheState.Local = combinedCacheState.Local || itemStatus.Local
-			combinedCacheState.Remote = combinedCacheState.Remote || itemStatus.Remote
-			return combinedCacheState, actualFiles, duration, err
+			combinedCacheState.Hit = itemStatus.Hit
+			combinedCacheState.Source = itemStatus.Source
+			combinedCacheState.TimeSaved = itemStatus.TimeSaved
+			return combinedCacheState, actualFiles, nil
 		}
 	}
 
-	return ItemStatus{Local: false, Remote: false}, nil, 0, nil
+	return NewCacheMiss(), nil, nil
 }
 
 func (mplex *cacheMultiplexer) Exists(target string) ItemStatus {
-	syncCacheState := ItemStatus{}
+	// Start with a cache miss
+	syncCacheState := NewCacheMiss()
 	for _, cache := range mplex.caches {
 		itemStatus := cache.Exists(target)
-		syncCacheState.Local = syncCacheState.Local || itemStatus.Local
-		syncCacheState.Remote = syncCacheState.Remote || itemStatus.Remote
+		// if there wa sa hit on any of the caches, we'll assign its properties
+		// Note: if both caches have a hit, the last one to return wins
+		if itemStatus.Hit {
+			syncCacheState.Hit = itemStatus.Hit
+			syncCacheState.Source = itemStatus.Source
+			syncCacheState.TimeSaved = itemStatus.TimeSaved
+		}
 	}
 
 	return syncCacheState

--- a/cli/internal/cache/cache_fs.go
+++ b/cli/internal/cache/cache_fs.go
@@ -33,7 +33,7 @@ func newFsCache(opts Opts, recorder analytics.Recorder, repoRoot turbopath.Absol
 }
 
 // Fetch returns true if items are cached. It moves them into position as a side effect.
-func (f *fsCache) Fetch(anchor turbopath.AbsoluteSystemPath, hash string, _ []string) (ItemStatus, []turbopath.AnchoredSystemPath, int, error) {
+func (f *fsCache) Fetch(anchor turbopath.AbsoluteSystemPath, hash string, _ []string) (ItemStatus, []turbopath.AnchoredSystemPath, error) {
 	uncompressedCachePath := f.cacheDirectory.UntypedJoin(hash + ".tar")
 	compressedCachePath := f.cacheDirectory.UntypedJoin(hash + ".tar.zst")
 
@@ -45,44 +45,44 @@ func (f *fsCache) Fetch(anchor turbopath.AbsoluteSystemPath, hash string, _ []st
 	} else {
 		// It's not in the cache, bail now
 		f.logFetch(false, hash, 0)
-		return ItemStatus{Local: false}, nil, 0, nil
+		return NewFSTaskCacheStatus(false, 0), nil, nil
 	}
 
 	cacheItem, openErr := cacheitem.Open(actualCachePath)
 	if openErr != nil {
-		return ItemStatus{Local: false}, nil, 0, openErr
+		return NewFSTaskCacheStatus(false, 0), nil, openErr
 	}
 
 	restoredFiles, restoreErr := cacheItem.Restore(anchor)
 	if restoreErr != nil {
 		_ = cacheItem.Close()
-		return ItemStatus{Local: false}, nil, 0, restoreErr
+		return NewFSTaskCacheStatus(false, 0), nil, restoreErr
 	}
 
 	meta, err := ReadCacheMetaFile(f.cacheDirectory.UntypedJoin(hash + "-meta.json"))
 	if err != nil {
 		_ = cacheItem.Close()
-		return ItemStatus{Local: false}, nil, 0, fmt.Errorf("error reading cache metadata: %w", err)
+		return NewFSTaskCacheStatus(false, 0), nil, fmt.Errorf("error reading cache metadata: %w", err)
 	}
 	f.logFetch(true, hash, meta.Duration)
 
 	// Wait to see what happens with close.
 	closeErr := cacheItem.Close()
 	if closeErr != nil {
-		return ItemStatus{Local: false}, restoredFiles, 0, closeErr
+		return NewFSTaskCacheStatus(false, 0), restoredFiles, closeErr
 	}
-	return ItemStatus{Local: true}, restoredFiles, meta.Duration, nil
+	return NewFSTaskCacheStatus(true, meta.Duration), restoredFiles, nil
 }
 
 func (f *fsCache) Exists(hash string) ItemStatus {
 	uncompressedCachePath := f.cacheDirectory.UntypedJoin(hash + ".tar")
 	compressedCachePath := f.cacheDirectory.UntypedJoin(hash + ".tar.zst")
 
+	// TODO: include timeSaved metric here
 	if compressedCachePath.FileExists() || uncompressedCachePath.FileExists() {
-		return ItemStatus{Local: true}
+		return NewFSTaskCacheStatus(true, 0)
 	}
-
-	return ItemStatus{Local: false}
+	return NewFSTaskCacheStatus(false, 0)
 }
 
 func (f *fsCache) logFetch(hit bool, hash string, duration int) {

--- a/cli/internal/cache/cache_fs_test.go
+++ b/cli/internal/cache/cache_fs_test.go
@@ -216,9 +216,9 @@ func TestFetch(t *testing.T) {
 
 	outputDir := turbopath.AbsoluteSystemPath(t.TempDir())
 	dstOutputPath := "some-package"
-	cacheStatus, files, _, err := cache.Fetch(outputDir, "the-hash", []string{})
+	cacheStatus, files, err := cache.Fetch(outputDir, "the-hash", []string{})
 	assert.NilError(t, err, "Fetch")
-	hit := cacheStatus.Local || cacheStatus.Remote
+	hit := cacheStatus.Hit
 	if !hit {
 		t.Error("Fetch got false, want true")
 	}

--- a/cli/internal/cache/cache_http_test.go
+++ b/cli/internal/cache/cache_http_test.go
@@ -59,7 +59,7 @@ func TestRemoteCachingDisabled(t *testing.T) {
 		requestLimiter: make(limiter, 20),
 	}
 	cd := &util.CacheDisabledError{}
-	_, _, _, err := cache.Fetch("unused-target", "some-hash", []string{"unused", "outputs"})
+	_, _, err := cache.Fetch("unused-target", "some-hash", []string{"unused", "outputs"})
 	if !errors.As(err, &cd) {
 		t.Errorf("cache.Fetch err got %v, want a CacheDisabled error", err)
 	}

--- a/cli/internal/cache/cache_noop.go
+++ b/cli/internal/cache/cache_noop.go
@@ -11,11 +11,12 @@ func newNoopCache() *noopCache {
 func (c *noopCache) Put(_ turbopath.AbsoluteSystemPath, _ string, _ int, _ []turbopath.AnchoredSystemPath) error {
 	return nil
 }
-func (c *noopCache) Fetch(_ turbopath.AbsoluteSystemPath, _ string, _ []string) (ItemStatus, []turbopath.AnchoredSystemPath, int, error) {
-	return ItemStatus{Local: false, Remote: false}, nil, 0, nil
+func (c *noopCache) Fetch(_ turbopath.AbsoluteSystemPath, _ string, _ []string) (ItemStatus, []turbopath.AnchoredSystemPath, error) {
+	return ItemStatus{Source: "Noop", Hit: false, TimeSaved: 0}, nil, nil
 }
+
 func (c *noopCache) Exists(_ string) ItemStatus {
-	return ItemStatus{}
+	return ItemStatus{Source: CacheSourceNone, Hit: false, TimeSaved: 0}
 }
 
 func (c *noopCache) Clean(_ turbopath.AbsoluteSystemPath) {}

--- a/cli/internal/cache/cache_test.go
+++ b/cli/internal/cache/cache_test.go
@@ -17,16 +17,16 @@ type testCache struct {
 	entries     map[string][]turbopath.AnchoredSystemPath
 }
 
-func (tc *testCache) Fetch(_ turbopath.AbsoluteSystemPath, hash string, _ []string) (ItemStatus, []turbopath.AnchoredSystemPath, int, error) {
+func (tc *testCache) Fetch(_ turbopath.AbsoluteSystemPath, hash string, _ []string) (ItemStatus, []turbopath.AnchoredSystemPath, error) {
 	if tc.disabledErr != nil {
-		return ItemStatus{}, nil, 0, tc.disabledErr
+		return ItemStatus{}, nil, tc.disabledErr
 	}
 	foundFiles, ok := tc.entries[hash]
 	if ok {
 		duration := 5
-		return ItemStatus{Local: true}, foundFiles, duration, nil
+		return NewFSTaskCacheStatus(true, duration), foundFiles, nil
 	}
-	return ItemStatus{}, nil, 0, nil
+	return NewCacheMiss(), nil, nil
 }
 
 func (tc *testCache) Exists(hash string) ItemStatus {
@@ -35,7 +35,7 @@ func (tc *testCache) Exists(hash string) ItemStatus {
 	}
 	_, ok := tc.entries[hash]
 	if ok {
-		return ItemStatus{Local: true}
+		return NewFSTaskCacheStatus(true, 0)
 	}
 	return ItemStatus{}
 }
@@ -106,11 +106,11 @@ func TestPutCachingDisabled(t *testing.T) {
 	mplex.mu.RUnlock()
 
 	// subsequent Fetch should still work
-	cacheStatus, _, _, err := mplex.Fetch("unused-target", "some-hash", []string{"unused", "files"})
+	cacheStatus, _, err := mplex.Fetch("unused-target", "some-hash", []string{"unused", "files"})
 	if err != nil {
 		t.Errorf("got error fetching files: %v", err)
 	}
-	hit := cacheStatus.Local || cacheStatus.Remote
+	hit := cacheStatus.Hit
 	if !hit {
 		t.Error("failed to find previously stored files")
 	}
@@ -131,7 +131,7 @@ func TestExists(t *testing.T) {
 	}
 
 	itemStatus := mplex.Exists("some-hash")
-	if itemStatus.Local {
+	if itemStatus.Hit {
 		t.Error("did not expect file to exist")
 	}
 
@@ -142,7 +142,7 @@ func TestExists(t *testing.T) {
 	}
 
 	itemStatus = mplex.Exists("some-hash")
-	if !itemStatus.Local {
+	if !itemStatus.Hit {
 		t.Error("failed to find previously stored files")
 	}
 }
@@ -186,12 +186,12 @@ func TestFetchCachingDisabled(t *testing.T) {
 		},
 	}
 
-	cacheStatus, _, _, err := mplex.Fetch("unused-target", "some-hash", []string{"unused", "files"})
+	cacheStatus, _, err := mplex.Fetch("unused-target", "some-hash", []string{"unused", "files"})
 	if err != nil {
 		// don't leak the cache removal
 		t.Errorf("Fetch got error %v, want <nil>", err)
 	}
-	hit := cacheStatus.Local || cacheStatus.Remote
+	hit := cacheStatus.Hit
 	if hit {
 		t.Error("hit on empty cache, expected miss")
 	}

--- a/cli/internal/run/real_run.go
+++ b/cli/internal/run/real_run.go
@@ -262,19 +262,19 @@ func (ec *execContext) exec(ctx gocontext.Context, packageTask *nodes.PackageTas
 		WarnPrefix:   prettyPrefix,
 	}
 
-	cacheStatus, timeSaved, err := taskCache.RestoreOutputs(ctx, prefixedUI, progressLogger)
+	cacheStatus, err := taskCache.RestoreOutputs(ctx, prefixedUI, progressLogger)
 
 	// It's safe to set the CacheStatus even if there's an error, because if there's
 	// an error, the 0 values are actually what we want. We save cacheStatus and timeSaved
 	// for the task, so that even if there's an error, we have those values for the taskSummary.
 	ec.taskHashTracker.SetCacheStatus(
 		packageTask.TaskID,
-		runsummary.NewTaskCacheSummary(cacheStatus, &timeSaved),
+		runsummary.NewTaskCacheSummary(cacheStatus, &cacheStatus.TimeSaved),
 	)
 
 	if err != nil {
 		prefixedUI.Error(fmt.Sprintf("error fetching from cache: %s", err))
-	} else if cacheStatus.Local || cacheStatus.Remote { // If there was a cache hit
+	} else if cacheStatus.Hit { // If there was a cache hit
 		ec.taskHashTracker.SetExpandedOutputs(packageTask.TaskID, taskCache.ExpandedOutputs)
 		// We only cache successful executions, so we can assume this is a successExitCode exit.
 		tracer(runsummary.TargetCached, nil, &successExitCode)

--- a/cli/internal/runsummary/task_summary.go
+++ b/cli/internal/runsummary/task_summary.go
@@ -25,21 +25,17 @@ type TaskCacheSummary struct {
 // from upstream, but that is a more invasive change.
 func NewTaskCacheSummary(itemStatus cache.ItemStatus, timeSaved *int) TaskCacheSummary {
 	status := cache.CacheEventMiss
-	if itemStatus.Local || itemStatus.Remote {
+	if itemStatus.Hit {
 		status = cache.CacheEventHit
 	}
-
 	var source string
-	if itemStatus.Local {
-		source = cache.CacheSourceFS
-	} else if itemStatus.Remote {
-		source = cache.CacheSourceRemote
+	if itemStatus.Hit {
+		source = itemStatus.Source
 	}
-
 	cs := TaskCacheSummary{
 		// copy these over
-		Local:  itemStatus.Local,
-		Remote: itemStatus.Remote,
+		Local:  itemStatus.Hit && itemStatus.Source == cache.CacheSourceFS,
+		Remote: itemStatus.Hit && itemStatus.Source == cache.CacheSourceRemote,
 		Status: status,
 		Source: source,
 	}


### PR DESCRIPTION
This is a pre-requisite to #4952. Things to test:

- [ ] cache hit from fs works (integration tests should cover this)
- [ ] remote cache hit works
- [ ] both misses work
- [ ] daemon skip cache check works
- [ ] hits from local _and_ remote works
- [ ] hit from remote populates local cache
- [ ] hit from local populates remote cache