### PR TITLE
add filewatching tests to document behaviour regarding file add/delete

### DIFF
--- a/cli/internal/filewatcher/filewatcher_test.go
+++ b/cli/internal/filewatcher/filewatcher_test.go
@@ -2,6 +2,7 @@ package filewatcher
 
 import (
 	"fmt"
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -43,7 +44,7 @@ func expectFilesystemEvent(t *testing.T, ch <-chan Event, expected Event) {
 				return
 			}
 		case <-timeout:
-			t.Errorf("Timed out waiting for filesystem event at %v", expected.Path)
+			t.Errorf("Timed out waiting for filesystem event at %v %v", expected.EventType, expected.Path)
 			return
 		}
 	}
@@ -149,4 +150,578 @@ func TestFileWatching(t *testing.T) {
 	err = gitFilePath.WriteFile([]byte("nope"), 0644)
 	assert.NilError(t, err, "WriteFile")
 	expectNoFilesystemEvent(t, ch)
+}
+
+// TestFileWatchingParentDeletion tests that when a directory is deleted,
+// recursive watching will still work for new folders
+//
+// ✅ macOS
+// ? Linux
+// ? Windows
+func TestFileWatchingSubfolderDeletion(t *testing.T) {
+	logger := hclog.Default()
+	logger.SetLevel(hclog.Debug)
+	repoRoot := fs.AbsoluteSystemPathFromUpstream(t.TempDir())
+	err := repoRoot.UntypedJoin(".git").MkdirAll(0775)
+	assert.NilError(t, err, "MkdirAll")
+	err = repoRoot.UntypedJoin("node_modules", "some-dep").MkdirAll(0775)
+	assert.NilError(t, err, "MkdirAll")
+	err = repoRoot.UntypedJoin("parent", "child").MkdirAll(0775)
+	assert.NilError(t, err, "MkdirAll")
+
+	// Directory layout:
+	// <repoRoot>/
+	//	 .git/
+	//   node_modules/
+	//     some-dep/
+	//   parent/
+	//     child/
+
+	watcher, err := GetPlatformSpecificBackend(logger)
+	assert.NilError(t, err, "GetPlatformSpecificBackend")
+	fw := New(logger, repoRoot, watcher)
+	err = fw.Start()
+	assert.NilError(t, err, "fw.Start")
+
+	// Add a client
+	ch := make(chan Event, 1)
+	c := &testClient{
+		notify: ch,
+	}
+	fw.AddClient(c)
+	expectedWatching := []turbopath.AbsoluteSystemPath{
+		repoRoot,
+		repoRoot.UntypedJoin("parent"),
+		repoRoot.UntypedJoin("parent", "child"),
+	}
+	expectWatching(t, c, expectedWatching)
+
+	// Delete parent folder during file watching
+	err = repoRoot.UntypedJoin("parent").RemoveAll()
+	assert.NilError(t, err, "RemoveAll")
+
+	// Ensure we don't get any event when creating file in deleted directory
+	folder := repoRoot.UntypedJoin("parent", "child")
+	err = os.MkdirAll(folder.ToString(), 0775)
+	assert.NilError(t, err, "MkdirAll")
+
+	expectFilesystemEvent(t, ch, Event{
+		EventType: FileAdded,
+		Path:      repoRoot.UntypedJoin("parent"),
+	})
+
+	expectFilesystemEvent(t, ch, Event{
+		EventType: FileAdded,
+		Path:      folder,
+	})
+
+	fooPath := folder.UntypedJoin("foo")
+	err = fooPath.WriteFile([]byte("hello"), 0644)
+	assert.NilError(t, err, "WriteFile")
+
+	expectFilesystemEvent(t, ch, Event{
+		EventType: FileAdded,
+		Path:      folder.UntypedJoin("foo"),
+	})
+
+	expectNoFilesystemEvent(t, ch)
+}
+
+// TestFileWatchingRootDeletion tests that when the root is deleted,
+// file watching will continue, and no deletion event will be sent.
+//
+// It additonally tests that when the root is recreated, file watching
+// will continue, and an add event will be sent for the re-created root.
+//
+// ✅ macOS
+// ? Linux
+// ? Windows
+func TestFileWatchingRootDeletion(t *testing.T) {
+	logger := hclog.Default()
+	logger.SetLevel(hclog.Debug)
+	repoRoot := fs.AbsoluteSystemPathFromUpstream(t.TempDir())
+	err := repoRoot.UntypedJoin(".git").MkdirAll(0775)
+	assert.NilError(t, err, "MkdirAll")
+	err = repoRoot.UntypedJoin("node_modules", "some-dep").MkdirAll(0775)
+	assert.NilError(t, err, "MkdirAll")
+	err = repoRoot.UntypedJoin("parent", "child").MkdirAll(0775)
+	assert.NilError(t, err, "MkdirAll")
+
+	// Directory layout:
+	// <repoRoot>/
+	//	 .git/
+	//   node_modules/
+	//     some-dep/
+	//   parent/
+	//     child/
+
+	watcher, err := GetPlatformSpecificBackend(logger)
+	assert.NilError(t, err, "GetPlatformSpecificBackend")
+	fw := New(logger, repoRoot, watcher)
+	err = fw.Start()
+	assert.NilError(t, err, "fw.Start")
+
+	// Add a client
+	ch := make(chan Event, 1)
+	c := &testClient{
+		notify: ch,
+	}
+	fw.AddClient(c)
+	expectedWatching := []turbopath.AbsoluteSystemPath{
+		repoRoot,
+		repoRoot.UntypedJoin("parent"),
+		repoRoot.UntypedJoin("parent", "child"),
+	}
+	expectWatching(t, c, expectedWatching)
+
+	// Delete parent folder during file watching
+	err = repoRoot.RemoveAll()
+	assert.NilError(t, err, "RemoveAll")
+
+	expectNoFilesystemEvent(t, ch)
+
+	// Ensure we don't get any event when creating file in deleted directory
+	err = repoRoot.MkdirAll(0775)
+	assert.NilError(t, err, "MkdirAll")
+
+	expectFilesystemEvent(t, ch, Event{
+		EventType: FileAdded,
+		Path:      repoRoot,
+	})
+}
+
+// TestFileWatchingSubfolderRename tests that when a parent folder is renamed,
+// file watching will continue, and a rename event will be sent.
+//
+// This test currently does not work on macOS, as rename events are not
+// being sent.
+//
+// ❌ macOS
+// ? Linux
+// ? Windows
+func TestFileWatchingSubfolderRename(t *testing.T) {
+	logger := hclog.Default()
+	logger.SetLevel(hclog.Debug)
+	repoRoot := fs.AbsoluteSystemPathFromUpstream(t.TempDir())
+	err := repoRoot.UntypedJoin(".git").MkdirAll(0775)
+	assert.NilError(t, err, "MkdirAll")
+	err = repoRoot.UntypedJoin("node_modules", "some-dep").MkdirAll(0775)
+	assert.NilError(t, err, "MkdirAll")
+	err = repoRoot.UntypedJoin("parent", "child").MkdirAll(0775)
+	assert.NilError(t, err, "MkdirAll")
+
+	// Directory layout:
+	// <repoRoot>/
+	//	 .git/
+	//   node_modules/
+	//     some-dep/
+	//   parent/
+	//     child/
+
+	watcher, err := GetPlatformSpecificBackend(logger)
+	assert.NilError(t, err, "GetPlatformSpecificBackend")
+	fw := New(logger, repoRoot, watcher)
+	err = fw.Start()
+	assert.NilError(t, err, "fw.Start")
+
+	// Add a client
+	ch := make(chan Event, 1)
+	c := &testClient{
+		notify: ch,
+	}
+	fw.AddClient(c)
+	expectedWatching := []turbopath.AbsoluteSystemPath{
+		repoRoot,
+		repoRoot.UntypedJoin("parent"),
+		repoRoot.UntypedJoin("parent", "child"),
+	}
+	expectWatching(t, c, expectedWatching)
+
+	// Rename parent folder during file watching
+	err = os.Rename(string(repoRoot.UntypedJoin("parent")), string(repoRoot.UntypedJoin("new_parent")))
+	assert.NilError(t, err, "Rename")
+	expectFilesystemEvent(t, ch, Event{
+		EventType: FileRenamed,
+		Path:      repoRoot.UntypedJoin("new_parent"),
+	})
+
+	// Ensure we get an event when creating a file in renamed directory
+	fooPath := repoRoot.UntypedJoin("new_parent", "child", "foo")
+	err = fooPath.WriteFile([]byte("hello"), 0644)
+	assert.NilError(t, err, "WriteFile")
+	expectFilesystemEvent(t, ch, Event{
+		EventType: FileAdded,
+		Path:      fooPath,
+	})
+}
+
+// TestFileWatchingRootRename tests that when the root is renamed,
+// file watching will stop watching that directory, and no new events
+// will be sent.
+//
+// It additonally tests that when the parent folder is renamed back to its
+// original name, file watching will continue, and a rename event will be sent.
+//
+// ✅ macOS
+// ? Linux
+// ? Windows
+func TestFileWatchingRootRename(t *testing.T) {
+	logger := hclog.Default()
+	logger.SetLevel(hclog.Debug)
+	oldRepoRoot := fs.AbsoluteSystemPathFromUpstream(t.TempDir())
+	err := oldRepoRoot.UntypedJoin(".git").MkdirAll(0775)
+	assert.NilError(t, err, "MkdirAll")
+	err = oldRepoRoot.UntypedJoin("node_modules", "some-dep").MkdirAll(0775)
+	assert.NilError(t, err, "MkdirAll")
+	err = oldRepoRoot.UntypedJoin("parent", "child").MkdirAll(0775)
+	assert.NilError(t, err, "MkdirAll")
+
+	// Directory layout:
+	// <oldRepoRoot>/
+	//	 .git/
+	//   node_modules/
+	//     some-dep/
+	//   parent/
+	//     child/
+
+	watcher, err := GetPlatformSpecificBackend(logger)
+	assert.NilError(t, err, "GetPlatformSpecificBackend")
+	fw := New(logger, oldRepoRoot, watcher)
+	err = fw.Start()
+	assert.NilError(t, err, "fw.Start")
+
+	// Add a client
+	ch := make(chan Event, 1)
+	c := &testClient{
+		notify: ch,
+	}
+	fw.AddClient(c)
+	expectedWatching := []turbopath.AbsoluteSystemPath{
+		oldRepoRoot,
+		oldRepoRoot.UntypedJoin("parent"),
+		oldRepoRoot.UntypedJoin("parent", "child"),
+	}
+	expectWatching(t, c, expectedWatching)
+
+	// Rename root folder during file watching
+	newRepoRoot := oldRepoRoot.Dir().UntypedJoin("new_repo_root")
+	err = os.Rename(string(oldRepoRoot), string(newRepoRoot))
+	assert.NilError(t, err, "Rename")
+
+	expectNoFilesystemEvent(t, ch)
+
+	// Ensure we get no event when creating a file in the renamed directory
+	fooPath := newRepoRoot.UntypedJoin("parent", "child", "foo")
+	err = fooPath.WriteFile([]byte("hello"), 0644)
+	assert.NilError(t, err, "WriteFile")
+
+	expectNoFilesystemEvent(t, ch)
+
+	// Rename root folder back to original name
+	err = os.Rename(string(newRepoRoot), string(oldRepoRoot))
+	assert.NilError(t, err, "Rename")
+
+	expectNoFilesystemEvent(t, ch)
+
+	// Ensure we get an event when creating a file in the renamed directory
+	fooPath = oldRepoRoot.UntypedJoin("parent", "child", "foo")
+	err = fooPath.WriteFile([]byte("hello"), 0644)
+	assert.NilError(t, err, "WriteFile")
+
+	// file watching has stopped
+	expectNoFilesystemEvent(t, ch)
+}
+
+// TestFileWatchSymlinkCreate tests that when a symlink is created,
+// file watching will continue, and a file create event is sent.
+// it also validates that new files in the symlinked directory will
+// be watched, and raise events with the original path.
+//
+// ✅ macOS
+// ? Linux
+// ? Windows
+func TestFileWatchSymlinkCreate(t *testing.T) {
+	logger := hclog.Default()
+	logger.SetLevel(hclog.Debug)
+	repoRoot := fs.AbsoluteSystemPathFromUpstream(t.TempDir())
+	err := repoRoot.UntypedJoin(".git").MkdirAll(0775)
+	assert.NilError(t, err, "MkdirAll")
+	err = repoRoot.UntypedJoin("node_modules", "some-dep").MkdirAll(0775)
+	assert.NilError(t, err, "MkdirAll")
+	err = repoRoot.UntypedJoin("parent", "child").MkdirAll(0775)
+	assert.NilError(t, err, "MkdirAll")
+
+	// Directory layout:
+	// <repoRoot>/
+	//	 .git/
+	//   node_modules/
+	//     some-dep/
+	//   parent/
+	//     child/
+
+	watcher, err := GetPlatformSpecificBackend(logger)
+	assert.NilError(t, err, "GetPlatformSpecificBackend")
+	fw := New(logger, repoRoot, watcher)
+	err = fw.Start()
+	assert.NilError(t, err, "fw.Start")
+
+	// Add a client
+	ch := make(chan Event, 1)
+	c := &testClient{
+		notify: ch,
+	}
+	fw.AddClient(c)
+	expectedWatching := []turbopath.AbsoluteSystemPath{
+		repoRoot,
+		repoRoot.UntypedJoin("parent"),
+		repoRoot.UntypedJoin("parent", "child"),
+	}
+	expectWatching(t, c, expectedWatching)
+
+	// Create symlink during file watching
+	symlinkPath := repoRoot.UntypedJoin("symlink")
+	err = os.Symlink(string(repoRoot.UntypedJoin("parent", "child")), string(symlinkPath))
+	assert.NilError(t, err, "Symlink")
+	expectFilesystemEvent(t, ch,
+		Event{
+			EventType: FileAdded,
+			Path:      symlinkPath,
+		},
+	)
+
+	// we expect that events in the symlinked directory will be raised with the original path
+	symlinkSubfile := symlinkPath.UntypedJoin("symlink_subfile")
+	err = symlinkSubfile.WriteFile([]byte("hello"), 0644)
+	assert.NilError(t, err, "WriteFile")
+	expectFilesystemEvent(t, ch,
+		Event{
+			EventType: FileAdded,
+			Path:      repoRoot.UntypedJoin("parent", "child", "symlink_subfile"),
+		},
+	)
+}
+
+// TestFileWatchSymlinkDelete tests that when a symlink is deleted,
+// file watching raises no events for the virtual path
+//
+// ✅ macOS
+// ? Linux
+// ? Windows
+func TestFileWatchSymlinkDelete(t *testing.T) {
+	logger := hclog.Default()
+	logger.SetLevel(hclog.Debug)
+	repoRoot := fs.AbsoluteSystemPathFromUpstream(t.TempDir())
+	err := repoRoot.UntypedJoin(".git").MkdirAll(0775)
+	assert.NilError(t, err, "MkdirAll")
+	err = repoRoot.UntypedJoin("node_modules", "some-dep").MkdirAll(0775)
+	assert.NilError(t, err, "MkdirAll")
+	err = repoRoot.UntypedJoin("parent", "child").MkdirAll(0775)
+	assert.NilError(t, err, "MkdirAll")
+	symlinkPath := repoRoot.UntypedJoin("symlink")
+	err = os.Symlink(string(repoRoot.UntypedJoin("parent", "child")), string(symlinkPath))
+	assert.NilError(t, err, "Symlink")
+
+	// Directory layout:
+	// <repoRoot>/
+	//	 .git/
+	//   node_modules/
+	//     some-dep/
+	//   parent/
+	//     child/
+	//   symlink -> parent/child
+
+	watcher, err := GetPlatformSpecificBackend(logger)
+	assert.NilError(t, err, "GetPlatformSpecificBackend")
+	fw := New(logger, repoRoot, watcher)
+	err = fw.Start()
+	assert.NilError(t, err, "fw.Start")
+
+	// Add a client
+	ch := make(chan Event, 1)
+	c := &testClient{
+		notify: ch,
+	}
+	fw.AddClient(c)
+	expectedWatching := []turbopath.AbsoluteSystemPath{
+		repoRoot,
+		repoRoot.UntypedJoin("parent"),
+		repoRoot.UntypedJoin("parent", "child"),
+	}
+	expectWatching(t, c, expectedWatching)
+
+	// Delete symlink during file watching
+	err = os.Remove(string(symlinkPath))
+	assert.NilError(t, err, "Remove")
+	expectNoFilesystemEvent(t, ch)
+}
+
+// TestFileWatchSymlinkRename tests that when a symlink is renamed,
+// file watching raises no events for the virtual path
+//
+// ✅ macOS
+// ? Linux
+// ? Windows
+func TestFileWatchSymlinkRename(t *testing.T) {
+	logger := hclog.Default()
+	logger.SetLevel(hclog.Debug)
+	repoRoot := fs.AbsoluteSystemPathFromUpstream(t.TempDir())
+	err := repoRoot.UntypedJoin(".git").MkdirAll(0775)
+	assert.NilError(t, err, "MkdirAll")
+	err = repoRoot.UntypedJoin("node_modules", "some-dep").MkdirAll(0775)
+	assert.NilError(t, err, "MkdirAll")
+	err = repoRoot.UntypedJoin("parent", "child").MkdirAll(0775)
+	assert.NilError(t, err, "MkdirAll")
+	symlinkPath := repoRoot.UntypedJoin("symlink")
+	err = os.Symlink(string(repoRoot.UntypedJoin("parent", "child")), string(symlinkPath))
+	assert.NilError(t, err, "Symlink")
+
+	// Directory layout:
+	// <repoRoot>/
+	//	 .git/
+	//   node_modules/
+	//     some-dep/
+	//   parent/
+	//     child/
+	//   symlink -> parent/child
+
+	watcher, err := GetPlatformSpecificBackend(logger)
+	assert.NilError(t, err, "GetPlatformSpecificBackend")
+	fw := New(logger, repoRoot, watcher)
+	err = fw.Start()
+	assert.NilError(t, err, "fw.Start")
+
+	// Add a client
+	ch := make(chan Event, 1)
+	c := &testClient{
+		notify: ch,
+	}
+	fw.AddClient(c)
+	expectedWatching := []turbopath.AbsoluteSystemPath{
+		repoRoot,
+		repoRoot.UntypedJoin("parent"),
+		repoRoot.UntypedJoin("parent", "child"),
+	}
+	expectWatching(t, c, expectedWatching)
+
+	// Rename symlink during file watching
+	newSymlinkPath := repoRoot.UntypedJoin("new_symlink")
+	err = os.Rename(string(symlinkPath), string(newSymlinkPath))
+	assert.NilError(t, err, "Rename")
+	expectNoFilesystemEvent(t, ch)
+}
+
+// TestFileWatchRootParentRename tests that when the parent directory of the root is renamed,
+// file watching stops reporting events
+//
+// additionally, renmaing the root parent directory back to its original name should cause file watching
+// to start reporting events again
+//
+// ✅ macOS
+// ? Linux
+// ? Windows
+func TestFileWatchRootParentRename(t *testing.T) {
+	logger := hclog.Default()
+	logger.SetLevel(hclog.Debug)
+
+	parent := fs.AbsoluteSystemPathFromUpstream(t.TempDir())
+	repoRoot := parent.UntypedJoin("repo")
+	err := repoRoot.UntypedJoin(".git").MkdirAll(0775)
+	assert.NilError(t, err, "MkdirAll")
+
+	// Directory layout:
+	// <parent>/
+	//   repo/
+	//     .git/
+
+	watcher, err := GetPlatformSpecificBackend(logger)
+	assert.NilError(t, err, "GetPlatformSpecificBackend")
+	fw := New(logger, repoRoot, watcher)
+	err = fw.Start()
+	assert.NilError(t, err, "fw.Start")
+
+	// Add a client
+	ch := make(chan Event, 1)
+	c := &testClient{
+		notify: ch,
+	}
+	fw.AddClient(c)
+	expectedWatching := []turbopath.AbsoluteSystemPath{
+		repoRoot,
+	}
+	expectWatching(t, c, expectedWatching)
+
+	// Rename parent directory during file watching
+	newRepoRoot := parent.UntypedJoin("new_repo")
+	err = os.Rename(string(repoRoot), string(newRepoRoot))
+	assert.NilError(t, err, "Rename")
+	expectNoFilesystemEvent(t, ch)
+
+	// Rename root parent directory back to original name
+	err = os.Rename(string(newRepoRoot), string(repoRoot))
+	assert.NilError(t, err, "Rename")
+	expectNoFilesystemEvent(t, ch)
+
+	// create a new file in the repo root
+	err = repoRoot.UntypedJoin("new_file").WriteFile([]byte("hello"), 0666)
+	assert.NilError(t, err, "WriteFile")
+	expectFilesystemEvent(t, ch, Event{
+		EventType: FileAdded,
+		Path:      repoRoot.UntypedJoin("new_file"),
+	})
+}
+
+// TestFileWatchRootParentDelete tests that when the parent directory of the root is deleted,
+// file watching stops reporting events
+//
+// additionally, recreating the root parent directory and the root should cause file watching
+// to start reporting events again
+//
+// ✅ macOS
+// ? Linux
+// ? Windows
+func TestFileWatchRootParentDelete(t *testing.T) {
+	logger := hclog.Default()
+	logger.SetLevel(hclog.Debug)
+
+	parent := fs.AbsoluteSystemPathFromUpstream(t.TempDir())
+	repoRoot := parent.UntypedJoin("repo")
+	err := repoRoot.UntypedJoin(".git").MkdirAll(0775)
+	assert.NilError(t, err, "MkdirAll")
+
+	// Directory layout:
+	// <parent>/
+	//   repo/
+	//     .git/
+
+	watcher, err := GetPlatformSpecificBackend(logger)
+	assert.NilError(t, err, "GetPlatformSpecificBackend")
+	fw := New(logger, repoRoot, watcher)
+	err = fw.Start()
+	assert.NilError(t, err, "fw.Start")
+
+	// Add a client
+	ch := make(chan Event, 1)
+	c := &testClient{
+		notify: ch,
+	}
+	fw.AddClient(c)
+	expectedWatching := []turbopath.AbsoluteSystemPath{
+		repoRoot,
+	}
+	expectWatching(t, c, expectedWatching)
+
+	// Delete parent directory during file watching
+	err = os.RemoveAll(string(parent))
+	assert.NilError(t, err, "RemoveAll")
+	expectNoFilesystemEvent(t, ch)
+
+	// create the root parent and the root again
+	err = repoRoot.MkdirAll(0775)
+	assert.NilError(t, err, "MkdirAll")
+
+	expectFilesystemEvent(t, ch, Event{
+		EventType: FileAdded,
+		Path:      repoRoot,
+	})
+
 }


### PR DESCRIPTION
### Description

This adds some basic tests to validate the behaviour of the filewatching implementation across platforms. The differences are mainly due to operating system specific behaviors.

Here's a summary of the differences:

1. **TestFileWatchingSubfolderDeletion**: This test checks the recursive watching ability when a directory is deleted. It passes on all three operating systems.

2. **TestFileWatchingRootDeletion**: This test checks if file watching continues when the root is deleted and when the root is recreated. It passes on macOS, but fails on Linux and Windows due to no event being emitted when the root is recreated.

3. **TestFileWatchingSubfolderRename**: This test checks the rename event when a parent folder is renamed. It fails on all three operating systems. On macOS, rename events are not sent. On Linux, renaming generates file creation events of the new folder (and all the sub-contents), not a rename. On Windows, you cannot rename a watched folder.

4. **TestFileWatchingRootRename**: This test checks if file watching continues when the root is renamed back to its original name. It passes on macOS, but fails on Linux and Windows due to varying reasons.

5. **TestFileWatchSymlinkCreate**: This test checks the file creation event when a symlink is created. It passes on macOS and Windows (with admin permissions) but fails on Linux, because symlinks do not produce events.

6. **TestFileWatchSymlinkDelete**: This test checks if any events are raised when a symlink is deleted. It passes on all three operating systems.

7. **TestFileWatchSymlinkRename**: This test checks if any events are raised when a symlink is renamed. It passes on macOS but fails on Linux and Windows as they both raise an event for creating the file.

8. **TestFileWatchRootParentRename**: This test checks if file watching continues to report events when the parent directory of the root is renamed and renamed back. It passes on all three operating systems.

9. **TestFileWatchRootParentDelete**: This test checks if file watching resumes reporting events when the parent directory of the root is deleted and then recreated. It passes on macOS but fails on Linux and Windows, as no create event is emitted in both cases. 

### Testing Instructions

You can run this using make go-test. This works ok on macOS but running our go test suite on other platforms is complicated.
