### PR TITLE
fix(turborepo): Tighten build globs

### DIFF
--- a/cli/turbo.json
+++ b/cli/turbo.json
@@ -14,9 +14,11 @@
       ],
 
       "inputs": [
-        "**/*.go",
-        "**/*_test.go",
-        "../crates/turborepo*/**" // Rust crates
+        "{internal,cmd}/**/*.go",
+        "!**/*_test.go",
+        "../crates/turborepo*/**/*.rs", // Rust crates
+        "../crates/turborepo*/Cargo.toml",
+        "!../crates/**/target"
       ]
     },
     "e2e": {


### PR DESCRIPTION
### Description

 - scopes `cli#build` inputs globs to fewer files. Previous version captured ~25k files, this is ~300

### Testing Instructions

 - verified shorter time to glob for integration tests
