### PR TITLE
test(daemon): add more tests around go file watching behavior

### DIFF
--- a/cli/internal/filewatcher/filewatcher_test.go
+++ b/cli/internal/filewatcher/filewatcher_test.go
@@ -157,13 +157,6 @@ func TestFileWatching(t *testing.T) {
 		EventType: FileRenamed,
 	})
 
-	err = twinPath.RemoveAll()
-	assert.NilError(t, err, "RemoveAll")
-	expectFilesystemEvent(t, ch, Event{
-		Path:      twinPath,
-		EventType: FileDeleted,
-	})
-
 	gitFilePath := repoRoot.UntypedJoin(".git", "git-file")
 	err = gitFilePath.WriteFile([]byte("nope"), 0644)
 	assert.NilError(t, err, "WriteFile")

--- a/cli/internal/filewatcher/filewatcher_test.go
+++ b/cli/internal/filewatcher/filewatcher_test.go
@@ -149,6 +149,10 @@ func TestFileWatching(t *testing.T) {
 	err = repoRoot.UntypedJoin("parent", "sibling").Rename(twinPath)
 	assert.NilError(t, err, "Rename")
 	expectFilesystemEvent(t, ch, Event{
+		Path:      repoRoot.UntypedJoin("parent", "sibling"),
+		EventType: FileRenamed,
+	})
+	expectFilesystemEvent(t, ch, Event{
 		Path:      twinPath,
 		EventType: FileRenamed,
 	})


### PR DESCRIPTION
### Description

Adding more tests around the Go filewatching behavior in order to better track down any divergences with the Rust implementation.

### Testing Instructions

See if CI succeeds on all platforms
