### PR TITLE
Remove EnvironmentIntention

### DIFF
--- a/crates/node-file-trace/src/lib.rs
+++ b/crates/node-file-trace/src/lib.rs
@@ -44,7 +44,7 @@ use turbopack_core::{
     asset::{Asset, AssetVc, AssetsVc},
     compile_time_info::CompileTimeInfo,
     context::{AssetContext, AssetContextVc},
-    environment::{EnvironmentIntention, EnvironmentVc, ExecutionEnvironment, NodeJsEnvironment},
+    environment::{EnvironmentVc, ExecutionEnvironment, NodeJsEnvironment},
     issue::{IssueContextExt, IssueReporter, IssueSeverity, IssueVc},
     reference::all_assets,
     resolve::options::{ImportMapping, ResolvedMap},
@@ -636,16 +636,13 @@ async fn create_module_asset(
     module_options: TransientInstance<ModuleOptionsContext>,
     resolve_options: TransientInstance<ResolveOptionsContext>,
 ) -> Result<ModuleAssetContextVc> {
-    let env = EnvironmentVc::new(
-        Value::new(ExecutionEnvironment::NodeJsLambda(
-            NodeJsEnvironment {
-                cwd: OptionStringVc::cell(process_cwd),
-                ..Default::default()
-            }
-            .into(),
-        )),
-        Value::new(EnvironmentIntention::Api),
-    );
+    let env = EnvironmentVc::new(Value::new(ExecutionEnvironment::NodeJsLambda(
+        NodeJsEnvironment {
+            cwd: OptionStringVc::cell(process_cwd),
+            ..Default::default()
+        }
+        .into(),
+    )));
     let compile_time_info = CompileTimeInfo::builder(env).cell();
     let glob_mappings = vec![
         (

--- a/crates/turbopack-cli/src/dev/web_entry_source.rs
+++ b/crates/turbopack-cli/src/dev/web_entry_source.rs
@@ -21,7 +21,7 @@ use turbopack_core::{
     compile_time_defines,
     compile_time_info::{CompileTimeDefinesVc, CompileTimeInfo, CompileTimeInfoVc},
     context::AssetContextVc,
-    environment::{BrowserEnvironment, EnvironmentIntention, EnvironmentVc, ExecutionEnvironment},
+    environment::{BrowserEnvironment, EnvironmentVc, ExecutionEnvironment},
     reference_type::{EntryReferenceSubType, ReferenceType},
     resolve::{
         options::{ImportMap, ImportMapVc, ImportMapping},
@@ -187,8 +187,8 @@ pub fn client_defines() -> CompileTimeDefinesVc {
 
 #[turbo_tasks::function]
 pub fn get_client_compile_time_info(browserslist_query: &str) -> CompileTimeInfoVc {
-    CompileTimeInfo::builder(EnvironmentVc::new(
-        Value::new(ExecutionEnvironment::Browser(
+    CompileTimeInfo::builder(EnvironmentVc::new(Value::new(
+        ExecutionEnvironment::Browser(
             BrowserEnvironment {
                 dom: true,
                 web_worker: false,
@@ -196,9 +196,8 @@ pub fn get_client_compile_time_info(browserslist_query: &str) -> CompileTimeInfo
                 browserslist_query: browserslist_query.to_owned(),
             }
             .into(),
-        )),
-        Value::new(EnvironmentIntention::Client),
-    ))
+        ),
+    )))
     .defines(client_defines())
     .cell()
 }

--- a/crates/turbopack-core/src/environment.rs
+++ b/crates/turbopack-core/src/environment.rs
@@ -159,44 +159,16 @@ pub enum ChunkLoading {
 pub struct Environment {
     // members must be private to avoid leaking non-custom types
     execution: ExecutionEnvironment,
-    intention: EnvironmentIntention,
 }
 
 #[turbo_tasks::value_impl]
 impl EnvironmentVc {
     #[turbo_tasks::function]
-    pub fn new(
-        execution: Value<ExecutionEnvironment>,
-        intention: Value<EnvironmentIntention>,
-    ) -> Self {
+    pub fn new(execution: Value<ExecutionEnvironment>) -> Self {
         Self::cell(Environment {
             execution: execution.into_value(),
-            intention: intention.into_value(),
         })
     }
-}
-
-#[turbo_tasks::value(serialization = "auto_for_input")]
-#[derive(PartialOrd, Ord, Debug, Hash, Clone, Copy)]
-pub enum EnvironmentIntention {
-    /// Intent to compute data needed for rendering
-    Data,
-    /// Intent to intercept requests before server handling
-    Middleware,
-    /// Intent to handle api requests
-    Api,
-    /// Intent to prerender on a server for hydration on a client
-    Prerendering,
-    /// Intent to render on a server
-    ServerRendering,
-    /// Intent to render into static content
-    StaticRendering,
-    /// Intent to render on the client
-    Client,
-    /// Intent to evaluate build time javascript code like config, plugins, etc.
-    Build,
-    // TODO allow custom trait here
-    Custom(u8),
 }
 
 #[turbo_tasks::value(serialization = "auto_for_input")]

--- a/crates/turbopack-ecmascript/benches/analyzer.rs
+++ b/crates/turbopack-ecmascript/benches/analyzer.rs
@@ -14,7 +14,7 @@ use turbo_tasks::Value;
 use turbo_tasks_testing::VcStorage;
 use turbopack_core::{
     compile_time_info::CompileTimeInfo,
-    environment::{EnvironmentIntention, EnvironmentVc, ExecutionEnvironment, NodeJsEnvironment},
+    environment::{EnvironmentVc, ExecutionEnvironment, NodeJsEnvironment},
     target::CompileTargetVc,
 };
 use turbopack_ecmascript::analyzer::{
@@ -93,16 +93,15 @@ fn bench_link(b: &mut Bencher, input: &BenchInput) {
     b.to_async(rt).iter(|| async {
         for val in input.var_graph.values.values() {
             VcStorage::with(async {
-                let compile_time_info = CompileTimeInfo::builder(EnvironmentVc::new(
-                    Value::new(ExecutionEnvironment::NodeJsLambda(
+                let compile_time_info = CompileTimeInfo::builder(EnvironmentVc::new(Value::new(
+                    ExecutionEnvironment::NodeJsLambda(
                         NodeJsEnvironment {
                             compile_target: CompileTargetVc::unknown(),
                             ..Default::default()
                         }
                         .into(),
-                    )),
-                    Value::new(EnvironmentIntention::ServerRendering),
-                ))
+                    ),
+                )))
                 .cell();
                 link(
                     &input.var_graph,

--- a/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -3250,9 +3250,7 @@ mod tests {
     use turbo_tasks::{util::FormatDuration, Value};
     use turbopack_core::{
         compile_time_info::CompileTimeInfo,
-        environment::{
-            EnvironmentIntention, EnvironmentVc, ExecutionEnvironment, NodeJsEnvironment,
-        },
+        environment::{EnvironmentVc, ExecutionEnvironment, NodeJsEnvironment},
         target::{Arch, CompileTarget, Endianness, Libc, Platform},
     };
 
@@ -3515,8 +3513,8 @@ mod tests {
 
     async fn resolve(var_graph: &VarGraph, val: JsValue) -> JsValue {
         turbo_tasks_testing::VcStorage::with(async {
-            let compile_time_info = CompileTimeInfo::builder(EnvironmentVc::new(
-                Value::new(ExecutionEnvironment::NodeJsLambda(
+            let compile_time_info = CompileTimeInfo::builder(EnvironmentVc::new(Value::new(
+                ExecutionEnvironment::NodeJsLambda(
                     NodeJsEnvironment {
                         compile_target: CompileTarget {
                             arch: Arch::X64,
@@ -3528,9 +3526,8 @@ mod tests {
                         ..Default::default()
                     }
                     .into(),
-                )),
-                Value::new(EnvironmentIntention::ServerRendering),
-            ))
+                ),
+            )))
             .cell();
             link(
                 var_graph,

--- a/crates/turbopack-tests/tests/snapshot.rs
+++ b/crates/turbopack-tests/tests/snapshot.rs
@@ -38,10 +38,7 @@ use turbopack_core::{
     compile_time_defines,
     compile_time_info::CompileTimeInfo,
     context::{AssetContext, AssetContextVc},
-    environment::{
-        BrowserEnvironment, EnvironmentIntention, EnvironmentVc, ExecutionEnvironment,
-        NodeJsEnvironment,
-    },
+    environment::{BrowserEnvironment, EnvironmentVc, ExecutionEnvironment, NodeJsEnvironment},
     issue::IssueVc,
     reference::all_referenced_assets,
     reference_type::{EntryReferenceSubType, ReferenceType},
@@ -213,29 +210,26 @@ async fn run_test(resource: &str) -> Result<FileSystemPathVc> {
     let entry_asset = project_path.join(&options.entry);
     let entry_paths = vec![entry_asset];
 
-    let env = EnvironmentVc::new(
-        Value::new(match options.environment {
-            Environment::Browser => {
-                ExecutionEnvironment::Browser(
-                    // TODO: load more from options.json
-                    BrowserEnvironment {
-                        dom: true,
-                        web_worker: false,
-                        service_worker: false,
-                        browserslist_query: options.browserslist.to_owned(),
-                    }
-                    .into(),
-                )
-            }
-            Environment::NodeJs => {
-                ExecutionEnvironment::NodeJsBuildTime(
-                    // TODO: load more from options.json
-                    NodeJsEnvironment::default().into(),
-                )
-            }
-        }),
-        Value::new(EnvironmentIntention::Client),
-    );
+    let env = EnvironmentVc::new(Value::new(match options.environment {
+        Environment::Browser => {
+            ExecutionEnvironment::Browser(
+                // TODO: load more from options.json
+                BrowserEnvironment {
+                    dom: true,
+                    web_worker: false,
+                    service_worker: false,
+                    browserslist_query: options.browserslist.to_owned(),
+                }
+                .into(),
+            )
+        }
+        Environment::NodeJs => {
+            ExecutionEnvironment::NodeJsBuildTime(
+                // TODO: load more from options.json
+                NodeJsEnvironment::default().into(),
+            )
+        }
+    }));
     let compile_time_info = CompileTimeInfo::builder(env)
         .defines(
             compile_time_defines!(

--- a/crates/turbopack/benches/node_file_trace.rs
+++ b/crates/turbopack/benches/node_file_trace.rs
@@ -13,7 +13,7 @@ use turbopack::{
 use turbopack_core::{
     compile_time_info::CompileTimeInfo,
     context::AssetContext,
-    environment::{EnvironmentIntention, EnvironmentVc, ExecutionEnvironment, NodeJsEnvironment},
+    environment::{EnvironmentVc, ExecutionEnvironment, NodeJsEnvironment},
     reference_type::ReferenceType,
     source_asset::SourceAssetVc,
 };
@@ -80,12 +80,9 @@ fn bench_emit(b: &mut Bencher, bench_input: &BenchInput) {
                 let output_dir = output_fs.root();
 
                 let source = SourceAssetVc::new(input);
-                let compile_time_info = CompileTimeInfo::builder(EnvironmentVc::new(
-                    Value::new(ExecutionEnvironment::NodeJsLambda(
-                        NodeJsEnvironment::default().into(),
-                    )),
-                    Value::new(EnvironmentIntention::ServerRendering),
-                ))
+                let compile_time_info = CompileTimeInfo::builder(EnvironmentVc::new(Value::new(
+                    ExecutionEnvironment::NodeJsLambda(NodeJsEnvironment::default().into()),
+                )))
                 .cell();
                 let context = ModuleAssetContextVc::new(
                     TransitionsByNameVc::cell(HashMap::new()),

--- a/crates/turbopack/examples/turbopack.rs
+++ b/crates/turbopack/examples/turbopack.rs
@@ -27,7 +27,7 @@ use turbopack::{
 use turbopack_core::{
     compile_time_info::CompileTimeInfoVc,
     context::AssetContext,
-    environment::{EnvironmentIntention, EnvironmentVc, ExecutionEnvironment, NodeJsEnvironment},
+    environment::{EnvironmentVc, ExecutionEnvironment, NodeJsEnvironment},
     source_asset::SourceAssetVc,
     PROJECT_FILESYSTEM_NAME,
 };
@@ -54,12 +54,9 @@ async fn main() -> Result<()> {
             let source = SourceAssetVc::new(entry);
             let context = turbopack::ModuleAssetContextVc::new(
                 TransitionsByNameVc::cell(HashMap::new()),
-                CompileTimeInfoVc::new(EnvironmentVc::new(
-                    Value::new(ExecutionEnvironment::NodeJsLambda(
-                        NodeJsEnvironment::default().into(),
-                    )),
-                    Value::new(EnvironmentIntention::ServerRendering),
-                )),
+                CompileTimeInfoVc::new(EnvironmentVc::new(Value::new(
+                    ExecutionEnvironment::NodeJsLambda(NodeJsEnvironment::default().into()),
+                ))),
                 Default::default(),
                 ResolveOptionsContext {
                     enable_typescript: true,

--- a/crates/turbopack/src/evaluate_context.rs
+++ b/crates/turbopack/src/evaluate_context.rs
@@ -6,7 +6,7 @@ use turbopack_core::{
     compile_time_defines,
     compile_time_info::CompileTimeInfo,
     context::AssetContextVc,
-    environment::{EnvironmentIntention, EnvironmentVc, ExecutionEnvironment, NodeJsEnvironment},
+    environment::{EnvironmentVc, ExecutionEnvironment, NodeJsEnvironment},
     resolve::options::{ImportMap, ImportMapVc, ImportMapping},
 };
 use turbopack_node::execution_context::ExecutionContextVc;
@@ -18,12 +18,9 @@ use crate::{
 
 #[turbo_tasks::function]
 pub fn node_build_environment() -> EnvironmentVc {
-    EnvironmentVc::new(
-        Value::new(ExecutionEnvironment::NodeJsBuildTime(
-            NodeJsEnvironment::default().cell(),
-        )),
-        Value::new(EnvironmentIntention::Build),
-    )
+    EnvironmentVc::new(Value::new(ExecutionEnvironment::NodeJsBuildTime(
+        NodeJsEnvironment::default().cell(),
+    )))
 }
 
 #[turbo_tasks::function]

--- a/crates/turbopack/tests/node-file-trace.rs
+++ b/crates/turbopack/tests/node-file-trace.rs
@@ -36,7 +36,7 @@ use turbopack_core::asset::Asset;
 use turbopack_core::{
     compile_time_info::CompileTimeInfoVc,
     context::AssetContext,
-    environment::{EnvironmentIntention, EnvironmentVc, ExecutionEnvironment, NodeJsEnvironment},
+    environment::{EnvironmentVc, ExecutionEnvironment, NodeJsEnvironment},
     reference_type::ReferenceType,
     source_asset::SourceAssetVc,
 };
@@ -415,12 +415,9 @@ fn node_file_trace<B: Backend + 'static>(
                     // TODO It's easy to make a mistake here as this should match the config in the
                     // binary. TODO These test cases should move into the
                     // `node-file-trace` crate and use the same config.
-                    CompileTimeInfoVc::new(EnvironmentVc::new(
-                        Value::new(ExecutionEnvironment::NodeJsLambda(
-                            NodeJsEnvironment::default().into(),
-                        )),
-                        Value::new(EnvironmentIntention::ServerRendering),
-                    )),
+                    CompileTimeInfoVc::new(EnvironmentVc::new(Value::new(
+                        ExecutionEnvironment::NodeJsLambda(NodeJsEnvironment::default().into()),
+                    ))),
                     ModuleOptionsContext {
                         enable_types: true,
                         ..Default::default()


### PR DESCRIPTION
### Description

This PR removes the `EnvironmentIntention` enum entirely. The enum wasn't being used anywhere and created artificial differences between environments that weren't useful (nor respected in some cases).

Next.js PR: https://github.com/vercel/next.js/pull/51965

### Testing Instructions

CI