### PR TITLE
fix(prune): copy pnpm workspace file to top level out directory

### DIFF
--- a/turborepo-tests/integration/tests/prune/docker.t
+++ b/turborepo-tests/integration/tests/prune/docker.t
@@ -15,6 +15,13 @@ Make sure patches are part of the json output
   patches
   pnpm-lock.yaml
   pnpm-workspace.yaml
+Make sure that pnpm-workspace.yaml is in the top out directory
+  $ ls out
+  full
+  json
+  package.json
+  pnpm-lock.yaml
+  pnpm-workspace.yaml
 
 Make sure the pnpm patches section is present
   $ cat out/json/package.json | jq '.pnpm.patchedDependencies'


### PR DESCRIPTION
### Description

Fixes #5599

In the Go code we put the workspace spec file in `out` instead of `out/json` where it should be as it is required for install. This means that many users have a `COPY out/pnpm-workspace.yaml .` line in their `Dockerfile`s and the removal of the top level copy resulted in a breakage.

### Testing Instructions

Added integration test to verify contents of the top level `out` directory. 
