### PR TITLE
chore: use fs-err in turborepo fs related libs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2516,6 +2516,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-err"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0845fa252299212f0389d64ba26f34fa32cfe41588355f21ed507c59a0f64541"
+
+[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9551,6 +9557,7 @@ dependencies = [
  "anyhow",
  "camino",
  "dunce",
+ "fs-err",
  "path-clean 1.0.1",
  "serde",
  "test-case",
@@ -9643,6 +9650,7 @@ name = "turborepo-fs"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "fs-err",
  "tempfile",
  "turbopath",
  "walkdir",

--- a/crates/turborepo-fs/Cargo.toml
+++ b/crates/turborepo-fs/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = { workspace = true }
+fs-err = "2.9.0"
 turbopath = { workspace = true }
 walkdir = "2.3.3"
 

--- a/crates/turborepo-fs/src/lib.rs
+++ b/crates/turborepo-fs/src/lib.rs
@@ -1,6 +1,7 @@
-use std::fs::{self, DirBuilder, Metadata};
+use std::fs::{DirBuilder, FileType, Metadata};
 
 use anyhow::Result;
+use fs_err as fs;
 use turbopath::{AbsoluteSystemPath, AnchoredSystemPathBuf};
 use walkdir::WalkDir;
 
@@ -89,7 +90,7 @@ pub fn copy_file(
 
 fn copy_file_with_type(
     from: impl AsRef<AbsoluteSystemPath>,
-    from_type: fs::FileType,
+    from_type: FileType,
     to: impl AsRef<AbsoluteSystemPath>,
 ) -> Result<()> {
     let from = from.as_ref();

--- a/crates/turborepo-paths/Cargo.toml
+++ b/crates/turborepo-paths/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 [dependencies]
 camino = { workspace = true }
 dunce = { workspace = true }
+fs-err = "2.9.0"
 path-clean = "1.0.1"
 # TODO: Make this a crate feature
 serde = { workspace = true }

--- a/crates/turborepo-paths/src/absolute_system_path.rs
+++ b/crates/turborepo-paths/src/absolute_system_path.rs
@@ -5,13 +5,14 @@ use std::os::unix::fs::symlink as symlink_dir;
 #[cfg(windows)]
 use std::os::windows::fs::{symlink_dir, symlink_file};
 use std::{
-    fmt, fs,
+    fmt,
     fs::{File, Metadata, OpenOptions},
     io,
     path::Path,
 };
 
 use camino::{Utf8Component, Utf8Components, Utf8Path, Utf8PathBuf};
+use fs_err as fs;
 use path_clean::PathClean;
 
 use crate::{

--- a/crates/turborepo-paths/src/absolute_system_path_buf.rs
+++ b/crates/turborepo-paths/src/absolute_system_path_buf.rs
@@ -1,12 +1,13 @@
 use std::{
     borrow::Borrow,
-    fmt, fs,
+    fmt,
     io::{self, Write},
     ops::Deref,
     path::{Path, PathBuf},
 };
 
 use camino::{Utf8Components, Utf8Path, Utf8PathBuf};
+use fs_err as fs;
 use path_clean::PathClean;
 use serde::Serialize;
 
@@ -233,7 +234,8 @@ impl AbsoluteSystemPathBuf {
     }
 
     pub fn try_exists(&self) -> Result<bool, PathError> {
-        Ok(fs::try_exists(&self.0)?)
+        // try_exists is an experimental API and not yet in fs_err
+        Ok(std::fs::try_exists(&self.0)?)
     }
 
     pub fn extension(&self) -> Option<&str> {


### PR DESCRIPTION
### Description
Swaps our usage of various `fs` methods to use `fs-err` instead. To quote the `fs-err` docs:

> Using [std::fs](https://doc.rust-lang.org/stable/std/fs/), if this code fails:
>
> `let file = File::open("does not exist.txt")?;`
>
> The error message that Rust gives you isn't very useful:
>
> `The system cannot find the file specified. (os error 2)`
>
> ...but if we use `fs-err` instead, our error contains more actionable information:
>
> ```failed to open file `does not exist.txt`
>    caused by: The system cannot find the file specified. (os error 2)```

### Testing Instructions
Existing unit tests pass
