### PR TITLE
refactor(turborepo): cli::run and args processing

### DIFF
--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -34,10 +34,10 @@ import (
 // ExecuteRun executes the run command
 func ExecuteRun(ctx gocontext.Context, helper *cmdutil.Helper, signalWatcher *signals.Watcher, executionState *turbostate.ExecutionState) error {
 	base, err := helper.GetCmdBase(executionState)
-	LogTag(base.Logger)
 	if err != nil {
 		return err
 	}
+	LogTag(base.Logger)
 	tasks := executionState.CLIArgs.Command.Run.Tasks
 	passThroughArgs := executionState.CLIArgs.Command.Run.PassThroughArgs
 	opts, err := optsFromArgs(&executionState.CLIArgs)

--- a/crates/turborepo-lib/src/cli.rs
+++ b/crates/turborepo-lib/src/cli.rs
@@ -576,14 +576,13 @@ pub async fn run(
         }
     }
 
-    let (single_package, cwd) = match (&repo_state, &command) {
-        (Some(repo_state), Command::Run(_)) => (
-            matches!(repo_state.mode, RepoMode::SinglePackage),
-            cli_args.cwd.as_deref(),
-        ),
-        (Some(repo_state), _) => (false, Some(repo_state.root.as_path())),
-        (None, _) => (false, cli_args.cwd.as_deref()),
-    };
+    let single_package =
+        matches!(&repo_state, Some(repo_state) if repo_state.mode == RepoMode::SinglePackage);
+
+    let cwd = repo_state
+        .as_ref()
+        .map(|state| state.root.as_path())
+        .or(cli_args.cwd.as_deref());
 
     let repo_root = if let Some(cwd) = cwd {
         AbsoluteSystemPathBuf::from_cwd(cwd)?

--- a/crates/turborepo-lib/src/execution_state.rs
+++ b/crates/turborepo-lib/src/execution_state.rs
@@ -1,25 +1,15 @@
 use serde::Serialize;
 use tracing::trace;
-use turbopath::AbsoluteSystemPathBuf;
 
 use crate::{
-    cli::Args, commands::CommandBase, opts::Opts, package_json::PackageJson,
-    package_manager::PackageManager,
+    cli::Args, commands::CommandBase, package_json::PackageJson, package_manager::PackageManager,
 };
 
 #[derive(Debug, Serialize)]
 pub struct ExecutionState<'a> {
     pub api_client_config: APIClientConfig<'a>,
     package_manager: PackageManager,
-    verbosity: u32,
-    trace_file: Option<String>,
-    heap_file: Option<String>,
-    cpu_profile_file: Option<String>,
-    color: bool,
-    no_color: bool,
-    opts: Opts<'a>,
-    repo_root: AbsoluteSystemPathBuf,
-    args: Args,
+    pub cli_args: &'a Args,
 }
 
 #[derive(Debug, Serialize, Default)]

--- a/crates/turborepo-lib/src/execution_state.rs
+++ b/crates/turborepo-lib/src/execution_state.rs
@@ -1,15 +1,25 @@
 use serde::Serialize;
 use tracing::trace;
+use turbopath::AbsoluteSystemPathBuf;
 
 use crate::{
-    cli::Args, commands::CommandBase, package_json::PackageJson, package_manager::PackageManager,
+    cli::Args, commands::CommandBase, opts::Opts, package_json::PackageJson,
+    package_manager::PackageManager,
 };
 
 #[derive(Debug, Serialize)]
 pub struct ExecutionState<'a> {
     pub api_client_config: APIClientConfig<'a>,
     package_manager: PackageManager,
-    pub cli_args: &'a Args,
+    verbosity: u32,
+    trace_file: Option<String>,
+    heap_file: Option<String>,
+    cpu_profile_file: Option<String>,
+    color: bool,
+    no_color: bool,
+    opts: Opts<'a>,
+    repo_root: AbsoluteSystemPathBuf,
+    args: Args,
 }
 
 #[derive(Debug, Serialize, Default)]


### PR DESCRIPTION
### Description

The `cli::run` function is pretty confusing and had a bug where `--skip-infer` would accidentally pass a relative path to the Go code and cause an error. I refactored this by moving all of the mutation to the end of the function so we can validate the different code paths a little easier. In the future we should do a scheme where `Args` is parsed into a separate struct with all of the fields properly validated and normalized.

This also moves `LogTag` so that if we encounter an error with constructing a `CommandBase`, we error instead of segfaulting.

### Testing Instructions

