### PR TITLE
fix(create-turbo): default example messaging

### DIFF
--- a/packages/turbo-utils/src/createProject.ts
+++ b/packages/turbo-utils/src/createProject.ts
@@ -139,7 +139,7 @@ export async function createProject({
    */
   const loader = turboLoader("Downloading files...");
   try {
-    if (repoInfo) {
+    if (!isDefaultExample && repoInfo) {
       console.log(
         `\nDownloading files from repo ${chalk.cyan(
           example


### PR DESCRIPTION
### Description

We hardcoded the repo info for the basic example as part of https://github.com/vercel/turbo/pull/4974, but forgot there is some logic downstream that depends on repo info only being populated if the full URL is provided, and switches the messaging depending on this. Because of this, just starting from the default example shows:

`Downloading files from repo basic. This might take a moment.`

Which is confusing, and should instead just display: 

`Downloading files. This might take a moment.`