### PR TITLE
Write the team ID to the repository config when a repo is linked to a Space

### DIFF
--- a/crates/turborepo-lib/src/commands/link.rs
+++ b/crates/turborepo-lib/src/commands/link.rs
@@ -247,6 +247,11 @@ pub async fn link(
                 )
             })?;
 
+            fs::create_dir_all(base.repo_root.join_component(".turbo"))
+                .context("could not create .turbo directory")?;
+            base.repo_config_mut()?
+                .set_team_id(Some(team_id.to_string()))?;
+
             println!(
                 "
     {} {} linked to {}


### PR DESCRIPTION
### Description

This PR writes the team ID to the repository configuration file when a user links the repository to a Space so that that team ID will be used in future requests.

### Testing Instructions

`npx turbo login`
`npx turbo link --target=spaces`
`less .turbo/config.json`
