### PR TITLE
move Asset::ident to more specific traits

### DIFF
--- a/crates/node-file-trace/src/nft_json.rs
+++ b/crates/node-file-trace/src/nft_json.rs
@@ -5,28 +5,26 @@ use turbo_tasks_fs::{File, FileSystem};
 use turbopack_core::{
     asset::{Asset, AssetContent},
     ident::AssetIdent,
+    module::Module,
     output::OutputAsset,
-    reference::all_assets,
+    reference::all_modules,
 };
 
 #[turbo_tasks::value(shared)]
 pub struct NftJsonAsset {
-    entry: Vc<Box<dyn Asset>>,
+    entry: Vc<Box<dyn Module>>,
 }
 
 #[turbo_tasks::value_impl]
 impl NftJsonAsset {
     #[turbo_tasks::function]
-    pub fn new(entry: Vc<Box<dyn Asset>>) -> Vc<Self> {
-        Self::cell(NftJsonAsset { entry })
+    pub fn new(entry: Vc<Box<dyn Module>>) -> Vc<Self> {
+        NftJsonAsset { entry }.cell()
     }
 }
 
 #[turbo_tasks::value_impl]
-impl OutputAsset for NftJsonAsset {}
-
-#[turbo_tasks::value_impl]
-impl Asset for NftJsonAsset {
+impl OutputAsset for NftJsonAsset {
     #[turbo_tasks::function]
     async fn ident(&self) -> Result<Vc<AssetIdent>> {
         let path = self.entry.ident().path().await?;
@@ -34,7 +32,10 @@ impl Asset for NftJsonAsset {
             path.fs.root().join(format!("{}.nft.json", path.path)),
         ))
     }
+}
 
+#[turbo_tasks::value_impl]
+impl Asset for NftJsonAsset {
     #[turbo_tasks::function]
     async fn content(&self) -> Result<Vc<AssetContent>> {
         let context = self.entry.ident().path().parent().await?;
@@ -42,7 +43,7 @@ impl Asset for NftJsonAsset {
         let entry_path = &*self.entry.ident().path().await?;
         let mut result = Vec::new();
         if let Some(self_path) = context.get_relative_path_to(entry_path) {
-            let set = all_assets(self.entry);
+            let set = all_modules(self.entry);
             for asset in set.await?.iter() {
                 let path = asset.ident().path().await?;
                 if let Some(rel_path) = context.get_relative_path_to(&path) {

--- a/crates/turbo-tasks-memory/src/memory_backend.rs
+++ b/crates/turbo-tasks-memory/src/memory_backend.rs
@@ -443,11 +443,17 @@ impl Backend for MemoryBackend {
 
     fn task_execution_result(
         &self,
-        task: TaskId,
+        task_id: TaskId,
         result: Result<Result<RawVc>, Option<Cow<'static, str>>>,
         turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackend>,
     ) {
-        self.with_task(task, |task| {
+        self.with_task(task_id, |task| {
+            #[cfg(debug_assertions)]
+            if let Ok(Ok(RawVc::TaskOutput(result))) = result.as_ref() {
+                if *result == task_id {
+                    panic!("Task {} returned itself as output", task.get_description());
+                }
+            }
             task.execution_result(result, self, turbo_tasks);
         })
     }

--- a/crates/turbo-tasks-memory/src/memory_backend.rs
+++ b/crates/turbo-tasks-memory/src/memory_backend.rs
@@ -443,17 +443,11 @@ impl Backend for MemoryBackend {
 
     fn task_execution_result(
         &self,
-        task_id: TaskId,
+        task: TaskId,
         result: Result<Result<RawVc>, Option<Cow<'static, str>>>,
         turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackend>,
     ) {
-        self.with_task(task_id, |task| {
-            #[cfg(debug_assertions)]
-            if let Ok(Ok(RawVc::TaskOutput(result))) = result.as_ref() {
-                if *result == task_id {
-                    panic!("Task {} returned itself as output", task.get_description());
-                }
-            }
+        self.with_task(task, |task| {
             task.execution_result(result, self, turbo_tasks);
         })
     }

--- a/crates/turbopack-build/src/chunking_context.rs
+++ b/crates/turbopack-build/src/chunking_context.rs
@@ -6,10 +6,10 @@ use turbo_tasks::{
 };
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
-    asset::Asset,
     chunk::{Chunk, ChunkableModule, ChunkingContext, Chunks, EvaluatableAssets},
     environment::Environment,
     ident::AssetIdent,
+    module::Module,
     output::{OutputAsset, OutputAssets},
 };
 use turbopack_css::chunk::CssChunk;
@@ -225,15 +225,15 @@ impl ChunkingContext for BuildChunkingContext {
     }
 
     #[turbo_tasks::function]
-    fn reference_chunk_source_maps(&self, _chunk: Vc<Box<dyn Asset>>) -> Vc<bool> {
+    fn reference_chunk_source_maps(&self, _chunk: Vc<Box<dyn OutputAsset>>) -> Vc<bool> {
         Vc::cell(true)
     }
 
     #[turbo_tasks::function]
     async fn can_be_in_same_chunk(
         &self,
-        asset_a: Vc<Box<dyn Asset>>,
-        asset_b: Vc<Box<dyn Asset>>,
+        asset_a: Vc<Box<dyn Module>>,
+        asset_b: Vc<Box<dyn Module>>,
     ) -> Result<Vc<bool>> {
         let parent_dir = asset_a.ident().path().parent().await?;
 

--- a/crates/turbopack-build/src/ecmascript/node/chunk.rs
+++ b/crates/turbopack-build/src/ecmascript/node/chunk.rs
@@ -3,7 +3,7 @@ use indexmap::IndexSet;
 use turbo_tasks::{ValueToString, Vc};
 use turbopack_core::{
     asset::{Asset, AssetContent},
-    chunk::ChunkingContext,
+    chunk::{Chunk, ChunkingContext},
     ident::AssetIdent,
     introspect::{Introspectable, IntrospectableChildren},
     output::OutputAsset,
@@ -62,16 +62,16 @@ impl EcmascriptBuildNodeChunk {
 }
 
 #[turbo_tasks::value_impl]
-impl OutputAsset for EcmascriptBuildNodeChunk {}
-
-#[turbo_tasks::value_impl]
-impl Asset for EcmascriptBuildNodeChunk {
+impl OutputAsset for EcmascriptBuildNodeChunk {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {
         let ident = self.chunk.ident().with_modifier(modifier());
         AssetIdent::from_path(self.chunking_context.chunk_path(ident, ".js".to_string()))
     }
+}
 
+#[turbo_tasks::value_impl]
+impl Asset for EcmascriptBuildNodeChunk {
     #[turbo_tasks::function]
     async fn references(self: Vc<Self>) -> Result<Vc<AssetReferences>> {
         let this = self.await?;

--- a/crates/turbopack-build/src/ecmascript/node/content.rs
+++ b/crates/turbopack-build/src/ecmascript/node/content.rs
@@ -5,8 +5,9 @@ use indoc::writedoc;
 use turbo_tasks::{TryJoinIterExt, Value, Vc};
 use turbo_tasks_fs::File;
 use turbopack_core::{
-    asset::{Asset, AssetContent},
+    asset::AssetContent,
     code_builder::{Code, CodeBuilder},
+    output::OutputAsset,
     source_map::{GenerateSourceMap, OptionSourceMap},
 };
 use turbopack_ecmascript::{

--- a/crates/turbopack-build/src/ecmascript/node/entry/chunk.rs
+++ b/crates/turbopack-build/src/ecmascript/node/entry/chunk.rs
@@ -180,15 +180,15 @@ fn chunk_reference_description() -> Vc<String> {
 }
 
 #[turbo_tasks::value_impl]
-impl OutputAsset for EcmascriptBuildNodeEntryChunk {}
-
-#[turbo_tasks::value_impl]
-impl Asset for EcmascriptBuildNodeEntryChunk {
+impl OutputAsset for EcmascriptBuildNodeEntryChunk {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {
         AssetIdent::from_path(self.path)
     }
+}
 
+#[turbo_tasks::value_impl]
+impl Asset for EcmascriptBuildNodeEntryChunk {
     #[turbo_tasks::function]
     async fn references(self: Vc<Self>) -> Result<Vc<AssetReferences>> {
         let this = self.await?;

--- a/crates/turbopack-build/src/ecmascript/node/entry/runtime.rs
+++ b/crates/turbopack-build/src/ecmascript/node/entry/runtime.rs
@@ -86,10 +86,7 @@ impl ValueToString for EcmascriptBuildNodeRuntimeChunk {
 }
 
 #[turbo_tasks::value_impl]
-impl OutputAsset for EcmascriptBuildNodeRuntimeChunk {}
-
-#[turbo_tasks::value_impl]
-impl Asset for EcmascriptBuildNodeRuntimeChunk {
+impl OutputAsset for EcmascriptBuildNodeRuntimeChunk {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {
         let ident = AssetIdent::from_path(
@@ -100,7 +97,10 @@ impl Asset for EcmascriptBuildNodeRuntimeChunk {
 
         AssetIdent::from_path(self.chunking_context.chunk_path(ident, ".js".to_string()))
     }
+}
 
+#[turbo_tasks::value_impl]
+impl Asset for EcmascriptBuildNodeRuntimeChunk {
     #[turbo_tasks::function]
     async fn references(self: Vc<Self>) -> Result<Vc<AssetReferences>> {
         let this = self.await?;

--- a/crates/turbopack-cli-utils/src/runtime_entry.rs
+++ b/crates/turbopack-cli-utils/src/runtime_entry.rs
@@ -2,10 +2,10 @@ use anyhow::{bail, Result};
 use turbo_tasks::{ValueToString, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
-    asset::Asset,
     chunk::{EvaluatableAsset, EvaluatableAssetExt, EvaluatableAssets},
     context::AssetContext,
     issue::{IssueSeverity, OptionIssueSource},
+    module::{convert_asset_to_module, Module},
     resolve::{origin::PlainResolveOrigin, parse::Request},
     source::Source,
 };
@@ -43,12 +43,13 @@ impl RuntimeEntry {
         .await?;
 
         let mut runtime_entries = Vec::with_capacity(assets.len());
-        for asset in &assets {
+        for &asset in &assets {
             if let Some(entry) =
-                Vc::try_resolve_sidecast::<Box<dyn EvaluatableAsset>>(*asset).await?
+                Vc::try_resolve_sidecast::<Box<dyn EvaluatableAsset>>(asset).await?
             {
                 runtime_entries.push(entry);
             } else {
+                let asset = convert_asset_to_module(asset);
                 bail!(
                     "runtime reference resolved to an asset ({}) that cannot be evaluated",
                     asset.ident().to_string().await?

--- a/crates/turbopack-core/src/asset.rs
+++ b/crates/turbopack-core/src/asset.rs
@@ -6,7 +6,6 @@ use turbo_tasks_fs::{
 };
 
 use crate::{
-    ident::AssetIdent,
     reference::AssetReferences,
     version::{VersionedAssetContent, VersionedContent},
 };
@@ -32,10 +31,6 @@ impl Assets {
 /// An asset. It also forms a graph when following [Asset::references].
 #[turbo_tasks::value_trait]
 pub trait Asset {
-    /// The identifier of the [Asset]. It's expected to be unique and capture
-    /// all properties of the [Asset].
-    fn ident(self: Vc<Self>) -> Vc<AssetIdent>;
-
     /// The content of the [Asset].
     fn content(self: Vc<Self>) -> Vc<AssetContent>;
 

--- a/crates/turbopack-core/src/chunk/availability_info.rs
+++ b/crates/turbopack-core/src/chunk/availability_info.rs
@@ -1,23 +1,23 @@
 use turbo_tasks::Vc;
 
 use super::available_assets::AvailableAssets;
-use crate::asset::Asset;
+use crate::module::Module;
 
 #[turbo_tasks::value(serialization = "auto_for_input")]
 #[derive(PartialOrd, Ord, Hash, Clone, Copy, Debug)]
 pub enum AvailabilityInfo {
     Untracked,
     Root {
-        current_availability_root: Vc<Box<dyn Asset>>,
+        current_availability_root: Vc<Box<dyn Module>>,
     },
     Inner {
         available_assets: Vc<AvailableAssets>,
-        current_availability_root: Vc<Box<dyn Asset>>,
+        current_availability_root: Vc<Box<dyn Module>>,
     },
 }
 
 impl AvailabilityInfo {
-    pub fn current_availability_root(&self) -> Option<Vc<Box<dyn Asset>>> {
+    pub fn current_availability_root(&self) -> Option<Vc<Box<dyn Module>>> {
         match self {
             Self::Untracked => None,
             Self::Root {

--- a/crates/turbopack-core/src/chunk/available_assets.rs
+++ b/crates/turbopack-core/src/chunk/available_assets.rs
@@ -10,7 +10,7 @@ use turbo_tasks_hash::Xxh3Hash64Hasher;
 
 use super::{ChunkableModuleReference, ChunkingType};
 use crate::{
-    asset::{Asset},
+    asset::Asset,
     module::{Module, ModulesSet},
     reference::AssetReference,
 };

--- a/crates/turbopack-core/src/chunk/available_assets.rs
+++ b/crates/turbopack-core/src/chunk/available_assets.rs
@@ -10,7 +10,8 @@ use turbo_tasks_hash::Xxh3Hash64Hasher;
 
 use super::{ChunkableModuleReference, ChunkingType};
 use crate::{
-    asset::{Asset, AssetsSet},
+    asset::{Asset},
+    module::{Module, ModulesSet},
     reference::AssetReference,
 };
 
@@ -20,7 +21,7 @@ use crate::{
 #[turbo_tasks::value]
 pub struct AvailableAssets {
     parent: Option<Vc<AvailableAssets>>,
-    roots: Vec<Vc<Box<dyn Asset>>>,
+    roots: Vec<Vc<Box<dyn Module>>>,
 }
 
 #[turbo_tasks::value_impl]
@@ -28,18 +29,18 @@ impl AvailableAssets {
     #[turbo_tasks::function]
     fn new_normalized(
         parent: Option<Vc<AvailableAssets>>,
-        roots: Vec<Vc<Box<dyn Asset>>>,
+        roots: Vec<Vc<Box<dyn Module>>>,
     ) -> Vc<Self> {
         AvailableAssets { parent, roots }.cell()
     }
 
     #[turbo_tasks::function]
-    pub fn new(roots: Vec<Vc<Box<dyn Asset>>>) -> Vc<Self> {
+    pub fn new(roots: Vec<Vc<Box<dyn Module>>>) -> Vc<Self> {
         Self::new_normalized(None, roots)
     }
 
     #[turbo_tasks::function]
-    pub async fn with_roots(self: Vc<Self>, roots: Vec<Vc<Box<dyn Asset>>>) -> Result<Vc<Self>> {
+    pub async fn with_roots(self: Vc<Self>, roots: Vec<Vc<Box<dyn Module>>>) -> Result<Vc<Self>> {
         let roots = roots
             .into_iter()
             .map(|root| async move { Ok((self.includes(root).await?, root)) })
@@ -67,7 +68,7 @@ impl AvailableAssets {
     }
 
     #[turbo_tasks::function]
-    pub async fn includes(self: Vc<Self>, asset: Vc<Box<dyn Asset>>) -> Result<Vc<bool>> {
+    pub async fn includes(self: Vc<Self>, asset: Vc<Box<dyn Module>>) -> Result<Vc<bool>> {
         let this = self.await?;
         if let Some(parent) = this.parent {
             if *parent.includes(asset).await? {
@@ -84,10 +85,10 @@ impl AvailableAssets {
 }
 
 #[turbo_tasks::function]
-async fn chunkable_assets_set(root: Vc<Box<dyn Asset>>) -> Result<Vc<AssetsSet>> {
+async fn chunkable_assets_set(root: Vc<Box<dyn Module>>) -> Result<Vc<ModulesSet>> {
     let assets = AdjacencyMap::new()
         .skip_duplicates()
-        .visit(once(root), |&asset: &Vc<Box<dyn Asset>>| async move {
+        .visit(once(root), |&asset: &Vc<Box<dyn Module>>| async move {
             Ok(asset
                 .references()
                 .await?
@@ -106,15 +107,19 @@ async fn chunkable_assets_set(root: Vc<Box<dyn Asset>>) -> Result<Vc<AssetsSet>>
                                     | ChunkingType::Placed
                             )
                         ) {
-                            return chunkable
+                            return Ok(chunkable
                                 .resolve_reference()
                                 .primary_assets()
                                 .await?
                                 .iter()
-                                .copied()
-                                .map(|asset| asset.resolve())
+                                .map(|&asset| async move {
+                                    Ok(Vc::try_resolve_downcast::<Box<dyn Module>>(asset).await?)
+                                })
                                 .try_join()
-                                .await;
+                                .await?
+                                .into_iter()
+                                .flatten()
+                                .collect());
                         }
                     }
                     Ok(Vec::new())

--- a/crates/turbopack-core/src/chunk/chunking_context.rs
+++ b/crates/turbopack-core/src/chunk/chunking_context.rs
@@ -2,7 +2,12 @@ use turbo_tasks::Vc;
 use turbo_tasks_fs::FileSystemPath;
 
 use super::{Chunk, EvaluatableAssets};
-use crate::{asset::Asset, environment::Environment, ident::AssetIdent, output::OutputAssets};
+use crate::{
+    environment::Environment,
+    ident::AssetIdent,
+    module::Module,
+    output::{OutputAsset, OutputAssets},
+};
 
 /// A context for the chunking that influences the way chunks are created
 #[turbo_tasks::value_trait]
@@ -22,12 +27,12 @@ pub trait ChunkingContext {
 
     // TODO(alexkirsz) Remove this from the chunking context.
     /// Reference Source Map Assets for chunks
-    fn reference_chunk_source_maps(self: Vc<Self>, chunk: Vc<Box<dyn Asset>>) -> Vc<bool>;
+    fn reference_chunk_source_maps(self: Vc<Self>, chunk: Vc<Box<dyn OutputAsset>>) -> Vc<bool>;
 
     fn can_be_in_same_chunk(
         self: Vc<Self>,
-        asset_a: Vc<Box<dyn Asset>>,
-        asset_b: Vc<Box<dyn Asset>>,
+        asset_a: Vc<Box<dyn Module>>,
+        asset_b: Vc<Box<dyn Module>>,
     ) -> Vc<bool>;
 
     fn asset_path(

--- a/crates/turbopack-core/src/chunk/data.rs
+++ b/crates/turbopack-core/src/chunk/data.rs
@@ -3,7 +3,6 @@ use turbo_tasks::{ReadRef, TryJoinIterExt, Vc};
 use turbo_tasks_fs::FileSystemPath;
 
 use crate::{
-    asset::Asset,
     chunk::{ModuleId, OutputChunk, OutputChunkRuntimeInfo},
     output::{OutputAsset, OutputAssets},
     reference::{AssetReferences, SingleAssetReference},
@@ -97,7 +96,7 @@ impl ChunkData {
                             (
                                 path.to_owned(),
                                 Vc::upcast(SingleAssetReference::new(
-                                    chunk,
+                                    Vc::upcast(chunk),
                                     module_chunk_reference_description(),
                                 )),
                             )

--- a/crates/turbopack-core/src/chunk/mod.rs
+++ b/crates/turbopack-core/src/chunk/mod.rs
@@ -35,7 +35,7 @@ pub use self::{
     passthrough_asset::PassthroughAsset,
 };
 use crate::{
-    asset::{Asset},
+    asset::Asset,
     ident::AssetIdent,
     module::{Module, Modules},
     output::OutputAssets,

--- a/crates/turbopack-core/src/chunk/mod.rs
+++ b/crates/turbopack-core/src/chunk/mod.rs
@@ -35,9 +35,9 @@ pub use self::{
     passthrough_asset::PassthroughAsset,
 };
 use crate::{
-    asset::{Asset, Assets},
+    asset::{Asset},
     ident::AssetIdent,
-    module::Module,
+    module::{Module, Modules},
     output::OutputAssets,
     reference::{AssetReference, AssetReferences},
     resolve::{PrimaryResolveResult, ResolveResult},
@@ -117,6 +117,7 @@ impl Chunks {
 /// It usually contains multiple chunk items.
 #[turbo_tasks::value_trait]
 pub trait Chunk: Asset {
+    fn ident(self: Vc<Self>) -> Vc<AssetIdent>;
     fn chunking_context(self: Vc<Self>) -> Vc<Box<dyn ChunkingContext>>;
     // TODO Once output assets have their own trait, this path() method will move
     // into that trait and ident() will be removed from that. Assets on the
@@ -142,7 +143,7 @@ pub struct OutputChunkRuntimeInfo {
     /// List of paths of chunks containing individual modules that are part of
     /// this chunk. This is useful for selectively loading modules from a chunk
     /// without loading the whole chunk.
-    pub module_chunks: Option<Vc<Assets>>,
+    pub module_chunks: Option<Vc<OutputAssets>>,
     pub placeholder_for_future_extensions: (),
 }
 
@@ -253,7 +254,7 @@ pub struct ChunkContentResult<I> {
 pub trait FromChunkableModule: ChunkItem {
     async fn from_asset(
         context: Vc<Box<dyn ChunkingContext>>,
-        asset: Vc<Box<dyn Asset>>,
+        asset: Vc<Box<dyn Module>>,
     ) -> Result<Option<Vc<Self>>>;
     async fn from_async_asset(
         context: Vc<Box<dyn ChunkingContext>>,
@@ -264,8 +265,8 @@ pub trait FromChunkableModule: ChunkItem {
 
 pub async fn chunk_content_split<I>(
     context: Vc<Box<dyn ChunkingContext>>,
-    entry: Vc<Box<dyn Asset>>,
-    additional_entries: Option<Vc<Assets>>,
+    entry: Vc<Box<dyn Module>>,
+    additional_entries: Option<Vc<Modules>>,
     availability_info: Value<AvailabilityInfo>,
 ) -> Result<ChunkContentResult<Vc<I>>>
 where
@@ -278,8 +279,8 @@ where
 
 pub async fn chunk_content<I>(
     context: Vc<Box<dyn ChunkingContext>>,
-    entry: Vc<Box<dyn Asset>>,
-    additional_entries: Option<Vc<Assets>>,
+    entry: Vc<Box<dyn Module>>,
+    additional_entries: Option<Vc<Modules>>,
     availability_info: Value<AvailabilityInfo>,
 ) -> Result<Option<ChunkContentResult<Vc<I>>>>
 where
@@ -293,11 +294,11 @@ where
 enum ChunkContentGraphNode<I> {
     // An asset not placed in the current chunk, but whose references we will
     // follow to find more graph nodes.
-    PassthroughAsset { asset: Vc<Box<dyn Asset>> },
+    PassthroughAsset { asset: Vc<Box<dyn Module>> },
     // Chunk items that are placed into the current chunk
     ChunkItem { item: I, ident: ReadRef<String> },
     // Asset that is already available and doesn't need to be included
-    AvailableAsset(Vc<Box<dyn Asset>>),
+    AvailableAsset(Vc<Box<dyn Module>>),
     // Chunks that are loaded in parallel to the current chunk
     Chunk(Vc<Box<dyn Chunk>>),
     ExternalAssetReference(Vc<Box<dyn AssetReference>>),
@@ -306,7 +307,7 @@ enum ChunkContentGraphNode<I> {
 #[derive(Clone, Copy)]
 struct ChunkContentContext {
     chunking_context: Vc<Box<dyn ChunkingContext>>,
-    entry: Vc<Box<dyn Asset>>,
+    entry: Vc<Box<dyn Module>>,
     availability_info: Value<AvailabilityInfo>,
     split: bool,
 }
@@ -316,7 +317,7 @@ async fn reference_to_graph_nodes<I>(
     reference: Vc<Box<dyn AssetReference>>,
 ) -> Result<
     Vec<(
-        Option<(Vc<Box<dyn Asset>>, ChunkingType)>,
+        Option<(Vc<Box<dyn Module>>, ChunkingType)>,
         ChunkContentGraphNode<Vc<I>>,
     )>,
 >
@@ -353,6 +354,10 @@ where
     let mut graph_nodes = vec![];
 
     for asset in assets {
+        let asset = asset.resolve().await?;
+        let Some(asset) = Vc::try_resolve_downcast::<Box<dyn Module>>(asset).await? else {
+            continue;
+        };
         if let Some(available_assets) = context.availability_info.available_assets() {
             if *available_assets.includes(asset).await? {
                 graph_nodes.push((
@@ -479,13 +484,13 @@ const MAX_CHUNK_ITEMS_COUNT: usize = 5000;
 struct ChunkContentVisit<I> {
     context: ChunkContentContext,
     chunk_items_count: usize,
-    processed_assets: HashSet<(ChunkingType, Vc<Box<dyn Asset>>)>,
+    processed_assets: HashSet<(ChunkingType, Vc<Box<dyn Module>>)>,
     _phantom: PhantomData<I>,
 }
 
 type ChunkItemToGraphNodesEdges<I> = impl Iterator<
     Item = (
-        Option<(Vc<Box<dyn Asset>>, ChunkingType)>,
+        Option<(Vc<Box<dyn Module>>, ChunkingType)>,
         ChunkContentGraphNode<Vc<I>>,
     ),
 >;
@@ -498,7 +503,7 @@ where
     I: FromChunkableModule,
 {
     type Edge = (
-        Option<(Vc<Box<dyn Asset>>, ChunkingType)>,
+        Option<(Vc<Box<dyn Module>>, ChunkingType)>,
         ChunkContentGraphNode<Vc<I>>,
     );
     type EdgesIntoIter = ChunkItemToGraphNodesEdges<I>;
@@ -507,7 +512,7 @@ where
     fn visit(
         &mut self,
         (option_key, node): (
-            Option<(Vc<Box<dyn Asset>>, ChunkingType)>,
+            Option<(Vc<Box<dyn Module>>, ChunkingType)>,
             ChunkContentGraphNode<Vc<I>>,
         ),
     ) -> VisitControlFlow<ChunkContentGraphNode<Vc<I>>, ()> {
@@ -570,8 +575,8 @@ where
 
 async fn chunk_content_internal_parallel<I>(
     chunking_context: Vc<Box<dyn ChunkingContext>>,
-    entry: Vc<Box<dyn Asset>>,
-    additional_entries: Option<Vc<Assets>>,
+    entry: Vc<Box<dyn Module>>,
+    additional_entries: Option<Vc<Modules>>,
     availability_info: Value<AvailabilityInfo>,
     split: bool,
 ) -> Result<Option<ChunkContentResult<Vc<I>>>>

--- a/crates/turbopack-core/src/chunk/passthrough_asset.rs
+++ b/crates/turbopack-core/src/chunk/passthrough_asset.rs
@@ -1,6 +1,6 @@
-use crate::asset::Asset;
+use crate::{asset::Asset, module::Module};
 
 /// An [Asset] that should never be placed into a chunk, but whose references
 /// should still be followed.
 #[turbo_tasks::value_trait]
-pub trait PassthroughAsset: Asset {}
+pub trait PassthroughAsset: Module + Asset {}

--- a/crates/turbopack-core/src/file_source.rs
+++ b/crates/turbopack-core/src/file_source.rs
@@ -25,15 +25,15 @@ impl FileSource {
 }
 
 #[turbo_tasks::value_impl]
-impl Source for FileSource {}
-
-#[turbo_tasks::value_impl]
-impl Asset for FileSource {
+impl Source for FileSource {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {
         AssetIdent::from_path(self.path)
     }
+}
 
+#[turbo_tasks::value_impl]
+impl Asset for FileSource {
     #[turbo_tasks::function]
     async fn content(&self) -> Result<Vc<AssetContent>> {
         let file_type = &*self.path.get_type().await?;

--- a/crates/turbopack-core/src/lib.rs
+++ b/crates/turbopack-core/src/lib.rs
@@ -36,6 +36,7 @@ pub mod source_transform;
 pub mod target;
 mod utils;
 pub mod version;
+pub mod virtual_output;
 pub mod virtual_source;
 
 pub mod virtual_fs {

--- a/crates/turbopack-core/src/module.rs
+++ b/crates/turbopack-core/src/module.rs
@@ -46,3 +46,5 @@ pub async fn convert_asset_to_module(asset: Vc<Box<dyn Asset>>) -> Result<Vc<Box
         bail!("Asset must be a Module or a Source")
     }
 }
+
+// TODO All Vc::try_resolve_downcast::<Box<dyn Module>> calls should be removed

--- a/crates/turbopack-core/src/module.rs
+++ b/crates/turbopack-core/src/module.rs
@@ -1,11 +1,48 @@
+use anyhow::{bail, Result};
+use indexmap::IndexSet;
 use turbo_tasks::Vc;
 
-use crate::asset::Asset;
+use crate::{asset::Asset, ident::AssetIdent, raw_module::RawModule, source::Source};
 
 /// A module. This usually represents parsed source code, which has references
 /// to other modules.
 #[turbo_tasks::value_trait]
-pub trait Module: Asset {}
+pub trait Module: Asset {
+    /// The identifier of the [Module]. It's expected to be unique and capture
+    /// all properties of the [Module].
+    fn ident(&self) -> Vc<AssetIdent>;
+}
 
 #[turbo_tasks::value(transparent)]
 pub struct OptionModule(Option<Vc<Box<dyn Module>>>);
+
+#[turbo_tasks::value(transparent)]
+pub struct Modules(Vec<Vc<Box<dyn Module>>>);
+
+#[turbo_tasks::value_impl]
+impl Modules {
+    #[turbo_tasks::function]
+    pub fn empty() -> Vc<Self> {
+        Vc::cell(Vec::new())
+    }
+}
+
+/// A set of [Module]s
+#[turbo_tasks::value(transparent)]
+pub struct ModulesSet(IndexSet<Vc<Box<dyn Module>>>);
+
+/// This is a temporary function that should be removed once the [Module]
+/// trait completely replaces the [Asset] trait.
+/// It converts an [Asset] into a [Module], but either casting it or wrapping it
+/// in a [RawModule].
+// TODO make this function unnecessary, it should never be a Source
+#[turbo_tasks::function]
+pub async fn convert_asset_to_module(asset: Vc<Box<dyn Asset>>) -> Result<Vc<Box<dyn Module>>> {
+    if let Some(module) = Vc::try_resolve_downcast::<Box<dyn Module>>(asset).await? {
+        Ok(module)
+    } else if let Some(source) = Vc::try_resolve_downcast::<Box<dyn Source>>(asset).await? {
+        Ok(Vc::upcast(RawModule::new(source)))
+    } else {
+        bail!("Asset must be a Module or a Source")
+    }
+}

--- a/crates/turbopack-core/src/output.rs
+++ b/crates/turbopack-core/src/output.rs
@@ -38,3 +38,6 @@ pub async fn asset_to_output_asset(asset: Vc<Box<dyn Asset>>) -> Result<Vc<Box<d
         .await?
         .context("Asset must be a OutputAsset")
 }
+
+// TODO All Vc::try_resolve_downcast::<Box<dyn OutputAsset>> calls should be
+// removed

--- a/crates/turbopack-core/src/output.rs
+++ b/crates/turbopack-core/src/output.rs
@@ -1,12 +1,18 @@
 use anyhow::{Context, Result};
+use indexmap::IndexSet;
 use turbo_tasks::Vc;
 
-use crate::asset::Asset;
+use crate::{asset::Asset, ident::AssetIdent};
 
 /// An asset that should be outputted, e. g. written to disk or served from a
 /// server.
 #[turbo_tasks::value_trait]
-pub trait OutputAsset: Asset {}
+pub trait OutputAsset: Asset {
+    // TODO change this to path() -> Vc<FileSystemPath>
+    /// The identifier of the [OutputAsset]. It's expected to be unique and
+    /// capture all properties of the [OutputAsset]. Only path must be used.
+    fn ident(&self) -> Vc<AssetIdent>;
+}
 
 #[turbo_tasks::value(transparent)]
 pub struct OutputAssets(Vec<Vc<Box<dyn OutputAsset>>>);
@@ -19,12 +25,16 @@ impl OutputAssets {
     }
 }
 
+/// A set of [OutputAsset]s
+#[turbo_tasks::value(transparent)]
+pub struct OutputAssetsSet(IndexSet<Vc<Box<dyn OutputAsset>>>);
+
 /// This is a temporary function that should be removed once the [OutputAsset]
 /// trait completely replaces the [Asset] trait.
 /// TODO make this function unnecessary
 #[turbo_tasks::function]
 pub async fn asset_to_output_asset(asset: Vc<Box<dyn Asset>>) -> Result<Vc<Box<dyn OutputAsset>>> {
-    Vc::try_resolve_sidecast::<Box<dyn OutputAsset>>(asset)
+    Vc::try_resolve_downcast::<Box<dyn OutputAsset>>(asset)
         .await?
         .context("Asset must be a OutputAsset")
 }

--- a/crates/turbopack-core/src/proxied_asset.rs
+++ b/crates/turbopack-core/src/proxied_asset.rs
@@ -29,15 +29,15 @@ impl ProxiedAsset {
 }
 
 #[turbo_tasks::value_impl]
-impl OutputAsset for ProxiedAsset {}
-
-#[turbo_tasks::value_impl]
-impl Asset for ProxiedAsset {
+impl OutputAsset for ProxiedAsset {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {
         AssetIdent::from_path(self.path)
     }
+}
 
+#[turbo_tasks::value_impl]
+impl Asset for ProxiedAsset {
     #[turbo_tasks::function]
     fn content(&self) -> Vc<AssetContent> {
         self.asset.content()

--- a/crates/turbopack-core/src/raw_module.rs
+++ b/crates/turbopack-core/src/raw_module.rs
@@ -15,15 +15,15 @@ pub struct RawModule {
 }
 
 #[turbo_tasks::value_impl]
-impl Module for RawModule {}
-
-#[turbo_tasks::value_impl]
-impl Asset for RawModule {
+impl Module for RawModule {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {
         self.source.ident()
     }
+}
 
+#[turbo_tasks::value_impl]
+impl Asset for RawModule {
     #[turbo_tasks::function]
     fn content(&self) -> Vc<AssetContent> {
         self.source.content()

--- a/crates/turbopack-core/src/raw_output.rs
+++ b/crates/turbopack-core/src/raw_output.rs
@@ -15,15 +15,15 @@ pub struct RawOutput {
 }
 
 #[turbo_tasks::value_impl]
-impl OutputAsset for RawOutput {}
-
-#[turbo_tasks::value_impl]
-impl Asset for RawOutput {
+impl OutputAsset for RawOutput {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {
         self.source.ident()
     }
+}
 
+#[turbo_tasks::value_impl]
+impl Asset for RawOutput {
     #[turbo_tasks::function]
     fn content(&self) -> Vc<AssetContent> {
         self.source.content()

--- a/crates/turbopack-core/src/reference/mod.rs
+++ b/crates/turbopack-core/src/reference/mod.rs
@@ -6,6 +6,8 @@ use turbo_tasks::{TryJoinIterExt, ValueToString, Vc};
 use crate::{
     asset::{Asset, Assets},
     issue::IssueContextExt,
+    module::{Module, Modules},
+    output::{OutputAsset, OutputAssets},
     resolve::{PrimaryResolveResult, ResolveResult},
 };
 pub mod source_map;
@@ -117,6 +119,172 @@ pub async fn all_referenced_assets(asset: Vc<Box<dyn Asset>>) -> Result<Vc<Asset
     Ok(Vc::cell(assets))
 }
 
+/// Aggregates all [Asset]s referenced by an [Asset]. [AssetReference]
+/// This does not include transitively references [Asset]s, but it includes
+/// primary and secondary [Asset]s referenced.
+///
+/// [Asset]: crate::asset::Asset
+#[turbo_tasks::function]
+pub async fn all_referenced_output_assets(
+    asset: Vc<Box<dyn OutputAsset>>,
+) -> Result<Vc<OutputAssets>> {
+    let references_set = asset.references().await?;
+    let mut assets = Vec::new();
+    let mut queue = VecDeque::with_capacity(32);
+    for reference in references_set.iter() {
+        queue.push_back(reference.resolve_reference());
+    }
+    // that would be non-deterministic:
+    // while let Some(result) = race_pop(&mut queue).await {
+    // match &*result? {
+    while let Some(resolve_result) = queue.pop_front() {
+        let ResolveResult {
+            primary,
+            references,
+        } = &*resolve_result.await?;
+        for result in primary {
+            if let PrimaryResolveResult::Asset(asset) = *result {
+                assets.push(asset);
+            }
+        }
+        for reference in references {
+            queue.push_back(reference.resolve_reference());
+        }
+    }
+    let output_assets =
+        assets
+            .into_iter()
+            .map(|asset| async move {
+                Ok(Vc::try_resolve_downcast::<Box<dyn OutputAsset>>(asset).await?)
+            })
+            .try_join()
+            .await?
+            .into_iter()
+            .flatten()
+            .collect();
+    Ok(Vc::cell(output_assets))
+}
+
+/// Aggregates all [Asset]s referenced by an [Asset]. [AssetReference]
+/// This does not include transitively references [Asset]s, but it includes
+/// primary and secondary [Asset]s referenced.
+///
+/// [Asset]: crate::asset::Asset
+#[turbo_tasks::function]
+pub async fn all_referenced_modules(module: Vc<Box<dyn Module>>) -> Result<Vc<Modules>> {
+    let references_set = module.references().await?;
+    let mut assets = Vec::new();
+    let mut queue = VecDeque::with_capacity(32);
+    for reference in references_set.iter() {
+        queue.push_back(reference.resolve_reference());
+    }
+    // that would be non-deterministic:
+    // while let Some(result) = race_pop(&mut queue).await {
+    // match &*result? {
+    while let Some(resolve_result) = queue.pop_front() {
+        let ResolveResult {
+            primary,
+            references,
+        } = &*resolve_result.await?;
+        for result in primary {
+            if let PrimaryResolveResult::Asset(asset) = *result {
+                assets.push(asset);
+            }
+        }
+        for reference in references {
+            queue.push_back(reference.resolve_reference());
+        }
+    }
+    let modules = assets
+        .into_iter()
+        .map(|asset| async move { Ok(Vc::try_resolve_downcast::<Box<dyn Module>>(asset).await?) })
+        .try_join()
+        .await?
+        .into_iter()
+        .flatten()
+        .collect();
+    Ok(Vc::cell(modules))
+}
+
+/// Aggregates all primary [Module]s referenced by an [Module]. [AssetReference]
+/// This does not include transitively references [Module]s, only includes
+/// primary [Module]s referenced.
+///
+/// [Module]: crate::module::Module
+#[turbo_tasks::function]
+pub async fn primary_referenced_modules(module: Vc<Box<dyn Module>>) -> Result<Vc<Modules>> {
+    let modules = module
+        .references()
+        .await?
+        .iter()
+        .map(|reference| async {
+            let ResolveResult { primary, .. } = &*reference.resolve_reference().await?;
+            Ok(primary
+                .iter()
+                .filter_map(|result| {
+                    if let PrimaryResolveResult::Asset(asset) = *result {
+                        Some(asset)
+                    } else {
+                        None
+                    }
+                })
+                .collect::<Vec<_>>())
+        })
+        .try_join()
+        .await?
+        .into_iter()
+        .flatten()
+        .map(|asset| async move { Ok(Vc::try_resolve_downcast::<Box<dyn Module>>(asset).await?) })
+        .try_join()
+        .await?
+        .into_iter()
+        .flatten()
+        .collect();
+    Ok(Vc::cell(modules))
+}
+
+/// Aggregates all primary [OutputAsset]s referenced by an [OutputAsset].
+/// [AssetReference] This does not include transitively references
+/// [OutputAsset]s, only includes primary [OutputAsset]s referenced.
+///
+/// [OutputAsset]: crate::output::OutputAsset
+#[turbo_tasks::function]
+pub async fn primary_referenced_output_assets(
+    output_asset: Vc<Box<dyn OutputAsset>>,
+) -> Result<Vc<OutputAssets>> {
+    let output_assets =
+        output_asset
+            .references()
+            .await?
+            .iter()
+            .map(|reference| async {
+                let ResolveResult { primary, .. } = &*reference.resolve_reference().await?;
+                Ok(primary
+                    .iter()
+                    .filter_map(|result| {
+                        if let PrimaryResolveResult::Asset(asset) = *result {
+                            Some(asset)
+                        } else {
+                            None
+                        }
+                    })
+                    .collect::<Vec<_>>())
+            })
+            .try_join()
+            .await?
+            .into_iter()
+            .flatten()
+            .map(|asset| async move {
+                Ok(Vc::try_resolve_downcast::<Box<dyn OutputAsset>>(asset).await?)
+            })
+            .try_join()
+            .await?
+            .into_iter()
+            .flatten()
+            .collect();
+    Ok(Vc::cell(output_assets))
+}
+
 /// Aggregates all primary [Asset]s referenced by an [Asset]. [AssetReference]
 /// This does not include transitively references [Asset]s, only includes
 /// primary [Asset]s referenced.
@@ -149,14 +317,14 @@ pub async fn primary_referenced_assets(asset: Vc<Box<dyn Asset>>) -> Result<Vc<A
     Ok(Vc::cell(assets))
 }
 
-/// Aggregates all [Asset]s referenced by an [Asset] including transitively
-/// referenced [Asset]s. This basically gives all [Asset]s in a subgraph
-/// starting from the passed [Asset].
+/// Aggregates all [Module]s referenced by an [Module] including transitively
+/// referenced [Module]s. This basically gives all [Module]s in a subgraph
+/// starting from the passed [Module].
 #[turbo_tasks::function]
-pub async fn all_assets(asset: Vc<Box<dyn Asset>>) -> Result<Vc<Assets>> {
+pub async fn all_modules(asset: Vc<Box<dyn Module>>) -> Result<Vc<Modules>> {
     // TODO need to track import path here
     let mut queue = VecDeque::with_capacity(32);
-    queue.push_back((asset, all_referenced_assets(asset)));
+    queue.push_back((asset, all_referenced_modules(asset)));
     let mut assets = HashSet::new();
     assets.insert(asset);
     while let Some((parent, references)) = queue.pop_front() {
@@ -165,7 +333,7 @@ pub async fn all_assets(asset: Vc<Box<dyn Asset>>) -> Result<Vc<Assets>> {
             .await?;
         for asset in references.await?.iter() {
             if assets.insert(*asset) {
-                queue.push_back((*asset, all_referenced_assets(*asset)));
+                queue.push_back((*asset, all_referenced_modules(*asset)));
             }
         }
     }

--- a/crates/turbopack-core/src/reference/mod.rs
+++ b/crates/turbopack-core/src/reference/mod.rs
@@ -6,7 +6,7 @@ use turbo_tasks::{TryJoinIterExt, ValueToString, Vc};
 use crate::{
     asset::{Asset, Assets},
     issue::IssueContextExt,
-    module::{Module, Modules},
+    module::{convert_asset_to_module, Module, Modules},
     output::{OutputAsset, OutputAssets},
     resolve::{PrimaryResolveResult, ResolveResult},
 };
@@ -195,14 +195,7 @@ pub async fn all_referenced_modules(module: Vc<Box<dyn Module>>) -> Result<Vc<Mo
             queue.push_back(reference.resolve_reference());
         }
     }
-    let modules = assets
-        .into_iter()
-        .map(|asset| async move { Ok(Vc::try_resolve_downcast::<Box<dyn Module>>(asset).await?) })
-        .try_join()
-        .await?
-        .into_iter()
-        .flatten()
-        .collect();
+    let modules = assets.into_iter().map(convert_asset_to_module).collect();
     Ok(Vc::cell(modules))
 }
 

--- a/crates/turbopack-core/src/reference_type.rs
+++ b/crates/turbopack-core/src/reference_type.rs
@@ -3,13 +3,13 @@ use std::fmt::Display;
 use indexmap::IndexMap;
 use turbo_tasks::Vc;
 
-use crate::{asset::Asset, resolve::ModulePart};
+use crate::{module::Module, resolve::ModulePart};
 
 /// Named references to inner assets. Modules can used them to allow to
 /// per-module aliases of some requests to already created module assets.
 /// Name is usually in UPPER_CASE to make it clear that this is an inner asset.
 #[turbo_tasks::value(transparent)]
-pub struct InnerAssets(IndexMap<String, Vc<Box<dyn Asset>>>);
+pub struct InnerAssets(IndexMap<String, Vc<Box<dyn Module>>>);
 
 #[turbo_tasks::value_impl]
 impl InnerAssets {

--- a/crates/turbopack-core/src/resolve/mod.rs
+++ b/crates/turbopack-core/src/resolve/mod.rs
@@ -33,6 +33,7 @@ use crate::{
         pattern::{read_matches, PatternMatch},
         plugin::ResolvePlugin,
     },
+    source::{asset_to_source, Source},
 };
 
 mod alias_map;
@@ -685,7 +686,8 @@ async fn handle_resolve_plugins(
     let mut new_references = Vec::new();
 
     for primary in result_value.primary.iter() {
-        if let PrimaryResolveResult::Asset(asset) = primary {
+        if let &PrimaryResolveResult::Asset(asset) = primary {
+            let asset = asset_to_source(asset);
             if let Some(new_result) = apply_plugins_to_path(
                 asset.ident().path().resolve().await?,
                 context,

--- a/crates/turbopack-core/src/resolve/origin.rs
+++ b/crates/turbopack-core/src/resolve/origin.rs
@@ -3,9 +3,7 @@ use turbo_tasks::{Upcast, Value, Vc};
 use turbo_tasks_fs::FileSystemPath;
 
 use super::{options::ResolveOptions, parse::Request, ResolveResult};
-use crate::{
-    context::AssetContext, module::OptionModule, reference_type::ReferenceType,
-};
+use crate::{context::AssetContext, module::OptionModule, reference_type::ReferenceType};
 
 /// A location where resolving can occur from. It carries some meta information
 /// that are needed for resolving from here.

--- a/crates/turbopack-core/src/resolve/origin.rs
+++ b/crates/turbopack-core/src/resolve/origin.rs
@@ -3,7 +3,9 @@ use turbo_tasks::{Upcast, Value, Vc};
 use turbo_tasks_fs::FileSystemPath;
 
 use super::{options::ResolveOptions, parse::Request, ResolveResult};
-use crate::{asset::AssetOption, context::AssetContext, reference_type::ReferenceType};
+use crate::{
+    context::AssetContext, module::OptionModule, reference_type::ReferenceType,
+};
 
 /// A location where resolving can occur from. It carries some meta information
 /// that are needed for resolving from here.
@@ -21,7 +23,8 @@ pub trait ResolveOrigin {
 
     /// Get an inner asset form this origin that doesn't require resolving but
     /// is directly attached
-    fn get_inner_asset(self: Vc<Self>, _request: Vc<Request>) -> Vc<AssetOption> {
+    fn get_inner_asset(self: Vc<Self>, request: Vc<Request>) -> Vc<OptionModule> {
+        let _ = request;
         Vc::cell(None)
     }
 }
@@ -83,7 +86,7 @@ async fn resolve_asset(
     reference_type: Value<ReferenceType>,
 ) -> Result<Vc<ResolveResult>> {
     if let Some(asset) = *resolve_origin.get_inner_asset(request).await? {
-        return Ok(ResolveResult::asset(asset).cell());
+        return Ok(ResolveResult::asset(Vc::upcast(asset)).cell());
     }
     Ok(resolve_origin.context().resolve_asset(
         resolve_origin.origin_path(),
@@ -147,7 +150,7 @@ impl ResolveOrigin for ResolveOriginWithTransition {
     }
 
     #[turbo_tasks::function]
-    fn get_inner_asset(&self, request: Vc<Request>) -> Vc<AssetOption> {
+    fn get_inner_asset(&self, request: Vc<Request>) -> Vc<OptionModule> {
         self.previous.get_inner_asset(request)
     }
 }

--- a/crates/turbopack-core/src/source.rs
+++ b/crates/turbopack-core/src/source.rs
@@ -46,3 +46,5 @@ pub async fn option_asset_to_source(asset: Vc<AssetOption>) -> Result<Vc<OptionS
         Ok(Vc::cell(None))
     }
 }
+
+// TODO All Vc::try_resolve_downcast::<Box<dyn Source>> calls should be removed

--- a/crates/turbopack-core/src/source.rs
+++ b/crates/turbopack-core/src/source.rs
@@ -1,12 +1,19 @@
 use anyhow::{Context, Result};
 use turbo_tasks::Vc;
 
-use crate::asset::{Asset, AssetOption};
+use crate::{
+    asset::{Asset, AssetOption},
+    ident::AssetIdent,
+};
 
 /// (Unparsed) Source Code. Source Code is processed into [Module]s by the
 /// [AssetContext]. All [Source]s have content and an identifier.
 #[turbo_tasks::value_trait]
-pub trait Source: Asset {}
+pub trait Source: Asset {
+    /// The identifier of the [Source]. It's expected to be unique and capture
+    /// all properties of the [Source].
+    fn ident(&self) -> Vc<AssetIdent>;
+}
 
 #[turbo_tasks::value(transparent)]
 pub struct OptionSource(Option<Vc<Box<dyn Source>>>);

--- a/crates/turbopack-core/src/source_map/source_map_asset.rs
+++ b/crates/turbopack-core/src/source_map/source_map_asset.rs
@@ -16,22 +16,19 @@ use crate::{
 /// Represents the source map of an ecmascript asset.
 #[turbo_tasks::value]
 pub struct SourceMapAsset {
-    asset: Vc<Box<dyn Asset>>,
+    asset: Vc<Box<dyn OutputAsset>>,
 }
 
 #[turbo_tasks::value_impl]
 impl SourceMapAsset {
     #[turbo_tasks::function]
-    pub fn new(asset: Vc<Box<dyn Asset>>) -> Vc<Self> {
+    pub fn new(asset: Vc<Box<dyn OutputAsset>>) -> Vc<Self> {
         SourceMapAsset { asset }.cell()
     }
 }
 
 #[turbo_tasks::value_impl]
-impl OutputAsset for SourceMapAsset {}
-
-#[turbo_tasks::value_impl]
-impl Asset for SourceMapAsset {
+impl OutputAsset for SourceMapAsset {
     #[turbo_tasks::function]
     async fn ident(&self) -> Result<Vc<AssetIdent>> {
         // NOTE(alexkirsz) We used to include the asset's version id in the path,
@@ -40,7 +37,10 @@ impl Asset for SourceMapAsset {
             self.asset.ident().path().append(".map".to_string()),
         ))
     }
+}
 
+#[turbo_tasks::value_impl]
+impl Asset for SourceMapAsset {
     #[turbo_tasks::function]
     async fn content(&self) -> Result<Vc<AssetContent>> {
         let Some(generate_source_map) =
@@ -100,13 +100,13 @@ impl Introspectable for SourceMapAsset {
 /// server/build system of the presence of the source map
 #[turbo_tasks::value]
 pub struct SourceMapAssetReference {
-    asset: Vc<Box<dyn Asset>>,
+    asset: Vc<Box<dyn OutputAsset>>,
 }
 
 #[turbo_tasks::value_impl]
 impl SourceMapAssetReference {
     #[turbo_tasks::function]
-    pub fn new(asset: Vc<Box<dyn Asset>>) -> Vc<Self> {
+    pub fn new(asset: Vc<Box<dyn OutputAsset>>) -> Vc<Self> {
         SourceMapAssetReference { asset }.cell()
     }
 }

--- a/crates/turbopack-core/src/virtual_output.rs
+++ b/crates/turbopack-core/src/virtual_output.rs
@@ -1,45 +1,38 @@
+
 use turbo_tasks::Vc;
 use turbo_tasks_fs::FileSystemPath;
 
 use crate::{
     asset::{Asset, AssetContent},
     ident::AssetIdent,
-    source::Source,
+    output::OutputAsset,
 };
 
 /// An [Asset] that is created from some passed source code.
 #[turbo_tasks::value]
-pub struct VirtualSource {
-    pub ident: Vc<AssetIdent>,
+pub struct VirtualOutputAsset {
+    pub path: Vc<FileSystemPath>,
     pub content: Vc<AssetContent>,
 }
 
 #[turbo_tasks::value_impl]
-impl VirtualSource {
+impl VirtualOutputAsset {
     #[turbo_tasks::function]
     pub fn new(path: Vc<FileSystemPath>, content: Vc<AssetContent>) -> Vc<Self> {
-        Self::cell(VirtualSource {
-            ident: AssetIdent::from_path(path),
-            content,
-        })
-    }
-
-    #[turbo_tasks::function]
-    pub fn new_with_ident(ident: Vc<AssetIdent>, content: Vc<AssetContent>) -> Vc<Self> {
-        Self::cell(VirtualSource { ident, content })
+        VirtualOutputAsset { path, content }.cell()
     }
 }
 
 #[turbo_tasks::value_impl]
-impl Source for VirtualSource {
+impl OutputAsset for VirtualOutputAsset {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {
-        self.ident
+        AssetIdent::from_path(self.path)
     }
 }
 
 #[turbo_tasks::value_impl]
-impl Asset for VirtualSource {
+impl Asset for VirtualOutputAsset {
     #[turbo_tasks::function]
     fn content(&self) -> Vc<AssetContent> {
         self.content

--- a/crates/turbopack-core/src/virtual_output.rs
+++ b/crates/turbopack-core/src/virtual_output.rs
@@ -1,4 +1,3 @@
-
 use turbo_tasks::Vc;
 use turbo_tasks_fs::FileSystemPath;
 

--- a/crates/turbopack-css/src/asset.rs
+++ b/crates/turbopack-css/src/asset.rs
@@ -82,12 +82,15 @@ impl ParseCss for CssModuleAsset {
 }
 
 #[turbo_tasks::value_impl]
-impl Asset for CssModuleAsset {
+impl Module for CssModuleAsset {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {
         self.source.ident().with_modifier(modifier())
     }
+}
 
+#[turbo_tasks::value_impl]
+impl Asset for CssModuleAsset {
     #[turbo_tasks::function]
     fn content(&self) -> Vc<AssetContent> {
         self.source.content()
@@ -105,9 +108,6 @@ impl Asset for CssModuleAsset {
         ))
     }
 }
-
-#[turbo_tasks::value_impl]
-impl Module for CssModuleAsset {}
 
 #[turbo_tasks::value_impl]
 impl ChunkableModule for CssModuleAsset {

--- a/crates/turbopack-css/src/chunk/single_item_chunk/chunk.rs
+++ b/crates/turbopack-css/src/chunk/single_item_chunk/chunk.rs
@@ -72,6 +72,12 @@ impl SingleItemCssChunk {
 #[turbo_tasks::value_impl]
 impl Chunk for SingleItemCssChunk {
     #[turbo_tasks::function]
+    fn ident(self: Vc<Self>) -> Vc<AssetIdent> {
+        let self_as_output_asset: Vc<Box<dyn OutputAsset>> = Vc::upcast(self);
+        self_as_output_asset.ident()
+    }
+
+    #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
         self.context
     }
@@ -83,10 +89,7 @@ fn single_item_modifier() -> Vc<String> {
 }
 
 #[turbo_tasks::value_impl]
-impl OutputAsset for SingleItemCssChunk {}
-
-#[turbo_tasks::value_impl]
-impl Asset for SingleItemCssChunk {
+impl OutputAsset for SingleItemCssChunk {
     #[turbo_tasks::function]
     async fn ident(&self) -> Result<Vc<AssetIdent>> {
         Ok(AssetIdent::from_path(
@@ -98,7 +101,10 @@ impl Asset for SingleItemCssChunk {
             ),
         ))
     }
+}
 
+#[turbo_tasks::value_impl]
+impl Asset for SingleItemCssChunk {
     #[turbo_tasks::function]
     async fn content(self: Vc<Self>) -> Result<Vc<AssetContent>> {
         let code = self.code().await?;

--- a/crates/turbopack-css/src/chunk/single_item_chunk/source_map.rs
+++ b/crates/turbopack-css/src/chunk/single_item_chunk/source_map.rs
@@ -28,17 +28,17 @@ impl SingleItemCssChunkSourceMapAsset {
 }
 
 #[turbo_tasks::value_impl]
-impl OutputAsset for SingleItemCssChunkSourceMapAsset {}
-
-#[turbo_tasks::value_impl]
-impl Asset for SingleItemCssChunkSourceMapAsset {
+impl OutputAsset for SingleItemCssChunkSourceMapAsset {
     #[turbo_tasks::function]
     async fn ident(&self) -> Result<Vc<AssetIdent>> {
         Ok(AssetIdent::from_path(
             self.chunk.path().append(".map".to_string()),
         ))
     }
+}
 
+#[turbo_tasks::value_impl]
+impl Asset for SingleItemCssChunkSourceMapAsset {
     #[turbo_tasks::function]
     async fn content(&self) -> Result<Vc<AssetContent>> {
         let sm = if let Some(sm) = *self.chunk.generate_source_map().await? {

--- a/crates/turbopack-css/src/chunk/source_map.rs
+++ b/crates/turbopack-css/src/chunk/source_map.rs
@@ -28,17 +28,17 @@ impl CssChunkSourceMapAsset {
 }
 
 #[turbo_tasks::value_impl]
-impl OutputAsset for CssChunkSourceMapAsset {}
-
-#[turbo_tasks::value_impl]
-impl Asset for CssChunkSourceMapAsset {
+impl OutputAsset for CssChunkSourceMapAsset {
     #[turbo_tasks::function]
     async fn ident(&self) -> Result<Vc<AssetIdent>> {
         Ok(AssetIdent::from_path(
             self.chunk.path().append(".map".to_string()),
         ))
     }
+}
 
+#[turbo_tasks::value_impl]
+impl Asset for CssChunkSourceMapAsset {
     #[turbo_tasks::function]
     async fn content(&self) -> Result<Vc<AssetContent>> {
         let sm = if let Some(sm) = *self.chunk.generate_source_map().await? {

--- a/crates/turbopack-css/src/embed.rs
+++ b/crates/turbopack-css/src/embed.rs
@@ -3,6 +3,7 @@ use turbopack_core::{
     asset::Asset,
     chunk::{ChunkableModule, ChunkingContext},
     module::Module,
+    output::OutputAsset,
     reference::AssetReferences,
 };
 
@@ -19,5 +20,5 @@ pub trait CssEmbed {
     /// TODO(alexkirsz) This should have a default impl that returns empty
     /// references.
     fn references(self: Vc<Self>) -> Vc<AssetReferences>;
-    fn embeddable_asset(self: Vc<Self>) -> Vc<Box<dyn Asset>>;
+    fn embeddable_asset(self: Vc<Self>) -> Vc<Box<dyn OutputAsset>>;
 }

--- a/crates/turbopack-css/src/global_asset.rs
+++ b/crates/turbopack-css/src/global_asset.rs
@@ -46,12 +46,15 @@ impl GlobalCssAsset {
 }
 
 #[turbo_tasks::value_impl]
-impl Asset for GlobalCssAsset {
+impl Module for GlobalCssAsset {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {
         self.source.ident().with_modifier(modifier())
     }
+}
 
+#[turbo_tasks::value_impl]
+impl Asset for GlobalCssAsset {
     #[turbo_tasks::function]
     fn content(&self) -> Result<Vc<AssetContent>> {
         bail!("CSS global asset has no contents")
@@ -64,9 +67,6 @@ impl Asset for GlobalCssAsset {
         ))])
     }
 }
-
-#[turbo_tasks::value_impl]
-impl Module for GlobalCssAsset {}
 
 #[turbo_tasks::function]
 fn modifier() -> Vc<String> {

--- a/crates/turbopack-css/src/module_asset.rs
+++ b/crates/turbopack-css/src/module_asset.rs
@@ -61,12 +61,15 @@ impl ModuleCssAsset {
 }
 
 #[turbo_tasks::value_impl]
-impl Asset for ModuleCssAsset {
+impl Module for ModuleCssAsset {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {
         self.source.ident().with_modifier(modifier())
     }
+}
 
+#[turbo_tasks::value_impl]
+impl Asset for ModuleCssAsset {
     #[turbo_tasks::function]
     fn content(&self) -> Result<Vc<AssetContent>> {
         bail!("CSS module asset has no contents")
@@ -201,9 +204,6 @@ impl ModuleCssAsset {
         Ok(Vc::cell(references))
     }
 }
-
-#[turbo_tasks::value_impl]
-impl Module for ModuleCssAsset {}
 
 #[turbo_tasks::value_impl]
 impl ChunkableModule for ModuleCssAsset {

--- a/crates/turbopack-css/src/references/internal.rs
+++ b/crates/turbopack-css/src/references/internal.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use turbo_tasks::{ValueToString, Vc};
 use turbopack_core::{
-    asset::Asset, chunk::ChunkableModuleReference, module::Module, reference::AssetReference,
+    chunk::ChunkableModuleReference, module::Module, reference::AssetReference,
     resolve::ResolveResult,
 };
 

--- a/crates/turbopack-css/src/references/url.rs
+++ b/crates/turbopack-css/src/references/url.rs
@@ -5,10 +5,10 @@ use swc_core::{
 };
 use turbo_tasks::{Value, ValueToString, Vc};
 use turbopack_core::{
-    asset::Asset,
     chunk::ChunkingContext,
     ident::AssetIdent,
     issue::{IssueSeverity, IssueSource},
+    output::OutputAsset,
     reference::AssetReference,
     reference_type::UrlReferenceSubType,
     resolve::{origin::ResolveOrigin, parse::Request, PrimaryResolveResult, ResolveResult},
@@ -24,7 +24,7 @@ use crate::{
 
 #[turbo_tasks::value(into = "new")]
 pub enum ReferencedAsset {
-    Some(Vc<Box<dyn Asset>>),
+    Some(Vc<Box<dyn OutputAsset>>),
     None,
 }
 

--- a/crates/turbopack-dev-server/src/html.rs
+++ b/crates/turbopack-dev-server/src/html.rs
@@ -37,15 +37,15 @@ fn dev_html_chunk_reference_description() -> Vc<String> {
 }
 
 #[turbo_tasks::value_impl]
-impl OutputAsset for DevHtmlAsset {}
-
-#[turbo_tasks::value_impl]
-impl Asset for DevHtmlAsset {
+impl OutputAsset for DevHtmlAsset {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {
         AssetIdent::from_path(self.path)
     }
+}
 
+#[turbo_tasks::value_impl]
+impl Asset for DevHtmlAsset {
     #[turbo_tasks::function]
     fn content(self: Vc<Self>) -> Vc<AssetContent> {
         self.html_content().content()

--- a/crates/turbopack-dev/src/chunking_context.rs
+++ b/crates/turbopack-dev/src/chunking_context.rs
@@ -6,10 +6,10 @@ use turbo_tasks::{
 };
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
-    asset::Asset,
     chunk::{Chunk, ChunkableModule, ChunkingContext, Chunks, EvaluatableAssets},
     environment::Environment,
     ident::AssetIdent,
+    module::Module,
     output::{OutputAsset, OutputAssets},
 };
 use turbopack_css::chunk::CssChunk;
@@ -233,7 +233,10 @@ impl ChunkingContext for DevChunkingContext {
     }
 
     #[turbo_tasks::function]
-    async fn reference_chunk_source_maps(&self, chunk: Vc<Box<dyn Asset>>) -> Result<Vc<bool>> {
+    async fn reference_chunk_source_maps(
+        &self,
+        chunk: Vc<Box<dyn OutputAsset>>,
+    ) -> Result<Vc<bool>> {
         let mut source_maps = self.reference_chunk_source_maps;
         let path = chunk.ident().path().await?;
         let extension = path.extension_ref().unwrap_or_default();
@@ -250,8 +253,8 @@ impl ChunkingContext for DevChunkingContext {
     #[turbo_tasks::function]
     async fn can_be_in_same_chunk(
         &self,
-        asset_a: Vc<Box<dyn Asset>>,
-        asset_b: Vc<Box<dyn Asset>>,
+        asset_a: Vc<Box<dyn Module>>,
+        asset_b: Vc<Box<dyn Module>>,
     ) -> Result<Vc<bool>> {
         let parent_dir = asset_a.ident().path().parent().await?;
 

--- a/crates/turbopack-dev/src/ecmascript/chunk.rs
+++ b/crates/turbopack-dev/src/ecmascript/chunk.rs
@@ -3,7 +3,7 @@ use indexmap::IndexSet;
 use turbo_tasks::{ValueToString, Vc};
 use turbopack_core::{
     asset::{Asset, AssetContent},
-    chunk::{ChunkingContext, OutputChunk, OutputChunkRuntimeInfo},
+    chunk::{Chunk, ChunkingContext, OutputChunk, OutputChunkRuntimeInfo},
     ident::AssetIdent,
     introspect::{Introspectable, IntrospectableChildren},
     output::OutputAsset,
@@ -74,16 +74,16 @@ impl EcmascriptDevChunk {
 }
 
 #[turbo_tasks::value_impl]
-impl OutputAsset for EcmascriptDevChunk {}
-
-#[turbo_tasks::value_impl]
-impl Asset for EcmascriptDevChunk {
+impl OutputAsset for EcmascriptDevChunk {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {
         let ident = self.chunk.ident().with_modifier(modifier());
         AssetIdent::from_path(self.chunking_context.chunk_path(ident, ".js".to_string()))
     }
+}
 
+#[turbo_tasks::value_impl]
+impl Asset for EcmascriptDevChunk {
     #[turbo_tasks::function]
     async fn references(self: Vc<Self>) -> Result<Vc<AssetReferences>> {
         let this = self.await?;

--- a/crates/turbopack-dev/src/ecmascript/content.rs
+++ b/crates/turbopack-dev/src/ecmascript/content.rs
@@ -5,9 +5,10 @@ use indoc::writedoc;
 use turbo_tasks::Vc;
 use turbo_tasks_fs::File;
 use turbopack_core::{
-    asset::{Asset, AssetContent},
+    asset::{AssetContent},
     chunk::{ChunkingContext, ModuleId},
     code_builder::{Code, CodeBuilder},
+    output::OutputAsset,
     source_map::{GenerateSourceMap, OptionSourceMap},
     version::{
         MergeableVersionedContent, Update, Version, VersionedContent, VersionedContentMerger,

--- a/crates/turbopack-dev/src/ecmascript/content.rs
+++ b/crates/turbopack-dev/src/ecmascript/content.rs
@@ -5,7 +5,7 @@ use indoc::writedoc;
 use turbo_tasks::Vc;
 use turbo_tasks_fs::File;
 use turbopack_core::{
-    asset::{AssetContent},
+    asset::AssetContent,
     chunk::{ChunkingContext, ModuleId},
     code_builder::{Code, CodeBuilder},
     output::OutputAsset,

--- a/crates/turbopack-dev/src/ecmascript/evaluate/chunk.rs
+++ b/crates/turbopack-dev/src/ecmascript/evaluate/chunk.rs
@@ -10,6 +10,7 @@ use turbopack_core::{
     chunk::{Chunk, ChunkData, ChunkingContext, ChunksData, EvaluatableAssets, ModuleId},
     code_builder::{Code, CodeBuilder},
     ident::AssetIdent,
+    module::Module,
     output::{OutputAsset, OutputAssets},
     reference::AssetReferences,
     source_map::{GenerateSourceMap, OptionSourceMap, SourceMapAssetReference},
@@ -175,10 +176,7 @@ fn modifier() -> Vc<String> {
 }
 
 #[turbo_tasks::value_impl]
-impl OutputAsset for EcmascriptDevEvaluateChunk {}
-
-#[turbo_tasks::value_impl]
-impl Asset for EcmascriptDevEvaluateChunk {
+impl OutputAsset for EcmascriptDevEvaluateChunk {
     #[turbo_tasks::function]
     async fn ident(&self) -> Result<Vc<AssetIdent>> {
         let mut ident = self.entry_chunk.ident().await?.clone_value();
@@ -201,7 +199,10 @@ impl Asset for EcmascriptDevEvaluateChunk {
             self.chunking_context.chunk_path(ident, ".js".to_string()),
         ))
     }
+}
 
+#[turbo_tasks::value_impl]
+impl Asset for EcmascriptDevEvaluateChunk {
     #[turbo_tasks::function]
     async fn references(self: Vc<Self>) -> Result<Vc<AssetReferences>> {
         let this = self.await?;

--- a/crates/turbopack-dev/src/ecmascript/list/asset.rs
+++ b/crates/turbopack-dev/src/ecmascript/list/asset.rs
@@ -76,10 +76,7 @@ fn chunk_list_chunk_reference_description() -> Vc<String> {
 }
 
 #[turbo_tasks::value_impl]
-impl OutputAsset for EcmascriptDevChunkList {}
-
-#[turbo_tasks::value_impl]
-impl Asset for EcmascriptDevChunkList {
+impl OutputAsset for EcmascriptDevChunkList {
     #[turbo_tasks::function]
     async fn ident(&self) -> Result<Vc<AssetIdent>> {
         let mut ident = self.entry_chunk.ident().await?.clone_value();
@@ -95,7 +92,10 @@ impl Asset for EcmascriptDevChunkList {
             self.chunking_context.chunk_path(ident, ".js".to_string()),
         ))
     }
+}
 
+#[turbo_tasks::value_impl]
+impl Asset for EcmascriptDevChunkList {
     #[turbo_tasks::function]
     async fn references(&self) -> Result<Vc<AssetReferences>> {
         Ok(Vc::cell(

--- a/crates/turbopack-dev/src/ecmascript/list/content.rs
+++ b/crates/turbopack-dev/src/ecmascript/list/content.rs
@@ -10,6 +10,7 @@ use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::ChunkingContext,
     code_builder::{Code, CodeBuilder},
+    output::OutputAsset,
     version::{
         MergeableVersionedContent, Update, Version, VersionedContent, VersionedContentMerger,
     },

--- a/crates/turbopack-dev/src/ecmascript/merged/update.rs
+++ b/crates/turbopack-dev/src/ecmascript/merged/update.rs
@@ -6,9 +6,9 @@ use serde::Serialize;
 use turbo_tasks::{IntoTraitRef, ReadRef, TryJoinIterExt, Vc};
 use turbo_tasks_fs::rope::Rope;
 use turbopack_core::{
-    asset::Asset,
     chunk::{ChunkingContext, ModuleId},
     code_builder::Code,
+    output::OutputAsset,
     version::{PartialUpdate, TotalUpdate, Update, Version},
 };
 

--- a/crates/turbopack-ecmascript/src/chunk/content.rs
+++ b/crates/turbopack-ecmascript/src/chunk/content.rs
@@ -110,12 +110,12 @@ async fn ecmascript_chunk_content_single_entry(
     entry: Vc<Box<dyn EcmascriptChunkPlaceable>>,
     availability_info: Value<AvailabilityInfo>,
 ) -> Result<Vc<EcmascriptChunkContent>> {
-    let asset = Vc::upcast(entry);
+    let module = Vc::upcast(entry);
 
     Ok(EcmascriptChunkContent::cell(
         if let Some(res) = chunk_content::<Box<dyn EcmascriptChunkItem>>(
             Vc::upcast(context),
-            asset,
+            module,
             None,
             availability_info,
         )
@@ -125,7 +125,7 @@ async fn ecmascript_chunk_content_single_entry(
         } else {
             chunk_content_split::<Box<dyn EcmascriptChunkItem>>(
                 Vc::upcast(context),
-                asset,
+                module,
                 None,
                 availability_info,
             )

--- a/crates/turbopack-ecmascript/src/chunk/mod.rs
+++ b/crates/turbopack-ecmascript/src/chunk/mod.rs
@@ -20,6 +20,7 @@ use turbopack_core::{
         asset::{children_from_asset_references, content_to_details, IntrospectableAsset},
         Introspectable, IntrospectableChildren,
     },
+    module::Module,
     reference::AssetReferences,
 };
 
@@ -218,6 +219,79 @@ pub struct EcmascriptChunkComparison {
 #[turbo_tasks::value_impl]
 impl Chunk for EcmascriptChunk {
     #[turbo_tasks::function]
+    async fn ident(self: Vc<Self>) -> Result<Vc<AssetIdent>> {
+        let this = self.await?;
+
+        // All information that makes the chunk unique need to be encoded in the params.
+
+        // All main entries are included
+        let main_entries = this.main_entries.await?;
+        let main_entry_key = Vc::cell(String::new());
+        let mut assets = main_entries
+            .iter()
+            .map(|entry| (main_entry_key, entry.ident()))
+            .collect::<Vec<_>>();
+
+        // The primary name of the chunk is the only entry or the common parent of all
+        // entries.
+        let path = if let [(_, ident)] = &assets[..] {
+            ident.path()
+        } else if let &Some(common_parent) = &*self.common_parent().await? {
+            common_parent
+        } else {
+            let (_, ident) = assets[0];
+            ident.path()
+        };
+
+        // All omit entries are included
+        if let Some(omit_entries) = this.omit_entries {
+            let omit_entries = omit_entries.await?;
+            let omit_entry_key = Vc::cell("omit".to_string());
+            for entry in omit_entries.iter() {
+                assets.push((omit_entry_key, entry.ident()))
+            }
+        }
+
+        // Current availability root is included
+        if let Some(current_availability_root) = this.availability_info.current_availability_root()
+        {
+            let ident = current_availability_root.ident();
+            let need_root = if let [(_, main_entry)] = &assets[..] {
+                main_entry.resolve().await? != ident.resolve().await?
+            } else {
+                true
+            };
+            if need_root {
+                let availability_root_key = Vc::cell("current_availability_root".to_string());
+                assets.push((availability_root_key, ident));
+            }
+        }
+
+        let mut modifiers = vec![];
+
+        // Available assets are included
+        if let Some(available_assets) = this.availability_info.available_assets() {
+            modifiers.push(Vc::cell(available_assets.hash().await?.to_string()));
+        }
+
+        // Simplify when it's only a single main entry without extra info
+        let ident = if assets.len() == 1 && modifiers.is_empty() {
+            assets[0].1
+        } else {
+            AssetIdent::new(Value::new(AssetIdent {
+                path,
+                query: None,
+                fragment: None,
+                assets,
+                modifiers,
+                part: None,
+            }))
+        };
+
+        Ok(ident)
+    }
+
+    #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
         Vc::upcast(self.context)
     }
@@ -297,79 +371,6 @@ impl EcmascriptChunk {
 
 #[turbo_tasks::value_impl]
 impl Asset for EcmascriptChunk {
-    #[turbo_tasks::function]
-    async fn ident(self: Vc<Self>) -> Result<Vc<AssetIdent>> {
-        let this = self.await?;
-
-        // All information that makes the chunk unique need to be encoded in the params.
-
-        // All main entries are included
-        let main_entries = this.main_entries.await?;
-        let main_entry_key = Vc::cell(String::new());
-        let mut assets = main_entries
-            .iter()
-            .map(|entry| (main_entry_key, entry.ident()))
-            .collect::<Vec<_>>();
-
-        // The primary name of the chunk is the only entry or the common parent of all
-        // entries.
-        let path = if let [(_, ident)] = &assets[..] {
-            ident.path()
-        } else if let &Some(common_parent) = &*self.common_parent().await? {
-            common_parent
-        } else {
-            let (_, ident) = assets[0];
-            ident.path()
-        };
-
-        // All omit entries are included
-        if let Some(omit_entries) = this.omit_entries {
-            let omit_entries = omit_entries.await?;
-            let omit_entry_key = Vc::cell("omit".to_string());
-            for entry in omit_entries.iter() {
-                assets.push((omit_entry_key, entry.ident()))
-            }
-        }
-
-        // Current availability root is included
-        if let Some(current_availability_root) = this.availability_info.current_availability_root()
-        {
-            let ident = current_availability_root.ident();
-            let need_root = if let [(_, main_entry)] = &assets[..] {
-                main_entry.resolve().await? != ident.resolve().await?
-            } else {
-                true
-            };
-            if need_root {
-                let availability_root_key = Vc::cell("current_availability_root".to_string());
-                assets.push((availability_root_key, ident));
-            }
-        }
-
-        let mut modifiers = vec![];
-
-        // Available assets are included
-        if let Some(available_assets) = this.availability_info.available_assets() {
-            modifiers.push(Vc::cell(available_assets.hash().await?.to_string()));
-        }
-
-        // Simplify when it's only a single main entry without extra info
-        let ident = if assets.len() == 1 && modifiers.is_empty() {
-            assets[0].1
-        } else {
-            AssetIdent::new(Value::new(AssetIdent {
-                path,
-                query: None,
-                fragment: None,
-                assets,
-                modifiers,
-                part: None,
-            }))
-        };
-
-        Ok(ident)
-    }
-
     #[turbo_tasks::function]
     fn content(self: Vc<Self>) -> Result<Vc<AssetContent>> {
         bail!("EcmascriptChunk::content() is not implemented")

--- a/crates/turbopack-ecmascript/src/chunk_group_files_asset.rs
+++ b/crates/turbopack-ecmascript/src/chunk_group_files_asset.rs
@@ -14,7 +14,7 @@ use turbopack_core::{
         Introspectable, IntrospectableChildren,
     },
     module::Module,
-    output::OutputAssets,
+    output::{OutputAsset, OutputAssets},
     reference::{AssetReference, AssetReferences, SingleAssetReference},
 };
 
@@ -53,12 +53,15 @@ fn runtime_entry_description() -> Vc<String> {
 }
 
 #[turbo_tasks::value_impl]
-impl Asset for ChunkGroupFilesAsset {
+impl Module for ChunkGroupFilesAsset {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {
         self.module.ident().with_modifier(modifier())
     }
+}
 
+#[turbo_tasks::value_impl]
+impl Asset for ChunkGroupFilesAsset {
     #[turbo_tasks::function]
     fn content(&self) -> Vc<AssetContent> {
         AssetContent::file(File::from("// Chunking only content".to_string()).into())
@@ -83,9 +86,6 @@ impl Asset for ChunkGroupFilesAsset {
         Ok(Vc::cell(references))
     }
 }
-
-#[turbo_tasks::value_impl]
-impl Module for ChunkGroupFilesAsset {}
 
 #[turbo_tasks::value_impl]
 impl ChunkableModule for ChunkGroupFilesAsset {

--- a/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
+++ b/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
@@ -83,12 +83,15 @@ fn manifest_chunk_reference_description() -> Vc<String> {
 }
 
 #[turbo_tasks::value_impl]
-impl Asset for ManifestChunkAsset {
+impl Module for ManifestChunkAsset {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {
         self.asset.ident().with_modifier(modifier())
     }
+}
 
+#[turbo_tasks::value_impl]
+impl Asset for ManifestChunkAsset {
     #[turbo_tasks::function]
     fn content(&self) -> Vc<AssetContent> {
         todo!()
@@ -113,9 +116,6 @@ impl Asset for ManifestChunkAsset {
         ))
     }
 }
-
-#[turbo_tasks::value_impl]
-impl Module for ManifestChunkAsset {}
 
 #[turbo_tasks::value_impl]
 impl ChunkableModule for ManifestChunkAsset {

--- a/crates/turbopack-ecmascript/src/manifest/chunk_item.rs
+++ b/crates/turbopack-ecmascript/src/manifest/chunk_item.rs
@@ -5,6 +5,7 @@ use turbopack_core::{
     asset::Asset,
     chunk::{ChunkData, ChunkItem, ChunkingContext, ChunksData},
     ident::AssetIdent,
+    module::Module,
     reference::AssetReferences,
 };
 

--- a/crates/turbopack-ecmascript/src/manifest/loader_item.rs
+++ b/crates/turbopack-ecmascript/src/manifest/loader_item.rs
@@ -4,9 +4,9 @@ use anyhow::{anyhow, Result};
 use indoc::writedoc;
 use turbo_tasks::{TryJoinIterExt, Vc};
 use turbopack_core::{
-    asset::Asset,
     chunk::{ChunkData, ChunkItem, ChunkingContext, ChunksData},
     ident::AssetIdent,
+    module::Module,
     reference::{AssetReferences, SingleAssetReference},
 };
 

--- a/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -2,16 +2,16 @@ use anyhow::{anyhow, bail, Result};
 use lazy_static::lazy_static;
 use swc_core::{
     common::DUMMY_SP,
-    ecma::ast::{Expr, ExprStmt, Ident, Lit, Module, ModuleItem, Program, Script, Stmt},
+    ecma::ast::{self, Expr, ExprStmt, Ident, Lit, ModuleItem, Program, Script, Stmt},
     quote,
 };
 use turbo_tasks::{Value, ValueToString, Vc};
 use turbopack_core::{
-    asset::Asset,
     chunk::{
         ChunkableModuleReference, ChunkingContext, ChunkingType, ChunkingTypeOption, ModuleId,
     },
     issue::{IssueSeverity, OptionIssueSource},
+    module::Module,
     reference::AssetReference,
     reference_type::EcmaScriptModulesReferenceSubType,
     resolve::{
@@ -278,7 +278,7 @@ lazy_static! {
 
 pub(crate) fn insert_hoisted_stmt(program: &mut Program, stmt: Stmt) {
     match program {
-        Program::Module(Module { body, .. }) => {
+        Program::Module(ast::Module { body, .. }) => {
             let pos = body.iter().position(|item| {
                 if let ModuleItem::Stmt(Stmt::Expr(ExprStmt {
                     expr: box Expr::Lit(Lit::Str(s)),

--- a/crates/turbopack-ecmascript/src/references/esm/export.rs
+++ b/crates/turbopack-ecmascript/src/references/esm/export.rs
@@ -8,16 +8,13 @@ use serde::{Deserialize, Serialize};
 use swc_core::{
     common::DUMMY_SP,
     ecma::ast::{
-        ComputedPropName, Expr, ExprStmt, Ident, KeyValueProp, Lit, MemberExpr, MemberProp, Module,
+        self, ComputedPropName, Expr, ExprStmt, Ident, KeyValueProp, Lit, MemberExpr, MemberProp,
         ModuleItem, ObjectLit, Program, Prop, PropName, PropOrSpread, Script, Stmt, Str,
     },
     quote, quote_expr,
 };
 use turbo_tasks::{trace::TraceRawVcs, ValueToString, Vc};
-use turbopack_core::{
-    asset::Asset,
-    issue::{analyze::AnalyzeIssue, IssueExt, IssueSeverity},
-};
+use turbopack_core::{issue::{analyze::AnalyzeIssue, IssueExt, IssueSeverity}, module::Module};
 
 use super::{base::ReferencedAsset, EsmAssetReference};
 use crate::{
@@ -243,7 +240,7 @@ impl CodeGenerateable for EsmExports {
                 getters: Expr = getters.clone()
             );
             match program {
-                Program::Module(Module { body, .. }) => {
+                Program::Module(ast::Module { body, .. }) => {
                     body.insert(0, ModuleItem::Stmt(stmt));
                 }
                 Program::Script(Script { body, .. }) => {

--- a/crates/turbopack-ecmascript/src/references/esm/export.rs
+++ b/crates/turbopack-ecmascript/src/references/esm/export.rs
@@ -14,7 +14,10 @@ use swc_core::{
     quote, quote_expr,
 };
 use turbo_tasks::{trace::TraceRawVcs, ValueToString, Vc};
-use turbopack_core::{issue::{analyze::AnalyzeIssue, IssueExt, IssueSeverity}, module::Module};
+use turbopack_core::{
+    issue::{analyze::AnalyzeIssue, IssueExt, IssueSeverity},
+    module::Module,
+};
 
 use super::{base::ReferencedAsset, EsmAssetReference};
 use crate::{

--- a/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
+++ b/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
@@ -4,9 +4,8 @@ use swc_core::{
     ecma::ast::{Expr, Lit},
     quote,
 };
-use turbo_tasks::{debug::ValueDebug, Value, ValueToString, Vc};
+use turbo_tasks::{debug::ValueDebug, Value, Vc};
 use turbopack_core::{
-    asset::Asset,
     chunk::{
         availability_info::AvailabilityInfo, ChunkableModule, ChunkingContext, FromChunkableModule,
         ModuleId,
@@ -189,7 +188,7 @@ impl PatternMapping {
                 }
             }
             if let Some(chunk_item) =
-                <Box<dyn EcmascriptChunkItem>>::from_asset(context, asset).await?
+                <Box<dyn EcmascriptChunkItem>>::from_asset(context, Vc::upcast(chunkable)).await?
             {
                 return Ok(PatternMapping::cell(PatternMapping::Single(
                     chunk_item.id().await?.clone_value(),
@@ -199,10 +198,9 @@ impl PatternMapping {
         CodeGenerationIssue {
             severity: IssueSeverity::Bug.into(),
             title: Vc::cell("non-ecmascript placeable asset".to_string()),
-            message: Vc::cell(format!(
-                "asset {} is not placeable in ESM chunks, so it doesn't have a module id",
-                asset.ident().to_string().await?
-            )),
+            message: Vc::cell(
+                "asset is not placeable in ESM chunks, so it doesn't have a module id".to_string(),
+            ),
             path: origin.origin_path(),
         }
         .cell()

--- a/crates/turbopack-ecmascript/src/references/raw.rs
+++ b/crates/turbopack-ecmascript/src/references/raw.rs
@@ -1,7 +1,6 @@
 use anyhow::Result;
 use turbo_tasks::{ValueToString, Vc};
 use turbopack_core::{
-    asset::Asset,
     reference::AssetReference,
     resolve::{pattern::Pattern, resolve_raw, ResolveResult},
     source::Source,

--- a/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -344,14 +344,17 @@ fn modifier(dir: String, include_subdirs: bool) -> Vc<String> {
 }
 
 #[turbo_tasks::value_impl]
-impl Asset for RequireContextAsset {
+impl Module for RequireContextAsset {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {
         self.source
             .ident()
             .with_modifier(modifier(self.dir.clone(), self.include_subdirs))
     }
+}
 
+#[turbo_tasks::value_impl]
+impl Asset for RequireContextAsset {
     #[turbo_tasks::function]
     fn content(&self) -> Vc<AssetContent> {
         unimplemented!()
@@ -368,9 +371,6 @@ impl Asset for RequireContextAsset {
         ))
     }
 }
-
-#[turbo_tasks::value_impl]
-impl Module for RequireContextAsset {}
 
 #[turbo_tasks::value_impl]
 impl ChunkableModule for RequireContextAsset {

--- a/crates/turbopack-ecmascript/src/resolve/node_native_binding.rs
+++ b/crates/turbopack-ecmascript/src/resolve/node_native_binding.rs
@@ -162,11 +162,11 @@ pub async fn resolve_node_pre_gyp_files(
                     .results
                     .values()
                 {
-                    match entry {
-                        &DirectoryEntry::File(dylib) => {
+                    match *entry {
+                        DirectoryEntry::File(dylib) => {
                             assets.insert(Vc::upcast(FileSource::new(dylib)));
                         }
-                        &DirectoryEntry::Symlink(dylib) => {
+                        DirectoryEntry::Symlink(dylib) => {
                             let realpath_with_links = dylib.realpath_with_links().await?;
                             for symlink in realpath_with_links.symlinks.iter() {
                                 assets.insert(Vc::upcast(FileSource::new(*symlink)));

--- a/crates/turbopack-ecmascript/src/resolve/node_native_binding.rs
+++ b/crates/turbopack-ecmascript/src/resolve/node_native_binding.rs
@@ -11,6 +11,7 @@ use turbo_tasks_fs::{
 use turbopack_core::{
     asset::{Asset, AssetContent},
     file_source::FileSource,
+    module::{convert_asset_to_module, Module},
     reference::AssetReference,
     resolve::{
         pattern::Pattern, resolve_raw, AffectingResolvingAssetReference, PrimaryResolveResult,
@@ -100,6 +101,7 @@ pub async fn resolve_node_pre_gyp_files(
         .await?;
     let compile_target = compile_target.await?;
     if let Some(config_asset) = *config {
+        let config_asset = convert_asset_to_module(config_asset);
         if let AssetContent::File(file) = &*config_asset.content().await? {
             if let FileContent::Content(ref config_file) = &*file.await? {
                 let config_file_path = config_asset.ident().path();
@@ -140,9 +142,10 @@ pub async fn resolve_node_pre_gyp_files(
                         .results
                         .iter()
                     {
-                        if let DirectoryEntry::File(dylib) | DirectoryEntry::Symlink(dylib) = entry
+                        if let &DirectoryEntry::File(dylib) | &DirectoryEntry::Symlink(dylib) =
+                            entry
                         {
-                            assets.insert(Vc::upcast(FileSource::new(*dylib)));
+                            assets.insert(Vc::upcast(FileSource::new(dylib)));
                         }
                     }
                     assets.insert(Vc::upcast(FileSource::new(resolved_file_vc)));
@@ -160,15 +163,15 @@ pub async fn resolve_node_pre_gyp_files(
                     .values()
                 {
                     match entry {
-                        DirectoryEntry::File(dylib) => {
-                            assets.insert(Vc::upcast(FileSource::new(*dylib)));
+                        &DirectoryEntry::File(dylib) => {
+                            assets.insert(Vc::upcast(FileSource::new(dylib)));
                         }
-                        DirectoryEntry::Symlink(dylib) => {
+                        &DirectoryEntry::Symlink(dylib) => {
                             let realpath_with_links = dylib.realpath_with_links().await?;
                             for symlink in realpath_with_links.symlinks.iter() {
                                 assets.insert(Vc::upcast(FileSource::new(*symlink)));
                             }
-                            assets.insert(Vc::upcast(FileSource::new(*dylib)));
+                            assets.insert(Vc::upcast(FileSource::new(dylib)));
                         }
                         _ => {}
                     }

--- a/crates/turbopack-ecmascript/src/text/mod.rs
+++ b/crates/turbopack-ecmascript/src/text/mod.rs
@@ -30,10 +30,7 @@ impl TextContentFileSource {
 }
 
 #[turbo_tasks::value_impl]
-impl Source for TextContentFileSource {}
-
-#[turbo_tasks::value_impl]
-impl Asset for TextContentFileSource {
+impl Source for TextContentFileSource {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {
         self.source
@@ -41,7 +38,10 @@ impl Asset for TextContentFileSource {
             .with_modifier(modifier())
             .rename_as("*.mjs".to_string())
     }
+}
 
+#[turbo_tasks::value_impl]
+impl Asset for TextContentFileSource {
     #[turbo_tasks::function]
     async fn content(&self) -> Result<Vc<AssetContent>> {
         let source = self.source.content().file_content();

--- a/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -44,6 +44,16 @@ impl EcmascriptModulePartAsset {
 }
 
 #[turbo_tasks::value_impl]
+impl Module for EcmascriptModulePartAsset {
+    #[turbo_tasks::function]
+    async fn ident(&self) -> Result<Vc<AssetIdent>> {
+        let inner = self.full_module.ident();
+
+        Ok(inner.with_part(self.part))
+    }
+}
+
+#[turbo_tasks::value_impl]
 impl Asset for EcmascriptModulePartAsset {
     #[turbo_tasks::function]
     fn content(&self) -> Vc<AssetContent> {
@@ -94,13 +104,6 @@ impl Asset for EcmascriptModulePartAsset {
 
         Ok(Vc::cell(assets))
     }
-
-    #[turbo_tasks::function]
-    async fn ident(&self) -> Result<Vc<AssetIdent>> {
-        let inner = self.full_module.ident();
-
-        Ok(inner.with_part(self.part))
-    }
 }
 
 #[turbo_tasks::value_impl]
@@ -124,9 +127,6 @@ impl EcmascriptChunkPlaceable for EcmascriptModulePartAsset {
         Ok(self.analyze().await?.exports)
     }
 }
-
-#[turbo_tasks::value_impl]
-impl Module for EcmascriptModulePartAsset {}
 
 #[turbo_tasks::value_impl]
 impl ChunkableModule for EcmascriptModulePartAsset {

--- a/crates/turbopack-ecmascript/src/tree_shake/chunk_item.rs
+++ b/crates/turbopack-ecmascript/src/tree_shake/chunk_item.rs
@@ -4,6 +4,7 @@ use turbopack_core::{
     asset::Asset,
     chunk::{availability_info::AvailabilityInfo, ChunkItem},
     ident::AssetIdent,
+    module::Module,
     reference::AssetReferences,
 };
 

--- a/crates/turbopack-ecmascript/src/typescript/mod.rs
+++ b/crates/turbopack-ecmascript/src/typescript/mod.rs
@@ -8,6 +8,7 @@ use turbopack_core::{
     asset::{Asset, AssetContent},
     ident::AssetIdent,
     issue::{IssueSeverity, OptionIssueSource},
+    module::Module,
     reference::{AssetReference, AssetReferences},
     reference_type::{CommonJsReferenceSubType, ReferenceType},
     resolve::{
@@ -38,12 +39,15 @@ impl TsConfigModuleAsset {
 }
 
 #[turbo_tasks::value_impl]
-impl Asset for TsConfigModuleAsset {
+impl Module for TsConfigModuleAsset {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {
         self.source.ident()
     }
+}
 
+#[turbo_tasks::value_impl]
+impl Asset for TsConfigModuleAsset {
     #[turbo_tasks::function]
     fn content(&self) -> Vc<AssetContent> {
         self.source.content()

--- a/crates/turbopack-ecmascript/src/webpack/mod.rs
+++ b/crates/turbopack-ecmascript/src/webpack/mod.rs
@@ -5,6 +5,7 @@ use turbopack_core::{
     asset::{Asset, AssetContent},
     file_source::FileSource,
     ident::AssetIdent,
+    module::Module,
     reference::{AssetReference, AssetReferences},
     reference_type::{CommonJsReferenceSubType, ReferenceType},
     resolve::{
@@ -51,12 +52,15 @@ impl WebpackModuleAsset {
 }
 
 #[turbo_tasks::value_impl]
-impl Asset for WebpackModuleAsset {
+impl Module for WebpackModuleAsset {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {
         self.source.ident().with_modifier(modifier())
     }
+}
 
+#[turbo_tasks::value_impl]
+impl Asset for WebpackModuleAsset {
     #[turbo_tasks::function]
     fn content(&self) -> Vc<AssetContent> {
         self.source.content()

--- a/crates/turbopack-ecmascript/src/webpack/parse.rs
+++ b/crates/turbopack-ecmascript/src/webpack/parse.rs
@@ -13,7 +13,7 @@ use swc_core::{
 };
 use turbo_tasks::{Value, Vc};
 use turbo_tasks_fs::FileSystemPath;
-use turbopack_core::{asset::Asset, source::Source};
+use turbopack_core::{source::Source};
 
 use crate::{
     analyzer::{graph::EvalContext, JsValue},

--- a/crates/turbopack-ecmascript/src/webpack/parse.rs
+++ b/crates/turbopack-ecmascript/src/webpack/parse.rs
@@ -13,7 +13,7 @@ use swc_core::{
 };
 use turbo_tasks::{Value, Vc};
 use turbo_tasks_fs::FileSystemPath;
-use turbopack_core::{source::Source};
+use turbopack_core::source::Source;
 
 use crate::{
     analyzer::{graph::EvalContext, JsValue},

--- a/crates/turbopack-env/src/asset.rs
+++ b/crates/turbopack-env/src/asset.rs
@@ -31,15 +31,15 @@ impl ProcessEnvAsset {
 }
 
 #[turbo_tasks::value_impl]
-impl Source for ProcessEnvAsset {}
-
-#[turbo_tasks::value_impl]
-impl Asset for ProcessEnvAsset {
+impl Source for ProcessEnvAsset {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {
         AssetIdent::from_path(self.root.join(".env.js".to_string()))
     }
+}
 
+#[turbo_tasks::value_impl]
+impl Asset for ProcessEnvAsset {
     #[turbo_tasks::function]
     async fn content(&self) -> Result<Vc<AssetContent>> {
         let env = self.env.read_all().await?;

--- a/crates/turbopack-json/src/lib.rs
+++ b/crates/turbopack-json/src/lib.rs
@@ -48,20 +48,20 @@ impl JsonModuleAsset {
 }
 
 #[turbo_tasks::value_impl]
-impl Asset for JsonModuleAsset {
+impl Module for JsonModuleAsset {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {
         self.source.ident().with_modifier(modifier())
     }
+}
 
+#[turbo_tasks::value_impl]
+impl Asset for JsonModuleAsset {
     #[turbo_tasks::function]
     fn content(&self) -> Vc<AssetContent> {
         self.source.content()
     }
 }
-
-#[turbo_tasks::value_impl]
-impl Module for JsonModuleAsset {}
 
 #[turbo_tasks::value_impl]
 impl ChunkableModule for JsonModuleAsset {

--- a/crates/turbopack-mdx/src/lib.rs
+++ b/crates/turbopack-mdx/src/lib.rs
@@ -166,12 +166,15 @@ impl MdxModuleAsset {
 }
 
 #[turbo_tasks::value_impl]
-impl Asset for MdxModuleAsset {
+impl Module for MdxModuleAsset {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {
         self.source.ident().with_modifier(modifier())
     }
+}
 
+#[turbo_tasks::value_impl]
+impl Asset for MdxModuleAsset {
     #[turbo_tasks::function]
     fn content(&self) -> Vc<AssetContent> {
         self.source.content()
@@ -182,9 +185,6 @@ impl Asset for MdxModuleAsset {
         Ok(self.failsafe_analyze().await?.references)
     }
 }
-
-#[turbo_tasks::value_impl]
-impl Module for MdxModuleAsset {}
 
 #[turbo_tasks::value_impl]
 impl ChunkableModule for MdxModuleAsset {

--- a/crates/turbopack-node/src/bootstrap.rs
+++ b/crates/turbopack-node/src/bootstrap.rs
@@ -7,7 +7,7 @@ use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{Chunk, ChunkingContext, EvaluatableAssets},
     ident::AssetIdent,
-    output::OutputAssets,
+    output::{OutputAsset, OutputAssets},
     reference::{AssetReferences, SingleAssetReference},
 };
 use turbopack_ecmascript::utils::StringifyJs;
@@ -33,12 +33,15 @@ impl NodeJsBootstrapAsset {
 }
 
 #[turbo_tasks::value_impl]
-impl Asset for NodeJsBootstrapAsset {
+impl OutputAsset for NodeJsBootstrapAsset {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {
         AssetIdent::from_path(self.path)
     }
+}
 
+#[turbo_tasks::value_impl]
+impl Asset for NodeJsBootstrapAsset {
     #[turbo_tasks::function]
     async fn content(&self) -> Result<Vc<AssetContent>> {
         let context_path = self.path.parent().await?;

--- a/crates/turbopack-node/src/evaluate.rs
+++ b/crates/turbopack-node/src/evaluate.rs
@@ -21,12 +21,13 @@ use turbo_tasks_fs::{
     glob::Glob, to_sys_path, DirectoryEntry, File, FileSystemPath, ReadGlobResult,
 };
 use turbopack_core::{
-    asset::{Asset, AssetContent},
+    asset::{AssetContent},
     chunk::{ChunkableModule, ChunkingContext, EvaluatableAsset, EvaluatableAssets},
     context::AssetContext,
     file_source::FileSource,
     ident::AssetIdent,
     issue::{Issue, IssueExt, IssueSeverity},
+    module::Module,
     reference_type::{InnerAssets, ReferenceType},
     virtual_source::VirtualSource,
 };
@@ -94,7 +95,7 @@ pub struct JavaScriptEvaluation(#[turbo_tasks(trace_ignore)] JavaScriptStream);
 /// Pass the file you cared as `runtime_entries` to invalidate and reload the
 /// evaluated result automatically.
 pub async fn get_evaluate_pool(
-    module_asset: Vc<Box<dyn Asset>>,
+    module_asset: Vc<Box<dyn Module>>,
     cwd: Vc<FileSystemPath>,
     env: Vc<Box<dyn ProcessEnv>>,
     context: Vc<Box<dyn AssetContext>>,
@@ -133,7 +134,7 @@ pub async fn get_evaluate_pool(
         )),
         Value::new(ReferenceType::Internal(Vc::cell(indexmap! {
             "INNER".to_string() => module_asset,
-            "RUNTIME".to_string() => Vc::upcast(runtime_asset)
+            "RUNTIME".to_string() => runtime_asset
         }))),
     );
 
@@ -179,7 +180,7 @@ pub async fn get_evaluate_pool(
         .cell(),
     );
 
-    let output_root = chunking_context.output_root();
+    let output_root: Vc<FileSystemPath> = chunking_context.output_root();
     let emit_package = emit_package_json(output_root);
     let emit = emit(bootstrap, output_root);
     let assets_for_source_mapping = internal_assets_for_source_mapping(bootstrap, output_root);
@@ -228,7 +229,7 @@ impl futures_retry::ErrorHandler<anyhow::Error> for PoolErrorHandler {
 /// evaluated result automatically.
 #[turbo_tasks::function]
 pub fn evaluate(
-    module_asset: Vc<Box<dyn Asset>>,
+    module_asset: Vc<Box<dyn Module>>,
     cwd: Vc<FileSystemPath>,
     env: Vc<Box<dyn ProcessEnv>>,
     context_ident_for_issue: Vc<AssetIdent>,
@@ -292,7 +293,7 @@ pub fn evaluate(
 
 #[turbo_tasks::function]
 async fn compute_evaluate_stream(
-    module_asset: Vc<Box<dyn Asset>>,
+    module_asset: Vc<Box<dyn Module>>,
     cwd: Vc<FileSystemPath>,
     env: Vc<Box<dyn ProcessEnv>>,
     context_ident_for_issue: Vc<AssetIdent>,

--- a/crates/turbopack-node/src/evaluate.rs
+++ b/crates/turbopack-node/src/evaluate.rs
@@ -21,7 +21,7 @@ use turbo_tasks_fs::{
     glob::Glob, to_sys_path, DirectoryEntry, File, FileSystemPath, ReadGlobResult,
 };
 use turbopack_core::{
-    asset::{AssetContent},
+    asset::AssetContent,
     chunk::{ChunkableModule, ChunkingContext, EvaluatableAsset, EvaluatableAssets},
     context::AssetContext,
     file_source::FileSource,

--- a/crates/turbopack-node/src/lib.rs
+++ b/crates/turbopack-node/src/lib.rs
@@ -17,11 +17,12 @@ use turbo_tasks::{
 use turbo_tasks_env::ProcessEnv;
 use turbo_tasks_fs::{to_sys_path, File, FileSystemPath};
 use turbopack_core::{
-    asset::{Asset, AssetContent, AssetsSet},
+    asset::{Asset, AssetContent},
     chunk::{ChunkableModule, ChunkingContext, EvaluatableAsset, EvaluatableAssets},
-    reference::primary_referenced_assets,
+    output::{OutputAsset, OutputAssetsSet},
+    reference::{primary_referenced_output_assets},
     source_map::GenerateSourceMap,
-    virtual_source::VirtualSource,
+    virtual_output::VirtualOutputAsset, module::Module,
 };
 
 use self::{bootstrap::NodeJsBootstrapAsset, pool::NodeJsPool, source_map::StructuredError};
@@ -40,7 +41,7 @@ pub mod transforms;
 
 #[turbo_tasks::function]
 async fn emit(
-    intermediate_asset: Vc<Box<dyn Asset>>,
+    intermediate_asset: Vc<Box<dyn OutputAsset>>,
     intermediate_output_path: Vc<FileSystemPath>,
 ) -> Result<Vc<Completion>> {
     Ok(Vc::<Completions>::cell(
@@ -59,8 +60,8 @@ async fn emit(
 #[derive(Debug)]
 #[turbo_tasks::value]
 struct SeparatedAssets {
-    internal_assets: Vc<AssetsSet>,
-    external_asset_entrypoints: Vc<AssetsSet>,
+    internal_assets: Vc<OutputAssetsSet>,
+    external_asset_entrypoints: Vc<OutputAssetsSet>,
 }
 
 /// Extracts the subgraph of "internal" assets (assets within the passes
@@ -68,9 +69,9 @@ struct SeparatedAssets {
 /// "internal" subgraph.
 #[turbo_tasks::function]
 async fn internal_assets(
-    intermediate_asset: Vc<Box<dyn Asset>>,
+    intermediate_asset: Vc<Box<dyn OutputAsset>>,
     intermediate_output_path: Vc<FileSystemPath>,
-) -> Result<Vc<AssetsSet>> {
+) -> Result<Vc<OutputAssetsSet>> {
     Ok(
         separate_assets(intermediate_asset, intermediate_output_path)
             .strongly_consistent()
@@ -86,7 +87,7 @@ pub struct AssetsForSourceMapping(HashMap<String, Vc<Box<dyn GenerateSourceMap>>
 /// the [GenerateSourceMap] trait.
 #[turbo_tasks::function]
 async fn internal_assets_for_source_mapping(
-    intermediate_asset: Vc<Box<dyn Asset>>,
+    intermediate_asset: Vc<Box<dyn OutputAsset>>,
     intermediate_output_path: Vc<FileSystemPath>,
 ) -> Result<Vc<AssetsForSourceMapping>> {
     let internal_assets = internal_assets(intermediate_asset, intermediate_output_path).await?;
@@ -113,7 +114,7 @@ pub async fn external_asset_entrypoints(
     runtime_entries: Vc<EvaluatableAssets>,
     chunking_context: Vc<Box<dyn ChunkingContext>>,
     intermediate_output_path: Vc<FileSystemPath>,
-) -> Result<Vc<AssetsSet>> {
+) -> Result<Vc<OutputAssetsSet>> {
     Ok(separate_assets(
         get_intermediate_asset(chunking_context, module, runtime_entries)
             .resolve()
@@ -129,20 +130,20 @@ pub async fn external_asset_entrypoints(
 /// assets.
 #[turbo_tasks::function]
 async fn separate_assets(
-    intermediate_asset: Vc<Box<dyn Asset>>,
+    intermediate_asset: Vc<Box<dyn OutputAsset>>,
     intermediate_output_path: Vc<FileSystemPath>,
 ) -> Result<Vc<SeparatedAssets>> {
     let intermediate_output_path = &*intermediate_output_path.await?;
     #[derive(PartialEq, Eq, Hash, Clone, Copy)]
     enum Type {
-        Internal(Vc<Box<dyn Asset>>),
-        External(Vc<Box<dyn Asset>>),
+        Internal(Vc<Box<dyn OutputAsset>>),
+        External(Vc<Box<dyn OutputAsset>>),
     }
     let get_asset_children = |asset| async move {
         let Type::Internal(asset) = asset else {
             return Ok(Vec::new());
         };
-        primary_referenced_assets(asset)
+        primary_referenced_output_assets(asset)
             .await?
             .iter()
             .map(|asset| async {
@@ -198,7 +199,7 @@ async fn separate_assets(
 /// ESM, for example.
 fn emit_package_json(dir: Vc<FileSystemPath>) -> Vc<Completion> {
     emit(
-        Vc::upcast(VirtualSource::new(
+        Vc::upcast(VirtualOutputAsset::new(
             dir.join("package.json".to_string()),
             AssetContent::file(File::from("{\"type\": \"commonjs\"}").into()),
         )),
@@ -211,7 +212,7 @@ fn emit_package_json(dir: Vc<FileSystemPath>) -> Vc<Completion> {
 pub async fn get_renderer_pool(
     cwd: Vc<FileSystemPath>,
     env: Vc<Box<dyn ProcessEnv>>,
-    intermediate_asset: Vc<Box<dyn Asset>>,
+    intermediate_asset: Vc<Box<dyn OutputAsset>>,
     intermediate_output_path: Vc<FileSystemPath>,
     output_root: Vc<FileSystemPath>,
     project_dir: Vc<FileSystemPath>,
@@ -262,7 +263,7 @@ pub async fn get_intermediate_asset(
     chunking_context: Vc<Box<dyn ChunkingContext>>,
     main_entry: Vc<Box<dyn EvaluatableAsset>>,
     other_entries: Vc<EvaluatableAssets>,
-) -> Result<Vc<Box<dyn Asset>>> {
+) -> Result<Vc<Box<dyn OutputAsset>>> {
     Ok(Vc::upcast(
         NodeJsBootstrapAsset {
             path: chunking_context.chunk_path(main_entry.ident(), ".js".to_string()),

--- a/crates/turbopack-node/src/lib.rs
+++ b/crates/turbopack-node/src/lib.rs
@@ -19,10 +19,11 @@ use turbo_tasks_fs::{to_sys_path, File, FileSystemPath};
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{ChunkableModule, ChunkingContext, EvaluatableAsset, EvaluatableAssets},
+    module::Module,
     output::{OutputAsset, OutputAssetsSet},
-    reference::{primary_referenced_output_assets},
+    reference::primary_referenced_output_assets,
     source_map::GenerateSourceMap,
-    virtual_output::VirtualOutputAsset, module::Module,
+    virtual_output::VirtualOutputAsset,
 };
 
 use self::{bootstrap::NodeJsBootstrapAsset, pool::NodeJsPool, source_map::StructuredError};

--- a/crates/turbopack-node/src/render/node_api_source.rs
+++ b/crates/turbopack-node/src/render/node_api_source.rs
@@ -191,11 +191,11 @@ impl Introspectable for NodeApiContentSource {
             ));
             set.insert((
                 Vc::cell("intermediate asset".to_string()),
-                IntrospectableAsset::new(get_intermediate_asset(
+                IntrospectableAsset::new(Vc::upcast(get_intermediate_asset(
                     entry.chunking_context,
                     entry.module,
                     entry.runtime_entries,
-                )),
+                ))),
             ));
         }
         Ok(Vc::cell(set))

--- a/crates/turbopack-node/src/render/render_proxy.rs
+++ b/crates/turbopack-node/src/render/render_proxy.rs
@@ -12,10 +12,10 @@ use turbo_tasks_bytes::{Bytes, Stream};
 use turbo_tasks_env::ProcessEnv;
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
-    asset::Asset,
     chunk::{ChunkingContext, EvaluatableAsset, EvaluatableAssets},
     error::PrettyPrintError,
     issue::IssueExt,
+    module::Module,
 };
 use turbopack_dev_server::source::{Body, ProxyResult};
 

--- a/crates/turbopack-node/src/render/render_static.rs
+++ b/crates/turbopack-node/src/render/render_static.rs
@@ -16,6 +16,7 @@ use turbopack_core::{
     chunk::{ChunkingContext, EvaluatableAsset, EvaluatableAssets},
     error::PrettyPrintError,
     issue::IssueExt,
+    module::Module,
 };
 use turbopack_dev_server::{
     html::DevHtmlAsset,

--- a/crates/turbopack-node/src/render/rendered_source.rs
+++ b/crates/turbopack-node/src/render/rendered_source.rs
@@ -1,13 +1,15 @@
 use anyhow::{anyhow, Result};
 use indexmap::IndexSet;
 use serde_json::Value as JsonValue;
-use turbo_tasks::{Value, Vc};
+use turbo_tasks::{TryJoinIterExt, Value, Vc};
 use turbo_tasks_env::ProcessEnv;
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     asset::Asset,
     introspect::{asset::IntrospectableAsset, Introspectable, IntrospectableChildren},
     issue::IssueContextExt,
+    module::Module,
+    output::{OutputAsset},
     reference::AssetReference,
     resolve::PrimaryResolveResult,
     version::VersionedContentExt,
@@ -123,7 +125,14 @@ impl GetContentSource for NodeRenderContentSource {
                         } else {
                             None
                         }
-                    }),
+                    })
+                    .map(|&asset| async move {
+                        Ok(Vc::try_resolve_downcast::<Box<dyn OutputAsset>>(asset).await?)
+                    })
+                    .try_join()
+                    .await?
+                    .into_iter()
+                    .flatten(),
             )
         }
         for &entry in entries.await?.iter() {
@@ -291,11 +300,11 @@ impl Introspectable for NodeRenderContentSource {
             ));
             set.insert((
                 Vc::cell("intermediate asset".to_string()),
-                IntrospectableAsset::new(get_intermediate_asset(
+                IntrospectableAsset::new(Vc::upcast(get_intermediate_asset(
                     entry.chunking_context,
                     entry.module,
                     entry.runtime_entries,
-                )),
+                ))),
             ));
         }
         Ok(Vc::cell(set))

--- a/crates/turbopack-node/src/render/rendered_source.rs
+++ b/crates/turbopack-node/src/render/rendered_source.rs
@@ -9,7 +9,7 @@ use turbopack_core::{
     introspect::{asset::IntrospectableAsset, Introspectable, IntrospectableChildren},
     issue::IssueContextExt,
     module::Module,
-    output::{OutputAsset},
+    output::OutputAsset,
     reference::AssetReference,
     resolve::PrimaryResolveResult,
     version::VersionedContentExt,

--- a/crates/turbopack-node/src/transforms/postcss.rs
+++ b/crates/turbopack-node/src/transforms/postcss.rs
@@ -109,15 +109,15 @@ struct PostCssTransformedAsset {
 }
 
 #[turbo_tasks::value_impl]
-impl Source for PostCssTransformedAsset {}
-
-#[turbo_tasks::value_impl]
-impl Asset for PostCssTransformedAsset {
+impl Source for PostCssTransformedAsset {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {
         self.source.ident()
     }
+}
 
+#[turbo_tasks::value_impl]
+impl Asset for PostCssTransformedAsset {
     #[turbo_tasks::function]
     async fn content(self: Vc<Self>) -> Result<Vc<AssetContent>> {
         let this = self.await?;
@@ -170,10 +170,10 @@ fn postcss_executor(
     context: Vc<Box<dyn AssetContext>>,
     postcss_config_path: Vc<FileSystemPath>,
 ) -> Vc<Box<dyn Module>> {
-    let config_asset = Vc::upcast(context.process(
+    let config_asset = context.process(
         Vc::upcast(FileSource::new(postcss_config_path)),
         Value::new(ReferenceType::Entry(EntryReferenceSubType::Undefined)),
-    ));
+    );
 
     context.process(
         Vc::upcast(VirtualSource::new(
@@ -228,7 +228,7 @@ impl PostCssTransformedAsset {
         let css_path = css_fs_path.path.as_str();
 
         let config_value = evaluate(
-            Vc::upcast(postcss_executor),
+            postcss_executor,
             project_path,
             env,
             this.source.ident(),

--- a/crates/turbopack-node/src/transforms/webpack.rs
+++ b/crates/turbopack-node/src/transforms/webpack.rs
@@ -91,10 +91,7 @@ struct WebpackLoadersProcessedAsset {
 }
 
 #[turbo_tasks::value_impl]
-impl Source for WebpackLoadersProcessedAsset {}
-
-#[turbo_tasks::value_impl]
-impl Asset for WebpackLoadersProcessedAsset {
+impl Source for WebpackLoadersProcessedAsset {
     #[turbo_tasks::function]
     async fn ident(&self) -> Result<Vc<AssetIdent>> {
         Ok(
@@ -105,7 +102,10 @@ impl Asset for WebpackLoadersProcessedAsset {
             },
         )
     }
+}
 
+#[turbo_tasks::value_impl]
+impl Asset for WebpackLoadersProcessedAsset {
     #[turbo_tasks::function]
     async fn content(self: Vc<Self>) -> Result<Vc<AssetContent>> {
         Ok(self.process().await?.content)
@@ -159,7 +159,7 @@ impl WebpackLoadersProcessedAsset {
         let resource_path = resource_fs_path.path.as_str();
         let loaders = transform.loaders.await?;
         let config_value = evaluate(
-            Vc::upcast(webpack_loaders_executor),
+            webpack_loaders_executor,
             project_path,
             env,
             this.source.ident(),

--- a/crates/turbopack-static/src/fixed.rs
+++ b/crates/turbopack-static/src/fixed.rs
@@ -29,15 +29,15 @@ impl FixedStaticAsset {
 }
 
 #[turbo_tasks::value_impl]
-impl OutputAsset for FixedStaticAsset {}
-
-#[turbo_tasks::value_impl]
-impl Asset for FixedStaticAsset {
+impl OutputAsset for FixedStaticAsset {
     #[turbo_tasks::function]
     async fn ident(&self) -> Result<Vc<AssetIdent>> {
         Ok(AssetIdent::from_path(self.output_path))
     }
+}
 
+#[turbo_tasks::value_impl]
+impl Asset for FixedStaticAsset {
     #[turbo_tasks::function]
     fn content(&self) -> Vc<AssetContent> {
         self.source.content()

--- a/crates/turbopack-static/src/lib.rs
+++ b/crates/turbopack-static/src/lib.rs
@@ -70,20 +70,20 @@ impl StaticModuleAsset {
 }
 
 #[turbo_tasks::value_impl]
-impl Asset for StaticModuleAsset {
+impl Module for StaticModuleAsset {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {
         self.source.ident().with_modifier(modifier())
     }
+}
 
+#[turbo_tasks::value_impl]
+impl Asset for StaticModuleAsset {
     #[turbo_tasks::function]
     fn content(&self) -> Vc<AssetContent> {
         self.source.content()
     }
 }
-
-#[turbo_tasks::value_impl]
-impl Module for StaticModuleAsset {}
 
 #[turbo_tasks::value_impl]
 impl ChunkableModule for StaticModuleAsset {
@@ -141,10 +141,7 @@ struct StaticAsset {
 }
 
 #[turbo_tasks::value_impl]
-impl OutputAsset for StaticAsset {}
-
-#[turbo_tasks::value_impl]
-impl Asset for StaticAsset {
+impl OutputAsset for StaticAsset {
     #[turbo_tasks::function]
     async fn ident(&self) -> Result<Vc<AssetIdent>> {
         let content = self.source.content();
@@ -163,7 +160,10 @@ impl Asset for StaticAsset {
             .asset_path(content_hash_b16, self.source.ident());
         Ok(AssetIdent::from_path(asset_path))
     }
+}
 
+#[turbo_tasks::value_impl]
+impl Asset for StaticAsset {
     #[turbo_tasks::function]
     fn content(&self) -> Vc<AssetContent> {
         self.source.content()
@@ -239,7 +239,7 @@ impl CssEmbed for StaticCssEmbed {
     }
 
     #[turbo_tasks::function]
-    fn embeddable_asset(&self) -> Vc<Box<dyn Asset>> {
+    fn embeddable_asset(&self) -> Vc<Box<dyn OutputAsset>> {
         Vc::upcast(self.static_asset)
     }
 }

--- a/crates/turbopack-swc-utils/src/emitter.rs
+++ b/crates/turbopack-swc-utils/src/emitter.rs
@@ -7,7 +7,6 @@ use swc_core::common::{
 };
 use turbo_tasks::Vc;
 use turbopack_core::{
-    asset::Asset,
     issue::{analyze::AnalyzeIssue, IssueExt, IssueSeverity, IssueSource},
     source::Source,
 };
@@ -43,7 +42,7 @@ impl Emitter for IssueEmitter {
 
         let source = db.span.primary_span().map(|span| {
             IssueSource::from_byte_offset(
-                Vc::upcast(self.source),
+                self.source,
                 self.source_map.lookup_byte_offset(span.lo()).pos.to_usize(),
                 self.source_map.lookup_byte_offset(span.lo()).pos.to_usize(),
             )

--- a/crates/turbopack-test-utils/src/snapshot.rs
+++ b/crates/turbopack-test-utils/src/snapshot.rs
@@ -49,7 +49,7 @@ pub async fn snapshot_issues<
         }
 
         // Annoyingly, the PlainIssue.source -> PlainIssueSource.asset ->
-        // PlainAsset.path -> FileSystemPath.fs -> DiskFileSystem.root changes
+        // PlainSource.path -> FileSystemPath.fs -> DiskFileSystem.root changes
         // for everyone.
         let content = debug_string
             .as_str()

--- a/crates/turbopack-tests/tests/execution.rs
+++ b/crates/turbopack-tests/tests/execution.rs
@@ -23,7 +23,6 @@ use turbopack::{
     resolve_options_context::ResolveOptionsContext, ModuleAssetContext,
 };
 use turbopack_core::{
-    asset::Asset,
     chunk::{EvaluatableAssetExt, EvaluatableAssets},
     compile_time_defines,
     compile_time_info::CompileTimeInfo,
@@ -33,6 +32,7 @@ use turbopack_core::{
     issue::{Issue, IssueContextExt},
     module::Module,
     reference_type::{EntryReferenceSubType, ReferenceType},
+    source::Source,
 };
 use turbopack_dev::DevChunkingContext;
 use turbopack_node::evaluate::evaluate;
@@ -251,7 +251,7 @@ async fn run_test(resource: String) -> Result<Vc<RunTestResult>> {
     let test_asset = FileSource::new(test_path);
 
     let res = evaluate(
-        Vc::upcast(jest_entry_asset),
+        jest_entry_asset,
         chunk_root_path,
         Vc::upcast(CommandLineProcessEnv::new()),
         test_asset.ident(),

--- a/crates/turbopack-tests/tests/execution/turbopack/basic/comptime/issues/Error resolving commonjs request-ee63e3.txt
+++ b/crates/turbopack-tests/tests/execution/turbopack/basic/comptime/issues/Error resolving commonjs request-ee63e3.txt
@@ -8,7 +8,7 @@ PlainIssue {
     documentation_link: "",
     source: Some(
         PlainIssueSource {
-            asset: PlainAsset {
+            asset: PlainSource {
                 ident: "[project]/crates/turbopack-tests/tests/execution/turbopack/basic/comptime/input/index.js",
             },
             start: SourcePos {

--- a/crates/turbopack-tests/tests/snapshot.rs
+++ b/crates/turbopack-tests/tests/snapshot.rs
@@ -37,6 +37,7 @@ use turbopack_core::{
     environment::{BrowserEnvironment, Environment, ExecutionEnvironment, NodeJsEnvironment},
     file_source::FileSource,
     issue::{Issue, IssueContextExt},
+    module::Module,
     output::OutputAsset,
     reference::all_referenced_assets,
     reference_type::{EntryReferenceSubType, ReferenceType},
@@ -413,7 +414,7 @@ async fn walk_asset(
             .iter()
             .copied()
             .map(|asset| async move {
-                Ok(Vc::try_resolve_sidecast::<Box<dyn OutputAsset>>(asset).await?)
+                Ok(Vc::try_resolve_downcast::<Box<dyn OutputAsset>>(asset).await?)
             })
             .try_join()
             .await?

--- a/crates/turbopack-tests/tests/snapshot/imports/resolve_error_cjs/issues/Error resolving commonjs request-b97684.txt
+++ b/crates/turbopack-tests/tests/snapshot/imports/resolve_error_cjs/issues/Error resolving commonjs request-b97684.txt
@@ -8,7 +8,7 @@ PlainIssue {
     documentation_link: "",
     source: Some(
         PlainIssueSource {
-            asset: PlainAsset {
+            asset: PlainSource {
                 ident: "[project]/crates/turbopack-tests/tests/snapshot/imports/resolve_error_cjs/input/index.js",
             },
             start: SourcePos {

--- a/crates/turbopack/examples/turbopack.rs
+++ b/crates/turbopack/examples/turbopack.rs
@@ -69,7 +69,7 @@ async fn main() -> Result<()> {
                 Vc::upcast(source),
                 Value::new(turbopack_core::reference_type::ReferenceType::Undefined),
             );
-            let rebased = RebasedAsset::new(Vc::upcast(module), input, output);
+            let rebased = RebasedAsset::new(module, input, output);
             emit_with_completion(Vc::upcast(rebased), output).await?;
 
             Ok(unit().node)

--- a/crates/turbopack/src/graph/mod.rs
+++ b/crates/turbopack/src/graph/mod.rs
@@ -2,11 +2,14 @@ use std::collections::HashSet;
 
 use anyhow::Result;
 use turbo_tasks::Vc;
-use turbopack_core::{asset::Asset, reference::all_referenced_assets};
+use turbopack_core::{
+    output::OutputAsset,
+    reference::{all_referenced_output_assets},
+};
 
 #[turbo_tasks::value(shared)]
 pub enum AggregatedGraph {
-    Leaf(Vc<Box<dyn Asset>>),
+    Leaf(Vc<Box<dyn OutputAsset>>),
     Node {
         depth: usize,
         content: HashSet<Vc<AggregatedGraph>>,
@@ -17,7 +20,7 @@ pub enum AggregatedGraph {
 #[turbo_tasks::value_impl]
 impl AggregatedGraph {
     #[turbo_tasks::function]
-    fn leaf(asset: Vc<Box<dyn Asset>>) -> Vc<Self> {
+    fn leaf(asset: Vc<Box<dyn OutputAsset>>) -> Vc<Self> {
         Self::cell(AggregatedGraph::Leaf(asset))
     }
 }
@@ -48,7 +51,7 @@ impl AggregatedGraph {
         Ok(match *self.await? {
             AggregatedGraph::Leaf(asset) => {
                 let mut refs = HashSet::new();
-                for reference in all_referenced_assets(asset).await?.iter() {
+                for reference in all_referenced_output_assets(asset).await?.iter() {
                     let reference = reference.resolve().await?;
                     if asset != reference {
                         refs.insert(AggregatedGraph::leaf(reference));
@@ -75,7 +78,7 @@ impl AggregatedGraph {
     async fn cost(self: Vc<Self>) -> Result<Vc<AggregationCost>> {
         Ok(match *self.await? {
             AggregatedGraph::Leaf(asset) => {
-                AggregationCost(all_referenced_assets(asset).await?.len()).into()
+                AggregationCost(all_referenced_output_assets(asset).await?.len()).into()
             }
             AggregatedGraph::Node { ref references, .. } => {
                 AggregationCost(references.len()).into()
@@ -116,7 +119,7 @@ impl AggregatedGraph {
 }
 
 #[turbo_tasks::function]
-pub async fn aggregate(asset: Vc<Box<dyn Asset>>) -> Result<Vc<AggregatedGraph>> {
+pub async fn aggregate(asset: Vc<Box<dyn OutputAsset>>) -> Result<Vc<AggregatedGraph>> {
     let mut current = AggregatedGraph::leaf(asset);
     loop {
         if current.references().await?.set.is_empty() {
@@ -189,7 +192,7 @@ struct AggregatedGraphsSet {
 
 #[turbo_tasks::value(shared)]
 pub enum AggregatedGraphNodeContent {
-    Asset(Vc<Box<dyn Asset>>),
+    Asset(Vc<Box<dyn OutputAsset>>),
     Children(HashSet<Vc<AggregatedGraph>>),
 }
 

--- a/crates/turbopack/src/graph/mod.rs
+++ b/crates/turbopack/src/graph/mod.rs
@@ -2,10 +2,7 @@ use std::collections::HashSet;
 
 use anyhow::Result;
 use turbo_tasks::Vc;
-use turbopack_core::{
-    output::OutputAsset,
-    reference::{all_referenced_output_assets},
-};
+use turbopack_core::{output::OutputAsset, reference::all_referenced_output_assets};
 
 #[turbo_tasks::value(shared)]
 pub enum AggregatedGraph {

--- a/crates/turbopack/tests/node-file-trace.rs
+++ b/crates/turbopack/tests/node-file-trace.rs
@@ -36,13 +36,12 @@ use turbopack::{
     emit_with_completion, module_options::ModuleOptionsContext, rebase::RebasedAsset, register,
     resolve_options_context::ResolveOptionsContext, ModuleAssetContext,
 };
-#[cfg(not(feature = "bench_against_node_nft"))]
-use turbopack_core::asset::Asset;
 use turbopack_core::{
     compile_time_info::CompileTimeInfo,
     context::AssetContext,
     environment::{Environment, ExecutionEnvironment, NodeJsEnvironment},
     file_source::FileSource,
+    output::OutputAsset,
     reference_type::ReferenceType,
 };
 


### PR DESCRIPTION
### Description

* `ident()` is no longer on Asset, but on `Module`, `Source`, `OutputAsset` or `Chunk`
* On the way, more AssetVc types needed to be switched to more specific traits

next.js PR: https://github.com/vercel/next.js/pull/52683
