### PR TITLE
chore: update `update-informer` to 1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10788,14 +10788,35 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "update-informer"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d952f24d9cd8b7564d22c7b2cde3429c48b50c6f4e72b07b382ae4ee5f21b3"
+checksum = "2f8811797a24ff123db3c6e1087aa42551d03d772b3724be421ad063da1f5f3f"
 dependencies = [
  "directories 5.0.1",
+ "reqwest",
  "semver 1.0.18",
  "serde",
  "serde_json",
+ "ureq",
+]
+
+[[package]]
+name = "ureq"
+version = "2.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338b31dd1314f68f3aabf3ed57ab922df95ffcd902476ca7ba3c4ce7b908c46d"
+dependencies = [
+ "base64 0.13.1",
+ "flate2",
+ "log",
+ "native-tls",
+ "once_cell",
+ "rustls",
+ "serde",
+ "serde_json",
+ "url",
+ "webpki",
+ "webpki-roots",
 ]
 
 [[package]]

--- a/crates/turborepo-updater/Cargo.toml
+++ b/crates/turborepo-updater/Cargo.toml
@@ -19,4 +19,6 @@ reqwest = { workspace = true, features = ["json", "blocking"] }
 semver = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
-update-informer = { version = "1.1", default-features = false, features = ["reqwest"] }
+update-informer = { version = "1.1", default-features = false, features = [
+  "reqwest",
+] }

--- a/crates/turborepo-updater/Cargo.toml
+++ b/crates/turborepo-updater/Cargo.toml
@@ -9,8 +9,8 @@ publish = false
 [features]
 # Allows configuring a specific tls backend for reqwest.
 # See top level Cargo.toml for more details.
-native-tls = ["reqwest/native-tls"]
-rustls-tls = ["reqwest/rustls-tls"]
+native-tls = ["reqwest/native-tls", "update-informer/native-tls"]
+rustls-tls = ["reqwest/rustls-tls", "update-informer/rustls-tls"]
 
 [dependencies]
 atty = { workspace = true }
@@ -19,4 +19,4 @@ reqwest = { workspace = true, features = ["json", "blocking"] }
 semver = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
-update-informer = { version = "1.0", default-features = false }
+update-informer = { version = "1.1", default-features = false, features = ["reqwest"] }

--- a/crates/turborepo-updater/src/lib.rs
+++ b/crates/turborepo-updater/src/lib.rs
@@ -7,7 +7,7 @@ use semver::Version as SemVerVersion;
 use serde::Deserialize;
 use thiserror::Error as ThisError;
 use update_informer::{
-    http_client::{GenericHttpClient, HeaderMap, HttpClient},
+    http_client::{GenericHttpClient, HttpClient},
     Check, Package, Registry, Result as UpdateResult,
 };
 
@@ -74,31 +74,6 @@ impl Registry for NPMRegistry {
     }
 }
 
-// Source https://github.com/mgrachev/update-informer/blob/main/src/http_client/reqwest.rs
-// Vendored here until update-informer allows us to control tls implementation
-pub struct ReqwestHttpClient;
-
-impl HttpClient for ReqwestHttpClient {
-    fn get<T: serde::de::DeserializeOwned>(
-        url: &str,
-        timeout: Duration,
-        headers: HeaderMap,
-    ) -> Result<T, Box<dyn std::error::Error>> {
-        let mut req = reqwest::blocking::Client::builder()
-            .timeout(timeout)
-            .build()?
-            .get(url);
-
-        for (key, value) in headers {
-            req = req.header(key, value);
-        }
-
-        let json = req.send()?.json()?;
-
-        Ok(json)
-    }
-}
-
 fn get_tag_from_version(pre: &semver::Prerelease) -> VersionTag {
     match pre {
         t if t.contains("canary") => VersionTag::Canary,
@@ -140,7 +115,6 @@ pub fn check_for_updates(
     let timeout = timeout.unwrap_or(DEFAULT_TIMEOUT);
     let interval = interval.unwrap_or(DEFAULT_INTERVAL);
     let informer = update_informer::new(NPMRegistry, package_name, current_version)
-        .http_client(ReqwestHttpClient)
         .timeout(timeout)
         .interval(interval);
     if let Ok(Some(version)) = informer.check_version() {


### PR DESCRIPTION
### Description

A new version of `update-informer` has been released: [v1.1](https://github.com/mgrachev/update-informer/releases/tag/v1.1.0).

<!--
  ✍️ Write a short summary of your work.
  If necessary, include relevant screenshots.
-->

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
