### PR TITLE
feat(logging): enable setting log order with an environment variable

### DIFF
--- a/crates/turborepo-lib/src/cli.rs
+++ b/crates/turborepo-lib/src/cli.rs
@@ -483,7 +483,7 @@ pub struct RunArgs {
     /// Set type of process output order. Use "stream" to show
     /// output as soon as it is available. Use "grouped" to
     /// show output when a command has finished execution. (default stream)
-    #[clap(long, value_enum, default_value_t = LogOrder::Stream)]
+    #[clap(long, env = "TURBO_LOG_ORDER", value_enum, default_value_t = LogOrder::Stream)]
     pub log_order: LogOrder,
     #[clap(long, hide = true)]
     pub only: bool,

--- a/turborepo-tests/integration/tests/no_args.t
+++ b/turborepo-tests/integration/tests/no_args.t
@@ -56,7 +56,7 @@ Make sure exit code is 2 when no args are passed
         --no-daemon                      Run without using turbo's daemon process
         --no-deps                        Exclude dependent task consumers from execution
         --output-logs <OUTPUT_LOGS>      Set type of process output logging. Use "full" to show all output. Use "hash-only" to show only turbo-computed task hashes. Use "new-only" to show only new output with only hashes for cached tasks. Use "none" to hide process output. (default full) [possible values: full, none, hash-only, new-only, errors-only]
-        --log-order <LOG_ORDER>          Set type of process output order. Use "stream" to show output as soon as it is available. Use "grouped" to show output when a command has finished execution. (default stream) [default: stream] [possible values: stream, grouped]
+        --log-order <LOG_ORDER>          Set type of process output order. Use "stream" to show output as soon as it is available. Use "grouped" to show output when a command has finished execution. (default stream) [env: TURBO_LOG_ORDER=] [default: stream] [possible values: stream, grouped]
         --parallel                       Execute all tasks in parallel
         --profile <PROFILE>              File to write turbo's performance profile output into. You can load the file up in chrome://tracing to see which parts of your build were slow
         --remote-only                    Ignore the local filesystem cache for all tasks. Only allow reading and caching artifacts using the remote cache

--- a/turborepo-tests/integration/tests/ordered/grouped.t
+++ b/turborepo-tests/integration/tests/ordered/grouped.t
@@ -25,6 +25,7 @@
    Tasks:    2 successful, 2 total
   Cached:    0 cached, 2 total
     Time:\s*[\.0-9]+m?s  (re)
+  
 
 # We can get the same behavior with an env var
   $ TURBO_LOG_ORDER=grouped ${TURBO} run build --force

--- a/turborepo-tests/integration/tests/ordered/grouped.t
+++ b/turborepo-tests/integration/tests/ordered/grouped.t
@@ -25,4 +25,52 @@
    Tasks:    2 successful, 2 total
   Cached:    0 cached, 2 total
     Time:\s*[\.0-9]+m?s  (re)
+
+# We can get the same behavior with an env var
+  $ TURBO_LOG_ORDER=grouped ${TURBO} run build --force
+  \xe2\x80\xa2 Packages in scope: my-app, util (esc)
+  \xe2\x80\xa2 Running build in 2 packages (esc)
+  \xe2\x80\xa2 Remote caching disabled (esc)
+  my-app:build: cache bypass, force executing [0-9a-f]+ (re)
+  my-app:build: 
+  my-app:build: > build
+  my-app:build: > echo 'building' && sleep 1 && echo 'done'
+  my-app:build: 
+  my-app:build: building
+  my-app:build: done
+  util:build: cache bypass, force executing [0-9a-f]+ (re)
+  util:build: 
+  util:build: > build
+  util:build: > sleep 0.5 && echo 'building' && sleep 1 && echo 'completed'
+  util:build: 
+  util:build: building
+  util:build: completed
+  
+   Tasks:    2 successful, 2 total
+  Cached:    0 cached, 2 total
+    Time:\s*[\.0-9]+m?s  (re)
+  
+# The flag wins over the env var
+  $ TURBO_LOG_ORDER=stream ${TURBO} run build --log-order grouped --force
+  \xe2\x80\xa2 Packages in scope: my-app, util (esc)
+  \xe2\x80\xa2 Running build in 2 packages (esc)
+  \xe2\x80\xa2 Remote caching disabled (esc)
+  my-app:build: cache bypass, force executing [0-9a-f]+ (re)
+  my-app:build: 
+  my-app:build: > build
+  my-app:build: > echo 'building' && sleep 1 && echo 'done'
+  my-app:build: 
+  my-app:build: building
+  my-app:build: done
+  util:build: cache bypass, force executing [0-9a-f]+ (re)
+  util:build: 
+  util:build: > build
+  util:build: > sleep 0.5 && echo 'building' && sleep 1 && echo 'completed'
+  util:build: 
+  util:build: building
+  util:build: completed
+  
+   Tasks:    2 successful, 2 total
+  Cached:    0 cached, 2 total
+    Time:\s*[\.0-9]+m?s  (re)
   

--- a/turborepo-tests/integration/tests/ordered/stream.t
+++ b/turborepo-tests/integration/tests/ordered/stream.t
@@ -26,3 +26,52 @@
   Cached:    0 cached, 2 total
     Time:\s*[\.0-9]+m?s  (re)
   
+The env var set to stream works (this is default, so this test doesn't guarantee the env var is "working"),
+it just guarantees setting this env var won't crash.
+  $ TURBO_LOG_ORDER=stream ${TURBO} run build --force
+  \xe2\x80\xa2 Packages in scope: my-app, util (esc)
+  \xe2\x80\xa2 Running build in 2 packages (esc)
+  \xe2\x80\xa2 Remote caching disabled (esc)
+  (my-app|util):build: cache bypass, force executing [0-9a-f]+ (re)
+  (my-app|util):build: cache bypass, force executing [0-9a-f]+ (re)
+  .* (re)
+  .* (re)
+  .* (re)
+  .* (re)
+  .* (re)
+  .* (re)
+  .* (re)
+  .* (re)
+  .* (re)
+  util:build: building
+  my-app:build: done
+  util:build: completed
+  
+   Tasks:    2 successful, 2 total
+  Cached:    0 cached, 2 total
+    Time:\s*[\.0-9]+m?s  (re)
+  
+The flag wins over the env var
+  $ TURBO_LOG_ORDER=grouped ${TURBO} run build --log-order stream --force
+  \xe2\x80\xa2 Packages in scope: my-app, util (esc)
+  \xe2\x80\xa2 Running build in 2 packages (esc)
+  \xe2\x80\xa2 Remote caching disabled (esc)
+  (my-app|util):build: cache bypass, force executing [0-9a-f]+ (re)
+  (my-app|util):build: cache bypass, force executing [0-9a-f]+ (re)
+  .* (re)
+  .* (re)
+  .* (re)
+  .* (re)
+  .* (re)
+  .* (re)
+  .* (re)
+  .* (re)
+  .* (re)
+  util:build: building
+  my-app:build: done
+  util:build: completed
+  
+   Tasks:    2 successful, 2 total
+  Cached:    0 cached, 2 total
+    Time:\s*[\.0-9]+m?s  (re)
+  

--- a/turborepo-tests/integration/tests/turbo_help.t
+++ b/turborepo-tests/integration/tests/turbo_help.t
@@ -56,7 +56,7 @@ Test help flag
         --no-daemon                      Run without using turbo's daemon process
         --no-deps                        Exclude dependent task consumers from execution
         --output-logs <OUTPUT_LOGS>      Set type of process output logging. Use "full" to show all output. Use "hash-only" to show only turbo-computed task hashes. Use "new-only" to show only new output with only hashes for cached tasks. Use "none" to hide process output. (default full) [possible values: full, none, hash-only, new-only, errors-only]
-        --log-order <LOG_ORDER>          Set type of process output order. Use "stream" to show output as soon as it is available. Use "grouped" to show output when a command has finished execution. (default stream) [default: stream] [possible values: stream, grouped]
+        --log-order <LOG_ORDER>          Set type of process output order. Use "stream" to show output as soon as it is available. Use "grouped" to show output when a command has finished execution. (default stream) [env: TURBO_LOG_ORDER=] [default: stream] [possible values: stream, grouped]
         --parallel                       Execute all tasks in parallel
         --profile <PROFILE>              File to write turbo's performance profile output into. You can load the file up in chrome://tracing to see which parts of your build were slow
         --remote-only                    Ignore the local filesystem cache for all tasks. Only allow reading and caching artifacts using the remote cache
@@ -124,7 +124,7 @@ Test help flag
         --no-daemon                      Run without using turbo's daemon process
         --no-deps                        Exclude dependent task consumers from execution
         --output-logs <OUTPUT_LOGS>      Set type of process output logging. Use "full" to show all output. Use "hash-only" to show only turbo-computed task hashes. Use "new-only" to show only new output with only hashes for cached tasks. Use "none" to hide process output. (default full) [possible values: full, none, hash-only, new-only, errors-only]
-        --log-order <LOG_ORDER>          Set type of process output order. Use "stream" to show output as soon as it is available. Use "grouped" to show output when a command has finished execution. (default stream) [default: stream] [possible values: stream, grouped]
+        --log-order <LOG_ORDER>          Set type of process output order. Use "stream" to show output as soon as it is available. Use "grouped" to show output when a command has finished execution. (default stream) [env: TURBO_LOG_ORDER=] [default: stream] [possible values: stream, grouped]
         --parallel                       Execute all tasks in parallel
         --profile <PROFILE>              File to write turbo's performance profile output into. You can load the file up in chrome://tracing to see which parts of your build were slow
         --remote-only                    Ignore the local filesystem cache for all tasks. Only allow reading and caching artifacts using the remote cache


### PR DESCRIPTION
I thought I would need this to implement grouping in github (#5318), but it actually isn't relevant. But in any case, I already added it, and we try to keep parity with env vars and flagging, so submitting anyway.