### PR TITLE
chore: Added clippy deny all to crates

### DIFF
--- a/crates/turborepo-api-client/src/lib.rs
+++ b/crates/turborepo-api-client/src/lib.rs
@@ -1,6 +1,7 @@
 #![feature(async_closure)]
 #![feature(provide_any)]
 #![feature(error_generic_member_access)]
+#![deny(clippy::all)]
 
 use std::env;
 

--- a/crates/turborepo-cache/src/http.rs
+++ b/crates/turborepo-cache/src/http.rs
@@ -129,7 +129,7 @@ impl HttpCache {
 
             let body = response.bytes().await.map_err(|e| {
                 CacheError::ApiClientError(
-                    turborepo_api_client::Error::ReqwestError(e),
+                    Box::new(turborepo_api_client::Error::ReqwestError(e)),
                     Backtrace::capture(),
                 )
             })?;
@@ -143,7 +143,7 @@ impl HttpCache {
         } else {
             response.bytes().await.map_err(|e| {
                 CacheError::ApiClientError(
-                    turborepo_api_client::Error::ReqwestError(e),
+                    Box::new(turborepo_api_client::Error::ReqwestError(e)),
                     Backtrace::capture(),
                 )
             })?

--- a/crates/turborepo-cache/src/lib.rs
+++ b/crates/turborepo-cache/src/lib.rs
@@ -1,5 +1,6 @@
 #![feature(error_generic_member_access)]
 #![feature(provide_any)]
+#![deny(clippy::all)]
 
 pub mod cache_archive;
 pub mod http;
@@ -25,7 +26,7 @@ pub enum CacheError {
     #[error("cannot untar file to {0}")]
     InvalidFilePath(String, #[backtrace] Backtrace),
     #[error("artifact verification failed: {0}")]
-    ApiClientError(#[from] turborepo_api_client::Error, #[backtrace] Backtrace),
+    ApiClientError(Box<turborepo_api_client::Error>, #[backtrace] Backtrace),
     #[error("signing artifact failed: {0}")]
     SignatureError(#[from] SignatureError, #[backtrace] Backtrace),
     #[error("invalid duration")]
@@ -50,6 +51,12 @@ pub enum CacheError {
     WindowsUnsafeName(String, #[backtrace] Backtrace),
     #[error("tar attempts to write outside of directory: {0}")]
     LinkOutsideOfDirectory(String, #[backtrace] Backtrace),
+}
+
+impl From<turborepo_api_client::Error> for CacheError {
+    fn from(value: turborepo_api_client::Error) -> Self {
+        CacheError::ApiClientError(Box::new(value), Backtrace::capture())
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/turborepo-env/src/lib.rs
+++ b/crates/turborepo-env/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(clippy::all)]
+
 use std::{
     collections::HashMap,
     env,

--- a/crates/turborepo-fs/src/lib.rs
+++ b/crates/turborepo-fs/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(clippy::all)]
+
 use std::fs::{self, DirBuilder, Metadata};
 
 use anyhow::Result;

--- a/crates/turborepo-globwalk/src/lib.rs
+++ b/crates/turborepo-globwalk/src/lib.rs
@@ -1,4 +1,5 @@
 #![feature(assert_matches)]
+#![deny(clippy::all)]
 
 mod empty_glob;
 

--- a/crates/turborepo-lib/src/lib.rs
+++ b/crates/turborepo-lib/src/lib.rs
@@ -2,6 +2,7 @@
 #![feature(box_patterns)]
 #![feature(error_generic_member_access)]
 #![feature(provide_any)]
+#![deny(clippy::all)]
 
 mod child;
 mod cli;

--- a/crates/turborepo-lockfiles/src/lib.rs
+++ b/crates/turborepo-lockfiles/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(clippy::all)]
+
 mod berry;
 mod error;
 mod npm;

--- a/crates/turborepo-paths/src/lib.rs
+++ b/crates/turborepo-paths/src/lib.rs
@@ -1,5 +1,6 @@
 #![feature(assert_matches)]
 #![feature(fs_try_exists)]
+#![deny(clippy::all)]
 
 /// Turborepo's path handling library
 /// Defines distinct path types for the different usecases of paths in turborepo

--- a/crates/turborepo-pidlock/src/lib.rs
+++ b/crates/turborepo-pidlock/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(clippy::all)]
+
 use std::{
     convert::TryInto,
     fs,

--- a/crates/turborepo-scm/src/lib.rs
+++ b/crates/turborepo-scm/src/lib.rs
@@ -1,6 +1,7 @@
 #![feature(error_generic_member_access)]
 #![feature(provide_any)]
 #![feature(assert_matches)]
+#![deny(clippy::all)]
 
 use std::{
     backtrace::{self, Backtrace},

--- a/crates/turborepo-updater/src/lib.rs
+++ b/crates/turborepo-updater/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(clippy::all)]
+
 use std::{fmt, time::Duration};
 
 use console::style;

--- a/crates/turborepo-vercel-api-mock/src/lib.rs
+++ b/crates/turborepo-vercel-api-mock/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(clippy::all)]
+
 use std::{collections::HashMap, fs::OpenOptions, io::Write, net::SocketAddr, sync::Arc};
 
 use anyhow::Result;

--- a/crates/turborepo/src/main.rs
+++ b/crates/turborepo/src/main.rs
@@ -1,3 +1,5 @@
+#![deny(clippy::all)]
+
 use std::{
     env::{consts, current_exe},
     process,


### PR DESCRIPTION
### Description

At some point I turned off clippy failing on warnings, so CI just silently passes. Now we error again and it's in the code,
so there's no easy way to turn it off.

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
