### PR TITLE
chore: Windows ARM Compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3016,6 +3016,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "hostname"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9562,14 +9571,15 @@ dependencies = [
  "chrono",
  "dunce",
  "hex",
+ "hmac",
  "lazy_static",
  "libc",
  "os_str_bytes",
  "path-clean 1.0.1",
  "petgraph",
- "ring",
  "serde",
  "serde_json",
+ "sha2",
  "tar",
  "tempfile",
  "test-case",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,7 +133,7 @@ turborepo-cache = { path = "crates/turborepo-cache" }
 turborepo-env = { path = "crates/turborepo-env" }
 turborepo-ffi = { path = "crates/turborepo-ffi" }
 turborepo-fs = { path = "crates/turborepo-fs" }
-turborepo-lib = { path = "crates/turborepo-lib" }
+turborepo-lib = { path = "crates/turborepo-lib", default-features = false }
 turborepo-lockfiles = { path = "crates/turborepo-lockfiles" }
 turborepo-scm = { path = "crates/turborepo-scm" }
 wax = { path = "crates/turborepo-wax" }

--- a/crates/turborepo-cache/Cargo.toml
+++ b/crates/turborepo-cache/Cargo.toml
@@ -23,13 +23,14 @@ camino = { workspace = true }
 chrono = { workspace = true }
 dunce = { workspace = true }
 hex = { workspace = true }
+hmac = "0.12.1"
 lazy_static = { workspace = true }
 os_str_bytes = "6.5.0"
 path-clean = { workspace = true }
 petgraph = "0.6.3"
-ring = "0.16.20"
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+sha2 = { workspace = true }
 tar = "0.4.38"
 thiserror = { workspace = true }
 tracing = { workspace = true }

--- a/crates/turborepo-cache/src/cache_archive/restore.rs
+++ b/crates/turborepo-cache/src/cache_archive/restore.rs
@@ -1,7 +1,7 @@
 use std::{backtrace::Backtrace, collections::HashMap, io::Read};
 
 use petgraph::graph::DiGraph;
-use ring::digest::{Context, SHA512};
+use sha2::{Digest, Sha512};
 use tar::Entry;
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPathBuf};
 
@@ -46,7 +46,7 @@ impl CacheReader {
     }
 
     pub fn get_sha(mut self) -> Result<Vec<u8>, CacheError> {
-        let mut context = Context::new(&SHA512);
+        let mut context = Sha512::new();
         let mut buffer = [0; 8192];
         loop {
             let n = self.reader.read(&mut buffer)?;
@@ -56,7 +56,7 @@ impl CacheReader {
             context.update(&buffer[..n]);
         }
 
-        Ok(context.finish().as_ref().to_vec())
+        Ok(context.finalize().to_vec())
     }
 
     pub fn restore(

--- a/crates/turborepo-cache/src/signature_authentication.rs
+++ b/crates/turborepo-cache/src/signature_authentication.rs
@@ -1,12 +1,12 @@
 use std::env;
 
 use base64::{prelude::BASE64_STANDARD, Engine};
+use hmac::{Hmac, Mac};
 use os_str_bytes::OsStringBytes;
-use ring::{
-    hmac,
-    hmac::{Algorithm, Tag, HMAC_SHA256},
-};
+use sha2::Sha256;
 use thiserror::Error;
+
+type HmacSha256 = Hmac<Sha256>;
 
 #[derive(Debug, Error)]
 pub enum SignatureError {
@@ -19,9 +19,9 @@ pub enum SignatureError {
     SerializationError(#[from] serde_json::Error),
     #[error("base64 encoding error: {0}")]
     Base64EncodingError(#[from] base64::DecodeError),
+    #[error(transparent)]
+    Hmac(#[from] hmac::digest::InvalidLength),
 }
-
-static TURBO_HMAC_ALGORITHM: Algorithm = HMAC_SHA256;
 
 #[derive(Debug)]
 pub struct ArtifactSignatureAuthenticator {
@@ -59,26 +59,25 @@ impl ArtifactSignatureAuthenticator {
         Ok(metadata)
     }
 
-    fn get_tag_generator(&self, hash: &[u8]) -> Result<hmac::Context, SignatureError> {
-        let secret_key = hmac::Key::new(TURBO_HMAC_ALGORITHM, &self.secret_key()?);
+    fn get_tag_generator(&self, hash: &[u8]) -> Result<HmacSha256, SignatureError> {
+        let mut mac = HmacSha256::new_from_slice(&self.secret_key()?)?;
         let metadata = self.construct_metadata(hash)?;
 
-        let mut hmac_ctx = hmac::Context::with_key(&secret_key);
-        hmac_ctx.update(&metadata);
+        mac.update(&metadata);
 
-        Ok(hmac_ctx)
+        Ok(mac)
     }
 
     pub fn generate_tag_bytes(
         &self,
         hash: &[u8],
         artifact_body: &[u8],
-    ) -> Result<Tag, SignatureError> {
-        let mut hmac_ctx = self.get_tag_generator(hash)?;
+    ) -> Result<Vec<u8>, SignatureError> {
+        let mut mac = self.get_tag_generator(hash)?;
 
-        hmac_ctx.update(artifact_body);
-        let hmac_output = hmac_ctx.sign();
-        Ok(hmac_output)
+        mac.update(artifact_body);
+        let hmac_output = mac.finalize();
+        Ok(hmac_output.into_bytes().to_vec())
     }
 
     pub fn generate_tag(
@@ -89,8 +88,8 @@ impl ArtifactSignatureAuthenticator {
         let mut hmac_ctx = self.get_tag_generator(hash)?;
 
         hmac_ctx.update(artifact_body);
-        let hmac_output = hmac_ctx.sign();
-        Ok(BASE64_STANDARD.encode(hmac_output))
+        let hmac_output = hmac_ctx.finalize();
+        Ok(BASE64_STANDARD.encode(hmac_output.into_bytes()))
     }
 
     pub fn validate(
@@ -99,11 +98,11 @@ impl ArtifactSignatureAuthenticator {
         artifact_body: &[u8],
         expected_tag: &str,
     ) -> Result<bool, SignatureError> {
-        let secret_key = hmac::Key::new(TURBO_HMAC_ALGORITHM, &self.secret_key()?);
+        let mac = HmacSha256::new_from_slice(&self.secret_key()?)?;
         let mut message = self.construct_metadata(hash)?;
         message.extend(artifact_body);
         let expected_bytes = BASE64_STANDARD.decode(expected_tag)?;
-        Ok(hmac::verify(&secret_key, &message, &expected_bytes).is_ok())
+        Ok(mac.verify_slice(&expected_bytes).is_ok())
     }
 }
 

--- a/crates/turborepo-lib/src/cli.rs
+++ b/crates/turborepo-lib/src/cli.rs
@@ -577,7 +577,7 @@ impl Default for LogPrefix {
 #[tokio::main]
 pub async fn run(
     repo_state: Option<RepoState>,
-    _logger: &TurboSubscriber,
+    #[allow(unused_variables)] logger: &TurboSubscriber,
     ui: UI,
 ) -> Result<Payload> {
     let mut cli_args = Args::new()?;
@@ -651,10 +651,7 @@ pub async fn run(
 
             Ok(Payload::Rust(Ok(0)))
         }
-        Command::Daemon {
-            command,
-            idle_time: _,
-        } => {
+        Command::Daemon { command, idle_time } => {
             let base = CommandBase::new(cli_args.clone(), repo_root, version, ui)?;
 
             match command {

--- a/crates/turborepo/Cargo.toml
+++ b/crates/turborepo/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MPL-2.0"
 
 [features]
-# By default, we enable native-tls for reqwest via downstream transitive features.
+# By default, we enable rustls-tls for reqwest via downstream transitive features.
 # This is for the convenience of running daily dev workflows, i.e running
 # `cargo xxx` without explicitly specifying features, not that we want to
 # promote this as default backend.
@@ -38,7 +38,7 @@ serde_yaml = { workspace = true }
 tiny-gradient = { workspace = true }
 tokio-util = { version = "0.7.7", features = ["io"] }
 tracing = { workspace = true }
-turborepo-lib = { workspace = true }
+turborepo-lib = { workspace = true, default-features = false }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = "0.3.9"


### PR DESCRIPTION
### Description

Removed ring as a required dependency, so that we can build Turbo natively on Windows ARM with the `aarch64-pc-windows-msvc` target. This does *not* let us distribute a native binary because we still have the MinGW/MSVC incompatibility between Go and Rust. However, it does allow us to run Rust tests on Windows ARM, and even build a full, albeit buggy `turbo` binary.

### Testing Instructions

Try it out on Windows ARM! Will require a 64 bit C toolchain and the following incantation `cargo build -p turbo --no-default features --features native-tls`
