### PR TITLE
chore: Enable `share-generics`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -16,4 +16,4 @@ tp-test = "nextest run --workspace --release --no-fail-fast --exclude turbo --ex
 tp-bench-test = "test --benches --workspace --release --no-fail-fast --exclude turbopack-bench --exclude turbo --exclude turborepo-* --exclude turbopath --exclude vercel-api-mock"
 
 [target.'cfg(all())']
-rustflags = ["--cfg", "tokio_unstable", "-Csymbol-mangling-version=v0", "-Aclippy::too_many_arguments"]
+rustflags = ["--cfg", "tokio_unstable", "-Zshare-generics=y", "-Csymbol-mangling-version=v0", "-Aclippy::too_many_arguments"]


### PR DESCRIPTION
### Description

This PR enables `-Zshare-generics` to reduce the binary size. This single option reduces binary size from `153.1MiB` to `132.9MiB`


### Testing Instructions

Let's look at the benchmark actions.

---


Closes WEB-1144