### PR TITLE
chore(turborepo): Port piece of kill_live_server test for version mismatch

### DIFF
--- a/crates/turborepo-lib/src/daemon/connector.rs
+++ b/crates/turborepo-lib/src/daemon/connector.rs
@@ -671,6 +671,10 @@ mod test {
             .map(TurbodClient::new)
             .unwrap();
 
+        // spawn the future for the server so that it responds to
+        // the hello request
+        let server_fut = tokio::spawn(server_fut);
+
         let hello_resp: DaemonError = client
             .hello(proto::HelloRequest {
                 version: "version-mismatch".to_string(),


### PR DESCRIPTION
### Description

While not the greatest test since it isn't testing actual server logic, it does assert that a client receiving a `failed_precondition` should translate that as a `VersionMismatch`. This matches the behavior in `connector_test.go`.

### Testing Instructions

New test functional added
