### PR TITLE
Allow fallback to be used outside VERCEL

### DIFF
--- a/packages/turbo-ignore/README.md
+++ b/packages/turbo-ignore/README.md
@@ -25,7 +25,8 @@ field of the "package.json" located at the current working directory.
 
 Flags:
   --fallback=<ref>    On Vercel, if no previously deployed SHA is available to compare against,
-                      fallback to comparing against the provided ref [default: None]
+                      fallback to comparing against the provided ref [default: None]. When not on Vercel,
+                      compare against the provided fallback
   --help, -h          Show this help message
   --version, -v       Show the version of this script
 
@@ -70,7 +71,7 @@ npx turbo-ignore docs
 npx turbo-ignore --fallback=HEAD~10
 ```
 
-> Only build if there are changes to the workspace in the current working directory, or any of it's dependencies. On Vercel, compare against the last successful deployment for the current branch. If this does not exist (first deploy of the branch), compare against the previous 10 commits. When not on Vercel, always compare against the parent commit (`HEAD^`).
+> Only build if there are changes to the workspace in the current working directory, or any of it's dependencies. On Vercel, compare against the last successful deployment for the current branch. If this does not exist (first deploy of the branch), compare against the previous 10 commits. When not on Vercel, compare against the parent commit (`HEAD^`) or the fallback provided.
 
 ---
 
@@ -78,7 +79,7 @@ npx turbo-ignore --fallback=HEAD~10
 npx turbo-ignore --fallback=HEAD^
 ```
 
-> Only build if there are changes to the workspace in the current working directory, or any of it's dependencies. On Vercel, compare against the last successful deployment for the current branch. If this does not exist (first deploy of the branch), compare against the parent commit (`HEAD^`). When not on Vercel, always compare against the parent commit (`HEAD^`).
+> Only build if there are changes to the workspace in the current working directory, or any of it's dependencies. On Vercel, compare against the last successful deployment for the current branch. If this does not exist (first deploy of the branch), compare against the parent commit (`HEAD^`). When not on Vercel, compare against the parent commit (`HEAD^`) or the fallback provided.
 
 ## How it Works
 

--- a/packages/turbo-ignore/src/getComparison.ts
+++ b/packages/turbo-ignore/src/getComparison.ts
@@ -34,6 +34,9 @@ export function getComparison(args: GetComparisonArgs): {
 
       return null;
     }
+  } else if (fallback) {
+    info(`Using ${fallback} to compare "${workspace}"`);
+    return { ref: fallback, type: "customFallback" };
   }
   return { ref: "HEAD^", type: "headRelative" };
 }


### PR DESCRIPTION
### Description

When not on vercel, there is no way to use fallback against a specific sha with turbo-ignore
This solves #1641

### Testing Instructions

Do a `turbo-ignore` with a provided `fallback` outside vercel
