### PR TITLE
Merge timesaved and cache status data structures

### DIFF
--- a/cli/internal/cache/async_cache.go
+++ b/cli/internal/cache/async_cache.go
@@ -50,7 +50,7 @@ func (c *asyncCache) Put(anchor turbopath.AbsoluteSystemPath, key string, durati
 	return nil
 }
 
-func (c *asyncCache) Fetch(anchor turbopath.AbsoluteSystemPath, key string, files []string) (ItemStatus, []turbopath.AnchoredSystemPath, int, error) {
+func (c *asyncCache) Fetch(anchor turbopath.AbsoluteSystemPath, key string, files []string) (ItemStatus, []turbopath.AnchoredSystemPath, error) {
 	return c.realCache.Fetch(anchor, key, files)
 }
 

--- a/cli/internal/cache/cache.go
+++ b/cli/internal/cache/cache.go
@@ -20,7 +20,7 @@ import (
 type Cache interface {
 	// Fetch returns true if there is a cache it. It is expected to move files
 	// into their correct position as a side effect
-	Fetch(anchor turbopath.AbsoluteSystemPath, hash string, files []string) (ItemStatus, []turbopath.AnchoredSystemPath, int, error)
+	Fetch(anchor turbopath.AbsoluteSystemPath, hash string, files []string) (ItemStatus, []turbopath.AnchoredSystemPath, error)
 	Exists(hash string) ItemStatus
 	// Put caches files for a given hash
 	Put(anchor turbopath.AbsoluteSystemPath, hash string, duration int, files []turbopath.AnchoredSystemPath) error
@@ -32,30 +32,34 @@ type Cache interface {
 // ItemStatus holds whether artifacts exists for a given hash on local
 // and/or remote caching server
 type ItemStatus struct {
-	Local  bool `json:"local"`
-	Remote bool `json:"remote"`
+	Hit       bool
+	Source    string // only relevant if Hit is true
+	TimeSaved int    // will be 0 if Hit is false
 }
 
 // NewCacheMiss returns an ItemStatus with the fields set to indicate a cache miss
 func NewCacheMiss() ItemStatus {
 	return ItemStatus{
-		Local:  false,
-		Remote: false,
+		Source:    CacheSourceNone,
+		Hit:       false,
+		TimeSaved: 0,
 	}
 }
 
 // newFSTaskCacheStatus returns an ItemStatus with the fields set to indicate a local cache hit
-func newFSTaskCacheStatus(hit bool, _ int) ItemStatus {
+func newFSTaskCacheStatus(hit bool, timeSaved int) ItemStatus {
 	return ItemStatus{
-		Local:  hit,
-		Remote: false,
+		Source:    CacheSourceFS,
+		Hit:       hit,
+		TimeSaved: timeSaved,
 	}
 }
 
-func newRemoteTaskCacheStatus(hit bool, _ int) ItemStatus {
+func newRemoteTaskCacheStatus(hit bool, timeSaved int) ItemStatus {
 	return ItemStatus{
-		Local:  false,
-		Remote: hit,
+		Source:    CacheSourceRemote,
+		Hit:       hit,
+		TimeSaved: timeSaved,
 	}
 }
 
@@ -64,6 +68,8 @@ const (
 	CacheSourceFS = "LOCAL"
 	// CacheSourceRemote is a constant to indicate remote cache hit
 	CacheSourceRemote = "REMOTE"
+	// CacheSourceNone is an empty string because there is no source for a cache miss
+	CacheSourceNone = ""
 	// CacheEventHit is a constant to indicate a cache hit
 	CacheEventHit = "HIT"
 	// CacheEventMiss is a constant to indicate a cache miss
@@ -263,24 +269,17 @@ func (mplex *cacheMultiplexer) removeCache(removal *cacheRemoval) {
 	}
 }
 
-func (mplex *cacheMultiplexer) Fetch(anchor turbopath.AbsoluteSystemPath, key string, files []string) (ItemStatus, []turbopath.AnchoredSystemPath, int, error) {
+func (mplex *cacheMultiplexer) Fetch(anchor turbopath.AbsoluteSystemPath, key string, files []string) (ItemStatus, []turbopath.AnchoredSystemPath, error) {
 	// Make a shallow copy of the caches, since storeUntil can call removeCache
 	mplex.mu.RLock()
 	caches := make([]Cache, len(mplex.caches))
 	copy(caches, mplex.caches)
 	mplex.mu.RUnlock()
 
-	// We need to return a composite cache status from multiple caches
-	// Initialize the empty struct so we can assign values to it. This is similar
-	// to how the Exists() method works.
-	combinedCacheState := ItemStatus{}
-
 	// Retrieve from caches sequentially; if we did them simultaneously we could
 	// easily write the same file from two goroutines at once.
 	for i, cache := range caches {
-		itemStatus, actualFiles, duration, err := cache.Fetch(anchor, key, files)
-		ok := itemStatus.Local || itemStatus.Remote
-
+		itemStatus, actualFiles, err := cache.Fetch(anchor, key, files)
 		if err != nil {
 			cd := &util.CacheDisabledError{}
 			if errors.As(err, &cd) {
@@ -294,31 +293,31 @@ func (mplex *cacheMultiplexer) Fetch(anchor turbopath.AbsoluteSystemPath, key st
 			// the operation. Future work that plumbs UI / Logging into the cache system
 			// should probably log this at least.
 		}
-		if ok {
+
+		if itemStatus.Hit {
 			// Store this into other caches. We can ignore errors here because we know
 			// we have previously successfully stored in a higher-priority cache, and so the overall
 			// result is a success at fetching. Storing in lower-priority caches is an optimization.
-			_ = mplex.storeUntil(anchor, key, duration, actualFiles, i)
+			_ = mplex.storeUntil(anchor, key, itemStatus.TimeSaved, actualFiles, i)
 
-			// If another cache had already set this to true, we don't need to set it again from this cache
-			combinedCacheState.Local = combinedCacheState.Local || itemStatus.Local
-			combinedCacheState.Remote = combinedCacheState.Remote || itemStatus.Remote
-			return combinedCacheState, actualFiles, duration, err
+			// Return this cache, and exit the for loop, since we don't need to keep looking.
+			return itemStatus, actualFiles, nil
 		}
 	}
 
-	return NewCacheMiss(), nil, 0, nil
+	return NewCacheMiss(), nil, nil
 }
 
+// Exists check each cache sequentially and return the first one that has a cache hit
 func (mplex *cacheMultiplexer) Exists(target string) ItemStatus {
-	syncCacheState := ItemStatus{}
 	for _, cache := range mplex.caches {
 		itemStatus := cache.Exists(target)
-		syncCacheState.Local = syncCacheState.Local || itemStatus.Local
-		syncCacheState.Remote = syncCacheState.Remote || itemStatus.Remote
+		if itemStatus.Hit {
+			return itemStatus
+		}
 	}
 
-	return syncCacheState
+	return NewCacheMiss()
 }
 
 func (mplex *cacheMultiplexer) Clean(anchor turbopath.AbsoluteSystemPath) {

--- a/cli/internal/cache/cache.go
+++ b/cli/internal/cache/cache.go
@@ -36,6 +36,29 @@ type ItemStatus struct {
 	Remote bool `json:"remote"`
 }
 
+// NewCacheMiss returns an ItemStatus with the fields set to indicate a cache miss
+func NewCacheMiss() ItemStatus {
+	return ItemStatus{
+		Local:  false,
+		Remote: false,
+	}
+}
+
+// newFSTaskCacheStatus returns an ItemStatus with the fields set to indicate a local cache hit
+func newFSTaskCacheStatus(hit bool, _ int) ItemStatus {
+	return ItemStatus{
+		Local:  hit,
+		Remote: false,
+	}
+}
+
+func newRemoteTaskCacheStatus(hit bool, _ int) ItemStatus {
+	return ItemStatus{
+		Local:  false,
+		Remote: hit,
+	}
+}
+
 const (
 	// CacheSourceFS is a constant to indicate local cache hit
 	CacheSourceFS = "LOCAL"
@@ -284,7 +307,7 @@ func (mplex *cacheMultiplexer) Fetch(anchor turbopath.AbsoluteSystemPath, key st
 		}
 	}
 
-	return ItemStatus{Local: false, Remote: false}, nil, 0, nil
+	return NewCacheMiss(), nil, 0, nil
 }
 
 func (mplex *cacheMultiplexer) Exists(target string) ItemStatus {

--- a/cli/internal/cache/cache_fs_test.go
+++ b/cli/internal/cache/cache_fs_test.go
@@ -216,9 +216,9 @@ func TestFetch(t *testing.T) {
 
 	outputDir := turbopath.AbsoluteSystemPath(t.TempDir())
 	dstOutputPath := "some-package"
-	cacheStatus, files, _, err := cache.Fetch(outputDir, "the-hash", []string{})
+	cacheStatus, files, err := cache.Fetch(outputDir, "the-hash", []string{})
 	assert.NilError(t, err, "Fetch")
-	hit := cacheStatus.Local || cacheStatus.Remote
+	hit := cacheStatus.Hit
 	if !hit {
 		t.Error("Fetch got false, want true")
 	}

--- a/cli/internal/cache/cache_http.go
+++ b/cli/internal/cache/cache_http.go
@@ -98,10 +98,10 @@ func (cache *httpCache) Fetch(_ turbopath.AbsoluteSystemPath, key string, _ []st
 	hit, files, duration, err := cache.retrieve(key)
 	if err != nil {
 		// TODO: analytics event?
-		return ItemStatus{Remote: false}, files, duration, fmt.Errorf("failed to retrieve files from HTTP cache: %w", err)
+		return newRemoteTaskCacheStatus(false, duration), files, duration, fmt.Errorf("failed to retrieve files from HTTP cache: %w", err)
 	}
 	cache.logFetch(hit, key, duration)
-	return ItemStatus{Remote: hit}, files, duration, err
+	return newRemoteTaskCacheStatus(hit, duration), files, duration, err
 }
 
 func (cache *httpCache) Exists(key string) ItemStatus {
@@ -109,9 +109,10 @@ func (cache *httpCache) Exists(key string) ItemStatus {
 	defer cache.requestLimiter.release()
 	hit, err := cache.exists(key)
 	if err != nil {
-		return ItemStatus{Remote: false}
+		return newRemoteTaskCacheStatus(false, 0)
 	}
-	return ItemStatus{Remote: hit}
+	// TODO: get timeSaved value in here
+	return newRemoteTaskCacheStatus(hit, 0)
 }
 
 func (cache *httpCache) logFetch(hit bool, hash string, duration int) {

--- a/cli/internal/cache/cache_http.go
+++ b/cli/internal/cache/cache_http.go
@@ -92,16 +92,16 @@ func (cache *httpCache) write(w io.WriteCloser, anchor turbopath.AbsoluteSystemP
 	cacheErrorChan <- cacheItem.Close()
 }
 
-func (cache *httpCache) Fetch(_ turbopath.AbsoluteSystemPath, key string, _ []string) (ItemStatus, []turbopath.AnchoredSystemPath, int, error) {
+func (cache *httpCache) Fetch(_ turbopath.AbsoluteSystemPath, key string, _ []string) (ItemStatus, []turbopath.AnchoredSystemPath, error) {
 	cache.requestLimiter.acquire()
 	defer cache.requestLimiter.release()
 	hit, files, duration, err := cache.retrieve(key)
 	if err != nil {
 		// TODO: analytics event?
-		return newRemoteTaskCacheStatus(false, duration), files, duration, fmt.Errorf("failed to retrieve files from HTTP cache: %w", err)
+		return newRemoteTaskCacheStatus(false, duration), files, fmt.Errorf("failed to retrieve files from HTTP cache: %w", err)
 	}
 	cache.logFetch(hit, key, duration)
-	return newRemoteTaskCacheStatus(hit, duration), files, duration, err
+	return newRemoteTaskCacheStatus(hit, duration), files, err
 }
 
 func (cache *httpCache) Exists(key string) ItemStatus {

--- a/cli/internal/cache/cache_http_test.go
+++ b/cli/internal/cache/cache_http_test.go
@@ -59,7 +59,7 @@ func TestRemoteCachingDisabled(t *testing.T) {
 		requestLimiter: make(limiter, 20),
 	}
 	cd := &util.CacheDisabledError{}
-	_, _, _, err := cache.Fetch("unused-target", "some-hash", []string{"unused", "outputs"})
+	_, _, err := cache.Fetch("unused-target", "some-hash", []string{"unused", "outputs"})
 	if !errors.As(err, &cd) {
 		t.Errorf("cache.Fetch err got %v, want a CacheDisabled error", err)
 	}

--- a/cli/internal/cache/cache_noop.go
+++ b/cli/internal/cache/cache_noop.go
@@ -11,8 +11,8 @@ func newNoopCache() *noopCache {
 func (c *noopCache) Put(_ turbopath.AbsoluteSystemPath, _ string, _ int, _ []turbopath.AnchoredSystemPath) error {
 	return nil
 }
-func (c *noopCache) Fetch(_ turbopath.AbsoluteSystemPath, _ string, _ []string) (ItemStatus, []turbopath.AnchoredSystemPath, int, error) {
-	return NewCacheMiss(), nil, 0, nil
+func (c *noopCache) Fetch(_ turbopath.AbsoluteSystemPath, _ string, _ []string) (ItemStatus, []turbopath.AnchoredSystemPath, error) {
+	return NewCacheMiss(), nil, nil
 }
 
 func (c *noopCache) Exists(_ string) ItemStatus {

--- a/cli/internal/cache/cache_noop.go
+++ b/cli/internal/cache/cache_noop.go
@@ -12,10 +12,11 @@ func (c *noopCache) Put(_ turbopath.AbsoluteSystemPath, _ string, _ int, _ []tur
 	return nil
 }
 func (c *noopCache) Fetch(_ turbopath.AbsoluteSystemPath, _ string, _ []string) (ItemStatus, []turbopath.AnchoredSystemPath, int, error) {
-	return ItemStatus{Local: false, Remote: false}, nil, 0, nil
+	return NewCacheMiss(), nil, 0, nil
 }
+
 func (c *noopCache) Exists(_ string) ItemStatus {
-	return ItemStatus{}
+	return NewCacheMiss()
 }
 
 func (c *noopCache) Clean(_ turbopath.AbsoluteSystemPath) {}

--- a/cli/internal/cache/cache_test.go
+++ b/cli/internal/cache/cache_test.go
@@ -17,16 +17,16 @@ type testCache struct {
 	entries     map[string][]turbopath.AnchoredSystemPath
 }
 
-func (tc *testCache) Fetch(_ turbopath.AbsoluteSystemPath, hash string, _ []string) (ItemStatus, []turbopath.AnchoredSystemPath, int, error) {
+func (tc *testCache) Fetch(_ turbopath.AbsoluteSystemPath, hash string, _ []string) (ItemStatus, []turbopath.AnchoredSystemPath, error) {
 	if tc.disabledErr != nil {
-		return ItemStatus{}, nil, 0, tc.disabledErr
+		return ItemStatus{}, nil, tc.disabledErr
 	}
 	foundFiles, ok := tc.entries[hash]
 	if ok {
 		duration := 5
-		return ItemStatus{Local: true}, foundFiles, duration, nil
+		return newFSTaskCacheStatus(true, duration), foundFiles, nil
 	}
-	return ItemStatus{}, nil, 0, nil
+	return NewCacheMiss(), nil, nil
 }
 
 func (tc *testCache) Exists(hash string) ItemStatus {
@@ -35,7 +35,7 @@ func (tc *testCache) Exists(hash string) ItemStatus {
 	}
 	_, ok := tc.entries[hash]
 	if ok {
-		return ItemStatus{Local: true}
+		return newFSTaskCacheStatus(true, 0)
 	}
 	return ItemStatus{}
 }
@@ -106,11 +106,11 @@ func TestPutCachingDisabled(t *testing.T) {
 	mplex.mu.RUnlock()
 
 	// subsequent Fetch should still work
-	cacheStatus, _, _, err := mplex.Fetch("unused-target", "some-hash", []string{"unused", "files"})
+	cacheStatus, _, err := mplex.Fetch("unused-target", "some-hash", []string{"unused", "files"})
 	if err != nil {
 		t.Errorf("got error fetching files: %v", err)
 	}
-	hit := cacheStatus.Local || cacheStatus.Remote
+	hit := cacheStatus.Hit
 	if !hit {
 		t.Error("failed to find previously stored files")
 	}
@@ -131,7 +131,7 @@ func TestExists(t *testing.T) {
 	}
 
 	itemStatus := mplex.Exists("some-hash")
-	if itemStatus.Local {
+	if itemStatus.Hit {
 		t.Error("did not expect file to exist")
 	}
 
@@ -142,7 +142,7 @@ func TestExists(t *testing.T) {
 	}
 
 	itemStatus = mplex.Exists("some-hash")
-	if !itemStatus.Local {
+	if !itemStatus.Hit {
 		t.Error("failed to find previously stored files")
 	}
 }
@@ -186,12 +186,12 @@ func TestFetchCachingDisabled(t *testing.T) {
 		},
 	}
 
-	cacheStatus, _, _, err := mplex.Fetch("unused-target", "some-hash", []string{"unused", "files"})
+	cacheStatus, _, err := mplex.Fetch("unused-target", "some-hash", []string{"unused", "files"})
 	if err != nil {
 		// don't leak the cache removal
 		t.Errorf("Fetch got error %v, want <nil>", err)
 	}
-	hit := cacheStatus.Local || cacheStatus.Remote
+	hit := cacheStatus.Hit
 	if hit {
 		t.Error("hit on empty cache, expected miss")
 	}

--- a/cli/internal/run/dry_run.go
+++ b/cli/internal/run/dry_run.go
@@ -116,7 +116,7 @@ func populateCacheState(turboCache cache.Cache, taskSummaries []*runsummary.Task
 			for index := range queue {
 				task := taskSummaries[index]
 				itemStatus := turboCache.Exists(task.Hash)
-				task.CacheSummary = runsummary.NewTaskCacheSummary(itemStatus, nil)
+				task.CacheSummary = runsummary.NewTaskCacheSummary(itemStatus)
 			}
 		}()
 	}

--- a/cli/internal/run/real_run.go
+++ b/cli/internal/run/real_run.go
@@ -264,19 +264,19 @@ func (ec *execContext) exec(ctx gocontext.Context, packageTask *nodes.PackageTas
 		WarnPrefix:   prettyPrefix,
 	}
 
-	cacheStatus, timeSaved, err := taskCache.RestoreOutputs(ctx, prefixedUI, progressLogger)
+	cacheStatus, err := taskCache.RestoreOutputs(ctx, prefixedUI, progressLogger)
 
 	// It's safe to set the CacheStatus even if there's an error, because if there's
 	// an error, the 0 values are actually what we want. We save cacheStatus and timeSaved
 	// for the task, so that even if there's an error, we have those values for the taskSummary.
 	ec.taskHashTracker.SetCacheStatus(
 		packageTask.TaskID,
-		runsummary.NewTaskCacheSummary(cacheStatus, &timeSaved),
+		runsummary.NewTaskCacheSummary(cacheStatus),
 	)
 
 	if err != nil {
 		prefixedUI.Error(fmt.Sprintf("error fetching from cache: %s", err))
-	} else if cacheStatus.Local || cacheStatus.Remote { // If there was a cache hit
+	} else if cacheStatus.Hit { // If there was a cache hit
 		ec.taskHashTracker.SetExpandedOutputs(packageTask.TaskID, taskCache.ExpandedOutputs)
 		// We only cache successful executions, so we can assume this is a successExitCode exit.
 		tracer(runsummary.TargetCached, nil, &successExitCode)

--- a/cli/internal/runcache/runcache.go
+++ b/cli/internal/runcache/runcache.go
@@ -115,7 +115,7 @@ func (tc *TaskCache) RestoreOutputs(ctx context.Context, prefixedUI *cli.Prefixe
 		if tc.taskOutputMode != util.NoTaskOutput && tc.taskOutputMode != util.ErrorTaskOutput {
 			prefixedUI.Output(fmt.Sprintf("cache bypass, force executing %s", ui.Dim(tc.hash)))
 		}
-		return cache.ItemStatus{Local: false, Remote: false}, 0, nil
+		return cache.NewCacheMiss(), 0, nil
 	}
 
 	changedOutputGlobs, timeSavedFromDaemon, err := tc.rc.outputWatcher.GetChangedOutputs(ctx, tc.hash, tc.repoRelativeGlobs.Inclusions)
@@ -141,13 +141,13 @@ func (tc *TaskCache) RestoreOutputs(ctx context.Context, prefixedUI *cli.Prefixe
 		cacheStatus = itemStatus
 		if err != nil {
 			// If there was an error fetching from cache, we'll say there was no cache hit
-			return cache.ItemStatus{Local: false, Remote: false}, 0, err
+			return cache.NewCacheMiss(), 0, err
 		} else if !hit {
 			if tc.taskOutputMode != util.NoTaskOutput && tc.taskOutputMode != util.ErrorTaskOutput {
 				prefixedUI.Output(fmt.Sprintf("cache miss, executing %s", ui.Dim(tc.hash)))
 			}
 			// If there was no hit, we can also say there was no hit
-			return cache.ItemStatus{Local: false, Remote: false}, 0, nil
+			return cache.NewCacheMiss(), 0, nil
 		}
 
 		if err := tc.rc.outputWatcher.NotifyOutputsWritten(ctx, tc.hash, tc.repoRelativeGlobs, timeSavedFromDaemon); err != nil {

--- a/cli/internal/runcache/runcache.go
+++ b/cli/internal/runcache/runcache.go
@@ -110,12 +110,12 @@ type TaskCache struct {
 // RestoreOutputs attempts to restore output for the corresponding task from the cache.
 // Returns the cacheStatus, the timeSaved, and error values, so the consumer can understand
 // what happened in here.
-func (tc *TaskCache) RestoreOutputs(ctx context.Context, prefixedUI *cli.PrefixedUi, progressLogger hclog.Logger) (cache.ItemStatus, int, error) {
+func (tc *TaskCache) RestoreOutputs(ctx context.Context, prefixedUI *cli.PrefixedUi, progressLogger hclog.Logger) (cache.ItemStatus, error) {
 	if tc.cachingDisabled || tc.rc.readsDisabled {
 		if tc.taskOutputMode != util.NoTaskOutput && tc.taskOutputMode != util.ErrorTaskOutput {
 			prefixedUI.Output(fmt.Sprintf("cache bypass, force executing %s", ui.Dim(tc.hash)))
 		}
-		return cache.NewCacheMiss(), 0, nil
+		return cache.NewCacheMiss(), nil
 	}
 
 	changedOutputGlobs, timeSavedFromDaemon, err := tc.rc.outputWatcher.GetChangedOutputs(ctx, tc.hash, tc.repoRelativeGlobs.Inclusions)
@@ -128,36 +128,36 @@ func (tc *TaskCache) RestoreOutputs(ctx context.Context, prefixedUI *cli.Prefixe
 
 	hasChangedOutputs := len(changedOutputGlobs) > 0
 	var cacheStatus cache.ItemStatus
-	var timeSaved int
 	if hasChangedOutputs {
 		// Note that we currently don't use the output globs when restoring, but we could in the
 		// future to avoid doing unnecessary file I/O. We also need to pass along the exclusion
 		// globs as well.
-		itemStatus, restoredFiles, duration, err := tc.rc.cache.Fetch(tc.rc.repoRoot, tc.hash, nil)
-		hit := itemStatus.Local || itemStatus.Remote
-		timeSaved = duration
-		tc.ExpandedOutputs = restoredFiles
+		itemStatus, restoredFiles, err := tc.rc.cache.Fetch(tc.rc.repoRoot, tc.hash, nil)
 		// Assign to this variable outside this closure so we can return at the end of the function
 		cacheStatus = itemStatus
+		tc.ExpandedOutputs = restoredFiles
 		if err != nil {
 			// If there was an error fetching from cache, we'll say there was no cache hit
-			return cache.NewCacheMiss(), 0, err
-		} else if !hit {
+			return cache.NewCacheMiss(), err
+		} else if !itemStatus.Hit {
 			if tc.taskOutputMode != util.NoTaskOutput && tc.taskOutputMode != util.ErrorTaskOutput {
 				prefixedUI.Output(fmt.Sprintf("cache miss, executing %s", ui.Dim(tc.hash)))
 			}
 			// If there was no hit, we can also say there was no hit
-			return cache.NewCacheMiss(), 0, nil
+			return cache.NewCacheMiss(), nil
 		}
 
-		if err := tc.rc.outputWatcher.NotifyOutputsWritten(ctx, tc.hash, tc.repoRelativeGlobs, timeSavedFromDaemon); err != nil {
+		if err := tc.rc.outputWatcher.NotifyOutputsWritten(ctx, tc.hash, tc.repoRelativeGlobs, cacheStatus.TimeSaved); err != nil {
 			// Don't fail the whole operation just because we failed to watch the outputs
 			prefixedUI.Warn(ui.Dim(fmt.Sprintf("Failed to mark outputs as cached for %v: %v", tc.pt.TaskID, err)))
 		}
 	} else {
 		// If no outputs have changed, that means we have a local cache hit.
-		cacheStatus.Local = true
-		timeSaved = timeSavedFromDaemon
+		cacheStatus = cache.ItemStatus{
+			Hit:       true,
+			Source:    cache.CacheSourceFS,
+			TimeSaved: timeSavedFromDaemon,
+		}
 		prefixedUI.Warn(fmt.Sprintf("Skipping cache check for %v, outputs have not changed since previous run.", tc.pt.TaskID))
 	}
 
@@ -176,9 +176,8 @@ func (tc *TaskCache) RestoreOutputs(ctx context.Context, prefixedUI *cli.Prefixe
 	default:
 		// NoLogs, do not output anything
 	}
-	// TODO: timeSaved could be part of cacheStatus, so we don't have to make a new struct
-	// downstream, but this would be a more invasive change right now.
-	return cacheStatus, timeSaved, nil
+
+	return cacheStatus, nil
 }
 
 // ReplayLogFile writes out the stored logfile to the terminal

--- a/cli/internal/runsummary/task_summary.go
+++ b/cli/internal/runsummary/task_summary.go
@@ -23,30 +23,31 @@ type TaskCacheSummary struct {
 // Importantly, it adds the derived keys of `source` and `status` based on
 // the local/remote booleans. It would be nice if these were just included
 // from upstream, but that is a more invasive change.
-func NewTaskCacheSummary(itemStatus cache.ItemStatus, timeSaved *int) TaskCacheSummary {
+func NewTaskCacheSummary(itemStatus cache.ItemStatus) TaskCacheSummary {
 	status := cache.CacheEventMiss
-	if itemStatus.Local || itemStatus.Remote {
+	if itemStatus.Hit {
 		status = cache.CacheEventHit
 	}
-
 	var source string
-	if itemStatus.Local {
-		source = cache.CacheSourceFS
-	} else if itemStatus.Remote {
-		source = cache.CacheSourceRemote
+	if itemStatus.Hit {
+		source = itemStatus.Source
 	}
 
 	cs := TaskCacheSummary{
-		// copy these over
-		Local:  itemStatus.Local,
-		Remote: itemStatus.Remote,
-		Status: status,
-		Source: source,
+		Status:    status,
+		Source:    source,
+		TimeSaved: itemStatus.TimeSaved,
 	}
-	// add in a dereferences timeSaved, should be 0 if nil
-	if timeSaved != nil {
-		cs.TimeSaved = *timeSaved
-	}
+
+	// Assign these deprecated fields Local and Remote based on the information available
+	// in the itemStatus. Note that these fields are problematic, because an ItemStatus isn't always
+	// the composite of both local and remote caches. That means that an ItemStatus might say it
+	// was a local cache hit, and we return remote: false here. That's misleading because it does
+	// not mean that there is no remote cache hit, it _could_ mean that we never checked the remote
+	// cache. These fields are being deprecated for this reason.
+	cs.Local = itemStatus.Hit && itemStatus.Source == cache.CacheSourceFS
+	cs.Remote = itemStatus.Hit && itemStatus.Source == cache.CacheSourceRemote
+
 	return cs
 }
 


### PR DESCRIPTION
- Instead of Local/Remote booleans, use a Source field.
This ensure that we are more truthful about where the cache
was restored from, rather than which cache happened to win
the race condition.
- Adds timeSaved value from the same cache source where restoration
happened from.