### PR TITLE
feat(turborepo): Move some shim paths over to AbsoluteSystemPath

### DIFF
--- a/crates/turborepo-lib/src/package_manager/mod.rs
+++ b/crates/turborepo-lib/src/package_manager/mod.rs
@@ -85,7 +85,7 @@ pub struct Globs {
 }
 
 impl Globs {
-    pub fn test(&self, root: PathBuf, target: PathBuf) -> Result<bool> {
+    pub fn test(&self, root: &Path, target: PathBuf) -> Result<bool> {
         let search_value = target
             .strip_prefix(root)?
             .to_str()
@@ -422,7 +422,7 @@ mod tests {
         }];
 
         for test in tests {
-            match test.globs.test(test.root, test.target) {
+            match test.globs.test(&test.root, test.target) {
                 Ok(value) => assert_eq!(value, test.output.unwrap()),
                 Err(value) => assert_eq!(value.to_string(), test.output.unwrap_err().to_string()),
             };

--- a/crates/turborepo-lib/src/shim.rs
+++ b/crates/turborepo-lib/src/shim.rs
@@ -1121,14 +1121,4 @@ mod test {
         assert!(!turbo_version_has_shim(old));
         assert!(!turbo_version_has_shim(old_canary));
     }
-
-    #[cfg(windows)]
-    #[test]
-    fn test_windows_path_normalization() -> Result<()> {
-        let cwd = current_dir()?;
-        let normalized = fs_canonicalize(&cwd)?;
-        // Just make sure it isn't a UNC path
-        assert!(!normalized.starts_with("\\\\?"));
-        Ok(())
-    }
 }

--- a/crates/turborepo-lib/src/shim.rs
+++ b/crates/turborepo-lib/src/shim.rs
@@ -473,10 +473,10 @@ impl RepoState {
                 // However, we don't have that functionality implemented in Rust yet.
                 // PackageManager::detect(path).get_workspace_globs().unwrap_or(None)
                 let workspace_globs = PackageManager::Pnpm
-                    .get_workspace_globs(path.as_path())
+                    .get_workspace_globs(path)
                     .unwrap_or_else(|_| {
                         PackageManager::Npm
-                            .get_workspace_globs(path.as_path())
+                            .get_workspace_globs(path)
                             .unwrap_or(None)
                     });
 

--- a/crates/turborepo-paths/src/absolute_system_path.rs
+++ b/crates/turborepo-paths/src/absolute_system_path.rs
@@ -103,8 +103,18 @@ impl AbsoluteSystemPath {
         }
     }
 
+    pub(crate) fn new_unchecked(path: &Path) -> &Self {
+        unsafe { &*(path as *const Path as *const Self) }
+    }
+
     pub fn as_path(&self) -> &Path {
         &self.0
+    }
+
+    pub fn ancestors(&self) -> impl Iterator<Item = &AbsoluteSystemPath> {
+        self.0
+            .ancestors()
+            .map(|ancestor| Self::new_unchecked(ancestor))
     }
 
     // intended for joining literals or obviously single-token strings


### PR DESCRIPTION
### Description

 - We were using `Path` and `PathBuf` loosely, with relative and absolute paths in a few places
 - Move `ShimArgs`, `RepoState` and `InferInfo` to use `AbsoluteSystemPathBuf`
 - Thread absolute paths through to the existing workspace glob function

### Testing Instructions

Updated tests to use `AbsoluteSystemPathBuf` where applicable, otherwise behavior unchanged