### PR TITLE
allow to create internal modules via AssetContext

### DIFF
--- a/crates/turbopack-core/src/reference_type.rs
+++ b/crates/turbopack-core/src/reference_type.rs
@@ -1,6 +1,11 @@
 use std::fmt::Display;
 
-use crate::resolve::ModulePartVc;
+use indexmap::IndexMap;
+
+use crate::{asset::AssetVc, resolve::ModulePartVc};
+
+#[turbo_tasks::value(transparent)]
+pub struct InnerAssets(IndexMap<String, AssetVc>);
 
 // These enums list well-known types, which we use internally. Plugins might add
 // custom types too.
@@ -72,6 +77,7 @@ pub enum ReferenceType {
     Url(UrlReferenceSubType),
     TypeScript(TypeScriptReferenceSubType),
     Entry(EntryReferenceSubType),
+    Internal(InnerAssetsVc),
     Custom(u8),
     Undefined,
 }
@@ -89,6 +95,7 @@ impl Display for ReferenceType {
             ReferenceType::Url(_) => "url",
             ReferenceType::TypeScript(_) => "typescript",
             ReferenceType::Entry(_) => "entry",
+            ReferenceType::Internal(_) => "internal",
             ReferenceType::Custom(_) => todo!(),
             ReferenceType::Undefined => "undefined",
         };
@@ -126,6 +133,7 @@ impl ReferenceType {
                 matches!(other, ReferenceType::Entry(_))
                     && matches!(sub_type, EntryReferenceSubType::Undefined)
             }
+            ReferenceType::Internal(_) => matches!(other, ReferenceType::Internal(_)),
             ReferenceType::Custom(_) => {
                 todo!()
             }

--- a/crates/turbopack-core/src/reference_type.rs
+++ b/crates/turbopack-core/src/reference_type.rs
@@ -7,6 +7,14 @@ use crate::{asset::AssetVc, resolve::ModulePartVc};
 #[turbo_tasks::value(transparent)]
 pub struct InnerAssets(IndexMap<String, AssetVc>);
 
+#[turbo_tasks::value_impl]
+impl InnerAssetsVc {
+    #[turbo_tasks::function]
+    pub fn empty() -> Self {
+        InnerAssetsVc::cell(IndexMap::new())
+    }
+}
+
 // These enums list well-known types, which we use internally. Plugins might add
 // custom types too.
 

--- a/crates/turbopack-ecmascript/src/lib.rs
+++ b/crates/turbopack-ecmascript/src/lib.rs
@@ -28,7 +28,6 @@ use chunk::{
     EcmascriptChunkingContextVc,
 };
 use code_gen::CodeGenerateableVc;
-use indexmap::IndexMap;
 use parse::{parse, ParseResult};
 pub use parse::{ParseResultSourceMap, ParseResultSourceMapVc};
 use path_visitor::ApplyVisitors;
@@ -60,9 +59,11 @@ use turbopack_core::{
     context::AssetContextVc,
     ident::AssetIdentVc,
     reference::{AssetReferencesReadRef, AssetReferencesVc},
+    reference_type::InnerAssetsVc,
     resolve::{
         origin::{ResolveOrigin, ResolveOriginVc},
         parse::RequestVc,
+        ModulePartVc,
     },
 };
 
@@ -76,6 +77,7 @@ use self::{
         CodeGen, CodeGenerateableWithAvailabilityInfo, CodeGenerateableWithAvailabilityInfoVc,
     },
     parse::ParseResultVc,
+    tree_shake::asset::EcmascriptModulePartAssetVc,
 };
 use crate::{
     chunk::{EcmascriptChunkPlaceable, EcmascriptChunkPlaceableVc},
@@ -118,9 +120,6 @@ pub enum EcmascriptModuleAssetType {
     TypescriptDeclaration,
 }
 
-#[turbo_tasks::value(transparent)]
-pub struct InnerAssets(IndexMap<String, AssetVc>);
-
 #[turbo_tasks::function]
 fn modifier() -> StringVc {
     StringVc::cell("ecmascript".to_string())
@@ -131,6 +130,62 @@ struct MemoizedSuccessfulAnalysis {
     operation: RawVc,
     references: AssetReferencesReadRef,
     exports: EcmascriptExportsReadRef,
+}
+
+pub struct EcmascriptModuleAssetBuilder {
+    source: AssetVc,
+    context: AssetContextVc,
+    ty: EcmascriptModuleAssetType,
+    transforms: EcmascriptInputTransformsVc,
+    options: EcmascriptOptions,
+    compile_time_info: CompileTimeInfoVc,
+    inner_assets: Option<InnerAssetsVc>,
+    part: Option<ModulePartVc>,
+}
+
+impl EcmascriptModuleAssetBuilder {
+    pub fn with_inner_assets(mut self, inner_assets: InnerAssetsVc) -> Self {
+        self.inner_assets = Some(inner_assets);
+        self
+    }
+
+    pub fn with_type(mut self, ty: EcmascriptModuleAssetType) -> Self {
+        self.ty = ty;
+        self
+    }
+
+    pub fn with_part(mut self, part: ModulePartVc) -> Self {
+        self.part = Some(part);
+        self
+    }
+
+    pub fn build(self) -> AssetVc {
+        let base = if let Some(inner_assets) = self.inner_assets {
+            EcmascriptModuleAssetVc::new_with_inner_assets(
+                self.source,
+                self.context,
+                Value::new(self.ty),
+                self.transforms,
+                Value::new(self.options),
+                self.compile_time_info,
+                inner_assets,
+            )
+        } else {
+            EcmascriptModuleAssetVc::new(
+                self.source,
+                self.context,
+                Value::new(self.ty),
+                self.transforms,
+                Value::new(self.options),
+                self.compile_time_info,
+            )
+        };
+        if let Some(part) = self.part {
+            EcmascriptModulePartAssetVc::new(base, part).into()
+        } else {
+            base.into()
+        }
+    }
 }
 
 #[turbo_tasks::value]
@@ -150,6 +205,27 @@ pub struct EcmascriptModuleAsset {
 /// An optional [EcmascriptModuleAsset]
 #[turbo_tasks::value(transparent)]
 pub struct OptionEcmascriptModuleAsset(Option<EcmascriptModuleAssetVc>);
+
+impl EcmascriptModuleAssetVc {
+    pub fn builder(
+        source: AssetVc,
+        context: AssetContextVc,
+        transforms: EcmascriptInputTransformsVc,
+        options: EcmascriptOptions,
+        compile_time_info: CompileTimeInfoVc,
+    ) -> EcmascriptModuleAssetBuilder {
+        EcmascriptModuleAssetBuilder {
+            source,
+            context,
+            ty: EcmascriptModuleAssetType::Ecmascript,
+            transforms,
+            options,
+            compile_time_info,
+            inner_assets: None,
+            part: None,
+        }
+    }
+}
 
 #[turbo_tasks::value_impl]
 impl EcmascriptModuleAssetVc {

--- a/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -30,16 +30,18 @@ pub struct EcmascriptModulePartAsset {
     pub(crate) part: ModulePartVc,
 }
 
+#[turbo_tasks::value_impl]
 impl EcmascriptModulePartAssetVc {
     /// Create a new instance of [EcmascriptModulePartAssetVc], whcih consists
     /// of a pointer to the full module and the [ModulePart] pointing the part
     /// of the module.
-    pub fn new(module: EcmascriptModuleAssetVc, part: ModulePartVc) -> Result<Self> {
-        Ok(EcmascriptModulePartAsset {
+    #[turbo_tasks::function]
+    pub fn new(module: EcmascriptModuleAssetVc, part: ModulePartVc) -> Self {
+        EcmascriptModulePartAsset {
             full_module: module,
             part,
         }
-        .cell())
+        .cell()
     }
 }
 
@@ -79,7 +81,7 @@ impl Asset for EcmascriptModulePartAsset {
                     EcmascriptModulePartAssetVc::new(
                         self.full_module,
                         ModulePartVc::internal(part_id),
-                    )?
+                    )
                     .as_asset(),
                     StringVc::cell("ecmascript module part".to_string()),
                 )

--- a/crates/turbopack-node/src/evaluate.rs
+++ b/crates/turbopack-node/src/evaluate.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, ops::ControlFlow, thread::available_parallelism, time::Duration};
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, bail, Result};
 use async_stream::try_stream as generator;
 use futures::{
     channel::mpsc::{unbounded, UnboundedSender},
@@ -24,17 +24,15 @@ use turbo_tasks_fs::{
 };
 use turbopack_core::{
     asset::{Asset, AssetVc},
-    chunk::{ChunkableAsset, ChunkingContext, ChunkingContextVc, EvaluatableAssetsVc},
+    chunk::{
+        ChunkableAsset, ChunkingContext, ChunkingContextVc, EvaluatableAssetVc, EvaluatableAssetsVc,
+    },
     context::{AssetContext, AssetContextVc},
     ident::AssetIdentVc,
     issue::{Issue, IssueSeverity, IssueSeverityVc, IssueVc},
-    reference_type::InnerAssetsVc,
+    reference_type::{InnerAssetsVc, ReferenceType},
     source_asset::SourceAssetVc,
     virtual_asset::VirtualAssetVc,
-};
-use turbopack_ecmascript::{
-    EcmascriptInputTransform, EcmascriptInputTransformsVc, EcmascriptModuleAssetType,
-    EcmascriptModuleAssetVc,
 };
 
 use crate::{
@@ -109,17 +107,10 @@ pub async fn get_evaluate_pool(
     additional_invalidation: CompletionVc,
     debug: bool,
 ) -> Result<NodeJsPoolVc> {
-    let runtime_asset = EcmascriptModuleAssetVc::new(
+    let runtime_asset = context.process(
         SourceAssetVc::new(embed_file_path("ipc/evaluate.ts")).into(),
-        context,
-        Value::new(EcmascriptModuleAssetType::Typescript),
-        EcmascriptInputTransformsVc::cell(vec![EcmascriptInputTransform::TypeScript {
-            use_define_for_class_fields: false,
-        }]),
-        Value::new(Default::default()),
-        context.compile_time_info(),
-    )
-    .as_asset();
+        Value::new(ReferenceType::Internal(InnerAssetsVc::empty())),
+    );
 
     let module_path = module_asset.ident().path().await?;
     let file_name = module_path.file_name();
@@ -131,7 +122,7 @@ pub async fn get_evaluate_pool(
         Cow::Owned(format!("{file_name}.js"))
     };
     let path = chunking_context.output_root().join(file_name.as_ref());
-    let entry_module = EcmascriptModuleAssetVc::new_with_inner_assets(
+    let entry_module = context.process(
         VirtualAssetVc::new(
             runtime_asset.ident().path().join("evaluate.js"),
             File::from(
@@ -141,40 +132,34 @@ pub async fn get_evaluate_pool(
             .into(),
         )
         .into(),
-        context,
-        Value::new(EcmascriptModuleAssetType::Typescript),
-        EcmascriptInputTransformsVc::cell(vec![EcmascriptInputTransform::TypeScript {
-            use_define_for_class_fields: false,
-        }]),
-        Value::new(Default::default()),
-        context.compile_time_info(),
-        InnerAssetsVc::cell(indexmap! {
+        Value::new(ReferenceType::Internal(InnerAssetsVc::cell(indexmap! {
             "INNER".to_string() => module_asset,
             "RUNTIME".to_string() => runtime_asset
-        }),
+        }))),
     );
+
+    let Some(entry_module) = EvaluatableAssetVc::resolve_from(entry_module).await? else {
+        bail!("Internal module is not evaluatable");
+    };
 
     let (Some(cwd), Some(entrypoint)) = (to_sys_path(cwd).await?, to_sys_path(path).await?) else {
         panic!("can only evaluate from a disk filesystem");
     };
 
     let runtime_entries = {
-        let globals_module = EcmascriptModuleAssetVc::new(
+        let globals_module = context.process(
             SourceAssetVc::new(embed_file_path("globals.ts")).into(),
-            context,
-            Value::new(EcmascriptModuleAssetType::Typescript),
-            EcmascriptInputTransformsVc::cell(vec![EcmascriptInputTransform::TypeScript {
-                use_define_for_class_fields: false,
-            }]),
-            Value::new(Default::default()),
-            context.compile_time_info(),
-        )
-        .as_evaluatable_asset();
+            Value::new(ReferenceType::Internal(InnerAssetsVc::empty())),
+        );
+
+        let Some(globals_module) = EvaluatableAssetVc::resolve_from(globals_module).await? else {
+            bail!("Internal module is not evaluatable");
+        };
 
         let mut entries = vec![globals_module];
         if let Some(runtime_entries) = runtime_entries {
-            for entry in &*runtime_entries.await? {
-                entries.push(*entry)
+            for &entry in &*runtime_entries.await? {
+                entries.push(entry)
             }
         }
 
@@ -185,7 +170,7 @@ pub async fn get_evaluate_pool(
         path,
         chunking_context,
         entry: entry_module.as_root_chunk(chunking_context),
-        evaluatable_assets: runtime_entries.with_entry(entry_module.into()),
+        evaluatable_assets: runtime_entries.with_entry(entry_module),
     }
     .cell()
     .into();

--- a/crates/turbopack-node/src/evaluate.rs
+++ b/crates/turbopack-node/src/evaluate.rs
@@ -28,12 +28,13 @@ use turbopack_core::{
     context::{AssetContext, AssetContextVc},
     ident::AssetIdentVc,
     issue::{Issue, IssueSeverity, IssueSeverityVc, IssueVc},
+    reference_type::InnerAssetsVc,
     source_asset::SourceAssetVc,
     virtual_asset::VirtualAssetVc,
 };
 use turbopack_ecmascript::{
     EcmascriptInputTransform, EcmascriptInputTransformsVc, EcmascriptModuleAssetType,
-    EcmascriptModuleAssetVc, InnerAssetsVc,
+    EcmascriptModuleAssetVc,
 };
 
 use crate::{

--- a/crates/turbopack-node/src/lib.rs
+++ b/crates/turbopack-node/src/lib.rs
@@ -24,7 +24,6 @@ use turbopack_core::{
     source_map::GenerateSourceMapVc,
     virtual_asset::VirtualAssetVc,
 };
-use turbopack_ecmascript::EcmascriptModuleAssetVc;
 
 use self::{
     bootstrap::NodeJsBootstrapAsset,
@@ -114,13 +113,13 @@ async fn internal_assets_for_source_mapping(
 /// subgraph
 #[turbo_tasks::function]
 pub async fn external_asset_entrypoints(
-    module: EcmascriptModuleAssetVc,
+    module: EvaluatableAssetVc,
     runtime_entries: EvaluatableAssetsVc,
     chunking_context: ChunkingContextVc,
     intermediate_output_path: FileSystemPathVc,
 ) -> Result<AssetsSetVc> {
     Ok(separate_assets(
-        get_intermediate_asset(chunking_context, module.into(), runtime_entries)
+        get_intermediate_asset(chunking_context, module, runtime_entries)
             .resolve()
             .await?,
         intermediate_output_path,

--- a/crates/turbopack-node/src/node_entry.rs
+++ b/crates/turbopack-node/src/node_entry.rs
@@ -1,14 +1,13 @@
 use anyhow::Result;
 use turbo_tasks::Value;
 use turbo_tasks_fs::FileSystemPathVc;
-use turbopack_core::chunk::{ChunkingContextVc, EvaluatableAssetsVc};
+use turbopack_core::chunk::{ChunkingContextVc, EvaluatableAssetVc, EvaluatableAssetsVc};
 use turbopack_dev_server::source::ContentSourceData;
-use turbopack_ecmascript::EcmascriptModuleAssetVc;
 
 #[turbo_tasks::value(shared)]
 pub struct NodeRenderingEntry {
     pub runtime_entries: EvaluatableAssetsVc,
-    pub module: EcmascriptModuleAssetVc,
+    pub module: EvaluatableAssetVc,
     pub chunking_context: ChunkingContextVc,
     pub intermediate_output_path: FileSystemPathVc,
     pub output_root: FileSystemPathVc,

--- a/crates/turbopack-node/src/render/render_proxy.rs
+++ b/crates/turbopack-node/src/render/render_proxy.rs
@@ -13,11 +13,10 @@ use turbo_tasks_env::ProcessEnvVc;
 use turbo_tasks_fs::FileSystemPathVc;
 use turbopack_core::{
     asset::Asset,
-    chunk::{ChunkingContextVc, EvaluatableAssetsVc},
+    chunk::{ChunkingContextVc, EvaluatableAssetVc, EvaluatableAssetsVc},
     error::PrettyPrintError,
 };
 use turbopack_dev_server::source::{Body, BodyVc, ProxyResult, ProxyResultVc};
-use turbopack_ecmascript::EcmascriptModuleAssetVc;
 
 use super::{
     issue::RenderingIssue, RenderDataVc, RenderProxyIncomingMessage, RenderProxyOutgoingMessage,
@@ -34,7 +33,7 @@ pub async fn render_proxy(
     cwd: FileSystemPathVc,
     env: ProcessEnvVc,
     path: FileSystemPathVc,
-    module: EcmascriptModuleAssetVc,
+    module: EvaluatableAssetVc,
     runtime_entries: EvaluatableAssetsVc,
     chunking_context: ChunkingContextVc,
     intermediate_output_path: FileSystemPathVc,
@@ -150,7 +149,7 @@ fn render_stream(
     cwd: FileSystemPathVc,
     env: ProcessEnvVc,
     path: FileSystemPathVc,
-    module: EcmascriptModuleAssetVc,
+    module: EvaluatableAssetVc,
     runtime_entries: EvaluatableAssetsVc,
     chunking_context: ChunkingContextVc,
     intermediate_output_path: FileSystemPathVc,
@@ -210,7 +209,7 @@ async fn render_stream_internal(
     cwd: FileSystemPathVc,
     env: ProcessEnvVc,
     path: FileSystemPathVc,
-    module: EcmascriptModuleAssetVc,
+    module: EvaluatableAssetVc,
     runtime_entries: EvaluatableAssetsVc,
     chunking_context: ChunkingContextVc,
     intermediate_output_path: FileSystemPathVc,

--- a/crates/turbopack-node/src/render/render_static.rs
+++ b/crates/turbopack-node/src/render/render_static.rs
@@ -13,14 +13,13 @@ use turbo_tasks_env::ProcessEnvVc;
 use turbo_tasks_fs::{File, FileContent, FileSystemPathVc};
 use turbopack_core::{
     asset::{Asset, AssetContentVc},
-    chunk::{ChunkingContextVc, EvaluatableAssetsVc},
+    chunk::{ChunkingContextVc, EvaluatableAssetVc, EvaluatableAssetsVc},
     error::PrettyPrintError,
 };
 use turbopack_dev_server::{
     html::DevHtmlAssetVc,
     source::{Body, HeaderListVc, RewriteBuilder, RewriteVc},
 };
-use turbopack_ecmascript::EcmascriptModuleAssetVc;
 
 use super::{
     issue::RenderingIssue, RenderDataVc, RenderStaticIncomingMessage, RenderStaticOutgoingMessage,
@@ -70,7 +69,7 @@ pub async fn render_static(
     cwd: FileSystemPathVc,
     env: ProcessEnvVc,
     path: FileSystemPathVc,
-    module: EcmascriptModuleAssetVc,
+    module: EvaluatableAssetVc,
     runtime_entries: EvaluatableAssetsVc,
     fallback_page: DevHtmlAssetVc,
     chunking_context: ChunkingContextVc,
@@ -195,7 +194,7 @@ fn render_stream(
     cwd: FileSystemPathVc,
     env: ProcessEnvVc,
     path: FileSystemPathVc,
-    module: EcmascriptModuleAssetVc,
+    module: EvaluatableAssetVc,
     runtime_entries: EvaluatableAssetsVc,
     fallback_page: DevHtmlAssetVc,
     chunking_context: ChunkingContextVc,
@@ -255,7 +254,7 @@ async fn render_stream_internal(
     cwd: FileSystemPathVc,
     env: ProcessEnvVc,
     path: FileSystemPathVc,
-    module: EcmascriptModuleAssetVc,
+    module: EvaluatableAssetVc,
     runtime_entries: EvaluatableAssetsVc,
     fallback_page: DevHtmlAssetVc,
     chunking_context: ChunkingContextVc,
@@ -274,7 +273,7 @@ async fn render_stream_internal(
     let stream = generator! {
         let intermediate_asset = get_intermediate_asset(
             chunking_context,
-            module.into(),
+            module,
             runtime_entries,
         );
         let renderer_pool = get_renderer_pool(

--- a/crates/turbopack-node/src/render/rendered_source.rs
+++ b/crates/turbopack-node/src/render/rendered_source.rs
@@ -301,7 +301,7 @@ impl Introspectable for NodeRenderContentSource {
                 StringVc::cell("intermediate asset".to_string()),
                 IntrospectableAssetVc::new(get_intermediate_asset(
                     entry.chunking_context,
-                    entry.module.into(),
+                    entry.module,
                     entry.runtime_entries,
                 )),
             ));

--- a/crates/turbopack-node/src/transforms/postcss.rs
+++ b/crates/turbopack-node/src/transforms/postcss.rs
@@ -21,9 +21,6 @@ use turbopack_core::{
     source_transform::{SourceTransform, SourceTransformVc},
     virtual_asset::VirtualAssetVc,
 };
-use turbopack_ecmascript::{
-    EcmascriptInputTransformsVc, EcmascriptModuleAssetType, EcmascriptModuleAssetVc,
-};
 
 use super::util::{emitted_assets_to_virtual_assets, EmittedAsset};
 use crate::{
@@ -146,15 +143,12 @@ async fn extra_configs(
             Ok(
                 matches!(&*path.get_type().await?, FileSystemEntryType::File).then(|| {
                     any_content_changed(
-                        EcmascriptModuleAssetVc::new(
-                            SourceAssetVc::new(path).into(),
-                            context,
-                            Value::new(EcmascriptModuleAssetType::Ecmascript),
-                            EcmascriptInputTransformsVc::cell(vec![]),
-                            Value::new(Default::default()),
-                            context.compile_time_info(),
-                        )
-                        .into(),
+                        context
+                            .process(
+                                SourceAssetVc::new(path).into(),
+                                Value::new(ReferenceType::Internal(InnerAssetsVc::empty())),
+                            )
+                            .into(),
                     )
                 }),
             )

--- a/crates/turbopack-node/src/transforms/postcss.rs
+++ b/crates/turbopack-node/src/transforms/postcss.rs
@@ -22,8 +22,7 @@ use turbopack_core::{
     virtual_asset::VirtualAssetVc,
 };
 use turbopack_ecmascript::{
-    EcmascriptInputTransform, EcmascriptInputTransformsVc, EcmascriptModuleAssetType,
-    EcmascriptModuleAssetVc,
+    EcmascriptInputTransformsVc, EcmascriptModuleAssetType, EcmascriptModuleAssetVc,
 };
 
 use super::util::{emitted_assets_to_virtual_assets, EmittedAsset};
@@ -176,24 +175,16 @@ fn postcss_executor(context: AssetContextVc, postcss_config_path: FileSystemPath
         Value::new(ReferenceType::Entry(EntryReferenceSubType::Undefined)),
     );
 
-    EcmascriptModuleAssetVc::new_with_inner_assets(
+    context.process(
         VirtualAssetVc::new(
-            postcss_config_path.join("transform.js"),
+            postcss_config_path.join("transform.ts"),
             AssetContent::File(embed_file("transforms/postcss.ts")).cell(),
         )
         .into(),
-        context,
-        Value::new(EcmascriptModuleAssetType::Typescript),
-        EcmascriptInputTransformsVc::cell(vec![EcmascriptInputTransform::TypeScript {
-            use_define_for_class_fields: false,
-        }]),
-        Value::new(Default::default()),
-        context.compile_time_info(),
-        InnerAssetsVc::cell(indexmap! {
+        Value::new(ReferenceType::Internal(InnerAssetsVc::cell(indexmap! {
             "CONFIG".to_string() => config_asset
-        }),
+        }))),
     )
-    .into()
 }
 
 #[turbo_tasks::value_impl]

--- a/crates/turbopack-node/src/transforms/postcss.rs
+++ b/crates/turbopack-node/src/transforms/postcss.rs
@@ -15,7 +15,7 @@ use turbopack_core::{
     context::{AssetContext, AssetContextVc},
     ident::AssetIdentVc,
     issue::IssueContextExt,
-    reference_type::{EntryReferenceSubType, ReferenceType},
+    reference_type::{EntryReferenceSubType, InnerAssetsVc, ReferenceType},
     resolve::{find_context_file, FindContextFileResult},
     source_asset::SourceAssetVc,
     source_transform::{SourceTransform, SourceTransformVc},
@@ -23,7 +23,7 @@ use turbopack_core::{
 };
 use turbopack_ecmascript::{
     EcmascriptInputTransform, EcmascriptInputTransformsVc, EcmascriptModuleAssetType,
-    EcmascriptModuleAssetVc, InnerAssetsVc,
+    EcmascriptModuleAssetVc,
 };
 
 use super::util::{emitted_assets_to_virtual_assets, EmittedAsset};

--- a/crates/turbopack-node/src/transforms/webpack.rs
+++ b/crates/turbopack-node/src/transforms/webpack.rs
@@ -8,13 +8,10 @@ use turbopack_core::{
     asset::{Asset, AssetContent, AssetContentVc, AssetVc},
     context::{AssetContext, AssetContextVc},
     ident::AssetIdentVc,
+    reference_type::{InnerAssetsVc, ReferenceType},
     source_asset::SourceAssetVc,
     source_transform::{SourceTransform, SourceTransformVc},
     virtual_asset::VirtualAssetVc,
-};
-use turbopack_ecmascript::{
-    EcmascriptInputTransform, EcmascriptInputTransformsVc, EcmascriptModuleAssetType,
-    EcmascriptModuleAssetVc,
 };
 
 use super::util::{emitted_assets_to_virtual_assets, EmittedAsset};
@@ -118,17 +115,12 @@ struct ProcessWebpackLoadersResult {
 
 #[turbo_tasks::function]
 fn webpack_loaders_executor(context: AssetContextVc) -> AssetVc {
-    EcmascriptModuleAssetVc::new(
-        SourceAssetVc::new(embed_file_path("transforms/webpack-loaders.ts")).into(),
-        context,
-        Value::new(EcmascriptModuleAssetType::Typescript),
-        EcmascriptInputTransformsVc::cell(vec![EcmascriptInputTransform::TypeScript {
-            use_define_for_class_fields: false,
-        }]),
-        Value::new(Default::default()),
-        context.compile_time_info(),
-    )
-    .into()
+    context
+        .process(
+            SourceAssetVc::new(embed_file_path("transforms/webpack-loaders.ts")).into(),
+            Value::new(ReferenceType::Internal(InnerAssetsVc::empty())),
+        )
+        .into()
 }
 
 #[turbo_tasks::value_impl]

--- a/crates/turbopack/src/lib.rs
+++ b/crates/turbopack/src/lib.rs
@@ -15,7 +15,6 @@ use std::{
 use anyhow::Result;
 use css::{CssModuleAssetVc, ModuleCssModuleAssetVc};
 use ecmascript::{
-    tree_shake::asset::EcmascriptModulePartAssetVc,
     typescript::resolve::TypescriptTypesAssetReferenceVc, EcmascriptModuleAssetType,
     EcmascriptModuleAssetVc,
 };
@@ -37,7 +36,7 @@ use turbopack_core::{
     issue::{Issue, IssueVc},
     plugin::CustomModuleType,
     reference::all_referenced_assets,
-    reference_type::{EcmaScriptModulesReferenceSubType, ReferenceType},
+    reference_type::{EcmaScriptModulesReferenceSubType, InnerAssetsVc, ReferenceType},
     resolve::{
         options::ResolveOptionsVc, origin::PlainResolveOriginVc, parse::RequestVc, resolve,
         ModulePartVc, ResolveResultVc,
@@ -103,67 +102,62 @@ async fn apply_module_type(
     context: ModuleAssetContextVc,
     module_type: ModuleTypeVc,
     part: Option<ModulePartVc>,
+    inner_assets: Option<InnerAssetsVc>,
 ) -> Result<AssetVc> {
-    Ok(match &*module_type.await? {
+    let module_type = &*module_type.await?;
+    Ok(match module_type {
         ModuleType::Ecmascript {
             transforms,
             options,
+        }
+        | ModuleType::Typescript {
+            transforms,
+            options,
+        }
+        | ModuleType::TypescriptWithTypes {
+            transforms,
+            options,
+        }
+        | ModuleType::TypescriptDeclaration {
+            transforms,
+            options,
         } => {
-            let base = EcmascriptModuleAssetVc::new(
+            let mut builder = EcmascriptModuleAssetVc::builder(
                 source,
                 context.into(),
-                Value::new(EcmascriptModuleAssetType::Ecmascript),
                 *transforms,
-                Value::new(*options),
+                *options,
                 context.compile_time_info(),
             );
+            match module_type {
+                ModuleType::Ecmascript { .. } => {
+                    builder = builder.with_type(EcmascriptModuleAssetType::Ecmascript)
+                }
+                ModuleType::Typescript { .. } => {
+                    builder = builder.with_type(EcmascriptModuleAssetType::Typescript)
+                }
+                ModuleType::TypescriptWithTypes { .. } => {
+                    builder = builder.with_type(EcmascriptModuleAssetType::TypescriptWithTypes)
+                }
+                ModuleType::TypescriptDeclaration { .. } => {
+                    builder = builder.with_type(EcmascriptModuleAssetType::TypescriptDeclaration)
+                }
+                _ => unreachable!(),
+            }
+
+            if let Some(inner_assets) = inner_assets {
+                builder = builder.with_inner_assets(inner_assets);
+            }
 
             if options.split_into_parts {
                 if let Some(part) = part {
-                    if let Ok(v) = EcmascriptModulePartAssetVc::new(base, part) {
-                        return Ok(v.into());
-                    }
+                    builder = builder.with_part(part);
                 }
             }
 
-            base.into()
+            builder.build().into()
         }
-        ModuleType::Typescript {
-            transforms,
-            options,
-        } => EcmascriptModuleAssetVc::new(
-            source,
-            context.into(),
-            Value::new(EcmascriptModuleAssetType::Typescript),
-            *transforms,
-            Value::new(*options),
-            context.compile_time_info(),
-        )
-        .into(),
-        ModuleType::TypescriptWithTypes {
-            transforms,
-            options,
-        } => EcmascriptModuleAssetVc::new(
-            source,
-            context.with_types_resolving_enabled().into(),
-            Value::new(EcmascriptModuleAssetType::TypescriptWithTypes),
-            *transforms,
-            Value::new(*options),
-            context.compile_time_info(),
-        )
-        .into(),
-        ModuleType::TypescriptDeclaration {
-            transforms,
-            options,
-        } => EcmascriptModuleAssetVc::new(
-            source,
-            context.with_types_resolving_enabled().into(),
-            Value::new(EcmascriptModuleAssetType::TypescriptDeclaration),
-            *transforms,
-            Value::new(*options),
-            context.compile_time_info(),
-        )
-        .into(),
+
         ModuleType::Json => JsonModuleAssetVc::new(source).into(),
         ModuleType::Raw => source,
         ModuleType::Css(transforms) => {
@@ -279,10 +273,14 @@ async fn process_default(
     let options = ModuleOptionsVc::new(ident.path().parent(), context.module_options_context());
 
     let reference_type = reference_type.into_value();
-    let part = match &reference_type {
+    let part: Option<ModulePartVc> = match &reference_type {
         ReferenceType::EcmaScriptModules(EcmaScriptModulesReferenceSubType::ImportPart(part)) => {
             Some(*part)
         }
+        _ => None,
+    };
+    let inner_assets = match &reference_type {
+        ReferenceType::Internal(inner_assets) => Some(*inner_assets),
         _ => None,
     };
     let mut current_source = source;
@@ -381,6 +379,7 @@ async fn process_default(
         context,
         module_type,
         part,
+        inner_assets,
     ))
 }
 

--- a/crates/turbopack/src/lib.rs
+++ b/crates/turbopack/src/lib.rs
@@ -122,9 +122,16 @@ async fn apply_module_type(
             transforms,
             options,
         } => {
+            let context_for_module = match module_type {
+                ModuleType::TypescriptWithTypes { .. }
+                | ModuleType::TypescriptDeclaration { .. } => {
+                    context.with_types_resolving_enabled()
+                }
+                _ => context,
+            };
             let mut builder = EcmascriptModuleAssetVc::builder(
                 source,
-                context.into(),
+                context_for_module.into(),
                 *transforms,
                 *options,
                 context.compile_time_info(),


### PR DESCRIPTION
### Description

This allows to create an Module with inner asset via AssetContext.

This will also respect transitions.

This change allows use to use `context.process(source, ReferenceType::Internal(inner_assets)` instead of `EcmascriptModuleAssetVc::new_with_inner_assets(..., ..., ..., ..., ..., inner_assets)`

next.js PR: https://github.com/vercel/next.js/pull/50338