### PR TITLE
fix(turborepo): use serde_jsonc recommended pattern.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9692,7 +9692,6 @@ dependencies = [
  "rustc_version_runtime",
  "semver 1.0.17",
  "serde",
- "serde_json",
  "serde_jsonc",
  "serde_yaml 0.9.21",
  "sha2",

--- a/crates/turborepo-lib/Cargo.toml
+++ b/crates/turborepo-lib/Cargo.toml
@@ -65,8 +65,7 @@ reqwest = { workspace = true, default-features = false, features = ["json"] }
 rustc_version_runtime = "0.2.1"
 semver = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
-serde_json = { workspace = true }
-serde_jsonc = { workspace = true }
+serde_json = { version = "1.0.96", package = "serde_jsonc" }
 serde_yaml = { workspace = true }
 sha2 = { workspace = true }
 shared_child = "1.0.0"

--- a/crates/turborepo-lib/src/config/mod.rs
+++ b/crates/turborepo-lib/src/config/mod.rs
@@ -38,8 +38,6 @@ pub enum Error {
     #[error(transparent)]
     SerdeJson(#[from] serde_json::Error),
     #[error(transparent)]
-    SerdeJsonC(#[from] serde_jsonc::Error),
-    #[error(transparent)]
     Config(#[from] ConfigError),
     #[error(transparent)]
     Io(#[from] std::io::Error),

--- a/crates/turborepo-lib/src/config/turbo.rs
+++ b/crates/turborepo-lib/src/config/turbo.rs
@@ -23,7 +23,7 @@ use crate::{
 pub struct SpacesJson {
     pub id: Option<String>,
     #[serde(flatten)]
-    pub other: Option<serde_jsonc::Value>,
+    pub other: Option<serde_json::Value>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -452,7 +452,7 @@ impl TurboJson {
     /// and then converts it into `TurboJson`
     fn read(path: &AbsoluteSystemPath) -> Result<TurboJson, Error> {
         let contents = fs::read_to_string(path)?;
-        let turbo_json: RawTurboJSON = serde_jsonc::from_str(&contents)?;
+        let turbo_json: RawTurboJSON = serde_json::from_str(&contents)?;
 
         turbo_json.try_into()
     }
@@ -697,8 +697,7 @@ mod tests {
         expected_raw_task_definition: RawTaskDefinition,
         expected_task_definition: BookkeepingTaskDefinition,
     ) -> Result<()> {
-        let raw_task_definition: RawTaskDefinition =
-            serde_jsonc::from_str(task_definition_content)?;
+        let raw_task_definition: RawTaskDefinition = serde_json::from_str(task_definition_content)?;
         assert_eq!(raw_task_definition, expected_raw_task_definition);
 
         let task_definition: BookkeepingTaskDefinition = raw_task_definition.try_into()?;
@@ -720,7 +719,7 @@ mod tests {
         task_outputs_str: &str,
         expected_task_outputs: TaskOutputs,
     ) -> Result<()> {
-        let raw_task_outputs: Vec<String> = serde_jsonc::from_str(task_outputs_str)?;
+        let raw_task_outputs: Vec<String> = serde_json::from_str(task_outputs_str)?;
         let task_outputs: TaskOutputs = raw_task_outputs.into();
         assert_eq!(task_outputs, expected_task_outputs);
 


### PR DESCRIPTION
`serde_jsonc` is 100% compatible with `serde_json` and can be used in place of `serde_json`.