### PR TITLE
Support installing tip-of-canary next for benchmarks

### DIFF
--- a/crates/turbopack-bench/src/util/npm.rs
+++ b/crates/turbopack-bench/src/util/npm.rs
@@ -42,7 +42,12 @@ pub fn install(install_dir: &Path, packages: &[NpmPackage<'_>]) -> Result<()> {
             .write_all(format!("{:#}", package_json).as_bytes())?;
     }
 
-    let mut args = vec!["install".to_owned(), "--force".to_owned()];
+    let mut args = vec![
+        "install".to_owned(),
+        "--force".to_owned(),
+        "--install-links".to_owned(),
+        "false".to_owned(),
+    ];
     args.append(
         &mut packages
             .iter()

--- a/crates/turbopack-node/src/evaluate.rs
+++ b/crates/turbopack-node/src/evaluate.rs
@@ -51,7 +51,7 @@ enum EvalJavaScriptOutgoingMessage<'a> {
     Evaluate { args: Vec<&'a JsonValue> },
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 #[serde(tag = "type", rename_all = "camelCase")]
 enum EvalJavaScriptIncomingMessage {
     FileDependency {


### PR DESCRIPTION
### Description

A small change to support installing a local `next@file:path/to/next.js/packages/next` next package. This fixes an issue where we run tip-of-canary `next-dev` vs the last published `next` package, and allows us to benchmark breaking changes.

The [`--install-links`](https://docs.npmjs.com/cli/v8/commands/npm-install#install-links) option is a little oxymoronic.  When set to true, it **doesn't** use symlinks, so we need to set it to false to avoid copying a bunch of files.

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
