### PR TITLE
Remove unnecessary ValueDebugFormat item, hide Vc field

### DIFF
--- a/crates/turbo-tasks-macros/src/derive/value_debug_macro.rs
+++ b/crates/turbo-tasks-macros/src/derive/value_debug_macro.rs
@@ -2,8 +2,6 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::{parse_macro_input, DeriveInput};
 
-use super::value_debug_format_macro::get_value_debug_format_ident;
-
 /// This macro generates the implementation of the `ValueDebug` trait for a
 /// given type.
 ///
@@ -11,18 +9,17 @@ use super::value_debug_format_macro::get_value_debug_format_ident;
 pub fn derive_value_debug(input: TokenStream) -> TokenStream {
     let derive_input = parse_macro_input!(input as DeriveInput);
     let ident = &derive_input.ident;
-    let value_debug_format_ident = get_value_debug_format_ident(ident);
     quote! {
         #[turbo_tasks::value_impl]
         impl turbo_tasks::debug::ValueDebug for #ident {
             #[turbo_tasks::function]
             async fn dbg(&self) -> anyhow::Result<turbo_tasks::Vc<turbo_tasks::debug::ValueDebugString>> {
-                self.#value_debug_format_ident(usize::MAX).await
+                turbo_tasks::debug::ValueDebugFormat::value_debug_format(self, usize::MAX).try_to_value_debug_string().await
             }
 
             #[turbo_tasks::function]
             async fn dbg_depth(&self, depth: usize) -> anyhow::Result<turbo_tasks::Vc<turbo_tasks::debug::ValueDebugString>> {
-                self.#value_debug_format_ident(depth).await
+                turbo_tasks::debug::ValueDebugFormat::value_debug_format(self, depth).try_to_value_debug_string().await
             }
         }
     }

--- a/crates/turbo-tasks/src/vc/mod.rs
+++ b/crates/turbo-tasks/src/vc/mod.rs
@@ -44,6 +44,7 @@ where
     // accessible.
     #[doc(hidden)]
     pub node: RawVc,
+    #[doc(hidden)]
     pub(crate) _t: PhantomData<T>,
 }
 


### PR DESCRIPTION
### Description

This removes unnecessary items from the IDE's autosuggestion.

I'd also like to get rid of all the `*_inline` suggestions, but RA will ignore `#[doc(hidden)]` when inside the same crate. I don't think there's a way to indicate "never, ever suggest this item". We could move some of these to be private to some generated module, but that module would probably still show up as a top level suggestion. 

### Testing Instructions

Automated tests.