### PR TITLE
only wait for JS chunks in none runtime backend

### DIFF
--- a/crates/turbopack-ecmascript-runtime/js/src/dev/runtime/none/runtime-backend-none.ts
+++ b/crates/turbopack-ecmascript-runtime/js/src/dev/runtime/none/runtime-backend-none.ts
@@ -50,7 +50,10 @@ function commonJsRequireContext(
         // modules.
         registerChunkRunner(
           chunkPath,
-          params.otherChunks,
+          params.otherChunks.filter((chunk) =>
+            // The none runtime can only handle JS chunks, so we only wait for these
+            getChunkPath(chunk).endsWith(".js")
+          ),
           params.runtimeModuleIds
         );
       }


### PR DESCRIPTION
### Description

When rendering RSC with CSS in edge, there might be CSS chunks in the none runtime, which shouldn't be waited for.
