### PR TITLE
fix: Forward verbosity flags to local turbo

### DIFF
--- a/crates/turborepo-lib/src/shim.rs
+++ b/crates/turborepo-lib/src/shim.rs
@@ -88,6 +88,7 @@ impl ShimArgs {
                 is_forwarded_args = true;
             } else if arg == "--verbosity" {
                 // If we see `--verbosity` we expect the next arg to be a number.
+                remaining_turbo_args.push(arg);
                 found_verbosity_flag = true
             } else if arg.starts_with("--verbosity=") || found_verbosity_flag {
                 let verbosity_count = if found_verbosity_flag {
@@ -98,8 +99,10 @@ impl ShimArgs {
                 };
 
                 verbosity = verbosity_count.parse::<usize>().unwrap_or(0);
+                remaining_turbo_args.push(arg);
             } else if arg == "-v" || arg.starts_with("-vv") {
                 verbosity = arg[1..].len();
+                remaining_turbo_args.push(arg);
             } else if found_cwd_flag {
                 // We've seen a `--cwd` and therefore set the cwd to this arg.
                 //cwd = Some(arg.into());

--- a/turborepo-tests/integration/tests/find_turbo/hard_mode.t
+++ b/turborepo-tests/integration/tests/find_turbo/hard_mode.t
@@ -20,7 +20,7 @@ It finds repo root and uses correct version
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running local turbo binary in .*/hard_mode.t/subdir/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: supports_skip_infer_and_single_package true (re)
-  --skip-infer build --filter foo --single-package --
+  --skip-infer build --filter foo -vv --single-package --
 
 It respects cwd
   $ ${TESTDIR}/set_version.sh $TESTROOT "1.8.0"
@@ -33,7 +33,7 @@ It respects cwd
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running local turbo binary in .*/hard_mode.t/subdir/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: supports_skip_infer_and_single_package true (re)
-  --skip-infer build --filter foo --single-package --
+  --skip-infer build --filter foo -vv --single-package --
 
 It respects cwd and finds repo root
   $ ${TESTDIR}/set_version.sh $TESTROOT "1.8.0"
@@ -46,4 +46,4 @@ It respects cwd and finds repo root
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running local turbo binary in .*/hard_mode.t/subdir/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: supports_skip_infer_and_single_package true (re)
-  --skip-infer build --filter foo --single-package --
+  --skip-infer build --filter foo -vv --single-package --

--- a/turborepo-tests/integration/tests/find_turbo/hoisted.t
+++ b/turborepo-tests/integration/tests/find_turbo/hoisted.t
@@ -12,7 +12,7 @@ Make sure we use local and do not pass --skip-infer to old binary
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running local turbo binary in .*/hoisted.t/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: supports_skip_infer_and_single_package false (re)
-  build --filter foo --
+  build --filter foo -vv --
 
 Make sure we use local and pass --skip-infer to newer binary
   $ ${TESTDIR}/set_version.sh $(pwd) "1.8.0"
@@ -24,4 +24,4 @@ Make sure we use local and pass --skip-infer to newer binary
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running local turbo binary in .*/hoisted.t/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: supports_skip_infer_and_single_package true (re)
-  --skip-infer build --filter foo --single-package --
+  --skip-infer build --filter foo -vv --single-package --

--- a/turborepo-tests/integration/tests/find_turbo/linked.t
+++ b/turborepo-tests/integration/tests/find_turbo/linked.t
@@ -14,7 +14,7 @@ Make sure we use local and do not pass --skip-infer to old binary
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running local turbo binary in .*/linked.t/node_modules/.pnpm/turbo-(darwin|linux|windows)-(64|arm64)@1.0.0/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: supports_skip_infer_and_single_package false (re)
-  build --filter foo --
+  build --filter foo -vv --
 
 Make sure we use local and pass --skip-infer to newer binary
   $ ${TESTDIR}/set_version.sh $(pwd) "1.8.0"
@@ -28,4 +28,4 @@ Make sure we use local and pass --skip-infer to newer binary
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running local turbo binary in .*/linked.t/node_modules/.pnpm/turbo-(darwin|linux|windows)-(64|arm64)@1.0.0/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: supports_skip_infer_and_single_package true (re)
-  --skip-infer build --filter foo --single-package --
+  --skip-infer build --filter foo -vv --single-package --

--- a/turborepo-tests/integration/tests/find_turbo/nested.t
+++ b/turborepo-tests/integration/tests/find_turbo/nested.t
@@ -13,7 +13,7 @@ Make sure we use local and do not pass --skip-infer to old binary
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running local turbo binary in .*/nested.t/node_modules/turbo/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: supports_skip_infer_and_single_package false (re)
-  build --filter foo --
+  build --filter foo -vv --
 
 Make sure we use local and pass --skip-infer to newer binary
   $ ${TESTDIR}/set_version.sh $(pwd) "1.8.0"
@@ -26,4 +26,4 @@ Make sure we use local and pass --skip-infer to newer binary
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running local turbo binary in .*/nested.t/node_modules/turbo/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: supports_skip_infer_and_single_package true (re)
-  --skip-infer build --filter foo --single-package --
+  --skip-infer build --filter foo -vv --single-package --

--- a/turborepo-tests/integration/tests/find_turbo/unplugged.t
+++ b/turborepo-tests/integration/tests/find_turbo/unplugged.t
@@ -14,7 +14,7 @@ Make sure we use local and do not pass --skip-infer to old binary
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running local turbo binary in .*/unplugged.t/.yarn/unplugged/turbo-(darwin|linux|windows)-(64|arm64)-npm-1.0.0-520925a700/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: supports_skip_infer_and_single_package false (re)
-  build --filter foo --
+  build --filter foo -vv --
 
 Make sure we use local and pass --skip-infer to newer binary
   $ ${TESTDIR}/set_version.sh $(pwd) "1.8.0"
@@ -28,4 +28,4 @@ Make sure we use local and pass --skip-infer to newer binary
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running local turbo binary in .*/unplugged.t/.yarn/unplugged/turbo-(darwin|linux|windows)-(64|arm64)-npm-1.0.0-520925a700/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: supports_skip_infer_and_single_package true (re)
-  --skip-infer build --filter foo --single-package --
+  --skip-infer build --filter foo -vv --single-package --

--- a/turborepo-tests/integration/tests/find_turbo/unplugged_env_moved.t
+++ b/turborepo-tests/integration/tests/find_turbo/unplugged_env_moved.t
@@ -15,7 +15,7 @@ Make sure we use local and do not pass --skip-infer to old binary
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running local turbo binary in .*/unplugged_env_moved.t/.moved/unplugged/turbo-(darwin|linux|windows)-(64|arm64)-npm-1.0.0-520925a700/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: supports_skip_infer_and_single_package false (re)
-  build --filter foo --
+  build --filter foo -vv --
 
 Make sure we use local and pass --skip-infer to newer binary
   $ ${TESTDIR}/set_version.sh $(pwd) "1.8.0"
@@ -30,4 +30,4 @@ Make sure we use local and pass --skip-infer to newer binary
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running local turbo binary in .*/unplugged_env_moved.t/.moved/unplugged/turbo-(darwin|linux|windows)-(64|arm64)-npm-1.0.0-520925a700/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: supports_skip_infer_and_single_package true (re)
-  --skip-infer build --filter foo --single-package --
+  --skip-infer build --filter foo -vv --single-package --

--- a/turborepo-tests/integration/tests/find_turbo/unplugged_moved.t
+++ b/turborepo-tests/integration/tests/find_turbo/unplugged_moved.t
@@ -14,7 +14,7 @@ Make sure we use local and do not pass --skip-infer to old binary
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running local turbo binary in .*/unplugged_moved.t/.moved/unplugged/turbo-(darwin|linux|windows)-(64|arm64)-npm-1.0.0-520925a700/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: supports_skip_infer_and_single_package false (re)
-  build --filter foo --
+  build --filter foo -vv --
 
 Make sure we use local and pass --skip-infer to newer binary
   $ ${TESTDIR}/set_version.sh $(pwd) "1.8.0"
@@ -28,4 +28,4 @@ Make sure we use local and pass --skip-infer to newer binary
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running local turbo binary in .*/unplugged_moved.t/.moved/unplugged/turbo-(darwin|linux|windows)-(64|arm64)-npm-1.0.0-520925a700/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: supports_skip_infer_and_single_package true (re)
-  --skip-infer build --filter foo --single-package --
+  --skip-infer build --filter foo -vv --single-package --


### PR DESCRIPTION
### Description

If you run `turbo run build -vvv`, the verbosity will only apply to global turbo and not local turbo

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
