### PR TITLE
perf: Remove debug string for published builds

### DIFF
--- a/crates/turbo-tasks-macros/src/derive/value_debug_format_macro.rs
+++ b/crates/turbo-tasks-macros/src/derive/value_debug_format_macro.rs
@@ -29,13 +29,21 @@ pub fn derive_value_debug_format(input: TokenStream) -> TokenStream {
             #[doc(hidden)]
             #[allow(non_snake_case)]
             async fn #value_debug_format_ident(&self, depth: usize) -> anyhow::Result<turbo_tasks::debug::ValueDebugStringVc> {
-                if depth == 0 {
-                    return Ok(turbo_tasks::debug::ValueDebugStringVc::new(stringify!(#ident).to_string()));
+                #[cfg(debug_assertions)]
+                {
+                    if depth == 0 {
+                        return Ok(turbo_tasks::debug::ValueDebugStringVc::new(stringify!(#ident).to_string()));
+                    }
+
+                    use turbo_tasks::debug::internal::*;
+                    use turbo_tasks::debug::ValueDebugFormat;
+                    Ok(turbo_tasks::debug::ValueDebugStringVc::new(format!("{:#?}", #formatting_logic)))
                 }
 
-                use turbo_tasks::debug::internal::*;
-                use turbo_tasks::debug::ValueDebugFormat;
-                Ok(turbo_tasks::debug::ValueDebugStringVc::new(format!("{:#?}", #formatting_logic)))
+                #[cfg(not(debug_assertions))]
+                {
+                    Ok(turbo_tasks::debug::ValueDebugStringVc::new(stringify!(#ident).to_string()))
+                }
             }
         }
 


### PR DESCRIPTION
### Description

To reduce binary size, I removed the heavy implementation of `Debug` for release builds

### Testing Instructions



---


Closes WEB-1199