### PR TITLE
ci: Remove go/rust toolchain from JS package tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -407,11 +407,12 @@ jobs:
           ref: ${{ github.ref }}
           fetch-depth: ${{ steps.fetch-depth.outputs.depth  }}
 
-      - name: Build turborepo CLI from source
-        uses: ./.github/actions/setup-turborepo-environment
+      - uses: ./.github/actions/setup-turborepo-environment
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           target: ${{ matrix.os.name }}
+          setup-go: false
+          setup-rust: false
 
       - name: Run tests
         run: |


### PR DESCRIPTION
This reapplies 7945a2c6c7092eb130033775d78dbe92aa60678d (again) after it was reverted in 4e035e61eae802cd472dda40779e141d2e896659. Now that we have the --filter arguments setup correctly, this job should never run tests for a workspace that needs Go or Rust. It should only run JS package tests.

@vercel/turbo-oss please merge this if you want! It will make JS package tests run a lot faster, but since it's been reverted twice (due to `--filter` not working the way I expected), I don't want to merge before going on leave.