### PR TITLE
feat(run outline): Hide package graph internals

### DIFF
--- a/crates/turborepo-lib/src/package_graph/mod.rs
+++ b/crates/turborepo-lib/src/package_graph/mod.rs
@@ -10,10 +10,10 @@ use crate::{package_json::PackageJson, package_manager::PackageManager};
 pub struct WorkspaceCatalog {}
 
 pub struct PackageGraph {
-    pub workspace_graph: Rc<petgraph::Graph<String, String>>,
-    pub workspace_infos: Rc<WorkspaceCatalog>,
-    pub package_manager: PackageManager,
-    pub lockfile: Box<dyn Lockfile>,
+    workspace_graph: Rc<petgraph::Graph<String, String>>,
+    workspace_infos: Rc<WorkspaceCatalog>,
+    package_manager: PackageManager,
+    lockfile: Box<dyn Lockfile>,
 }
 
 impl PackageGraph {
@@ -23,7 +23,7 @@ impl PackageGraph {
             workspace_graph: Rc::new(petgraph::Graph::new()),
             workspace_infos: Rc::new(WorkspaceCatalog::default()),
             package_manager: PackageManager::Npm,
-            lockfile: Box::new(turborepo_lockfiles::NpmLockfile::default()),
+            lockfile: Box::<turborepo_lockfiles::NpmLockfile>::default(),
         })
     }
 
@@ -36,7 +36,7 @@ impl PackageGraph {
             workspace_graph: Rc::new(petgraph::Graph::new()),
             workspace_infos: Rc::new(WorkspaceCatalog::default()),
             package_manager: PackageManager::Npm,
-            lockfile: Box::new(turborepo_lockfiles::NpmLockfile::default()),
+            lockfile: Box::<turborepo_lockfiles::NpmLockfile>::default(),
         })
     }
 
@@ -47,5 +47,13 @@ impl PackageGraph {
 
     pub fn len(&self) -> usize {
         self.workspace_graph.node_count()
+    }
+
+    pub fn package_manager(&self) -> &PackageManager {
+        &self.package_manager
+    }
+
+    pub fn lockfile(&self) -> &dyn Lockfile {
+        self.lockfile.as_ref()
     }
 }

--- a/crates/turborepo-lib/src/run/global_hash.rs
+++ b/crates/turborepo-lib/src/run/global_hash.rs
@@ -23,12 +23,12 @@ pub struct GlobalHashableInputs {
     dot_env: Vec<RelativeUnixPathBuf>,
 }
 
-pub fn get_global_hash_inputs(
+pub fn get_global_hash_inputs<L: ?Sized + Lockfile>(
     _ui: &UI,
     _root_path: &AbsoluteSystemPath,
     _root_package_json: &PackageJson,
-    _package_manager: PackageManager,
-    _lockfile: Box<dyn Lockfile>,
+    _package_manager: &PackageManager,
+    _lockfile: &L,
     _global_file_dependencies: Vec<String>,
     env_at_execution_start: &EnvironmentVariableMap,
     global_env: Vec<String>,

--- a/crates/turborepo-lib/src/run/graph.rs
+++ b/crates/turborepo-lib/src/run/graph.rs
@@ -5,14 +5,14 @@ use turbopath::AbsoluteSystemPath;
 
 use crate::{
     config::TurboJson,
-    package_graph::WorkspaceCatalog,
+    package_graph::{self, PackageGraph, WorkspaceCatalog},
     task_graph::{Pipeline, TaskDefinition},
 };
 
 pub struct CompleteGraph<'run> {
     // TODO: This should actually be an acyclic graph type
     // Expresses the dependencies between packages
-    workspace_graph: Rc<petgraph::Graph<String, String>>,
+    package_graph: &'run PackageGraph,
     // Config from turbo.json
     pipeline: Pipeline,
     // Stores the package.json contents by package name
@@ -27,15 +27,12 @@ pub struct CompleteGraph<'run> {
 }
 
 impl<'run> CompleteGraph<'run> {
-    pub fn new(
-        workspace_graph: Rc<petgraph::Graph<String, String>>,
-        workspace_infos: Rc<WorkspaceCatalog>,
-        repo_root: &'run AbsoluteSystemPath,
-    ) -> Self {
+    pub fn new(package_graph: &'run PackageGraph, repo_root: &'run AbsoluteSystemPath) -> Self {
         Self {
-            workspace_graph,
+            package_graph,
             pipeline: Pipeline::default(),
-            workspace_infos,
+            // TODO: build during construction by querying package graph
+            workspace_infos: Default::default(),
             repo_root,
             global_hash: None,
             task_definitions: BTreeMap::new(),

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -76,11 +76,7 @@ impl Run {
             .validate()
             .context("Invalid package dependency graph")?;
 
-        let g = CompleteGraph::new(
-            pkg_dep_graph.workspace_graph.clone(),
-            pkg_dep_graph.workspace_infos.clone(),
-            &self.base.repo_root,
-        );
+        let g = CompleteGraph::new(&pkg_dep_graph, &self.base.repo_root);
 
         let is_single_package = opts.run_opts.single_package;
         let turbo_json = g.get_turbo_config_from_workspace(ROOT_PKG_NAME, is_single_package)?;
@@ -112,8 +108,8 @@ impl Run {
             &self.base.ui,
             &self.base.repo_root,
             &root_package_json,
-            pkg_dep_graph.package_manager,
-            pkg_dep_graph.lockfile,
+            pkg_dep_graph.package_manager(),
+            pkg_dep_graph.lockfile(),
             // TODO: Fill in these vec![] once turbo.json is ported
             vec![],
             &env_at_execution_start,

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -146,9 +146,11 @@ mod test {
         let dir = tempdir()?;
         let repo_root = AbsoluteSystemPathBuf::new(dir.path())?;
         let mut args = Args::default();
-        let mut run_args = RunArgs::default();
         // Daemon does not work with run stub yet
-        run_args.no_daemon = true;
+        let run_args = RunArgs {
+            no_daemon: true,
+            ..Default::default()
+        };
         args.command = Some(Command::Run(Box::new(run_args)));
 
         let ui = UI::infer();


### PR DESCRIPTION
### Description
Slight refactor to hide internals of the package graph and instead have the `CompleteGraph` hold a reference to the entire package graph and use methods to query the required information. I intend for `WorkspaceCatalog` to get lazily built by `CompleteGraph` as it is used during the execution of `run`.

There are a few clippy fixes in this as well 😄 

### Testing Instructions

👀 
