### PR TITLE
Remove binary optimization step.

### DIFF
--- a/packages/turbo/install.js
+++ b/packages/turbo/install.js
@@ -4,7 +4,6 @@
 
 const nodePlatform = require("./node-platform");
 const fs = require("fs");
-const os = require("os");
 const path = require("path");
 const zlib = require("zlib");
 const https = require("https");
@@ -17,7 +16,6 @@ const {
 const TURBO_VERSION = require("./package.json").version;
 
 const toPath = path.join(__dirname, "bin", "turbo");
-const goToPath = path.join(__dirname, "bin", "go-turbo");
 let isToPathJS = true;
 
 function validateBinaryVersion(...command) {
@@ -48,14 +46,6 @@ function validateBinaryVersion(...command) {
       )}`
     );
   }
-}
-
-function isYarn() {
-  const { npm_config_user_agent } = process.env;
-  if (npm_config_user_agent) {
-    return /\byarn\//.test(npm_config_user_agent);
-  }
-  return false;
 }
 
 function fetch(url) {
@@ -168,66 +158,6 @@ function removeRecursive(dir) {
   fs.rmSync(dir);
 }
 
-function maybeOptimizePackage(binPath) {
-  // Everything else that this installation does is fine, but the optimization
-  // step rewrites existing files. We need to make sure that this does not
-  // happen during development. We determine that by looking for a file in
-  // the package that is not published in the `npm` registry.
-  if (fs.existsSync(path.join(__dirname, ".dev-mode"))) {
-    return;
-  }
-
-  // This package contains a "bin/turbo" JavaScript file that finds and runs
-  // the appropriate binary executable. However, this means that running the
-  // "turbo" command runs another instance of "node" which is way slower than
-  // just running the binary executable directly.
-  //
-  // Here we optimize for this by replacing the JavaScript file with the binary
-  // executable at install time. This optimization does not work on Windows
-  // because on Windows the binary executable must be called "turbo.exe"
-  // instead of "turbo".
-  //
-  // This also doesn't work with Yarn both because of lack of support for binary
-  // files in Yarn 2+ (see https://github.com/yarnpkg/berry/issues/882) and
-  // because Yarn (even Yarn 1?) may run the same install scripts in the same
-  // place multiple times from different platforms, especially when people use
-  // Docker. Avoid idempotency issues by just not optimizing when using Yarn.
-  //
-  // This optimization also doesn't apply when npm's "--ignore-scripts" flag is
-  // used since in that case this install script will not be run.
-  if (os.platform() !== "win32" && !isYarn()) {
-    const optimizeBin = (from, to, temp) => {
-      const tempPath = path.join(__dirname, temp);
-      try {
-        // First link the binary with a temporary file. If this fails and throws an
-        // error, then we'll just end up doing nothing. This uses a hard link to
-        // avoid taking up additional space on the file system.
-        fs.linkSync(from, tempPath);
-
-        // Then use rename to atomically replace the target file with the temporary
-        // file. If this fails and throws an error, then we'll just end up leaving
-        // the temporary file there, which is harmless.
-        fs.renameSync(tempPath, to);
-
-        // If we get here, then we know that the target location is now a binary
-        // executable instead of a JavaScript file.
-        isToPathJS = false;
-
-        // If this install script is being re-run, then "renameSync" will fail
-        // since the underlying inode is the same (it just returns without doing
-        // anything, and without throwing an error). In that case we should remove
-        // the file manually.
-        fs.unlinkSync(tempPath);
-      } catch {
-        // Ignore errors here since this optimization is optional
-      }
-    };
-    const goBinPath = path.join(path.dirname(binPath), "go-turbo");
-    optimizeBin(goBinPath, goToPath, "bin-go-turbo");
-    optimizeBin(binPath, toPath, "bin-turbo");
-  }
-}
-
 async function downloadDirectlyFromNPM(pkg, subpath, binPath) {
   // If that fails, the user could have npm configured incorrectly or could not
   // have npm installed. Try downloading directly from npm as a last resort.
@@ -303,8 +233,6 @@ this. If that fails, you need to remove the "--no-optional" flag to use turbo.
       }
     }
   }
-
-  maybeOptimizePackage(binPath);
 }
 
 checkAndPreparePackage().then(() => {


### PR DESCRIPTION
The binary optimization step that we perform on installation mutates files on disk in a way that can result in surprising behavior for lots of ecosystem tools.

The resulting loss in reliability via creation of numerous additional ways in which a `turbo` run can go wrong, and fail in entirely unexpected and unclear ways based upon the a cache state or stale directory, is not worth the few milliseconds of the `node` wrapper.

The attendant loss of confidence in `turbo` is far worse than shaving milliseconds.

***

Path forward:

If you directly-invoke a globally-installed `turbo` it will directly-execute the correct `turbo` version without the `node` wrapper; regardless of the installation behavior. We don't currently make it easy to install `turbo` without something like `npm` (which means that the global would _also_ be wrapped in a `node` invocation) but that is the path I would propose to take for people who want every-last-millisecond rather than rewriting in-project files.

***

The direct-invocation path for the global `turbo` is something like this, which, lol:

`~/.nvm/versions/node/v18.16.1/lib/node_modules/turbo/node_modules/turbo-darwin-arm64/bin/turbo`

***

Probably fixes #5381.