### PR TITLE
Fix ESLint script command.

### DIFF
--- a/docs/pages/repo/docs/handbook/linting/eslint.mdx
+++ b/docs/pages/repo/docs/handbook/linting/eslint.mdx
@@ -118,7 +118,7 @@ Each `package.json` script should look like this:
 ```json filename="packages/*/package.json"
 {
   "scripts": {
-    "lint": "eslint"
+    "lint": "eslint ."
   }
 }
 ```


### PR DESCRIPTION
ESLint needs you to tell it the directory it will run in. If you don't, it will silently do nothing, making it look like your script passed with no errors (at least unless you're *really* paying attention).