### PR TITLE
fix: re-enable go-daemon

### DIFF
--- a/crates/turborepo/Cargo.toml
+++ b/crates/turborepo/Cargo.toml
@@ -9,7 +9,7 @@ license = "MPL-2.0"
 # This is for the convenience of running daily dev workflows, i.e running
 # `cargo xxx` without explicitly specifying features, not that we want to
 # promote this as default backend.
-default = ["rustls-tls"]
+default = ["rustls-tls", "go-daemon"]
 native-tls = ["turborepo-lib/native-tls"]
 rustls-tls = ["turborepo-lib/rustls-tls"]
 http = ["turborepo-lib/http"]


### PR DESCRIPTION
### Description
#5479 unintentionally re-enabled the Rust daemon. This PR sets the go daemon to be the default once again.

### Testing Instructions

Verify that the `go-daemon` feature is now enabled by default when building `turbo`:
```
[0 olszewski@chriss-mbp] /Users/olszewski/code/vercel/turborepo/crates/turborepo $ cargo tree -f "{p} {f}" | rg -C 5 go-daemon
turbo v0.1.0 (/Users/olszewski/code/vercel/turborepo/crates/turborepo) default,go-daemon,rustls-tls
├── anyhow v1.0.71 backtrace,default,std
│   └── backtrace v0.3.67 default,std
│       ├── addr2line v0.19.0 
│       │   └── gimli v0.27.2 read,read-core
│       ├── cfg-if v1.0.0 
--
│       │   ├── quote v1.0.28 default,proc-macro (*)
│       │   └── syn v2.0.25 clone-impls,default,derive,extra-traits,full,parsing,printing,proc-macro,quote,visit-mut (*)
│       └── tracing-core v0.1.31 default,once_cell,std
│           └── once_cell v1.18.0 alloc,default,race,std
├── tracing v0.1.37 attributes,default,log,std,tracing-attributes (*)
└── turborepo-lib v0.1.0 (/Users/olszewski/code/vercel/turborepo/crates/turborepo-lib) go-daemon,rustls-tls
```
