### PR TITLE
fix(gen): fix ts config interference

### DIFF
--- a/packages/turbo-gen/src/utils/error.ts
+++ b/packages/turbo-gen/src/utils/error.ts
@@ -3,6 +3,7 @@ export type GenerateErrorType =
   | "plop_error_running_generator"
   | "plop_unable_to_load_config"
   | "plop_generator_not_found"
+  | "plop_no_config"
   | "config_directory_already_exists"
   // default
   | "unknown";


### PR DESCRIPTION
### Description

If a root `tsconfig.json` exists in a repo, we use that to try and load the generator configs. However, there exists a situation in which the root tsconfig can prevent the generator configs from being loaded. This fixes that by setting an override for `module` and `moduleResolution`.

This error was also being buried, which made it harder to diagnose. That has been fixed in this PR as well. 

Fixes https://github.com/vercel/turbo/issues/5249

