### PR TITLE
Hide some turbo_tasks internals

### DIFF
--- a/crates/node-file-trace/src/lib.rs
+++ b/crates/node-file-trace/src/lib.rs
@@ -496,7 +496,7 @@ async fn run<B: Backend + 'static, F: Future<Output = ()>>(
                 resolve_options,
             );
 
-            let source = TransientValue::new(output.node);
+            let source = TransientValue::new(Vc::into_raw(output));
             let issues = output
                 .peek_issues_with_path()
                 .await?
@@ -518,7 +518,7 @@ async fn run<B: Backend + 'static, F: Future<Output = ()>>(
                 sender.send(output_iter.collect::<Vec<String>>()).await?;
                 drop(sender);
             }
-            Ok(unit().node)
+            Ok(unit())
         })
     });
     finish(tt, task).await?;

--- a/crates/turbo-tasks-fs/examples/hash_directory.rs
+++ b/crates/turbo-tasks-fs/examples/hash_directory.rs
@@ -38,7 +38,7 @@ async fn main() -> Result<()> {
             let input = fs.root().join("demo".to_string());
             let dir_hash = hash_directory(input);
             print_hash(dir_hash).await?;
-            Ok(unit().node)
+            Ok(unit())
         })
     });
     tt.wait_task_completion(task, true).await.unwrap();

--- a/crates/turbo-tasks-fs/examples/hash_glob.rs
+++ b/crates/turbo-tasks-fs/examples/hash_glob.rs
@@ -37,7 +37,7 @@ async fn main() -> Result<()> {
             let glob_result = input.read_glob(glob, true);
             let dir_hash = hash_glob_result(glob_result);
             print_hash(dir_hash).await?;
-            Ok(unit().node)
+            Ok(unit())
         })
     });
     tt.wait_task_completion(task, true).await.unwrap();

--- a/crates/turbo-tasks-memory/benches/scope_stress.rs
+++ b/crates/turbo-tasks-memory/benches/scope_stress.rs
@@ -47,7 +47,7 @@ pub fn scope_stress(c: &mut Criterion) {
                                 async move {
                                     let task = tt.spawn_once_task(async move {
                                         rectangle(a, b).strongly_consistent().await?;
-                                        Ok(unit().node)
+                                        Ok(unit())
                                     });
                                     tt.wait_task_completion(task, false).await
                                 }

--- a/crates/turbo-tasks-memory/benches/stress.rs
+++ b/crates/turbo-tasks-memory/benches/stress.rs
@@ -41,7 +41,7 @@ pub fn fibonacci(c: &mut Criterion) {
                         // size >= 1 => + fib(0) = 1
                         // size >= 2 => + fib(1) = 2
                         (0..size).map(|i| fib(i, i)).try_join().await?;
-                        Ok(unit().node)
+                        Ok(unit())
                     });
                     tt.wait_task_completion(task, false).await.unwrap();
                     tt

--- a/crates/turbo-tasks-memory/src/task.rs
+++ b/crates/turbo-tasks-memory/src/task.rs
@@ -2269,7 +2269,7 @@ impl Task {
                             read_task_id,
                             &*turbo_tasks,
                         );
-                        RawVc::TaskOutput(task).into_read::<AutoSet<RawVc>>()
+                        unsafe { <Vc<AutoSet<RawVc>>>::from_task_id(task) }
                     })
                 })
             })
@@ -2280,7 +2280,9 @@ impl Task {
                 current.add(*v);
             }
         }
-        Ok(Vc::<AutoSet<_>>::cell(current.iter().copied().collect()).node)
+        Ok(Vc::into_raw(Vc::cell::<AutoSet<RawVc>>(
+            current.iter().copied().collect(),
+        )))
     }
 
     pub(crate) fn read_task_collectibles(

--- a/crates/turbo-tasks-memory/src/task.rs
+++ b/crates/turbo-tasks-memory/src/task.rs
@@ -2280,7 +2280,7 @@ impl Task {
                 current.add(*v);
             }
         }
-        Ok(Vc::into_raw(Vc::cell::<AutoSet<RawVc>>(
+        Ok(Vc::into_raw(Vc::<AutoSet<RawVc>>::cell(
             current.iter().copied().collect(),
         )))
     }

--- a/crates/turbo-tasks/src/lib.rs
+++ b/crates/turbo-tasks/src/lib.rs
@@ -58,6 +58,7 @@ mod once_map;
 pub mod persisted_graph;
 pub mod primitives;
 mod raw_vc;
+mod raw_vc_set;
 mod read_ref;
 pub mod registry;
 pub mod small_duration;

--- a/crates/turbo-tasks/src/primitives.rs
+++ b/crates/turbo-tasks/src/primitives.rs
@@ -1,13 +1,12 @@
 use std::{future::IntoFuture, ops::Deref};
 
 use anyhow::Result;
-use auto_hash_map::AutoSet;
 use futures::TryFutureExt;
 // This specific macro identifier is detected by turbo-tasks-build.
 use turbo_tasks_macros::primitive as __turbo_tasks_internal_primitive;
 
 use crate::{
-    RawVc, TryJoinIterExt, Vc, {self as turbo_tasks},
+    TryJoinIterExt, Vc, {self as turbo_tasks},
 };
 
 __turbo_tasks_internal_primitive!(());
@@ -72,7 +71,6 @@ __turbo_tasks_internal_primitive!(i64);
 __turbo_tasks_internal_primitive!(i128);
 __turbo_tasks_internal_primitive!(usize);
 __turbo_tasks_internal_primitive!(isize);
-__turbo_tasks_internal_primitive!(AutoSet<RawVc>);
 __turbo_tasks_internal_primitive!(serde_json::Value);
 __turbo_tasks_internal_primitive!(Vec<u8>);
 

--- a/crates/turbo-tasks/src/raw_vc.rs
+++ b/crates/turbo-tasks/src/raw_vc.rs
@@ -85,14 +85,6 @@ impl RawVc {
         ReadRawVcFuture::new(self)
     }
 
-    pub(crate) fn into_strongly_consistent_trait_read<T: VcValueTrait + Sized>(
-        self,
-    ) -> ReadRawVcFuture<T, VcValueTraitCast<T>> {
-        // returns a custom future to have something concrete and sized
-        // this avoids boxing in IntoFuture
-        ReadRawVcFuture::new_strongly_consistent(self)
-    }
-
     /// INVALIDATION: Be careful with this, it will not track dependencies, so
     /// using it could break cache invalidation.
     pub(crate) fn into_read_untracked_with_turbo_tasks<T: Any + VcValueType>(
@@ -230,13 +222,6 @@ impl RawVc {
     pub(crate) fn connect(&self) {
         let tt = turbo_tasks();
         tt.connect_task(self.get_task_id());
-    }
-
-    pub(crate) fn is_resolved(&self) -> bool {
-        match self {
-            RawVc::TaskOutput(_) => false,
-            RawVc::TaskCell(_, _) => true,
-        }
     }
 
     pub fn get_task_id(&self) -> TaskId {

--- a/crates/turbo-tasks/src/raw_vc.rs
+++ b/crates/turbo-tasks/src/raw_vc.rs
@@ -102,14 +102,6 @@ impl RawVc {
         ReadRawVcFuture::new_untracked(self)
     }
 
-    /// INVALIDATION: Be careful with this, it will not track dependencies, so
-    /// using it could break cache invalidation.
-    pub(crate) fn into_strongly_consistent_read_untracked<T: Any + VcValueType>(
-        self,
-    ) -> ReadRawVcFuture<T, VcValueTypeCast<T>> {
-        ReadRawVcFuture::new_strongly_consistent_untracked(self)
-    }
-
     pub(crate) async fn resolve_trait(
         self,
         trait_type: TraitTypeId,
@@ -328,19 +320,6 @@ impl<T: ?Sized, Cast: VcCast> ReadRawVcFuture<T, Cast> {
             strongly_consistent: true,
             current: vc,
             untracked: false,
-            listener: None,
-            phantom_data: PhantomData,
-            _cast: PhantomData,
-        }
-    }
-
-    fn new_strongly_consistent_untracked(vc: RawVc) -> Self {
-        let tt = turbo_tasks();
-        ReadRawVcFuture {
-            turbo_tasks: tt,
-            strongly_consistent: true,
-            current: vc,
-            untracked: true,
             listener: None,
             phantom_data: PhantomData,
             _cast: PhantomData,

--- a/crates/turbo-tasks/src/raw_vc.rs
+++ b/crates/turbo-tasks/src/raw_vc.rs
@@ -105,6 +105,7 @@ impl RawVc {
     /// INVALIDATION: Be careful with this, it will not track dependencies, so
     /// using it could break cache invalidation.
     pub(crate) fn into_strongly_consistent_read_untracked<T: Any + VcValueType>(
+        self,
     ) -> ReadRawVcFuture<T, VcValueTypeCast<T>> {
         ReadRawVcFuture::new_strongly_consistent_untracked(self)
     }

--- a/crates/turbo-tasks/src/raw_vc.rs
+++ b/crates/turbo-tasks/src/raw_vc.rs
@@ -63,13 +63,13 @@ pub enum RawVc {
 }
 
 impl RawVc {
-    pub fn into_read<T: VcValueType>(self) -> ReadRawVcFuture<T, VcValueTypeCast<T>> {
+    pub(crate) fn into_read<T: VcValueType>(self) -> ReadRawVcFuture<T, VcValueTypeCast<T>> {
         // returns a custom future to have something concrete and sized
         // this avoids boxing in IntoFuture
         ReadRawVcFuture::new(self)
     }
 
-    pub fn into_strongly_consistent_read<T: VcValueType>(
+    pub(crate) fn into_strongly_consistent_read<T: VcValueType>(
         self,
     ) -> ReadRawVcFuture<T, VcValueTypeCast<T>> {
         // returns a custom future to have something concrete and sized
@@ -77,7 +77,7 @@ impl RawVc {
         ReadRawVcFuture::new_strongly_consistent(self)
     }
 
-    pub fn into_trait_read<T: VcValueTrait + ?Sized>(
+    pub(crate) fn into_trait_read<T: VcValueTrait + ?Sized>(
         self,
     ) -> ReadRawVcFuture<T, VcValueTraitCast<T>> {
         // returns a custom future to have something concrete and sized
@@ -85,7 +85,7 @@ impl RawVc {
         ReadRawVcFuture::new(self)
     }
 
-    pub fn into_strongly_consistent_trait_read<T: VcValueTrait + Sized>(
+    pub(crate) fn into_strongly_consistent_trait_read<T: VcValueTrait + Sized>(
         self,
     ) -> ReadRawVcFuture<T, VcValueTraitCast<T>> {
         // returns a custom future to have something concrete and sized
@@ -95,7 +95,7 @@ impl RawVc {
 
     /// INVALIDATION: Be careful with this, it will not track dependencies, so
     /// using it could break cache invalidation.
-    pub fn into_read_untracked_with_turbo_tasks<T: Any + VcValueType>(
+    pub(crate) fn into_read_untracked_with_turbo_tasks<T: Any + VcValueType>(
         self,
         turbo_tasks: &dyn TurboTasksApi,
     ) -> ReadRawVcFuture<T, VcValueTypeCast<T>> {
@@ -104,7 +104,7 @@ impl RawVc {
 
     /// INVALIDATION: Be careful with this, it will not track dependencies, so
     /// using it could break cache invalidation.
-    pub fn into_trait_read_untracked<T: VcValueTrait + ?Sized>(
+    pub(crate) fn into_trait_read_untracked<T: VcValueTrait + ?Sized>(
         self,
     ) -> ReadRawVcFuture<T, VcValueTraitCast<T>> {
         ReadRawVcFuture::new_untracked(self)
@@ -112,13 +112,12 @@ impl RawVc {
 
     /// INVALIDATION: Be careful with this, it will not track dependencies, so
     /// using it could break cache invalidation.
-    pub fn into_strongly_consistent_read_untracked<T: Any + VcValueType>(
-        self,
+    pub(crate) fn into_strongly_consistent_read_untracked<T: Any + VcValueType>(
     ) -> ReadRawVcFuture<T, VcValueTypeCast<T>> {
         ReadRawVcFuture::new_strongly_consistent_untracked(self)
     }
 
-    pub async fn resolve_trait(
+    pub(crate) async fn resolve_trait(
         self,
         trait_type: TraitTypeId,
     ) -> Result<Option<RawVc>, ResolveTypeError> {
@@ -154,7 +153,7 @@ impl RawVc {
         }
     }
 
-    pub async fn resolve_value(
+    pub(crate) async fn resolve_value(
         self,
         value_type: ValueTypeId,
     ) -> Result<Option<RawVc>, ResolveTypeError> {
@@ -191,7 +190,7 @@ impl RawVc {
     }
 
     /// See [`crate::Vc::resolve`].
-    pub async fn resolve(self) -> Result<RawVc> {
+    pub(crate) async fn resolve(self) -> Result<RawVc> {
         let tt = turbo_tasks();
         let mut current = self;
         let mut notified = false;
@@ -208,8 +207,9 @@ impl RawVc {
             }
         }
     }
+
     /// See [`crate::Vc::resolve_strongly_consistent`].
-    pub async fn resolve_strongly_consistent(self) -> Result<RawVc> {
+    pub(crate) async fn resolve_strongly_consistent(self) -> Result<RawVc> {
         let tt = turbo_tasks();
         let mut current = self;
         let mut notified = false;
@@ -227,12 +227,12 @@ impl RawVc {
         }
     }
 
-    pub fn connect(&self) {
+    pub(crate) fn connect(&self) {
         let tt = turbo_tasks();
         tt.connect_task(self.get_task_id());
     }
 
-    pub fn is_resolved(&self) -> bool {
+    pub(crate) fn is_resolved(&self) -> bool {
         match self {
             RawVc::TaskOutput(_) => false,
             RawVc::TaskCell(_, _) => true,
@@ -250,8 +250,7 @@ impl CollectiblesSource for RawVc {
     fn peek_collectibles<T: VcValueTrait>(self) -> CollectiblesFuture<T> {
         let tt = turbo_tasks();
         tt.notify_scheduled_tasks();
-        let set: Vc<AutoSet<RawVc>> =
-            tt.read_task_collectibles(self.get_task_id(), T::get_trait_type_id());
+        let set = tt.read_task_collectibles(self.get_task_id(), T::get_trait_type_id());
         CollectiblesFuture {
             turbo_tasks: tt,
             inner: set.into_future(),
@@ -263,8 +262,7 @@ impl CollectiblesSource for RawVc {
     fn take_collectibles<T: VcValueTrait>(self) -> CollectiblesFuture<T> {
         let tt = turbo_tasks();
         tt.notify_scheduled_tasks();
-        let set: Vc<AutoSet<RawVc>> =
-            tt.read_task_collectibles(self.get_task_id(), T::get_trait_type_id());
+        let set = tt.read_task_collectibles(self.get_task_id(), T::get_trait_type_id());
         CollectiblesFuture {
             turbo_tasks: tt,
             inner: set.into_future(),

--- a/crates/turbo-tasks/src/raw_vc_set.rs
+++ b/crates/turbo-tasks/src/raw_vc_set.rs
@@ -1,0 +1,24 @@
+use std::marker::PhantomData;
+
+use auto_hash_map::AutoSet;
+// This specific macro identifier is detected by turbo-tasks-build.
+use turbo_tasks_macros::primitive as __turbo_tasks_internal_primitive;
+
+use crate as turbo_tasks;
+use crate::{RawVc, TaskId, Vc};
+
+__turbo_tasks_internal_primitive!(AutoSet<RawVc>);
+
+impl Vc<AutoSet<RawVc>> {
+    /// Casts a `TaskId` to a `Vc<AutoSet<RawVc>>`.
+    ///
+    /// # Safety
+    ///
+    /// The `TaskId` must be point to a valid `AutoSet<RawVc>`.
+    pub unsafe fn from_task_id(task_id: TaskId) -> Self {
+        Vc {
+            node: RawVc::TaskOutput(task_id),
+            _t: PhantomData,
+        }
+    }
+}

--- a/crates/turbopack-cli/src/build/mod.rs
+++ b/crates/turbopack-cli/src/build/mod.rs
@@ -143,7 +143,7 @@ impl TurbopackBuildBuilder {
             )
             .await?;
 
-            Ok(unit().node)
+            Ok(unit())
         });
 
         self.turbo_tasks.wait_task_completion(task, true).await?;

--- a/crates/turbopack-core/src/issue/mod.rs
+++ b/crates/turbopack-core/src/issue/mod.rs
@@ -759,7 +759,7 @@ pub async fn handle_issues<T>(
 
     let has_fatal = issue_reporter.report_issues(
         TransientInstance::new(issues.clone()),
-        TransientValue::new(source.node),
+        TransientValue::new(Vc::into_raw(source)),
         min_failing_severity,
     );
 

--- a/crates/turbopack-dev-server/src/introspect/mod.rs
+++ b/crates/turbopack-dev-server/src/introspect/mod.rs
@@ -103,16 +103,8 @@ impl GetContentSourceContent for IntrospectionSource {
             }
         } else {
             parse_json_with_source_context(path)?
-        }
-        .resolve()
-        .await?;
-        let raw_vc: RawVc = introspectable.node;
-        let internal_ty = if let RawVc::TaskCell(_, CellId { type_id, index }) = raw_vc {
-            let value_ty = registry::get_value_type(type_id);
-            format!("{}#{}", value_ty.name, index)
-        } else {
-            unreachable!()
         };
+        let internal_ty = Vc::debug_identifier(introspectable).await?;
         fn str_or_err(s: &Result<ReadRef<String>>) -> Cow<'_, str> {
             s.as_ref().map_or_else(
                 |e| Cow::<'_, str>::Owned(format!("ERROR: {:?}", e)),

--- a/crates/turbopack-dev-server/src/introspect/mod.rs
+++ b/crates/turbopack-dev-server/src/introspect/mod.rs
@@ -1,7 +1,7 @@
 use std::{borrow::Cow, collections::HashSet, fmt::Display};
 
 use anyhow::Result;
-use turbo_tasks::{registry, CellId, RawVc, ReadRef, TryJoinIterExt, Vc};
+use turbo_tasks::{ReadRef, TryJoinIterExt, Vc};
 use turbo_tasks_fs::{json::parse_json_with_source_context, File};
 use turbopack_core::{
     asset::AssetContent,

--- a/crates/turbopack-ecmascript/src/lib.rs
+++ b/crates/turbopack-ecmascript/src/lib.rs
@@ -119,7 +119,7 @@ fn modifier() -> Vc<String> {
 
 #[derive(PartialEq, Eq, Clone, TraceRawVcs)]
 struct MemoizedSuccessfulAnalysis {
-    operation: RawVc,
+    operation: Vc<AnalyzeEcmascriptModuleResult>,
     references: ReadRef<ModuleReferences>,
     exports: ReadRef<EcmascriptExports>,
     async_module: ReadRef<OptionAsyncModule>,
@@ -295,7 +295,7 @@ impl EcmascriptModuleAsset {
         if result_value.successful {
             this.last_successful_analysis
                 .set(Some(MemoizedSuccessfulAnalysis {
-                    operation: result.node,
+                    operation: result,
                     // We need to store the ReadRefs since we want to keep a snapshot.
                     references: result_value.references.await?,
                     exports: result_value.exports.await?,
@@ -310,7 +310,7 @@ impl EcmascriptModuleAsset {
         {
             // It's important to connect to the last operation here to keep it active, so
             // it's potentially recomputed when garbage collected
-            operation.connect();
+            Vc::connect(*operation);
             return Ok(AnalyzeEcmascriptModuleResult {
                 references: ReadRef::cell(references.clone()),
                 exports: ReadRef::cell(exports.clone()),

--- a/crates/turbopack-ecmascript/src/lib.rs
+++ b/crates/turbopack-ecmascript/src/lib.rs
@@ -49,7 +49,7 @@ pub use transform::{
     CustomTransformer, EcmascriptInputTransform, EcmascriptInputTransforms, OptionTransformPlugin,
     TransformContext, TransformPlugin, UnsupportedServerActionIssue,
 };
-use turbo_tasks::{trace::TraceRawVcs, RawVc, ReadRef, TryJoinIterExt, Value, ValueToString, Vc};
+use turbo_tasks::{trace::TraceRawVcs, ReadRef, TryJoinIterExt, Value, ValueToString, Vc};
 use turbo_tasks_fs::{rope::Rope, FileSystemPath};
 use turbopack_core::{
     asset::{Asset, AssetContent},

--- a/crates/turbopack-tests/tests/snapshot.rs
+++ b/crates/turbopack-tests/tests/snapshot.rs
@@ -156,7 +156,7 @@ async fn run(resource: PathBuf) -> Result<()> {
         snapshot_issues(plain_issues, out.join("issues".to_string()), &REPO_ROOT)
             .await
             .context("Unable to handle issues")?;
-        Ok(unit().node)
+        Ok(unit())
     });
     tt.wait_task_completion(task, true).await?;
 

--- a/crates/turbopack/benches/node_file_trace.rs
+++ b/crates/turbopack/benches/node_file_trace.rs
@@ -103,7 +103,7 @@ fn bench_emit(b: &mut Bencher, bench_input: &BenchInput) {
 
                 emit_with_completion(Vc::upcast(rebased), output_dir).await?;
 
-                Ok(unit().node)
+                Ok(unit())
             });
             tt.wait_task_completion(task, true).await.unwrap();
         }

--- a/crates/turbopack/examples/turbopack.rs
+++ b/crates/turbopack/examples/turbopack.rs
@@ -72,7 +72,7 @@ async fn main() -> Result<()> {
             let rebased = RebasedAsset::new(module, input, output);
             emit_with_completion(Vc::upcast(rebased), output).await?;
 
-            Ok(unit().node)
+            Ok(unit())
         })
     });
     spawn({


### PR DESCRIPTION
### Description

This hides _some_ turbo_tasks internals from its public API.

It's currently not possible to completely hide them (hence `Vc::into_raw`/unsafe `Vc::<AutoSet<RawVc>>::from_task_id`) because turbo-tasks-memory still depends on some internal types, but this is a step in the right direction.