### PR TITLE
chore(ci): binstall tools 

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -65,13 +65,9 @@ runs:
         save-if: ${{ github.ref == 'refs/heads/main' && inputs.save-cache || 'false' }}
 
     - name: "Install cargo-sweep"
-      uses: baptiste0928/cargo-install@v1
+      uses: taiki-e/install-action@v2
       with:
-        crate: cargo-sweep
-
-    - name: "Install cargo-groups"
-      shell: bash
-      run: cargo install cargo-groups
+        tool: cargo-sweep,cargo-groups
 
     - name: "Run cargo-sweep"
       uses: ./.github/actions/cargo-sweep


### PR DESCRIPTION
### Description

Some more CI improvements. We use tools like `cargo-sweep` and `cargo-groups`, that currently are built on each run. Instead let's try to download a pre-built binary when possible. 

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
