### PR TITLE
ci: revert to older goreleaser version

### DIFF
--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -298,7 +298,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
-          version: latest
+          version: v1.18.2
           install-only: true
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -138,7 +138,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
-          version: latest
+          version: v1.18.2
           install-only: true
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
@@ -186,7 +186,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
-          version: latest
+          version: v1.18.2
           install-only: true
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/cli/combined-shim.yml
+++ b/cli/combined-shim.yml
@@ -29,13 +29,10 @@ snapshot:
   name_template: "{{ incpatch .Version }}"
 archives:
   - id: github
-    name_template: >-
-      {{ .ProjectName }}-
-      {{ .Version }}-
-      {{- title .Os }}-
-      {{- if eq .Arch "amd64" }}64
-      {{- else }}{{ .Arch }}{{ end }}
+    name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
     wrap_in_directory: true
+    replacements:
+      amd64: 64
     format: tar.gz
     format_overrides:
       - goos: windows
@@ -44,12 +41,10 @@ archives:
       - LICENSE
       - README.md
   - id: npm
-    name_template: >-
-      {{ .ProjectName }}-
-      {{ - title .Os }}-
-      {{- if eq .Arch "amd64" }}64
-      {{- else }}{{ .Arch }}{{ end }}
+    name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
     wrap_in_directory: true
+    replacements:
+      amd64: 64
     format: tar.gz
     files:
       - LICENSE


### PR DESCRIPTION
### Description

- Pin the goreleaser version to the last successful release ([1.18.2](https://github.com/vercel/turbo/actions/runs/5403991582/jobs/9818340124#step:8:14))
- Revert commit that swapped out the use of `replaces` #5424 

### Testing Instructions

See actions docs about the [version flag](https://github.com/goreleaser/goreleaser-action/tree/master#inputs)
