### PR TITLE
feat(create-turbo): use latest turbo by default

### DIFF
--- a/packages/create-turbo/src/cli.ts
+++ b/packages/create-turbo/src/cli.ts
@@ -28,6 +28,10 @@ createTurboCli
     false
   )
   .option(
+    "--turbo-version <version>",
+    "Use a specific version of turbo (default: latest)"
+  )
+  .option(
     "-e, --example [name]|[github-url]",
     `
   An example to bootstrap the app with. You can use an example name
@@ -44,8 +48,8 @@ createTurboCli
   --example-path foo/bar
 `
   )
-  .version(cliPkg.version, "-v, --version", "output the current version")
-  .helpOption()
+  .version(cliPkg.version, "-v, --version", "Output the current version")
+  .helpOption("-h, --help", "Display help for command")
   .action(create);
 
 createTurboCli

--- a/packages/create-turbo/src/commands/create/types.ts
+++ b/packages/create-turbo/src/commands/create/types.ts
@@ -1,8 +1,9 @@
-export type CreateCommandArgument = "string" | undefined;
+export type CreateCommandArgument = string | undefined;
 
 export interface CreateCommandOptions {
   skipInstall?: boolean;
   skipTransforms?: boolean;
+  turboVersion?: string;
   example?: string;
   examplePath?: string;
 }

--- a/packages/create-turbo/src/transforms/official-starter.ts
+++ b/packages/create-turbo/src/transforms/official-starter.ts
@@ -12,7 +12,7 @@ const meta = {
 
 // applied to "official starter" examples (those hosted within vercel/turbo/examples)
 export async function transform(args: TransformInput): TransformResult {
-  const { prompts, example } = args;
+  const { prompts, example, opts } = args;
 
   const defaultExample = isDefaultExample(example.name);
   const isOfficialStarter =
@@ -50,10 +50,19 @@ export async function transform(args: TransformInput): TransformResult {
         packageJsonContent.name = prompts.projectName;
       }
 
-      // if we're using a pre-release version of create-turbo, install turbo canary instead of latest
-      const shouldUsePreRelease = semverPrerelease(cliPkgJson.version) !== null;
-      if (shouldUsePreRelease && packageJsonContent?.devDependencies?.turbo) {
-        packageJsonContent.devDependencies.turbo = "canary";
+      if (packageJsonContent?.devDependencies?.turbo) {
+        const shouldUsePreRelease =
+          semverPrerelease(cliPkgJson.version) !== null;
+        // if the user specified a turbo version, use that
+        if (opts.turboVersion) {
+          packageJsonContent.devDependencies.turbo = opts.turboVersion;
+          // if we're using a pre-release version of create-turbo, use turbo canary
+        } else if (shouldUsePreRelease) {
+          packageJsonContent.devDependencies.turbo = "canary";
+          // otherwise, use the latest stable version
+        } else {
+          packageJsonContent.devDependencies.turbo = "latest";
+        }
       }
 
       try {


### PR DESCRIPTION
### Description

Use latest turbo by default (unless using create-turbo@canary). 

Also support new option `--turbo-version <version>`
