### PR TITLE
Fix `PrefixedRouterContentSourceVc`'s `debug_assertion`

### DIFF
--- a/crates/turbopack-dev-server/src/source/router.rs
+++ b/crates/turbopack-dev-server/src/source/router.rs
@@ -36,7 +36,7 @@ impl PrefixedRouterContentSourceVc {
         if cfg!(debug_assertions) {
             let prefix_string = prefix.await?;
             debug_assert!(prefix_string.is_empty() || prefix_string.ends_with('/'));
-            debug_assert!(prefix_string.starts_with('/'));
+            debug_assert!(!prefix_string.starts_with('/'));
         }
         Ok(PrefixedRouterContentSource {
             prefix,


### PR DESCRIPTION

### Description

`ContentSource` paths do not begin with a `/`, and the prefix should match that. 🤦 

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
