### PR TITLE
Add Vercel to CI providers.

### DIFF
--- a/docs/pages/repo/docs/ci.mdx
+++ b/docs/pages/repo/docs/ci.mdx
@@ -7,6 +7,7 @@ description: Recipes for using Turborepo with GitHub Actions, CircleCI, and othe
 
 Turborepo not only speeds up builds, but also your CI pipeline. Below are a few ways to use Turborepo with various Continuous Integration providers.
 
+- [Vercel](/repo/docs/ci/vercel)
 - [CircleCI](/repo/docs/ci/circleci)
 - [GitHub Actions](/repo/docs/ci/github-actions)
 - [GitLab CI](/repo/docs/ci/gitlabci)

--- a/docs/pages/repo/docs/ci/_meta.json
+++ b/docs/pages/repo/docs/ci/_meta.json
@@ -1,4 +1,5 @@
 {
+  "vercel": "Vercel",
   "circleci": "CircleCI",
   "github-actions": "GitHub Actions",
   "gitlabci": "GitLab CI",

--- a/docs/pages/repo/docs/ci/vercel.mdx
+++ b/docs/pages/repo/docs/ci/vercel.mdx
@@ -1,0 +1,12 @@
+---
+title: Using Turborepo with GitHub Actions
+description: How to use GitHub Actions with Turborepo to optimize your CI workflow
+---
+
+# Using Turborepo with Vercel
+
+Vercel's zero-config integration with Turborepo automatically understands your monorepo.
+
+To deploy your Turborepo on Vercel, [create a new project](https://vercel.com/new) and import your code. Your projects will be pre-configured with the correct settings to successfully deploy on Vercel.
+
+For more information about deploying your Turborepo to Vercel, [visit the Vercel documentation](https://vercel.com/docs/concepts/monorepos/turborepo).


### PR DESCRIPTION
We get a lot of folks with questions on how to deploy their Turborepos to Vercel. Let's get them pointed at the documentation!