### PR TITLE
Copy benckmark deps into directory

### DIFF
--- a/crates/turbopack-bench/src/util/npm.rs
+++ b/crates/turbopack-bench/src/util/npm.rs
@@ -46,7 +46,7 @@ pub fn install(install_dir: &Path, packages: &[NpmPackage<'_>]) -> Result<()> {
         "install".to_owned(),
         "--force".to_owned(),
         "--install-links".to_owned(),
-        "false".to_owned(),
+        "true".to_owned(),
     ];
     args.append(
         &mut packages

--- a/crates/turbopack-bench/src/util/npm.rs
+++ b/crates/turbopack-bench/src/util/npm.rs
@@ -45,6 +45,8 @@ pub fn install(install_dir: &Path, packages: &[NpmPackage<'_>]) -> Result<()> {
     let mut args = vec![
         "install".to_owned(),
         "--force".to_owned(),
+        // install-links will copy local dependencies into the node_modules folder instead of
+        // symlinking, which fixes our root detection.
         "--install-links".to_owned(),
         "true".to_owned(),
     ];


### PR DESCRIPTION
### Description

#5156 turned out to be flakey, and it seems our root detection will prevent us from running the local `next` package unless we copy it over into the benchmark app.

I _really_ hate our root detection, and think we should get rid of it. I don't care where the file is located, it should be readable by our bundler.

### Testing Instructions
