### PR TITLE
fix(turborepo): Convert globs to slashes on windows, test go when rust changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -183,7 +183,7 @@ jobs:
       turbopack_typescript: ${{ steps.ci.outputs.diff != '' || steps.turbopack_typescript.outputs.diff != '' }}
       turborepo_rust: ${{ steps.ci.outputs.diff != '' || steps.turborepo_rust.outputs.diff != '' }}
       turbopack_bench: ${{ steps.ci.outputs.diff != '' || steps.turbopack_bench.outputs.diff != '' }}
-      go: ${{ steps.ci.outputs.diff != '' || steps.turborepo_go.outputs.diff != '' }}
+      go: ${{ steps.ci.outputs.diff != '' || steps.turborepo_go.outputs.diff != '' || steps.turborepo_rust.outputs.diff != '' }}
       turborepo_e2e: ${{ steps.ci.outputs.diff != '' || steps.turborepo_go.outputs.diff != '' || steps.turborepo_rust.outputs.diff != ''  || steps.turborepo_e2e.outputs.diff != '' }}
       go_integration: ${{ steps.ci.outputs.diff != '' || steps.turborepo_go.outputs.diff != '' || steps.turborepo_rust.outputs.diff != ''  || steps.turborepo_integration.outputs.diff != '' }}
       examples: ${{ steps.ci.outputs.diff != '' || steps.turborepo_go.outputs.diff != '' || steps.turborepo_rust.outputs.diff != '' || steps.examples.outputs.diff != '' }}

--- a/cli/internal/hashing/package_deps_hash_test.go
+++ b/cli/internal/hashing/package_deps_hash_test.go
@@ -478,7 +478,6 @@ func Test_getPackageFileHashesFromProcessingGitIgnore(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to calculate manual hashes: %v", err)
 	}
-	t.Logf("hashes %v", justFileHashes)
 	for path, spec := range files {
 		systemPath := path.ToSystemPath()
 		if systemPath.HasPrefix(pkgName) {

--- a/cli/internal/hashing/package_deps_hash_test.go
+++ b/cli/internal/hashing/package_deps_hash_test.go
@@ -478,6 +478,7 @@ func Test_getPackageFileHashesFromProcessingGitIgnore(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to calculate manual hashes: %v", err)
 	}
+	t.Logf("hashes %v", justFileHashes)
 	for path, spec := range files {
 		systemPath := path.ToSystemPath()
 		if systemPath.HasPrefix(pkgName) {

--- a/crates/turborepo-globwalk/src/lib.rs
+++ b/crates/turborepo-globwalk/src/lib.rs
@@ -245,10 +245,24 @@ fn trailing_doublestar() -> &'static Regex {
 
 pub fn fix_glob_pattern(pattern: &str) -> String {
     // This is a no-op on unix systems, but converts to slashes on windows
+    #[cfg(not(windows))]
+    let needs_trailing_slash = false;
+    #[cfg(windows)]
+    let needs_trailing_slash = pattern.ends_with('/') || pattern.ends_with('\\');
     let converted = Path::new(pattern)
         .to_slash()
         .expect("failed to roundtrip through Path");
-    let p1 = double_doublestar().replace(&converted, "**");
+    // TODO: consider inlining path-slash to handle this bug
+    // technically this won't happen on unix, the to_slash conversion
+    // is a no-op, so it doesn't strip trailing slashes. path-slash
+    // strips trailing _unix_ slashes from windows paths, rather than
+    // "converting" (leaving) them.
+    let p0 = if needs_trailing_slash {
+        format!("{}/", converted)
+    } else {
+        converted.to_string()
+    };
+    let p1 = double_doublestar().replace(&p0, "**");
     let p2 = leading_doublestar().replace(&p1, "**/*$suffix");
     let p3 = trailing_doublestar().replace(&p2, "$prefix*/**");
 

--- a/crates/turborepo-globwalk/src/lib.rs
+++ b/crates/turborepo-globwalk/src/lib.rs
@@ -244,7 +244,11 @@ fn trailing_doublestar() -> &'static Regex {
 }
 
 pub fn fix_glob_pattern(pattern: &str) -> String {
-    let p1 = double_doublestar().replace(pattern, "**");
+    // This is a no-op on unix systems, but converts to slashes on windows
+    let converted = Path::new(pattern)
+        .to_slash()
+        .expect("failed to roundtrip through Path");
+    let p1 = double_doublestar().replace(&converted, "**");
     let p2 = leading_doublestar().replace(&p1, "**/*$suffix");
     let p3 = trailing_doublestar().replace(&p2, "$prefix*/**");
 


### PR DESCRIPTION
### Description

 - call `.to_slash` on globs before fixing them up. They should be in unix format anyways
 - add turborepo-rust changes to the set of triggers for running Go unit tests, which would've caught this earlier

### Testing Instructions

Existing test suite, including Go unit tests which should now run.
