### PR TITLE
fix(daemon) add time saved metric to Go daemon

### DIFF
--- a/cli/internal/server/server.go
+++ b/cli/internal/server/server.go
@@ -33,6 +33,8 @@ type Server struct {
 	repoRoot     turbopath.AbsoluteSystemPath
 	closerMu     sync.Mutex
 	closer       *closer
+	timeSavedMu  sync.Mutex
+	timesSaved   map[string]uint64
 }
 
 // GRPCServer is the interface that the turbo server needs to the underlying
@@ -82,6 +84,7 @@ func New(serverName string, logger hclog.Logger, repoRoot turbopath.AbsoluteSyst
 		started:      time.Now(),
 		logFilePath:  logFilePath,
 		repoRoot:     repoRoot,
+		timesSaved:   map[string]uint64{},
 	}
 	server.watcher.AddClient(cookieJar)
 	server.watcher.AddClient(globWatcher)
@@ -137,6 +140,9 @@ func (s *Server) Register(grpcServer GRPCServer) {
 
 // NotifyOutputsWritten implements the NotifyOutputsWritten rpc from turbo.proto
 func (s *Server) NotifyOutputsWritten(ctx context.Context, req *turbodprotocol.NotifyOutputsWrittenRequest) (*turbodprotocol.NotifyOutputsWrittenResponse, error) {
+	s.timeSavedMu.Lock()
+	s.timesSaved[req.Hash] = req.TimeSaved
+	s.timeSavedMu.Unlock()
 	outputs := fs.TaskOutputs{
 		Inclusions: req.OutputGlobs,
 		Exclusions: req.OutputExclusionGlobs,
@@ -151,6 +157,9 @@ func (s *Server) NotifyOutputsWritten(ctx context.Context, req *turbodprotocol.N
 
 // GetChangedOutputs implements the GetChangedOutputs rpc from turbo.proto
 func (s *Server) GetChangedOutputs(ctx context.Context, req *turbodprotocol.GetChangedOutputsRequest) (*turbodprotocol.GetChangedOutputsResponse, error) {
+	s.timeSavedMu.Lock()
+	timeSaved := s.timesSaved[req.Hash]
+	s.timeSavedMu.Unlock()
 
 	changedGlobs, err := s.globWatcher.GetChangedGlobs(req.Hash, req.OutputGlobs)
 	if err != nil {
@@ -158,6 +167,7 @@ func (s *Server) GetChangedOutputs(ctx context.Context, req *turbodprotocol.GetC
 	}
 	return &turbodprotocol.GetChangedOutputsResponse{
 		ChangedOutputGlobs: changedGlobs,
+		TimeSaved:          timeSaved,
 	}, nil
 }
 


### PR DESCRIPTION
### Description

A port of the changes to the Rust daemon in #4952

### Testing Instructions

Followed same testing protocol as described in initial PR.
