### PR TITLE
[turborepo] Add --since flag to turbo-ignore

### DIFF
--- a/packages/turbo-ignore/README.md
+++ b/packages/turbo-ignore/README.md
@@ -24,6 +24,7 @@ If <workspace> is not provided, it will be inferred from the "name"
 field of the "package.json" located at the current working directory.
 
 Flags:
+  --since=<ref>       A ref/head to compare against
   --fallback=<ref>    On Vercel, if no previously deployed SHA is available to compare against,
                       fallback to comparing against the provided ref [default: None]
   --help, -h          Show this help message

--- a/packages/turbo-ignore/src/args.ts
+++ b/packages/turbo-ignore/src/args.ts
@@ -19,6 +19,7 @@ If <workspace> is not provided, it will be inferred from the "name"
 field of the "package.json" located at the current working directory.
 
 Flags:
+  --since=<ref>       A ref/head to compare against
   --fallback=<ref>    On Vercel, if no previously deployed SHA is available to compare against,
                       fallback to comparing against the provided ref
   --help, -h          Show this help message
@@ -83,6 +84,13 @@ export default function parseArgs({
   const fallbackArg = argv.find((arg) => arg.startsWith(fallbackSentinel));
   if (fallbackArg && fallbackArg.length > fallbackSentinel.length) {
     args.fallback = fallbackArg.split("=")[1];
+  }
+
+  // set since (if provided)
+  const sinceSentinel = "--since=";
+  const sinceArg = argv.find((arg) => arg.startsWith(sinceSentinel));
+  if (sinceArg && sinceArg.length > sinceSentinel.length) {
+    args.since = fallbackArg.split("=")[1];
   }
 
   return args;

--- a/packages/turbo-ignore/src/getComparison.ts
+++ b/packages/turbo-ignore/src/getComparison.ts
@@ -8,9 +8,15 @@ export interface GetComparisonArgs extends TurboIgnoreArgs {
 
 export function getComparison(args: GetComparisonArgs): {
   ref: string;
-  type: "previousDeploy" | "headRelative" | "customFallback";
+  type: "previousDeploy" | "headRelative" | "customFallback" | "specifiedManually";
 } | null {
-  const { fallback, workspace } = args;
+  const { fallback, since, workspace } = args;
+
+  if (since) {
+    // if user has provided a commit to compare to, we use it in the first place
+    return { ref: since, type: 'specifiedManually' };
+  }
+
   if (process.env.VERCEL === "1") {
     if (process.env.VERCEL_GIT_PREVIOUS_SHA) {
       // use the commit SHA of the last successful deployment for this project / branch

--- a/packages/turbo-ignore/src/getComparison.ts
+++ b/packages/turbo-ignore/src/getComparison.ts
@@ -4,8 +4,6 @@ import { TurboIgnoreArgs } from "./types";
 export interface GetComparisonArgs extends TurboIgnoreArgs {
   // the workspace to check for changes
   workspace: string;
-  // A ref/head to compare against if no previously deployed SHA is available
-  fallback?: string;
 }
 
 export function getComparison(args: GetComparisonArgs): {

--- a/packages/turbo-ignore/src/types.ts
+++ b/packages/turbo-ignore/src/types.ts
@@ -20,6 +20,6 @@ export interface TurboIgnoreArgs {
   task?: string;
   // A ref/head to compare against
   since?: string;
-  // A ref/head to compare against if no previously deployed SHA is available
+  // On Vercel, a fallback ref/head to compare against if no previously deployed SHA is available
   fallback?: string;
 }

--- a/packages/turbo-ignore/src/types.ts
+++ b/packages/turbo-ignore/src/types.ts
@@ -18,6 +18,8 @@ export interface TurboIgnoreArgs {
   workspace?: string;
   // the task to run, if not build
   task?: string;
+  // A ref/head to compare against
+  since?: string;
   // A ref/head to compare against if no previously deployed SHA is available
   fallback?: string;
 }


### PR DESCRIPTION
### Description

This PR adds a new `--since` flag to the `turbo-ignore` package. 

This flag allows to specify a commit ref to compare against. Detailed motivation can be found in #5080.

Fixes: #5080 #5136

### Progress

- [x] Add --since flag
- [ ] Add tests
- [ ] Make changes to the docs

### Testing Instructions

To Do