### PR TITLE
fix(daemon): plumb through flush watch errors

### DIFF
--- a/crates/turborepo-globwatch/examples/cancel.rs
+++ b/crates/turborepo-globwatch/examples/cancel.rs
@@ -9,7 +9,7 @@ async fn main() {
     tracing_subscriber::fmt::init();
     let (watcher, config) = GlobWatcher::new("./flush".into()).unwrap();
     let stop = stop_token::StopSource::new();
-    let mut stream = watcher.into_stream(stop.token());
+    let mut stream = watcher.into_stream(stop.token()).await.unwrap();
 
     let watch_fut = async {
         let span = info_span!("watch_fut");

--- a/crates/turborepo-globwatch/examples/cancel.rs
+++ b/crates/turborepo-globwatch/examples/cancel.rs
@@ -9,7 +9,7 @@ async fn main() {
     tracing_subscriber::fmt::init();
     let (watcher, config) = GlobWatcher::new("./flush".into()).unwrap();
     let stop = stop_token::StopSource::new();
-    let mut stream = watcher.into_stream(stop.token()).await.unwrap();
+    let mut stream = watcher.into_stream(stop.token());
 
     let watch_fut = async {
         let span = info_span!("watch_fut");

--- a/crates/turborepo-lib/src/daemon/client.rs
+++ b/crates/turborepo-lib/src/daemon/client.rs
@@ -148,7 +148,7 @@ pub enum DaemonError {
     InvalidTimeout(String),
     /// The server is unable to start file watching.
     #[error("unable to start file watching")]
-    FileWatching(#[from] globwatch::Error),
+    FileWatching(#[from] notify::Error),
 
     #[error("unable to display output: {0}")]
     DisplayError(#[from] serde_json::Error),

--- a/crates/turborepo-lib/src/daemon/server.rs
+++ b/crates/turborepo-lib/src/daemon/server.rs
@@ -115,6 +115,7 @@ impl<T: Watcher + Send + 'static> DaemonServer<T> {
         let stop = StopSource::new();
         let watcher = self.watcher.clone();
         let watcher_fut = watcher.watch(stop.token());
+        tokio::pin!(watcher_fut);
 
         let timer = self.timeout.clone();
         let timeout_fut = timer.wait();
@@ -133,12 +134,12 @@ impl<T: Watcher + Send + 'static> DaemonServer<T> {
         };
 
         // when one of these futures complete, let the server gracefully shutdown
-        let mut shutdown_reason = Option::None;
-        let shutdown_fut = async {
-            shutdown_reason = select! {
-                _ = shutdown_fut => Some(CloseReason::Shutdown),
-                _ = timeout_fut => Some(CloseReason::Timeout),
-                _ = ctrl_c() => Some(CloseReason::Interrupt),
+        let (shutdown_tx, shutdown_reason) = oneshot::channel();
+        let shutdown_fut = async move {
+            select! {
+                _ = shutdown_fut => shutdown_tx.send(CloseReason::Shutdown).ok(),
+                _ = timeout_fut => shutdown_tx.send(CloseReason::Timeout).ok(),
+                _ = ctrl_c() => shutdown_tx.send(CloseReason::Interrupt).ok(),
             };
         };
 
@@ -184,23 +185,22 @@ impl<T: Watcher + Send + 'static> DaemonServer<T> {
                     .serve_with_incoming_shutdown(stream, shutdown_fut),
             )
         };
+        tokio::pin!(server_fut);
 
-        select! {
-            _ = server_fut => {
-                match shutdown_reason {
-                    Some(reason) => reason,
-                    None => CloseReason::ServerClosed,
-                }
-            },
-            watch_res = watcher_fut => {
-                match watch_res {
-                    Ok(()) => CloseReason::WatcherClosed,
-                    Err(e) => {
-                        error!("Globwatch config error: {:?}", e);
-                        CloseReason::WatcherClosed
-                    },
-                }
-            },
+        loop {
+            select! {
+                    _ = &mut server_fut => {
+                    return shutdown_reason.await.unwrap_or(CloseReason::ServerClosed);
+                },
+                watch_res = &mut watcher_fut => {
+                    match watch_res {
+                        Ok(()) => return CloseReason::WatcherClosed,
+                        Err(e) => {
+                            error!("Globwatch config error: {:?}", e);
+                        },
+                    }
+                },
+            }
         }
 
         // here the stop token is dropped, and the pid lock is dropped
@@ -286,7 +286,7 @@ impl<T: Watcher + Send + 'static> proto::turbod_server::Turbod for DaemonServer<
                 changed_output_globs: changed.into_iter().collect(),
             })),
             Err(e) => {
-                error!("failed to watch flush directory: {:?}", e);
+                error!("flush directory operation failed: {:?}", e);
                 Err(tonic::Status::internal("failed to watch flush directory"))
             }
         }

--- a/crates/turborepo-lib/src/globwatcher/mod.rs
+++ b/crates/turborepo-lib/src/globwatcher/mod.rs
@@ -75,13 +75,17 @@ impl<T: Watcher> HashGlobWatcher<T> {
                 .collect::<Vec<_>>()
         };
 
-        let mut stream = match self.watcher.lock().expect("only fails if poisoned").take() {
-            Some(watcher) => watcher.into_stream(token),
+        let watcher = self.watcher.lock().expect("only fails if poisoned").take();
+        let mut stream = match watcher {
+            Some(watcher) => watcher
+                .into_stream(token)
+                .await
+                .map_err(|err| ConfigError::WatchError(vec![err])),
             None => {
                 warn!("watcher already consumed");
-                return Err(ConfigError::WatchingAlready);
+                Err(ConfigError::WatchingAlready)
             }
-        };
+        }?;
 
         // watch the root of the repo to shut down if the folder is deleted
         self.config.include_path(&self.relative_to).await?;
@@ -146,7 +150,10 @@ impl<T: Watcher> HashGlobWatcher<T> {
         // this is a best effort, and times out after 500ms in
         // case there is a lot of activity on the filesystem
         match timeout(FLUSH_TIMEOUT, self.config.flush()).await {
-            Ok(_) => {}
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => {
+                return Err(e);
+            }
             Err(_) => {
                 trace!("timed out waiting for flush");
             }
@@ -223,7 +230,7 @@ impl<T: Watcher> HashGlobWatcher<T> {
         &self,
         hash: &Hash,
         mut candidates: HashSet<String>,
-    ) -> HashSet<String> {
+    ) -> Result<HashSet<String>, ConfigError> {
         // wait for a the watcher to flush its events
         // that will ensure that we have seen all filesystem writes
         // *by the calling client*. Other tasks _could_ write to the
@@ -233,7 +240,8 @@ impl<T: Watcher> HashGlobWatcher<T> {
         // this is a best effort, and times out after 500ms in
         // case there is a lot of activity on the filesystem
         match timeout(FLUSH_TIMEOUT, self.config.flush()).await {
-            Ok(_) => {}
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => return Err(e),
             Err(_) => {
                 trace!("timed out waiting for flush");
             }
@@ -243,13 +251,13 @@ impl<T: Watcher> HashGlobWatcher<T> {
         // if a hash is not in globs, then either everything has changed
         // or it was never registered. either way, we return all candidates
         let hash_globs = self.hash_globs.lock().expect("only fails if poisoned");
-        match hash_globs.get(hash) {
+        Ok(match hash_globs.get(hash) {
             Some(glob) => {
                 candidates.retain(|c| !glob.include.contains(c));
                 candidates
             }
             None => candidates,
-        }
+        })
     }
 }
 
@@ -412,7 +420,8 @@ mod test {
 
         let changed = watcher
             .changed_globs(&hash, include.clone().into_iter().collect())
-            .await;
+            .await
+            .unwrap();
 
         assert!(
             changed.is_empty(),
@@ -425,7 +434,8 @@ mod test {
         File::create(dir.path().join("my-pkg/irrelevant2")).unwrap();
         let changed = watcher
             .changed_globs(&hash, include.clone().into_iter().collect())
-            .await;
+            .await
+            .unwrap();
 
         assert!(
             changed.is_empty(),
@@ -438,7 +448,8 @@ mod test {
         File::create(dir.path().join("my-pkg/.next/cache/next-file2")).unwrap();
         let changed = watcher
             .changed_globs(&hash, include.clone().into_iter().collect())
-            .await;
+            .await
+            .unwrap();
 
         assert!(
             changed.is_empty(),
@@ -451,7 +462,8 @@ mod test {
         File::create(dir.path().join("my-pkg/dist/dist-file2")).unwrap();
         let changed = watcher
             .changed_globs(&hash, include.clone().into_iter().collect())
-            .await;
+            .await
+            .unwrap();
 
         assert_eq!(
             changed,
@@ -465,7 +477,8 @@ mod test {
         File::create(dir.path().join("my-pkg/.next/next-file2")).unwrap();
         let changed = watcher
             .changed_globs(&hash, include.clone().into_iter().collect())
-            .await;
+            .await
+            .unwrap();
 
         assert_eq!(
             changed,
@@ -533,7 +546,8 @@ mod test {
 
         let changed = watcher
             .changed_globs(&hash1, globs1_inclusion.clone().into_iter().collect())
-            .await;
+            .await
+            .unwrap();
 
         assert!(
             changed.is_empty(),
@@ -543,7 +557,8 @@ mod test {
 
         let changed = watcher
             .changed_globs(&hash2, globs2_inclusion.clone().into_iter().collect())
-            .await;
+            .await
+            .unwrap();
 
         assert!(
             changed.is_empty(),
@@ -556,7 +571,8 @@ mod test {
         File::create(dir.path().join("my-pkg/.next/cache/next-file2")).unwrap();
         let changed = watcher
             .changed_globs(&hash1, globs1_inclusion.clone().into_iter().collect())
-            .await;
+            .await
+            .unwrap();
 
         assert_eq!(
             changed,
@@ -566,7 +582,8 @@ mod test {
 
         let changed = watcher
             .changed_globs(&hash2, globs2_inclusion.clone().into_iter().collect())
-            .await;
+            .await
+            .unwrap();
 
         assert!(
             changed.is_empty(),
@@ -579,7 +596,8 @@ mod test {
         File::create(dir.path().join("my-pkg/.next/next-file2")).unwrap();
         let changed = watcher
             .changed_globs(&hash2, globs2_inclusion.clone().into_iter().collect())
-            .await;
+            .await
+            .unwrap();
 
         assert_eq!(
             changed,
@@ -638,7 +656,8 @@ mod test {
         File::create(dir.path().join("my-pkg/.next/irrelevant")).unwrap();
         let changed = watcher
             .changed_globs(&hash, inclusions.clone().into_iter().collect())
-            .await;
+            .await
+            .unwrap();
 
         assert!(
             changed.is_empty(),
@@ -649,7 +668,8 @@ mod test {
         File::create(dir.path().join("my-pkg/.next/next-file")).unwrap();
         let changed = watcher
             .changed_globs(&hash, inclusions.clone().into_iter().collect())
-            .await;
+            .await
+            .unwrap();
 
         assert_eq!(
             changed,


### PR DESCRIPTION
### Description

First pass as plumbing the status of watching the flush directory to the glob watcher and watcher configs.
Notable changes:
 - Before we start to process flush commands we wait until we get confirmation that we are watching the flush directory so we can properly handle flush commands
 - Failing to watch the flush directory will cause the watch future held by the server to exit. The daemon server won't shut down, but will respond with errors to all glob watching related RPC requests

Reviewer notes:
 - The current timeout logic means that if erroring on setting up the flush directory takes over 500ms we skip the flush and proceed as usual
 - We now return errors for `get_changed_outputs` RPC call
 - I'm unsure of the changes to the `serve` function. I've manually tested them, but they feel off. In the future when we possibly have multiple long running futures this won't scale.

### Testing Instructions

Unit test should now consistently pass and not depend on watching the flush directory succeeding before the watcher is converted into a stream.

Did some manual testing to make sure that we don't exit if glob watching fails and instead report an error to clients:
From the daemon logs:
```
2023-05-23T15:36:56.894-0700 [TRACE] globwatch: watching "/private/tmp/turborepo-netflix-cache-repro"              
2023-05-23T15:36:56.898-0700 [TRACE] globwatch: watching flush dir: "/private/var/folders/3m/rxkycvgs5jgfvs0k9xcgp6
km0000gn/T/turbod/3e1692e405755b5a/flush"                                                                          
ERROR faked failure for globawatch                                                                                 
ERROR Globwatch config error: ServerFailedToStart                                                                  
2023-05-23T15:37:21.582-0700 [TRACE] log: registering event source with poller: token=Token(1), interests=READABLE 
| WRITABLE
```
From the turbo output:
```
web:build: Failed to check if we can skip restoring outputs for web#build: rpc error: code = Internal desc = failed to watch flush directory. Proceeding to check cache
```
