### PR TITLE
Make PrefixedRouterContentSourceVc::new public

### DIFF
--- a/crates/turbopack-dev-server/src/source/router.rs
+++ b/crates/turbopack-dev-server/src/source/router.rs
@@ -28,7 +28,7 @@ pub struct PrefixedRouterContentSource {
 #[turbo_tasks::value_impl]
 impl PrefixedRouterContentSourceVc {
     #[turbo_tasks::function]
-    async fn new(
+    pub async fn new(
         prefix: StringVc,
         routes: Vec<(String, ContentSourceVc)>,
         fallback: ContentSourceVc,


### PR DESCRIPTION
### Description

It needs to be public for next-dev to instantiate it. 🤦 

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
