### PR TITLE
feat(turborepo): Wait for a pid file, then a sock file

### DIFF
--- a/cli/internal/daemon/connector/connector.go
+++ b/cli/internal/daemon/connector/connector.go
@@ -360,9 +360,20 @@ func (c *Connector) waitForSocket() error {
 	// Note that we don't care if this is our daemon
 	// or not. We started a process, but someone else could beat
 	// use to listening. That's fine, we'll check the version
-	// later.
+	// later. However, we need to ensure that _some_ pid file
+	// exists to protect against stale .sock files
+	if err := waitForFile(c.PidPath); err != nil {
+		return err
+	}
+	if err := waitForFile(c.SockPath); err != nil {
+		return err
+	}
+	return nil
+}
+
+func waitForFile(file turbopath.AbsoluteSystemPath) error {
 	err := backoff.Retry(func() error {
-		if !c.SockPath.FileExists() {
+		if !file.FileExists() {
 			return errNeedsRetry
 		}
 		return nil

--- a/cli/internal/daemon/connector/connector.go
+++ b/cli/internal/daemon/connector/connector.go
@@ -365,10 +365,7 @@ func (c *Connector) waitForSocket() error {
 	if err := waitForFile(c.PidPath); err != nil {
 		return err
 	}
-	if err := waitForFile(c.SockPath); err != nil {
-		return err
-	}
-	return nil
+	return waitForFile(c.SockPath)
 }
 
 func waitForFile(file turbopath.AbsoluteSystemPath) error {


### PR DESCRIPTION
### Description

In the event of a stale `.sock` file, we should wait for a `.pid` file before trying to use the socket

### Testing Instructions

Verified experimentally in upgrade path with a stale `.sock` file.