### PR TITLE
feat(turborepo): refactor scm and thread into scope calculation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9634,6 +9634,7 @@ dependencies = [
  "tempfile",
  "test-case",
  "thiserror",
+ "tracing",
  "turbopath",
  "wax",
  "which",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9593,6 +9593,7 @@ dependencies = [
  "turborepo-api-client",
  "turborepo-env",
  "turborepo-lockfiles",
+ "turborepo-scm",
  "uds_windows",
  "url",
  "vercel-api-mock",

--- a/crates/turborepo-ffi/src/lib.rs
+++ b/crates/turborepo-ffi/src/lib.rs
@@ -4,7 +4,7 @@
 //! and in ffi.go before modifying this file.
 mod lockfile;
 
-use std::{collections::HashMap, mem::ManuallyDrop, path::PathBuf};
+use std::{collections::HashMap, mem::ManuallyDrop};
 
 use globwalk::globwalk;
 pub use lockfile::{patches, subgraph, transitive_closure};
@@ -120,7 +120,7 @@ pub extern "C" fn previous_content(buffer: Buffer) -> Buffer {
     let response = match turborepo_scm::git::previous_content(
         req.git_root.into(),
         &req.from_commit,
-        PathBuf::from(req.file_path),
+        req.file_path,
     ) {
         Ok(content) => proto::previous_content_resp::Response::Content(content),
         Err(err) => proto::previous_content_resp::Response::Error(err.to_string()),

--- a/crates/turborepo-ffi/src/lib.rs
+++ b/crates/turborepo-ffi/src/lib.rs
@@ -249,7 +249,7 @@ pub extern "C" fn get_package_file_hashes(buffer: Buffer) -> Buffer {
         }
     };
     let inputs = req.inputs.as_slice();
-    let hasher = turborepo_scm::Hasher::new(&turbo_root);
+    let hasher = turborepo_scm::SCM::new(&turbo_root);
     let response = match hasher.get_package_file_hashes(&turbo_root, &package_path, inputs) {
         Ok(hashes) => {
             let mut to_return = HashMap::new();
@@ -317,7 +317,7 @@ pub extern "C" fn get_hashes_for_files(buffer: Buffer) -> Buffer {
             return resp.into();
         }
     };
-    let hasher = turborepo_scm::Hasher::new(&turbo_root);
+    let hasher = turborepo_scm::SCM::new(&turbo_root);
     let result = if allow_missing {
         hasher.hash_existing_of(&turbo_root, files.into_iter())
     } else {

--- a/crates/turborepo-ffi/src/lib.rs
+++ b/crates/turborepo-ffi/src/lib.rs
@@ -249,7 +249,7 @@ pub extern "C" fn get_package_file_hashes(buffer: Buffer) -> Buffer {
         }
     };
     let inputs = req.inputs.as_slice();
-    let hasher = turborepo_scm::package_deps::Hasher::new(&turbo_root);
+    let hasher = turborepo_scm::Hasher::new(&turbo_root);
     let response = match hasher.get_package_file_hashes(&turbo_root, &package_path, inputs) {
         Ok(hashes) => {
             let mut to_return = HashMap::new();
@@ -317,7 +317,7 @@ pub extern "C" fn get_hashes_for_files(buffer: Buffer) -> Buffer {
             return resp.into();
         }
     };
-    let hasher = turborepo_scm::package_deps::Hasher::new(&turbo_root);
+    let hasher = turborepo_scm::Hasher::new(&turbo_root);
     let result = if allow_missing {
         hasher.hash_existing_of(&turbo_root, files.into_iter())
     } else {

--- a/crates/turborepo-lib/Cargo.toml
+++ b/crates/turborepo-lib/Cargo.toml
@@ -101,6 +101,7 @@ turbopath = { workspace = true }
 turborepo-api-client = { workspace = true }
 turborepo-env = { workspace = true }
 turborepo-lockfiles = { workspace = true }
+turborepo-scm = { workspace = true }
 wax = { workspace = true }
 webbrowser = { workspace = true }
 which = { workspace = true }

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -9,6 +9,7 @@ use anyhow::{Context as ErrorContext, Result};
 use graph::CompleteGraph;
 use tracing::{debug, info};
 use turborepo_env::EnvironmentVariableMap;
+use turborepo_scm::SCM;
 
 use crate::{
     commands::CommandBase,
@@ -88,8 +89,10 @@ impl Run {
 
         let pipeline = &turbo_json.pipeline;
 
+        let scm = SCM::new(&self.base.repo_root);
+
         let mut filtered_pkgs =
-            scope::resolve_packages(&opts.scope_opts, &self.base, &pkg_dep_graph)?;
+            scope::resolve_packages(&opts.scope_opts, &self.base, &pkg_dep_graph, &scm)?;
 
         if filtered_pkgs.len() == pkg_dep_graph.len() {
             for target in targets {

--- a/crates/turborepo-lib/src/run/scope.rs
+++ b/crates/turborepo-lib/src/run/scope.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 
 use anyhow::Result;
 use tracing::warn;
+use turborepo_scm::SCM;
 
 use crate::{commands::CommandBase, opts::ScopeOpts, package_graph};
 
@@ -9,6 +10,7 @@ pub fn resolve_packages(
     _opts: &ScopeOpts,
     _base: &CommandBase,
     _ctx: &package_graph::PackageGraph,
+    _scm: &SCM,
 ) -> Result<HashSet<String>> {
     warn!("resolve packages not implemented yet");
     Ok(HashSet::new())

--- a/crates/turborepo-scm/Cargo.toml
+++ b/crates/turborepo-scm/Cargo.toml
@@ -16,6 +16,7 @@ itertools.workspace = true
 nom = "7.1.3"
 sha1 = "0.10.5"
 thiserror = { workspace = true }
+tracing = { workspace = true }
 turbopath = { workspace = true }
 wax = { workspace = true }
 which = { workspace = true }

--- a/crates/turborepo-scm/src/git.rs
+++ b/crates/turborepo-scm/src/git.rs
@@ -198,30 +198,7 @@ pub fn previous_content(
     // exactly
     let absolute_file_path = AbsoluteSystemPathBuf::from_unknown(&git_root, &file_path);
 
-    // let anchored_file_path = if file_path.is_absolute() {
-    //     let absolute_file_path = AbsoluteSystemPathBuf::try_from(file_path)?;
-    //     git_root.anchor(absolute_file_path)?
-    // } else {
-    //     file_path.as_path().try_into()?
-    // };
-
     scm.previous_content(from_commit, &absolute_file_path)
-    // let git_binary = which("git")?;
-    // let mut command = Command::new(git_binary);
-    // let command = command
-    //     .arg("show")
-    //     .arg(format!("{}:{}", from_commit, anchored_file_path.as_str()))
-    //     .current_dir(&git_root);
-
-    // let output = command.output()?;
-    // if output.status.success() {
-    //     Ok(output.stdout)
-    // } else {
-    //     Err(Error::Git(
-    //         String::from_utf8_lossy(&output.stderr).to_string(),
-    //         Backtrace::capture(),
-    //     ))
-    // }
 }
 
 #[cfg(test)]

--- a/crates/turborepo-scm/src/git.rs
+++ b/crates/turborepo-scm/src/git.rs
@@ -1,6 +1,4 @@
-use std::{
-    backtrace::Backtrace, borrow::Borrow, collections::HashSet, path::PathBuf, process::Command,
-};
+use std::{backtrace::Backtrace, collections::HashSet, path::PathBuf, process::Command};
 
 use turbopath::{
     AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPathBuf, RelativeUnixPath,
@@ -145,7 +143,7 @@ impl Git {
         path: &RelativeUnixPath,
     ) -> Result<AnchoredSystemPathBuf, Error> {
         let absolute_file_path = self.root.join_unix_path(path)?;
-        let anchored_to_turbo_root_file_path = turbo_root.anchor(absolute_file_path.borrow())?;
+        let anchored_to_turbo_root_file_path = turbo_root.anchor(&absolute_file_path)?;
         Ok(anchored_to_turbo_root_file_path)
     }
 

--- a/crates/turborepo-scm/src/git.rs
+++ b/crates/turborepo-scm/src/git.rs
@@ -5,9 +5,33 @@ use std::{
 use turbopath::{
     AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPathBuf, RelativeUnixPath,
 };
-use which::which;
 
-use crate::Error;
+use crate::{Error, Git, Hasher};
+
+impl Hasher {
+    pub fn changed_files(
+        &self,
+        turbo_root: &AbsoluteSystemPath,
+        from_commit: Option<&str>,
+        to_commit: &str,
+    ) -> Result<HashSet<AnchoredSystemPathBuf>, Error> {
+        match self {
+            Self::Git(git) => git.changed_files(turbo_root, from_commit, to_commit),
+            Self::Manual => Err(Error::GitRequired(turbo_root.to_owned())),
+        }
+    }
+
+    pub fn previous_content(
+        &self,
+        from_commit: &str,
+        file_path: &AbsoluteSystemPath,
+    ) -> Result<Vec<u8>, Error> {
+        match self {
+            Self::Git(git) => git.previous_content(from_commit, file_path),
+            Self::Manual => Err(Error::GitRequired(file_path.to_owned())),
+        }
+    }
+}
 
 /// Finds the changed files in a repository between index and working directory
 /// (unstaged changes) and between two commits. Includes untracked files,
@@ -33,97 +57,120 @@ pub fn changed_files(
     to_commit: &str,
 ) -> Result<HashSet<String>, Error> {
     let git_root = AbsoluteSystemPath::from_std_path(&git_root)?;
+    let scm = Hasher::new(git_root);
+
     let turbo_root = AbsoluteSystemPathBuf::try_from(turbo_root.as_path())?;
-    let turbo_root_relative_to_git_root = git_root.anchor(&turbo_root)?;
-    let pathspec = turbo_root_relative_to_git_root.as_str();
-
-    let mut files = HashSet::new();
-
-    let output = execute_git_command(
-        git_root.borrow(),
-        &["diff", "--name-only", to_commit],
-        pathspec,
-    )?;
-
-    add_files_from_stdout(&mut files, git_root, &turbo_root, output);
-
-    if let Some(from_commit) = from_commit {
-        let output = execute_git_command(
-            git_root.borrow(),
-            &[
-                "diff",
-                "--name-only",
-                &format!("{}...{}", from_commit, to_commit),
-            ],
-            pathspec,
-        )?;
-
-        add_files_from_stdout(&mut files, git_root, &turbo_root, output);
-    }
-
-    let output = execute_git_command(
-        git_root.borrow(),
-        &["ls-files", "--others", "--exclude-standard"],
-        pathspec,
-    )?;
-
-    add_files_from_stdout(&mut files, git_root, &turbo_root, output);
-
-    Ok(files)
+    let files = scm.changed_files(&turbo_root, from_commit, to_commit)?;
+    Ok(files
+        .into_iter()
+        .map(|f| f.to_string())
+        .collect::<HashSet<_>>())
 }
 
-fn execute_git_command(
-    git_root: &AbsoluteSystemPath,
-    args: &[&str],
-    pathspec: &str,
-) -> Result<Vec<u8>, Error> {
-    let git_binary = which("git")?;
-    let mut command = Command::new(git_binary);
-    command.args(args).current_dir(git_root);
+impl Git {
+    fn changed_files(
+        &self,
+        turbo_root: &AbsoluteSystemPath,
+        from_commit: Option<&str>,
+        to_commit: &str,
+    ) -> Result<HashSet<AnchoredSystemPathBuf>, Error> {
+        let turbo_root_relative_to_git_root = self.root.anchor(turbo_root)?;
+        let pathspec = turbo_root_relative_to_git_root.as_str();
 
-    add_pathspec(&mut command, pathspec);
+        let mut files = HashSet::new();
 
-    let output = command.output()?;
+        let output = self.execute_git_command(&["diff", "--name-only", to_commit], pathspec)?;
 
-    if !output.status.success() {
-        let stderr = String::from_utf8(output.stderr).unwrap();
-        Err(Error::Git(stderr, Backtrace::capture()))
-    } else {
-        Ok(output.stdout)
+        self.add_files_from_stdout(&mut files, &turbo_root, output);
+
+        if let Some(from_commit) = from_commit {
+            let output = self.execute_git_command(
+                &[
+                    "diff",
+                    "--name-only",
+                    &format!("{}...{}", from_commit, to_commit),
+                ],
+                pathspec,
+            )?;
+
+            self.add_files_from_stdout(&mut files, &turbo_root, output);
+        }
+
+        let output =
+            self.execute_git_command(&["ls-files", "--others", "--exclude-standard"], pathspec)?;
+
+        self.add_files_from_stdout(&mut files, &turbo_root, output);
+
+        Ok(files)
     }
-}
 
-fn add_pathspec(command: &mut Command, pathspec: &str) {
-    if !pathspec.is_empty() {
-        command.arg("--").arg(pathspec);
+    fn execute_git_command(&self, args: &[&str], pathspec: &str) -> Result<Vec<u8>, Error> {
+        let mut command = Command::new(self.bin.as_std_path());
+        command.args(args).current_dir(&self.root);
+
+        if !pathspec.is_empty() {
+            command.arg("--").arg(pathspec);
+        }
+
+        let output = command.output()?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+            Err(Error::Git(stderr, Backtrace::capture()))
+        } else {
+            Ok(output.stdout)
+        }
     }
-}
 
-fn add_files_from_stdout(
-    files: &mut HashSet<String>,
-    git_root: impl AsRef<AbsoluteSystemPath>,
-    turbo_root: impl AsRef<AbsoluteSystemPath>,
-    stdout: Vec<u8>,
-) {
-    let git_root = git_root.as_ref();
-    let turbo_root = turbo_root.as_ref();
-    let stdout = String::from_utf8(stdout).unwrap();
-    for line in stdout.lines() {
-        let path = RelativeUnixPath::new(line).unwrap();
-        let anchored_to_turbo_root_file_path =
-            reanchor_path_from_git_root_to_turbo_root(git_root, turbo_root, path).unwrap();
-        files.insert(anchored_to_turbo_root_file_path.to_string());
+    fn add_files_from_stdout(
+        &self,
+        files: &mut HashSet<AnchoredSystemPathBuf>,
+        turbo_root: &AbsoluteSystemPath,
+        stdout: Vec<u8>,
+    ) {
+        let turbo_root = turbo_root.as_ref();
+        let stdout = String::from_utf8(stdout).unwrap();
+        for line in stdout.lines() {
+            let path = RelativeUnixPath::new(line).unwrap();
+            let anchored_to_turbo_root_file_path = self
+                .reanchor_path_from_git_root_to_turbo_root(turbo_root, path)
+                .unwrap();
+            files.insert(anchored_to_turbo_root_file_path);
+        }
     }
-}
 
-fn reanchor_path_from_git_root_to_turbo_root(
-    git_root: &AbsoluteSystemPath,
-    turbo_root: &AbsoluteSystemPath,
-    path: &RelativeUnixPath,
-) -> Result<AnchoredSystemPathBuf, Error> {
-    let absolute_file_path = git_root.join_unix_path(path)?;
-    let anchored_to_turbo_root_file_path = turbo_root.anchor(absolute_file_path.borrow())?;
-    Ok(anchored_to_turbo_root_file_path)
+    fn reanchor_path_from_git_root_to_turbo_root(
+        &self,
+        turbo_root: &AbsoluteSystemPath,
+        path: &RelativeUnixPath,
+    ) -> Result<AnchoredSystemPathBuf, Error> {
+        let absolute_file_path = self.root.join_unix_path(path)?;
+        let anchored_to_turbo_root_file_path = turbo_root.anchor(absolute_file_path.borrow())?;
+        Ok(anchored_to_turbo_root_file_path)
+    }
+
+    fn previous_content(
+        &self,
+        from_commit: &str,
+        file_path: &AbsoluteSystemPath,
+    ) -> Result<Vec<u8>, Error> {
+        let anchored_file_path = self.root.anchor(file_path)?;
+        let mut command = Command::new(self.bin.as_std_path());
+        let command = command
+            .arg("show")
+            .arg(format!("{}:{}", from_commit, anchored_file_path.as_str()))
+            .current_dir(&self.root);
+
+        let output = command.output()?;
+        if output.status.success() {
+            Ok(output.stdout)
+        } else {
+            Err(Error::Git(
+                String::from_utf8_lossy(&output.stderr).to_string(),
+                Backtrace::capture(),
+            ))
+        }
+    }
 }
 
 /// Finds the content of a file at a previous commit. Assumes file is in a git
@@ -139,51 +186,53 @@ fn reanchor_path_from_git_root_to_turbo_root(
 pub fn previous_content(
     git_root: PathBuf,
     from_commit: &str,
-    file_path: PathBuf,
+    file_path: String,
 ) -> Result<Vec<u8>, Error> {
     // If git root is not absolute, we error.
     let git_root = AbsoluteSystemPathBuf::try_from(git_root)?;
+    let scm = Hasher::new(&git_root);
 
     // However for file path we handle both absolute and relative paths
     // Note that we assume any relative file path is relative to the git root
-    let anchored_file_path = if file_path.is_absolute() {
-        let absolute_file_path = AbsoluteSystemPathBuf::try_from(file_path)?;
-        git_root.anchor(absolute_file_path)?
-    } else {
-        file_path.as_path().try_into()?
-    };
+    // FIXME: this is probably wrong. We should know the path to the lockfile
+    // exactly
+    let absolute_file_path = AbsoluteSystemPathBuf::from_unknown(&git_root, &file_path);
 
-    let git_binary = which("git")?;
-    let mut command = Command::new(git_binary);
-    let command = command
-        .arg("show")
-        .arg(format!("{}:{}", from_commit, anchored_file_path.as_str()))
-        .current_dir(&git_root);
+    // let anchored_file_path = if file_path.is_absolute() {
+    //     let absolute_file_path = AbsoluteSystemPathBuf::try_from(file_path)?;
+    //     git_root.anchor(absolute_file_path)?
+    // } else {
+    //     file_path.as_path().try_into()?
+    // };
 
-    let output = command.output()?;
-    if output.status.success() {
-        Ok(output.stdout)
-    } else {
-        Err(Error::Git(
-            String::from_utf8_lossy(&output.stderr).to_string(),
-            Backtrace::capture(),
-        ))
-    }
+    scm.previous_content(from_commit, &absolute_file_path)
+    // let git_binary = which("git")?;
+    // let mut command = Command::new(git_binary);
+    // let command = command
+    //     .arg("show")
+    //     .arg(format!("{}:{}", from_commit, anchored_file_path.as_str()))
+    //     .current_dir(&git_root);
+
+    // let output = command.output()?;
+    // if output.status.success() {
+    //     Ok(output.stdout)
+    // } else {
+    //     Err(Error::Git(
+    //         String::from_utf8_lossy(&output.stderr).to_string(),
+    //         Backtrace::capture(),
+    //     ))
+    // }
 }
 
 #[cfg(test)]
 mod tests {
     use std::{
-        assert_matches::assert_matches,
-        collections::HashSet,
-        fs,
-        path::{Path, PathBuf},
-        process::Command,
+        assert_matches::assert_matches, collections::HashSet, fs, path::Path, process::Command,
     };
 
     use git2::{Oid, Repository};
     use tempfile::TempDir;
-    use turbopath::PathError;
+    use turbopath::{AbsoluteSystemPathBuf, PathError};
     use which::which;
 
     use super::previous_content;
@@ -507,8 +556,9 @@ mod tests {
     fn test_previous_content() -> Result<(), Error> {
         let (repo_root, repo) = setup_repository()?;
 
-        let file = repo_root.path().join("foo.js");
-        fs::write(&file, "let z = 0;")?;
+        let root = AbsoluteSystemPathBuf::try_from(repo_root.path()).unwrap();
+        let file = root.join_component("foo.js");
+        file.create_with_contents("let z = 0;")?;
 
         let first_commit_oid = commit_file(&repo, Path::new("foo.js"), None);
         fs::write(&file, "let z = 1;")?;
@@ -517,7 +567,7 @@ mod tests {
         let content = previous_content(
             repo_root.path().to_path_buf(),
             first_commit_oid.to_string().as_str(),
-            file.clone(),
+            file.to_string(),
         )?;
 
         assert_eq!(content, b"let z = 0;");
@@ -525,14 +575,14 @@ mod tests {
         let content = previous_content(
             repo_root.path().to_path_buf(),
             second_commit_oid.to_string().as_str(),
-            file,
+            file.to_string(),
         )?;
         assert_eq!(content, b"let z = 1;");
 
         let content = previous_content(
             repo_root.path().to_path_buf(),
             second_commit_oid.to_string().as_str(),
-            PathBuf::from("foo.js"),
+            "foo.js".to_string(),
         )?;
         assert_eq!(content, b"let z = 1;");
 
@@ -542,9 +592,10 @@ mod tests {
     #[test]
     fn test_revparse() -> Result<(), Error> {
         let (repo_root, repo) = setup_repository()?;
+        let root = AbsoluteSystemPathBuf::try_from(repo_root.path()).unwrap();
 
-        let file = repo_root.path().join("foo.js");
-        fs::write(&file, "let z = 0;")?;
+        let file = root.join_component("foo.js");
+        file.create_with_contents("let z = 0;")?;
 
         let first_commit_oid = commit_file(&repo, Path::new("foo.js"), None);
         fs::write(&file, "let z = 1;")?;
@@ -563,7 +614,7 @@ mod tests {
         )?;
         assert_eq!(files, HashSet::from(["foo.js".to_string()]));
 
-        let content = previous_content(repo_root.path().to_path_buf(), "HEAD^", file)?;
+        let content = previous_content(repo_root.path().to_path_buf(), "HEAD^", file.to_string())?;
         assert_eq!(content, b"let z = 0;");
 
         let new_file = repo_root.path().join("bar.js");
@@ -593,9 +644,10 @@ mod tests {
             "HEAD",
         );
 
-        assert_matches!(repo_does_not_exist, Err(Error::Git(_, _)));
+        assert_matches!(repo_does_not_exist, Err(Error::GitRequired(_)));
 
         let (repo_root, _repo) = setup_repository()?;
+        let root = AbsoluteSystemPathBuf::try_from(repo_root.path()).unwrap();
 
         let commit_does_not_exist = changed_files(
             repo_root.path().to_path_buf(),
@@ -609,7 +661,7 @@ mod tests {
         let file_does_not_exist = previous_content(
             repo_root.path().to_path_buf(),
             "HEAD",
-            repo_root.path().join("does-not-exist"),
+            root.join_component("does-not-exist").to_string(),
         );
         assert_matches!(file_does_not_exist, Err(Error::Git(_, _)));
 

--- a/crates/turborepo-scm/src/git.rs
+++ b/crates/turborepo-scm/src/git.rs
@@ -6,9 +6,9 @@ use turbopath::{
     AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPathBuf, RelativeUnixPath,
 };
 
-use crate::{Error, Git, Hasher};
+use crate::{Error, Git, SCM};
 
-impl Hasher {
+impl SCM {
     pub fn changed_files(
         &self,
         turbo_root: &AbsoluteSystemPath,
@@ -57,7 +57,7 @@ pub fn changed_files(
     to_commit: &str,
 ) -> Result<HashSet<String>, Error> {
     let git_root = AbsoluteSystemPath::from_std_path(&git_root)?;
-    let scm = Hasher::new(git_root);
+    let scm = SCM::new(git_root);
 
     let turbo_root = AbsoluteSystemPathBuf::try_from(turbo_root.as_path())?;
     let files = scm.changed_files(&turbo_root, from_commit, to_commit)?;
@@ -190,7 +190,7 @@ pub fn previous_content(
 ) -> Result<Vec<u8>, Error> {
     // If git root is not absolute, we error.
     let git_root = AbsoluteSystemPathBuf::try_from(git_root)?;
-    let scm = Hasher::new(&git_root);
+    let scm = SCM::new(&git_root);
 
     // However for file path we handle both absolute and relative paths
     // Note that we assume any relative file path is relative to the git root

--- a/crates/turborepo-scm/src/hash_object.rs
+++ b/crates/turborepo-scm/src/hash_object.rs
@@ -43,7 +43,7 @@ mod test {
     use turbopath::{AbsoluteSystemPathBuf, RelativeUnixPathBuf, RelativeUnixPathBufTestExt};
 
     use super::hash_objects;
-    use crate::package_deps::{find_git_root, GitHashes};
+    use crate::{find_git_root, package_deps::GitHashes};
 
     #[test]
     fn test_read_object_hashes() {

--- a/crates/turborepo-scm/src/lib.rs
+++ b/crates/turborepo-scm/src/lib.rs
@@ -25,6 +25,11 @@ pub enum Error {
     Git2(git2::Error, String, #[backtrace] backtrace::Backtrace),
     #[error("git error: {0}")]
     Git(String, #[backtrace] backtrace::Backtrace),
+    #[error(
+        "{0} is not part of a git repository. git is required for operations based on source \
+         control"
+    )]
+    GitRequired(AbsoluteSystemPathBuf),
     #[error("io error: {0}")]
     Io(#[from] std::io::Error, #[backtrace] backtrace::Backtrace),
     #[error("path error: {0}")]

--- a/crates/turborepo-scm/src/lib.rs
+++ b/crates/turborepo-scm/src/lib.rs
@@ -156,16 +156,14 @@ fn find_git_root(turbo_root: &AbsoluteSystemPath) -> Result<AbsoluteSystemPathBu
 }
 
 #[derive(Debug)]
-pub enum Hasher {
+pub enum SCM {
     Git(Git),
     Manual,
 }
 
-impl Hasher {
-    pub fn new(path_in_repo: &AbsoluteSystemPath) -> Hasher {
-        Git::find(path_in_repo)
-            .map(Hasher::Git)
-            .unwrap_or(Hasher::Manual)
+impl SCM {
+    pub fn new(path_in_repo: &AbsoluteSystemPath) -> SCM {
+        Git::find(path_in_repo).map(SCM::Git).unwrap_or(SCM::Manual)
     }
 }
 

--- a/crates/turborepo-scm/src/lib.rs
+++ b/crates/turborepo-scm/src/lib.rs
@@ -5,11 +5,12 @@
 use std::{
     backtrace::{self, Backtrace},
     io::Read,
-    process::Child,
+    process::{Child, Command},
 };
 
+use bstr::io::BufReadExt;
 use thiserror::Error;
-use turbopath::{AbsoluteSystemPath, PathError};
+use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, PathError, RelativeUnixPathBuf};
 
 pub mod git;
 mod hash_object;
@@ -105,4 +106,118 @@ pub(crate) fn wait_for_success<R: Read, T>(
         command, path_text, parse_error_text, exit_text, stderr_text
     );
     Err(Error::Git(err_text, Backtrace::capture()))
+}
+
+#[derive(Debug)]
+pub struct Git {
+    root: AbsoluteSystemPathBuf,
+    bin: AbsoluteSystemPathBuf,
+}
+
+impl Git {
+    pub(crate) fn find(path_in_repo: &AbsoluteSystemPath) -> Option<Self> {
+        let bin = which::which("git").ok()?;
+        let bin = AbsoluteSystemPathBuf::try_from(bin).ok()?;
+        let root = find_git_root(path_in_repo).ok()?;
+        Some(Self { root, bin })
+    }
+}
+
+fn find_git_root(turbo_root: &AbsoluteSystemPath) -> Result<AbsoluteSystemPathBuf, Error> {
+    let rev_parse = Command::new("git")
+        .args(["rev-parse", "--show-cdup"])
+        .current_dir(turbo_root)
+        .output()?;
+    if !rev_parse.status.success() {
+        let stderr = String::from_utf8_lossy(&rev_parse.stderr);
+        return Err(Error::git_error(format!(
+            "git rev-parse --show-cdup error: {}",
+            stderr
+        )));
+    }
+    let cursor = std::io::Cursor::new(rev_parse.stdout);
+    let mut lines = cursor.byte_lines();
+    if let Some(line) = lines.next() {
+        let line = String::from_utf8(line?)?;
+        let tail = RelativeUnixPathBuf::new(line)?;
+        turbo_root.join_unix_path(tail).map_err(|e| e.into())
+    } else {
+        let stderr = String::from_utf8_lossy(&rev_parse.stderr);
+        Err(Error::git_error(format!(
+            "git rev-parse --show-cdup error: no values on stdout. stderr: {}",
+            stderr
+        )))
+    }
+}
+
+#[derive(Debug)]
+pub enum Hasher {
+    Git(Git),
+    Manual,
+}
+
+impl Hasher {
+    pub fn new(path_in_repo: &AbsoluteSystemPath) -> Hasher {
+        Git::find(path_in_repo)
+            .map(Hasher::Git)
+            .unwrap_or(Hasher::Manual)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{assert_matches::assert_matches, process::Command};
+
+    use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
+
+    use super::find_git_root;
+    use crate::Error;
+
+    fn tmp_dir() -> (tempfile::TempDir, AbsoluteSystemPathBuf) {
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let dir = AbsoluteSystemPathBuf::try_from(tmp_dir.path())
+            .unwrap()
+            .to_realpath()
+            .unwrap();
+        (tmp_dir, dir)
+    }
+
+    fn require_git_cmd(repo_root: &AbsoluteSystemPath, args: &[&str]) {
+        let mut cmd = Command::new("git");
+        cmd.args(args).current_dir(repo_root);
+        assert!(cmd.output().unwrap().status.success());
+    }
+
+    fn setup_repository(repo_root: &AbsoluteSystemPath) {
+        let cmds: &[&[&str]] = &[
+            &["init", "."],
+            &["config", "--local", "user.name", "test"],
+            &["config", "--local", "user.email", "test@example.com"],
+        ];
+        for cmd in cmds {
+            require_git_cmd(repo_root, cmd);
+        }
+    }
+
+    #[test]
+    fn test_symlinked_git_root() {
+        let (_, tmp_root) = tmp_dir();
+        let git_root = tmp_root.join_component("actual_repo");
+        git_root.create_dir_all().unwrap();
+        setup_repository(&git_root);
+        git_root.join_component("inside").create_dir_all().unwrap();
+        let link = tmp_root.join_component("link");
+        link.symlink_to_dir("actual_repo").unwrap();
+        let turbo_root = link.join_component("inside");
+        let result = find_git_root(&turbo_root).unwrap();
+        assert_eq!(result, link);
+    }
+
+    #[test]
+    fn test_no_git_root() {
+        let (_, tmp_root) = tmp_dir();
+        tmp_root.create_dir_all().unwrap();
+        let result = find_git_root(&tmp_root);
+        assert_matches!(result, Err(Error::Git(_, _)));
+    }
 }

--- a/crates/turborepo-scm/src/package_deps.rs
+++ b/crates/turborepo-scm/src/package_deps.rs
@@ -3,11 +3,11 @@ use std::collections::HashMap;
 use itertools::{Either, Itertools};
 use turbopath::{AbsoluteSystemPath, AnchoredSystemPathBuf, PathError, RelativeUnixPathBuf};
 
-use crate::{hash_object::hash_objects, Error, Git, Hasher};
+use crate::{hash_object::hash_objects, Error, Git, SCM};
 
 pub type GitHashes = HashMap<RelativeUnixPathBuf, String>;
 
-impl Hasher {
+impl SCM {
     pub fn get_package_file_hashes<S: AsRef<str>>(
         &self,
         turbo_root: &AbsoluteSystemPath,
@@ -15,12 +15,12 @@ impl Hasher {
         inputs: &[S],
     ) -> Result<GitHashes, Error> {
         match self {
-            Hasher::Manual => crate::manual::get_package_file_hashes_from_processing_gitignore(
+            SCM::Manual => crate::manual::get_package_file_hashes_from_processing_gitignore(
                 turbo_root,
                 package_path,
                 inputs,
             ),
-            Hasher::Git(git) => git.get_package_file_hashes(turbo_root, package_path, inputs),
+            SCM::Git(git) => git.get_package_file_hashes(turbo_root, package_path, inputs),
         }
     }
 
@@ -30,8 +30,8 @@ impl Hasher {
         files: impl Iterator<Item = AnchoredSystemPathBuf>,
     ) -> Result<GitHashes, Error> {
         match self {
-            Hasher::Manual => crate::manual::hash_files(turbo_root, files, false),
-            Hasher::Git(git) => git.hash_files(turbo_root, files),
+            SCM::Manual => crate::manual::hash_files(turbo_root, files, false),
+            SCM::Git(git) => git.hash_files(turbo_root, files),
         }
     }
 
@@ -160,7 +160,7 @@ mod tests {
     use turbopath::{AbsoluteSystemPathBuf, RelativeUnixPathBuf};
 
     use super::*;
-    use crate::{manual::get_package_file_hashes_from_processing_gitignore, Hasher};
+    use crate::{manual::get_package_file_hashes_from_processing_gitignore, SCM};
 
     fn tmp_dir() -> (tempfile::TempDir, AbsoluteSystemPathBuf) {
         let tmp_dir = tempfile::tempdir().unwrap();
@@ -252,8 +252,8 @@ mod tests {
 
         setup_repository(&repo_root);
         commit_all(&repo_root);
-        let git = Hasher::new(&repo_root);
-        let Hasher::Git(git) = git else {
+        let git = SCM::new(&repo_root);
+        let SCM::Git(git) = git else {
             panic!("expected git, found {:?}", git);
         };
 

--- a/crates/turborepo-scm/src/package_deps.rs
+++ b/crates/turborepo-scm/src/package_deps.rs
@@ -1,35 +1,13 @@
-use std::{collections::HashMap, process::Command};
+use std::collections::HashMap;
 
-use bstr::io::BufReadExt;
 use itertools::{Either, Itertools};
-use turbopath::{
-    AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPathBuf, PathError,
-    RelativeUnixPathBuf,
-};
+use turbopath::{AbsoluteSystemPath, AnchoredSystemPathBuf, PathError, RelativeUnixPathBuf};
 
-use crate::{hash_object::hash_objects, ls_tree::git_ls_tree, status::append_git_status, Error};
+use crate::{hash_object::hash_objects, Error, Git, Hasher};
 
 pub type GitHashes = HashMap<RelativeUnixPathBuf, String>;
 
-#[derive(Debug)]
-pub struct Git {
-    root: AbsoluteSystemPathBuf,
-    _bin: AbsoluteSystemPathBuf,
-}
-
-#[derive(Debug)]
-pub enum Hasher {
-    Git(Git),
-    Manual,
-}
-
 impl Hasher {
-    pub fn new(path_in_repo: &AbsoluteSystemPath) -> Hasher {
-        Git::find(path_in_repo)
-            .map(Hasher::Git)
-            .unwrap_or(Hasher::Manual)
-    }
-
     pub fn get_package_file_hashes<S: AsRef<str>>(
         &self,
         turbo_root: &AbsoluteSystemPath,
@@ -70,13 +48,6 @@ impl Hasher {
 }
 
 impl Git {
-    fn find(path_in_repo: &AbsoluteSystemPath) -> Option<Self> {
-        let bin = which::which("git").ok()?;
-        let bin = AbsoluteSystemPathBuf::try_from(bin).ok()?;
-        let root = find_git_root(path_in_repo).ok()?;
-        Some(Self { root, _bin: bin })
-    }
-
     fn get_package_file_hashes<S: AsRef<str>>(
         &self,
         turbo_root: &AbsoluteSystemPath,
@@ -98,9 +69,9 @@ impl Git {
         let full_pkg_path = turbo_root.resolve(package_path);
         let git_to_pkg_path = self.root.anchor(&full_pkg_path)?;
         let pkg_prefix = git_to_pkg_path.to_unix()?;
-        let mut hashes = git_ls_tree(&full_pkg_path)?;
+        let mut hashes = self.git_ls_tree(&full_pkg_path)?;
         // Note: to_hash is *git repo relative*
-        let to_hash = append_git_status(&full_pkg_path, &pkg_prefix, &mut hashes)?;
+        let to_hash = self.append_git_status(&full_pkg_path, &pkg_prefix, &mut hashes)?;
         hash_objects(&self.root, &full_pkg_path, to_hash, &mut hashes)?;
         Ok(hashes)
     }
@@ -182,41 +153,14 @@ impl Git {
     }
 }
 
-pub(crate) fn find_git_root(
-    turbo_root: &AbsoluteSystemPath,
-) -> Result<AbsoluteSystemPathBuf, Error> {
-    let rev_parse = Command::new("git")
-        .args(["rev-parse", "--show-cdup"])
-        .current_dir(turbo_root)
-        .output()?;
-    if !rev_parse.status.success() {
-        let stderr = String::from_utf8_lossy(&rev_parse.stderr);
-        return Err(Error::git_error(format!(
-            "git rev-parse --show-cdup error: {}",
-            stderr
-        )));
-    }
-    let cursor = std::io::Cursor::new(rev_parse.stdout);
-    let mut lines = cursor.byte_lines();
-    if let Some(line) = lines.next() {
-        let line = String::from_utf8(line?)?;
-        let tail = RelativeUnixPathBuf::new(line)?;
-        turbo_root.join_unix_path(tail).map_err(|e| e.into())
-    } else {
-        let stderr = String::from_utf8_lossy(&rev_parse.stderr);
-        Err(Error::git_error(format!(
-            "git rev-parse --show-cdup error: no values on stdout. stderr: {}",
-            stderr
-        )))
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use std::{assert_matches::assert_matches, process::Command};
+    use std::{collections::HashMap, process::Command};
+
+    use turbopath::{AbsoluteSystemPathBuf, RelativeUnixPathBuf};
 
     use super::*;
-    use crate::manual::get_package_file_hashes_from_processing_gitignore;
+    use crate::{manual::get_package_file_hashes_from_processing_gitignore, Hasher};
 
     fn tmp_dir() -> (tempfile::TempDir, AbsoluteSystemPathBuf) {
         let tmp_dir = tempfile::tempdir().unwrap();
@@ -272,28 +216,6 @@ mod tests {
             get_package_file_hashes_from_processing_gitignore(&git_root, &pkg_path, &["l*"])
                 .unwrap();
         assert!(manual_hashes.is_empty());
-    }
-
-    #[test]
-    fn test_symlinked_git_root() {
-        let (_, tmp_root) = tmp_dir();
-        let git_root = tmp_root.join_component("actual_repo");
-        git_root.create_dir_all().unwrap();
-        setup_repository(&git_root);
-        git_root.join_component("inside").create_dir_all().unwrap();
-        let link = tmp_root.join_component("link");
-        link.symlink_to_dir("actual_repo").unwrap();
-        let turbo_root = link.join_component("inside");
-        let result = find_git_root(&turbo_root).unwrap();
-        assert_eq!(result, link);
-    }
-
-    #[test]
-    fn test_no_git_root() {
-        let (_, tmp_root) = tmp_dir();
-        tmp_root.create_dir_all().unwrap();
-        let result = find_git_root(&tmp_root);
-        assert_matches!(result, Err(Error::Git(_, _)));
     }
 
     #[test]


### PR DESCRIPTION
### Description

 - move scm-related functions into a `Git` struct
 - rename `Hasher` to `SCM`
 - use turbopath more throughout
 - create an `SCM` instance in run outline and pass it to scope

### Testing Instructions

 Existing test suite
