### PR TITLE
feat(turborepo): Remove as_absolute_path() in favor of Deref

### DIFF
--- a/crates/turborepo-lib/src/execution_state.rs
+++ b/crates/turborepo-lib/src/execution_state.rs
@@ -28,12 +28,8 @@ impl<'a> TryFrom<&'a CommandBase> for ExecutionState<'a> {
     type Error = anyhow::Error;
 
     fn try_from(base: &'a CommandBase) -> Result<Self, Self::Error> {
-        let root_package_json = PackageJson::load(
-            base.repo_root
-                .join_component("package.json")
-                .as_absolute_path(),
-        )
-        .ok();
+        let root_package_json =
+            PackageJson::load(&base.repo_root.join_component("package.json")).ok();
 
         let package_manager =
             PackageManager::get_package_manager(base, root_package_json.as_ref())?;

--- a/crates/turborepo-lib/src/package_manager/mod.rs
+++ b/crates/turborepo-lib/src/package_manager/mod.rs
@@ -435,7 +435,7 @@ mod tests {
         let with_yarn = repo_root.join_components(&["examples", "with-yarn"]);
         let package_manager = PackageManager::Npm;
         let globs = package_manager
-            .get_workspace_globs(with_yarn.as_absolute_path())
+            .get_workspace_globs(&with_yarn)
             .unwrap()
             .unwrap();
 

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -42,8 +42,8 @@ impl Run {
     pub async fn run(&mut self) -> Result<()> {
         let _start_at = std::time::Instant::now();
         let package_json_path = self.base.repo_root.join_component("package.json");
-        let root_package_json = PackageJson::load(package_json_path.as_absolute_path())
-            .context("failed to read package.json")?;
+        let root_package_json =
+            PackageJson::load(&package_json_path).context("failed to read package.json")?;
         let targets = self.targets();
         let mut opts = self.opts()?;
 
@@ -78,7 +78,7 @@ impl Run {
         let g = CompleteGraph::new(
             pkg_dep_graph.workspace_graph.clone(),
             pkg_dep_graph.workspace_infos.clone(),
-            self.base.repo_root.as_absolute_path(),
+            &self.base.repo_root,
         );
 
         let is_single_package = opts.run_opts.single_package;

--- a/crates/turborepo-lib/src/shim.rs
+++ b/crates/turborepo-lib/src/shim.rs
@@ -753,12 +753,12 @@ pub fn run() -> Result<Payload> {
     // it to execute local turbo. We simply use it to set the `--single-package`
     // and `--cwd` flags.
     if is_turbo_binary_path_set() {
-        let repo_state = RepoState::infer(args.cwd.as_absolute_path())?;
+        let repo_state = RepoState::infer(&args.cwd)?;
         debug!("Repository Root: {}", repo_state.root.to_string_lossy());
         return cli::run(Some(repo_state), &subscriber, ui);
     }
 
-    match RepoState::infer(args.cwd.as_absolute_path()) {
+    match RepoState::infer(&args.cwd) {
         Ok(repo_state) => {
             debug!("Repository Root: {}", repo_state.root.to_string_lossy());
             repo_state.run_correct_turbo(args, &subscriber, ui)

--- a/crates/turborepo-paths/src/absolute_system_path_buf.rs
+++ b/crates/turborepo-paths/src/absolute_system_path_buf.rs
@@ -3,13 +3,14 @@ use std::{
     ffi::OsStr,
     fmt, fs,
     io::{self, Write},
+    ops::Deref,
     path::{Components, Path, PathBuf},
 };
 
 use path_clean::PathClean;
 use serde::Serialize;
 
-use crate::{AbsoluteSystemPath, AnchoredSystemPathBuf, IntoSystem, PathError, RelativeUnixPath};
+use crate::{AbsoluteSystemPath, AnchoredSystemPathBuf, IntoSystem, PathError};
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Serialize)]
 pub struct AbsoluteSystemPathBuf(pub(crate) PathBuf);
@@ -23,6 +24,14 @@ impl Borrow<AbsoluteSystemPath> for AbsoluteSystemPathBuf {
 
 impl AsRef<AbsoluteSystemPath> for AbsoluteSystemPathBuf {
     fn as_ref(&self) -> &AbsoluteSystemPath {
+        self
+    }
+}
+
+impl Deref for AbsoluteSystemPathBuf {
+    type Target = AbsoluteSystemPath;
+
+    fn deref(&self) -> &Self::Target {
         self.borrow()
     }
 }
@@ -78,15 +87,11 @@ impl AbsoluteSystemPathBuf {
 
     pub fn from_cwd(unknown: impl Into<PathBuf>) -> Result<Self, PathError> {
         let cwd = Self::cwd()?;
-        Ok(Self::from_unknown(cwd.as_absolute_path(), unknown))
+        Ok(Self::from_unknown(&cwd, unknown))
     }
 
     pub fn cwd() -> Result<Self, PathError> {
         Ok(Self(std::env::current_dir()?))
-    }
-
-    pub fn ancestors(&self) -> impl Iterator<Item = &AbsoluteSystemPath> {
-        self.as_absolute_path().ancestors()
     }
 
     /// Anchors `path` at `self`.
@@ -159,10 +164,6 @@ impl AbsoluteSystemPathBuf {
         self.0.as_path()
     }
 
-    pub fn as_absolute_path(&self) -> &AbsoluteSystemPath {
-        self.borrow()
-    }
-
     pub fn components(&self) -> Components<'_> {
         self.0.components()
     }
@@ -179,21 +180,6 @@ impl AbsoluteSystemPathBuf {
 
     pub fn ends_with<P: AsRef<Path>>(&self, child: P) -> bool {
         self.0.ends_with(child.as_ref())
-    }
-
-    pub fn join_component(&self, segment: &str) -> Self {
-        self.as_absolute_path().join_component(segment)
-    }
-
-    pub fn join_components(&self, segments: &[&str]) -> Self {
-        self.as_absolute_path().join_components(segments)
-    }
-
-    pub fn join_unix_path(
-        &self,
-        unix_path: impl AsRef<RelativeUnixPath>,
-    ) -> Result<AbsoluteSystemPathBuf, PathError> {
-        self.as_absolute_path().join_unix_path(unix_path)
     }
 
     pub fn ensure_dir(&self) -> Result<(), io::Error> {
@@ -260,14 +246,6 @@ impl AbsoluteSystemPathBuf {
         let realpath = dunce::canonicalize(&self.0)?;
         Ok(Self(realpath))
     }
-
-    pub fn symlink_to_file(&self, target: impl AsRef<Path>) -> Result<(), PathError> {
-        self.as_absolute_path().symlink_to_file(target)
-    }
-
-    pub fn symlink_to_dir(&self, target: impl AsRef<Path>) -> Result<(), PathError> {
-        self.as_absolute_path().symlink_to_dir(target)
-    }
 }
 
 impl From<AbsoluteSystemPathBuf> for PathBuf {
@@ -313,7 +291,6 @@ mod tests {
         assert_eq!(
             AbsoluteSystemPathBuf::new("/some/dir")
                 .unwrap()
-                .as_absolute_path()
                 .join_unix_path(&tail)
                 .unwrap(),
             AbsoluteSystemPathBuf::new("/some/other").unwrap(),
@@ -342,7 +319,6 @@ mod tests {
         assert_eq!(
             AbsoluteSystemPathBuf::new("C:\\some\\dir")
                 .unwrap()
-                .as_absolute_path()
                 .join_unix_path(&tail)
                 .unwrap(),
             AbsoluteSystemPathBuf::new("C:\\some\\other").unwrap(),


### PR DESCRIPTION
### Description

- Implements `Deref` to `&AbsoluteSystemPath` for `AbsoluteSystemPathBuf`
- Removes all calls to `.as_absolute_path()`

### Testing Instructions

Existing tests