### PR TITLE
fix(turborepo): Restructure spaces client and test error handling

### DIFF
--- a/cli/internal/analytics/analytics_test.go
+++ b/cli/internal/analytics/analytics_test.go
@@ -27,7 +27,7 @@ func newDummySink() *dummySink {
 	}
 }
 
-func (d *dummySink) RecordAnalyticsEvents(events Events, _ time.Duration) error {
+func (d *dummySink) RecordAnalyticsEvents(_ context.Context, events Events) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	// Make a copy in case a test is holding a copy too

--- a/cli/internal/client/analytics.go
+++ b/cli/internal/client/analytics.go
@@ -1,12 +1,12 @@
 package client
 
 import (
+	"context"
 	"encoding/json"
-	"time"
 )
 
 // RecordAnalyticsEvents is a specific method for POSTing events to Vercel
-func (c *APIClient) RecordAnalyticsEvents(events []map[string]interface{}, timeout time.Duration) error {
+func (c *APIClient) RecordAnalyticsEvents(ctx context.Context, events []map[string]interface{}) error {
 	body, err := json.Marshal(events)
 	if err != nil {
 		return err
@@ -14,7 +14,7 @@ func (c *APIClient) RecordAnalyticsEvents(events []map[string]interface{}, timeo
 	}
 
 	// We don't care about the response here
-	if _, err := c.JSONPost("/v8/artifacts/events", body, timeout); err != nil {
+	if _, err := c.JSONPost(ctx, "/v8/artifacts/events", body); err != nil {
 		return err
 	}
 

--- a/cli/internal/client/client.go
+++ b/cli/internal/client/client.go
@@ -199,44 +199,16 @@ func (c *APIClient) addTeamParam(params *url.Values) {
 }
 
 // JSONPatch sends a byte array (json.marshalled payload) to a given endpoint with PATCH
-func (c *APIClient) JSONPatch(endpoint string, body []byte, timeout time.Duration) ([]byte, error) {
-	resp, err := c.request(endpoint, http.MethodPatch, body, timeout)
-	if err != nil {
-		return nil, err
-	}
-
-	rawResponse, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response %v", err)
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("%s", string(rawResponse))
-	}
-
-	return rawResponse, nil
+func (c *APIClient) JSONPatch(ctx context.Context, endpoint string, body []byte) ([]byte, error) {
+	return c.request(ctx, endpoint, http.MethodPatch, body)
 }
 
 // JSONPost sends a byte array (json.marshalled payload) to a given endpoint with POST
-func (c *APIClient) JSONPost(endpoint string, body []byte, timeout time.Duration) ([]byte, error) {
-	resp, err := c.request(endpoint, http.MethodPost, body, timeout)
-	if err != nil {
-		return nil, err
-	}
-
-	rawResponse, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response %v", err)
-	}
-
-	// For non 200/201 status codes, return the response body as an error
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		return nil, fmt.Errorf("%s", string(rawResponse))
-	}
-
-	return rawResponse, nil
+func (c *APIClient) JSONPost(ctx context.Context, endpoint string, body []byte) ([]byte, error) {
+	return c.request(ctx, endpoint, http.MethodPost, body)
 }
 
-func (c *APIClient) request(endpoint string, method string, body []byte, timeout time.Duration) (*http.Response, error) {
+func (c *APIClient) request(ctx context.Context, endpoint string, method string, body []byte) ([]byte, error) {
 	if err := c.okToRequest(); err != nil {
 		return nil, err
 	}
@@ -266,8 +238,6 @@ func (c *APIClient) request(endpoint string, method string, body []byte, timeout
 	if err != nil {
 		return nil, err
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
 	req.WithContext(ctx)
 
 	// Set headers
@@ -292,5 +262,15 @@ func (c *APIClient) request(endpoint string, method string, body []byte, timeout
 		return nil, fmt.Errorf("response from %s is nil, something went wrong", requestURL)
 	}
 
-	return resp, nil
+	rawResponse, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response %v", err)
+	}
+
+	// For non 200/201 status codes, return the response body as an error
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return nil, fmt.Errorf("%s", string(rawResponse))
+	}
+
+	return rawResponse, nil
 }

--- a/cli/internal/client/client_test.go
+++ b/cli/internal/client/client_test.go
@@ -59,8 +59,8 @@ func Test_sendToServer(t *testing.T) {
 			"event":     "MISS",
 		},
 	}
-
-	err = apiClient.RecordAnalyticsEvents(events, 10*time.Second)
+	ctx := context.Background()
+	err = apiClient.RecordAnalyticsEvents(ctx, events)
 	assert.NilError(t, err, "RecordAnalyticsEvent")
 
 	body := <-ch
@@ -177,7 +177,9 @@ func Test_Timeout(t *testing.T) {
 	}
 	apiClient := NewClient(apiClientConfig, hclog.Default(), "v1")
 
-	_, err := apiClient.JSONPost("/", []byte{}, 1*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+	defer cancel()
+	_, err := apiClient.JSONPost(ctx, "/", []byte{})
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Errorf("JSONPost got %v, want DeadlineExceeded", err)
 	}

--- a/cli/internal/run/dry_run.go
+++ b/cli/internal/run/dry_run.go
@@ -93,7 +93,7 @@ func DryRun(
 
 	// The exitCode isn't really used by the Run Summary Close() method for dry runs
 	// but we pass in a successful value to match Real Runs.
-	return summary.Close(ctx, 0, g.WorkspaceInfos)
+	return summary.Close(ctx, 0, g.WorkspaceInfos, base.UI)
 }
 
 func populateCacheState(turboCache cache.Cache, taskSummaries []*runsummary.TaskSummary) {

--- a/cli/internal/run/real_run.go
+++ b/cli/internal/run/real_run.go
@@ -232,7 +232,7 @@ func RealRun(
 		logWaitGroup.Wait()
 	}
 
-	if err := runSummary.Close(ctx, exitCode, g.WorkspaceInfos); err != nil {
+	if err := runSummary.Close(ctx, exitCode, g.WorkspaceInfos, base.UI); err != nil {
 		// We don't need to throw an error, but we can warn on this.
 		// Note: this method doesn't actually return an error for Real Runs at the time of writing.
 		base.UI.Info(fmt.Sprintf("Failed to close Run Summary %v", err))

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -357,7 +357,6 @@ func (r *run) run(ctx gocontext.Context, targets []string, executionState *turbo
 	// the tasks that we expect to run based on the user command.
 	summary := runsummary.NewRunSummary(
 		startAt,
-		r.base.UI,
 		r.base.RepoRoot,
 		rs.Opts.scopeOpts.PackageInferenceRoot,
 		r.base.TurboVersion,

--- a/cli/internal/runsummary/format_execution_summary.go
+++ b/cli/internal/runsummary/format_execution_summary.go
@@ -8,14 +8,14 @@ import (
 	"time"
 
 	"github.com/fatih/color"
+	"github.com/mitchellh/cli"
 	internalUI "github.com/vercel/turbo/cli/internal/ui"
 	"github.com/vercel/turbo/cli/internal/util"
 )
 
-func (rsm *Meta) printExecutionSummary() {
+func (rsm *Meta) printExecutionSummary(ui cli.Ui) {
 	maybeFullTurbo := ""
 	summary := rsm.RunSummary
-	ui := rsm.ui
 
 	attempted := summary.ExecutionSummary.attempted
 	successful := summary.ExecutionSummary.cached + summary.ExecutionSummary.success

--- a/cli/internal/runsummary/format_text.go
+++ b/cli/internal/runsummary/format_text.go
@@ -8,13 +8,13 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"github.com/mitchellh/cli"
 	"github.com/vercel/turbo/cli/internal/util"
 	"github.com/vercel/turbo/cli/internal/workspace"
 )
 
 // FormatAndPrintText prints a Run Summary to the Terminal UI
-func (rsm Meta) FormatAndPrintText(workspaceInfos workspace.Catalog) error {
-	ui := rsm.ui
+func (rsm Meta) FormatAndPrintText(workspaceInfos workspace.Catalog, ui cli.Ui) error {
 	summary := rsm.RunSummary
 
 	rsm.normalize() // normalize data

--- a/cli/internal/runsummary/spaces.go
+++ b/cli/internal/runsummary/spaces.go
@@ -1,14 +1,15 @@
 package runsummary
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"sync"
 	"time"
 
 	"github.com/mitchellh/cli"
+	"github.com/pkg/errors"
 	"github.com/vercel/turbo/cli/internal/ci"
-	"github.com/vercel/turbo/cli/internal/client"
 )
 
 const runsEndpoint = "/v0/spaces/%s/runs"
@@ -21,24 +22,28 @@ type spaceRequest struct {
 	url     string
 	body    interface{}
 	makeURL func(self *spaceRequest, r *spaceRun) error // Should set url on self
-	onDone  func(self *spaceRequest, response []byte)   // Handler for when request completes
+	//onDone  func(self *spaceRequest, response []byte, err error) // Handler for when request completes
 }
 
-func (req *spaceRequest) error(msg string) error {
-	return fmt.Errorf("[%s] %s: %s", req.method, req.url, msg)
+type spacesAPIClient interface {
+	JSONPost(ctx context.Context, url string, payload []byte) ([]byte, error)
+	JSONPatch(ctx context.Context, url string, payload []byte) ([]byte, error)
+	IsLinked() bool
 }
 
 type spacesClient struct {
 	requests       chan *spaceRequest
-	errors         []error
-	api            *client.APIClient
-	ui             cli.Ui
+	api            spacesAPIClient
 	run            *spaceRun
 	runCreated     chan struct{}
+	runCreateError error
 	wg             sync.WaitGroup
 	spaceID        string
 	enabled        bool
 	requestTimeout time.Duration
+
+	errMu  sync.Mutex
+	errors []error
 }
 
 type spaceRun struct {
@@ -46,10 +51,9 @@ type spaceRun struct {
 	URL string
 }
 
-func newSpacesClient(spaceID string, api *client.APIClient, ui cli.Ui) *spacesClient {
+func newSpacesClient(spaceID string, api spacesAPIClient) *spacesClient {
 	c := &spacesClient{
 		api:            api,
-		ui:             ui,
 		spaceID:        spaceID,
 		enabled:        false,                    // Start with disabled
 		requests:       make(chan *spaceRequest), // TODO: give this a size based on tasks
@@ -82,7 +86,6 @@ func newSpacesClient(spaceID string, api *client.APIClient, ui cli.Ui) *spacesCl
 func (c *spacesClient) start() {
 	// Start an immediately invoked go routine that listens for requests coming in from a channel
 	pending := []*spaceRequest{}
-	firstRequestStarted := false
 
 	// Create a labeled statement so we can break out of the for loop more easily
 
@@ -100,15 +103,9 @@ FirstRequest:
 			if !isOpen {
 				break FirstRequest
 			}
-			// Make the first request right away in a goroutine,
-			// queue all other requests. When the first request is done,
+			// Queue everything. When the first request is done,
 			// we'll get a message on the other channel and break out of this loop
-			if !firstRequestStarted {
-				firstRequestStarted = true
-				go c.dequeueRequest(req)
-			} else {
-				pending = append(pending, req)
-			}
+			pending = append(pending, req)
 			// Wait for c.runCreated channel to be closed and:
 		case <-c.runCreated:
 			// 1. flush pending requests
@@ -127,7 +124,7 @@ FirstRequest:
 	}
 }
 
-func (c *spacesClient) makeRequest(req *spaceRequest) {
+func makeRequest(ctx context.Context, api spacesAPIClient, req *spaceRequest, run *spaceRun) ([]byte, error) {
 	// The runID is required for POST task requests and PATCH run request URLS,
 	// so we have to construct these URLs lazily with a `makeURL` affordance.
 	//
@@ -140,63 +137,47 @@ func (c *spacesClient) makeRequest(req *spaceRequest) {
 	// for every request that fails. On the other hand, if that POST /run request fails, and N
 	// requests fail after that as a consequence, it is ok to print all of those errors.
 	if req.makeURL != nil {
-		if err := req.makeURL(req, c.run); err != nil {
-			c.errors = append(c.errors, err)
-			return
+		if err := req.makeURL(req, run); err != nil {
+			return nil, err
 		}
-	}
-
-	// We only care about POST and PATCH right now
-	if req.method != "POST" && req.method != "PATCH" {
-		c.errors = append(c.errors, req.error(fmt.Sprintf("Unsupported method %s", req.method)))
-		return
 	}
 
 	payload, err := json.Marshal(req.body)
 	if err != nil {
-		c.errors = append(c.errors, req.error(fmt.Sprintf("Failed to create payload: %s", err)))
-		return
+		return nil, err
 	}
 
 	// Make the request
-	var resp []byte
-	var reqErr error
 	if req.method == "POST" {
-		resp, reqErr = c.api.JSONPost(req.url, payload, c.requestTimeout)
+		return api.JSONPost(ctx, req.url, payload)
 	} else if req.method == "PATCH" {
-		resp, reqErr = c.api.JSONPatch(req.url, payload, c.requestTimeout)
-	} else {
-		c.errors = append(c.errors, req.error("Unsupported request method"))
+		return api.JSONPatch(ctx, req.url, payload)
 	}
-
-	if reqErr != nil {
-		c.errors = append(c.errors, req.error(fmt.Sprintf("%s", reqErr)))
-		return
-	}
-
-	// Call the onDone handler if there is one
-	if req.onDone != nil {
-		req.onDone(req, resp)
-	}
+	panic(fmt.Sprintf("Unsupported method %v", req.method))
 }
 
-func (c *spacesClient) createRun(rsm *Meta) {
-	c.queueRequest(&spaceRequest{
-		method: "POST",
-		url:    fmt.Sprintf(runsEndpoint, c.spaceID),
-		body:   newSpacesRunCreatePayload(rsm),
+func (c *spacesClient) createRun(payload *spacesRunPayload) {
+	c.wg.Add(1)
+	go func() {
+		defer c.wg.Done()
+		defer close(c.runCreated)
+		ctx, cancel := context.WithTimeout(context.Background(), c.requestTimeout)
+		defer cancel()
 
-		// handler for when the request finishes. We set the response into a struct on the client
-		// because we need the run ID and URL from the server later.
-		onDone: func(req *spaceRequest, response []byte) {
-			if err := json.Unmarshal(response, c.run); err != nil {
-				c.errors = append(c.errors, req.error(fmt.Sprintf("Error unmarshaling response: %s", err)))
-			}
-
-			// close the run.created channel, because all other requests are blocked on it
-			close(c.runCreated)
-		},
-	})
+		req := &spaceRequest{
+			method: "POST",
+			url:    fmt.Sprintf(runsEndpoint, c.spaceID),
+			body:   payload,
+		}
+		resp, err := makeRequest(ctx, c.api, req, c.run)
+		if err != nil {
+			c.runCreateError = err
+			return
+		}
+		if err := json.Unmarshal(resp, c.run); err != nil {
+			c.runCreateError = errors.Wrap(err, "failed to unmarshal create run response")
+		}
+	}()
 }
 
 func (c *spacesClient) postTask(task *TaskSummary) {
@@ -236,14 +217,25 @@ func (c *spacesClient) queueRequest(req *spaceRequest) {
 // dequeueRequest makes the request in a go routine and decrements the waitGroup counter
 func (c *spacesClient) dequeueRequest(req *spaceRequest) {
 	defer c.wg.Done()
-	c.makeRequest(req)
+	// Only send requests if we successfully created the Run
+	if c.runCreateError != nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), c.requestTimeout)
+	defer cancel()
+	_, err := makeRequest(ctx, c.api, req, c.run)
+	if err != nil {
+		c.errMu.Lock()
+		defer c.errMu.Unlock()
+		c.errors = append(c.errors, err)
+	}
 }
 
-func (c *spacesClient) printErrors() {
+func (c *spacesClient) printErrors(ui cli.Ui) {
 	// Print any errors
 	if len(c.errors) > 0 {
 		for _, err := range c.errors {
-			c.ui.Warn(fmt.Sprintf("%s", err))
+			ui.Warn(fmt.Sprintf("%s", err))
 		}
 	}
 }

--- a/cli/internal/runsummary/spaces_test.go
+++ b/cli/internal/runsummary/spaces_test.go
@@ -1,0 +1,68 @@
+package runsummary
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type failFirstClient struct {
+	mu                 sync.Mutex
+	sawFirst           bool
+	additionalRequests int
+}
+
+func (f *failFirstClient) IsLinked() bool {
+	return true
+}
+
+func (f *failFirstClient) request() ([]byte, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.sawFirst {
+		f.additionalRequests++
+		return []byte("some response"), nil
+	}
+	f.sawFirst = true
+	return nil, errors.New("failed request")
+}
+
+func (f *failFirstClient) JSONPost(_ context.Context, _ string, _ []byte) ([]byte, error) {
+	return f.request()
+}
+
+func (f *failFirstClient) JSONPatch(_ context.Context, _ string, _ []byte) ([]byte, error) {
+	return f.request()
+}
+
+func TestFailToCreateRun(t *testing.T) {
+	api := &failFirstClient{}
+
+	c := newSpacesClient("my-space-id", api)
+	go c.start()
+	payload := &spacesRunPayload{}
+	c.createRun(payload)
+	exitCode := 1
+	ts := &TaskSummary{
+		TaskID:  "my-id",
+		Task:    "task",
+		Package: "package",
+		Hash:    "hash",
+		Execution: &TaskExecutionSummary{
+			startAt:  time.Now(),
+			Duration: 3 * time.Second,
+			exitCode: &exitCode,
+		},
+	}
+	c.postTask(ts)
+	c.postTask(ts)
+	c.postTask(ts)
+	c.Close()
+
+	assert.True(t, api.sawFirst)
+	assert.Equal(t, api.additionalRequests, 0)
+}


### PR DESCRIPTION
### Description

 - Restructure timeouts to more properly thread contexts
 - Refactor JSON posting methods in api client
 - Refactor spaces client to be a bit more testable
 - Refactor spaces client to specially handle the create run call, since it's the only one that needs a response and unlocks the remaining api calls
 - Handle failure to create a run by skipping subsequent requests

### Testing Instructions

 - added a new test for failing to create a run, ensuring that we can still call `Close` on a run summary
