### PR TITLE
ci: remove replacement usage from goreleaser

### DIFF
--- a/cli/combined-shim.yml
+++ b/cli/combined-shim.yml
@@ -29,10 +29,13 @@ snapshot:
   name_template: "{{ incpatch .Version }}"
 archives:
   - id: github
-    name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
+    name_template: >-
+      {{ .ProjectName }}-
+      {{ .Version }}-
+      {{- title .Os }}-
+      {{- if eq .Arch "amd64" }}64
+      {{- else }}{{ .Arch }}{{ end }}
     wrap_in_directory: true
-    replacements:
-      amd64: 64
     format: tar.gz
     format_overrides:
       - goos: windows
@@ -41,10 +44,12 @@ archives:
       - LICENSE
       - README.md
   - id: npm
-    name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
+    name_template: >-
+      {{ .ProjectName }}-
+      {{ - title .Os }}-
+      {{- if eq .Arch "amd64" }}64
+      {{- else }}{{ .Arch }}{{ end }}
     wrap_in_directory: true
-    replacements:
-      amd64: 64
     format: tar.gz
     files:
       - LICENSE


### PR DESCRIPTION
### Description

As of the latest version of GoReleaser the `replacements` field is [removed and results in an error](https://goreleaser.com/deprecations/?h=replacements#archivesreplacements) 

### Testing Instructions

`brew install goreleaser` to get the latest version and then `goreleaser -f combined-shim.yml --snapshot` and verify we no longer get a YAML marshal error
