### PR TITLE
feat(docs): sort examples

### DIFF
--- a/docs/components/ExamplesArea.tsx
+++ b/docs/components/ExamplesArea.tsx
@@ -1,28 +1,65 @@
 import { useSSG } from "nextra/ssg";
 import { ExampleCard } from "./ExamplesCard";
 
+interface Example {
+  name: string;
+  description: string;
+  slug: string;
+  template?: string;
+  featured?: boolean;
+  boost?: boolean;
+}
+
+const ExamplesGroup = ({ examples }: { examples: Array<Example> }) => {
+  return (
+    <>
+      {examples.map(({ name, description, slug, template }) => (
+        <ExampleCard
+          key={name}
+          name={name}
+          description={description}
+          slug={slug}
+          template={template}
+        />
+      ))}
+    </>
+  );
+};
+
 export const ExamplesArea = ({
   filter = "featured",
 }: {
   filter: "featured" | "all";
 }) => {
-  const { examples } = useSSG();
+  const { examples }: { examples: Array<Example> } = useSSG();
+
+  const sortedExamples = examples
+    .filter(({ featured }) => (filter === "featured" ? featured : true))
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  const withBoost = [];
+  const withTemplate = [];
+  const withoutTemplate = [];
+  sortedExamples.forEach((e) => {
+    if (e.boost) {
+      withBoost.push(e);
+    } else if (e.template) {
+      withTemplate.push(e);
+    } else {
+      withoutTemplate.push(e);
+    }
+  });
 
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 lg:mt-16 mt-12 gap-x-6 gap-y-12  lg:gap-x-8 lg:gap-y-12">
-      {examples
-        .filter(({ featured }) => (filter === "featured" ? featured : true))
-        // sort templates to the top
-        .sort((a) => (a.template ? -1 : 1))
-        .map(({ name, description, slug, featured, template }) => (
-          <ExampleCard
-            key={name}
-            name={name}
-            description={description}
-            slug={slug}
-            template={template}
-          />
-        ))}
+      {/* Render examples in three groups -
+        1. Examples that have been explicitly boosted
+        2. Examples with Vercel templates
+        3. All others
+      */}
+      <ExamplesGroup examples={withBoost} />
+      <ExamplesGroup examples={withTemplate} />
+      <ExamplesGroup examples={withoutTemplate} />
     </div>
   );
 };

--- a/examples/basic/meta.json
+++ b/examples/basic/meta.json
@@ -2,5 +2,6 @@
   "name": "Basic",
   "description": "Minimal Turborepo example for learning the fundamentals.",
   "template": "https://vercel.com/templates/next.js/turborepo-next-basic",
-  "featured": true
+  "featured": true,
+  "boost": true
 }

--- a/examples/with-svelte/meta.json
+++ b/examples/with-svelte/meta.json
@@ -2,5 +2,6 @@
   "name": "SvelteKit",
   "description": "Monorepo with multiple SvelteKit apps sharing a UI Library",
   "featured": true,
-  "template": "https://vercel.com/templates/svelte/turborepo-sveltekit-starter"
+  "template": "https://vercel.com/templates/svelte/turborepo-sveltekit-starter",
+  "boost": true
 }


### PR DESCRIPTION
### Description

Renders examples by sorting into three groups

1. Examples that have been explicitly boosted
2. Examples with Vercel templates
3. All others

Each group is sorted alphabetically 

