### PR TITLE
feat(logging): add "auto" options for log prefixing and ordering

### DIFF
--- a/crates/turborepo-lib/src/cli.rs
+++ b/crates/turborepo-lib/src/cli.rs
@@ -482,12 +482,14 @@ pub struct RunArgs {
     /// output. (default full)
     #[clap(long, value_enum)]
     pub output_logs: Option<OutputLogsMode>,
-    /// Set type of process output order. Use "stream" to show
+
+    /// Set type of task output order. Use "stream" to show
     /// output as soon as it is available. Use "grouped" to
     /// show output when a command has finished execution. Use "auto" to let
     /// turbo decide based on its own heuristics. (default auto)
     #[clap(long, env = "TURBO_LOG_ORDER", value_enum, default_value_t = LogOrder::Auto)]
     pub log_order: LogOrder,
+
     #[clap(long, hide = true)]
     pub only: bool,
     /// Execute all tasks in parallel.
@@ -516,15 +518,17 @@ pub struct RunArgs {
     /// Generate a summary of the turbo run
     #[clap(long, env = "TURBO_RUN_SUMMARY", default_missing_value = "true")]
     pub summarize: Option<Option<bool>>,
-    /// Use "none" to remove prefixes from task logs. Use "auto" to let turbo
-    /// decide how to prefix the logs based on the execution environment. In
-    /// most cases this will be the same as --log-order="task". Use "task"
-    /// to get task id prefixing.
-    /// Note that tasks running in parallel interleave their logs, so removing
-    /// prefixes can make it difficult to associate logs with tasks. You can use
-    /// --log-order=grouped to prevent interleaving.
+
+    /// Use "none" to remove prefixes from task logs. Use "task" to get task id
+    /// prefixing. Use "auto" to let turbo decide how to prefix the logs
+    /// based on the execution environment. In most cases this will be the same
+    /// as "task". Note that tasks running in parallel interleave their
+    /// logs, so removing prefixes can make it difficult to associate logs
+    /// with tasks. Use --log-order=grouped to prevent interleaving. (default
+    /// auto)
     #[clap(long, value_enum, default_value_t = LogPrefix::Auto)]
     pub log_prefix: LogPrefix,
+
     // NOTE: The following two are hidden because clap displays them in the help text incorrectly:
     // > Usage: turbo [OPTIONS] [TASKS]... [-- <FORWARDED_ARGS>...] [COMMAND]
     #[clap(hide = true)]

--- a/crates/turborepo-lib/src/cli.rs
+++ b/crates/turborepo-lib/src/cli.rs
@@ -48,6 +48,8 @@ impl Default for OutputLogsMode {
 
 #[derive(Copy, Clone, Debug, PartialEq, Serialize, ValueEnum)]
 pub enum LogOrder {
+    #[serde(rename = "auto")]
+    Auto,
     #[serde(rename = "stream")]
     Stream,
     #[serde(rename = "grouped")]
@@ -56,7 +58,7 @@ pub enum LogOrder {
 
 impl Default for LogOrder {
     fn default() -> Self {
-        Self::Stream
+        Self::Auto
     }
 }
 
@@ -482,8 +484,9 @@ pub struct RunArgs {
     pub output_logs: Option<OutputLogsMode>,
     /// Set type of process output order. Use "stream" to show
     /// output as soon as it is available. Use "grouped" to
-    /// show output when a command has finished execution. (default stream)
-    #[clap(long, env = "TURBO_LOG_ORDER", value_enum, default_value_t = LogOrder::Stream)]
+    /// show output when a command has finished execution. Use "auto" to let
+    /// turbo decide based on its own heuristics. (default auto)
+    #[clap(long, env = "TURBO_LOG_ORDER", value_enum, default_value_t = LogOrder::Auto)]
     pub log_order: LogOrder,
     #[clap(long, hide = true)]
     pub only: bool,
@@ -1295,7 +1298,7 @@ mod test {
             Args {
                 command: Some(Command::Run(Box::new(RunArgs {
                     tasks: vec!["build".to_string()],
-                    log_order: LogOrder::Stream,
+                    log_order: LogOrder::Auto,
                     ..get_default_run_args()
                 }))),
                 ..Args::default()

--- a/crates/turborepo-lib/src/opts.rs
+++ b/crates/turborepo-lib/src/opts.rs
@@ -84,7 +84,7 @@ pub struct RunOpts<'a> {
     graph_file: Option<&'a str>,
     pub(crate) no_daemon: bool,
     pub(crate) single_package: bool,
-    log_prefix: Option<LogPrefix>,
+    log_prefix: LogPrefix,
     summarize: Option<Option<bool>>,
     pub(crate) experimental_space_id: Option<String>,
 }

--- a/turborepo-tests/integration/tests/no_args.t
+++ b/turborepo-tests/integration/tests/no_args.t
@@ -56,14 +56,14 @@ Make sure exit code is 2 when no args are passed
         --no-daemon                      Run without using turbo's daemon process
         --no-deps                        Exclude dependent task consumers from execution
         --output-logs <OUTPUT_LOGS>      Set type of process output logging. Use "full" to show all output. Use "hash-only" to show only turbo-computed task hashes. Use "new-only" to show only new output with only hashes for cached tasks. Use "none" to hide process output. (default full) [possible values: full, none, hash-only, new-only, errors-only]
-        --log-order <LOG_ORDER>          Set type of process output order. Use "stream" to show output as soon as it is available. Use "grouped" to show output when a command has finished execution. (default stream) [env: TURBO_LOG_ORDER=] [default: stream] [possible values: stream, grouped]
+        --log-order <LOG_ORDER>          Set type of task output order. Use "stream" to show output as soon as it is available. Use "grouped" to show output when a command has finished execution. Use "auto" to let turbo decide based on its own heuristics. (default auto) [env: TURBO_LOG_ORDER=] [default: auto] [possible values: auto, stream, grouped]
         --parallel                       Execute all tasks in parallel
         --profile <PROFILE>              File to write turbo's performance profile output into. You can load the file up in chrome://tracing to see which parts of your build were slow
         --remote-only [<BOOL>]           Ignore the local filesystem cache for all tasks. Only allow reading and caching artifacts using the remote cache [env: TURBO_REMOTE_ONLY=] [default: false] [possible values: true, false]
         --scope <SCOPE>                  Specify package(s) to act as entry points for task execution. Supports globs
         --since <SINCE>                  Limit/Set scope to changed packages since a mergebase. This uses the git diff ${target_branch}... mechanism to identify which packages have changed
         --summarize [<SUMMARIZE>]        Generate a summary of the turbo run [env: TURBO_RUN_SUMMARY=] [possible values: true, false]
-        --log-prefix <LOG_PREFIX>        Use "none" to remove prefixes from task logs. Note that tasks running in parallel interleave their logs and prefix is the only way to identify which task produced a log [possible values: none]
+        --log-prefix <LOG_PREFIX>        Use "none" to remove prefixes from task logs. Use "task" to get task id prefixing. Use "auto" to let turbo decide how to prefix the logs based on the execution environment. In most cases this will be the same as "task". Note that tasks running in parallel interleave their logs, so removing prefixes can make it difficult to associate logs with tasks. Use --log-order=grouped to prevent interleaving. (default auto) [default: auto] [possible values: auto, none, task]
   [1]
   $ ${TURBO} run
   ERROR at least one task must be specified

--- a/turborepo-tests/integration/tests/run-logging/log_prefix.t
+++ b/turborepo-tests/integration/tests/run-logging/log_prefix.t
@@ -62,7 +62,7 @@ Setup
 # Running with bogus option
   $ ${TURBO} run build --log-prefix=blah
   ERROR invalid value 'blah' for '--log-prefix <LOG_PREFIX>'
-    [possible values: none]
+    [possible values: auto, none, task]
   
   For more information, try '--help'.
   
@@ -71,7 +71,7 @@ Setup
 # Running with missing value for option
   $ ${TURBO} run build --log-prefix
   ERROR a value is required for '--log-prefix <LOG_PREFIX>' but none was supplied
-    [possible values: none]
+    [possible values: auto, none, task]
   
   For more information, try '--help'.
   

--- a/turborepo-tests/integration/tests/turbo_help.t
+++ b/turborepo-tests/integration/tests/turbo_help.t
@@ -56,14 +56,14 @@ Test help flag
         --no-daemon                      Run without using turbo's daemon process
         --no-deps                        Exclude dependent task consumers from execution
         --output-logs <OUTPUT_LOGS>      Set type of process output logging. Use "full" to show all output. Use "hash-only" to show only turbo-computed task hashes. Use "new-only" to show only new output with only hashes for cached tasks. Use "none" to hide process output. (default full) [possible values: full, none, hash-only, new-only, errors-only]
-        --log-order <LOG_ORDER>          Set type of process output order. Use "stream" to show output as soon as it is available. Use "grouped" to show output when a command has finished execution. (default stream) [env: TURBO_LOG_ORDER=] [default: stream] [possible values: stream, grouped]
+        --log-order <LOG_ORDER>          Set type of task output order. Use "stream" to show output as soon as it is available. Use "grouped" to show output when a command has finished execution. Use "auto" to let turbo decide based on its own heuristics. (default auto) [env: TURBO_LOG_ORDER=] [default: auto] [possible values: auto, stream, grouped]
         --parallel                       Execute all tasks in parallel
         --profile <PROFILE>              File to write turbo's performance profile output into. You can load the file up in chrome://tracing to see which parts of your build were slow
         --remote-only [<BOOL>]           Ignore the local filesystem cache for all tasks. Only allow reading and caching artifacts using the remote cache [env: TURBO_REMOTE_ONLY=] [default: false] [possible values: true, false]
         --scope <SCOPE>                  Specify package(s) to act as entry points for task execution. Supports globs
         --since <SINCE>                  Limit/Set scope to changed packages since a mergebase. This uses the git diff ${target_branch}... mechanism to identify which packages have changed
         --summarize [<SUMMARIZE>]        Generate a summary of the turbo run [env: TURBO_RUN_SUMMARY=] [possible values: true, false]
-        --log-prefix <LOG_PREFIX>        Use "none" to remove prefixes from task logs. Note that tasks running in parallel interleave their logs and prefix is the only way to identify which task produced a log [possible values: none]
+        --log-prefix <LOG_PREFIX>        Use "none" to remove prefixes from task logs. Use "task" to get task id prefixing. Use "auto" to let turbo decide how to prefix the logs based on the execution environment. In most cases this will be the same as "task". Note that tasks running in parallel interleave their logs, so removing prefixes can make it difficult to associate logs with tasks. Use --log-order=grouped to prevent interleaving. (default auto) [default: auto] [possible values: auto, none, task]
 
 
 
@@ -124,14 +124,14 @@ Test help flag
         --no-daemon                      Run without using turbo's daemon process
         --no-deps                        Exclude dependent task consumers from execution
         --output-logs <OUTPUT_LOGS>      Set type of process output logging. Use "full" to show all output. Use "hash-only" to show only turbo-computed task hashes. Use "new-only" to show only new output with only hashes for cached tasks. Use "none" to hide process output. (default full) [possible values: full, none, hash-only, new-only, errors-only]
-        --log-order <LOG_ORDER>          Set type of process output order. Use "stream" to show output as soon as it is available. Use "grouped" to show output when a command has finished execution. (default stream) [env: TURBO_LOG_ORDER=] [default: stream] [possible values: stream, grouped]
+        --log-order <LOG_ORDER>          Set type of task output order. Use "stream" to show output as soon as it is available. Use "grouped" to show output when a command has finished execution. Use "auto" to let turbo decide based on its own heuristics. (default auto) [env: TURBO_LOG_ORDER=] [default: auto] [possible values: auto, stream, grouped]
         --parallel                       Execute all tasks in parallel
         --profile <PROFILE>              File to write turbo's performance profile output into. You can load the file up in chrome://tracing to see which parts of your build were slow
         --remote-only [<BOOL>]           Ignore the local filesystem cache for all tasks. Only allow reading and caching artifacts using the remote cache [env: TURBO_REMOTE_ONLY=] [default: false] [possible values: true, false]
         --scope <SCOPE>                  Specify package(s) to act as entry points for task execution. Supports globs
         --since <SINCE>                  Limit/Set scope to changed packages since a mergebase. This uses the git diff ${target_branch}... mechanism to identify which packages have changed
         --summarize [<SUMMARIZE>]        Generate a summary of the turbo run [env: TURBO_RUN_SUMMARY=] [possible values: true, false]
-        --log-prefix <LOG_PREFIX>        Use "none" to remove prefixes from task logs. Note that tasks running in parallel interleave their logs and prefix is the only way to identify which task produced a log [possible values: none]
+        --log-prefix <LOG_PREFIX>        Use "none" to remove prefixes from task logs. Use "task" to get task id prefixing. Use "auto" to let turbo decide how to prefix the logs based on the execution environment. In most cases this will be the same as "task". Note that tasks running in parallel interleave their logs, so removing prefixes can make it difficult to associate logs with tasks. Use --log-order=grouped to prevent interleaving. (default auto) [default: auto] [possible values: auto, none, task]
 
 Test help flag for link command
   $ ${TURBO} link -h


### PR DESCRIPTION
To make #5318 work well, we need to make our default options for log prefixing and ordering "auto". This way we can use heuristics (like `GITHUB_ACTIONS=true` env var) to change the settings for the user without any interventions, and we can be sure that the user didn't intend to turn _off_ these features/heuristics.

For `--log-prefix` , since "auto" becomes the default, I also add "task" so users can lock their behavior to what they have now, if they don't like any heuristics we introduce. 

Just adding these options shoudln't need to change any behavior in Go / `run` code, because "auto" will just do what it does, and if `--log-prefix=task` is selected, we also get default behavior (we only do something different on `--log-prefix=none` right now)