### PR TITLE
fix(turborepo): Handle empty workspace tasks

### DIFF
--- a/packages/eslint-plugin-turbo/lib/utils/calculate-inputs.ts
+++ b/packages/eslint-plugin-turbo/lib/utils/calculate-inputs.ts
@@ -436,7 +436,7 @@ export class Project {
       ),
     ];
 
-    if (workspaceName) {
+    if (workspaceName && this._test.workspaceTasks[workspaceName]) {
       tests.push(
         ...Object.values(this._test.workspaceTasks[workspaceName]).map(
           (context) => environmentTestArray(context)


### PR DESCRIPTION
### Description

 - Don't crash if the given workspace doesn't have any tasks defined in its own `turbo.json`

### Testing Instructions

 - Verified manually on the `pnpm` `kitchen-sink` example. This is a step on the path to getting the examples running properly, which will in turn then validate this change in an ongoing fashion
