### PR TITLE
fix(daemon): add short sleep to repo root removal

### DIFF
--- a/crates/turborepo-lib/src/globwatcher/mod.rs
+++ b/crates/turborepo-lib/src/globwatcher/mod.rs
@@ -689,7 +689,7 @@ mod test {
 
         // dropped when the test ends
         let task = tokio::task::spawn(async move { task_watcher.watch(token).await });
-
+        tokio::time::sleep(Duration::from_millis(500)).await;
         watcher.config.flush().await.unwrap();
         std::fs::remove_dir_all(dir.path()).unwrap();
 


### PR DESCRIPTION
### Description

Add a short delay to our repo root removal to ensure that we are watching the config flush directory before we attempt to flush it. This should be a super short lived hack

### Testing Instructions

CI
