### PR TITLE
fix(turborepo): Add top-level rust cargo files to cli deps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -277,8 +277,6 @@ jobs:
 
       - name: Integration Tests
         run: turbo run test --filter=turborepo-tests-integration --color
-        env:
-          GO_TAG: rust
 
   turborepo_e2e:
     name: Turborepo E2E Tests

--- a/cli/turbo.json
+++ b/cli/turbo.json
@@ -3,7 +3,7 @@
   "extends": ["//"],
   "pipeline": {
     "build": {
-      "env": ["GO_TAG", "RUNNER_OS"],
+      "env": ["RUNNER_OS"],
       "outputs": [
         "../target/debug/go-turbo",
         "../target/debug/turbo",

--- a/cli/turbo.json
+++ b/cli/turbo.json
@@ -18,6 +18,8 @@
         "!**/*_test.go",
         "../crates/turborepo*/**/*.rs", // Rust crates
         "../crates/turborepo*/Cargo.toml",
+        "../Cargo.toml",
+        "../Cargo.lock",
         "!../crates/**/target"
       ]
     }

--- a/cli/turbo.json
+++ b/cli/turbo.json
@@ -6,9 +6,11 @@
       "env": ["RUNNER_OS"],
       "outputs": [
         "../target/debug/go-turbo",
+        "../target/debug/go-turbo.exe",
         "../target/debug/turbo",
         "../target/debug/turbo.exe",
         "../target/release/go-turbo",
+        "../target/release/go-turbo.exe",
         "../target/release/turbo",
         "../target/release/turbo.exe"
       ],


### PR DESCRIPTION
### Description

 - Our rust build depends on `Cargo.toml` / `Cargo.lock`
 - Remove `GO_TAG` from our deps
 - Remove `GO_TAG` from the env vars for `test.yml`
 - Add windows Go binary to outputs

### Testing Instructions


