### PR TITLE
feat(turbo): add main pointing to bin

### DIFF
--- a/packages/turbo/package.json
+++ b/packages/turbo/package.json
@@ -6,6 +6,7 @@
   "bugs": "https://github.com/vercel/turbo/issues",
   "homepage": "https://turbo.build/repo",
   "license": "MPL-2.0",
+  "main": "./bin/turbo",
   "scripts": {
     "postversion": "node bump-version.js",
     "postinstall": "node install.js"


### PR DESCRIPTION
### Description

<!--
  ✍️ Write a short summary of your work.
  If necessary, include relevant screenshots.
-->

Add a `package.json` `main` filed so that `require.resolve` works.

### Testing Instructions

```
// before
require.resolve('turbo');
// Throws module not found error

// After
require.resolve('turbo');
// /path/to/turbo/bin/turbo
```

Many tools rely on `require.resolve` to find where a package was installed. Adding this field to the cli package shouldn't change any behaviors when using the package in currently documented ways. The only downside here is that this package does not export javascript, so this will mean that someone require/import'ing the package will get a different error. AFAIK there is no other reliable way to find where on disk a package was installed than `require.resolve`, so `main` being missing would have errored for those folks anyway.