### PR TITLE
fix(turborepo) Set package inference and single_package even without a repo state

### DIFF
--- a/crates/turborepo-lib/src/cli.rs
+++ b/crates/turborepo-lib/src/cli.rs
@@ -596,28 +596,36 @@ pub async fn run(
         Command::Run(Box::new(run_args))
     };
 
-    let mut pkg_inference_root = None;
-    // If this is a run command, and we know the actual invocation path, set the
-    // inference root, as long as the user hasn't overridden the cwd
-    if cli_args.cwd.is_none() && matches!(command, Command::Run(_)) {
-        if let Ok(invocation_dir) = env::var(INVOCATION_DIR_ENV_VAR) {
-            let invocation_path = Path::new(&invocation_dir);
+    // Set some run flags if we have the data and are executing a Run
+    if let Command::Run(run_args) = &mut command {
+        // Don't overwrite the flag if it's already been set for whatever reason
+        run_args.single_package = run_args.single_package
+            || repo_state
+                .as_ref()
+                .map(|repo_state| matches!(repo_state.mode, RepoMode::SinglePackage))
+                .unwrap_or(false);
+        // If this is a run command, and we know the actual invocation path, set the
+        // inference root, as long as the user hasn't overridden the cwd
+        if cli_args.cwd.is_none() {
+            if let Ok(invocation_dir) = env::var(INVOCATION_DIR_ENV_VAR) {
+                let invocation_path = Path::new(&invocation_dir);
 
-            // If repo state doesn't exist, we're either local turbo running at the root
-            // (cwd), or inference failed.
-            // If repo state does exist, we're global turbo, and want to calculate
-            // package inference based on the repo root
-            let this_dir = AbsoluteSystemPathBuf::cwd()?;
-            let repo_root = repo_state.as_ref().map_or(&this_dir, |r| &r.root);
-            if let Ok(relative_path) = invocation_path.strip_prefix(repo_root) {
-                debug!("pkg_inference_root set to \"{}\"", relative_path.display());
-                let utf8_path = relative_path
-                    .to_str()
-                    .ok_or_else(|| anyhow!("invalid utf8 path: {:?}", relative_path))?;
-                pkg_inference_root = Some(utf8_path.to_owned());
+                // If repo state doesn't exist, we're either local turbo running at the root
+                // (cwd), or inference failed.
+                // If repo state does exist, we're global turbo, and want to calculate
+                // package inference based on the repo root
+                let this_dir = AbsoluteSystemPathBuf::cwd()?;
+                let repo_root = repo_state.as_ref().map_or(&this_dir, |r| &r.root);
+                if let Ok(relative_path) = invocation_path.strip_prefix(repo_root) {
+                    debug!("pkg_inference_root set to \"{}\"", relative_path.display());
+                    let utf8_path = relative_path
+                        .to_str()
+                        .ok_or_else(|| anyhow!("invalid utf8 path: {:?}", relative_path))?;
+                    run_args.pkg_inference_root = Some(utf8_path.to_owned());
+                }
+            } else {
+                debug!("{} not set", INVOCATION_DIR_ENV_VAR);
             }
-        } else {
-            debug!("{} not set", INVOCATION_DIR_ENV_VAR);
         }
     }
 
@@ -634,19 +642,6 @@ pub async fn run(
 
     let version = get_version();
 
-    // Save all the mutation for the end. In the future, we should refactor this
-    // into a "parse don't validate" scheme where we construct a config struct
-    // that is contains all of the normalized, validated, and defaulted values.
-    if let Some(repo_state) = repo_state {
-        if let Command::Run(run_args) = &mut command {
-            if let Some(pkg_inference_root) = pkg_inference_root {
-                run_args.pkg_inference_root = Some(pkg_inference_root);
-            }
-            // Don't overwrite the flag if it's already been set for whatever reason
-            run_args.single_package =
-                run_args.single_package || matches!(repo_state.mode, RepoMode::SinglePackage);
-        }
-    }
     cli_args.command = Some(command);
     cli_args.cwd = Some(repo_root.as_path().to_owned());
 

--- a/turborepo-tests/integration/tests/pkg-inference.t
+++ b/turborepo-tests/integration/tests/pkg-inference.t
@@ -1,0 +1,20 @@
+Setup
+  $ . ${TESTDIR}/../../helpers/setup.sh
+  $ . ${TESTDIR}/_helpers/setup_monorepo.sh $(pwd)
+
+# Run as if called by global turbo
+  $ TURBO_INVOCATION_DIR=$(pwd)/packages/util ${TURBO} build --skip-infer
+  \xe2\x80\xa2 Packages in scope: util (esc)
+  \xe2\x80\xa2 Running build in 1 packages (esc)
+  \xe2\x80\xa2 Remote caching disabled (esc)
+  util:build: cache miss, executing 76ab904c7ecb2d51
+  util:build: 
+  util:build: > build
+  util:build: > echo 'building'
+  util:build: 
+  util:build: building
+  
+   Tasks:    1 successful, 1 total
+  Cached:    0 cached, 1 total
+    Time:\s*[\.0-9]+m?s  (re)
+  


### PR DESCRIPTION
### Description

 - don't gate setting flags on the existence of `repo_state`. In local turbo, it usually doesn't exist

### Testing Instructions

Verified experimentally. 
Added an integration test

Fixes #5429 