### PR TITLE
chore(turborepo): Move SCM to use vendored wax crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,7 +187,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86d6b683edf8d1119fe420a94f8a7e389239666aa72e65495d91c00462510151"
 dependencies = [
  "anstyle",
- "bstr 1.4.0",
+ "bstr",
  "doc-comment",
  "predicates",
  "predicates-core",
@@ -764,15 +764,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "brownstone"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5839ee4f953e811bfdcf223f509cb2c6a3e1447959b0bff459405575bc17f22"
-dependencies = [
- "arrayvec 0.7.2",
-]
-
-[[package]]
 name = "browserslist-rs"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -794,17 +785,6 @@ dependencies = [
  "string_cache_codegen",
  "thiserror",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "bstr"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
-dependencies = [
- "lazy_static",
- "memchr",
- "regex-automata",
 ]
 
 [[package]]
@@ -2765,7 +2745,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "029d74589adefde59de1a0c4f4732695c32805624aec7b68d91503d4dba79afc"
 dependencies = [
  "aho-corasick 0.7.20",
- "bstr 1.4.0",
+ "bstr",
  "fnv",
  "log",
  "regex",
@@ -2782,7 +2762,7 @@ dependencies = [
  "thiserror",
  "turbopath",
  "walkdir",
- "wax 0.5.0",
+ "wax",
 ]
 
 [[package]]
@@ -3232,12 +3212,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indent_write"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cfe9645a18782869361d9c8732246be7b410ad4e919d3609ebabdac00ba12c3"
-
-[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3481,12 +3455,6 @@ checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "joinery"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72167d68f5fce3b8655487b8038691a3c9984ee769590f93f2a631f4ad64e4f5"
 
 [[package]]
 name = "jpeg-decoder"
@@ -4368,19 +4336,6 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
-]
-
-[[package]]
-name = "nom-supreme"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd3ae6c901f1959588759ff51c95d24b491ecb9ff91aa9c2ef4acc5b1dcab27"
-dependencies = [
- "brownstone",
- "indent_write",
- "joinery",
- "memchr",
- "nom",
 ]
 
 [[package]]
@@ -9464,13 +9419,13 @@ name = "turbopath"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "bstr 1.4.0",
+ "bstr",
  "dunce",
  "path-clean 1.0.1",
  "path-slash",
  "serde",
  "thiserror",
- "wax 0.5.0",
+ "wax",
 ]
 
 [[package]]
@@ -9628,7 +9583,7 @@ dependencies = [
  "uds_windows",
  "url",
  "vercel-api-mock",
- "wax 0.5.0",
+ "wax",
  "webbrowser",
  "which",
 ]
@@ -9654,7 +9609,7 @@ dependencies = [
 name = "turborepo-scm"
 version = "0.1.0"
 dependencies = [
- "bstr 1.4.0",
+ "bstr",
  "git2 0.16.1",
  "globwalk",
  "hex",
@@ -9666,7 +9621,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "turbopath",
- "wax 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wax",
  "which",
 ]
 
@@ -10535,24 +10490,6 @@ dependencies = [
  "regex",
  "tardar",
  "tempfile",
- "thiserror",
- "walkdir",
-]
-
-[[package]]
-name = "wax"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06c7a3bac6110ac062b7b422a442b7ee23e07209e2784a036654cab1e71bbafc"
-dependencies = [
- "bstr 0.2.17",
- "const_format",
- "itertools",
- "nom",
- "nom-supreme",
- "pori",
- "regex",
- "smallvec",
  "thiserror",
  "walkdir",
 ]

--- a/crates/turborepo-scm/Cargo.toml
+++ b/crates/turborepo-scm/Cargo.toml
@@ -18,7 +18,7 @@ path-slash = "0.2.1"
 sha1 = "0.10.5"
 thiserror = { workspace = true }
 turbopath = { workspace = true }
-wax = "0.5.0"
+wax = { workspace = true }
 which = { workspace = true }
 
 [dev-dependencies]

--- a/crates/turborepo-scm/src/lib.rs
+++ b/crates/turborepo-scm/src/lib.rs
@@ -38,13 +38,13 @@ pub enum Error {
     #[error("package traversal error: {0}")]
     Ignore(#[from] ignore::Error, #[backtrace] backtrace::Backtrace),
     #[error("invalid glob: {0}")]
-    Glob(Box<wax::BuildError<'static>>, backtrace::Backtrace),
+    Glob(Box<wax::BuildError>, backtrace::Backtrace),
     #[error(transparent)]
     Walk(#[from] globwalk::WalkError),
 }
 
-impl From<wax::BuildError<'static>> for Error {
-    fn from(value: wax::BuildError<'static>) -> Self {
+impl From<wax::BuildError> for Error {
+    fn from(value: wax::BuildError) -> Self {
         Error::Glob(Box::new(value), Backtrace::capture())
     }
 }

--- a/crates/turborepo-scm/src/manual.rs
+++ b/crates/turborepo-scm/src/manual.rs
@@ -40,30 +40,26 @@ pub fn get_package_file_hashes_from_processing_gitignore<S: AsRef<str>>(
                 .to_slash()
                 .ok_or_else(|| PathError::invalid_utf8_error(exclusion.as_bytes()))?
                 .into_owned();
-            let g = Glob::new(glob.as_str())
-                .map(|g| g.into_owned())
-                .map_err(|e| e.into_owned())?;
+            let g = Glob::new(glob.as_str()).map(|g| g.into_owned())?;
             excludes.push(g);
         } else {
             let glob = Path::new(pattern)
                 .to_slash()
                 .ok_or_else(|| PathError::invalid_utf8_error(pattern.as_bytes()))?
                 .into_owned();
-            let g = Glob::new(glob.as_str())
-                .map(|g| g.into_owned())
-                .map_err(|e| e.into_owned())?;
+            let g = Glob::new(glob.as_str()).map(|g| g.into_owned())?;
             includes.push(g);
         }
     }
     let include_pattern = if includes.is_empty() {
         None
     } else {
-        Some(any::<Glob<'static>, _>(includes)?)
+        Some(any(includes)?)
     };
     let exclude_pattern = if excludes.is_empty() {
         None
     } else {
-        Some(wax::any::<Glob<'static>, _>(excludes.into_iter())?)
+        Some(any(excludes.into_iter())?)
     };
     let walker = walker_builder
         .follow_links(false)


### PR DESCRIPTION
### Description

We should have everything use the vendored wax crate to avoid confusing issues. Also a prerequisite for #5272 because when we build all the turborepo crates, `crates/turborepo-wax` included, cargo gets confused about whether we mean the vendored wax crate or the upstream wax crate.

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
