### PR TITLE
sec-228: ignore example repos

### DIFF
--- a/socket.yaml
+++ b/socket.yaml
@@ -4,3 +4,4 @@ version: 2
 projectIgnorePaths:
   - turborepo-tests
   - packages/turbo-codemod/__tests__/
+  - examples/


### PR DESCRIPTION
### Description

This will exclude `examples/` from socket scans, to reduce noise in the PR checks.

<!--
https://linear.app/vercel/issue/SEC-228/ignorepaths-socket-turbo
-->