### PR TITLE
Implement hashing fallback

### DIFF
--- a/crates/turborepo-paths/src/absolute_system_path.rs
+++ b/crates/turborepo-paths/src/absolute_system_path.rs
@@ -119,6 +119,10 @@ impl AbsoluteSystemPath {
         fs::create_dir_all(&self.0)
     }
 
+    pub fn remove_dir_all(&self) -> Result<(), io::Error> {
+        fs::remove_dir_all(&self.0)
+    }
+
     pub fn extension(&self) -> Option<&str> {
         self.0.extension()
     }

--- a/crates/turborepo-paths/src/absolute_system_path_buf.rs
+++ b/crates/turborepo-paths/src/absolute_system_path_buf.rs
@@ -202,6 +202,10 @@ impl AbsoluteSystemPathBuf {
         fs::remove_file(self.0.as_path())
     }
 
+    pub fn remove_dir_all(&self) -> Result<(), io::Error> {
+        fs::remove_dir_all(self.0.as_path())
+    }
+
     pub fn set_readonly(&self) -> Result<(), PathError> {
         let metadata = fs::symlink_metadata(self)?;
         let mut perms = metadata.permissions();

--- a/crates/turborepo-paths/src/absolute_system_path_buf.rs
+++ b/crates/turborepo-paths/src/absolute_system_path_buf.rs
@@ -202,10 +202,6 @@ impl AbsoluteSystemPathBuf {
         fs::remove_file(self.0.as_path())
     }
 
-    pub fn remove_dir_all(&self) -> Result<(), io::Error> {
-        fs::remove_dir_all(self.0.as_path())
-    }
-
     pub fn set_readonly(&self) -> Result<(), PathError> {
         let metadata = fs::symlink_metadata(self)?;
         let mut perms = metadata.permissions();


### PR DESCRIPTION
### Description

 - add manual file hashing as a fallback for _any_ error from git-based hashing

### Testing Instructions

Added a new test that verifies we can still hash when git errors