### PR TITLE
fix(turborepo): Restructure reading from stderr, fix parsing of ls-tree

### DIFF
--- a/crates/turborepo-scm/src/hash_object.rs
+++ b/crates/turborepo-scm/src/hash_object.rs
@@ -8,7 +8,7 @@ use std::{
 use nom::{Finish, IResult};
 use turbopath::{AbsoluteSystemPathBuf, RelativeUnixPathBuf};
 
-use crate::{package_deps::GitHashes, read_git_error, wait_for_success, Error};
+use crate::{package_deps::GitHashes, wait_for_success, Error};
 
 pub(crate) fn hash_objects(
     pkg_path: &AbsoluteSystemPathBuf,
@@ -41,10 +41,8 @@ pub(crate) fn hash_objects(
         .stderr
         .take()
         .ok_or_else(|| Error::git_error("failed to get stderr for git hash-object"))?;
-    read_object_hashes(stdout, stdin, &to_hash, pkg_prefix, hashes)
-        .map_err(|err| read_git_error(&mut stderr).unwrap_or(err))?;
-    wait_for_success(git, &mut stderr, "git hash-object", pkg_path)?;
-    Ok(())
+    let parse_result = read_object_hashes(stdout, stdin, &to_hash, pkg_prefix, hashes);
+    wait_for_success(git, &mut stderr, "git hash-object", pkg_path, parse_result)
 }
 
 const HASH_LEN: usize = 40;

--- a/crates/turborepo-scm/src/lib.rs
+++ b/crates/turborepo-scm/src/lib.rs
@@ -69,7 +69,7 @@ pub(crate) fn wait_for_success<R: Read, T>(
     let stderr_output = read_git_error_to_string(stderr);
     let stderr_text = stderr_output
         .map(|stderr| format!(" stderr: {}", stderr))
-        .unwrap_or("".to_string());
+        .unwrap_or_default();
     let exit_text = if exit_status.success() {
         "".to_string()
     } else {

--- a/crates/turborepo-scm/src/lib.rs
+++ b/crates/turborepo-scm/src/lib.rs
@@ -61,10 +61,8 @@ pub(crate) fn wait_for_success<R: Read, T>(
     parse_result: Result<T, Error>,
 ) -> Result<T, Error> {
     let exit_status = child.wait()?;
-    if exit_status.success() {
-        if let Ok(result) = parse_result {
-            return Ok(result);
-        }
+    if exit_status.success() && parse_result.is_ok() {
+        return parse_result;
     }
     let stderr_output = read_git_error_to_string(stderr);
     let stderr_text = stderr_output

--- a/crates/turborepo-scm/src/status.rs
+++ b/crates/turborepo-scm/src/status.rs
@@ -6,7 +6,7 @@ use std::{
 use nom::Finish;
 use turbopath::{AbsoluteSystemPathBuf, RelativeUnixPathBuf};
 
-use crate::{package_deps::GitHashes, read_git_error, wait_for_success, Error};
+use crate::{package_deps::GitHashes, wait_for_success, Error};
 
 pub(crate) fn append_git_status(
     root_path: &AbsoluteSystemPathBuf,
@@ -35,10 +35,8 @@ pub(crate) fn append_git_status(
         .stderr
         .take()
         .ok_or_else(|| Error::git_error("failed to get stderr for git status"))?;
-    let to_hash = read_status(stdout, pkg_prefix, hashes)
-        .map_err(|err| read_git_error(&mut stderr).unwrap_or(err))?;
-    wait_for_success(git, &mut stderr, "git status", &root_path)?;
-    Ok(to_hash)
+    let parse_result = read_status(stdout, pkg_prefix, hashes);
+    wait_for_success(git, &mut stderr, "git status", &root_path, parse_result)
 }
 
 fn read_status<R: Read>(


### PR DESCRIPTION
### Description

 - Ensure we read `stderr` after calling `wait()` on the child process
 - Fix parsing of `git ls-tree` to not truncate filenames at spaces

### Testing Instructions

Added a test of a filename with spaces
