### PR TITLE
feat(lockfiles): add support pnpm lockfile version 6.1

### DIFF
--- a/crates/turborepo-lockfiles/fixtures/pnpm-v6.1.yaml
+++ b/crates/turborepo-lockfiles/fixtures/pnpm-v6.1.yaml
@@ -1,0 +1,22 @@
+lockfileVersion: "6.1"
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+  .: {}
+
+  packages/a:
+    dependencies:
+      c:
+        specifier: workspace:*
+        version: link:../c
+
+  packages/b:
+    dependencies:
+      c:
+        specifier: workspace:*
+        version: link:../c
+
+  packages/c: {}

--- a/crates/turborepo-lockfiles/src/pnpm/data.rs
+++ b/crates/turborepo-lockfiles/src/pnpm/data.rs
@@ -440,7 +440,8 @@ pub fn pnpm_global_change(
     Ok(prev_data.lockfile_version != curr_data.lockfile_version
         || prev_data.package_extensions_checksum != curr_data.package_extensions_checksum
         || prev_data.overrides != curr_data.overrides
-        || prev_data.patched_dependencies != curr_data.patched_dependencies)
+        || prev_data.patched_dependencies != curr_data.patched_dependencies
+        || prev_data.settings != curr_data.settings)
 }
 
 #[cfg(test)]

--- a/crates/turborepo-lockfiles/src/pnpm/data.rs
+++ b/crates/turborepo-lockfiles/src/pnpm/data.rs
@@ -11,6 +11,8 @@ type Map<K, V> = std::collections::BTreeMap<K, V>;
 pub struct PnpmLockfile {
     lockfile_version: LockfileVersion,
     #[serde(skip_serializing_if = "Option::is_none")]
+    settings: Option<LockfileSettings>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     never_built_dependencies: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     only_built_dependencies: Option<Vec<String>>,
@@ -25,8 +27,6 @@ pub struct PnpmLockfile {
     packages: Option<Map<String, PackageSnapshot>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     time: Option<Map<String, String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    settings: Option<LockfileSettings>,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]

--- a/crates/turborepo-lockfiles/src/pnpm/data.rs
+++ b/crates/turborepo-lockfiles/src/pnpm/data.rs
@@ -25,6 +25,8 @@ pub struct PnpmLockfile {
     packages: Option<Map<String, PackageSnapshot>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     time: Option<Map<String, String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    settings: Option<LockfileSettings>,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
@@ -123,6 +125,13 @@ pub struct PackageResolution {
     repo: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     commit: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[serde(rename_all = "camelCase")]
+struct LockfileSettings {
+    auto_install_peer_deps: Option<bool>,
+    exclude_links_from_lockfile: Option<bool>,
 }
 
 impl PnpmLockfile {
@@ -293,6 +302,7 @@ impl PnpmLockfile {
             package_extensions_checksum: self.package_extensions_checksum.clone(),
             patched_dependencies: patches,
             time: None,
+            settings: self.settings.clone(),
         })
     }
 
@@ -441,6 +451,7 @@ mod tests {
     const PNPM6: &[u8] = include_bytes!("../../fixtures/pnpm6-workspace.yaml").as_slice();
     const PNPM7: &[u8] = include_bytes!("../../fixtures/pnpm7-workspace.yaml").as_slice();
     const PNPM8: &[u8] = include_bytes!("../../fixtures/pnpm8.yaml").as_slice();
+    const PNPM8_6: &[u8] = include_bytes!("../../fixtures/pnpm-v6.1.yaml").as_slice();
     const PNPM_ABSOLUTE: &[u8] = include_bytes!("../../fixtures/pnpm-absolute.yaml").as_slice();
     const PNPM_ABSOLUTE_V6: &[u8] =
         include_bytes!("../../fixtures/pnpm-absolute-v6.yaml").as_slice();
@@ -456,7 +467,7 @@ mod tests {
 
     #[test]
     fn test_roundtrip() {
-        for fixture in &[PNPM6, PNPM7, PNPM8] {
+        for fixture in &[PNPM6, PNPM7, PNPM8, PNPM8_6] {
             let lockfile = PnpmLockfile::from_bytes(fixture).unwrap();
             let serialized_lockfile = serde_yaml::to_string(&lockfile).unwrap();
             let lockfile_from_serialized =


### PR DESCRIPTION
### Description

Adds parse support for the new lockfile version added in https://github.com/pnpm/pnpm/pull/6557 fixing #5117 

The behavioral change is pretty small for us. The new information was added to allow for `pnpm install --frozen-lockfile` to produce an identical lockfile even if the `.npmrc` that was present during the lockfile's creation is no longer present. This does lead to a better UX for prune users as they will no longer need to copy `.npmrc` in their `Dockerfile`.

### Testing Instructions

Existing unit tests pass and added new fixture with the settings field that correctly parses.
