### PR TITLE
ci(integration): add colors to turbo run invocation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -276,7 +276,7 @@ jobs:
           key: prysk-venv-${{ matrix.os.name }}
 
       - name: Integration Tests
-        run: turbo run test --filter=turborepo-tests-integration
+        run: turbo run test --filter=turborepo-tests-integration --color
         env:
           GO_TAG: rust
 


### PR DESCRIPTION
We can add --color flag for the turbo invocation. We previously did not do this, because we were doing it with an environment variable and it was filtering down to the tests themselves. but using a flag does not do that.