### PR TITLE
fix(glob): add glob pattern codemods into globwalk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2828,6 +2828,7 @@ dependencies = [
  "tempdir",
  "test-case",
  "thiserror",
+ "tracing",
  "turbopath",
  "walkdir",
  "wax",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2824,6 +2824,7 @@ version = "0.1.0"
 dependencies = [
  "itertools",
  "path-slash",
+ "regex",
  "tempdir",
  "test-case",
  "thiserror",

--- a/crates/turborepo-globwalk/Cargo.toml
+++ b/crates/turborepo-globwalk/Cargo.toml
@@ -9,6 +9,7 @@ license = "MPL-2.0"
 [dependencies]
 itertools.workspace = true
 path-slash = "0.2.1"
+regex.workspace = true
 thiserror.workspace = true
 turbopath.workspace = true
 walkdir = "2.3.3"

--- a/crates/turborepo-globwalk/Cargo.toml
+++ b/crates/turborepo-globwalk/Cargo.toml
@@ -11,6 +11,7 @@ itertools.workspace = true
 path-slash = "0.2.1"
 regex.workspace = true
 thiserror.workspace = true
+tracing = "0.1.37"
 turbopath.workspace = true
 walkdir = "2.3.3"
 wax.workspace = true

--- a/crates/turborepo-globwalk/src/lib.rs
+++ b/crates/turborepo-globwalk/src/lib.rs
@@ -201,7 +201,8 @@ fn preprocess_paths_and_globs(
     let mut exclude_paths = vec![];
     for split in exclude
         .iter()
-        .map(|s| join_unix_like_paths(&base_path_slash, s))
+        .map(|s| fix_glob_pattern(s))
+        .map(|s| join_unix_like_paths(&base_path_slash, &s))
         .filter_map(|g| collapse_path(&g).map(|(s, _)| s.to_string()))
     {
         let split = split.to_string();
@@ -613,6 +614,8 @@ mod test {
     }
 
     #[test_case("a*/**", 22, 22 => matches None ; "wildcard followed by doublestar")]
+    #[test_case("**/*f", 4, 4 => matches None ; "leading doublestar expansion")]
+    #[test_case("**f", 4, 4 => matches None ; "transform leading doublestar")]
     #[test_case("a**", 22, 22 => matches None ; "transform trailing doublestar")]
     #[test_case("abc", 1, 1 => matches None ; "exact match")]
     #[test_case("*", 19, 15 => matches None ; "single star match")]

--- a/crates/turborepo-globwalk/src/lib.rs
+++ b/crates/turborepo-globwalk/src/lib.rs
@@ -242,7 +242,7 @@ fn trailing_doublestar() -> &'static Regex {
     RE.get_or_init(|| Regex::new(r"(?P<prefix>[^*/]+)\*\*").unwrap())
 }
 
-fn fix_glob_pattern(pattern: &str) -> String {
+pub fn fix_glob_pattern(pattern: &str) -> String {
     let p1 = double_doublestar().replace(pattern, "**");
     let p2 = leading_doublestar().replace(&p1, "**/*$suffix");
     let p3 = trailing_doublestar().replace(&p2, "$prefix*/**");

--- a/crates/turborepo-scm/src/manual.rs
+++ b/crates/turborepo-scm/src/manual.rs
@@ -1,5 +1,6 @@
 use std::{fs::Metadata, io::Read};
 
+use globwalk::fix_glob_pattern;
 use hex::ToHex;
 use ignore::WalkBuilder;
 use sha1::{Digest, Sha1};
@@ -58,11 +59,11 @@ pub(crate) fn get_package_file_hashes_from_processing_gitignore<S: AsRef<str>>(
     for pattern in inputs {
         let pattern = pattern.as_ref();
         if let Some(exclusion) = pattern.strip_prefix('!') {
-            let glob = exclusion.into_unix();
+            let glob = fix_glob_pattern(exclusion).into_unix();
             let g = Glob::new(glob.as_str()).map(|g| g.into_owned())?;
             excludes.push(g);
         } else {
-            let glob = pattern.into_unix();
+            let glob = fix_glob_pattern(pattern).into_unix();
             let g = Glob::new(glob.as_str()).map(|g| g.into_owned())?;
             includes.push(g);
         }


### PR DESCRIPTION
### Description

Bad globs were more common than expected and used in places other than `turbo.json` where we shouldn't be as prescriptive e.g. `pnpm-workspace.yaml`

### Testing Instructions

Added some unit tests to verify that common glob fixes match what we expect them to match. Manual testing of a repository with a bad glob as `inputs`
