### PR TITLE
fix(turborepo): Rebuild turbo if Go code has changed

### DIFF
--- a/crates/turborepo/build.rs
+++ b/crates/turborepo/build.rs
@@ -1,6 +1,7 @@
 use std::{env, fs, path::PathBuf, process::Command};
 
 fn main() {
+    println!("cargo:rerun-if-changed=../../cli");
     let profile = env::var("PROFILE").unwrap();
     let is_ci_release =
         &profile == "release" && matches!(env::var("RELEASE_TURBO_CLI"), Ok(v) if v == "true");


### PR DESCRIPTION
### Description

 - add back the line to rerun if Go code changes, dropped in #5007 

### Testing Instructions

Verified that `touch go.sum` triggers a rebuild of the Go binary when invoking `make turbo`