### PR TITLE
fix(spaces): read logs correctly when invoked from subdirectory

### DIFF
--- a/cli/internal/graph/graph.go
+++ b/cli/internal/graph/graph.go
@@ -239,8 +239,7 @@ func (g *CompleteGraph) GetPackageJSONFromWorkspace(workspaceName string) (*fs.P
 // taskLogFile returns the path to the log file for this task execution as an absolute path
 func taskLogFile(root turbopath.AbsoluteSystemPath, dir turbopath.AnchoredSystemPath, taskName string) turbopath.AbsoluteSystemPath {
 	pkgDir := dir.RestoreAnchor(root)
-	filename := fmt.Sprintf("turbo-%v.log", taskName)
-	return pkgDir.Join(".turbo", turbopath.RelativeSystemPath(filename))
+	return pkgDir.UntypedJoin(".turbo", fmt.Sprintf("turbo-%v.log", taskName))
 }
 
 // getTaskGraphAncestors gets all the ancestors for a given task in the graph.

--- a/cli/internal/graph/graph.go
+++ b/cli/internal/graph/graph.go
@@ -4,7 +4,6 @@ package graph
 import (
 	gocontext "context"
 	"fmt"
-	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
@@ -124,8 +123,15 @@ func (g *CompleteGraph) GetPackageTaskVisitor(
 		expandedInputs := g.TaskHashTracker.GetExpandedInputs(packageTask)
 		framework := g.TaskHashTracker.GetFramework(taskID)
 
-		logFile := repoRelativeLogFile(pkgDir, taskName)
-		packageTask.LogFile = logFile
+		logFileAbsolutePath := taskLogFile(g.RepoRoot, pkgDir, taskName)
+
+		var logFileRelativePath string
+		if logRelative, err := logFileAbsolutePath.RelativeTo(g.RepoRoot); err == nil {
+			logFileRelativePath = logRelative.ToString()
+		}
+
+		// Give packageTask a string version of the logFile relative to root.
+		packageTask.LogFile = logFileRelativePath
 		packageTask.Command = command
 
 		envVarPassThroughMap, err := g.TaskHashTracker.EnvAtExecutionStart.FromWildcards(taskDefinition.PassThroughEnv)
@@ -146,7 +152,8 @@ func (g *CompleteGraph) GetPackageTaskVisitor(
 			Dir:                    pkgDir.ToString(),
 			Outputs:                taskDefinition.Outputs.Inclusions,
 			ExcludedOutputs:        taskDefinition.Outputs.Exclusions,
-			LogFile:                logFile,
+			LogFileRelativePath:    logFileRelativePath,
+			LogFileAbsolutePath:    logFileAbsolutePath,
 			ResolvedTaskDefinition: taskDefinition,
 			ExpandedInputs:         expandedInputs,
 			ExpandedOutputs:        []turbopath.AnchoredSystemPath{},
@@ -229,10 +236,11 @@ func (g *CompleteGraph) GetPackageJSONFromWorkspace(workspaceName string) (*fs.P
 	return nil, fmt.Errorf("No package.json for %s", workspaceName)
 }
 
-// repoRelativeLogFile returns the path to the log file for this task execution as a
-// relative path from the root of the monorepo.
-func repoRelativeLogFile(dir turbopath.AnchoredSystemPath, taskName string) string {
-	return filepath.Join(dir.ToStringDuringMigration(), ".turbo", fmt.Sprintf("turbo-%v.log", taskName))
+// taskLogFile returns the path to the log file for this task execution as an absolute path
+func taskLogFile(root turbopath.AbsoluteSystemPath, dir turbopath.AnchoredSystemPath, taskName string) turbopath.AbsoluteSystemPath {
+	pkgDir := dir.RestoreAnchor(root)
+	filename := fmt.Sprintf("turbo-%v.log", taskName)
+	return pkgDir.Join(".turbo", turbopath.RelativeSystemPath(filename))
 }
 
 // getTaskGraphAncestors gets all the ancestors for a given task in the graph.

--- a/cli/internal/runsummary/format_text.go
+++ b/cli/internal/runsummary/format_text.go
@@ -82,7 +82,7 @@ func (rsm Meta) FormatAndPrintText(workspaceInfos workspace.Catalog) error {
 
 		fmt.Fprintln(w, util.Sprintf("  ${GREY}Command\t=\t%s\t${RESET}", task.Command))
 		fmt.Fprintln(w, util.Sprintf("  ${GREY}Outputs\t=\t%s\t${RESET}", strings.Join(task.Outputs, ", ")))
-		fmt.Fprintln(w, util.Sprintf("  ${GREY}Log File\t=\t%s\t${RESET}", task.LogFile))
+		fmt.Fprintln(w, util.Sprintf("  ${GREY}Log File\t=\t%s\t${RESET}", task.LogFileRelativePath))
 		fmt.Fprintln(w, util.Sprintf("  ${GREY}Dependencies\t=\t%s\t${RESET}", strings.Join(task.Dependencies, ", ")))
 		fmt.Fprintln(w, util.Sprintf("  ${GREY}Dependendents\t=\t%s\t${RESET}", strings.Join(task.Dependents, ", ")))
 		fmt.Fprintln(w, util.Sprintf("  ${GREY}Inputs Files Considered\t=\t%d\t${RESET}", len(task.ExpandedInputs)))

--- a/cli/internal/runsummary/task_summary.go
+++ b/cli/internal/runsummary/task_summary.go
@@ -1,8 +1,6 @@
 package runsummary
 
 import (
-	"os"
-
 	"github.com/vercel/turbo/cli/internal/cache"
 	"github.com/vercel/turbo/cli/internal/fs"
 	"github.com/vercel/turbo/cli/internal/turbopath"
@@ -83,7 +81,7 @@ type TaskSummary struct {
 
 // GetLogs reads the log file and returns the data
 func (ts *TaskSummary) GetLogs() []byte {
-	bytes, err := os.ReadFile(ts.LogFileAbsolutePath.ToString())
+	bytes, err := ts.LogFileAbsolutePath.ReadFile()
 	if err != nil {
 		return []byte{}
 	}

--- a/cli/internal/runsummary/task_summary.go
+++ b/cli/internal/runsummary/task_summary.go
@@ -67,7 +67,8 @@ type TaskSummary struct {
 	CommandArguments       []string                              `json:"cliArguments"`
 	Outputs                []string                              `json:"outputs"`
 	ExcludedOutputs        []string                              `json:"excludedOutputs"`
-	LogFile                string                                `json:"logFile"`
+	LogFileRelativePath    string                                `json:"logFile"`
+	LogFileAbsolutePath    turbopath.AbsoluteSystemPath          `json:"-"`
 	Dir                    string                                `json:"directory,omitempty"`
 	Dependencies           []string                              `json:"dependencies"`
 	Dependents             []string                              `json:"dependents"`
@@ -80,9 +81,9 @@ type TaskSummary struct {
 	Execution              *TaskExecutionSummary                 `json:"execution,omitempty"` // omit when it's not set
 }
 
-// GetLogs reads the Logfile and returns the data
+// GetLogs reads the log file and returns the data
 func (ts *TaskSummary) GetLogs() []byte {
-	bytes, err := os.ReadFile(ts.LogFile)
+	bytes, err := os.ReadFile(ts.LogFileAbsolutePath.ToString())
 	if err != nil {
 		return []byte{}
 	}


### PR DESCRIPTION
When running `turbo <task>` from a sub directory, the `logFile` is not sufficient to actual read the logs, because it is a relative path. We need to anchor it from the root of the repo.

One way this comes up is for monorepos on Vercel, where the Root Directory is set, which causes the os.read to fail and no logs are sent to spaces.