### PR TITLE
fix clippy CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -566,7 +566,7 @@ jobs:
           clippy_output="$(cargo clippy --workspace --all-targets --features rustls-tls 2>&1)"
 
           # Clippy will be invoked and report on each crate individually. We need to sum manually.
-          for warnings in $(echo "$clippy_output" | sed -n 's/.*generated \([0-9]*\) warnings\?$/\1/p'); do
+          for warnings in $(echo "$clippy_output" | sed -n 's/.*generated \([0-9]*\) warning.*/\1/p'); do
             count=$((count + warnings))
           done
 


### PR DESCRIPTION
### Description
Counting the number of warnings broke because the output format probably changed (?)
