### PR TITLE
refactor: Do not duplicate SWC transforms in the final binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -659,9 +659,9 @@ dependencies = [
 
 [[package]]
 name = "binding_macros"
-version = "0.50.31"
+version = "0.50.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ee27f9ffe528bb0a1e94d858d70217ce12076ef01978f73ce4ed50a20dedcc"
+checksum = "a31f397ada59fbcd6cb7f0a9d5bab4a53bb7cfc3ee2277b9f93d0ea2c88704d6"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -3940,9 +3940,9 @@ dependencies = [
 
 [[package]]
 name = "mimalloc-rust"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6973866e0bc6504c03a16b6817b7e70839cc8a1dbd5d6dab00c65d8034868d8b"
+checksum = "5eb726c8298efb4010b2c46d8050e4be36cf807b9d9e98cb112f830914fc9bbe"
 dependencies = [
  "cty",
  "mimalloc-rust-sys",
@@ -3950,9 +3950,9 @@ dependencies = [
 
 [[package]]
 name = "mimalloc-rust-sys"
-version = "1.7.6-source"
+version = "1.7.9-source"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a50daf45336b979a202a19f53b4b382f2c4bd50f392a8dbdb4c6c56ba5dfa64"
+checksum = "6413e13241a9809f291568133eca6694572cf528c1a6175502d090adce5dd5db"
 dependencies = [
  "cc",
  "cty",
@@ -6576,9 +6576,9 @@ dependencies = [
 
 [[package]]
 name = "swc"
-version = "0.261.31"
+version = "0.261.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95cbbf554d5643f670e66ca9094dd375c7fc060106202b17da1729d36c1fb711"
+checksum = "56428a57e7898982bee4530923a85ba17ad2b555a1502bcdccf6dc7ae483621f"
 dependencies = [
  "ahash 0.7.6",
  "anyhow",
@@ -6655,9 +6655,9 @@ dependencies = [
 
 [[package]]
 name = "swc_bundler"
-version = "0.214.23"
+version = "0.214.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc8061fcf233b059656a3c20e098971c6302346da23dc6cf21cb468335c27a1c"
+checksum = "1a20b862690e5c6c5e70fc0d56c156175514520c98e89220d408fc0e0d62759a"
 dependencies = [
  "ahash 0.7.6",
  "anyhow",
@@ -6761,9 +6761,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "0.76.37"
+version = "0.76.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18c40087bc20b5e2611bef9a02924ed990f04a446f0afc0d9a748382f797f948"
+checksum = "e8cd48cee857b467c1a7f3ff14ec26bfcdbe6a08f3218577e15d8157701da958"
 dependencies = [
  "binding_macros",
  "swc",
@@ -7049,9 +7049,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "0.181.23"
+version = "0.181.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f054b72aee9b9e92568c8045d8bd2f1622e7caed54a83c70613c36c25e209fd6"
+checksum = "4006ddfdcdcf8eb3a83f077ae03b6ee5a94bd9d55d52198bbed2228a6acafcbe"
 dependencies = [
  "ahash 0.7.6",
  "arrayvec 0.7.2",
@@ -7105,9 +7105,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "0.195.22"
+version = "0.195.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71c3e40213af349ff5c873963cc1aa03add9b2d1a891dca94590aaed889c216"
+checksum = "cfa9f2862180c733b633572be7d42b690cf2d878280a199a9b5f7cfba2cfd89e"
 dependencies = [
  "ahash 0.7.6",
  "anyhow",
@@ -7160,9 +7160,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.218.20"
+version = "0.218.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f359eeb44c37ae4fda275f02a8e718c750ad2b0c8ce2254aca624925be8c8943"
+checksum = "1ef09fbed21e8bcdf22bbfd88e5ec83c2acc2c831c39ca2fde01e1f040a85167"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -7286,9 +7286,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.187.20"
+version = "0.187.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baa08d0945505263edb8f1fadc71a8afdf530f582d1a133c434055cc4d76298c"
+checksum = "8d27c12926427f235d149e60f9a9e67a2181fe1eb418c12b53b8e0778c5052a2"
 dependencies = [
  "ahash 0.7.6",
  "dashmap",
@@ -7384,9 +7384,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.177.20"
+version = "0.177.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "340cc027a6e87966715005b94e3a7ac95baf76c80b8aedad8afdd1c134740c80"
+checksum = "dd32915040ed6ffdfeafb7a63276529df9ed83d8b6e7a6ce22d95ce98d137a21"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -9564,8 +9564,8 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
- "rand 0.8.5",
+ "cfg-if 0.1.10",
+ "rand 0.4.6",
  "static_assertions",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ mdxjs = { version = "0.1.12" }
 modularize_imports = { version = "0.30.0" }
 styled_components = { version = "0.57.0" }
 styled_jsx = { version = "0.34.0" }
-swc_core = { version = "0.76.37" }
+swc_core = { version = "0.76.41" }
 swc_emotion = { version = "0.33.0" }
 swc_relay = { version = "0.5.0" }
 testing = { version = "0.33.13" }

--- a/crates/turbopack-ecmascript/src/transform/mod.rs
+++ b/crates/turbopack-ecmascript/src/transform/mod.rs
@@ -169,9 +169,11 @@ impl EcmascriptInputTransform {
                     ..Default::default()
                 };
 
-                program.visit_mut_with(&mut react(
+                // Explicit type annotation to ensure that we don't duplicate transforms in the
+                // final binary
+                program.visit_mut_with(&mut react::<&dyn Comments>(
                     source_map.clone(),
-                    Some(comments.clone()),
+                    Some(&comments),
                     config,
                     top_level_mark,
                     unresolved_mark,

--- a/crates/turbopack-ecmascript/src/transform/mod.rs
+++ b/crates/turbopack-ecmascript/src/transform/mod.rs
@@ -216,8 +216,10 @@ impl EcmascriptInputTransform {
                     module_program
                 };
 
+                // Explicit type annotation to ensure that we don't duplicate transforms in the
+                // final binary
                 *program = module_program.fold_with(&mut chain!(
-                    preset_env::preset_env(
+                    preset_env::preset_env::<&'_ dyn Comments>(
                         top_level_mark,
                         Some(comments.clone()),
                         config,

--- a/crates/turbopack-ecmascript/src/transform/mod.rs
+++ b/crates/turbopack-ecmascript/src/transform/mod.rs
@@ -180,7 +180,11 @@ impl EcmascriptInputTransform {
                 ));
             }
             EcmascriptInputTransform::CommonJs => {
-                program.visit_mut_with(&mut swc_core::ecma::transforms::module::common_js(
+                // Explicit type annotation to ensure that we don't duplicate transforms in the
+                // final binary
+                program.visit_mut_with(&mut swc_core::ecma::transforms::module::common_js::<
+                    &dyn Comments,
+                >(
                     unresolved_mark,
                     swc_core::ecma::transforms::module::util::Config {
                         allow_top_level_this: true,
@@ -190,7 +194,7 @@ impl EcmascriptInputTransform {
                         ..Default::default()
                     },
                     swc_core::ecma::transforms::base::feature::FeatureFlag::all(),
-                    Some(comments.clone()),
+                    Some(&comments),
                 ));
             }
             EcmascriptInputTransform::PresetEnv(env) => {

--- a/crates/turbopack-ecmascript/src/transform/mod.rs
+++ b/crates/turbopack-ecmascript/src/transform/mod.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use swc_core::{
     base::SwcComments,
-    common::{chain, util::take::Take, Mark, SourceMap},
+    common::{chain, comments::Comments, util::take::Take, Mark, SourceMap},
     ecma::{
         ast::{Module, ModuleItem, Program, Script},
         preset_env::{self, Targets},
@@ -221,7 +221,7 @@ impl EcmascriptInputTransform {
                 *program = module_program.fold_with(&mut chain!(
                     preset_env::preset_env::<&'_ dyn Comments>(
                         top_level_mark,
-                        Some(comments.clone()),
+                        Some(&comments),
                         config,
                         Assumptions::default(),
                         &mut FeatureFlag::empty(),


### PR DESCRIPTION
### Description

This PR modifies generic instantiation to use `&dyn Comments` instead of `SwcComments`, to reduce binary size along with https://github.com/swc-project/swc/pull/7489.

### Testing Instructions

I'll post the binary size once https://github.com/swc-project/swc/pull/7489 is merged.

---

 - Previous binary size: `133.4MiB`
 - New binary size: `132.4MiB`


---


Closes WEB-1148