### PR TITLE
chore: add new types for task id and task name

### DIFF
--- a/crates/turborepo-lib/src/config/turbo.rs
+++ b/crates/turborepo-lib/src/config/turbo.rs
@@ -12,7 +12,7 @@ use crate::{
     config::Error,
     opts::RemoteCacheOpts,
     package_json::PackageJson,
-    run::task_id::{get_package_task_from_id, is_package_task, root_task_id},
+    run::task_id::{TaskName, ROOT_PKG_NAME},
     task_graph::{
         BookkeepingTaskDefinition, Pipeline, TaskDefinitionHashable, TaskOutputMode, TaskOutputs,
     },
@@ -71,7 +71,7 @@ pub struct RawTurboJSON {
 
 #[derive(Serialize, Deserialize, Default, Debug, PartialEq, Clone)]
 #[serde(transparent)]
-struct RawPipeline(BTreeMap<String, RawTaskDefinition>);
+struct RawPipeline(BTreeMap<TaskName<'static>, RawTaskDefinition>);
 
 #[derive(Serialize, Deserialize, Default, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -290,24 +290,14 @@ impl RawTurboJSON {
         let mut this = self.clone();
         if let Some(pipeline) = &mut this.pipeline {
             pipeline.0.retain(|task_name, _| {
-                workspaces
-                    .iter()
-                    .any(|workspace| Self::is_task_in_package(task_name, workspace.as_ref()))
+                task_name.in_workspace(ROOT_PKG_NAME)
+                    || workspaces
+                        .iter()
+                        .any(|workspace| task_name.in_workspace(workspace.as_ref()))
             })
         }
 
         this
-    }
-
-    // TODO this will be moved to a more comprehensive task name module
-    // when porting the task graph
-    fn is_task_in_package(task: &str, workspace: &str) -> bool {
-        match task.split_once('#') {
-            // If a specific package task, then check that the task is for the given workspace
-            Some((package_name, _)) => package_name == workspace || package_name == "//",
-            // If there's no '#' then it isn't a specific package task
-            None => true,
-        }
     }
 }
 
@@ -435,11 +425,14 @@ impl TurboJson {
             // tasks
             (true, Ok(mut turbo_from_files)) => {
                 let mut pipeline = Pipeline::default();
-                for (task_id, task_definition) in turbo_from_files.pipeline {
-                    if is_package_task(&task_id) {
-                        return Err(Error::PackageTaskInSinglePackageMode { task_id });
+                for (task_name, task_definition) in turbo_from_files.pipeline {
+                    if task_name.is_package_task() {
+                        return Err(Error::PackageTaskInSinglePackageMode {
+                            task_id: task_name.to_string(),
+                        });
                     }
-                    pipeline.insert(root_task_id(&task_id), task_definition);
+
+                    pipeline.insert(TaskName::root_task(task_name.as_ref()), task_definition);
                 }
 
                 turbo_from_files.pipeline = pipeline;
@@ -450,7 +443,7 @@ impl TurboJson {
 
         for script_name in root_package_json.scripts.keys() {
             if !turbo_json.has_task(script_name) {
-                let task_name = root_task_id(script_name);
+                let task_name = TaskName::root_task(script_name);
                 // Explicitly set Cache to false in this definition and add the bookkeeping
                 // fields so downstream we can pretend that it was set on
                 // purpose (as if read from a config file) rather than
@@ -478,12 +471,11 @@ impl TurboJson {
 
     fn has_task(&self, task: &str) -> bool {
         for key in self.pipeline.keys() {
-            if key == task {
+            if key.as_ref() == task {
                 return true;
             }
-            if is_package_task(key) {
-                let (_, task_name) = get_package_task_from_id(key);
-                if task_name == task {
+            if let Some(task_id) = key.task_id() {
+                if task_id.task() == task {
                     return true;
                 }
             }
@@ -582,7 +574,7 @@ mod tests {
         },
         TurboJson {
             pipeline: [(
-                "//#build".to_string(),
+                "//#build".into(),
                 BookkeepingTaskDefinition {
                     defined_fields: ["Cache".to_string()].into_iter().collect(),
                     task_definition: TaskDefinitionHashable {
@@ -617,7 +609,7 @@ mod tests {
         },
         TurboJson {
             pipeline: [(
-                "//#build".to_string(),
+                "//#build".into(),
                 BookkeepingTaskDefinition {
                     defined_fields: ["Cache".to_string()].into_iter().collect(),
                     task_definition: TaskDefinitionHashable {
@@ -628,7 +620,7 @@ mod tests {
                 }
             ),
             (
-                "//#test".to_string(),
+                "//#test".into(),
                 BookkeepingTaskDefinition {
                     defined_fields: ["Cache".to_string()].into_iter().collect(),
                     task_definition: TaskDefinitionHashable {

--- a/crates/turborepo-lib/src/run/task_id.rs
+++ b/crates/turborepo-lib/src/run/task_id.rs
@@ -1,47 +1,138 @@
+use std::{borrow::Cow, fmt};
+
+use serde::{Deserialize, Serialize};
+
 pub const TASK_DELIMITER: &str = "#";
 pub const ROOT_PKG_NAME: &str = "//";
 
-pub fn get_task_id(pkg_name: impl std::fmt::Display, target: &str) -> String {
-    if is_package_task(target) {
-        return target.to_owned();
+/// A task identifier as it will appear in the task graph
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct TaskId<'a> {
+    package: Cow<'a, str>,
+    task: Cow<'a, str>,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("No workspace found in task id '{input}'")]
+pub struct Error<'a> {
+    input: &'a str,
+}
+
+impl<'a> fmt::Display for TaskId<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_fmt(format_args!(
+            "{}{TASK_DELIMITER}{}",
+            self.package, self.task
+        ))
     }
-    format!("{}{}{}", pkg_name, TASK_DELIMITER, target)
 }
 
-pub fn root_task_id(target: &str) -> String {
-    get_task_id(ROOT_PKG_NAME, target)
-}
-
-// TODO: Investigate if we should use split_once instead
-pub fn get_package_task_from_id(task_id: &str) -> (String, String) {
-    let arr: Vec<&str> = task_id.split(TASK_DELIMITER).collect();
-    (arr[0].to_owned(), arr[1].to_owned())
-}
-
-pub fn root_task_task_name(task_id: &str) -> String {
-    task_id
-        .trim_start_matches(ROOT_PKG_NAME)
-        .trim_start_matches(TASK_DELIMITER)
-        .to_owned()
-}
-
-pub fn is_package_task(task: &str) -> bool {
-    task.contains(TASK_DELIMITER) && !task.starts_with(TASK_DELIMITER)
-}
-
-pub fn is_task_in_package(task: &str, package_name: &str) -> bool {
-    if !is_package_task(task) {
-        return true;
+impl<'a> TaskId<'a> {
+    pub fn new(package: &'a str, task: &'a str) -> Self {
+        TaskId::try_from(task).unwrap_or_else(|_| Self {
+            package: package.into(),
+            task: task.into(),
+        })
     }
-    let (package_name_expected, _) = get_package_task_from_id(task);
-    package_name_expected == package_name
+
+    pub fn package(&self) -> &str {
+        &self.package
+    }
+
+    pub fn task(&self) -> &str {
+        &self.task
+    }
 }
 
-pub fn strip_package_name(task_id: &str) -> String {
-    if is_package_task(task_id) {
-        let (_, task) = get_package_task_from_id(task_id);
-        task
-    } else {
-        task_id.to_string()
+impl<'a> TryFrom<&'a str> for TaskId<'a> {
+    type Error = Error<'a>;
+
+    fn try_from(value: &'a str) -> Result<Self, Self::Error> {
+        // We use split once here as the Go code will fail to find any task
+        //  name that contains a '#' in the task graph.
+        // e.g. workspace#test#check can't run as we'll look for test and
+        // attempt to run test instead of test#check
+        match value.split_once(TASK_DELIMITER) {
+            None | Some(("", _)) => Err(Error { input: value }),
+            Some((package, task)) => Ok(TaskId {
+                package: package.into(),
+                task: task.into(),
+            }),
+        }
+    }
+}
+
+/// A task name as it appears in in a `turbo.json` it might be for all
+/// workspaces or just one.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Hash)]
+#[serde(transparent)]
+pub struct TaskName<'a>(Cow<'a, str>);
+
+impl<'a> From<&'a str> for TaskName<'a> {
+    fn from(value: &'a str) -> Self {
+        Self(value.into())
+    }
+}
+
+impl From<String> for TaskName<'static> {
+    fn from(value: String) -> Self {
+        Self(value.into())
+    }
+}
+
+impl<'a> fmt::Display for TaskName<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl<'a> TaskName<'a> {
+    // Makes a task a root workspace task
+    // e.g. build to //#build
+    pub fn root_task(name: &str) -> TaskName<'static> {
+        TaskName(format!("{ROOT_PKG_NAME}{TASK_DELIMITER}{name}").into())
+    }
+
+    pub fn task_id(&self) -> Option<TaskId<'_>> {
+        let name: &str = &self.0;
+        TaskId::try_from(name).ok()
+    }
+
+    pub fn is_package_task(&self) -> bool {
+        self.task_id().is_some()
+    }
+
+    pub fn in_workspace(&self, workspace: &str) -> bool {
+        self.task_id()
+            .map_or(true, |task_id| task_id.package == workspace)
+    }
+}
+
+impl<'a> AsRef<str> for TaskName<'a> {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use test_case::test_case;
+
+    use super::*;
+
+    #[test_case("foo#build" ; "workspace task")]
+    #[test_case("//#root" ; "root task")]
+    #[test_case("@scope/foo#build" ; "workspace with scope")]
+    fn test_roundtrip(input: &str) {
+        assert_eq!(input, TaskId::try_from(input).unwrap().to_string());
+    }
+
+    #[test_case("foo", "build", "foo#build" ; "normal task")]
+    #[test_case("foo", "bar#build", "bar#build" ; "workspace specific task")]
+    #[test_case("foo", "//#build", "//#build" ; "root task")]
+    fn test_new_task_id(package_name: &str, task_name: &str, expected: &str) {
+        let expected = TaskId::try_from(expected).unwrap();
+        let actual = TaskId::new(package_name, task_name);
+        assert_eq!(actual, expected);
     }
 }

--- a/crates/turborepo-lib/src/task_graph/mod.rs
+++ b/crates/turborepo-lib/src/task_graph/mod.rs
@@ -3,7 +3,9 @@ use std::collections::{HashMap, HashSet};
 use serde::{Deserialize, Serialize};
 use turbopath::RelativeUnixPathBuf;
 
-pub type Pipeline = HashMap<String, BookkeepingTaskDefinition>;
+use crate::run::task_id::TaskName;
+
+pub type Pipeline = HashMap<TaskName<'static>, BookkeepingTaskDefinition>;
 
 #[derive(Clone, Debug, Default, Serialize, PartialEq, Eq)]
 pub struct BookkeepingTaskDefinition {


### PR DESCRIPTION
### Description

In Go we used strings to represent both task ids and task names. Since these are so similar and could easily get mixed up I'm changing these to be two distinct types to avoid mixups.

- `TaskName`: A task as it appears in the `pipeline` object in `turbo.json`. It can be either a normal task name (`build`) or a workspace specific task name (`app#build`)
- `TaskId`: A task as the task graph understands it. Any task names that aren't workspace specific will get a workspace associated with them: e.g. `build` will become `app#build` and `ui#build`

### Testing Instructions

Added some new unit tests. Existing unit tests.
