### PR TITLE
Fix internal JS/TS references not being processed

### DIFF
--- a/crates/turbopack/src/module_options/mod.rs
+++ b/crates/turbopack/src/module_options/mod.rs
@@ -225,7 +225,7 @@ impl ModuleOptionsVc {
                 ModuleRuleCondition::ResourcePathEndsWith(".json".to_string()),
                 vec![ModuleRuleEffect::ModuleType(ModuleType::Json)],
             ),
-            ModuleRule::new(
+            ModuleRule::new_all(
                 ModuleRuleCondition::any(vec![
                     ModuleRuleCondition::ResourcePathEndsWith(".js".to_string()),
                     ModuleRuleCondition::ResourcePathEndsWith(".jsx".to_string()),
@@ -255,7 +255,7 @@ impl ModuleOptionsVc {
                     },
                 })],
             ),
-            ModuleRule::new(
+            ModuleRule::new_all(
                 ModuleRuleCondition::any(vec![
                     ModuleRuleCondition::ResourcePathEndsWith(".ts".to_string()),
                     ModuleRuleCondition::ResourcePathEndsWith(".tsx".to_string()),

--- a/crates/turbopack/src/module_options/module_rule.rs
+++ b/crates/turbopack/src/module_options/module_rule.rs
@@ -18,20 +18,21 @@ pub struct ModuleRule {
     match_mode: MatchMode,
 }
 
-#[derive(Default, Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, TraceRawVcs)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, TraceRawVcs)]
 enum MatchMode {
     // Match all but internal references.
-    #[default]
-    Default,
+    NonInternal,
     // Only match internal references.
     Internal,
+    // Match both internal and non-internal references.
+    All,
 }
 
 impl MatchMode {
     fn matches(&self, reference_type: &ReferenceType) -> bool {
         matches!(
             (self, reference_type.is_internal()),
-            (MatchMode::Default, false) | (MatchMode::Internal, true)
+            (MatchMode::All, _) | (MatchMode::NonInternal, false) | (MatchMode::Internal, true)
         )
     }
 }
@@ -42,7 +43,7 @@ impl ModuleRule {
         ModuleRule {
             condition,
             effects,
-            match_mode: Default::default(),
+            match_mode: MatchMode::NonInternal,
         }
     }
 
@@ -52,6 +53,15 @@ impl ModuleRule {
             condition,
             effects,
             match_mode: MatchMode::Internal,
+        }
+    }
+
+    /// Creates a new module rule. Will only matches internal references.
+    pub fn new_all(condition: ModuleRuleCondition, effects: Vec<ModuleRuleEffect>) -> Self {
+        ModuleRule {
+            condition,
+            effects,
+            match_mode: MatchMode::All,
         }
     }
 


### PR DESCRIPTION
### Description

My recent change in #5397 added a way to create rules that only apply to internal references. In the process, I also made it so the default rules don't apply to internal references as well. However, we still need them to apply to TS and JS files, as we use that with ReferenceType::Internal in Next.js.

### Testing Instructions

Next.js CI