### PR TITLE
feat(turborepo) Add timeout to api client json methods

### DIFF
--- a/cli/internal/analytics/analytics.go
+++ b/cli/internal/analytics/analytics.go
@@ -26,12 +26,12 @@ type Client interface {
 }
 
 type Sink interface {
-	RecordAnalyticsEvents(events Events) error
+	RecordAnalyticsEvents(events Events, timeout time.Duration) error
 }
 
 type nullSink struct{}
 
-func (n *nullSink) RecordAnalyticsEvents(events Events) error {
+func (n *nullSink) RecordAnalyticsEvents(events Events, timeout time.Duration) error {
 	return nil
 }
 
@@ -60,6 +60,7 @@ type worker struct {
 const bufferThreshold = 10
 const eventTimeout = 200 * time.Millisecond
 const noTimeout = 24 * time.Hour
+const requestTimeout = 10 * time.Second
 
 func newWorker(ctx context.Context, ch <-chan EventPayload, sink Sink, logger hclog.Logger) *worker {
 	buffer := []EventPayload{}
@@ -154,7 +155,7 @@ func (w *worker) sendEvents(events []EventPayload) {
 		if err != nil {
 			w.logger.Debug("failed to encode cache usage analytics", "error", err)
 		}
-		err = w.sink.RecordAnalyticsEvents(payload)
+		err = w.sink.RecordAnalyticsEvents(payload, requestTimeout)
 		if err != nil {
 			w.logger.Debug("failed to record cache usage analytics", "error", err)
 		}

--- a/cli/internal/analytics/analytics.go
+++ b/cli/internal/analytics/analytics.go
@@ -31,7 +31,7 @@ type Sink interface {
 
 type nullSink struct{}
 
-func (n *nullSink) RecordAnalyticsEvents(events Events, timeout time.Duration) error {
+func (n *nullSink) RecordAnalyticsEvents(_ Events, _ time.Duration) error {
 	return nil
 }
 

--- a/cli/internal/analytics/analytics_test.go
+++ b/cli/internal/analytics/analytics_test.go
@@ -27,7 +27,7 @@ func newDummySink() *dummySink {
 	}
 }
 
-func (d *dummySink) RecordAnalyticsEvents(events Events, timeout time.Duration) error {
+func (d *dummySink) RecordAnalyticsEvents(events Events, _ time.Duration) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	// Make a copy in case a test is holding a copy too

--- a/cli/internal/analytics/analytics_test.go
+++ b/cli/internal/analytics/analytics_test.go
@@ -27,7 +27,7 @@ func newDummySink() *dummySink {
 	}
 }
 
-func (d *dummySink) RecordAnalyticsEvents(events Events) error {
+func (d *dummySink) RecordAnalyticsEvents(events Events, timeout time.Duration) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	// Make a copy in case a test is holding a copy too

--- a/cli/internal/client/analytics.go
+++ b/cli/internal/client/analytics.go
@@ -2,10 +2,11 @@ package client
 
 import (
 	"encoding/json"
+	"time"
 )
 
 // RecordAnalyticsEvents is a specific method for POSTing events to Vercel
-func (c *APIClient) RecordAnalyticsEvents(events []map[string]interface{}) error {
+func (c *APIClient) RecordAnalyticsEvents(events []map[string]interface{}, timeout time.Duration) error {
 	body, err := json.Marshal(events)
 	if err != nil {
 		return err
@@ -13,7 +14,7 @@ func (c *APIClient) RecordAnalyticsEvents(events []map[string]interface{}) error
 	}
 
 	// We don't care about the response here
-	if _, err := c.JSONPost("/v8/artifacts/events", body); err != nil {
+	if _, err := c.JSONPost("/v8/artifacts/events", body, timeout); err != nil {
 		return err
 	}
 

--- a/cli/internal/client/client.go
+++ b/cli/internal/client/client.go
@@ -199,8 +199,8 @@ func (c *APIClient) addTeamParam(params *url.Values) {
 }
 
 // JSONPatch sends a byte array (json.marshalled payload) to a given endpoint with PATCH
-func (c *APIClient) JSONPatch(endpoint string, body []byte) ([]byte, error) {
-	resp, err := c.request(endpoint, http.MethodPatch, body)
+func (c *APIClient) JSONPatch(endpoint string, body []byte, timeout time.Duration) ([]byte, error) {
+	resp, err := c.request(endpoint, http.MethodPatch, body, timeout)
 	if err != nil {
 		return nil, err
 	}
@@ -217,8 +217,8 @@ func (c *APIClient) JSONPatch(endpoint string, body []byte) ([]byte, error) {
 }
 
 // JSONPost sends a byte array (json.marshalled payload) to a given endpoint with POST
-func (c *APIClient) JSONPost(endpoint string, body []byte) ([]byte, error) {
-	resp, err := c.request(endpoint, http.MethodPost, body)
+func (c *APIClient) JSONPost(endpoint string, body []byte, timeout time.Duration) ([]byte, error) {
+	resp, err := c.request(endpoint, http.MethodPost, body, timeout)
 	if err != nil {
 		return nil, err
 	}
@@ -236,7 +236,7 @@ func (c *APIClient) JSONPost(endpoint string, body []byte) ([]byte, error) {
 	return rawResponse, nil
 }
 
-func (c *APIClient) request(endpoint string, method string, body []byte) (*http.Response, error) {
+func (c *APIClient) request(endpoint string, method string, body []byte, timeout time.Duration) (*http.Response, error) {
 	if err := c.okToRequest(); err != nil {
 		return nil, err
 	}
@@ -266,6 +266,8 @@ func (c *APIClient) request(endpoint string, method string, body []byte) (*http.
 	if err != nil {
 		return nil, err
 	}
+	ctx, _ := context.WithTimeout(context.Background(), timeout)
+	req.WithContext(ctx)
 
 	// Set headers
 	req.Header.Set("Content-Type", "application/json")

--- a/cli/internal/client/client.go
+++ b/cli/internal/client/client.go
@@ -266,7 +266,8 @@ func (c *APIClient) request(endpoint string, method string, body []byte, timeout
 	if err != nil {
 		return nil, err
 	}
-	ctx, _ := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
 	req.WithContext(ctx)
 
 	// Set headers

--- a/cli/internal/client/client_test.go
+++ b/cli/internal/client/client_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/vercel/turbo/cli/internal/turbostate"
 	"github.com/vercel/turbo/cli/internal/util"
+	"gotest.tools/v3/assert"
 )
 
 func Test_sendToServer(t *testing.T) {
@@ -59,7 +60,8 @@ func Test_sendToServer(t *testing.T) {
 		},
 	}
 
-	apiClient.RecordAnalyticsEvents(events, 10*time.Second)
+	err = apiClient.RecordAnalyticsEvents(events, 10*time.Second)
+	assert.NilError(t, err, "RecordAnalyticsEvent")
 
 	body := <-ch
 


### PR DESCRIPTION
### Description

 - Add a timeout param to JSONPost and JSONPatch
 - Set a default timeout of 10 seconds for analytics and spaces

### Testing Instructions

 - Add a test for request timeout