### PR TITLE
refactor: Fix binary bloat caused by `ValueDebugFormat` impl

### DIFF
--- a/crates/turbo-tasks-macros/src/derive/value_debug_format_macro.rs
+++ b/crates/turbo-tasks-macros/src/derive/value_debug_format_macro.rs
@@ -55,7 +55,7 @@ pub fn derive_value_debug_format(input: TokenStream) -> TokenStream {
 /// Formats a single field nested inside named or unnamed fields.
 fn format_field(value: TokenStream2) -> TokenStream2 {
     quote! {
-        turbo_tasks::macro_helpers::value_debug_format_field(&#value, depth).await
+        turbo_tasks::macro_helpers::value_debug_format_field(#value.value_debug_format(depth.saturating_sub(1))).await
     }
 }
 

--- a/crates/turbo-tasks-macros/src/derive/value_debug_format_macro.rs
+++ b/crates/turbo-tasks-macros/src/derive/value_debug_format_macro.rs
@@ -55,13 +55,7 @@ pub fn derive_value_debug_format(input: TokenStream) -> TokenStream {
 /// Formats a single field nested inside named or unnamed fields.
 fn format_field(value: TokenStream2) -> TokenStream2 {
     quote! {
-        match #value.value_debug_format(depth.saturating_sub(1)).try_to_value_debug_string().await {
-            Ok(result) => match result.await {
-                Ok(result) => result.to_string(),
-                Err(err) => format!("{:?}", err),
-            },
-            Err(err) => format!("{:?}", err),
-        }
+        ::turbo_tasks::macro_rt::value_debug_format_field(&#value, depth).await
     }
 }
 

--- a/crates/turbo-tasks-macros/src/derive/value_debug_format_macro.rs
+++ b/crates/turbo-tasks-macros/src/derive/value_debug_format_macro.rs
@@ -55,7 +55,7 @@ pub fn derive_value_debug_format(input: TokenStream) -> TokenStream {
 /// Formats a single field nested inside named or unnamed fields.
 fn format_field(value: TokenStream2) -> TokenStream2 {
     quote! {
-        ::turbo_tasks::macro_rt::value_debug_format_field(&#value, depth).await
+        turbo_tasks::macro_helpers::value_debug_format_field(&#value, depth).await
     }
 }
 

--- a/crates/turbo-tasks/src/lib.rs
+++ b/crates/turbo-tasks/src/lib.rs
@@ -45,6 +45,7 @@ mod id;
 mod id_factory;
 mod invalidation;
 mod join_iter_ext;
+pub mod macro_rt;
 mod magic_any;
 mod manager;
 mod native_function;

--- a/crates/turbo-tasks/src/lib.rs
+++ b/crates/turbo-tasks/src/lib.rs
@@ -45,7 +45,8 @@ mod id;
 mod id_factory;
 mod invalidation;
 mod join_iter_ext;
-pub mod macro_rt;
+#[doc(hidden)]
+pub mod macro_helpers;
 mod magic_any;
 mod manager;
 mod native_function;
@@ -102,18 +103,15 @@ pub use value_type::{
     ValueType, ValueVc,
 };
 
-#[doc(hidden)]
-pub mod macro_helpers {
-    pub use once_cell::sync::{Lazy, OnceCell};
-    pub use tracing;
-
-    pub use super::manager::{find_cell_by_type, notify_scheduled_tasks, spawn_detached};
-}
-
 pub mod test_helpers {
     pub use super::manager::{current_task_for_testing, with_turbo_tasks_for_testing};
 }
 
 pub fn register() {
     include!(concat!(env!("OUT_DIR"), "/register.rs"));
+}
+
+/// Helper for derive macros
+mod turbo_tasks {
+    pub use crate::macro_helpers;
 }

--- a/crates/turbo-tasks/src/lib.rs
+++ b/crates/turbo-tasks/src/lib.rs
@@ -112,6 +112,7 @@ pub fn register() {
 }
 
 /// Helper for derive macros
+#[doc(hidden)]
 mod turbo_tasks {
     pub use crate::macro_helpers;
 }

--- a/crates/turbo-tasks/src/macro_helpers.rs
+++ b/crates/turbo-tasks/src/macro_helpers.rs
@@ -10,12 +10,8 @@ pub async fn value_debug_format_field(value: ValueDebugFormatString<'_>) -> Stri
     match value.try_to_value_debug_string().await {
         Ok(result) => match result.await {
             Ok(result) => result.to_string(),
-            Err(err) => {
-                format!("{0:?}", err)
-            }
+            Err(err) => format!("{0:?}", err),
         },
-        Err(err) => {
-            format!("{0:?}", err)
-        }
+        Err(err) => format!("{0:?}", err),
     }
 }

--- a/crates/turbo-tasks/src/macro_helpers.rs
+++ b/crates/turbo-tasks/src/macro_helpers.rs
@@ -3,18 +3,11 @@ pub use once_cell::sync::{Lazy, OnceCell};
 pub use tracing;
 
 pub use super::manager::{find_cell_by_type, notify_scheduled_tasks, spawn_detached};
-use crate::debug::ValueDebugFormat;
+use crate::debug::ValueDebugFormatString;
 
 #[inline(never)]
-pub async fn value_debug_format_field(
-    value: &(dyn ValueDebugFormat + Sync),
-    depth: usize,
-) -> String {
-    match value
-        .value_debug_format(depth.saturating_sub(1))
-        .try_to_value_debug_string()
-        .await
-    {
+pub async fn value_debug_format_field(value: ValueDebugFormatString<'_>) -> String {
+    match value.try_to_value_debug_string().await {
         Ok(result) => match result.await {
             Ok(result) => result.to_string(),
             Err(err) => {

--- a/crates/turbo-tasks/src/macro_helpers.rs
+++ b/crates/turbo-tasks/src/macro_helpers.rs
@@ -1,5 +1,8 @@
 //! Runtime helpers for [turbo-tasks-macro].
+pub use once_cell::sync::{Lazy, OnceCell};
+pub use tracing;
 
+pub use super::manager::{find_cell_by_type, notify_scheduled_tasks, spawn_detached};
 use crate::debug::ValueDebugFormat;
 
 #[inline(never)]

--- a/crates/turbo-tasks/src/macro_helpers.rs
+++ b/crates/turbo-tasks/src/macro_helpers.rs
@@ -6,7 +6,10 @@ pub use super::manager::{find_cell_by_type, notify_scheduled_tasks, spawn_detach
 use crate::debug::ValueDebugFormat;
 
 #[inline(never)]
-pub async fn value_debug_format_field(value: &dyn ValueDebugFormat, depth: usize) -> String {
+pub async fn value_debug_format_field(
+    value: &(dyn ValueDebugFormat + Sync),
+    depth: usize,
+) -> String {
     match value
         .value_debug_format(depth.saturating_sub(1))
         .try_to_value_debug_string()

--- a/crates/turbo-tasks/src/macro_rt.rs
+++ b/crates/turbo-tasks/src/macro_rt.rs
@@ -1,0 +1,21 @@
+//! Runtime helpers for [turbo-tasks-macro].
+
+use crate::debug::ValueDebugFormat;
+
+pub async fn format_field(value: &dyn ValueDebugFormat, depth: usize) -> String {
+    match value
+        .value_debug_format(depth.saturating_sub(1))
+        .try_to_value_debug_string()
+        .await
+    {
+        Ok(result) => match result.await {
+            Ok(result) => result.to_string(),
+            Err(err) => {
+                format!("{0:?}", err)
+            }
+        },
+        Err(err) => {
+            format!("{0:?}", err)
+        }
+    }
+}

--- a/crates/turbo-tasks/src/macro_rt.rs
+++ b/crates/turbo-tasks/src/macro_rt.rs
@@ -2,7 +2,8 @@
 
 use crate::debug::ValueDebugFormat;
 
-pub async fn format_field(value: &dyn ValueDebugFormat, depth: usize) -> String {
+#[inline(never)]
+pub async fn value_debug_format_field(value: &dyn ValueDebugFormat, depth: usize) -> String {
     match value
         .value_debug_format(depth.saturating_sub(1))
         .try_to_value_debug_string()


### PR DESCRIPTION
### Description

```
    Finished release [optimized] target(s) in 0.43s
    Analyzing target/release/libnext_swc_napi.dylib

 File  .text     Size                          Crate Name
 0.1%   0.3% 185.1KiB               swc_css_prefixer <swc_css_prefixer::prefixer::Prefixer as swc_css_visit::VisitMut>::visit_mut_declaration
 0.0%   0.1%  53.9KiB       swc_ecma_transforms_base <swc_ecma_transforms_base::helpers::InjectHelpers>::build_imports::{closure#0}
 0.0%   0.1%  41.4KiB                      next_core <next_core::next_config::NextConfig>::__value_debug_format_NextConfig::{closure#0}
 0.0%   0.1%  39.6KiB                 turbopack_core turbopack_core::register
 0.0%   0.1%  36.5KiB                            std core::ptr::drop_in_place::<<next_core::next_config::NextConfig>::__value_debug_format_NextConfig::{closure#0}>
 0.0%   0.1%  36.5KiB                            std core::ptr::drop_in_place::<<next_core::next_config::NextConfig>::__value_debug_format_NextConfig::{closure#0}>
 0.0%   0.1%  34.5KiB           turbopack_ecmascript turbopack_ecmascript::register
 0.0%   0.1%  34.4KiB                      next_core next_core::register
 0.0%   0.1%  32.6KiB     swc_ecma_transforms_module <swc_ecma_transforms_module::system_js::SystemJs as swc_ecma_visit::Fold>::fold_module
 0.0%   0.0%  30.5KiB                          regex <regex::exec::ExecNoSync as regex::re_trait::RegularExpression>::captures_read_at
 0.0%   0.0%  27.5KiB                   browserslist browserslist::data::caniuse::features::get_feature_stat
 0.0%   0.0%  27.5KiB                            swc <swc::config::Options>::build_as_input::<swc_visit::AndThen<swc_visit::Optional<next_swc::disallow_re_export_all_in_page::DisallowReExportAllInPage>, swc_visit::AndThen<either::Either<swc_e...
 0.0%   0.0%  27.2KiB           turbopack_ecmascript turbopack_ecmascript::references::analyze_ecmascript_module_inline::{closure#0}
```

### Testing Instructions




---

 - Closes WEB-1116