### PR TITLE
fix(turborepo): Copy bytes from stdout and stderr before saving them

### DIFF
--- a/cli/internal/run/real_run.go
+++ b/cli/internal/run/real_run.go
@@ -112,7 +112,11 @@ type logBufferWriter struct {
 // Write implements io.Writer.Write for logBufferWriter
 func (lbw *logBufferWriter) Write(bytes []byte) (int, error) {
 	n := len(bytes)
-	lbw.logBuffer.LogLine(bytes, lbw.isStdout)
+	// The io.Writer contract states that we cannot retain the bytes we are passed,
+	// so we need to make a copy of them
+	cpy := make([]byte, n, n)
+	copy(cpy, bytes)
+	lbw.logBuffer.LogLine(cpy, lbw.isStdout)
 	return n, nil
 }
 

--- a/cli/internal/run/real_run.go
+++ b/cli/internal/run/real_run.go
@@ -114,7 +114,7 @@ func (lbw *logBufferWriter) Write(bytes []byte) (int, error) {
 	n := len(bytes)
 	// The io.Writer contract states that we cannot retain the bytes we are passed,
 	// so we need to make a copy of them
-	cpy := make([]byte, n, n)
+	cpy := make([]byte, n)
 	copy(cpy, bytes)
 	lbw.logBuffer.LogLine(cpy, lbw.isStdout)
 	return n, nil


### PR DESCRIPTION
### Description

 - `io.Writer` states that we cannot retain the bytes we are passed, so we need to make a copy of them before we save them

### Testing Instructions

Verified manually running vercel-site typechecking and observing the output is now correct