### PR TITLE
fix(lockfile): Fix directory resolution variant

### DIFF
--- a/crates/turborepo-lockfiles/src/pnpm/data.rs
+++ b/crates/turborepo-lockfiles/src/pnpm/data.rs
@@ -80,8 +80,6 @@ pub struct Dependency {
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct PackageSnapshot {
-    // We don't use any fields in resolution in order to avoid losing data we parse it as a generic
-    // value
     resolution: PackageResolution,
     #[serde(skip_serializing_if = "Option::is_none")]
     id: Option<String>,


### PR DESCRIPTION
### Description

Fixes #5529

During the Rust migration I must've messed up the directory field name. Double checked against [`@pnpm/lockfile-types`](https://github.com/pnpm/pnpm/blob/main/lockfile/lockfile-types/src/index.ts#L86) to make sure all of the fields are correct now.

`PackageResolution` should be an enum, but the fact that tarballs are an untagged variant makes that tricky to communicate to `serde`. A struct does enough for us.

### Testing Instructions

Added new unit test to make sure we don't lose any fields for the various variants of the `resolution` field

