### PR TITLE
fix: update ctrlc to 3.4.0 to allow have new signal handlers overwrite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1755,9 +1755,9 @@ dependencies = [
 
 [[package]]
 name = "ctrlc"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04d778600249295e82b6ab12e291ed9029407efee0cfb7baf67157edc65964df"
+checksum = "2a011bbe2c35ce9c1f143b7af6f94f29a167beb4cd1d29e6740ce836f723120e"
 dependencies = [
  "nix",
  "windows-sys 0.48.0",
@@ -9634,7 +9634,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "rand 0.8.5",
  "static_assertions",
 ]

--- a/crates/turborepo-lib/Cargo.toml
+++ b/crates/turborepo-lib/Cargo.toml
@@ -43,7 +43,7 @@ clap_complete = { workspace = true }
 command-group = { version = "2.1.0", features = ["with-tokio"] }
 config = "0.13"
 console = { workspace = true }
-ctrlc = { version = "3.2.5", features = ["termination"] }
+ctrlc = { version = "3.4.0", features = ["termination"] }
 dialoguer = { workspace = true, features = ["fuzzy-select"] }
 directories = "4.0.1"
 dirs-next = "2.0.0"


### PR DESCRIPTION
### Description

Another piece to the signal handling saga, the `ctrlc` crate was not overwriting signal handlers and instead throwing an error. Updating fixes this. For more context, see here: https://github.com/Detegr/rust-ctrlc/issues/103

### Testing Instructions

See this issue and repro: closes https://github.com/vercel/turbo/issues/5337 https://github.com/notaphplover/turborepo-trap-issue
