### PR TITLE
fix: update storybook dev command

### DIFF
--- a/docs/pages/repo/docs/handbook/tools/storybook.mdx
+++ b/docs/pages/repo/docs/handbook/tools/storybook.mdx
@@ -181,7 +181,7 @@ The last thing that we need to do is make sure that Storybook is lined up with t
 {
   // ...
   "scripts": {
-    "dev": "start-storybook -p 6006",
+    "dev": "storybook dev -p 6006",
     "build": "build-storybook"
   }
 }


### PR DESCRIPTION
### Description

The `start-storybook` command [has been replaced](https://github.com/storybookjs/storybook/issues/18923) with `storybook dev` in v7. Users running `pnpx sb init` as instructed on this page will get v7, and will not be able to run the old command.

### Testing Instructions

Running `dev` causes this error.

```sh
workshop:dev: > start-storybook -p 6006
workshop:dev:
workshop:dev: sh: start-storybook: command not found
workshop:dev: ELIFECYCLE  Command failed.
```

With the updated command, running `dev` will start storybook normally.
