### PR TITLE
feat(ecma-analyzer): support super() call in class ctor

### DIFF
--- a/crates/turbopack-ecmascript/tests/analyzer/graph/class_super/graph-effects.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/class_super/graph-effects.snapshot
@@ -1,0 +1,362 @@
+[
+    Call {
+        func: SuperCall(
+            2,
+            [
+                Variable(
+                    (
+                        Atom('*arrow function 138*' type=dynamic),
+                        #0,
+                    ),
+                ),
+            ],
+        ),
+        args: [
+            Closure(
+                Variable(
+                    (
+                        Atom('*arrow function 138*' type=dynamic),
+                        #0,
+                    ),
+                ),
+                EffectsBlock {
+                    effects: [
+                        ImportedBinding {
+                            esm_reference_index: 1,
+                            export: Some(
+                                "named",
+                            ),
+                            ast_path: [
+                                Program(
+                                    Module,
+                                ),
+                                Module(
+                                    Body(
+                                        2,
+                                    ),
+                                ),
+                                ModuleItem(
+                                    Stmt,
+                                ),
+                                Stmt(
+                                    Decl,
+                                ),
+                                Decl(
+                                    Class,
+                                ),
+                                ClassDecl(
+                                    Class,
+                                ),
+                                Class(
+                                    Body(
+                                        0,
+                                    ),
+                                ),
+                                ClassMember(
+                                    Constructor,
+                                ),
+                                Constructor(
+                                    Body,
+                                ),
+                                BlockStmt(
+                                    Stmts(
+                                        0,
+                                    ),
+                                ),
+                                Stmt(
+                                    Expr,
+                                ),
+                                ExprStmt(
+                                    Expr,
+                                ),
+                                Expr(
+                                    Call,
+                                ),
+                                CallExpr(
+                                    Args(
+                                        0,
+                                    ),
+                                ),
+                                ExprOrSpread(
+                                    Expr,
+                                ),
+                                Expr(
+                                    Arrow,
+                                ),
+                                ArrowExpr(
+                                    Body,
+                                ),
+                                BlockStmtOrExpr(
+                                    BlockStmt,
+                                ),
+                                BlockStmt(
+                                    Stmts(
+                                        0,
+                                    ),
+                                ),
+                                Stmt(
+                                    Expr,
+                                ),
+                                ExprStmt(
+                                    Expr,
+                                ),
+                                Expr(
+                                    Call,
+                                ),
+                                CallExpr(
+                                    Callee,
+                                ),
+                                Callee(
+                                    Expr,
+                                ),
+                                Expr(
+                                    Ident,
+                                ),
+                            ],
+                            span: Span {
+                                lo: BytePos(
+                                    152,
+                                ),
+                                hi: BytePos(
+                                    157,
+                                ),
+                                ctxt: #2,
+                            },
+                            in_try: false,
+                        },
+                        Call {
+                            func: Member(
+                                3,
+                                Module(
+                                    ModuleValue {
+                                        module: Atom('./module.js' type=dynamic),
+                                        annotations: ImportAnnotations {
+                                            map: {},
+                                        },
+                                    },
+                                ),
+                                Constant(
+                                    Str(
+                                        Word(
+                                            Atom('named' type=inline),
+                                        ),
+                                    ),
+                                ),
+                            ),
+                            args: [],
+                            ast_path: [
+                                Program(
+                                    Module,
+                                ),
+                                Module(
+                                    Body(
+                                        2,
+                                    ),
+                                ),
+                                ModuleItem(
+                                    Stmt,
+                                ),
+                                Stmt(
+                                    Decl,
+                                ),
+                                Decl(
+                                    Class,
+                                ),
+                                ClassDecl(
+                                    Class,
+                                ),
+                                Class(
+                                    Body(
+                                        0,
+                                    ),
+                                ),
+                                ClassMember(
+                                    Constructor,
+                                ),
+                                Constructor(
+                                    Body,
+                                ),
+                                BlockStmt(
+                                    Stmts(
+                                        0,
+                                    ),
+                                ),
+                                Stmt(
+                                    Expr,
+                                ),
+                                ExprStmt(
+                                    Expr,
+                                ),
+                                Expr(
+                                    Call,
+                                ),
+                                CallExpr(
+                                    Args(
+                                        0,
+                                    ),
+                                ),
+                                ExprOrSpread(
+                                    Expr,
+                                ),
+                                Expr(
+                                    Arrow,
+                                ),
+                                ArrowExpr(
+                                    Body,
+                                ),
+                                BlockStmtOrExpr(
+                                    BlockStmt,
+                                ),
+                                BlockStmt(
+                                    Stmts(
+                                        0,
+                                    ),
+                                ),
+                                Stmt(
+                                    Expr,
+                                ),
+                                ExprStmt(
+                                    Expr,
+                                ),
+                                Expr(
+                                    Call,
+                                ),
+                            ],
+                            span: Span {
+                                lo: BytePos(
+                                    152,
+                                ),
+                                hi: BytePos(
+                                    159,
+                                ),
+                                ctxt: #0,
+                            },
+                            in_try: false,
+                        },
+                    ],
+                    ast_path: [
+                        Program(
+                            Module,
+                        ),
+                        Module(
+                            Body(
+                                2,
+                            ),
+                        ),
+                        ModuleItem(
+                            Stmt,
+                        ),
+                        Stmt(
+                            Decl,
+                        ),
+                        Decl(
+                            Class,
+                        ),
+                        ClassDecl(
+                            Class,
+                        ),
+                        Class(
+                            Body(
+                                0,
+                            ),
+                        ),
+                        ClassMember(
+                            Constructor,
+                        ),
+                        Constructor(
+                            Body,
+                        ),
+                        BlockStmt(
+                            Stmts(
+                                0,
+                            ),
+                        ),
+                        Stmt(
+                            Expr,
+                        ),
+                        ExprStmt(
+                            Expr,
+                        ),
+                        Expr(
+                            Call,
+                        ),
+                        CallExpr(
+                            Args(
+                                0,
+                            ),
+                        ),
+                        ExprOrSpread(
+                            Expr,
+                        ),
+                        Expr(
+                            Arrow,
+                        ),
+                        ArrowExpr(
+                            Body,
+                        ),
+                        BlockStmtOrExpr(
+                            BlockStmt,
+                        ),
+                    ],
+                },
+            ),
+        ],
+        ast_path: [
+            Program(
+                Module,
+            ),
+            Module(
+                Body(
+                    2,
+                ),
+            ),
+            ModuleItem(
+                Stmt,
+            ),
+            Stmt(
+                Decl,
+            ),
+            Decl(
+                Class,
+            ),
+            ClassDecl(
+                Class,
+            ),
+            Class(
+                Body(
+                    0,
+                ),
+            ),
+            ClassMember(
+                Constructor,
+            ),
+            Constructor(
+                Body,
+            ),
+            BlockStmt(
+                Stmts(
+                    0,
+                ),
+            ),
+            Stmt(
+                Expr,
+            ),
+            ExprStmt(
+                Expr,
+            ),
+            Expr(
+                Call,
+            ),
+        ],
+        span: Span {
+            lo: BytePos(
+                132,
+            ),
+            hi: BytePos(
+                167,
+            ),
+            ctxt: #0,
+        },
+        in_try: false,
+    },
+]

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/class_super/graph-explained.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/class_super/graph-explained.snapshot
@@ -1,0 +1,9 @@
+*arrow function 138* = (...) => undefined
+
+BaseClass = ???*0*
+- *0* unsupported expression
+
+SubClass = ???*0*
+- *0* unsupported expression
+
+fn = arguments[0]

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/class_super/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/class_super/graph.snapshot
@@ -1,0 +1,33 @@
+[
+    (
+        "*arrow function 138*",
+        Function(
+            2,
+            138,
+            Constant(
+                Undefined,
+            ),
+        ),
+    ),
+    (
+        "BaseClass",
+        Unknown(
+            None,
+            "unsupported expression",
+        ),
+    ),
+    (
+        "SubClass",
+        Unknown(
+            None,
+            "unsupported expression",
+        ),
+    ),
+    (
+        "fn",
+        Argument(
+            0,
+            0,
+        ),
+    ),
+]

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/class_super/input.js
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/class_super/input.js
@@ -1,0 +1,13 @@
+import { named } from "./module.js";
+
+class BaseClass {
+  super(fn) {}
+}
+
+class SubClass extends BaseClass {
+  constructor() {
+    super(() => {
+      named();
+    });
+  }
+}

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/class_super/resolved-effects.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/class_super/resolved-effects.snapshot
@@ -1,0 +1,3 @@
+0 -> 1 call = super((...) => undefined)((...) => undefined)
+
+1 -> 3 call = module<./module.js, {}>["named"]()

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/class_super/resolved-explained.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/class_super/resolved-explained.snapshot
@@ -1,0 +1,11 @@
+*arrow function 138* = (...) => undefined
+
+BaseClass = ???*0*
+- *0* unsupported expression
+
+SubClass = ???*0*
+- *0* unsupported expression
+
+fn = ???*0*
+- *0* arguments[0]
+  ⚠️  function calls are not analysed yet


### PR DESCRIPTION
### Description

Attempt to close WEB-1089.

PR tries to support import resolustion inside of `super` call, if given args are referencing esm imports.

Since super() is sort of expr_call, I originally tried to reuse JsValue::Call as-is but not successfully. Still that might be a simple mistake and new addition to JsValue::Super may not be required.