### PR TITLE
refactor(turborepo): Move paths to UTF-8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -877,6 +877,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "camino"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c530edf18f37068ac2d977409ed5cd50d53d73bc653c7647b48eb78976ac9ae2"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "cargo-lock"
 version = "8.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2762,6 +2771,7 @@ dependencies = [
 name = "globwatch"
 version = "0.1.0"
 dependencies = [
+ "camino",
  "futures",
  "itertools",
  "merge-streams",
@@ -9411,10 +9421,9 @@ name = "turbopath"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "bstr",
+ "camino",
  "dunce",
  "path-clean 1.0.1",
- "path-slash",
  "serde",
  "thiserror",
  "wax",
@@ -9506,6 +9515,7 @@ dependencies = [
  "atty",
  "axum",
  "axum-server",
+ "camino",
  "chrono",
  "clap 4.1.11",
  "clap_complete",
@@ -9610,7 +9620,6 @@ dependencies = [
  "ignore",
  "itertools",
  "nom",
- "path-slash",
  "sha1 0.10.5",
  "tempfile",
  "thiserror",

--- a/crates/turborepo-ffi/src/lib.rs
+++ b/crates/turborepo-ffi/src/lib.rs
@@ -262,15 +262,7 @@ pub extern "C" fn get_package_file_hashes_from_git_index(buffer: Buffer) -> Buff
         Ok(hashes) => {
             let mut to_return = HashMap::new();
             for (filename, hash) in hashes {
-                let filename = match filename.as_str() {
-                    Ok(s) => s.to_owned(),
-                    Err(err) => {
-                        let resp = proto::GetPackageFileHashesFromGitIndexResponse {
-                            response: Some(proto::get_package_file_hashes_from_git_index_response::Response::Error(err.to_string()))
-                        };
-                        return resp.into();
-                    }
-                };
+                let filename = filename.to_string();
                 to_return.insert(filename, hash);
             }
             let file_hashes = proto::FileHashes { hashes: to_return };
@@ -347,15 +339,7 @@ pub extern "C" fn get_package_file_hashes_from_processing_git_ignore(buffer: Buf
         Ok(hashes) => {
             let mut to_return = HashMap::new();
             for (filename, hash) in hashes {
-                let filename = match filename.as_str() {
-                    Ok(s) => s.to_owned(),
-                    Err(err) => {
-                        let resp = proto::GetPackageFileHashesFromProcessingGitIgnoreResponse {
-                            response: Some(proto::get_package_file_hashes_from_processing_git_ignore_response::Response::Error(err.to_string()))
-                        };
-                        return resp.into();
-                    }
-                };
+                let filename = filename.to_string();
                 to_return.insert(filename, hash);
             }
             let file_hashes = proto::FileHashes { hashes: to_return };
@@ -432,15 +416,7 @@ pub extern "C" fn get_package_file_hashes_from_inputs(buffer: Buffer) -> Buffer 
         Ok(hashes) => {
             let mut to_return = HashMap::new();
             for (filename, hash) in hashes {
-                let filename = match filename.as_str() {
-                    Ok(s) => s.to_owned(),
-                    Err(err) => {
-                        let resp = proto::GetPackageFileHashesFromInputsResponse {
-                            response: Some(proto::get_package_file_hashes_from_inputs_response::Response::Error(err.to_string()))
-                        };
-                        return resp.into();
-                    }
-                };
+                let filename = filename.to_string();
                 to_return.insert(filename, hash);
             }
             let file_hashes = proto::FileHashes { hashes: to_return };
@@ -498,11 +474,8 @@ pub extern "C" fn glob(buffer: Buffer) -> Buffer {
         }
     };
 
-    // TODO: is to_string_lossy the right thing to do here? We could error...
-    let files: Vec<_> = files
-        .into_iter()
-        .map(|path| path.to_string_lossy().to_string())
-        .collect();
+    let files: Vec<_> = files.into_iter().map(|path| path.to_string()).collect();
+
     proto::GlobResp {
         response: Some(proto::glob_resp::Response::Files(proto::GlobRespList {
             files,

--- a/crates/turborepo-fs/src/lib.rs
+++ b/crates/turborepo-fs/src/lib.rs
@@ -26,7 +26,7 @@ pub fn recursive_copy(
                 }
                 Ok(entry) => {
                     let path = entry.path();
-                    let path = AbsoluteSystemPath::new(path)?;
+                    let path = AbsoluteSystemPath::from_std_path(path)?;
                     let file_type = entry.file_type();
                     // currently we support symlinked files, but not symlinked directories:
                     // For copying, we Mkdir and bail if we encounter a symlink to a directoy
@@ -116,7 +116,7 @@ mod tests {
 
     fn tmp_dir<'a>() -> Result<(tempfile::TempDir, AbsoluteSystemPathBuf)> {
         let tmp_dir = tempfile::tempdir()?;
-        let dir = AbsoluteSystemPathBuf::new(tmp_dir.path())?;
+        let dir = AbsoluteSystemPathBuf::try_from(tmp_dir.path())?;
         Ok((tmp_dir, dir))
     }
 

--- a/crates/turborepo-globwalk/src/lib.rs
+++ b/crates/turborepo-globwalk/src/lib.rs
@@ -673,7 +673,7 @@ mod test {
     fn glob_walk_inner(pattern: &str, result_count: usize) -> Option<WalkError> {
         let dir = setup();
 
-        let path = AbsoluteSystemPathBuf::new(dir.path()).unwrap();
+        let path = AbsoluteSystemPathBuf::try_from(dir.path()).unwrap();
         let success = match super::globwalk(&path, &[pattern.into()], &[], crate::WalkType::All) {
             Ok(e) => e.into_iter(),
             Err(e) => return Some(e),
@@ -1237,7 +1237,7 @@ mod test {
     ) {
         let dir = setup_files(files);
         let base_path = base_path.trim_start_matches('/');
-        let path = AbsoluteSystemPathBuf::new(dir.path().join(base_path)).unwrap();
+        let path = AbsoluteSystemPathBuf::try_from(dir.path().join(base_path)).unwrap();
         let include: Vec<_> = include.iter().map(|s| s.to_string()).collect();
         let exclude: Vec<_> = exclude.iter().map(|s| s.to_string()).collect();
 
@@ -1249,13 +1249,7 @@ mod test {
 
             let success = success
                 .iter()
-                .map(|p| {
-                    p.as_path()
-                        .strip_prefix(dir.path())
-                        .unwrap()
-                        .to_str()
-                        .unwrap()
-                })
+                .map(|p| p.as_path().strip_prefix(dir.path()).unwrap().as_str())
                 .sorted()
                 .collect::<Vec<_>>();
 
@@ -1334,7 +1328,7 @@ mod test {
     fn test_directory_traversal() {
         let files = &["root-file", "child/some-file"];
         let tmp = setup_files(files);
-        let root = AbsoluteSystemPathBuf::new(tmp.path()).unwrap();
+        let root = AbsoluteSystemPathBuf::try_from(tmp.path()).unwrap();
         let child = root.join_component("child");
         let include = &["../*-file".to_string()];
         let exclude = &[];
@@ -1342,7 +1336,7 @@ mod test {
             .unwrap()
             .into_iter();
         let results = iter
-            .map(|entry| root.anchor(entry).unwrap().to_str().unwrap().to_string())
+            .map(|entry| root.anchor(entry).unwrap().to_string())
             .collect::<Vec<_>>();
         let expected = vec!["root-file".to_string()];
         assert_eq!(results, expected);
@@ -1359,7 +1353,7 @@ mod test {
             "apps/some-app/node_modules/dep/package.json",
         ];
         let tmp = setup_files(files);
-        let root = AbsoluteSystemPathBuf::new(tmp.path()).unwrap();
+        let root = AbsoluteSystemPathBuf::try_from(tmp.path()).unwrap();
         let include = &[
             "apps/*/package.json".to_string(),
             "docs/package.json".to_string(),
@@ -1370,7 +1364,7 @@ mod test {
             .into_iter()
             .map(|path| {
                 let relative = root.anchor(path).unwrap();
-                relative.to_str().unwrap().to_string()
+                relative.to_string()
             })
             .collect::<HashSet<_>>();
         let expected: HashSet<String> = HashSet::from_iter(

--- a/crates/turborepo-globwatch/Cargo.toml
+++ b/crates/turborepo-globwatch/Cargo.toml
@@ -6,6 +6,7 @@ description = "Watch a set of globs efficiently"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
+camino = "1.1.4"
 futures = { version = "0.3.26" }
 itertools.workspace = true
 merge-streams = "0.1.2"

--- a/crates/turborepo-globwatch/src/lib.rs
+++ b/crates/turborepo-globwatch/src/lib.rs
@@ -30,6 +30,7 @@ use std::{
     },
 };
 
+use camino::Utf8PathBuf;
 use futures::{channel::oneshot, future::Either, FutureExt, Stream, StreamExt as _};
 use itertools::Itertools;
 use merge_streams::MergeStreams;
@@ -58,7 +59,7 @@ impl GlobWatcher {
     /// see the module-level documentation.
     #[tracing::instrument]
     pub fn new(
-        flush_dir: PathBuf,
+        flush_dir: Utf8PathBuf,
     ) -> Result<(Self, WatchConfig<notify::RecommendedWatcher>), notify::Error> {
         let (send_event, receive_event) = tokio::sync::mpsc::unbounded_channel();
         let (send_config, receive_config) = tokio::sync::mpsc::unbounded_channel();
@@ -414,25 +415,25 @@ enum GlobSymbol<'a> {
 /// specified in minimatch glob syntax.
 ///
 /// syntax:
-/// ?		Matches any single character.
+/// ?    Matches any single character.
 ///
 /// *      Matches zero or more characters, except for path separators.
 ///
-/// **		Matches zero or more characters, including path separators.
+/// **      Matches zero or more characters, including path separators.
 ///         Must match a complete path segment.
 ///
-/// [ab]	Matches one of the characters contained in the brackets.
+/// [ab]    Matches one of the characters contained in the brackets.
 ///         Character ranges, e.g. [a-z] are also supported. Use [!ab] or [^ab]
 ///         to match any character except those contained in the brackets.
 ///
-/// {a,b}	Matches one of the patterns contained in the braces. Any of the
+/// {a,b}   Matches one of the patterns contained in the braces. Any of the
 ///         wildcard characters can be used in the sub-patterns. Braces may
 ///         be nested up to 10 levels deep.
 ///
-/// !		When at the start of the glob, this negates the result.
+/// !       When at the start of the glob, this negates the result.
 ///         Multiple ! characters negate the glob multiple times.
 ///
-/// \		A backslash character may be used to escape any special characters.
+/// \       A backslash character may be used to escape any special characters.
 ///
 /// Of these, we only handle `{` and escaping.
 ///

--- a/crates/turborepo-lib/Cargo.toml
+++ b/crates/turborepo-lib/Cargo.toml
@@ -82,6 +82,7 @@ tower = "0.4.13"
 uds_windows = "1.0.2"
 url = "2.3.1"
 
+camino = "1.1.4"
 const_format = "0.2.30"
 globwalk = { version = "0.1.0", path = "../turborepo-globwalk" }
 go-parse-duration = "0.1.1"

--- a/crates/turborepo-lib/src/cli.rs
+++ b/crates/turborepo-lib/src/cli.rs
@@ -645,7 +645,7 @@ pub async fn run(
         run_args.single_package = single_package;
     }
     cli_args.command = Some(command);
-    cli_args.cwd = Some(repo_root.clone().into());
+    cli_args.cwd = Some(repo_root.as_path().to_owned());
 
     match cli_args.command.as_ref().unwrap() {
         Command::Bin { .. } => {

--- a/crates/turborepo-lib/src/cli.rs
+++ b/crates/turborepo-lib/src/cli.rs
@@ -1,10 +1,7 @@
-use std::{
-    env, io, mem,
-    path::{Path, PathBuf},
-    process,
-};
+use std::{env, io, mem, path::Path, process};
 
 use anyhow::{anyhow, Result};
+use camino::Utf8PathBuf;
 use clap::{ArgAction, CommandFactory, Parser, Subcommand, ValueEnum};
 use clap_complete::{generate, Shell};
 use serde::Serialize;
@@ -107,7 +104,7 @@ pub struct Args {
     pub cpu_profile: Option<String>,
     /// The directory in which to run turbo
     #[clap(long, global = true, value_parser)]
-    pub cwd: Option<PathBuf>,
+    pub cwd: Option<Utf8PathBuf>,
     /// Specify a file to save a pprof heap profile
     #[clap(long, global = true, value_parser)]
     pub heap: Option<String>,
@@ -778,8 +775,7 @@ pub async fn run(
 
 #[cfg(test)]
 mod test {
-    use std::path::PathBuf;
-
+    use camino::Utf8PathBuf;
     use clap::Parser;
     use itertools::Itertools;
     use pretty_assertions::assert_eq;
@@ -1518,7 +1514,7 @@ mod test {
             global_args: vec![vec!["--cwd", "../examples/with-yarn"]],
             expected_output: Args {
                 command: Some(Command::Bin {}),
-                cwd: Some(PathBuf::from("../examples/with-yarn")),
+                cwd: Some(Utf8PathBuf::from("../examples/with-yarn")),
                 ..Args::default()
             },
         }
@@ -1541,7 +1537,7 @@ mod test {
             global_args: vec![vec!["--cwd", "../examples/with-yarn"]],
             expected_output: Args {
                 command: Some(Command::Login { sso_team: None }),
-                cwd: Some(PathBuf::from("../examples/with-yarn")),
+                cwd: Some(Utf8PathBuf::from("../examples/with-yarn")),
                 ..Args::default()
             },
         }
@@ -1555,7 +1551,7 @@ mod test {
                 command: Some(Command::Login {
                     sso_team: Some("my-team".to_string()),
                 }),
-                cwd: Some(PathBuf::from("../examples/with-yarn")),
+                cwd: Some(Utf8PathBuf::from("../examples/with-yarn")),
                 ..Args::default()
             },
         }
@@ -1578,7 +1574,7 @@ mod test {
             global_args: vec![vec!["--cwd", "../examples/with-yarn"]],
             expected_output: Args {
                 command: Some(Command::Logout {}),
-                cwd: Some(PathBuf::from("../examples/with-yarn")),
+                cwd: Some(Utf8PathBuf::from("../examples/with-yarn")),
                 ..Args::default()
             },
         }
@@ -1605,7 +1601,7 @@ mod test {
                 command: Some(Command::Unlink {
                     target: crate::cli::LinkTarget::RemoteCache,
                 }),
-                cwd: Some(PathBuf::from("../examples/with-yarn")),
+                cwd: Some(Utf8PathBuf::from("../examples/with-yarn")),
                 ..Args::default()
             },
         }
@@ -1634,7 +1630,7 @@ mod test {
             global_args: vec![vec!["--cwd", "../examples/with-yarn"]],
             expected_output: Args {
                 command: Some(default_prune),
-                cwd: Some(PathBuf::from("../examples/with-yarn")),
+                cwd: Some(Utf8PathBuf::from("../examples/with-yarn")),
                 ..Args::default()
             },
         }
@@ -1701,7 +1697,7 @@ mod test {
                     docker: true,
                     output_dir: "dist".to_string(),
                 }),
-                cwd: Some(PathBuf::from("../examples/with-yarn")),
+                cwd: Some(Utf8PathBuf::from("../examples/with-yarn")),
                 ..Args::default()
             },
         }

--- a/crates/turborepo-lib/src/commands/link.rs
+++ b/crates/turborepo-lib/src/commands/link.rs
@@ -452,7 +452,6 @@ mod test {
     use std::fs;
 
     use anyhow::Result;
-    use camino::{Utf8Path, Utf8PathBuf};
     use tempfile::{NamedTempFile, TempDir};
     use tokio::sync::OnceCell;
     use turbopath::AbsoluteSystemPathBuf;

--- a/crates/turborepo-lib/src/commands/login.rs
+++ b/crates/turborepo-lib/src/commands/login.rs
@@ -326,7 +326,7 @@ mod test {
         let user_config_file = NamedTempFile::new().unwrap();
         fs::write(user_config_file.path(), r#"{ "token": "hello" }"#).unwrap();
         let repo_config_file = NamedTempFile::new().unwrap();
-        let repo_config_path = AbsoluteSystemPathBuf::new(repo_config_file.path()).unwrap();
+        let repo_config_path = AbsoluteSystemPathBuf::try_from(repo_config_file.path()).unwrap();
         // Explicitly pass the wrong port to confirm that we're reading it from the
         // manual override
         fs::write(
@@ -340,7 +340,7 @@ mod test {
             ui: UI::new(false),
             client_config: OnceCell::from(ClientConfigLoader::new().load().unwrap()),
             user_config: OnceCell::from(
-                UserConfigLoader::new(user_config_file.path().to_path_buf())
+                UserConfigLoader::new(user_config_file.path().to_str().unwrap())
                     .load()
                     .unwrap(),
             ),
@@ -378,7 +378,7 @@ mod test {
         let user_config_file = NamedTempFile::new().unwrap();
         fs::write(user_config_file.path(), r#"{ "token": "hello" }"#).unwrap();
         let repo_config_file = NamedTempFile::new().unwrap();
-        let repo_config_path = AbsoluteSystemPathBuf::new(repo_config_file.path()).unwrap();
+        let repo_config_path = AbsoluteSystemPathBuf::try_from(repo_config_file.path()).unwrap();
         // Explicitly pass the wrong port to confirm that we're reading it from the
         // manual override
         fs::write(
@@ -392,7 +392,7 @@ mod test {
             ui: UI::new(false),
             client_config: OnceCell::from(ClientConfigLoader::new().load().unwrap()),
             user_config: OnceCell::from(
-                UserConfigLoader::new(user_config_file.path().to_path_buf())
+                UserConfigLoader::new(user_config_file.path().to_str().unwrap())
                     .load()
                     .unwrap(),
             ),

--- a/crates/turborepo-lib/src/commands/mod.rs
+++ b/crates/turborepo-lib/src/commands/mod.rs
@@ -150,8 +150,8 @@ impl CommandBase {
         Ok(APIClient::new(api_url, timeout, self.version)?)
     }
 
-    pub fn daemon_file_root(&self) -> turbopath::AbsoluteSystemPathBuf {
-        turbopath::AbsoluteSystemPathBuf::new(std::env::temp_dir())
+    pub fn daemon_file_root(&self) -> AbsoluteSystemPathBuf {
+        AbsoluteSystemPathBuf::new(std::env::temp_dir().to_str().expect("UTF-8 path"))
             .expect("temp dir is valid")
             .join_component("turbod")
             .join_component(self.repo_hash().as_str())
@@ -159,7 +159,7 @@ impl CommandBase {
 
     fn repo_hash(&self) -> String {
         let mut hasher = Sha256::new();
-        hasher.update(self.repo_root.to_str().unwrap().as_bytes());
+        hasher.update(self.repo_root.as_bytes());
         hex::encode(&hasher.finalize()[..8])
     }
 }

--- a/crates/turborepo-lib/src/config/mod.rs
+++ b/crates/turborepo-lib/src/config/mod.rs
@@ -4,9 +4,10 @@ mod repo;
 mod turbo;
 mod user;
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use anyhow::{Context, Result};
+use camino::{Utf8Path, Utf8PathBuf};
 pub use client::{ClientConfig, ClientConfigLoader};
 #[cfg(not(windows))]
 use dirs_next::config_dir;
@@ -22,10 +23,12 @@ use serde::Serialize;
 pub use turbo::{SpacesJson, TurboJson};
 pub use user::{UserConfig, UserConfigLoader};
 
-pub fn default_user_config_path() -> Result<PathBuf> {
-    config_dir()
-        .map(|p| p.join("turborepo").join("config.json"))
-        .context("default config path not found")
+pub fn default_user_config_path() -> Result<Utf8PathBuf> {
+    Ok(Utf8PathBuf::try_from(
+        config_dir()
+            .map(|p| p.join("turborepo").join("config.json"))
+            .context("default config path not found")?,
+    )?)
 }
 
 #[allow(dead_code)]
@@ -33,7 +36,7 @@ pub fn data_dir() -> Option<PathBuf> {
     dirs_next::data_dir().map(|p| p.join("turborepo"))
 }
 
-fn write_to_disk<T>(path: &Path, config: &T) -> Result<()>
+fn write_to_disk<T>(path: &Utf8Path, config: &T) -> Result<()>
 where
     T: Serialize,
 {

--- a/crates/turborepo-lib/src/config/repo.rs
+++ b/crates/turborepo-lib/src/config/repo.rs
@@ -144,7 +144,7 @@ impl RepoConfigLoader {
         } = self;
         let raw_disk_config = Config::builder()
             .add_source(
-                config::File::with_name(path.to_string_lossy().as_ref())
+                config::File::with_name(path.as_str())
                     .format(config::FileFormat::Json)
                     .required(false),
             )
@@ -218,7 +218,7 @@ mod test {
     #[test_case("TEAMSLUG" ; "ALLCAPS")]
     fn test_repo_config_with_different_cases(field_name: &str) -> Result<()> {
         let mut config_file = NamedTempFile::new()?;
-        let config_path = AbsoluteSystemPathBuf::new(config_file.path())?;
+        let config_path = AbsoluteSystemPathBuf::try_from(config_file.path())?;
         writeln!(&mut config_file, "{{\"{}\": \"123\"}}", field_name)?;
 
         let config = RepoConfigLoader::new(config_path).load()?;
@@ -231,7 +231,7 @@ mod test {
     #[test]
     fn test_repo_config_with_team_and_api_flags() -> Result<()> {
         let mut config_file = NamedTempFile::new()?;
-        let config_path = AbsoluteSystemPathBuf::new(config_file.path())?;
+        let config_path = AbsoluteSystemPathBuf::try_from(config_file.path())?;
         writeln!(&mut config_file, "{{\"teamId\": \"123\"}}")?;
 
         let config = RepoConfigLoader::new(config_path)
@@ -266,7 +266,7 @@ mod test {
     #[test]
     fn test_team_override_clears_id() -> Result<()> {
         let mut config_file = NamedTempFile::new()?;
-        let config_path = AbsoluteSystemPathBuf::new(config_file.path())?;
+        let config_path = AbsoluteSystemPathBuf::try_from(config_file.path())?;
         writeln!(&mut config_file, "{{\"teamId\": \"123\"}}")?;
         let loader = RepoConfigLoader::new(config_path).with_team_slug(Some("foo".into()));
 
@@ -280,7 +280,7 @@ mod test {
     #[test]
     fn test_set_team_clears_id() -> Result<()> {
         let mut config_file = NamedTempFile::new()?;
-        let config_path = AbsoluteSystemPathBuf::new(config_file.path())?;
+        let config_path = AbsoluteSystemPathBuf::try_from(config_file.path())?;
         // We will never pragmatically write the "teamslug" field as camelCase,
         // but viper is case insensitive and we want to keep this functionality.
         writeln!(&mut config_file, "{{\"teamSlug\": \"my-team\"}}")?;
@@ -299,7 +299,7 @@ mod test {
     #[test]
     fn test_repo_env_variable() -> Result<()> {
         let mut config_file = NamedTempFile::new()?;
-        let config_path = AbsoluteSystemPathBuf::new(config_file.path())?;
+        let config_path = AbsoluteSystemPathBuf::try_from(config_file.path())?;
         writeln!(&mut config_file, "{{\"teamslug\": \"other-team\"}}")?;
         let login_url = "http://my-login-url";
         let api_url = "http://my-api";

--- a/crates/turborepo-lib/src/config/user.rs
+++ b/crates/turborepo-lib/src/config/user.rs
@@ -113,7 +113,6 @@ impl UserConfigLoader {
 mod test {
     use std::io::Write;
 
-    use camino::Utf8Path;
     use tempfile::{NamedTempFile, TempDir};
 
     use super::*;

--- a/crates/turborepo-lib/src/daemon/connector.rs
+++ b/crates/turborepo-lib/src/daemon/connector.rs
@@ -391,10 +391,7 @@ enum WaitAction {
 
 #[cfg(test)]
 mod test {
-    use std::{
-        assert_matches::assert_matches,
-        path::{Path, PathBuf},
-    };
+    use std::{assert_matches::assert_matches, path::Path};
 
     use sysinfo::Pid;
     use tokio::{

--- a/crates/turborepo-lib/src/daemon/endpoint.rs
+++ b/crates/turborepo-lib/src/daemon/endpoint.rs
@@ -41,7 +41,7 @@ pub async fn listen_socket(
 > {
     let pid_path = path.join_component("turbod.pid");
     let sock_path = path.join_component("turbod.sock");
-    let mut lock = pidlock::Pidlock::new(pid_path.as_path().to_owned());
+    let mut lock = pidlock::Pidlock::new(pid_path.as_std_path().to_owned());
 
     trace!("acquiring pidlock");
     // this will fail if the pid is already owned
@@ -190,7 +190,7 @@ mod test {
     use crate::daemon::endpoint::SocketOpenError;
 
     fn pid_path(tmp_path: &Path) -> AbsoluteSystemPathBuf {
-        AbsoluteSystemPathBuf::new(tmp_path.join("turbod.pid")).unwrap()
+        AbsoluteSystemPathBuf::try_from(tmp_path.join("turbod.pid")).unwrap()
     }
 
     #[tokio::test]

--- a/crates/turborepo-lib/src/daemon/server.rs
+++ b/crates/turborepo-lib/src/daemon/server.rs
@@ -86,7 +86,7 @@ impl DaemonServer<notify::RecommendedWatcher> {
         let daemon_root = base.daemon_file_root();
 
         let watcher = Arc::new(HashGlobWatcher::new(
-            AbsoluteSystemPathBuf::new(base.repo_root.clone()).expect("valid repo root"),
+            base.repo_root.clone(),
             daemon_root.join_component("flush").as_path().to_owned(),
         )?);
 
@@ -258,7 +258,7 @@ impl<T: Watcher + Send + 'static> proto::turbod_server::Turbod for DaemonServer<
         Ok(tonic::Response::new(proto::StatusResponse {
             daemon_status: Some(proto::DaemonStatus {
                 uptime_msec: self.start_time.elapsed().as_millis() as u64,
-                log_file: self.log_file.to_str().unwrap().to_string(),
+                log_file: self.log_file.to_string(),
             }),
         }))
     }
@@ -342,7 +342,7 @@ mod test {
     #[tracing_test::traced_test]
     async fn lifecycle() {
         let tempdir = tempfile::tempdir().unwrap();
-        let path = AbsoluteSystemPathBuf::new(tempdir.path()).unwrap();
+        let path = AbsoluteSystemPathBuf::try_from(tempdir.path()).unwrap();
 
         tracing::info!("start");
 
@@ -385,7 +385,7 @@ mod test {
     #[tracing_test::traced_test]
     async fn timeout() {
         let tempdir = tempfile::tempdir().unwrap();
-        let path = AbsoluteSystemPathBuf::new(tempdir.path()).unwrap();
+        let path = AbsoluteSystemPathBuf::try_from(tempdir.path()).unwrap();
 
         let daemon = DaemonServer::new(
             &CommandBase::new(

--- a/crates/turborepo-lib/src/globwatcher/mod.rs
+++ b/crates/turborepo-lib/src/globwatcher/mod.rs
@@ -5,6 +5,7 @@ use std::{
     time::Duration,
 };
 
+use camino::Utf8PathBuf;
 use futures::{stream::iter, StreamExt};
 use globwatch::{ConfigError, GlobWatcher, StopToken, WatchConfig, Watcher};
 use itertools::Itertools;
@@ -51,7 +52,7 @@ impl HashGlobWatcher<RecommendedWatcher> {
     #[tracing::instrument]
     pub fn new(
         relative_to: AbsoluteSystemPathBuf,
-        flush_folder: PathBuf,
+        flush_folder: Utf8PathBuf,
     ) -> Result<Self, notify::Error> {
         let (watcher, config) = GlobWatcher::new(flush_folder)?;
         Ok(Self {
@@ -358,6 +359,7 @@ fn clear_hash_globs(
 mod test {
     use std::{fs::File, sync::Arc, time::Duration};
 
+    use camino::Utf8PathBuf;
     use globwatch::StopSource;
     use tokio::time::timeout;
     use turbopath::AbsoluteSystemPathBuf;
@@ -392,8 +394,8 @@ mod test {
         let flush = tempdir::TempDir::new("globwatch-flush").unwrap();
         let watcher = Arc::new(
             super::HashGlobWatcher::new(
-                AbsoluteSystemPathBuf::new(dir.path()).unwrap(),
-                flush.path().to_path_buf(),
+                AbsoluteSystemPathBuf::try_from(dir.path()).unwrap(),
+                Utf8PathBuf::try_from(flush.path().to_path_buf()).unwrap(),
             )
             .unwrap(),
         );
@@ -508,8 +510,8 @@ mod test {
         let flush = tempdir::TempDir::new("globwatch-flush").unwrap();
         let watcher = Arc::new(
             super::HashGlobWatcher::new(
-                AbsoluteSystemPathBuf::new(dir.path()).unwrap(),
-                flush.path().to_path_buf(),
+                AbsoluteSystemPathBuf::try_from(dir.path()).unwrap(),
+                Utf8PathBuf::try_from(flush.path().to_path_buf()).unwrap(),
             )
             .unwrap(),
         );
@@ -630,8 +632,8 @@ mod test {
         let flush = tempdir::TempDir::new("globwatch-flush").unwrap();
         let watcher = Arc::new(
             super::HashGlobWatcher::new(
-                AbsoluteSystemPathBuf::new(dir.path()).unwrap(),
-                flush.path().to_path_buf(),
+                AbsoluteSystemPathBuf::try_from(dir.path()).unwrap(),
+                Utf8PathBuf::try_from(flush.path().to_path_buf()).unwrap(),
             )
             .unwrap(),
         );
@@ -699,8 +701,8 @@ mod test {
         let flush = tempdir::TempDir::new("globwatch-flush").unwrap();
         let watcher = Arc::new(
             super::HashGlobWatcher::new(
-                AbsoluteSystemPathBuf::new(dir.path()).unwrap(),
-                flush.path().to_path_buf(),
+                AbsoluteSystemPathBuf::try_from(dir.path()).unwrap(),
+                Utf8PathBuf::try_from(flush.path().to_path_buf()).unwrap(),
             )
             .unwrap(),
         );

--- a/crates/turborepo-lib/src/package_manager/mod.rs
+++ b/crates/turborepo-lib/src/package_manager/mod.rs
@@ -623,7 +623,7 @@ mod tests {
     #[test]
     fn test_detect_multiple_package_managers() -> Result<(), Error> {
         let repo_root = tempdir()?;
-        let repo_root_path = AbsoluteSystemPathBuf::new(repo_root.path())?;
+        let repo_root_path = AbsoluteSystemPathBuf::try_from(repo_root.path())?;
 
         let package_lock_json_path = repo_root.path().join(npm::LOCKFILE);
         File::create(&package_lock_json_path)?;

--- a/crates/turborepo-lib/src/package_manager/npm.rs
+++ b/crates/turborepo-lib/src/package_manager/npm.rs
@@ -51,7 +51,7 @@ mod tests {
     #[test]
     fn test_detect_npm() -> Result<()> {
         let repo_root = tempdir()?;
-        let repo_root_path = AbsoluteSystemPathBuf::new(repo_root.path())?;
+        let repo_root_path = AbsoluteSystemPathBuf::try_from(repo_root.path())?;
 
         let lockfile_path = repo_root.path().join(LOCKFILE);
         File::create(lockfile_path)?;

--- a/crates/turborepo-lib/src/package_manager/pnpm.rs
+++ b/crates/turborepo-lib/src/package_manager/pnpm.rs
@@ -57,7 +57,7 @@ mod tests {
     #[test]
     fn test_detect_pnpm() -> Result<()> {
         let repo_root = tempdir()?;
-        let repo_root_path = AbsoluteSystemPathBuf::new(repo_root.path())?;
+        let repo_root_path = AbsoluteSystemPathBuf::try_from(repo_root.path())?;
         let lockfile_path = repo_root.path().join(LOCKFILE);
         File::create(lockfile_path)?;
         let package_manager = PackageManager::detect_package_manager(&repo_root_path)?;

--- a/crates/turborepo-lib/src/package_manager/yarn.rs
+++ b/crates/turborepo-lib/src/package_manager/yarn.rs
@@ -89,7 +89,7 @@ mod tests {
     #[test]
     fn test_detect_yarn() -> Result<()> {
         let repo_root = tempdir()?;
-        let repo_root_path = AbsoluteSystemPathBuf::new(repo_root.path())?;
+        let repo_root_path = AbsoluteSystemPathBuf::try_from(repo_root.path())?;
 
         let yarn_lock_path = repo_root.path().join(LOCKFILE);
         File::create(yarn_lock_path)?;

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -144,7 +144,7 @@ mod test {
     #[tokio::test]
     async fn test_run() -> Result<()> {
         let dir = tempdir()?;
-        let repo_root = AbsoluteSystemPathBuf::new(dir.path())?;
+        let repo_root = AbsoluteSystemPathBuf::try_from(dir.path())?;
         let mut args = Args::default();
         // Daemon does not work with run stub yet
         let run_args = RunArgs {

--- a/crates/turborepo-paths/Cargo.toml
+++ b/crates/turborepo-paths/Cargo.toml
@@ -7,10 +7,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bstr = "1.4.0"
+camino = { version = "1.1.4", features = ["serde1"] }
 dunce = { workspace = true }
 path-clean = "1.0.1"
-path-slash = "0.2.1"
 # TODO: Make this a crate feature
 serde = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/turborepo-paths/src/absolute_system_path_buf.rs
+++ b/crates/turborepo-paths/src/absolute_system_path_buf.rs
@@ -69,7 +69,7 @@ impl AbsoluteSystemPathBuf {
     pub fn new(unchecked_path: impl Into<String>) -> Result<Self, PathError> {
         let unchecked_path = unchecked_path.into();
         if !Path::new(&unchecked_path).is_absolute() {
-            return Err(PathError::NotAbsolute(unchecked_path).into());
+            return Err(PathError::NotAbsolute(unchecked_path));
         }
 
         let system_path = unchecked_path.into_system();
@@ -128,7 +128,7 @@ impl AbsoluteSystemPathBuf {
     ///   let base = AbsoluteSystemPathBuf::new("C:\\Users\\user").unwrap();
     ///   let anchored_path = AbsoluteSystemPathBuf::new("C:\\Users\\user\\Documents").unwrap();
     ///   let anchored_path = base.anchor(&anchored_path).unwrap();
-    ///  assert_eq!(anchored_path.to_str().unwrap(), "Documents");
+    ///  assert_eq!(anchored_path.as_str(), "Documents");
     /// }
     /// ```
     pub fn anchor(
@@ -160,9 +160,9 @@ impl AbsoluteSystemPathBuf {
     /// let resolved_path = absolute_path.resolve(&anchored_path);
     ///
     /// #[cfg(not(windows))]
-    /// assert_eq!(resolved_path.as_path(), Path::new("/Users/user/Documents"));
+    /// assert_eq!(resolved_path.as_str(), "/Users/user/Documents");
     /// #[cfg(windows)]
-    /// assert_eq!(resolved_path.as_path(), Path::new("C:\\Users\\user\\Documents"));
+    /// assert_eq!(resolved_path.as_str(), "C:\\Users\\user\\Documents");
     /// ```
     pub fn resolve(&self, path: &AnchoredSystemPathBuf) -> AbsoluteSystemPathBuf {
         AbsoluteSystemPathBuf(self.0.join(path))

--- a/crates/turborepo-paths/src/relative_unix_path.rs
+++ b/crates/turborepo-paths/src/relative_unix_path.rs
@@ -1,44 +1,49 @@
-use std::path::PathBuf;
+use std::{
+    fmt,
+    fmt::{Display, Formatter},
+};
 
-use bstr::BStr;
+use camino::{Utf8Path, Utf8PathBuf};
 
 use crate::{PathError, RelativeUnixPathBuf};
 
 #[repr(transparent)]
-pub struct RelativeUnixPath(pub(crate) BStr);
+pub struct RelativeUnixPath(str);
+
+impl Display for RelativeUnixPath {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", &self.0)
+    }
+}
 
 impl RelativeUnixPath {
-    pub fn new<P: AsRef<BStr>>(value: &P) -> Result<&Self, PathError> {
+    pub fn new<'a, P: AsRef<str> + 'a>(value: P) -> Result<&'a Self, PathError> {
         let path = value.as_ref();
-        if path.first() == Some(&b'/') {
-            return Err(PathError::not_relative_error(path));
+        if path.starts_with('/') {
+            return Err(PathError::NotRelative(path.to_string()));
         }
         // copied from stdlib path.rs: relies on the representation of
-        // RelativeUnixPath being just a BStr, the same way Path relies on
+        // RelativeUnixPath being just a str, the same way Path relies on
         // just being an OsStr
-        Ok(unsafe { &*(path as *const BStr as *const Self) })
+        Ok(unsafe { &*(path as *const str as *const Self) })
     }
 
-    pub(crate) fn to_system_path_buf(&self) -> Result<PathBuf, PathError> {
+    pub fn to_string(&self) -> String {
+        self.0.to_string()
+    }
+
+    pub(crate) fn to_system_path_buf(&self) -> Result<Utf8PathBuf, PathError> {
         #[cfg(unix)]
         {
-            // On unix, unix paths are already system paths. Copy the bytes
+            // On unix, unix paths are already system paths. Copy the string
             // but skip validation.
-            use std::{ffi::OsString, os::unix::prelude::OsStringExt};
-            Ok(PathBuf::from(OsString::from_vec(self.0.to_vec())))
+            Ok(Utf8PathBuf::from(&self.0))
         }
 
         #[cfg(windows)]
         {
-            let system_path_bytes = self
-                .0
-                .iter()
-                .map(|byte| if *byte == b'/' { b'\\' } else { *byte })
-                .collect::<Vec<u8>>();
-            let system_path_string = String::from_utf8(system_path_bytes).map_err(|err| {
-                PathError::InvalidUnicode(String::from_utf8_lossy(err.as_bytes()).to_string())
-            })?;
-            Ok(PathBuf::from(system_path_string))
+            let system_path_string = self.replace('/', "\\");
+            Ok(Utf8PathBuf::from(system_path_string))
         }
     }
 
@@ -49,38 +54,26 @@ impl RelativeUnixPath {
     pub fn strip_prefix(
         &self,
         prefix: impl AsRef<RelativeUnixPath>,
-    ) -> Result<RelativeUnixPathBuf, PathError> {
-        let prefix = prefix.as_ref();
-        let prefix_len = prefix.0.len();
-        if prefix_len == 0 {
-            return Ok(RelativeUnixPathBuf(self.0.to_owned()));
-        }
-        if !self.0.starts_with(&prefix.0) {
-            return Err(PathError::NotParent(
-                prefix.0.to_string(),
-                self.0.to_string(),
-            ));
-        }
+    ) -> Result<&RelativeUnixPath, PathError> {
+        let stripped_path = self
+            .0
+            .strip_prefix(&prefix.as_ref().0)
+            .ok_or_else(|| PathError::NotParent(prefix.as_ref().to_string(), self.to_string()))?;
 
-        // Handle the case where we are stripping the entire contents of this path
-        if self.0.len() == prefix.0.len() {
-            return RelativeUnixPathBuf::new("");
-        }
+        // Remove leading '/' if present
+        let stripped_path = stripped_path.strip_prefix('/').unwrap_or(stripped_path);
 
-        // We now know that this path starts with the prefix, and that this path's
-        // length is greater than the prefix's length
-        if self.0[prefix_len] != b'/' {
-            let prefix_str = prefix.0.to_string();
-            let this = self.0.to_string();
-            return Err(PathError::PrefixError(prefix_str, this));
-        }
-
-        let tail_slice = &self.0[(prefix_len + 1)..];
-        RelativeUnixPathBuf::new(tail_slice.to_vec())
+        Ok(unsafe { &*(stripped_path as *const str as *const Self) })
     }
 
-    pub fn ends_with(&self, suffix: impl AsRef<[u8]>) -> bool {
+    // NOTE: This only applies to full path components. If you
+    // want to check a file extension, use `RelativeUnixPathBuf::extension`.
+    pub fn ends_with(&self, suffix: impl AsRef<str>) -> bool {
         self.0.ends_with(suffix.as_ref())
+    }
+
+    pub fn extension(&self) -> Option<&str> {
+        Utf8Path::new(&self.0).extension()
     }
 }
 

--- a/crates/turborepo-paths/src/relative_unix_path.rs
+++ b/crates/turborepo-paths/src/relative_unix_path.rs
@@ -28,10 +28,6 @@ impl RelativeUnixPath {
         Ok(unsafe { &*(path as *const str as *const Self) })
     }
 
-    pub fn to_string(&self) -> String {
-        self.0.to_string()
-    }
-
     pub(crate) fn to_system_path_buf(&self) -> Result<Utf8PathBuf, PathError> {
         #[cfg(unix)]
         {
@@ -42,7 +38,7 @@ impl RelativeUnixPath {
 
         #[cfg(windows)]
         {
-            let system_path_string = self.replace('/', "\\");
+            let system_path_string = self.0.replace('/', "\\");
             Ok(Utf8PathBuf::from(system_path_string))
         }
     }

--- a/crates/turborepo-paths/src/relative_unix_path_buf.rs
+++ b/crates/turborepo-paths/src/relative_unix_path_buf.rs
@@ -21,7 +21,7 @@ impl RelativeUnixPathBuf {
     pub fn new(path: impl Into<String>) -> Result<Self, PathError> {
         let path_string = path.into();
         if path_string.starts_with('/') {
-            return Err(PathError::NotRelative(path_string).into());
+            return Err(PathError::NotRelative(path_string));
         }
         Ok(Self(path_string))
     }
@@ -109,7 +109,7 @@ impl RelativeUnixPathBufTestExt for RelativeUnixPathBuf {
 
 impl Borrow<RelativeUnixPath> for RelativeUnixPathBuf {
     fn borrow(&self) -> &RelativeUnixPath {
-        let inner: &str = &self.0.borrow();
+        let inner: &str = self.0.borrow();
         unsafe { &*(inner as *const str as *const RelativeUnixPath) }
     }
 }

--- a/crates/turborepo-scm/Cargo.toml
+++ b/crates/turborepo-scm/Cargo.toml
@@ -14,7 +14,6 @@ hex = "0.4.3"
 ignore = "0.4.20"
 itertools.workspace = true
 nom = "7.1.3"
-path-slash = "0.2.1"
 sha1 = "0.10.5"
 thiserror = { workspace = true }
 turbopath = { workspace = true }

--- a/crates/turborepo-scm/src/git.rs
+++ b/crates/turborepo-scm/src/git.rs
@@ -45,7 +45,7 @@ pub fn changed_files(
         pathspec,
     )?;
 
-    add_files_from_stdout(&mut files, &git_root, &turbo_root, output);
+    add_files_from_stdout(&mut files, git_root, &turbo_root, output);
 
     if let Some(from_commit) = from_commit {
         let output = execute_git_command(
@@ -58,7 +58,7 @@ pub fn changed_files(
             pathspec,
         )?;
 
-        add_files_from_stdout(&mut files, &git_root, &turbo_root, output);
+        add_files_from_stdout(&mut files, git_root, &turbo_root, output);
     }
 
     let output = execute_git_command(
@@ -67,7 +67,7 @@ pub fn changed_files(
         pathspec,
     )?;
 
-    add_files_from_stdout(&mut files, &git_root, &turbo_root, output);
+    add_files_from_stdout(&mut files, git_root, &turbo_root, output);
 
     Ok(files)
 }
@@ -109,7 +109,7 @@ fn add_files_from_stdout(
     let turbo_root = turbo_root.as_ref();
     let stdout = String::from_utf8(stdout).unwrap();
     for line in stdout.lines() {
-        let path = RelativeUnixPath::new(&line).unwrap();
+        let path = RelativeUnixPath::new(line).unwrap();
         let anchored_to_turbo_root_file_path =
             reanchor_path_from_git_root_to_turbo_root(git_root, turbo_root, path).unwrap();
         files.insert(anchored_to_turbo_root_file_path.to_string());
@@ -148,7 +148,7 @@ pub fn previous_content(
     // Note that we assume any relative file path is relative to the git root
     let anchored_file_path = if file_path.is_absolute() {
         let absolute_file_path = AbsoluteSystemPathBuf::try_from(file_path)?;
-        git_root.anchor(&absolute_file_path)?
+        git_root.anchor(absolute_file_path)?
     } else {
         file_path.as_path().try_into()?
     };

--- a/crates/turborepo-scm/src/hash_object.rs
+++ b/crates/turborepo-scm/src/hash_object.rs
@@ -30,7 +30,7 @@ mod test {
         // Note that cwd can be different based on where the test suite is running from
         // or if the test is launched in debug mode from VSCode
         let cwd = std::env::current_dir().unwrap();
-        let cwd = AbsoluteSystemPathBuf::new(cwd).unwrap();
+        let cwd = AbsoluteSystemPathBuf::try_from(cwd).unwrap();
         let git_root = find_git_root(&cwd).unwrap();
         let fixture_path = git_root.join_components(&[
             "crates",

--- a/crates/turborepo-scm/src/manual.rs
+++ b/crates/turborepo-scm/src/manual.rs
@@ -69,7 +69,7 @@ pub fn get_package_file_hashes_from_processing_gitignore<S: AsRef<str>>(
             continue;
         }
         let path = AbsoluteSystemPath::from_std_path(dirent.path())?;
-        let relative_path = full_package_path.anchor(&path)?;
+        let relative_path = full_package_path.anchor(path)?;
         let relative_path = relative_path.to_unix()?;
         if let Some(include_pattern) = include_pattern.as_ref() {
             if !include_pattern.is_match(relative_path.as_str()) {


### PR DESCRIPTION
### Description

We're moving all paths to UTF-8 for a whole bunch of reasons such as:

- We know it'll be supported everywhere, across platforms, in the browser, and so on.
- We have no evidence that any user is using non-UTF-8 paths
- It's very very hard to manipulate paths without converting them to Rust Strings.
    - For instance the [only way to add a trailing slash](https://users.rust-lang.org/t/trailing-in-paths/43166/8) to a path is by doing `path.push("")`
- `bstr` [implicitly converts](https://docs.rs/bstr/latest/bstr/#handling-of-invalid-utf-8) invalid Unicode into replacement characters, which is probably not what we want
- `bstr` also explicitly notes that the end result of its conversion functions (which again either error or implicitly convert) is [“you’re guaranteed to write correct code for Unix, at the cost of getting a corner case wrong on Windows”](https://docs.rs/bstr/latest/bstr/#file-paths-and-os-strings)
    - Considering we know that we have Windows users and are committed to supporting Windows, that should be a higher priority than supporting hypothetical users using non-UTF-8 encodings.
- To quote [camino](https://docs.rs/camino/latest/camino/):
    - “Unicode is the common subset of supported paths across Windows and Unix platforms.”
    - “The '[makefile problem](https://www.mercurial-scm.org/wiki/EncodingStrategy#The_.22makefile_problem.22)' (which also applies to `Cargo.toml`, and any other metadata file that lists the names of other files) has *no general, cross-platform solution* in systems that support non-UTF-8 paths. However, restricting paths to UTF-8 eliminates this problem.”
        - Basically, if we have non-Unicode encodings, you could have “packages/星巴克” in your turbo.json that does not match to “packages/星巴克” in your file system because the file system is using big5 and turbo.json is using Unicode.
    - “There are already many systems, such as Cargo, that only support UTF-8 paths. If your own tool interacts with any such system, you can assume that paths are valid UTF-8 without creating any additional burdens on consumers.”
- [npm does not allow even Unicode in package names](https://github.com/npm/validate-npm-package-name). Only url-safe characters, i.e. characters, numbers and a few other ASCII characters
- Next has [issues with Unicode paths too](https://github.com/vercel/next.js/issues/10084)
- How would you even import a non-Unicode JavaScript file? JavaScript strings are Unicode.
- `path-slash` also only works on `AsRef<str` or requires a lossy conversion.
- Glob walking appears to assume UTF-8 as well.
- This simplifies our code significantly since we can drop a lot of errors on invalid Unicode that are sprinkled throughout the codebase.

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
