### PR TITLE
fix(docs): remove non-existent options

### DIFF
--- a/docs/pages/repo/docs/reference/command-line-reference/link.mdx
+++ b/docs/pages/repo/docs/reference/command-line-reference/link.mdx
@@ -7,11 +7,3 @@ description: Turborepo CLI Reference for `link` command
 
 Link the current directory to Remote Cache scope. The selected owner (either a user or and organization) will be able to share [cache artifacts](/repo/docs/core-concepts/caching) through [Remote Caching](/repo/docs/core-concepts/remote-caching).
 You should run this command from the root of your monorepo.
-
-### Options
-
-#### `--api`
-
-`type: string`
-
-Defaults to `https://api.vercel.com`

--- a/docs/pages/repo/docs/reference/command-line-reference/login.mdx
+++ b/docs/pages/repo/docs/reference/command-line-reference/login.mdx
@@ -7,20 +7,6 @@ description: Turborepo CLI Reference for `login` command
 
 Connect machine to your Remote Cache provider. The default provider is [Vercel](https://vercel.com/).
 
-### Options
-
-#### `--url`
-
-`type: string`
-
-Defaults to `https://vercel.com/`.
-
-#### `--api`
-
-`type: string`
-
-Defaults to `https://vercel.com/api`.
-
 #### `--sso-team`
 
 `type: string`


### PR DESCRIPTION
### Description

This PR removes non-existent options in `link` and `login` commands. I've also noticed that `link` has some un-documented options (`--no-gitignore` and `--target`). Is this intended because unstable, or should I add the missing docs?

https://github.com/vercel/turbo/blob/32b6e5b3b8e0f460828a691f2fdff89fe82f005a/crates/turborepo-lib/src/cli.rs#L310

### Testing Instructions

Nothing to test