### PR TITLE
ci: Revert "ci: Remove go/rust toolchain from JS package tests (#5036)"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -441,8 +441,6 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           target: ${{ matrix.os.name }}
-          setup-go: false
-          setup-rust: false
 
       - name: Run tests
         run: |


### PR DESCRIPTION
This reverts commit 7945a2c6c7092eb130033775d78dbe92aa60678d.

### Description

Reverts #5036 which disabled the Rust/Go setup for the JS package tests. This is a temporary fix until we get our filters correct. 

### Testing Instructions

Failures were introduced by removing the Rust/Go setup
