### PR TITLE
fix(turborepo): Handle unimplemented and failed_precondition in daemon clients

### DIFF
--- a/cli/internal/daemon/connector/connector.go
+++ b/cli/internal/daemon/connector/connector.go
@@ -329,6 +329,8 @@ func (c *Connector) sendHello(ctx context.Context, client turbodprotocol.TurbodC
 	switch status.Code() {
 	case codes.OK:
 		return nil
+	case codes.Unimplemented:
+		fallthrough // some versions of the rust daemon return Unimplemented rather than FailedPrecondition
 	case codes.FailedPrecondition:
 		return ErrVersionMismatch
 	case codes.Unavailable:

--- a/crates/turborepo-lib/src/daemon/client.rs
+++ b/crates/turborepo-lib/src/daemon/client.rs
@@ -162,7 +162,7 @@ pub enum DaemonError {
 impl From<Status> for DaemonError {
     fn from(status: Status) -> DaemonError {
         match status.code() {
-            Code::FailedPrecondition => DaemonError::VersionMismatch,
+            Code::FailedPrecondition | Code::Unimplemented => DaemonError::VersionMismatch,
             Code::Unavailable => DaemonError::Unavailable,
             c => DaemonError::GrpcFailure(c),
         }

--- a/crates/turborepo-lib/src/daemon/server.rs
+++ b/crates/turborepo-lib/src/daemon/server.rs
@@ -221,8 +221,13 @@ impl<T: Watcher + Send + 'static> proto::turbod_server::Turbod for DaemonServer<
         &self,
         request: tonic::Request<proto::HelloRequest>,
     ) -> Result<tonic::Response<proto::HelloResponse>, tonic::Status> {
-        if request.into_inner().version != get_version() {
-            return Err(tonic::Status::unimplemented("version mismatch"));
+        let client_version = request.into_inner().version;
+        let server_version = get_version();
+        if client_version != server_version {
+            return Err(tonic::Status::failed_precondition(format!(
+                "version mismatch. Client {} Server {}",
+                client_version, server_version
+            )));
         } else {
             Ok(tonic::Response::new(proto::HelloResponse {}))
         }


### PR DESCRIPTION
### Description

 - sets both daemon clients to handle `unimplemented` as identical to `failed_precondition`
 - sets the rust daemon server to return `failed_precondition` instead of `unimplemented` for a version mismatch

### Testing Instructions

Existing test suite. I will follow up with a rust test to capture the behavior
