### PR TITLE
ci(e2e): turn on remote caching for e2e tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -183,7 +183,7 @@ jobs:
       turborepo_rust: ${{ steps.ci.outputs.diff != '' || steps.turborepo_rust.outputs.diff != '' }}
       turbopack_bench: ${{ steps.ci.outputs.diff != '' || steps.turbopack_bench.outputs.diff != '' }}
       go: ${{ steps.ci.outputs.diff != '' || steps.turborepo_go.outputs.diff != '' }}
-      go_e2e: ${{ steps.ci.outputs.diff != '' || steps.turborepo_go.outputs.diff != '' || steps.turborepo_rust.outputs.diff != ''  || steps.turborepo_e2e.outputs.diff != '' }}
+      turborepo_e2e: ${{ steps.ci.outputs.diff != '' || steps.turborepo_go.outputs.diff != '' || steps.turborepo_rust.outputs.diff != ''  || steps.turborepo_e2e.outputs.diff != '' }}
       go_integration: ${{ steps.ci.outputs.diff != '' || steps.turborepo_go.outputs.diff != '' || steps.turborepo_rust.outputs.diff != ''  || steps.turborepo_integration.outputs.diff != '' }}
       examples: ${{ steps.ci.outputs.diff != '' || steps.examples.outputs.diff != '' }}
       turborepo_js: ${{ steps.ci.outputs.diff != '' || steps.turborepo_js.outputs.diff != '' }}
@@ -280,10 +280,10 @@ jobs:
         env:
           GO_TAG: rust
 
-  go_e2e:
-    name: Go E2E Tests
+  turborepo_e2e:
+    name: Turborepo E2E Tests
     needs: determine_jobs
-    if: needs.determine_jobs.outputs.go_e2e == 'true'
+    if: needs.determine_jobs.outputs.turborepo_e2e == 'true'
     timeout-minutes: 60
     runs-on: ${{ matrix.os.runner }}
     strategy:
@@ -304,7 +304,7 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: E2E Tests
-        run: turbo run test --filter=turborepo-tests-e2e
+        run: turbo run test --filter=turborepo-tests-e2e --remote-only --token=${{ secrets.TURBO_TOKEN }} --team=${{ vars.TURBO_TEAM }}
 
   turborepo_examples:
     name: Turborepo Examples
@@ -1256,7 +1256,7 @@ jobs:
       - go_lint
       - go_unit
       - turborepo_examples
-      - go_e2e
+      - turborepo_e2e
       - go_integration
       - js_packages
       - rust_prepare
@@ -1294,7 +1294,7 @@ jobs:
           subjob ${{needs.go_lint.result}} "Go lints"
           subjob ${{needs.go_unit.result}} "Go unit tests"
           subjob ${{needs.turborepo_examples.result}} "Turborepo examples"
-          subjob ${{needs.go_e2e.result}} "Go e2e tests"
+          subjob ${{needs.turborepo_e2e.result}} "Go e2e tests"
           subjob ${{needs.go_integration.result}} "Go integration tests"
           subjob ${{needs.js_packages.result}} "JS Package tests"
           subjob ${{needs.rust_prepare.result}} "Rust prepare"
@@ -1408,7 +1408,7 @@ jobs:
       - go_lint
       - go_unit
       - turborepo_examples
-      - go_e2e
+      - turborepo_e2e
       - go_integration
       - rust_prepare
       - rust_lint
@@ -1449,7 +1449,7 @@ jobs:
           subjob ${{needs.go_lint.result}} "Go lints"
           subjob ${{needs.go_unit.result}} "Go unit tests"
           subjob ${{needs.turborepo_examples.result}} "Turborepo examples"
-          subjob ${{needs.go_e2e.result}} "Go e2e tests"
+          subjob ${{needs.turborepo_e2e.result}} "Turborepo e2e tests"
           subjob ${{needs.go_integration.result}} "Go integration tests"
           subjob ${{needs.rust_prepare.result}} "Rust prepare"
           subjob ${{needs.rust_lint.result}} "Rust lints"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -304,7 +304,7 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: E2E Tests
-        run: turbo run test --filter=turborepo-tests-e2e --remote-only --token=${{ secrets.TURBO_TOKEN }} --team=${{ vars.TURBO_TEAM }}
+        run: turbo run test --filter=turborepo-tests-e2e --remote-only --token=${{ secrets.TURBO_TOKEN }} --team=${{ vars.TURBO_TEAM }} --color
 
   turborepo_examples:
     name: Turborepo Examples

--- a/cli/turbo.json
+++ b/cli/turbo.json
@@ -3,7 +3,7 @@
   "extends": ["//"],
   "pipeline": {
     "build": {
-      "env": ["GO_TAG"],
+      "env": ["GO_TAG", "RUNNER_OS"],
       "outputs": [
         "../target/debug/go-turbo",
         "../target/debug/turbo",

--- a/cli/turbo.json
+++ b/cli/turbo.json
@@ -20,13 +20,6 @@
         "../crates/turborepo*/Cargo.toml",
         "!../crates/**/target"
       ]
-    },
-    "e2e": {
-      "outputs": [],
-      "inputs": ["**/*.go", "go.mod", "go.sum", "scripts/e2e/e2e.ts"]
-    },
-    "e2e-prebuilt": {
-      "inputs": ["**/*.go", "go.mod", "go.sum", "scripts/e2e/e2e.ts"]
     }
   }
 }

--- a/turborepo-tests/e2e/turbo.json
+++ b/turborepo-tests/e2e/turbo.json
@@ -3,7 +3,9 @@
   "pipeline": {
     "test": {
       "dependsOn": ["cli#build", "^build"],
-      "output": []
+      "output": [],
+      // For github actions
+      "env": ["RUNNER_OS"]
     }
   }
 }

--- a/turborepo-tests/integration/tests/prune/produces_valid_turbo_json.t
+++ b/turborepo-tests/integration/tests/prune/produces_valid_turbo_json.t
@@ -27,7 +27,9 @@ Make sure we prune tasks that reference a pruned workspace
         "dotEnv": null
       }
     },
-    "remoteCache": {}
+    "remoteCache": {
+      "enabled": true
+    }
   }
 
 Verify turbo can read the produced turbo.json

--- a/turborepo-tests/integration/tests/prune/produces_valid_turbo_json.t
+++ b/turborepo-tests/integration/tests/prune/produces_valid_turbo_json.t
@@ -27,9 +27,7 @@ Make sure we prune tasks that reference a pruned workspace
         "dotEnv": null
       }
     },
-    "remoteCache": {
-      "enabled": true
-    }
+    "remoteCache": {}
   }
 
 Verify turbo can read the produced turbo.json


### PR DESCRIPTION
This should get us one step closer to running all our tests in a single job and allow turbo caching to save us time, rather than skipping with github ignore patterns