### PR TITLE
Fix bug with `imports` field from a nested directory

### DIFF
--- a/crates/turbopack-core/src/resolve/mod.rs
+++ b/crates/turbopack-core/src/resolve/mod.rs
@@ -1343,7 +1343,7 @@ async fn resolve_package_internal_with_imports_field(
     };
 
     handle_exports_imports_field(
-        context,
+        package_json_path.parent(),
         *package_json_path,
         resolve_options,
         imports,

--- a/crates/turbopack-tests/tests/snapshot/imports/subpath-imports-nested/input/foo.js
+++ b/crates/turbopack-tests/tests/snapshot/imports/subpath-imports-nested/input/foo.js
@@ -1,0 +1,1 @@
+export default "foo";

--- a/crates/turbopack-tests/tests/snapshot/imports/subpath-imports-nested/input/index.js
+++ b/crates/turbopack-tests/tests/snapshot/imports/subpath-imports-nested/input/index.js
@@ -1,0 +1,3 @@
+import foo from "./nested";
+
+console.log(foo);

--- a/crates/turbopack-tests/tests/snapshot/imports/subpath-imports-nested/input/nested/index.js
+++ b/crates/turbopack-tests/tests/snapshot/imports/subpath-imports-nested/input/nested/index.js
@@ -1,0 +1,2 @@
+import foo from "#foo";
+export default foo;

--- a/crates/turbopack-tests/tests/snapshot/imports/subpath-imports-nested/input/package.json
+++ b/crates/turbopack-tests/tests/snapshot/imports/subpath-imports-nested/input/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "subpath-imports",
+  "imports": {
+    "#foo": "./foo.js"
+  }
+}

--- a/crates/turbopack-tests/tests/snapshot/imports/subpath-imports-nested/output/a587c_tests_snapshot_imports_subpath-imports-nested_input_index_5771e1.js
+++ b/crates/turbopack-tests/tests/snapshot/imports/subpath-imports-nested/output/a587c_tests_snapshot_imports_subpath-imports-nested_input_index_5771e1.js
@@ -1,0 +1,11 @@
+(globalThis.TURBOPACK = globalThis.TURBOPACK || []).push([
+    "output/a587c_tests_snapshot_imports_subpath-imports-nested_input_index_5771e1.js",
+    {},
+]);
+(globalThis.TURBOPACK_CHUNK_LISTS = globalThis.TURBOPACK_CHUNK_LISTS || []).push({
+  "path": "output/a587c_tests_snapshot_imports_subpath-imports-nested_input_index_5771e1.js",
+  "chunks": [
+    "output/a587c_tests_snapshot_imports_subpath-imports-nested_input_index_b53fce.js"
+  ],
+  "source": "entry"
+});

--- a/crates/turbopack-tests/tests/snapshot/imports/subpath-imports-nested/output/a587c_tests_snapshot_imports_subpath-imports-nested_input_index_b53fce.js
+++ b/crates/turbopack-tests/tests/snapshot/imports/subpath-imports-nested/output/a587c_tests_snapshot_imports_subpath-imports-nested_input_index_b53fce.js
@@ -1,0 +1,32 @@
+(globalThis.TURBOPACK = globalThis.TURBOPACK || []).push(["output/a587c_tests_snapshot_imports_subpath-imports-nested_input_index_b53fce.js", {
+
+"[project]/crates/turbopack-tests/tests/snapshot/imports/subpath-imports-nested/input/foo.js (ecmascript)": (({ r: __turbopack_require__, f: __turbopack_require_context__, i: __turbopack_import__, s: __turbopack_esm__, v: __turbopack_export_value__, n: __turbopack_export_namespace__, c: __turbopack_cache__, l: __turbopack_load__, j: __turbopack_cjs__, g: global, __dirname, k: __turbopack_refresh__ }) => (() => {
+
+__turbopack_esm__({
+    "default": ()=>__TURBOPACK__default__export__
+});
+const __TURBOPACK__default__export__ = "foo";
+
+})()),
+"[project]/crates/turbopack-tests/tests/snapshot/imports/subpath-imports-nested/input/nested/index.js (ecmascript)": (({ r: __turbopack_require__, f: __turbopack_require_context__, i: __turbopack_import__, s: __turbopack_esm__, v: __turbopack_export_value__, n: __turbopack_export_namespace__, c: __turbopack_cache__, l: __turbopack_load__, j: __turbopack_cjs__, g: global, __dirname, k: __turbopack_refresh__ }) => (() => {
+
+__turbopack_esm__({
+    "default": ()=>__TURBOPACK__default__export__
+});
+var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$imports$2f$subpath$2d$imports$2d$nested$2f$input$2f$foo$2e$js__$28$ecmascript$29$__ = __turbopack_import__("[project]/crates/turbopack-tests/tests/snapshot/imports/subpath-imports-nested/input/foo.js (ecmascript)");
+"__TURBOPACK__ecmascript__hoisting__location__";
+;
+const __TURBOPACK__default__export__ = __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$imports$2f$subpath$2d$imports$2d$nested$2f$input$2f$foo$2e$js__$28$ecmascript$29$__["default"];
+
+})()),
+"[project]/crates/turbopack-tests/tests/snapshot/imports/subpath-imports-nested/input/index.js (ecmascript)": (({ r: __turbopack_require__, f: __turbopack_require_context__, i: __turbopack_import__, s: __turbopack_esm__, v: __turbopack_export_value__, n: __turbopack_export_namespace__, c: __turbopack_cache__, l: __turbopack_load__, j: __turbopack_cjs__, g: global, __dirname, k: __turbopack_refresh__ }) => (() => {
+
+var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$imports$2f$subpath$2d$imports$2d$nested$2f$input$2f$nested$2f$index$2e$js__$28$ecmascript$29$__ = __turbopack_import__("[project]/crates/turbopack-tests/tests/snapshot/imports/subpath-imports-nested/input/nested/index.js (ecmascript)");
+"__TURBOPACK__ecmascript__hoisting__location__";
+;
+console.log(__TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$imports$2f$subpath$2d$imports$2d$nested$2f$input$2f$nested$2f$index$2e$js__$28$ecmascript$29$__["default"]);
+
+})()),
+}]);
+
+//# sourceMappingURL=a587c_tests_snapshot_imports_subpath-imports-nested_input_index_b53fce.js.map

--- a/crates/turbopack-tests/tests/snapshot/imports/subpath-imports-nested/output/a587c_tests_snapshot_imports_subpath-imports-nested_input_index_b53fce.js.map
+++ b/crates/turbopack-tests/tests/snapshot/imports/subpath-imports-nested/output/a587c_tests_snapshot_imports_subpath-imports-nested_input_index_b53fce.js.map
@@ -1,0 +1,10 @@
+{
+  "version": 3,
+  "sections": [
+    {"offset": {"line": 4, "column": 0}, "map": {"version":3,"sources":["/turbopack/[project]/crates/turbopack-tests/tests/snapshot/imports/subpath-imports-nested/input/foo.js"],"sourcesContent":["export default \"foo\";\n"],"names":[],"mappings":";;;uCAAe"}},
+    {"offset": {"line": 8, "column": 0}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}},
+    {"offset": {"line": 12, "column": 0}, "map": {"version":3,"sources":[],"names":[],"mappings":""}},
+    {"offset": {"line": 19, "column": 0}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}},
+    {"offset": {"line": 23, "column": 0}, "map": {"version":3,"sources":["/turbopack/[project]/crates/turbopack-tests/tests/snapshot/imports/subpath-imports-nested/input/index.js"],"sourcesContent":["import foo from \"./nested\";\n\nconsole.log(foo);\n"],"names":[],"mappings":";;;AAEA,QAAQ"}},
+    {"offset": {"line": 27, "column": 0}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}}]
+}

--- a/crates/turbopack-tests/tests/snapshot/imports/subpath-imports-nested/output/a587c_tests_snapshot_imports_subpath-imports-nested_input_index_dc7802.js
+++ b/crates/turbopack-tests/tests/snapshot/imports/subpath-imports-nested/output/a587c_tests_snapshot_imports_subpath-imports-nested_input_index_dc7802.js
@@ -1,0 +1,6 @@
+(globalThis.TURBOPACK = globalThis.TURBOPACK || []).push([
+    "output/a587c_tests_snapshot_imports_subpath-imports-nested_input_index_dc7802.js",
+    {},
+    {"otherChunks":[{"path":"output/a587c_tests_snapshot_imports_subpath-imports-nested_input_index_b53fce.js","included":["[project]/crates/turbopack-tests/tests/snapshot/imports/subpath-imports-nested/input/index.js (ecmascript)"]}],"runtimeModuleIds":["[project]/crates/turbopack-tests/tests/snapshot/imports/subpath-imports-nested/input/index.js (ecmascript)"]}
+]);
+// Dummy runtime

--- a/crates/turbopack-tests/tests/snapshot/imports/subpath-imports-nested/output/a587c_tests_snapshot_imports_subpath-imports-nested_input_index_dc7802.js.map
+++ b/crates/turbopack-tests/tests/snapshot/imports/subpath-imports-nested/output/a587c_tests_snapshot_imports_subpath-imports-nested_input_index_dc7802.js.map
@@ -1,0 +1,4 @@
+{
+  "version": 3,
+  "sections": []
+}


### PR DESCRIPTION
### Description

When importing a `#foo` subpath import, the resolved file is relative the the `package.json` containing the `imports` field, not the file with the import statement. This fixes subpath imports to use the proper context path during that resolve.

### Testing Instructions

```
RUST_BACKTRACE=1 cargo nextest run -p turbopack-tests -E 'test(snapshot__imports__subpath_imports_nested)' --no-capture
```

Fixes WEB-1216