### PR TITLE
feat(run summary): Add whether turbo detected monorepo or not

### DIFF
--- a/cli/internal/runsummary/format_json.go
+++ b/cli/internal/runsummary/format_json.go
@@ -62,6 +62,7 @@ type nonMonorepoRunSummary struct {
 	ID                 ksuid.KSUID        `json:"id"`
 	Version            string             `json:"version"`
 	TurboVersion       string             `json:"turboVersion"`
+	Monorepo           bool               `json:"monorepo"`
 	GlobalHashSummary  *GlobalHashSummary `json:"globalCacheInputs"`
 	Packages           []string           `json:"-"`
 	EnvMode            util.EnvMode       `json:"envMode"`

--- a/cli/internal/runsummary/run_summary.go
+++ b/cli/internal/runsummary/run_summary.go
@@ -60,6 +60,7 @@ type RunSummary struct {
 	ID                 ksuid.KSUID        `json:"id"`
 	Version            string             `json:"version"`
 	TurboVersion       string             `json:"turboVersion"`
+	Monorepo           bool               `json:"monorepo"`
 	GlobalHashSummary  *GlobalHashSummary `json:"globalCacheInputs"`
 	Packages           []string           `json:"packages"`
 	EnvMode            util.EnvMode       `json:"envMode"`
@@ -100,6 +101,11 @@ func NewRunSummary(
 
 	executionSummary := newExecutionSummary(synthesizedCommand, repoPath, startAt, profile)
 
+	isMonorepo := true
+	if singlePackage {
+		isMonorepo = false
+	}
+
 	rsm := Meta{
 		RunSummary: &RunSummary{
 			ID:                 ksuid.New(),
@@ -113,6 +119,7 @@ func NewRunSummary(
 			GlobalHashSummary:  globalHashSummary,
 			SCM:                getSCMState(envAtExecutionStart, repoRoot),
 			User:               getUser(envAtExecutionStart, repoRoot),
+			Monorepo:           isMonorepo,
 		},
 		ui:                 ui,
 		runType:            runType,

--- a/cli/internal/runsummary/run_summary.go
+++ b/cli/internal/runsummary/run_summary.go
@@ -101,11 +101,6 @@ func NewRunSummary(
 
 	executionSummary := newExecutionSummary(synthesizedCommand, repoPath, startAt, profile)
 
-	isMonorepo := true
-	if singlePackage {
-		isMonorepo = false
-	}
-
 	rsm := Meta{
 		RunSummary: &RunSummary{
 			ID:                 ksuid.New(),
@@ -119,7 +114,7 @@ func NewRunSummary(
 			GlobalHashSummary:  globalHashSummary,
 			SCM:                getSCMState(envAtExecutionStart, repoRoot),
 			User:               getUser(envAtExecutionStart, repoRoot),
-			Monorepo:           isMonorepo,
+			Monorepo:           !singlePackage,
 		},
 		ui:                 ui,
 		runType:            runType,

--- a/turborepo-tests/integration/tests/dry_json/monorepo.t
+++ b/turborepo-tests/integration/tests/dry_json/monorepo.t
@@ -36,6 +36,7 @@ Setup
     "frameworkInference",
     "globalCacheInputs",
     "id",
+    "monorepo",
     "packages",
     "scm",
     "tasks",

--- a/turborepo-tests/integration/tests/dry_json/single_package.t
+++ b/turborepo-tests/integration/tests/dry_json/single_package.t
@@ -7,6 +7,7 @@ Setup
     "id": "[a-zA-Z0-9]+", (re)
     "version": "1",
     "turboVersion": "[a-z0-9\.-]+", (re)
+    "monorepo": false,
     "globalCacheInputs": {
       "rootKey": "You don't understand! I coulda had class. I coulda been a contender. I could've been somebody, instead of a bum, which is what I am.",
       "files": {

--- a/turborepo-tests/integration/tests/dry_json/single_package_no_config.t
+++ b/turborepo-tests/integration/tests/dry_json/single_package_no_config.t
@@ -9,6 +9,7 @@ Setup
     "id": "[a-zA-Z0-9]+", (re)
     "version": "1",
     "turboVersion": "[a-z0-9\.-]+", (re)
+    "monorepo": false,
     "globalCacheInputs": {
       "rootKey": "You don't understand! I coulda had class. I coulda been a contender. I could've been somebody, instead of a bum, which is what I am.",
       "files": {

--- a/turborepo-tests/integration/tests/dry_json/single_package_with_deps.t
+++ b/turborepo-tests/integration/tests/dry_json/single_package_with_deps.t
@@ -7,6 +7,7 @@ Setup
     "id": "[a-zA-Z0-9]+", (re)
     "version": "1",
     "turboVersion": "[a-z0-9\.-]+", (re)
+    "monorepo": false,
     "globalCacheInputs": {
       "rootKey": "You don't understand! I coulda had class. I coulda been a contender. I could've been somebody, instead of a bum, which is what I am.",
       "files": {

--- a/turborepo-tests/integration/tests/run-summary/monorepo.t
+++ b/turborepo-tests/integration/tests/run-summary/monorepo.t
@@ -36,6 +36,7 @@ Setup
     "frameworkInference",
     "globalCacheInputs",
     "id",
+    "monorepo",
     "packages",
     "scm",
     "tasks",

--- a/turborepo-tests/integration/tests/run-summary/single-package.t
+++ b/turborepo-tests/integration/tests/run-summary/single-package.t
@@ -36,6 +36,7 @@ Check
     "frameworkInference",
     "globalCacheInputs",
     "id",
+    "monorepo",
     "scm",
     "tasks",
     "turboVersion",


### PR DESCRIPTION
While debugging another issue, I came across a confusing behavior where it seemed like turbo was operating in single package mode. I added this bit of information in to get some visibility in, and figured it was a good feature for everyone. 