### PR TITLE
feat(ecmascript-plugins): support swc ecmatransform plugins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -662,9 +662,9 @@ dependencies = [
 
 [[package]]
 name = "binding_macros"
-version = "0.50.15"
+version = "0.50.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c27b5a99b81edf924c402afc315a4d7e1484c5fe754b951c6c60e7251a461f"
+checksum = "42a268ad04979a5280103ae7eb7a1c758c6ad4d9abda0585e68e8608ad65f88a"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -6512,9 +6512,9 @@ dependencies = [
 
 [[package]]
 name = "swc"
-version = "0.261.15"
+version = "0.261.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9a91c1ba8d37fd7a40e3302fa139db401ec8d56db03bddddd02cd9f68d2f8e4"
+checksum = "837e438498c6d3657bf77bb4dbbf2fd2089b7bcd2e2e7c49e5a76b4ff67a4dde"
 dependencies = [
  "ahash 0.7.6",
  "anyhow",
@@ -6591,9 +6591,9 @@ dependencies = [
 
 [[package]]
 name = "swc_bundler"
-version = "0.214.12"
+version = "0.214.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7ea395e617a3cd3d5e8e7b641e78f3b0ed3a20fadad3ccaff8362bc6cbea485"
+checksum = "5925d482bad78a946f37fa424b017b9534b08d9d4703de4ac570707ad26e5033"
 dependencies = [
  "ahash 0.7.6",
  "anyhow",
@@ -6697,9 +6697,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "0.76.18"
+version = "0.76.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaca8a6b6843b9620d97fdec71b6da2abc0a73fa54032586774d49e1665310e7"
+checksum = "d5cff14350b6c64ca2316b0f57de6087ad783b8dde541dd316263d86d0bd74b1"
 dependencies = [
  "binding_macros",
  "swc",
@@ -6928,9 +6928,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ext_transforms"
-version = "0.103.6"
+version = "0.103.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f769d6fdaafa1315ade648571d5d12f37af8552f7c3eb872c19c93fff7790d"
+checksum = "e4cf36abbe8cf5c92adc3e4e1fd7acf73234da08bab47eb7f408b0daeaa78789"
 dependencies = [
  "phf",
  "swc_atoms",
@@ -6942,9 +6942,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_lints"
-version = "0.82.8"
+version = "0.82.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bc4db70121f00b2dee7b026fa03f992affe6150eaf55c542e098cf7132d2a45"
+checksum = "eebefb9932b2c8fe4d60bfe201fa93e3957d0a844c4fa1dd38c0248475650b82"
 dependencies = [
  "ahash 0.7.6",
  "auto_impl",
@@ -6985,9 +6985,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "0.181.12"
+version = "0.181.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ff198c926730e87cbbb170a24002b931f72f77dd04642955881b40c5b692007"
+checksum = "e3f1afb839cccb3ea1d7c7d7f31d2bad7c7be8a6f1d493a181f2a77b5b90ee11"
 dependencies = [
  "ahash 0.7.6",
  "arrayvec 0.7.2",
@@ -7041,9 +7041,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "0.195.10"
+version = "0.195.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98afe07cbf07d1446ddc910b7ee434b8212d4ce202b08381c76ff6315b2b78e"
+checksum = "ebd8a251aa5a6d7762394f8cba9e71becd7c520419a69ef107fde1c8cecc0379"
 dependencies = [
  "ahash 0.7.6",
  "anyhow",
@@ -7096,9 +7096,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.218.10"
+version = "0.218.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e692b321f71a01a4b199fe69a76cd68bc3d49f8207e9aa9eb1cb8593945e587e"
+checksum = "b457414690eec14cc52ed4e93175953220ed762f4a18d4295012fe802490052b"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -7116,9 +7116,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.127.8"
+version = "0.127.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25fe955e33c6c6018b53f486c1999bb13244a227b441b8c7d714992eafdf0fd6"
+checksum = "997d916576f0f318503211c31145188e0d1cd428a7a35f051b4e30fff19e66bb"
 dependencies = [
  "better_scoped_tls",
  "bitflags 2.2.1",
@@ -7140,9 +7140,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "0.116.8"
+version = "0.116.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afcd87153f6b5b418feb33079ad561ccfa78f26e1592f3a36fe7aea66696b648"
+checksum = "ec46f14f1f1514ca93abe61c072763661474eaecc1a622e7e6c84814e7d4a6ec"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -7154,9 +7154,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "0.153.9"
+version = "0.153.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb1edb6a1ad970920fc5789f131411dd3d6ff16bd3feb974ccfccf3e26d4b96d"
+checksum = "3396ae7196b54f1eff615e4f7650bac35bdc84e39c2f87da4d7e54b355bb5f63"
 dependencies = [
  "ahash 0.7.6",
  "arrayvec 0.7.2",
@@ -7194,9 +7194,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "0.170.9"
+version = "0.170.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98e1c2d7321cd630ddcc0a1d326a6dfb37287aca2682fdd6197a870e91095348"
+checksum = "6816d6fa7fbb88f5ecec51b974d910f973073e6822a6326a3a1907eaaa2f130a"
 dependencies = [
  "Inflector",
  "ahash 0.7.6",
@@ -7222,9 +7222,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.187.10"
+version = "0.187.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a82d7afd6839202d7d06c7d7c42a19502493684c7d43173693a68315a4e9aa"
+checksum = "7fade0baf4655e71c23a8a2251b7c5902c21b241e737286f1e33a78ae16c08ea"
 dependencies = [
  "ahash 0.7.6",
  "dashmap",
@@ -7248,9 +7248,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "0.161.10"
+version = "0.161.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d20b22d617ae6613638fd4d7a94c37c41e35dfdbaba1e4c18387e152d0d4cbf"
+checksum = "77578b8af3667caf8349c6e412dfb25b082c546225a9a99411fad05aecaa22ec"
 dependencies = [
  "either",
  "rustc-hash",
@@ -7268,9 +7268,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.173.9"
+version = "0.173.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dc7c0ab3fb3fc48be623bde91f18c3f2406d3a233c330d2a4157b371a6bdb11"
+checksum = "40828707190f85857c1cd0a2552a37837a1a9dc3cb4e40cd7e23d68370fbc7dd"
 dependencies = [
  "ahash 0.7.6",
  "base64 0.13.1",
@@ -7294,9 +7294,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_testing"
-version = "0.130.8"
+version = "0.130.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41c5fec1a5689f77ec257dbdf25a8a2e2c46a83cc7c46bd7670ba4916deff240"
+checksum = "f109b3cf69dc0894fb5aa2fe7440bc223fa042392778f31e091805591482e908"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -7320,9 +7320,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.177.10"
+version = "0.177.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c85de2a852057c85185dc6742431b137168f0e812c2b03e341db09d1ee15cf0"
+checksum = "970fb50a864f84c94710028e3da42510608c38d60fec7685b1c1ff5983b33561"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -7336,9 +7336,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_usage_analyzer"
-version = "0.13.7"
+version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46de8c285adae9e6a46d3f060a41ba5800d2c1fc03cf135e363234f5b18b0f54"
+checksum = "1c8f1434a74613b325c3450f530ed34786a1b4f55473ebc768eba1dd05f08e1e"
 dependencies = [
  "ahash 0.7.6",
  "indexmap",
@@ -7354,9 +7354,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.117.6"
+version = "0.117.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c5a1682c0791004b1d49acb877320f8a87930525d7ca7e93bf6f606a742fb48"
+checksum = "2b4d78807adf9902eb7fe66663bd831d153e69c251fd5b263573017ac6fb5e80"
 dependencies = [
  "indexmap",
  "num_cpus",
@@ -9098,6 +9098,7 @@ dependencies = [
  "indexmap",
  "modularize_imports",
  "serde",
+ "serde_json",
  "styled_components",
  "styled_jsx",
  "swc_core",
@@ -9106,6 +9107,7 @@ dependencies = [
  "turbo-tasks",
  "turbo-tasks-build",
  "turbo-tasks-fs",
+ "turbopack-core",
  "turbopack-ecmascript",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ mdxjs = { version = "0.1.12" }
 modularize_imports = { version = "0.30.0" }
 styled_components = { version = "0.57.0" }
 styled_jsx = { version = "0.34.0" }
-swc_core = { version = "0.76.18" }
+swc_core = { version = "0.76.21" }
 swc_emotion = { version = "0.33.0" }
 swc_relay = { version = "0.5.0" }
 testing = { version = "0.33.11" }

--- a/crates/turbopack-binding/Cargo.toml
+++ b/crates/turbopack-binding/Cargo.toml
@@ -51,7 +51,10 @@ __swc_core_binding_napi = [
   "swc_core/ecma_utils",
   "swc_core/ecma_visit",
 ]
-__swc_core_binding_napi_plugin = ["swc_core/plugin_transform_host_native"]
+__swc_core_binding_napi_plugin = [
+  "swc_core/plugin_transform_host_native",
+  "turbopack-ecmascript-plugins/swc_ecma_transform_plugin",
+]
 __swc_core_binding_napi_allocator = ["swc_core/allocator_node"]
 
 __swc_core_binding_wasm = [

--- a/crates/turbopack-ecmascript-plugins/Cargo.toml
+++ b/crates/turbopack-ecmascript-plugins/Cargo.toml
@@ -11,15 +11,19 @@ bench = false
 
 [features]
 transform_emotion = []
+# [NOTE]: Be careful to explicitly enable this only for the supported platform / targets.
+swc_ecma_transform_plugin = ["swc_core/plugin_transform_host_native"]
 
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 indexmap = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 
 turbo-tasks = { workspace = true }
 turbo-tasks-fs = { workspace = true }
+turbopack-core = { workspace = true }
 turbopack-ecmascript = { workspace = true }
 
 modularize_imports = { workspace = true }

--- a/crates/turbopack-ecmascript-plugins/src/transform/mod.rs
+++ b/crates/turbopack-ecmascript-plugins/src/transform/mod.rs
@@ -4,3 +4,4 @@ pub mod modularize_imports;
 pub mod relay;
 pub mod styled_components;
 pub mod styled_jsx;
+pub mod swc_ecma_transform_plugins;

--- a/crates/turbopack-ecmascript-plugins/src/transform/swc_ecma_transform_plugins.rs
+++ b/crates/turbopack-ecmascript-plugins/src/transform/swc_ecma_transform_plugins.rs
@@ -1,0 +1,193 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use swc_core::ecma::ast::Program;
+use turbo_tasks::primitives::StringVc;
+use turbo_tasks_fs::FileSystemPathVc;
+use turbopack_core::issue::{Issue, IssueSeverity, IssueSeverityVc, IssueVc};
+use turbopack_ecmascript::{CustomTransformer, TransformContext};
+
+#[turbo_tasks::value(transparent)]
+pub struct PluginModule(
+    #[turbo_tasks(trace_ignore)]
+    #[cfg(feature = "swc_ecma_transform_plugin")]
+    pub swc_core::plugin_runner::plugin_module_bytes::CompiledPluginModuleBytes,
+    // Dummy field to avoid turbo_tasks macro complains about empty struct.
+    // This is due to we can't import CompiledPluginModuleBytes by default, it should be only
+    // available for the target / platforms can support swc plugins (which can build wasmer)
+    #[cfg(not(feature = "swc_ecma_transform_plugin"))] pub Option<()>,
+);
+
+#[turbo_tasks::value(shared)]
+struct UnsupportedSwcEcmaTransformPluginsIssue {
+    pub context: FileSystemPathVc,
+}
+
+#[turbo_tasks::value_impl]
+impl Issue for UnsupportedSwcEcmaTransformPluginsIssue {
+    #[turbo_tasks::function]
+    fn severity(&self) -> IssueSeverityVc {
+        IssueSeverity::Warning.into()
+    }
+
+    #[turbo_tasks::function]
+    fn category(&self) -> StringVc {
+        StringVc::cell("transform".to_string())
+    }
+
+    #[turbo_tasks::function]
+    async fn title(&self) -> Result<StringVc> {
+        Ok(StringVc::cell(format!(
+            "Unsupported SWC Ecma transform plugins on this platform."
+        )))
+    }
+
+    #[turbo_tasks::function]
+    fn context(&self) -> FileSystemPathVc {
+        self.context
+    }
+
+    #[turbo_tasks::function]
+    fn description(&self) -> StringVc {
+        StringVc::cell(
+            "Turbopack does not yet support running SWC ecma transform plugins on this platform."
+                .to_string(),
+        )
+    }
+}
+
+#[derive(Debug)]
+pub struct SwcEcmaTransformPluginsTransformer {
+    #[cfg(feature = "swc_ecma_transform_plugin")]
+    plugins: Vec<(PluginModuleVc, serde_json::Value)>,
+}
+
+impl SwcEcmaTransformPluginsTransformer {
+    #[cfg(feature = "swc_ecma_transform_plugin")]
+    pub fn new(plugins: Vec<(PluginModuleVc, serde_json::Value)>) -> Self {
+        Self { plugins }
+    }
+
+    #[cfg(not(feature = "swc_ecma_transform_plugin"))]
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+#[async_trait]
+impl CustomTransformer for SwcEcmaTransformPluginsTransformer {
+    #[cfg_attr(not(feature = "swc_ecma_transform_plugin"), allow(unused))]
+    async fn transform(&self, program: &mut Program, ctx: &TransformContext<'_>) -> Result<()> {
+        #[cfg(feature = "swc_ecma_transform_plugin")]
+        {
+            use std::{cell::RefCell, rc::Rc, sync::Arc};
+
+            use swc_core::{
+                common::{
+                    comments::SingleThreadedComments,
+                    plugin::{
+                        metadata::TransformPluginMetadataContext, serialized::PluginSerializedBytes,
+                    },
+                    util::take::Take,
+                },
+                ecma::ast::Module,
+                plugin::proxies::{HostCommentsStorage, COMMENTS},
+                plugin_runner::plugin_module_bytes::PluginModuleBytes,
+            };
+
+            let mut plugins = vec![];
+            for (plugin_module, config) in &self.plugins {
+                let plugin_module = &plugin_module.await?.0;
+
+                plugins.push((
+                    plugin_module.get_module_name().to_string(),
+                    config.clone(),
+                    Box::new(plugin_module.clone()),
+                ));
+            }
+
+            let should_enable_comments_proxy =
+                !ctx.comments.leading.is_empty() && !ctx.comments.trailing.is_empty();
+
+            //[TODO]: as same as swc/core does, we should set should_enable_comments_proxy
+            // depends on the src's comments availability. For now, check naively if leading
+            // / trailing comments are empty.
+            let comments = if should_enable_comments_proxy {
+                // Plugin only able to accept singlethreaded comments, interop from
+                // multithreaded comments.
+                let mut leading =
+                    swc_core::common::comments::SingleThreadedCommentsMapInner::default();
+                ctx.comments.leading.as_ref().into_iter().for_each(|c| {
+                    leading.insert(c.key().clone(), c.value().clone());
+                });
+
+                let mut trailing =
+                    swc_core::common::comments::SingleThreadedCommentsMapInner::default();
+                ctx.comments.trailing.as_ref().into_iter().for_each(|c| {
+                    trailing.insert(c.key().clone(), c.value().clone());
+                });
+
+                Some(SingleThreadedComments::from_leading_and_trailing(
+                    Rc::new(RefCell::new(leading)),
+                    Rc::new(RefCell::new(trailing)),
+                ))
+            } else {
+                None
+            };
+
+            let transformed_program =
+                COMMENTS.set(&HostCommentsStorage { inner: comments }, || {
+                    let module_program =
+                        std::mem::replace(program, Program::Module(Module::dummy()));
+                    let module_program =
+                        swc_core::common::plugin::serialized::VersionedSerializable::new(
+                            module_program,
+                        );
+                    let mut serialized_program =
+                        PluginSerializedBytes::try_serialize(&module_program)?;
+
+                    let transform_metadata_context = Arc::new(TransformPluginMetadataContext::new(
+                        Some(ctx.file_name_str.to_string()),
+                        //[TODO]: Support env-related variable injection, i.e process.env.NODE_ENV
+                        "development".to_string(),
+                        None,
+                    ));
+
+                    // Run plugin transformation against current program.
+                    // We do not serialize / deserialize between each plugin execution but
+                    // copies raw transformed bytes directly into plugin's memory space.
+                    // Note: This doesn't mean plugin won't perform any se/deserialization: it
+                    // still have to construct from raw bytes internally to perform actual
+                    // transform.
+                    for (_plugin_name, plugin_config, plugin_module) in plugins.drain(..) {
+                        let mut transform_plugin_executor =
+                            swc_core::plugin_runner::create_plugin_transform_executor(
+                                &ctx.source_map,
+                                &ctx.unresolved_mark,
+                                &transform_metadata_context,
+                                plugin_module,
+                                Some(plugin_config),
+                            );
+
+                        serialized_program = transform_plugin_executor
+                            .transform(&serialized_program, Some(should_enable_comments_proxy))?;
+                    }
+
+                    serialized_program.deserialize().map(|v| v.into_inner())
+                })?;
+
+            *program = transformed_program;
+        }
+
+        #[cfg(not(feature = "swc_ecma_transform_plugin"))]
+        {
+            let issue: UnsupportedSwcEcmaTransformPluginsIssueVc =
+                UnsupportedSwcEcmaTransformPluginsIssue {
+                    context: ctx.file_path,
+                }
+                .into();
+            issue.as_issue().emit();
+        }
+
+        Ok(())
+    }
+}

--- a/crates/turbopack-ecmascript-plugins/src/transform/swc_ecma_transform_plugins.rs
+++ b/crates/turbopack-ecmascript-plugins/src/transform/swc_ecma_transform_plugins.rs
@@ -22,9 +22,9 @@ pub struct SwcPluginModule(
     #[turbo_tasks(trace_ignore)]
     #[cfg(feature = "swc_ecma_transform_plugin")]
     pub swc_core::plugin_runner::plugin_module_bytes::CompiledPluginModuleBytes,
-    // Dummy field to avoid turbo_tasks macro complains about empty struct.
-    // This is due to we can't import CompiledPluginModuleBytes by default, it should be only
-    // available for the target / platforms can support swc plugins (which can build wasmer)
+    // Dummy field to avoid turbo_tasks macro complaining about empty struct.
+    // This is because we can't import CompiledPluginModuleBytes by default, it should be only
+    // available for the target / platforms that support swc plugins (which can build wasmer)
     #[cfg(not(feature = "swc_ecma_transform_plugin"))] pub (),
 );
 

--- a/crates/turbopack-ecmascript-plugins/src/transform/swc_ecma_transform_plugins.rs
+++ b/crates/turbopack-ecmascript-plugins/src/transform/swc_ecma_transform_plugins.rs
@@ -6,8 +6,8 @@ use turbo_tasks_fs::FileSystemPathVc;
 use turbopack_core::issue::{Issue, IssueSeverity, IssueSeverityVc, IssueVc};
 use turbopack_ecmascript::{CustomTransformer, TransformContext};
 
-/// A wrapper around a SWC's ecma transform wasm plugin module bytes, allowing
-/// it to operate with the turbo_task caching requirements.
+/// A wrapper around an SWC's ecma transform wasm plugin module bytes, allowing
+/// it to operate with the turbo_tasks caching requirements.
 /// Internally this contains a `CompiledPluginModuleBytes`, which points to the
 /// compiled, serialized wasmer::Module instead of raw file bytes to reduce the
 /// cost of the compilation.

--- a/crates/turbopack-ecmascript-plugins/src/transform/swc_ecma_transform_plugins.rs
+++ b/crates/turbopack-ecmascript-plugins/src/transform/swc_ecma_transform_plugins.rs
@@ -79,12 +79,14 @@ impl Issue for UnsupportedSwcEcmaTransformPluginsIssue {
     #[turbo_tasks::function]
     fn description(&self) -> StringVc {
         StringVc::cell(
-            "Turbopack does not yet support running SWC ecma transform plugins on this platform."
+            "Turbopack does not yet support running SWC EcmaScript transform plugins on this \
+             platform."
                 .to_string(),
         )
     }
 }
 
+/// A custom transformer plugin to execute SWC's transform plugins.
 #[derive(Debug)]
 pub struct SwcEcmaTransformPluginsTransformer {
     #[cfg(feature = "swc_ecma_transform_plugin")]
@@ -97,6 +99,8 @@ impl SwcEcmaTransformPluginsTransformer {
         Self { plugins }
     }
 
+    // [TODO] Due to WEB-1102 putting this module itself behind compile time feature
+    // doesn't work. Instead allow to instantiate dummy instance.
     #[cfg(not(feature = "swc_ecma_transform_plugin"))]
     pub fn new() -> Self {
         Self {}

--- a/crates/turbopack-ecmascript-plugins/src/transform/swc_ecma_transform_plugins.rs
+++ b/crates/turbopack-ecmascript-plugins/src/transform/swc_ecma_transform_plugins.rs
@@ -67,7 +67,7 @@ impl Issue for UnsupportedSwcEcmaTransformPluginsIssue {
     #[turbo_tasks::function]
     async fn title(&self) -> Result<StringVc> {
         Ok(StringVc::cell(format!(
-            "Unsupported SWC Ecma transform plugins on this platform."
+            "Unsupported SWC EcmaScript transform plugins on this platform."
         )))
     }
 


### PR DESCRIPTION
### Description

Part 1 for WEB-998.

This PR implements a new turbopack-ecmascript plugin for the swc's ecmatransform plugin. New transform `SwcEcmaTransformPluginsTransformer` accepts array of plugin module contains `CompiledPluginModuleBytes` from swc's wasm plugin then executes it. It doesn't utilize SWC's internal cache mechanism to keep compiled / serialized wasm module (`wasmer::Module`), instead expect turbopack manages it. For those reason, we only accepts `CompiledPluginModuleBytes` from swc as it is a serialized copy does not requires re-compilation, while swc have few other different representation to the module bytes.

It is exposed as a separate feature instead of being default: there are some of platforms / targets we can't support plugins yet, and making it default will makes `next-swc` to fail to build.