### PR TITLE
Add missing feature to syn

### DIFF
--- a/crates/turbo-tasks-macros-shared/Cargo.toml
+++ b/crates/turbo-tasks-macros-shared/Cargo.toml
@@ -11,4 +11,4 @@ bench = false
 [dependencies]
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
-syn = { workspace = true, features = ["full"] }
+syn = { workspace = true, features = ["full", "extra-traits"] }


### PR DESCRIPTION
### Description

Cargo check currently fails with:

```
error[E0277]: `syn::Type` doesn't implement `Debug`
 --> crates/turbo-tasks-macros-shared/src/primitive_input.rs:8:5
  |
6 | #[derive(Debug)]
  |          ----- in this derive macro expansion
7 | pub struct PrimitiveInput {
8 |     pub ty: Type,
  |     ^^^^^^^^^^^^ `syn::Type` cannot be formatted using `{:?}` because it doesn't implement `Debug`
  |
  = help: the trait `Debug` is not implemented for `syn::Type`
  = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)

For more information about this error, try `rustc --explain E0277`.
error: could not compile `turbo-tasks-macros-shared` (lib) due to previous error
```

This is because because turbo-tasks-macros-shared (which is missing a syn feature to enable the debug trait) is part of the workspace default members, while turbo-tasks-macros (which has the feature) isn’t.

### Testing Instructions

`cargo check`