### PR TITLE
fix: use correct enum values for task output mode

### DIFF
--- a/crates/turborepo-lib/src/config/turbo.rs
+++ b/crates/turborepo-lib/src/config/turbo.rs
@@ -790,4 +790,28 @@ mod tests {
 
         assert_eq!(pruned_json, expected);
     }
+
+    #[test_case("full", Some(TaskOutputMode::Full) ; "full")]
+    #[test_case("hash-only", Some(TaskOutputMode::HashOnly) ; "hash-only")]
+    #[test_case("new-only", Some(TaskOutputMode::NewOnly) ; "new-only")]
+    #[test_case("errors-only", Some(TaskOutputMode::ErrorsOnly) ; "errors-only")]
+    #[test_case("none", Some(TaskOutputMode::None) ; "none")]
+    #[test_case("junk", None ; "invalid value")]
+    fn test_parsing_output_mode(output_mode: &str, expected: Option<TaskOutputMode>) {
+        let json: Result<RawTurboJSON, _> = serde_json::from_value(serde_json::json!({
+            "pipeline": {
+                "build": {
+                    "outputMode": output_mode,
+                }
+            }
+        }));
+
+        let actual = json
+            .as_ref()
+            .ok()
+            .and_then(|j| j.pipeline.as_ref())
+            .and_then(|pipeline| pipeline.0.get("build"))
+            .and_then(|build| build.output_mode);
+        assert_eq!(actual, expected);
+    }
 }

--- a/crates/turborepo-lib/src/task_graph/mod.rs
+++ b/crates/turborepo-lib/src/task_graph/mod.rs
@@ -30,8 +30,8 @@ pub struct TaskOutputs {
 }
 
 // TaskOutputMode defines the ways turbo can display task output during a run
-#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "lowercase")]
+#[derive(Copy, Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
 pub enum TaskOutputMode {
     // FullTaskOutput will show all task output
     #[default]
@@ -39,13 +39,13 @@ pub enum TaskOutputMode {
     // None will hide all task output
     None,
     // Hash will display turbo-computed task hashes
-    Hash,
+    HashOnly,
     // New will show all new task output and turbo-computed task hashes for cached
     // output
-    New,
+    NewOnly,
     // Error will show task output for failures only; no cache miss/hit messages are
     // emitted
-    Error,
+    ErrorsOnly,
 }
 
 // taskDefinitionHashable exists as a definition for PristinePipeline, which is


### PR DESCRIPTION
### Description

Fixes #5598

We weren't correctly (de)serializing the `outputMode` values to our enum causing prune to fail when parsing an `outputMode` that contained an `-only` suffix.

### Testing Instructions

Added new unit tests for making sure we can parse `outputMode`s that we support.
Verify that unit tests match the supported values listed in [our docs](https://turbo.build/repo/docs/reference/configuration#outputmode)
