### PR TITLE
Fix `vdbg!` depth and JSON error messages

### DIFF
--- a/crates/turbo-tasks-fs/src/json.rs
+++ b/crates/turbo-tasks-fs/src/json.rs
@@ -47,7 +47,10 @@ impl UnparseableJson {
         Self {
             message: inner.to_string().into(),
             path: Some(e.path().to_string()),
-            start_location: Some((inner.line() - 1, inner.column() - 1)),
+            start_location: Some((
+                inner.line().saturating_sub(1),
+                inner.column().saturating_sub(1),
+            )),
             end_location: None,
         }
     }

--- a/crates/turbo-tasks/src/debug/vdbg.rs
+++ b/crates/turbo-tasks/src/debug/vdbg.rs
@@ -66,7 +66,7 @@ macro_rules! vdbg {
     (__repeat $str:literal) => { "" };
 
     ($($val:expr),* ; depth = $depth:expr) => {
-        $crate::vdbg!(__init $depth ; $($val),*)
+        $crate::vdbg!(__init $depth ; [ $($val),* ] [])
     };
     ($($val:expr),+ $(,)?) => {
         $crate::vdbg!(__init usize::MAX ; [ $($val),* ] [])


### PR DESCRIPTION
### Description

Two small fixes:

- The `vdbg!(vc; depth = 1)` macro would error out
  - the expanded `__init` syntax wasn't updated in #4995
- The JSON error message could panic if the line and/or column was `0`
  - This comes up when trying to deserialize into a struct with a missing prop, because it errors at the opening `{` brace

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
