### PR TITLE
Revert "export namespace object instead commonjs interop object"

### DIFF
--- a/crates/turbopack-build/src/ecmascript/node/entry/chunk.rs
+++ b/crates/turbopack-build/src/ecmascript/node/entry/chunk.rs
@@ -138,8 +138,7 @@ impl EcmascriptBuildNodeEntryChunk {
         writedoc!(
             code,
             r#"
-                    const internalModule = runtime.getOrInstantiateRuntimeModule({}, CHUNK_PUBLIC_PATH);
-                    module.exports = internalModule.namespace ?? internalModule.exports;
+                    module.exports = runtime.getOrInstantiateRuntimeModule({}, CHUNK_PUBLIC_PATH).exports;
                 "#,
             StringifyJs(&*runtime_module_id),
         )?;

--- a/crates/turbopack-tests/tests/snapshot/runtime/default_build_runtime/output/index.entry.js
+++ b/crates/turbopack-tests/tests/snapshot/runtime/default_build_runtime/output/index.entry.js
@@ -2,5 +2,4 @@ const CHUNK_PUBLIC_PATH = "output/index.entry.js";
 const runtime = require("./[turbopack]_runtime.js");
 runtime.loadChunk("output/79fb1_turbopack-tests_tests_snapshot_runtime_default_build_runtime_input_index_e254c5.js");
 runtime.getOrInstantiateRuntimeModule("[project]/crates/turbopack-tests/tests/snapshot/runtime/default_build_runtime/input/index.js (ecmascript)", CHUNK_PUBLIC_PATH);
-const internalModule = runtime.getOrInstantiateRuntimeModule("[project]/crates/turbopack-tests/tests/snapshot/runtime/default_build_runtime/input/index.js (ecmascript)", CHUNK_PUBLIC_PATH);
-module.exports = internalModule.namespace ?? internalModule.exports;
+module.exports = runtime.getOrInstantiateRuntimeModule("[project]/crates/turbopack-tests/tests/snapshot/runtime/default_build_runtime/input/index.js (ecmascript)", CHUNK_PUBLIC_PATH).exports;


### PR DESCRIPTION
Reverts vercel/turbo#5619

That's just wrong. There is no `namespace` property, just `namespaceObject`, but in case of ESM `namespaceObject === export` anyway.