### PR TITLE
add glob pattern codemods into globwalk

### DIFF
--- a/crates/turborepo-globwalk/src/lib.rs
+++ b/crates/turborepo-globwalk/src/lib.rs
@@ -242,7 +242,7 @@ fn trailing_doublestar() -> &'static Regex {
     RE.get_or_init(|| Regex::new(r"(?P<prefix>[^*/]+)\*\*").unwrap())
 }
 
-fn fix_glob_pattern(pattern: &str) -> String {
+pub fn fix_glob_pattern(pattern: &str) -> String {
     let p1 = double_doublestar().replace(pattern, "**");
     let p2 = leading_doublestar().replace(&p1, "**/*$suffix");
     let p3 = trailing_doublestar().replace(&p2, "$prefix*/**");


### PR DESCRIPTION
### Description

 - uses expanded globs in workspace discovery
 - adds text of failed globs to returned errors

### Testing Instructions

 - verified experimentally that it handles `!**/dist**`
