### PR TITLE
Mark Vcs as `must-use`

### DIFF
--- a/crates/node-file-trace/src/lib.rs
+++ b/crates/node-file-trace/src/lib.rs
@@ -501,7 +501,8 @@ async fn run<B: Backend + 'static, F: Future<Output = ()>>(
             let console_ui = ConsoleUiVc::new(log_options);
             console_ui
                 .as_issue_reporter()
-                .report_issues(TransientInstance::new(issues), source);
+                .report_issues(TransientInstance::new(issues), source)
+                .await?;
 
             if has_return_value {
                 let output_read_ref = output.await?;

--- a/crates/turbo-tasks-fs/examples/hash_directory.rs
+++ b/crates/turbo-tasks-fs/examples/hash_directory.rs
@@ -39,7 +39,7 @@ async fn main() -> Result<()> {
             let fs: FileSystemVc = disk_fs.into();
             let input = fs.root().join("demo");
             let dir_hash = hash_directory(input);
-            print_hash(dir_hash);
+            print_hash(dir_hash).await?;
             Ok(NothingVc::new().into())
         })
     });
@@ -57,9 +57,9 @@ async fn main() -> Result<()> {
 }
 
 #[turbo_tasks::function]
-async fn print_hash(dir_hash: StringVc) -> Result<()> {
+async fn print_hash(dir_hash: StringVc) -> Result<NothingVc> {
     println!("DIR HASH: {}", dir_hash.await?.as_str());
-    Ok(())
+    Ok(NothingVc::new())
 }
 
 async fn filename(path: FileSystemPathVc) -> Result<String> {

--- a/crates/turbo-tasks-fs/examples/hash_glob.rs
+++ b/crates/turbo-tasks-fs/examples/hash_glob.rs
@@ -38,7 +38,7 @@ async fn main() -> Result<()> {
             let glob = GlobVc::new("**/*.rs");
             let glob_result = input.read_glob(glob, true);
             let dir_hash = hash_glob_result(glob_result);
-            print_hash(dir_hash);
+            print_hash(dir_hash).await?;
             Ok(NothingVc::new().into())
         })
     });
@@ -61,9 +61,9 @@ pub fn empty_string() -> StringVc {
 }
 
 #[turbo_tasks::function]
-async fn print_hash(dir_hash: StringVc) -> Result<()> {
+async fn print_hash(dir_hash: StringVc) -> Result<NothingVc> {
     println!("DIR HASH: {}", dir_hash.await?.as_str());
-    Ok(())
+    Ok(NothingVc::new())
 }
 
 #[turbo_tasks::function]

--- a/crates/turbo-tasks-macros/src/func.rs
+++ b/crates/turbo-tasks-macros/src/func.rs
@@ -212,12 +212,10 @@ pub fn split_signature(sig: &Signature) -> (Signature, Signature, Type, TokenStr
     if is_empty_type(raw_output_type) {
         // Can't emit a diagnostic on OutputType alone as it can be omitted from the
         // text for `()`. Use the whole signature span.
-        sig.span()
-            .unwrap()
-            .error(
-                "Cannot return `()` from a turbo_tasks function. Return Result<NothingVc> instead.",
-            )
-            .emit();
+        abort!(
+            sig.span(),
+            "Cannot return `()` from a turbo_tasks function. Return a NothingVc instead.",
+        )
     }
 
     let inline_ident = get_internal_function_ident(&sig.ident);

--- a/crates/turbo-tasks-macros/src/function_macro.rs
+++ b/crates/turbo-tasks-macros/src/function_macro.rs
@@ -39,6 +39,7 @@ pub fn function(_args: TokenStream, input: TokenStream) -> TokenStream {
     );
 
     quote! {
+        #[must_use]
         #(#attrs)*
         #vis #external_sig {
             let result = turbo_tasks::dynamic_call(*#function_id_ident, vec![#(#input_raw_vc_arguments),*]);

--- a/crates/turbo-tasks-macros/src/value_macro.rs
+++ b/crates/turbo-tasks-macros/src/value_macro.rs
@@ -588,6 +588,7 @@ pub fn value(args: TokenStream, input: TokenStream) -> TokenStream {
         ///
         /// A reference is equal to another reference when it points to the same thing. No resolving is applied on comparison.
         #[derive(Clone, Copy, Debug, std::cmp::PartialOrd, std::cmp::Ord, std::hash::Hash, std::cmp::Eq, std::cmp::PartialEq, serde::Serialize, serde::Deserialize)]
+        #[must_use]
         #vis struct #ref_ident {
             node: turbo_tasks::RawVc,
         }

--- a/crates/turbo-tasks-macros/src/value_trait_macro.rs
+++ b/crates/turbo-tasks-macros/src/value_trait_macro.rs
@@ -244,6 +244,7 @@ pub fn value_trait(args: TokenStream, input: TokenStream) -> TokenStream {
     };
 
     let expanded = quote! {
+        #[must_use]
         #(#attrs)*
         #vis #trait_token #ident #colon_token #(#supertraits)+* #where_clause {
             #(#items)*

--- a/crates/turbo-tasks-memory/tests/collectibles.rs
+++ b/crates/turbo-tasks-memory/tests/collectibles.rs
@@ -124,11 +124,11 @@ async fn my_collecting_function_indirect() -> Result<ThingVc> {
 }
 
 #[turbo_tasks::function]
-fn my_multi_emitting_function() -> ThingVc {
-    my_transitive_emitting_function("", "a");
-    my_transitive_emitting_function("", "b");
+async fn my_multi_emitting_function() -> Result<ThingVc> {
+    my_transitive_emitting_function("", "a").await?;
+    my_transitive_emitting_function("", "b").await?;
     my_emitting_function("");
-    ThingVc::cell(Thing(0))
+    Ok(ThingVc::cell(Thing(0)))
 }
 
 #[turbo_tasks::function]

--- a/crates/turbo-tasks-memory/tests/collectibles.rs
+++ b/crates/turbo-tasks-memory/tests/collectibles.rs
@@ -4,7 +4,9 @@ use std::{collections::HashSet, time::Duration};
 
 use anyhow::{bail, Result};
 use tokio::time::sleep;
-use turbo_tasks::{emit, primitives::StringVc, CollectiblesSource, ValueToString, ValueToStringVc};
+use turbo_tasks::{
+    emit, primitives::StringVc, CollectiblesSource, NothingVc, ValueToString, ValueToStringVc,
+};
 use turbo_tasks_testing::{register, run};
 register!();
 
@@ -125,15 +127,15 @@ async fn my_collecting_function_indirect() -> Result<ThingVc> {
 
 #[turbo_tasks::function]
 async fn my_multi_emitting_function() -> Result<ThingVc> {
-    my_transitive_emitting_function("", "a").await?;
-    my_transitive_emitting_function("", "b").await?;
-    my_emitting_function("");
+    let _ = my_transitive_emitting_function("", "a");
+    let _ = my_transitive_emitting_function("", "b");
+    let _ = my_emitting_function("");
     Ok(ThingVc::cell(Thing(0)))
 }
 
 #[turbo_tasks::function]
 fn my_transitive_emitting_function(key: &str, _key2: &str) -> ThingVc {
-    my_emitting_function(key);
+    let _ = my_emitting_function(key);
     ThingVc::cell(Thing(0))
 }
 
@@ -150,11 +152,11 @@ async fn my_transitive_emitting_function_with_child_scope(
 }
 
 #[turbo_tasks::function]
-async fn my_emitting_function(_key: &str) -> Result<()> {
+async fn my_emitting_function(_key: &str) -> Result<NothingVc> {
     sleep(Duration::from_millis(100)).await;
     emit(ThingVc::new(123).as_value_to_string());
     emit(ThingVc::new(42).as_value_to_string());
-    Ok(())
+    Ok(NothingVc::new())
 }
 
 #[turbo_tasks::function]

--- a/crates/turbo-tasks/src/nothing.rs
+++ b/crates/turbo-tasks/src/nothing.rs
@@ -1,7 +1,7 @@
 use crate::{self as turbo_tasks};
 
 /// Just an empty type.
-/// [NothingVc] can be used as return value instead of `()`
+/// [NothingVc] should be used as return value instead of `()`
 /// to have a concrete reference that can be awaited.
 #[turbo_tasks::value]
 pub struct Nothing;

--- a/crates/turbopack-core/src/resolve/mod.rs
+++ b/crates/turbopack-core/src/resolve/mod.rs
@@ -214,14 +214,14 @@ impl ResolveResult {
 #[turbo_tasks::value_impl]
 impl ResolveResultVc {
     #[turbo_tasks::function]
-    pub async fn add_reference(self, reference: AssetReferenceVc) -> Result<Self> {
+    pub async fn with_reference(self, reference: AssetReferenceVc) -> Result<Self> {
         let mut this = self.await?.clone_value();
         this.add_reference(reference);
         Ok(this.into())
     }
 
     #[turbo_tasks::function]
-    pub async fn add_references(self, references: Vec<AssetReferenceVc>) -> Result<Self> {
+    pub async fn with_references(self, references: Vec<AssetReferenceVc>) -> Result<Self> {
         let mut this = self.await?.clone_value();
         for reference in references {
             this.add_reference(reference);
@@ -279,7 +279,7 @@ impl ResolveResultVc {
                 .into_iter()
                 .next()
                 .unwrap()
-                .add_references(references));
+                .with_references(references));
         }
         let mut iter = results.into_iter().try_join().await?.into_iter();
         if let Some(current) = iter.next() {
@@ -577,7 +577,7 @@ fn merge_results_with_references(
             .into_iter()
             .next()
             .unwrap()
-            .add_references(references),
+            .with_references(references),
         _ => ResolveResultVc::alternatives_with_references(results, references),
     }
 }
@@ -1170,7 +1170,7 @@ async fn resolve_alias_field_result(
             RequestVc::parse(Value::new(Pattern::Constant(value.to_string()))),
             resolve_options,
         )
-        .add_references(refs));
+        .with_references(refs));
     }
     let issue: ResolvingIssueVc = ResolvingIssue {
         severity: IssueSeverity::Error.cell(),

--- a/crates/turbopack-ecmascript/src/resolve/mod.rs
+++ b/crates/turbopack-ecmascript/src/resolve/mod.rs
@@ -105,7 +105,7 @@ pub async fn url_resolve(
     } else {
         rel_result
     };
-    handle_resolve_error(
+    let _ = handle_resolve_error(
         result,
         ty.clone(),
         origin.origin_path(),

--- a/crates/turbopack-ecmascript/src/resolve/mod.rs
+++ b/crates/turbopack-ecmascript/src/resolve/mod.rs
@@ -101,7 +101,7 @@ pub async fn url_resolve(
     let result = if *rel_result.is_unresolveable().await? && rel_request.resolve().await? != request
     {
         resolve(origin.origin_path().parent(), request, resolve_options)
-            .add_references(rel_result.await?.get_references().clone())
+            .with_references(rel_result.await?.get_references().clone())
     } else {
         rel_result
     };

--- a/crates/turbopack/src/lib.rs
+++ b/crates/turbopack/src/lib.rs
@@ -427,7 +427,7 @@ impl AssetContext for ModuleAssetContext {
         let context_path = origin_path.parent().resolve().await?;
 
         let result = resolve(context_path, request, resolve_options);
-        let result = self_vc.process_resolve_result(result, reference_type);
+        let mut result = self_vc.process_resolve_result(result, reference_type);
 
         if *self_vc.is_types_resolving_enabled().await? {
             let types_reference = TypescriptTypesAssetReferenceVc::new(
@@ -435,7 +435,7 @@ impl AssetContext for ModuleAssetContext {
                 request,
             );
 
-            result.add_reference(types_reference.into()).await?;
+            result = result.with_reference(types_reference.into());
         }
 
         Ok(result)

--- a/crates/turbopack/src/lib.rs
+++ b/crates/turbopack/src/lib.rs
@@ -435,7 +435,7 @@ impl AssetContext for ModuleAssetContext {
                 request,
             );
 
-            result.add_reference(types_reference.into());
+            result.add_reference(types_reference.into()).await?;
         }
 
         Ok(result)


### PR DESCRIPTION
This uses the `#[must-use]` macro [0] to mark Vcs as needing to be used when created. The compiler creates warnings for each case.

Test Plan: Create a Vc in code and verify a warning is shown when Turbopack is built.

[0] https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-must_use-attribute
