### PR TITLE
fix(turborepo): Set corepack dir for examples

### DIFF
--- a/examples-tests/setup.sh
+++ b/examples-tests/setup.sh
@@ -37,12 +37,14 @@ function set_package_manager() {
 
 # Enable corepack so that when we set the packageManager in package.json it actually makes a diference.
 if [ "$PRYSK_TEMP" == "" ]; then
-  COREPACK_INSTALL_DIR=
+  COREPACK_INSTALL_DIR_CMD=
 else
-  mkdir -p "${PRYSK_TEMP}/corepack"
-  COREPACK_INSTALL_DIR="--install-directory=${PRYSK_TEMP}/corepack"
+  COREPACK_INSTALL_DIR="${PRYSK_TEMP}/corepack"
+  mkdir -p "${COREPACK_INSTALL_DIR}"
+  export PATH=${COREPACK_INSTALL_DIR}:$PATH
+  COREPACK_INSTALL_DIR_CMD="--install-directory=${COREPACK_INSTALL_DIR}"
 fi
-corepack enable "${COREPACK_INSTALL_DIR}"
+corepack enable "${COREPACK_INSTALL_DIR_CMD}"
 
 # Set the packageManger version
 NPM_PACKAGE_MANAGER_VALUE="npm@8.1.2"

--- a/examples-tests/setup.sh
+++ b/examples-tests/setup.sh
@@ -36,7 +36,13 @@ function set_package_manager() {
 }
 
 # Enable corepack so that when we set the packageManager in package.json it actually makes a diference.
-corepack enable
+if [ "$PRYSK_TEMP" == "" ]; then
+  COREPACK_INSTALL_DIR=
+else
+  mkdir -p "${PRYSK_TEMP}/corepack"
+  COREPACK_INSTALL_DIR="--install-directory=${PRYSK_TEMP}/corepack"
+fi
+corepack enable "${COREPACK_INSTALL_DIR}"
 
 # Set the packageManger version
 NPM_PACKAGE_MANAGER_VALUE="npm@8.1.2"


### PR DESCRIPTION
### Description

 - set a corepack install directory per example to avoid concurrency issues
 - set the `PATH` for the test to include the corepack directory

### Testing Instructions

Examples tests