### PR TITLE
fix: prevent looking up workspace task if name is not in there

### DIFF
--- a/packages/eslint-plugin-turbo/lib/utils/calculate-inputs.ts
+++ b/packages/eslint-plugin-turbo/lib/utils/calculate-inputs.ts
@@ -436,7 +436,7 @@ export class Project {
       ),
     ];
 
-    if (workspaceName) {
+    if (workspaceName && workspaceName in this._test.workspaceTasks) {
       tests.push(
         ...Object.values(this._test.workspaceTasks[workspaceName]).map(
           (context) => environmentTestArray(context)


### PR DESCRIPTION
### Description

Closes #5355

### Testing Instructions

Look at this repo for a demonstration of the issue. https://github.com/benmarch/eslint-plugin-turbo-error-example
