### PR TITLE
fix(turborepo): Hashing symlinks is erroring

### DIFF
--- a/cli/internal/hashing/package_deps_hash_test.go
+++ b/cli/internal/hashing/package_deps_hash_test.go
@@ -398,11 +398,10 @@ func Test_hashSymlink(t *testing.T) {
 	requireGitCmd(t, repoRoot, "add", ".")
 	requireGitCmd(t, repoRoot, "commit", "-m", "foo")
 
-	toHash, err := link.RelativeTo(repoRoot)
-	assert.NilError(t, err, "RelativeTo")
-	hashes, err := gitHashObject(repoRoot, []turbopath.AnchoredSystemPath{toHash})
+	hashes, err := GetPackageFileHashes(repoRoot, turbopath.AnchoredSystemPathFromUpstream(""), []string{"l*"})
 	assert.NilError(t, err, "getHashObject")
-	println(hashes)
+	// We expect to skip hashing the symlink. Note that this is a bug and should be fixed
+	assert.Equal(t, len(hashes), 0)
 }
 
 func Test_getPackageFileHashesFromProcessingGitIgnore(t *testing.T) {

--- a/crates/turborepo-scm/src/hash_object.rs
+++ b/crates/turborepo-scm/src/hash_object.rs
@@ -22,7 +22,6 @@ pub(crate) fn hash_objects(
                 // them, and the Go implementation errors on them, switches to
                 // manual, and then skips them. For now, we'll skip them too.
                 if e.class() == git2::ErrorClass::Os
-                    && e.message() == "error reading file for hashing: Is a directory"
                     && full_file_path
                         .symlink_metadata()
                         .map(|md| md.is_symlink())

--- a/crates/turborepo-scm/src/hash_object.rs
+++ b/crates/turborepo-scm/src/hash_object.rs
@@ -10,11 +10,31 @@ pub(crate) fn hash_objects(
 ) -> Result<(), Error> {
     for filename in to_hash {
         let full_file_path = git_root.join_unix_path(filename)?;
-        let hash = git2::Oid::hash_file(git2::ObjectType::Blob, &full_file_path)
-            .map_err(|e| Error::git2_error_context(e, full_file_path.to_string()))?;
-        let package_relative_path =
-            AnchoredSystemPathBuf::relative_path_between(pkg_path, &full_file_path).to_unix()?;
-        hashes.insert(package_relative_path, hash.to_string());
+        match git2::Oid::hash_file(git2::ObjectType::Blob, &full_file_path) {
+            Ok(hash) => {
+                let package_relative_path =
+                    AnchoredSystemPathBuf::relative_path_between(pkg_path, &full_file_path)
+                        .to_unix()?;
+                hashes.insert(package_relative_path, hash.to_string());
+            }
+            Err(e) => {
+                // FIXME: we currently do not hash symlinks. "git hash-object" cannot handle
+                // them, and the Go implementation errors on them, switches to
+                // manual, and then skips them. For now, we'll skip them too.
+                if e.class() == git2::ErrorClass::Os
+                    && e.message() == "error reading file for hashing: Is a directory"
+                    && full_file_path
+                        .symlink_metadata()
+                        .map(|md| md.is_symlink())
+                        .unwrap_or(false)
+                {
+                    continue;
+                } else {
+                    // For any other error, ensure we attach some context to it
+                    return Err(Error::git2_error_context(e, full_file_path.to_string()));
+                }
+            }
+        }
     }
     Ok(())
 }

--- a/crates/turborepo-scm/src/hash_object.rs
+++ b/crates/turborepo-scm/src/hash_object.rs
@@ -10,7 +10,8 @@ pub(crate) fn hash_objects(
 ) -> Result<(), Error> {
     for filename in to_hash {
         let full_file_path = git_root.join_unix_path(filename)?;
-        let hash = git2::Oid::hash_file(git2::ObjectType::Blob, &full_file_path)?;
+        let hash = git2::Oid::hash_file(git2::ObjectType::Blob, &full_file_path)
+            .map_err(|e| Error::git2_error_context(e, full_file_path.to_string()))?;
         let package_relative_path =
             AnchoredSystemPathBuf::relative_path_between(pkg_path, &full_file_path).to_unix()?;
         hashes.insert(package_relative_path, hash.to_string());

--- a/crates/turborepo-scm/src/lib.rs
+++ b/crates/turborepo-scm/src/lib.rs
@@ -20,8 +20,8 @@ mod status;
 
 #[derive(Debug, Error)]
 pub enum Error {
-    #[error("git error: {0}")]
-    Git2(#[from] git2::Error, #[backtrace] backtrace::Backtrace),
+    #[error("git error on {1}: {0}")]
+    Git2(git2::Error, String, #[backtrace] backtrace::Backtrace),
     #[error("git error: {0}")]
     Git(String, #[backtrace] backtrace::Backtrace),
     #[error("io error: {0}")]
@@ -52,6 +52,10 @@ impl From<wax::BuildError> for Error {
 impl Error {
     pub(crate) fn git_error(s: impl Into<String>) -> Self {
         Error::Git(s.into(), Backtrace::capture())
+    }
+
+    pub(crate) fn git2_error_context(error: git2::Error, context: String) -> Self {
+        Error::Git2(error, context, Backtrace::capture())
     }
 }
 

--- a/crates/turborepo-scm/src/manual.rs
+++ b/crates/turborepo-scm/src/manual.rs
@@ -81,6 +81,10 @@ pub fn get_package_file_hashes_from_processing_gitignore<S: AsRef<str>>(
                 continue;
             }
         }
+        // FIXME: we don't hash symlinks...
+        if metadata.is_symlink() {
+            continue;
+        }
         let hash = git_like_hash_file(path, &metadata)?;
         hashes.insert(relative_path, hash);
     }

--- a/crates/turborepo-scm/src/package_deps.rs
+++ b/crates/turborepo-scm/src/package_deps.rs
@@ -162,7 +162,10 @@ mod tests {
         link.symlink_to_dir("inside").unwrap();
         let to_hash = vec![RelativeUnixPathBuf::new("link").unwrap()];
         let mut hashes = GitHashes::new();
+        // FIXME: This test verifies a bug: we don't hash symlinks.
+        // TODO: update this test to point at get_package_file_hashes
         hash_objects(&git_root, &git_root, to_hash, &mut hashes).unwrap();
+        assert!(hashes.is_empty());
     }
 
     #[test]

--- a/crates/turborepo-scm/src/package_deps.rs
+++ b/crates/turborepo-scm/src/package_deps.rs
@@ -116,9 +116,8 @@ pub(crate) fn find_git_root(
 mod tests {
     use std::{assert_matches::assert_matches, process::Command};
 
-    use crate::manual::get_package_file_hashes_from_processing_gitignore;
-
     use super::*;
+    use crate::manual::get_package_file_hashes_from_processing_gitignore;
 
     fn tmp_dir() -> (tempfile::TempDir, AbsoluteSystemPathBuf) {
         let tmp_dir = tempfile::tempdir().unwrap();
@@ -170,7 +169,9 @@ mod tests {
         assert!(hashes.is_empty());
 
         let pkg_path = git_root.anchor(&git_root).unwrap();
-        let manual_hashes = get_package_file_hashes_from_processing_gitignore(&git_root, &pkg_path, &["l*"]).unwrap();
+        let manual_hashes =
+            get_package_file_hashes_from_processing_gitignore(&git_root, &pkg_path, &["l*"])
+                .unwrap();
         assert!(manual_hashes.is_empty());
     }
 

--- a/crates/turborepo-scm/src/package_deps.rs
+++ b/crates/turborepo-scm/src/package_deps.rs
@@ -152,6 +152,20 @@ mod tests {
     }
 
     #[test]
+    fn test_hash_symlink() {
+        let (_, tmp_root) = tmp_dir();
+        let git_root = tmp_root.join_component("actual_repo");
+        git_root.create_dir_all().unwrap();
+        setup_repository(&git_root);
+        git_root.join_component("inside").create_dir_all().unwrap();
+        let link = git_root.join_component("link");
+        link.symlink_to_dir("inside").unwrap();
+        let to_hash = vec![RelativeUnixPathBuf::new("link").unwrap()];
+        let mut hashes = GitHashes::new();
+        hash_objects(&git_root, &git_root, to_hash, &mut hashes).unwrap();
+    }
+
+    #[test]
     fn test_symlinked_git_root() {
         let (_, tmp_root) = tmp_dir();
         let git_root = tmp_root.join_component("actual_repo");

--- a/crates/turborepo-scm/src/package_deps.rs
+++ b/crates/turborepo-scm/src/package_deps.rs
@@ -116,6 +116,8 @@ pub(crate) fn find_git_root(
 mod tests {
     use std::{assert_matches::assert_matches, process::Command};
 
+    use crate::manual::get_package_file_hashes_from_processing_gitignore;
+
     use super::*;
 
     fn tmp_dir() -> (tempfile::TempDir, AbsoluteSystemPathBuf) {
@@ -166,6 +168,10 @@ mod tests {
         // TODO: update this test to point at get_package_file_hashes
         hash_objects(&git_root, &git_root, to_hash, &mut hashes).unwrap();
         assert!(hashes.is_empty());
+
+        let pkg_path = git_root.anchor(&git_root).unwrap();
+        let manual_hashes = get_package_file_hashes_from_processing_gitignore(&git_root, &pkg_path, &["l*"]).unwrap();
+        assert!(manual_hashes.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
### Description
In the Go implementation, we silently skipped hashing symlinks. The `git`-based hashing would fail, and then our walk of the filesystem would ignore symlinks due to considering them as directories. The rust implementation did not ignore them, and so was producing errors. 

Post-port, we should fix the underlying issue.

 - Fixes #5260
 - Ignores hash-object errors for symlinks to match Go behavior
 - Adds tests to Rust and Go for (skipping) hashing symlinks
 - Adds a context field to `git2` errors

### Testing Instructions

 - new tests in both Rust and Go implementations
 - updated tests to prefer `.unwrap()` in cases where we don't care to attach a context
