### PR TITLE
ci(examples): Skip npm install when setting up git for examples tests

### DIFF
--- a/turborepo-tests/examples/run-example.sh
+++ b/turborepo-tests/examples/run-example.sh
@@ -12,7 +12,7 @@ TEST_FILE="tests/$2-$1.t"
 
 if [ -f "$TEST_FILE" ]; then
   echo "Running $TEST_FILE"
-  .cram_env/bin/prysk --shell="$(which bash)" "$TEST_FILE"
+  .cram_env/bin/prysk --shell="$(which bash)" "$TEST_FILE" --keep-tmpdir
 else
   echo "Could not find $TEST_FILE"
   exit 1

--- a/turborepo-tests/examples/tests/setup.sh
+++ b/turborepo-tests/examples/tests/setup.sh
@@ -48,4 +48,4 @@ fi
 # Delete .git directory if it's there, we'll set up a new git repo
 [ ! -d .git ] || rm -rf .git
 
-"$MONOREPO_ROOT_DIR/turborepo-tests/helpers/setup_git.sh" "${TARGET_DIR}"
+"$MONOREPO_ROOT_DIR/turborepo-tests/helpers/setup_git.sh" "${TARGET_DIR}" "false"

--- a/turborepo-tests/helpers/setup_git.sh
+++ b/turborepo-tests/helpers/setup_git.sh
@@ -1,11 +1,17 @@
 #!/usr/bin/env bash
 
 TARGET_DIR=$1
+# If a second parameter isn't passed, default to true
+SHOULD_INSTALL=${2:-true}
+
 git init ${TARGET_DIR} --quiet --initial-branch=main
 GIT_ARGS="--git-dir=${TARGET_DIR}/.git --work-tree=${TARGET_DIR}"
 git ${GIT_ARGS} config user.email "turbo-test@example.com"
 git ${GIT_ARGS} config user.name "Turbo Test"
 echo "script-shell=$(which bash)" > ${TARGET_DIR}/.npmrc
-npm --prefix=${TARGET_DIR} install --silent
+
+if [ $SHOULD_INSTALL == "true" ]; then
+  npm --prefix=${TARGET_DIR} install --silent
+fi
 git ${GIT_ARGS} add .
 git ${GIT_ARGS} commit -m "Initial" --quiet


### PR DESCRIPTION
The extra npm install step creates a package-lock.json which causes
turborepo to detect the wrong package manager, which ends up changing
behavior.

(Fix is lifted from https://github.com/vercel/turbo/pull/5011)