### PR TITLE
export namespace object instead commonjs interop object

### DIFF
--- a/crates/turbopack-build/src/ecmascript/node/entry/chunk.rs
+++ b/crates/turbopack-build/src/ecmascript/node/entry/chunk.rs
@@ -138,7 +138,8 @@ impl EcmascriptBuildNodeEntryChunk {
         writedoc!(
             code,
             r#"
-                    module.exports = runtime.getOrInstantiateRuntimeModule({}, CHUNK_PUBLIC_PATH).exports;
+                    const internalModule = runtime.getOrInstantiateRuntimeModule({}, CHUNK_PUBLIC_PATH);
+                    module.exports = internalModule.namespace ?? internalModule.exports;
                 "#,
             StringifyJs(&*runtime_module_id),
         )?;

--- a/crates/turbopack-tests/tests/snapshot/runtime/default_build_runtime/output/index.entry.js
+++ b/crates/turbopack-tests/tests/snapshot/runtime/default_build_runtime/output/index.entry.js
@@ -2,4 +2,5 @@ const CHUNK_PUBLIC_PATH = "output/index.entry.js";
 const runtime = require("./[turbopack]_runtime.js");
 runtime.loadChunk("output/79fb1_turbopack-tests_tests_snapshot_runtime_default_build_runtime_input_index_e254c5.js");
 runtime.getOrInstantiateRuntimeModule("[project]/crates/turbopack-tests/tests/snapshot/runtime/default_build_runtime/input/index.js (ecmascript)", CHUNK_PUBLIC_PATH);
-module.exports = runtime.getOrInstantiateRuntimeModule("[project]/crates/turbopack-tests/tests/snapshot/runtime/default_build_runtime/input/index.js (ecmascript)", CHUNK_PUBLIC_PATH).exports;
+const internalModule = runtime.getOrInstantiateRuntimeModule("[project]/crates/turbopack-tests/tests/snapshot/runtime/default_build_runtime/input/index.js (ecmascript)", CHUNK_PUBLIC_PATH);
+module.exports = internalModule.namespace ?? internalModule.exports;


### PR DESCRIPTION
### Description

needed for next.rs API: next.js checks if routes doesn't contain a default export

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
