### PR TITLE
fix(create-turbo): git init must use add

### DIFF
--- a/packages/create-turbo/__tests__/git.test.ts
+++ b/packages/create-turbo/__tests__/git.test.ts
@@ -140,6 +140,7 @@ describe("git", () => {
       const calls = [
         "git init",
         "git checkout -b main",
+        "git add -A",
         'git commit --author="Turbobot <turbobot@vercel.com>" -am "test commit"',
       ];
       expect(mockExecSync).toHaveBeenCalledTimes(calls.length + 2);
@@ -227,9 +228,9 @@ describe("git", () => {
       expect(result).toBe(false);
 
       const calls = [
+        "git rev-parse --is-inside-work-tree",
+        "hg --cwd . root",
         "git init",
-        "git checkout -b main",
-        'git commit --author="Turbobot <turbobot@vercel.com>" -am "test commit"',
       ];
 
       expect(mockExecSync).toHaveBeenCalledTimes(calls.length + 2);

--- a/packages/create-turbo/src/utils/git.ts
+++ b/packages/create-turbo/src/utils/git.ts
@@ -56,6 +56,8 @@ export function tryGitInit(root: string, message: string): boolean {
     }
 
     execSync("git init", { stdio: "ignore" });
+    execSync("git add -A", { stdio: "ignore" });
+
     didInit = true;
 
     execSync("git checkout -b main", { stdio: "ignore" });


### PR DESCRIPTION
### Description

Git logic was changed as part of https://github.com/vercel/turbo/pull/4941 to hardcode the author, as a side effect of this change, git init now fails. The repo must be initialized explicitly using `add`:

The error message from init is shown below:

```
git commit --author="Turbobot <turbobot@vercel.com>" -am "feat(create-turbo): create basic"
On branch main

Initial commit

Untracked files:
  (use "git add <file>..." to include in what will be committed)
	.eslintrc.js
	.gitignore
	.npmrc
	README.md
	apps/
	package.json
	packages/
	pnpm-lock.yaml
	pnpm-workspace.yaml
	turbo.json

nothing added to commit but untracked files present (use "git add" to track)
```

### Testing Instructions

1. Create a repo with `npx create-turbo@latest` - there will be no git repo because init failed. 
