### PR TITLE
feat(turborepo): Remove anyhow from package manager detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3497,6 +3497,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
 
 [[package]]
+name = "lazy-regex"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff63c423c68ea6814b7da9e88ce585f793c87ddd9e78f646970891769c8235d4"
+dependencies = [
+ "lazy-regex-proc_macros",
+ "once_cell",
+ "regex",
+]
+
+[[package]]
+name = "lazy-regex-proc_macros"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8edfc11b8f56ce85e207e62ea21557cfa09bb24a8f6b04ae181b086ff8611c22"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9380,6 +9403,7 @@ dependencies = [
  "path-slash",
  "serde",
  "thiserror",
+ "wax",
 ]
 
 [[package]]
@@ -9477,6 +9501,7 @@ dependencies = [
  "indicatif",
  "is-terminal",
  "itertools",
+ "lazy-regex",
  "lazy_static",
  "libc",
  "node-semver",

--- a/crates/turborepo-lib/Cargo.toml
+++ b/crates/turborepo-lib/Cargo.toml
@@ -85,6 +85,7 @@ url = "2.3.1"
 const_format = "0.2.30"
 go-parse-duration = "0.1.1"
 is-terminal = "0.4.7"
+lazy-regex = "2.5.0"
 node-semver = "2.1.0"
 num_cpus = "1.15.0"
 owo-colors.workspace = true

--- a/crates/turborepo-lib/src/execution_state.rs
+++ b/crates/turborepo-lib/src/execution_state.rs
@@ -32,7 +32,7 @@ impl<'a> TryFrom<&'a CommandBase> for ExecutionState<'a> {
             PackageJson::load(&base.repo_root.join_component("package.json")).ok();
 
         let package_manager =
-            PackageManager::get_package_manager(base, root_package_json.as_ref())?;
+            PackageManager::get_package_manager(&base.repo_root, root_package_json.as_ref())?;
         trace!("Found {} as package manager", package_manager);
 
         let repo_config = base.repo_config()?;

--- a/crates/turborepo-lib/src/lib.rs
+++ b/crates/turborepo-lib/src/lib.rs
@@ -1,5 +1,7 @@
 #![feature(assert_matches)]
 #![feature(box_patterns)]
+#![feature(error_generic_member_access)]
+#![feature(provide_any)]
 
 mod child;
 mod cli;

--- a/crates/turborepo-lib/src/package_manager/mod.rs
+++ b/crates/turborepo-lib/src/package_manager/mod.rs
@@ -180,7 +180,7 @@ impl Display for MissingWorkspaceError {
                  thus packages to be defined in the root pnpm-workspace.yaml"
             }
             PackageManager::Yarn | PackageManager::Berry => {
-                "package.json: no workspaces found. Turborepo requires Yarn workspaces to be \
+                "package.json: no workspaces found. Turborepo requires yarn workspaces to be \
                  defined in the root package.json"
             }
             PackageManager::Npm => {

--- a/crates/turborepo-lib/src/package_manager/npm.rs
+++ b/crates/turborepo-lib/src/package_manager/npm.rs
@@ -1,17 +1,16 @@
-use anyhow::Result;
-use turbopath::AbsoluteSystemPathBuf;
+use turbopath::AbsoluteSystemPath;
 
-use crate::package_manager::PackageManager;
+use crate::package_manager::{Error, PackageManager};
 
 pub const LOCKFILE: &str = "package-lock.json";
 
 pub struct NpmDetector<'a> {
-    repo_root: &'a AbsoluteSystemPathBuf,
+    repo_root: &'a AbsoluteSystemPath,
     found: bool,
 }
 
 impl<'a> NpmDetector<'a> {
-    pub fn new(repo_root: &'a AbsoluteSystemPathBuf) -> Self {
+    pub fn new(repo_root: &'a AbsoluteSystemPath) -> Self {
         Self {
             repo_root,
             found: false,
@@ -20,7 +19,7 @@ impl<'a> NpmDetector<'a> {
 }
 
 impl<'a> Iterator for NpmDetector<'a> {
-    type Item = Result<PackageManager>;
+    type Item = Result<PackageManager, Error>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.found {
@@ -47,24 +46,16 @@ mod tests {
     use turbopath::AbsoluteSystemPathBuf;
 
     use super::LOCKFILE;
-    use crate::{
-        commands::CommandBase, get_version, package_manager::PackageManager, ui::UI, Args,
-    };
+    use crate::package_manager::PackageManager;
 
     #[test]
     fn test_detect_npm() -> Result<()> {
         let repo_root = tempdir()?;
         let repo_root_path = AbsoluteSystemPathBuf::new(repo_root.path())?;
-        let mut base = CommandBase::new(
-            Args::default(),
-            repo_root_path,
-            get_version(),
-            UI::new(true),
-        )?;
 
         let lockfile_path = repo_root.path().join(LOCKFILE);
         File::create(&lockfile_path)?;
-        let package_manager = PackageManager::detect_package_manager(&mut base)?;
+        let package_manager = PackageManager::detect_package_manager(&repo_root_path)?;
         assert_eq!(package_manager, PackageManager::Npm);
 
         Ok(())

--- a/crates/turborepo-lib/src/shim.rs
+++ b/crates/turborepo-lib/src/shim.rs
@@ -448,7 +448,7 @@ impl InferInfo {
     pub fn is_workspace_root_of(&self, target_path: &Path) -> bool {
         match &self.workspace_globs {
             Some(globs) => globs
-                .test(self.path.as_path(), target_path.to_path_buf())
+                .test(&self.path, target_path.to_path_buf())
                 .unwrap_or(false),
             None => false,
         }
@@ -472,13 +472,16 @@ impl RepoState {
                 // FIXME: This should be based upon detecting the pacakage manager.
                 // However, we don't have that functionality implemented in Rust yet.
                 // PackageManager::detect(path).get_workspace_globs().unwrap_or(None)
-                let workspace_globs = PackageManager::Pnpm
-                    .get_workspace_globs(path)
-                    .unwrap_or_else(|_| {
-                        PackageManager::Npm
-                            .get_workspace_globs(path)
-                            .unwrap_or(None)
-                    });
+                let workspace_globs = PackageManager::get_package_manager(reference_dir, None)
+                    .and_then(|mgr| mgr.get_workspace_globs(reference_dir))
+                    .ok();
+                // let workspace_globs = PackageManager::Pnpm
+                //     .get_workspace_globs(path)
+                //     .unwrap_or_else(|_| {
+                //         PackageManager::Npm
+                //             .get_workspace_globs(path)
+                //             .unwrap_or(None)
+                //     });
 
                 Some(InferInfo {
                     path: path.to_owned(),

--- a/crates/turborepo-paths/Cargo.toml
+++ b/crates/turborepo-paths/Cargo.toml
@@ -14,6 +14,7 @@ path-slash = "0.2.1"
 # TODO: Make this a crate feature
 serde = { workspace = true }
 thiserror = { workspace = true }
+wax = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/crates/turborepo-paths/src/anchored_system_path_buf.rs
+++ b/crates/turborepo-paths/src/anchored_system_path_buf.rs
@@ -20,6 +20,13 @@ impl TryFrom<&Path> for AnchoredSystemPathBuf {
     }
 }
 
+// TODO: perhaps we ought to be converting to a unix path?
+impl<'a> Into<wax::CandidatePath<'a>> for &'a AnchoredSystemPathBuf {
+    fn into(self) -> wax::CandidatePath<'a> {
+        self.as_path().into()
+    }
+}
+
 impl AnchoredSystemPathBuf {
     pub fn new(
         root: impl AsRef<AbsoluteSystemPath>,


### PR DESCRIPTION
### Description

 - Removes usage of `anyhow` from `package_manager` so that we have enumerated errors
 - moves `shim.rs` to use package manager detection
 - use `lazy_regex` for the package manager regex

Notable other changes
 - Package manager detection no longer requires a `CommandBase` instance, but the resulting error, in one case, no longer has a URL underlined. I've preserved the underline version in a currently-unused method on that error. TBD on the best way to plumb that out to the user.
 - I've added an implementation that allows `AnchorSystemPathBuf` to be fed directly to `wax`. I'm not yet sure we instead want to move that to `RelativeUnixPathBuf`. This needs some windows testing 

### Testing Instructions

Existing test suite
