### PR TITLE
fix(ci): Pinning action versions

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -27,7 +27,7 @@ runs:
         version: 7.12.1
 
     - name: Setup Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v3.6.0
       with:
         node-version: ${{ inputs.node-version }}
         cache: pnpm

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1376,7 +1376,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v3.6.0
         with:
           node-version: 18
 


### PR DESCRIPTION
### Description

Seems like `setup-node@3.7.0` broke our CI. Pinning out version to `3.6.0`

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
