### PR TITLE
chore: improve turbopack test snapshots and error recovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9534,12 +9534,14 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "once_cell",
+ "regex",
  "serde",
  "similar",
  "turbo-tasks",
  "turbo-tasks-build",
  "turbo-tasks-fs",
  "turbo-tasks-hash",
+ "turbopack-cli-utils",
  "turbopack-core",
 ]
 
@@ -9563,6 +9565,7 @@ dependencies = [
  "turbo-tasks-memory",
  "turbopack",
  "turbopack-build",
+ "turbopack-cli-utils",
  "turbopack-core",
  "turbopack-dev",
  "turbopack-ecmascript-plugins",

--- a/crates/turbopack-test-utils/Cargo.toml
+++ b/crates/turbopack-test-utils/Cargo.toml
@@ -10,14 +10,16 @@ autobenches = false
 bench = false
 
 [dependencies]
-anyhow = "1.0.47"
+anyhow = { workspace = true }
 once_cell = { workspace = true }
+regex = { workspace = true, features = ["pattern"] }
 serde = { workspace = true }
 similar = "2.2.0"
-turbo-tasks = { path = "../turbo-tasks" }
-turbo-tasks-fs = { path = "../turbo-tasks-fs" }
-turbo-tasks-hash = { path = "../turbo-tasks-hash" }
-turbopack-core = { path = "../turbopack-core" }
+turbo-tasks = { workspace = true }
+turbo-tasks-fs = { workspace = true }
+turbo-tasks-hash = { workspace = true }
+turbopack-cli-utils = { workspace = true }
+turbopack-core = { workspace = true }
 
 [build-dependencies]
-turbo-tasks-build = { path = "../turbo-tasks-build" }
+turbo-tasks-build = { workspace = true }

--- a/crates/turbopack-tests/Cargo.toml
+++ b/crates/turbopack-tests/Cargo.toml
@@ -27,6 +27,7 @@ turbo-tasks-env = { workspace = true }
 turbo-tasks-fs = { workspace = true }
 turbo-tasks-memory = { workspace = true }
 turbopack-build = { workspace = true, features = ["test"] }
+turbopack-cli-utils = { workspace = true }
 turbopack-core = { workspace = true, features = ["issue_path"] }
 turbopack-dev = { workspace = true, features = ["test"] }
 turbopack-ecmascript-plugins = { workspace = true, features = [

--- a/crates/turbopack-tests/tests/execution/turbopack/async-modules/export-all/issues/unexpected export __star__-884def.txt
+++ b/crates/turbopack-tests/tests/execution/turbopack/async-modules/export-all/issues/unexpected export __star__-884def.txt
@@ -1,14 +1,3 @@
-PlainIssue {
-    severity: Warning,
-    context: "[project]/crates/turbopack-tests/tests/execution/turbopack/async-modules/export-all/input/exports.js",
-    category: "analyze",
-    title: "unexpected export *",
-    description: "export * used with module [project]/crates/turbopack-tests/tests/execution/turbopack/async-modules/export-all/input/exports.js (ecmascript) which is a CommonJS module with exports only available at runtime\nList all export names manually (`export { a, b, c } from \"...\") or rewrite the module to ESM, to avoid the additional runtime code.`",
-    detail: "",
-    documentation_link: "",
-    source: None,
-    sub_issues: [],
-    processing_path: Some(
-        [],
-    ),
-}
+warning - [analyze] [project]/crates/turbopack-tests/tests/execution/turbopack/async-modules/export-all/input/exports.js  unexpected export *
+  export * used with module [project]/crates/turbopack-tests/tests/execution/turbopack/async-modules/export-all/input/exports.js (ecmascript) which is a CommonJS module with exports only available at runtime
+  List all export names manually (`export { a, b, c } from "...") or rewrite the module to ESM, to avoid the additional runtime code.`

--- a/crates/turbopack-tests/tests/execution/turbopack/basic/comptime/issues/Error resolving commonjs request-ee63e3.txt
+++ b/crates/turbopack-tests/tests/execution/turbopack/basic/comptime/issues/Error resolving commonjs request-ee63e3.txt
@@ -1,28 +1,20 @@
-PlainIssue {
-    severity: Error,
-    context: "[project]/crates/turbopack-tests/tests/execution/turbopack/basic/comptime/input/index.js",
-    category: "resolve",
-    title: "Error resolving commonjs request",
-    description: "unable to resolve relative \"./not-existing-file\"",
-    detail: "It was not possible to find the requested file.\nParsed request as written in source code: relative \"./not-existing-file\"\nPath where resolving has started: [project]/crates/turbopack-tests/tests/execution/turbopack/basic/comptime/input/index.js\nType of request: commonjs request\nImport map: No import map entry\n",
-    documentation_link: "",
-    source: Some(
-        PlainIssueSource {
-            asset: PlainSource {
-                ident: "[project]/crates/turbopack-tests/tests/execution/turbopack/basic/comptime/input/index.js",
-            },
-            start: SourcePos {
-                line: 3,
-                column: 5,
-            },
-            end: SourcePos {
-                line: 3,
-                column: 35,
-            },
-        },
-    ),
-    sub_issues: [],
-    processing_path: Some(
-        [],
-    ),
-}
+error - [resolve] [project]/crates/turbopack-tests/tests/execution/turbopack/basic/comptime/input/index.js  /crates/turbopack-tests/tests/execution/turbopack/basic/comptime/input/index.js:4:5  Error resolving commonjs request
+       1 | it("importing a not existing file should throw", () => {
+       2 |   // This is a check to make sure that the following tests would fail if they require("fail")
+       3 |   expect(() => {
+         +      v----------------------------v
+       4 +     require("./not-existing-file");
+         +      ^----------------------------^
+       5 |   }).toThrow();
+       6 | });
+       7 | 
+       8 | function maybeReturn(x) {
+  
+  unable to resolve relative "./not-existing-file"
+  
+  | It was not possible to find the requested file.
+  | Parsed request as written in source code: relative "./not-existing-file"
+  | Path where resolving has started: [project]/crates/turbopack-tests/tests/execution/turbopack/basic/comptime/input/index.js
+  | Type of request: commonjs request
+  | Import map: No import map entry
+  |

--- a/crates/turbopack-tests/tests/execution/turbopack/basic/error/issues/Reading source code for parsing failed-3b6255.txt
+++ b/crates/turbopack-tests/tests/execution/turbopack/basic/error/issues/Reading source code for parsing failed-3b6255.txt
@@ -1,14 +1,5 @@
-PlainIssue {
-    severity: Error,
-    context: "[project]/crates/turbopack-tests/tests/execution/turbopack/basic/error/input/broken.js",
-    category: "parse",
-    title: "Reading source code for parsing failed",
-    description: "An unexpected error happened while trying to read the source code to parse: failed to convert rope into string\n\nCaused by:\n- invalid utf-8 sequence of 1 bytes from index 1",
-    detail: "",
-    documentation_link: "",
-    source: None,
-    sub_issues: [],
-    processing_path: Some(
-        [],
-    ),
-}
+error - [parse] [project]/crates/turbopack-tests/tests/execution/turbopack/basic/error/input/broken.js  Reading source code for parsing failed
+  An unexpected error happened while trying to read the source code to parse: failed to convert rope into string
+  
+  Caused by:
+  - invalid utf-8 sequence of 1 bytes from index 1

--- a/crates/turbopack-tests/tests/execution/turbopack/basic/node-default-import/issues/Specified module format (CommonJs) is not matching-5fdb68.txt
+++ b/crates/turbopack-tests/tests/execution/turbopack/basic/node-default-import/issues/Specified module format (CommonJs) is not matching-5fdb68.txt
@@ -1,14 +1,4 @@
-PlainIssue {
-    severity: Error,
-    context: "[project]/crates/turbopack-tests/tests/execution/turbopack/basic/node-default-import/input/node_modules/esm-package/invalid-exports.cjs",
-    category: "module type",
-    title: "Specified module format (CommonJs) is not matching the module format of the source code (EcmaScript Modules)",
-    description: "The CommonJs module format was specified in the package.json that is affecting this source file or by using an special extension, but Ecmascript import/export syntax is used in the source code.\nThe module was automatically converted to an EcmaScript module, but that is in conflict with the specified module format. Either change the \"type\" field in the package.json or replace EcmaScript import/export syntax with CommonJs syntas in the source file.\nIn some cases EcmaScript import/export syntax is added by an transform and isn't actually part of the source code. In these cases revisit transformation options to inject the correct syntax.",
-    detail: "",
-    documentation_link: "",
-    source: None,
-    sub_issues: [],
-    processing_path: Some(
-        [],
-    ),
-}
+error - [module type] [project]/crates/turbopack-tests/tests/execution/turbopack/basic/node-default-import/input/node_modules/esm-package/invalid-exports.cjs  Specified module format (CommonJs) is not matching the module format of the source code (EcmaScript Modules)
+  The CommonJs module format was specified in the package.json that is affecting this source file or by using an special extension, but Ecmascript import/export syntax is used in the source code.
+  The module was automatically converted to an EcmaScript module, but that is in conflict with the specified module format. Either change the "type" field in the package.json or replace EcmaScript import/export syntax with CommonJs syntas in the source file.
+  In some cases EcmaScript import/export syntax is added by an transform and isn't actually part of the source code. In these cases revisit transformation options to inject the correct syntax.

--- a/crates/turbopack-tests/tests/execution/turbopack/basic/node-default-import/issues/Specified module format (EcmaScript Modules) is no-34c311.txt
+++ b/crates/turbopack-tests/tests/execution/turbopack/basic/node-default-import/issues/Specified module format (EcmaScript Modules) is no-34c311.txt
@@ -1,14 +1,3 @@
-PlainIssue {
-    severity: Warning,
-    context: "[project]/crates/turbopack-tests/tests/execution/turbopack/basic/node-default-import/input/node_modules/esm-package/invalid-exports.js",
-    category: "module type",
-    title: "Specified module format (EcmaScript Modules) is not matching the module format of the source code (CommonJs)",
-    description: "The EcmaScript module format was specified in the package.json that is affecting this source file or by using an special extension, but it looks like that CommonJs syntax is used in the source code.\nExports made by CommonJs syntax will lead to a runtime error, since the module is in EcmaScript mode. Either change the \"type\" field in the package.json or replace CommonJs syntax with EcmaScript import/export syntax in the source file.",
-    detail: "",
-    documentation_link: "",
-    source: None,
-    sub_issues: [],
-    processing_path: Some(
-        [],
-    ),
-}
+warning - [module type] [project]/crates/turbopack-tests/tests/execution/turbopack/basic/node-default-import/input/node_modules/esm-package/invalid-exports.js  Specified module format (EcmaScript Modules) is not matching the module format of the source code (CommonJs)
+  The EcmaScript module format was specified in the package.json that is affecting this source file or by using an special extension, but it looks like that CommonJs syntax is used in the source code.
+  Exports made by CommonJs syntax will lead to a runtime error, since the module is in EcmaScript mode. Either change the "type" field in the package.json or replace CommonJs syntax with EcmaScript import/export syntax in the source file.

--- a/crates/turbopack-tests/tests/snapshot.rs
+++ b/crates/turbopack-tests/tests/snapshot.rs
@@ -11,9 +11,7 @@ use std::{
 use anyhow::{bail, Context, Result};
 use dunce::canonicalize;
 use serde::Deserialize;
-use turbo_tasks::{
-    debug::ValueDebug, unit, ReadRef, TryJoinIterExt, TurboTasks, Value, ValueToString, Vc,
-};
+use turbo_tasks::{unit, ReadRef, TryJoinIterExt, TurboTasks, Value, ValueToString, Vc};
 use turbo_tasks_env::DotenvProcessEnv;
 use turbo_tasks_fs::{
     json::parse_json_with_source_context, util::sys_to_unix, DiskFileSystem, FileSystem,
@@ -148,12 +146,7 @@ async fn run(resource: PathBuf) -> Result<()> {
 
         let plain_issues = captured_issues
             .iter_with_shortest_path()
-            .map(|(issue_vc, path)| async move {
-                Ok((
-                    issue_vc.into_plain(path).await?,
-                    issue_vc.into_plain(path).dbg().await?,
-                ))
-            })
+            .map(|(issue_vc, path)| async move { issue_vc.into_plain(path).await })
             .try_join()
             .await?;
 

--- a/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/issues/unexpected export __star__-c9d8a6.txt
+++ b/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/issues/unexpected export __star__-c9d8a6.txt
@@ -1,14 +1,3 @@
-PlainIssue {
-    severity: Warning,
-    context: "[project]/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/input/commonjs.js",
-    category: "analyze",
-    title: "unexpected export *",
-    description: "export * used with module [project]/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/input/commonjs.js (ecmascript) which is a CommonJS module with exports only available at runtime\nList all export names manually (`export { a, b, c } from \"...\") or rewrite the module to ESM, to avoid the additional runtime code.`",
-    detail: "",
-    documentation_link: "",
-    source: None,
-    sub_issues: [],
-    processing_path: Some(
-        [],
-    ),
-}
+warning - [analyze] [project]/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/input/commonjs.js  unexpected export *
+  export * used with module [project]/crates/turbopack-tests/tests/snapshot/export-alls/cjs-2/input/commonjs.js (ecmascript) which is a CommonJS module with exports only available at runtime
+  List all export names manually (`export { a, b, c } from "...") or rewrite the module to ESM, to avoid the additional runtime code.`

--- a/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/issues/unexpected export __star__-38cf67.txt
+++ b/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/issues/unexpected export __star__-38cf67.txt
@@ -1,14 +1,3 @@
-PlainIssue {
-    severity: Warning,
-    context: "[project]/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/input/exported.cjs",
-    category: "analyze",
-    title: "unexpected export *",
-    description: "export * used with module [project]/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/input/exported.cjs (ecmascript) which is a CommonJS module with exports only available at runtime\nList all export names manually (`export { a, b, c } from \"...\") or rewrite the module to ESM, to avoid the additional runtime code.`",
-    detail: "",
-    documentation_link: "",
-    source: None,
-    sub_issues: [],
-    processing_path: Some(
-        [],
-    ),
-}
+warning - [analyze] [project]/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/input/exported.cjs  unexpected export *
+  export * used with module [project]/crates/turbopack-tests/tests/snapshot/export-alls/cjs-script/input/exported.cjs (ecmascript) which is a CommonJS module with exports only available at runtime
+  List all export names manually (`export { a, b, c } from "...") or rewrite the module to ESM, to avoid the additional runtime code.`

--- a/crates/turbopack-tests/tests/snapshot/imports/json/issues/Code generation for chunk item errored-5567c6.txt
+++ b/crates/turbopack-tests/tests/snapshot/imports/json/issues/Code generation for chunk item errored-5567c6.txt
@@ -1,14 +1,18 @@
-PlainIssue {
-    severity: Error,
-    context: "[project]/crates/turbopack-tests/tests/snapshot/imports/json/input/invalid.json",
-    category: "code generation",
-    title: "Code generation for chunk item errored",
-    description: "An error occurred while generating the chunk item [project]/crates/turbopack-tests/tests/snapshot/imports/json/input/invalid.json (json)\n\nCaused by:\n- Unable to make a module from invalid JSON: expected `,` or `}` at line 3 column 26\n\nDebug info:\n- An error occurred while generating the chunk item [project]/crates/turbopack-tests/tests/snapshot/imports/json/input/invalid.json (json)\n- Execution of <JsonChunkItem as EcmascriptChunkItem>::content failed\n- Unable to make a module from invalid JSON: expected `,` or `}` at line 3 column 26\n    at nested.?\n       1 | {\n       2 |   \"nested\": {\n         |                          v\n       3 +     \"this-is\": \"invalid\" // lint-staged will remove trailing commas, so here's a comment\n         |                          ^\n       4 |   }\n       5 | }",
-    detail: "",
-    documentation_link: "",
-    source: None,
-    sub_issues: [],
-    processing_path: Some(
-        [],
-    ),
-}
+error - [code generation] [project]/crates/turbopack-tests/tests/snapshot/imports/json/input/invalid.json  Code generation for chunk item errored
+  An error occurred while generating the chunk item [project]/crates/turbopack-tests/tests/snapshot/imports/json/input/invalid.json (json)
+  
+  Caused by:
+  - Unable to make a module from invalid JSON: expected `,` or `}` at line 3 column 26
+  
+  Debug info:
+  - An error occurred while generating the chunk item [project]/crates/turbopack-tests/tests/snapshot/imports/json/input/invalid.json (json)
+  - Execution of <JsonChunkItem as EcmascriptChunkItem>::content failed
+  - Unable to make a module from invalid JSON: expected `,` or `}` at line 3 column 26
+      at nested.?
+         1 | {
+         2 |   "nested": {
+           |                          v
+         3 +     "this-is": "invalid" // lint-staged will remove trailing commas, so here's a comment
+           |                          ^
+         4 |   }
+         5 | }

--- a/crates/turbopack-tests/tests/snapshot/imports/resolve_error_cjs/issues/Error resolving commonjs request-b97684.txt
+++ b/crates/turbopack-tests/tests/snapshot/imports/resolve_error_cjs/issues/Error resolving commonjs request-b97684.txt
@@ -1,28 +1,16 @@
-PlainIssue {
-    severity: Error,
-    context: "[project]/crates/turbopack-tests/tests/snapshot/imports/resolve_error_cjs/input/index.js",
-    category: "resolve",
-    title: "Error resolving commonjs request",
-    description: "unable to resolve module \"does-not-exist\" with subpath \"/path\"",
-    detail: "It was not possible to find the requested file.\nParsed request as written in source code: module \"does-not-exist\" with subpath \"/path\"\nPath where resolving has started: [project]/crates/turbopack-tests/tests/snapshot/imports/resolve_error_cjs/input/index.js\nType of request: commonjs request\nImport map: No import map entry\n",
-    documentation_link: "",
-    source: Some(
-        PlainIssueSource {
-            asset: PlainSource {
-                ident: "[project]/crates/turbopack-tests/tests/snapshot/imports/resolve_error_cjs/input/index.js",
-            },
-            start: SourcePos {
-                line: 0,
-                column: 13,
-            },
-            end: SourcePos {
-                line: 0,
-                column: 43,
-            },
-        },
-    ),
-    sub_issues: [],
-    processing_path: Some(
-        [],
-    ),
-}
+error - [resolve] [project]/crates/turbopack-tests/tests/snapshot/imports/resolve_error_cjs/input/index.js  /crates/turbopack-tests/tests/snapshot/imports/resolve_error_cjs/input/index.js:1:13  Error resolving commonjs request
+         +              v----------------------------v
+       1 + const dne = require("does-not-exist/path");
+         +              ^----------------------------^
+       2 | 
+       3 | console.log(dne);
+       4 | 
+  
+  unable to resolve module "does-not-exist" with subpath "/path"
+  
+  | It was not possible to find the requested file.
+  | Parsed request as written in source code: module "does-not-exist" with subpath "/path"
+  | Path where resolving has started: [project]/crates/turbopack-tests/tests/snapshot/imports/resolve_error_cjs/input/index.js
+  | Type of request: commonjs request
+  | Import map: No import map entry
+  |

--- a/crates/turbopack-tests/tests/snapshot/imports/resolve_error_esm/issues/Error resolving EcmaScript Modules request-aff400.txt
+++ b/crates/turbopack-tests/tests/snapshot/imports/resolve_error_esm/issues/Error resolving EcmaScript Modules request-aff400.txt
@@ -1,14 +1,9 @@
-PlainIssue {
-    severity: Error,
-    context: "[project]/crates/turbopack-tests/tests/snapshot/imports/resolve_error_esm/input/index.js",
-    category: "resolve",
-    title: "Error resolving EcmaScript Modules request",
-    description: "unable to resolve module \"does-not-exist\" with subpath \"/path\"",
-    detail: "It was not possible to find the requested file.\nParsed request as written in source code: module \"does-not-exist\" with subpath \"/path\"\nPath where resolving has started: [project]/crates/turbopack-tests/tests/snapshot/imports/resolve_error_esm/input/index.js\nType of request: EcmaScript Modules request\nImport map: No import map entry\n",
-    documentation_link: "",
-    source: None,
-    sub_issues: [],
-    processing_path: Some(
-        [],
-    ),
-}
+error - [resolve] [project]/crates/turbopack-tests/tests/snapshot/imports/resolve_error_esm/input/index.js  Error resolving EcmaScript Modules request
+  unable to resolve module "does-not-exist" with subpath "/path"
+  
+  | It was not possible to find the requested file.
+  | Parsed request as written in source code: module "does-not-exist" with subpath "/path"
+  | Path where resolving has started: [project]/crates/turbopack-tests/tests/snapshot/imports/resolve_error_esm/input/index.js
+  | Type of request: EcmaScript Modules request
+  | Import map: No import map entry
+  |


### PR DESCRIPTION
### Description
Issue snapshots now get saved as human-readable text instead of the `.dbg()` output

Execution eval errors get handled properly