### PR TITLE
fix(turborepo): Fix path match for parent dir in subtree match case

### DIFF
--- a/cli/internal/scope/filter/filter.go
+++ b/cli/internal/scope/filter/filter.go
@@ -335,7 +335,7 @@ func (r *Resolver) filterSubtreesWithSelector(selector *TargetSelector) (util.Se
 	for name, pkg := range r.WorkspaceInfos.PackageJSONs {
 		if parentDir == "" {
 			entryPackages.Add(name)
-		} else if matches, err := doublestar.PathMatch(parentDir.ToString(), pkg.Dir.RestoreAnchor(r.Cwd).ToString()); err != nil {
+		} else if matches, err := doublestar.PathMatch(r.Cwd.Join(parentDir).ToString(), pkg.Dir.RestoreAnchor(r.Cwd).ToString()); err != nil {
 			return nil, fmt.Errorf("failed to resolve directory relationship %v contains %v: %v", selector.parentDir, pkg.Dir, err)
 		} else if matches {
 			entryPackages.Add(name)

--- a/cli/internal/scope/filter/filter_test.go
+++ b/cli/internal/scope/filter/filter_test.go
@@ -600,6 +600,17 @@ func Test_SCM(t *testing.T) {
 			},
 			[]string{"package-3"},
 		},
+		{
+			"match dependency subtree",
+			[]*TargetSelector{
+				{
+					fromRef:           "HEAD~2",
+					parentDir:         "./packages/*",
+					matchDependencies: true,
+				},
+			},
+			[]string{"package-3"},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/cli/internal/scope/filter/filter_test.go
+++ b/cli/internal/scope/filter/filter_test.go
@@ -604,12 +604,12 @@ func Test_SCM(t *testing.T) {
 			"match dependency subtree",
 			[]*TargetSelector{
 				{
-					fromRef:           "HEAD~2",
-					parentDir:         "./packages/*",
+					fromRef:           "HEAD~1",
+					parentDir:         "package-*",
 					matchDependencies: true,
 				},
 			},
-			[]string{"package-3"},
+			[]string{"package-1", "package-2"},
 		},
 	}
 


### PR DESCRIPTION
### Description

 - adds correct cwd to `parentDir` in the filter case where we match a subtree of dependencies

### Testing Instructions

 - added new test case to cover this scenario
