### PR TITLE
Port filter and scope to rust

### DIFF
--- a/crates/turborepo-cache/src/cache_archive/create.rs
+++ b/crates/turborepo-cache/src/cache_archive/create.rs
@@ -83,7 +83,7 @@ impl<'a> CacheWriter<'a> {
         let file_info = source_path.symlink_metadata()?;
 
         // Normalize the path within the cache
-        let mut file_path = file_path.to_unix()?;
+        let mut file_path = file_path.to_unix();
         file_path.make_canonical_for_tar(file_info.is_dir());
 
         let mut header = Self::create_header(&source_path, &file_info)?;

--- a/crates/turborepo-lib/src/commands/prune.rs
+++ b/crates/turborepo-lib/src/commands/prune.rs
@@ -308,7 +308,7 @@ impl<'a> Prune<'a> {
         Ok(())
     }
 
-    fn copy_workspace(&self, package_json_path: &AnchoredSystemPathBuf) -> Result<(), Error> {
+    fn copy_workspace(&self, package_json_path: &AnchoredSystemPath) -> Result<(), Error> {
         let package_json_path = self.root.resolve(package_json_path);
         let original_dir = package_json_path
             .parent()

--- a/crates/turborepo-lib/src/commands/prune.rs
+++ b/crates/turborepo-lib/src/commands/prune.rs
@@ -111,7 +111,7 @@ pub fn prune(
                     .package_json_path()
                     .parent()
                     .unwrap()
-                    .to_unix()?
+                    .to_unix()
                     .to_string(),
             );
 

--- a/crates/turborepo-lib/src/engine/builder.rs
+++ b/crates/turborepo-lib/src/engine/builder.rs
@@ -425,6 +425,10 @@ mod test {
         fn encode(&self) -> Result<Vec<u8>, turborepo_lockfiles::Error> {
             unreachable!()
         }
+
+        fn global_change_key(&self) -> Vec<u8> {
+            unreachable!()
+        }
     }
 
     macro_rules! package_jsons {

--- a/crates/turborepo-lib/src/engine/builder.rs
+++ b/crates/turborepo-lib/src/engine/builder.rs
@@ -197,7 +197,7 @@ impl<'a> EngineBuilder<'a> {
 
             let dep_pkgs = self
                 .package_graph
-                .dependencies(&WorkspaceNode::Workspace(to_task_id.package().into()));
+                .immediate_dependencies(&WorkspaceNode::Workspace(to_task_id.package().into()));
 
             let mut has_deps = false;
             let mut has_topo_deps = false;

--- a/crates/turborepo-lib/src/engine/builder.rs
+++ b/crates/turborepo-lib/src/engine/builder.rs
@@ -209,7 +209,7 @@ impl<'a> EngineBuilder<'a> {
                     // We don't need to add an edge from the root node if we're in this branch
                     if let WorkspaceNode::Workspace(dependency_workspace) = dependency_workspace {
                         has_topo_deps = true;
-                        let from_task_id = TaskId::from_graph(&dependency_workspace, from);
+                        let from_task_id = TaskId::from_graph(dependency_workspace, from);
                         let from_task_index = engine.get_index(&from_task_id);
                         engine
                             .task_graph

--- a/crates/turborepo-lib/src/engine/builder.rs
+++ b/crates/turborepo-lib/src/engine/builder.rs
@@ -209,7 +209,7 @@ impl<'a> EngineBuilder<'a> {
                     // We don't need to add an edge from the root node if we're in this branch
                     if let WorkspaceNode::Workspace(dependency_workspace) = dependency_workspace {
                         has_topo_deps = true;
-                        let from_task_id = TaskId::from_graph(dependency_workspace, from);
+                        let from_task_id = TaskId::from_graph(&dependency_workspace, from);
                         let from_task_index = engine.get_index(&from_task_id);
                         engine
                             .task_graph

--- a/crates/turborepo-lib/src/lib.rs
+++ b/crates/turborepo-lib/src/lib.rs
@@ -2,6 +2,7 @@
 #![feature(box_patterns)]
 #![feature(error_generic_member_access)]
 #![feature(provide_any)]
+#![feature(hash_extract_if)]
 #![feature(option_get_or_insert_default)]
 #![feature(once_cell_try)]
 #![deny(clippy::all)]

--- a/crates/turborepo-lib/src/opts.rs
+++ b/crates/turborepo-lib/src/opts.rs
@@ -165,7 +165,7 @@ impl LegacyFilter {
         let suffix = if self.include_dependencies { "..." } else { "" };
         if self.entrypoints.is_empty() {
             if let Some(since) = self.since.as_ref() {
-                vec![format!("[{}{}{}]", prefix, since, suffix)]
+                vec![format!("{}[{}]{}", prefix, since, suffix)]
             } else {
                 Vec::new()
             }
@@ -240,5 +240,40 @@ impl ScopeOpts {
             self.legacy_filter.as_filter_pattern(),
         ]
         .concat()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use test_case::test_case;
+
+    use super::LegacyFilter;
+
+    #[test_case(LegacyFilter {
+            include_dependencies: true,
+            skip_dependents: false,
+            entrypoints: vec![],
+            since: Some("since".to_string()),
+        }, &["...[since]..."])]
+    #[test_case(LegacyFilter {
+            include_dependencies: false,
+            skip_dependents: true,
+            entrypoints: vec![],
+            since: Some("since".to_string()),
+        }, &["[since]"])]
+    #[test_case(LegacyFilter {
+            include_dependencies: false,
+            skip_dependents: true,
+            entrypoints: vec!["entry".to_string()],
+            since: Some("since".to_string()),
+        }, &["entry...since"])]
+    fn basic_legacy_filter_pattern(filter: LegacyFilter, expected: &[&str]) {
+        assert_eq!(
+            filter.as_filter_pattern(),
+            expected
+                .into_iter()
+                .map(|s| s.to_string())
+                .collect::<Vec<_>>()
+        )
     }
 }

--- a/crates/turborepo-lib/src/opts.rs
+++ b/crates/turborepo-lib/src/opts.rs
@@ -270,10 +270,7 @@ mod test {
     fn basic_legacy_filter_pattern(filter: LegacyFilter, expected: &[&str]) {
         assert_eq!(
             filter.as_filter_pattern(),
-            expected
-                .into_iter()
-                .map(|s| s.to_string())
-                .collect::<Vec<_>>()
+            expected.iter().map(|s| s.to_string()).collect::<Vec<_>>()
         )
     }
 }

--- a/crates/turborepo-lib/src/opts.rs
+++ b/crates/turborepo-lib/src/opts.rs
@@ -170,11 +170,10 @@ impl LegacyFilter {
                 Vec::new()
             }
         } else {
-            let since = if let Some(since) = self.since.as_ref() {
-                format!("...{}", since)
-            } else {
-                "".to_string()
-            };
+            let since = self
+                .since
+                .as_ref()
+                .map_or_else(String::new, |s| format!("...{}", s));
             self.entrypoints
                 .iter()
                 .map(|pattern| {

--- a/crates/turborepo-lib/src/package_graph/builder.rs
+++ b/crates/turborepo-lib/src/package_graph/builder.rs
@@ -394,7 +394,7 @@ impl<'a> BuildState<'a, ResolvedLockfile> {
                     .package_json_path
                     .parent()
                     .unwrap_or(AnchoredSystemPath::new("")?)
-                    .to_unix()?;
+                    .to_unix();
                 let workspace_string = workspace_path.as_str();
                 let external_deps = entry
                     .unresolved_external_dependencies
@@ -609,7 +609,7 @@ impl WorkspaceInfo {
             .package_json_path
             .parent()
             .unwrap_or_else(|| AnchoredSystemPath::new("").expect("empty path is anchored"))
-            .to_unix()?;
+            .to_unix();
         Ok(unix.to_string())
     }
 }

--- a/crates/turborepo-lib/src/package_graph/mod.rs
+++ b/crates/turborepo-lib/src/package_graph/mod.rs
@@ -5,10 +5,7 @@ use std::{
 
 use anyhow::Result;
 use itertools::Itertools;
-use petgraph::{
-    visit::{depth_first_search, EdgeRef, Reversed},
-    Directed,
-};
+use petgraph::visit::{depth_first_search, EdgeRef, Reversed};
 use turbopath::{AbsoluteSystemPath, AnchoredSystemPath, AnchoredSystemPathBuf};
 use turborepo_lockfiles::Lockfile;
 
@@ -189,6 +186,7 @@ impl PackageGraph {
     /// a -> b -> c
     ///
     /// immediate_ancestors(c) -> {b}
+    #[allow(dead_code)]
     pub fn immediate_ancestors(
         &self,
         workspace: &WorkspaceNode,
@@ -214,6 +212,7 @@ impl PackageGraph {
     /// a -> b -> c (external)
     ///
     /// dependencies(a) = {b, c}
+    #[allow(dead_code)]
     pub fn dependencies<'a>(&'a self, node: &WorkspaceNode) -> HashSet<&'a WorkspaceNode> {
         let mut dependencies =
             self.transitive_closure_inner(Some(node), petgraph::Direction::Outgoing);
@@ -305,7 +304,7 @@ impl PackageGraph {
 
         let external_deps = self
             .workspaces()
-            .filter_map(|(name, info)| {
+            .filter_map(|(_name, info)| {
                 info.unresolved_external_dependencies.as_ref().map(|dep| {
                     (
                         info.package_path().to_unix().to_string(),
@@ -329,12 +328,12 @@ impl PackageGraph {
         } else {
             self.workspaces
                 .iter()
-                .filter(|(name, info)| {
+                .filter(|(_name, info)| {
                     closures.get(info.package_path().as_str())
                         != info.transitive_dependencies.as_ref()
                 })
-                .map(|(name, info)| match name {
-                    n => Some(n.to_owned()),
+                .map(|(name, _info)| match name {
+                    WorkspaceName::Other(n) => Some(WorkspaceName::Other(n.to_owned())),
                     // if the root package has changed, then we should report `None`
                     // since all packages need to be revalidated
                     WorkspaceName::Root => None,

--- a/crates/turborepo-lib/src/package_graph/mod.rs
+++ b/crates/turborepo-lib/src/package_graph/mod.rs
@@ -36,6 +36,16 @@ impl WorkspaceInfo {
     pub fn package_json_path(&self) -> &AnchoredSystemPath {
         &self.package_json_path
     }
+
+    /// Get the path to this workspace.
+    ///
+    /// note: This is infallible because pacakge_json_path is guaranteed to have
+    ///       at least one segment
+    pub fn package_path(&self) -> &AnchoredSystemPath {
+        self.package_json_path
+            .parent()
+            .expect("at least one segment")
+    }
 }
 
 type PackageName = String;
@@ -219,11 +229,11 @@ impl PackageGraph {
 
         let external_deps = self
             .workspaces()
-            .filter_map(|(a, b)| {
-                b.unresolved_external_dependencies.as_ref().map(|b| {
+            .filter_map(|(name, info)| {
+                info.unresolved_external_dependencies.as_ref().map(|dep| {
                     (
-                        a.to_string(),
-                        b.iter()
+                        info.package_path().to_unix().to_string(),
+                        dep.iter()
                             .map(|(name, version)| (name.to_owned(), version.to_owned()))
                             .collect(),
                     )

--- a/crates/turborepo-lib/src/package_graph/mod.rs
+++ b/crates/turborepo-lib/src/package_graph/mod.rs
@@ -148,6 +148,20 @@ impl PackageGraph {
         )
     }
 
+    pub fn dependents(&self, workspace: &WorkspaceNode) -> Option<HashSet<&WorkspaceNode>> {
+        let index = self.node_lookup.get(workspace)?;
+        Some(
+            self.workspace_graph
+                .neighbors_directed(*index, petgraph::Incoming)
+                .map(|index| {
+                    self.workspace_graph
+                        .node_weight(index)
+                        .expect("node index from neighbors should be present")
+                })
+                .collect(),
+        )
+    }
+
     pub fn transitive_closure<'a, I: IntoIterator<Item = &'a WorkspaceNode>>(
         &self,
         nodes: I,

--- a/crates/turborepo-lib/src/package_graph/mod.rs
+++ b/crates/turborepo-lib/src/package_graph/mod.rs
@@ -54,6 +54,15 @@ pub enum WorkspaceNode {
     Workspace(WorkspaceName),
 }
 
+impl WorkspaceNode {
+    pub fn as_workspace(&self) -> &WorkspaceName {
+        match self {
+            WorkspaceNode::Workspace(name) => name,
+            WorkspaceNode::Root => &WorkspaceName::Root,
+        }
+    }
+}
+
 impl PackageGraph {
     pub fn builder(
         repo_root: &AbsoluteSystemPath,

--- a/crates/turborepo-lib/src/package_graph/mod.rs
+++ b/crates/turborepo-lib/src/package_graph/mod.rs
@@ -42,8 +42,8 @@ impl WorkspaceInfo {
 
     /// Get the path to this workspace.
     ///
-    /// note: This is infallible because pacakge_json_path is guaranteed to have
-    ///       at least one segment
+    /// note: This is infallible because `package_json_path` is guaranteed to
+    /// have       at least one segment
     pub fn package_path(&self) -> &AnchoredSystemPath {
         self.package_json_path
             .parent()
@@ -335,6 +335,8 @@ impl PackageGraph {
                 })
                 .map(|(name, info)| match name {
                     n => Some(n.to_owned()),
+                    // if the root package has changed, then we should report `None`
+                    // since all packages need to be revalidated
                     WorkspaceName::Root => None,
                 })
                 .collect::<Option<Vec<WorkspaceName>>>()

--- a/crates/turborepo-lib/src/package_graph/mod.rs
+++ b/crates/turborepo-lib/src/package_graph/mod.rs
@@ -221,11 +221,7 @@ impl PackageGraph {
         &self,
         previous: &dyn Lockfile,
     ) -> Result<Vec<WorkspaceName>, ChangedPackagesError> {
-        let current = if let Some(lockfile) = self.lockfile() {
-            lockfile
-        } else {
-            return Err(ChangedPackagesError::NoLockfile);
-        };
+        let current = self.lockfile().ok_or(ChangedPackagesError::NoLockfile)?;
 
         let external_deps = self
             .workspaces()

--- a/crates/turborepo-lib/src/package_graph/mod.rs
+++ b/crates/turborepo-lib/src/package_graph/mod.rs
@@ -33,7 +33,7 @@ pub struct WorkspaceInfo {
 }
 
 impl WorkspaceInfo {
-    pub fn package_json_path(&self) -> &AnchoredSystemPathBuf {
+    pub fn package_json_path(&self) -> &AnchoredSystemPath {
         &self.package_json_path
     }
 }

--- a/crates/turborepo-lib/src/package_json.rs
+++ b/crates/turborepo-lib/src/package_json.rs
@@ -91,7 +91,7 @@ mod test {
     #[test_case(json!({"name": "foo", "pnpm": {"another-field": 1}}) ; "pnpm without patches")]
     fn test_roundtrip(json: Value) {
         let package_json: PackageJson = serde_json::from_value(json.clone()).unwrap();
-        let actual = serde_json::to_value(&package_json).unwrap();
+        let actual = serde_json::to_value(package_json).unwrap();
         assert_eq!(actual, json);
     }
 

--- a/crates/turborepo-lib/src/package_manager/mod.rs
+++ b/crates/turborepo-lib/src/package_manager/mod.rs
@@ -497,15 +497,7 @@ impl PackageManager {
     }
 
     pub fn lockfile_path(&self, turbo_root: &AbsoluteSystemPath) -> AbsoluteSystemPathBuf {
-        let file_name = match self {
-            PackageManager::Berry => yarn::LOCKFILE,
-            PackageManager::Npm => npm::LOCKFILE,
-            PackageManager::Pnpm => pnpm::LOCKFILE,
-            PackageManager::Pnpm6 => pnpm::LOCKFILE,
-            PackageManager::Yarn => yarn::LOCKFILE,
-        };
-
-        turbo_root.join_component(file_name)
+        turbo_root.join_component(self.lockfile_name())
     }
 }
 

--- a/crates/turborepo-lib/src/package_manager/mod.rs
+++ b/crates/turborepo-lib/src/package_manager/mod.rs
@@ -69,6 +69,20 @@ pub enum PackageManager {
     Yarn,
 }
 
+impl PackageManager {
+    pub fn lockfile_path(&self, turbo_root: &AbsoluteSystemPath) -> AbsoluteSystemPathBuf {
+        let file_name = match self {
+            PackageManager::Berry => yarn::LOCKFILE,
+            PackageManager::Npm => npm::LOCKFILE,
+            PackageManager::Pnpm => pnpm::LOCKFILE,
+            PackageManager::Pnpm6 => pnpm::LOCKFILE,
+            PackageManager::Yarn => yarn::LOCKFILE,
+        };
+
+        turbo_root.join_component(file_name)
+    }
+}
+
 impl fmt::Display for PackageManager {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // Do not change these without also changing `GetPackageManager` in

--- a/crates/turborepo-lib/src/package_manager/mod.rs
+++ b/crates/turborepo-lib/src/package_manager/mod.rs
@@ -562,7 +562,7 @@ mod tests {
         for mgr in &[PackageManager::Pnpm, PackageManager::Pnpm6] {
             let found = mgr.get_package_jsons(&basic).unwrap();
             let found: HashSet<AbsoluteSystemPathBuf> = HashSet::from_iter(found);
-            assert_eq!(found, basic_expected);
+            assert_eq!(found, basic_expected, "{}", mgr);
         }
     }
 

--- a/crates/turborepo-lib/src/package_manager/mod.rs
+++ b/crates/turborepo-lib/src/package_manager/mod.rs
@@ -69,20 +69,6 @@ pub enum PackageManager {
     Yarn,
 }
 
-impl PackageManager {
-    pub fn lockfile_path(&self, turbo_root: &AbsoluteSystemPath) -> AbsoluteSystemPathBuf {
-        let file_name = match self {
-            PackageManager::Berry => yarn::LOCKFILE,
-            PackageManager::Npm => npm::LOCKFILE,
-            PackageManager::Pnpm => pnpm::LOCKFILE,
-            PackageManager::Pnpm6 => pnpm::LOCKFILE,
-            PackageManager::Yarn => yarn::LOCKFILE,
-        };
-
-        turbo_root.join_component(file_name)
-    }
-}
-
 impl fmt::Display for PackageManager {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // Do not change these without also changing `GetPackageManager` in
@@ -508,6 +494,18 @@ impl PackageManager {
                 unreachable!("npm and yarn 1 don't have a concept of patches")
             }
         }
+    }
+
+    pub fn lockfile_path(&self, turbo_root: &AbsoluteSystemPath) -> AbsoluteSystemPathBuf {
+        let file_name = match self {
+            PackageManager::Berry => yarn::LOCKFILE,
+            PackageManager::Npm => npm::LOCKFILE,
+            PackageManager::Pnpm => pnpm::LOCKFILE,
+            PackageManager::Pnpm6 => pnpm::LOCKFILE,
+            PackageManager::Yarn => yarn::LOCKFILE,
+        };
+
+        turbo_root.join_component(file_name)
     }
 }
 

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -99,7 +99,7 @@ impl Run {
         let scm = SCM::new(&self.base.repo_root);
 
         let filtered_pkgs =
-            scope::resolve_packages(&opts.scope_opts, &self.base, &pkg_dep_graph, &scm)?;
+            scope::resolve_packages(&opts.scope_opts, &self.base.repo_root, &pkg_dep_graph, &scm)?;
 
         // TODO: Add this back once scope/filter is implemented.
         //       Currently this code has lifetime issues

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -101,6 +101,8 @@ impl Run {
         let filtered_pkgs =
             scope::resolve_packages(&opts.scope_opts, &self.base.repo_root, &pkg_dep_graph, &scm)?;
 
+        println!("filtered_pkgs: {:?}", _filtered_pkgs);
+
         // TODO: Add this back once scope/filter is implemented.
         //       Currently this code has lifetime issues
         // if filtered_pkgs.len() != pkg_dep_graph.len() {

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -101,10 +101,8 @@ impl Run {
         let filtered_pkgs =
             scope::resolve_packages(&opts.scope_opts, &self.base.repo_root, &pkg_dep_graph, &scm)?;
 
-        println!("filtered_pkgs: {:?}", _filtered_pkgs);
+        println!("filtered_pkgs: {:?}", filtered_pkgs);
 
-        // TODO: Add this back once scope/filter is implemented.
-        //       Currently this code has lifetime issues
         // if filtered_pkgs.len() != pkg_dep_graph.len() {
         //     for target in targets {
         //         let key = task_id::root_task_id(target);
@@ -114,6 +112,7 @@ impl Run {
         //         }
         //     }
         // }
+
         let env_at_execution_start = EnvironmentVariableMap::infer();
 
         let _global_hash_inputs = get_global_hash_inputs(

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -160,12 +160,7 @@ impl Run {
                 .collect(),
         ))
         .with_tasks_only(opts.run_opts.only)
-        .with_workspaces(
-            filtered_pkgs
-                .iter()
-                .map(|workspace| WorkspaceName::from(workspace.as_str()))
-                .collect(),
-        )
+        .with_workspaces(filtered_pkgs.into_iter().collect())
         .with_tasks(
             opts.run_opts
                 .tasks

--- a/crates/turborepo-lib/src/run/scope/change_detector.rs
+++ b/crates/turborepo-lib/src/run/scope/change_detector.rs
@@ -124,11 +124,12 @@ impl<'a> SCMChangeDetector<'a> {
                 if name == &WorkspaceName::Root {
                     continue;
                 }
-                let package_path = entry.package_json_path();
-                if Self::is_file_in_package(file, package_path) {
-                    changed_packages.insert(name.to_owned());
-                    found = true;
-                    break;
+                if let Some(package_path) = entry.package_json_path.parent() {
+                    if Self::is_file_in_package(file, package_path) {
+                        changed_packages.insert(name.to_owned());
+                        found = true;
+                        break;
+                    }
                 }
             }
             if !found {

--- a/crates/turborepo-lib/src/run/scope/change_detector.rs
+++ b/crates/turborepo-lib/src/run/scope/change_detector.rs
@@ -1,0 +1,177 @@
+use std::collections::HashSet;
+
+use turbopath::{AbsoluteSystemPath, AnchoredSystemPath, AnchoredSystemPathBuf};
+use turborepo_scm::SCM;
+use wax::Pattern;
+
+use crate::{
+    package_graph::{PackageGraph, WorkspaceName},
+    run::task_id::ROOT_PKG_NAME,
+};
+
+pub trait PackageChangeDetector {
+    /// Get the list of changed packages between two refs.
+    fn changed_packages(
+        &self,
+        from_ref: &str,
+        to_ref: &str,
+    ) -> Result<HashSet<String>, turborepo_scm::Error>;
+}
+
+pub struct SCMChangeDetector<'a> {
+    turbo_root: &'a AbsoluteSystemPath,
+
+    scm: &'a SCM,
+    pkg_graph: &'a PackageGraph,
+
+    global_deps: Vec<String>,
+    ignore_patterns: Vec<String>,
+}
+
+impl<'a> PackageChangeDetector for SCMChangeDetector<'a> {
+    fn changed_packages(
+        &self,
+        from_ref: &str,
+        to_ref: &str,
+    ) -> Result<HashSet<String>, turborepo_scm::Error> {
+        let mut changed_files = HashSet::new();
+        if !from_ref.is_empty() {
+            changed_files = self
+                .scm
+                .changed_files(self.turbo_root, Some(from_ref), to_ref)?;
+        }
+
+        let global_change =
+            self.repo_global_file_has_changed(&Self::DEFAULT_GLOBAL_DEPS, &changed_files)?;
+
+        if global_change {
+            return Ok(self
+                .pkg_graph
+                .workspaces()
+                .map(|(n, _)| n.to_string())
+                .collect());
+        }
+
+        // get filtered files and add the packages that contain them
+        let filtered_changed_files = self.filter_ignored_files(changed_files.iter())?;
+        let mut changed_pkgs =
+            self.get_changed_packages(filtered_changed_files.into_iter(), self.pkg_graph)?;
+
+        let (lockfile_changes, full_changes) =
+            self.get_changes_from_lockfile(&changed_files, from_ref)?;
+
+        if !full_changes {
+            changed_pkgs.extend(lockfile_changes);
+        } else {
+            return Ok(self
+                .pkg_graph
+                .workspaces()
+                .map(|(n, _)| n.to_string())
+                .collect());
+        }
+        Ok(changed_pkgs)
+    }
+}
+
+impl<'a> SCMChangeDetector<'a> {
+    const DEFAULT_GLOBAL_DEPS: [&'static str; 2] = ["package.json", "turbo.json"];
+
+    pub fn new(
+        turbo_root: &'a AbsoluteSystemPath,
+
+        scm: &'a SCM,
+        pkg_graph: &'a PackageGraph,
+        global_deps: Vec<String>,
+        ignore_patterns: Vec<String>,
+    ) -> Self {
+        Self {
+            turbo_root,
+            scm,
+            pkg_graph,
+            global_deps,
+            ignore_patterns,
+        }
+    }
+
+    fn repo_global_file_has_changed(
+        &self,
+        default_global_deps: &[&str],
+        changed_files: &HashSet<AnchoredSystemPathBuf>,
+    ) -> Result<bool, turborepo_scm::Error> {
+        let global_deps = self.global_deps.iter().map(|s| s.as_str());
+        let filters = global_deps.chain(default_global_deps.iter().copied());
+        let matcher = wax::any(filters).unwrap();
+        Ok(changed_files.iter().any(|f| matcher.is_match(f.as_path())))
+    }
+
+    fn filter_ignored_files<'b>(
+        &self,
+        changed_files: impl Iterator<Item = &'b AnchoredSystemPathBuf> + 'b,
+    ) -> Result<HashSet<&'b AnchoredSystemPathBuf>, turborepo_scm::Error> {
+        let matcher = wax::any(self.ignore_patterns.iter().map(|s| s.as_str())).unwrap();
+        Ok(changed_files
+            .filter(move |f| !matcher.is_match(f.as_path()))
+            .collect())
+    }
+
+    // note: this could probably be optimized by using a hashmap of package paths
+    fn get_changed_packages<'b>(
+        &self,
+        files: impl Iterator<Item = &'b AnchoredSystemPathBuf>,
+        graph: &PackageGraph,
+    ) -> Result<HashSet<String>, turborepo_scm::Error> {
+        let mut changed_packages = HashSet::new();
+        for file in files {
+            let mut found = false;
+            for (name, entry) in graph.workspaces() {
+                if name == &WorkspaceName::Root {
+                    continue;
+                }
+                let package_path = entry.package_json_path();
+                if Self::is_file_in_package(file, package_path) {
+                    changed_packages.insert(name.to_string());
+                    found = true;
+                    break;
+                }
+            }
+            if !found {
+                // if the file is not in any package, it must be in the root package
+                changed_packages.insert(ROOT_PKG_NAME.to_string());
+            }
+        }
+
+        Ok(changed_packages)
+    }
+
+    fn is_file_in_package(file: &AnchoredSystemPath, package_path: &AnchoredSystemPath) -> bool {
+        file.components()
+            .zip(package_path.components())
+            .all(|(a, b)| a == b)
+    }
+
+    fn get_changes_from_lockfile(
+        &self,
+        changed_files: &HashSet<AnchoredSystemPathBuf>,
+        _from_ref: &str,
+    ) -> Result<(Vec<String>, bool), wax::BuildError> {
+        let lockfile_path = self
+            .pkg_graph
+            .package_manager()
+            .lockfile_path(self.turbo_root);
+
+        let matcher = wax::Glob::new(lockfile_path.as_str())?;
+
+        if !changed_files.iter().any(|f| matcher.is_match(f.as_path())) {
+            return Ok((vec![], false));
+        }
+
+        // todo: implement once lockfile parsing is supported
+        // let previous_file = self.scm.previous_content(from_ref,
+        // &lockfile_path).unwrap(); let previous_lockfile = parse_lockfile();
+        // let additional_packages = changed_packages(prev_lockfile);
+
+        let additional_packages = vec![];
+
+        Ok((additional_packages, false))
+    }
+}

--- a/crates/turborepo-lib/src/run/scope/filter.rs
+++ b/crates/turborepo-lib/src/run/scope/filter.rs
@@ -14,7 +14,7 @@ use super::{
     target_selector::{InvalidSelectorError, TargetSelector},
 };
 use crate::{
-    package_graph::{self, PackageGraph},
+    package_graph::{self, PackageGraph, WorkspaceName, WorkspaceNode},
     run::task_id::ROOT_PKG_NAME,
 };
 
@@ -81,12 +81,9 @@ impl PackageInference {
         } else if self.package_name.is_none() {
             // fallback: the user didn't set a parent directory and we didn't find a single
             // package, so use the directory we inferred and select all subdirectories
-            let doublestar = {
-                let mut tmp = AnchoredSystemPathBuf::default();
-                tmp.push("**");
-                tmp
-            };
-            selector.parent_dir = self.directory_root.join(&doublestar);
+            let mut parent_dir = self.directory_root.clone();
+            parent_dir.push("**");
+            selector.parent_dir = parent_dir;
         }
     }
 }
@@ -145,7 +142,7 @@ impl<'a, T: PackageChangeDetector> FilterResolver<'a, T> {
     pub(crate) fn resolve(
         &self,
         patterns: &Vec<String>,
-    ) -> Result<HashSet<String>, ResolutionError> {
+    ) -> Result<HashSet<WorkspaceName>, ResolutionError> {
         // inference is None only if we are in the root
         let is_all_packages = patterns.is_empty() && self.inference.is_none();
 
@@ -153,7 +150,7 @@ impl<'a, T: PackageChangeDetector> FilterResolver<'a, T> {
             // return all packages in the workspace
             self.pkg_graph
                 .workspaces()
-                .map(|(name, _)| name.to_string())
+                .map(|(name, _)| name.to_owned())
                 .collect()
         } else {
             self.get_packages_from_patterns(patterns)?
@@ -161,7 +158,8 @@ impl<'a, T: PackageChangeDetector> FilterResolver<'a, T> {
 
         // if the root package is in the filtered packages, remove it
         if let Some(pkg_name) = &self.pkg_graph.root_package_json().name {
-            filter_patterns.remove(pkg_name);
+            let name = WorkspaceName::Other(pkg_name.to_owned());
+            filter_patterns.remove(&name);
         }
 
         Ok(filter_patterns)
@@ -170,7 +168,7 @@ impl<'a, T: PackageChangeDetector> FilterResolver<'a, T> {
     fn get_packages_from_patterns(
         &self,
         patterns: &[String],
-    ) -> Result<HashSet<String>, ResolutionError> {
+    ) -> Result<HashSet<WorkspaceName>, ResolutionError> {
         let selectors = patterns
             .iter()
             .map(|pattern| TargetSelector::from_str(pattern))
@@ -182,7 +180,7 @@ impl<'a, T: PackageChangeDetector> FilterResolver<'a, T> {
     fn get_filtered_packages(
         &self,
         selectors: Vec<TargetSelector>,
-    ) -> Result<HashSet<String>, ResolutionError> {
+    ) -> Result<HashSet<WorkspaceName>, ResolutionError> {
         let (_prod_selectors, all_selectors) = self
             .apply_inference(selectors)
             .into_iter()
@@ -218,7 +216,7 @@ impl<'a, T: PackageChangeDetector> FilterResolver<'a, T> {
     fn filter_graph(
         &self,
         selectors: Vec<TargetSelector>,
-    ) -> Result<HashSet<String>, ResolutionError> {
+    ) -> Result<HashSet<WorkspaceName>, ResolutionError> {
         let (include_selectors, exclude_selectors) =
             selectors.into_iter().partition::<Vec<_>, _>(|t| !t.exclude);
 
@@ -227,8 +225,9 @@ impl<'a, T: PackageChangeDetector> FilterResolver<'a, T> {
         } else {
             self.pkg_graph
                 .workspaces()
-                .filter(|(name, _)| !name.to_string().eq(ROOT_PKG_NAME)) // the root package has to be explicitly included
-                .map(|(name, _)| name.to_string())
+                // todo: a type-level way of dealing with non-root packages
+                .filter(|(name, _)| WorkspaceName::Root.eq(name)) // the root package has to be explicitly included
+                .map(|(name, _)| name.to_owned())
                 .collect()
         };
 
@@ -242,7 +241,7 @@ impl<'a, T: PackageChangeDetector> FilterResolver<'a, T> {
     fn filter_graph_with_selectors(
         &self,
         selectors: Vec<TargetSelector>,
-    ) -> Result<HashSet<String>, ResolutionError> {
+    ) -> Result<HashSet<WorkspaceName>, ResolutionError> {
         let mut unmatched_selectors = Vec::new();
         let mut walked_dependencies = HashSet::new();
         let mut walked_dependents = HashSet::new();
@@ -258,16 +257,14 @@ impl<'a, T: PackageChangeDetector> FilterResolver<'a, T> {
             }
 
             for package in selector_packages {
-                let node = package_graph::WorkspaceNode::Workspace(
-                    package_graph::WorkspaceName::Other(package.clone()),
-                );
+                let node = package_graph::WorkspaceNode::Workspace(package.clone());
 
                 if selector.include_dependencies {
                     let dependencies = self.pkg_graph.dependencies(&node);
                     let dependencies = dependencies
                         .iter()
                         .flatten()
-                        .flat_map(|i| i.name().map(str::to_string))
+                        .map(|i| i.as_workspace().to_owned())
                         .collect::<Vec<_>>();
 
                     // flatmap through the option, the set, and then the optional package name
@@ -276,29 +273,24 @@ impl<'a, T: PackageChangeDetector> FilterResolver<'a, T> {
 
                 if selector.include_dependents {
                     let dependents = self.pkg_graph.dependents(&node);
-                    for dependent in dependents
-                        .iter()
-                        .flatten()
-                        .flat_map(|i| i.name().map(str::to_string))
-                    {
+                    for dependent in dependents.iter().flatten().map(|i| i.as_workspace()) {
                         walked_dependents.insert(dependent.clone());
 
                         // get the dependent's dependencies
                         if selector.include_dependencies {
-                            let dependent_node = package_graph::WorkspaceNode::Workspace(
-                                package_graph::WorkspaceName::Other(dependent),
-                            );
+                            let dependent_node =
+                                package_graph::WorkspaceNode::Workspace(dependent.to_owned());
 
                             let dependent_dependencies =
                                 self.pkg_graph.dependencies(&dependent_node);
 
-                            let x = dependent_dependencies
+                            let dependent_dependencies = dependent_dependencies
                                 .iter()
                                 .flatten()
-                                .flat_map(|i| i.name().map(str::to_string))
+                                .map(|i| i.as_workspace().to_owned())
                                 .collect::<HashSet<_>>();
 
-                            walked_dependent_dependencies.extend(x);
+                            walked_dependent_dependencies.extend(dependent_dependencies);
                         }
                     }
                 }
@@ -329,7 +321,7 @@ impl<'a, T: PackageChangeDetector> FilterResolver<'a, T> {
     fn filter_graph_with_selector(
         &self,
         selector: &TargetSelector,
-    ) -> Result<HashSet<String>, ResolutionError> {
+    ) -> Result<HashSet<WorkspaceName>, ResolutionError> {
         if selector.match_dependencies {
             self.filter_subtrees_with_selector(selector)
         } else {
@@ -349,12 +341,12 @@ impl<'a, T: PackageChangeDetector> FilterResolver<'a, T> {
     fn filter_subtrees_with_selector(
         &self,
         selector: &TargetSelector,
-    ) -> Result<HashSet<String>, ResolutionError> {
+    ) -> Result<HashSet<WorkspaceName>, ResolutionError> {
         let mut entry_packages = HashSet::new();
 
         for (name, info) in self.pkg_graph.workspaces() {
             if selector.parent_dir == AnchoredSystemPathBuf::default() {
-                entry_packages.insert(name.to_string());
+                entry_packages.insert(name.to_owned());
             } else {
                 let path = self
                     .turbo_root
@@ -365,7 +357,7 @@ impl<'a, T: PackageChangeDetector> FilterResolver<'a, T> {
                 let matches = matcher.is_match(p.as_std_path());
 
                 if matches {
-                    entry_packages.insert(name.to_string());
+                    entry_packages.insert(name.to_owned());
                 }
             }
         }
@@ -388,10 +380,7 @@ impl<'a, T: PackageChangeDetector> FilterResolver<'a, T> {
                 continue;
             }
 
-            let workspace_node = package_graph::WorkspaceNode::Workspace(
-                package_graph::WorkspaceName::Other(package.clone()),
-            );
-
+            let workspace_node = package_graph::WorkspaceNode::Workspace(package.clone());
             let dependencies = self.pkg_graph.dependencies(&workspace_node);
 
             for changed_package in &changed_packages {
@@ -400,9 +389,8 @@ impl<'a, T: PackageChangeDetector> FilterResolver<'a, T> {
                     break;
                 }
 
-                let changed_node = package_graph::WorkspaceNode::Workspace(
-                    package_graph::WorkspaceName::Other(changed_package.clone()),
-                );
+                let changed_node =
+                    package_graph::WorkspaceNode::Workspace(changed_package.to_owned());
 
                 if dependencies
                     .as_ref()
@@ -422,7 +410,7 @@ impl<'a, T: PackageChangeDetector> FilterResolver<'a, T> {
     fn filter_nodes_with_selector(
         &self,
         selector: &TargetSelector,
-    ) -> Result<HashSet<String>, ResolutionError> {
+    ) -> Result<HashSet<WorkspaceName>, ResolutionError> {
         let mut entry_packages = HashSet::new();
         let mut selector_valid = false;
 
@@ -439,7 +427,7 @@ impl<'a, T: PackageChangeDetector> FilterResolver<'a, T> {
             let package_path_lookup = self
                 .pkg_graph
                 .workspaces()
-                .map(|(name, entry)| (name.to_string(), entry.package_json_path()))
+                .map(|(name, entry)| (name, entry.package_json_path()))
                 .collect::<HashMap<_, _>>();
 
             for package in changed_packages {
@@ -448,7 +436,7 @@ impl<'a, T: PackageChangeDetector> FilterResolver<'a, T> {
                     continue;
                 };
 
-                if package == ROOT_PKG_NAME {
+                if package == WorkspaceName::Root {
                     // The root package changed, only add it if
                     // the parentDir is equivalent to the root
                     if globber.matched(&self.turbo_root.into()).is_some() {
@@ -457,7 +445,7 @@ impl<'a, T: PackageChangeDetector> FilterResolver<'a, T> {
                 } else {
                     let path = package_path_lookup
                         .get(&package)
-                        .ok_or(ResolutionError::MissingPackageInfo(package.clone()))?;
+                        .ok_or(ResolutionError::MissingPackageInfo(package.to_string()))?;
 
                     let path = self.turbo_root.resolve(path);
                     if globber.is_match(path.as_std_path()) {
@@ -469,7 +457,7 @@ impl<'a, T: PackageChangeDetector> FilterResolver<'a, T> {
             selector_valid = true;
             if selector.parent_dir == AnchoredSystemPathBuf::from_raw(".").expect("valid anchored")
             {
-                entry_packages.insert(ROOT_PKG_NAME.to_owned());
+                entry_packages.insert(WorkspaceName::Root);
             } else {
                 let path = self
                     .turbo_root
@@ -481,7 +469,7 @@ impl<'a, T: PackageChangeDetector> FilterResolver<'a, T> {
                     let path = self.turbo_root.resolve(&info.package_json_path);
                     globber.is_match(path.as_std_path())
                 }) {
-                    entry_packages.insert(name.to_string());
+                    entry_packages.insert(name.to_owned());
                 }
             }
         }
@@ -492,7 +480,7 @@ impl<'a, T: PackageChangeDetector> FilterResolver<'a, T> {
                     &selector.name_pattern,
                     self.pkg_graph
                         .workspaces()
-                        .map(|(name, _)| name.to_string())
+                        .map(|(name, _)| name.to_owned())
                         .collect(),
                 )?;
                 selector_valid = true;
@@ -516,17 +504,17 @@ impl<'a, T: PackageChangeDetector> FilterResolver<'a, T> {
         &self,
         from_ref: &str,
         to_ref: &str,
-    ) -> Result<HashSet<String>, turborepo_scm::Error> {
+    ) -> Result<HashSet<WorkspaceName>, turborepo_scm::Error> {
         self.change_detector.changed_packages(from_ref, to_ref)
     }
 
     fn match_package_names_to_vertices(
         &self,
         name_pattern: &str,
-        mut entry_packages: HashSet<String>,
-    ) -> Result<HashSet<String>, ResolutionError> {
+        mut entry_packages: HashSet<WorkspaceName>,
+    ) -> Result<HashSet<WorkspaceName>, ResolutionError> {
         // add the root package to the entry packages
-        entry_packages.insert(ROOT_PKG_NAME.to_owned());
+        entry_packages.insert(WorkspaceName::Root);
 
         Ok(match_package_names(name_pattern, entry_packages)?)
     }
@@ -538,11 +526,11 @@ impl<'a, T: PackageChangeDetector> FilterResolver<'a, T> {
 /// the pattern is normalized, replacing `\*` with `.*`
 fn match_package_names(
     name_pattern: &str,
-    mut entry_packages: HashSet<String>,
-) -> Result<HashSet<String>, regex::Error> {
+    mut entry_packages: HashSet<WorkspaceName>,
+) -> Result<HashSet<WorkspaceName>, regex::Error> {
     let matcher = SimpleGlob::new(name_pattern)?;
     let matched_packages = entry_packages
-        .extract_if(|e| matcher.is_match(e.as_str()))
+        .extract_if(|e| matcher.is_match(e.as_ref()))
         .collect::<HashSet<_>>();
 
     // if we got no matches and the pattern is not scoped
@@ -556,7 +544,7 @@ fn match_package_names(
 
         let (first_item, multiple_matches) = {
             let mut scoped_matched_packages =
-                entry_packages.extract_if(|e| scoped_matcher.is_match(e.as_str())); // we can extract again since the original set is untouched
+                entry_packages.extract_if(|e| scoped_matcher.is_match(e.as_ref())); // we can extract again since the original set is untouched
             let first_item = scoped_matched_packages.next();
             (first_item, scoped_matched_packages.count() > 0)
         };

--- a/crates/turborepo-lib/src/run/scope/filter.rs
+++ b/crates/turborepo-lib/src/run/scope/filter.rs
@@ -1,8 +1,22 @@
+use std::{
+    borrow::Borrow,
+    collections::{HashMap, HashSet},
+    str::FromStr,
+};
+
 use tracing::debug;
 use turbopath::{AbsoluteSystemPath, AnchoredSystemPathBuf};
 use turborepo_scm::SCM;
+use wax::Pattern;
 
-use crate::package_graph::{self, PackageGraph};
+use super::{
+    change_detector::{PackageChangeDetector, SCMChangeDetector},
+    simple_glob::{Match, SimpleGlob},
+};
+use crate::{
+    package_graph::{self, PackageGraph},
+    run::task_id::ROOT_PKG_NAME,
+};
 
 pub struct PackageInference {
     package_name: Option<String>,
@@ -51,27 +65,1083 @@ impl PackageInference {
             directory_root: pkg_inference_path.to_owned(),
         }
     }
+
+    pub fn apply(&self, selector: &mut TargetSelector) {
+        // if the name pattern is provided, do not attempt inference
+        if !selector.name_pattern.is_empty() {
+            return;
+        };
+
+        if let Some(name) = &self.package_name {
+            selector.name_pattern = name.to_owned();
+        }
+
+        if selector.parent_dir != turbopath::AnchoredSystemPathBuf::default() {
+            selector.parent_dir = self.directory_root.join(&selector.parent_dir);
+        } else if self.package_name.is_none() {
+            // fallback: the user didn't set a parent directory and we didn't find a single
+            // package, so use the directory we inferred and select all subdirectories
+            let doublestar = {
+                let mut tmp = AnchoredSystemPathBuf::default();
+                tmp.push("**");
+                tmp
+            };
+            selector.parent_dir = self.directory_root.join(&doublestar);
+        }
+    }
 }
 
-pub struct Resolver<'a> {
+pub struct FilterResolver<'a, T: PackageChangeDetector> {
     pkg_graph: &'a PackageGraph,
     turbo_root: &'a AbsoluteSystemPath,
     inference: Option<PackageInference>,
     scm: &'a SCM,
+    change_detector: T,
 }
 
-impl<'a> Resolver<'a> {
+impl<'a> FilterResolver<'a, SCMChangeDetector<'a>> {
     pub(crate) fn new(
+        opts: &'a super::ScopeOpts,
         pkg_graph: &'a PackageGraph,
         turbo_root: &'a AbsoluteSystemPath,
         inference: Option<PackageInference>,
         scm: &'a SCM,
+    ) -> Self {
+        let change_detector = SCMChangeDetector::new(
+            turbo_root,
+            scm,
+            pkg_graph,
+            opts.global_deps.clone(),
+            opts.ignore_patterns.clone(),
+        );
+        Self::new_with_change_detector(pkg_graph, turbo_root, inference, scm, change_detector)
+    }
+}
+
+impl<'a, T: PackageChangeDetector> FilterResolver<'a, T> {
+    pub(crate) fn new_with_change_detector(
+        pkg_graph: &'a PackageGraph,
+        turbo_root: &'a AbsoluteSystemPath,
+        inference: Option<PackageInference>,
+        scm: &'a SCM,
+        change_detector: T,
     ) -> Self {
         Self {
             pkg_graph,
             turbo_root,
             inference,
             scm,
+            change_detector,
+        }
+    }
+
+    /// Resolves a set of filter patterns into a set of packages,
+    /// based on the current state of the workspace. The result is
+    /// guaranteed to be a subset of the packages in the workspace,
+    /// and non-empty. If the filter is empty, none of the packages
+    /// in the workspace will be returned.
+    ///
+    /// It applies the following rules:
+    pub(crate) fn resolve(
+        &self,
+        patterns: &Vec<String>,
+    ) -> Result<HashSet<String>, ResolutionError> {
+        // inference is None only if we are in the root
+        let is_all_packages = patterns.is_empty() && self.inference.is_none();
+
+        let mut filter_patterns = if is_all_packages {
+            // return all packages in the workspace
+            self.pkg_graph
+                .workspaces()
+                .map(|(name, _)| name.to_string())
+                .collect()
+        } else {
+            self.get_packages_from_patterns(patterns)?
+        };
+
+        // if the root package is in the filtered packages, remove it
+        if let Some(pkg_name) = &self.pkg_graph.root_package_json().name {
+            filter_patterns.remove(pkg_name);
+        }
+
+        Ok(filter_patterns)
+    }
+
+    fn get_packages_from_patterns(
+        &self,
+        patterns: &[String],
+    ) -> Result<HashSet<String>, ResolutionError> {
+        let selectors = patterns
+            .iter()
+            .map(|pattern| TargetSelector::from_str(pattern))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        self.get_filtered_packages(selectors)
+    }
+
+    fn get_filtered_packages(
+        &self,
+        selectors: Vec<TargetSelector>,
+    ) -> Result<HashSet<String>, ResolutionError> {
+        let (_prod_selectors, all_selectors) = self
+            .apply_inference(selectors)
+            .into_iter()
+            .partition::<Vec<_>, _>(|t| t.follow_prod_deps_only);
+
+        if !all_selectors.is_empty() {
+            self.filter_graph(all_selectors)
+        } else {
+            Ok(Default::default())
+        }
+    }
+
+    fn apply_inference(&self, selectors: Vec<TargetSelector>) -> Vec<TargetSelector> {
+        let inference = match self.inference {
+            Some(ref inference) => inference,
+            None => return selectors,
+        };
+
+        // if there is no selector provided, synthesize one
+        let mut selectors = if selectors.is_empty() {
+            vec![Default::default()]
+        } else {
+            selectors
+        };
+
+        for selector in &mut selectors {
+            inference.apply(selector);
+        }
+
+        selectors
+    }
+
+    fn filter_graph(
+        &self,
+        selectors: Vec<TargetSelector>,
+    ) -> Result<HashSet<String>, ResolutionError> {
+        let (include_selectors, exclude_selectors) =
+            selectors.into_iter().partition::<Vec<_>, _>(|t| !t.exclude);
+
+        let mut include = if !include_selectors.is_empty() {
+            self.filter_graph_with_selectors(include_selectors)?
+        } else {
+            self.pkg_graph
+                .workspaces()
+                .map(|(name, _)| name.to_string())
+                .collect()
+        };
+
+        let exclude = self.filter_graph_with_selectors(exclude_selectors)?;
+
+        include.retain(|i| !exclude.contains(i));
+
+        Ok(include)
+    }
+
+    fn filter_graph_with_selectors(
+        &self,
+        selectors: Vec<TargetSelector>,
+    ) -> Result<HashSet<String>, ResolutionError> {
+        let mut unmatched_selectors = Vec::new();
+        let mut walked_dependencies = HashSet::new();
+        let mut walked_dependents = HashSet::new();
+        let mut walked_dependent_dependencies = HashSet::new();
+        let mut cherry_picked_packages = HashSet::new();
+
+        for selector in selectors {
+            let selector_packages = self.filter_graph_with_selector(&selector)?;
+            let no_selectors = selector_packages.is_empty();
+
+            for package in selector_packages {
+                let node = package_graph::WorkspaceNode::Workspace(
+                    package_graph::WorkspaceName::Other(package.clone()),
+                );
+
+                if selector.include_dependencies {
+                    let dependencies = self.pkg_graph.dependencies(&node);
+                    let dependencies = dependencies
+                        .iter()
+                        .flat_map(|i| i.name().map(str::to_string))
+                        .collect::<Vec<_>>();
+
+                    // flatmap through the option, the set, and then the optional package name
+                    walked_dependencies.extend(dependencies);
+                }
+
+                if selector.include_dependents {
+                    let dependents = self.pkg_graph.dependents(&node);
+                    for dependent in dependents.iter().flat_map(|i| i.name().map(str::to_string)) {
+                        walked_dependents.insert(dependent.clone());
+
+                        // get the dependent's dependencies
+                        if selector.include_dependencies {
+                            let dependent_node = package_graph::WorkspaceNode::Workspace(
+                                package_graph::WorkspaceName::Other(dependent),
+                            );
+
+                            let dependent_dependencies =
+                                self.pkg_graph.dependencies(&dependent_node);
+
+                            let x = dependent_dependencies
+                                .iter()
+                                .flat_map(|i| i.name().map(str::to_string))
+                                .collect::<HashSet<_>>();
+
+                            walked_dependent_dependencies.extend(x);
+                        }
+                    }
+                }
+
+                if (selector.include_dependents || selector.include_dependencies)
+                    && !selector.exclude_self
+                {
+                    // if we are including dependents or dependencies, and we are not excluding
+                    // ourselves, then we should add ourselves to the list of packages
+                    walked_dependencies.insert(package);
+                } else if !selector.include_dependencies && !selector.include_dependents {
+                    // if we are neither including dependents or dependencies, then
+                    // add  to the list of cherry picked packages
+                    cherry_picked_packages.insert(package);
+                }
+            }
+
+            if no_selectors {
+                unmatched_selectors.push(selector);
+            }
+        }
+
+        let mut all_packages = HashSet::new();
+        all_packages.extend(walked_dependencies);
+        all_packages.extend(walked_dependents);
+        all_packages.extend(walked_dependent_dependencies);
+        all_packages.extend(cherry_picked_packages);
+
+        Ok(all_packages)
+    }
+
+    fn filter_graph_with_selector(
+        &self,
+        selector: &TargetSelector,
+    ) -> Result<HashSet<String>, ResolutionError> {
+        if selector.match_dependencies {
+            self.filter_subtrees_with_selector(selector)
+        } else {
+            self.filter_nodes_with_selector(selector)
+        }
+    }
+
+    /// returns the set of nodes where the node or any of its dependencies match
+    /// the selector.
+    ///
+    /// Example:
+    /// a -> b -> c
+    /// a -> d
+    ///
+    /// filter(b) = {a, b, c}
+    /// filter(d) = {a, d}
+    fn filter_subtrees_with_selector(
+        &self,
+        selector: &TargetSelector,
+    ) -> Result<HashSet<String>, ResolutionError> {
+        let mut entry_packages = HashSet::new();
+
+        for (name, info) in self.pkg_graph.workspaces() {
+            if selector.parent_dir == AnchoredSystemPathBuf::default() {
+                entry_packages.insert(name.to_string());
+            } else {
+                let path = self
+                    .turbo_root
+                    .join_unix_path(selector.parent_dir.to_unix().unwrap())
+                    .unwrap();
+                let matcher = wax::Glob::new(path.as_str())?;
+                let p = info.package_json_path.restore_anchor(self.turbo_root);
+                let matches = matcher.is_match(p.as_std_path());
+
+                if matches {
+                    entry_packages.insert(name.to_string());
+                }
+            }
+        }
+
+        // if we have a filter, use it to filter the entry packages
+        let filtered_entry_packages = if !selector.name_pattern.is_empty() {
+            match_package_names(&selector.name_pattern, entry_packages)?
+        } else {
+            entry_packages
+        };
+
+        let mut roots = HashSet::new();
+        let mut matched = HashSet::new();
+        let changed_packages =
+            self.packages_changed_in_range(&selector.from_ref, selector.to_ref())?;
+
+        for package in filtered_entry_packages {
+            if matched.contains(&package) {
+                roots.insert(package);
+                continue;
+            }
+
+            let workspace_node = package_graph::WorkspaceNode::Workspace(
+                package_graph::WorkspaceName::Other(package.clone()),
+            );
+
+            let dependencies = self.pkg_graph.dependencies(&workspace_node);
+
+            for changed_package in &changed_packages {
+                if !selector.exclude_self && package.eq(changed_package) {
+                    roots.insert(package);
+                    break;
+                }
+
+                let changed_node = package_graph::WorkspaceNode::Workspace(
+                    package_graph::WorkspaceName::Other(changed_package.clone()),
+                );
+
+                if dependencies.contains(&changed_node) {
+                    roots.insert(package.clone());
+                    matched.insert(package);
+                    break;
+                }
+            }
+        }
+
+        Ok(roots)
+    }
+
+    fn filter_nodes_with_selector(
+        &self,
+        selector: &TargetSelector,
+    ) -> Result<HashSet<String>, ResolutionError> {
+        let mut entry_packages = HashSet::new();
+        let mut selector_used = false;
+
+        let path = self
+            .turbo_root
+            .join_unix_path(selector.parent_dir.to_unix().unwrap())
+            .unwrap();
+        let globber = wax::Glob::new(path.as_str()).unwrap();
+
+        if !selector.from_ref.is_empty() {
+            selector_used = true;
+            let changed_packages =
+                self.packages_changed_in_range(&selector.from_ref, selector.to_ref())?;
+            let package_path_lookup = self
+                .pkg_graph
+                .workspaces()
+                .map(|(name, entry)| (name.to_string(), entry.package_json_path()))
+                .collect::<HashMap<_, _>>();
+
+            for package in changed_packages {
+                if selector.parent_dir == AnchoredSystemPathBuf::default() {
+                    entry_packages.insert(package);
+                    continue;
+                };
+
+                if package == ROOT_PKG_NAME {
+                    // The root package changed, only add it if
+                    // the parentDir is equivalent to the root
+                    if globber.matched(&self.turbo_root.into()).is_some() {
+                        entry_packages.insert(package);
+                    }
+                } else {
+                    let path = package_path_lookup
+                        .get(&package)
+                        .ok_or(ResolutionError::MissingPackageInfo(package.clone()))?;
+
+                    let path = path.restore_anchor(self.turbo_root);
+                    if globber.is_match(path.as_std_path()) {
+                        entry_packages.insert(package);
+                    }
+                }
+            }
+        } else if selector.parent_dir != AnchoredSystemPathBuf::default() {
+            selector_used = true;
+            if selector.parent_dir == AnchoredSystemPathBuf::from_raw(".").expect("valid anchored")
+            {
+                entry_packages.insert(ROOT_PKG_NAME.to_owned());
+            } else {
+                let path = self
+                    .turbo_root
+                    .join_unix_path(selector.parent_dir.to_unix().unwrap())
+                    .unwrap();
+                let globber = wax::Glob::new(path.as_str())?;
+                let packages = self.pkg_graph.workspaces();
+                for (name, _) in packages.filter(|(name, info)| {
+                    let path = info.package_json_path.restore_anchor(self.turbo_root);
+                    globber.is_match(path.as_std_path())
+                }) {
+                    entry_packages.insert(name.to_string());
+                }
+            }
+        }
+
+        if !selector.name_pattern.is_empty() {
+            if !selector_used {
+                entry_packages = self.match_package_names_to_vertices(
+                    &selector.name_pattern,
+                    self.pkg_graph
+                        .workspaces()
+                        .map(|(name, _)| name.to_string())
+                        .collect(),
+                )?;
+                selector_used = true;
+            } else {
+                entry_packages = match_package_names(&selector.name_pattern, entry_packages)?;
+            }
+        }
+
+        if !selector_used {
+            Err(ResolutionError::InvalidSelector(
+                InvalidSelectorError::InvalidSelector(selector.raw.clone()),
+            ))
+        } else {
+            Ok(entry_packages)
+        }
+    }
+
+    fn packages_changed_in_range(
+        &self,
+        from_ref: &str,
+        to_ref: &str,
+    ) -> Result<HashSet<String>, turborepo_scm::Error> {
+        self.change_detector.changed_packages(from_ref, to_ref)
+    }
+
+    fn match_package_names_to_vertices(
+        &self,
+        name_pattern: &str,
+        mut entry_packages: HashSet<String>,
+    ) -> Result<HashSet<String>, ResolutionError> {
+        // add the root package to the entry packages
+        entry_packages.insert(ROOT_PKG_NAME.to_owned());
+
+        Ok(match_package_names(name_pattern, entry_packages)?)
+    }
+}
+
+/// match the provided name pattern against the provided set of packages
+/// and return the set of packages that match the pattern
+///
+/// the pattern is normalized, replacing `\*` with `.*`
+fn match_package_names(
+    name_pattern: &str,
+    mut entry_packages: HashSet<String>,
+) -> Result<HashSet<String>, regex::Error> {
+    let matcher = SimpleGlob::new(name_pattern)?;
+    let matched_packages = entry_packages
+        .extract_if(|e| matcher.is_match(e.as_str()))
+        .collect::<HashSet<_>>();
+
+    // if we got no matches and the pattern is not scoped
+    // check if we have exactly one scoped package that does match
+    if matched_packages.is_empty()
+        && !name_pattern.starts_with('@')
+        && !name_pattern.starts_with('/')
+    {
+        let scoped_pattern = format!("@*/{}", name_pattern);
+        let scoped_matcher = SimpleGlob::new(&scoped_pattern)?;
+
+        let (first_item, multiple_matches) = {
+            let mut scoped_matched_packages =
+                entry_packages.extract_if(|e| scoped_matcher.is_match(e.as_str())); // we can extract again since the original set is untouched
+            let first_item = scoped_matched_packages.next();
+            (first_item, scoped_matched_packages.count() > 0)
+        };
+
+        if multiple_matches {
+            // if we have more than one, we can't disambiguate
+            Ok(Default::default())
+        } else {
+            // otherwise we either have a match or no match
+            Ok(first_item.into_iter().collect())
+        }
+    } else {
+        Ok(matched_packages)
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ResolutionError {
+    #[error("missing info for package")]
+    MissingPackageInfo(String),
+    #[error("No packages matched the provided filter")]
+    NoPackagesMatched,
+    #[error("Multiple packages matched the provided filter")]
+    MultiplePackagesMatched,
+    #[error("The provided filter matched a package that is not in the workspace")]
+    PackageNotInWorkspace,
+    #[error("Invalid filter selector: {0}")]
+    InvalidSelector(#[from] InvalidSelectorError),
+    #[error("Invalid regex pattern")]
+    InvalidRegex(#[from] regex::Error),
+    #[error("Invalid glob pattern")]
+    InvalidGlob(#[from] wax::BuildError),
+    #[error("Unable to query SCM: {0}")]
+    Scm(#[from] turborepo_scm::Error),
+}
+
+#[derive(Debug, Default)]
+pub struct TargetSelector {
+    include_dependencies: bool,
+    match_dependencies: bool,
+    include_dependents: bool,
+    exclude: bool,
+    exclude_self: bool,
+    follow_prod_deps_only: bool,
+    parent_dir: turbopath::AnchoredSystemPathBuf,
+    name_pattern: String,
+    from_ref: String,
+    to_ref_override: String,
+    raw: String,
+}
+
+impl TargetSelector {
+    pub fn to_ref(&self) -> &str {
+        if self.to_ref_override.is_empty() {
+            "HEAD"
+        } else {
+            &self.to_ref_override
+        }
+    }
+}
+
+impl FromStr for TargetSelector {
+    type Err = InvalidSelectorError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Err(InvalidSelectorError::InvalidSelector(s.to_string()))
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum InvalidSelectorError {
+    #[error("Invalid filter selector: {0}")]
+    InvalidSelector(String),
+}
+
+#[cfg(test)]
+mod test {
+    use std::collections::{HashMap, HashSet};
+
+    use test_case::test_case;
+    use turbopath::{AbsoluteSystemPathBuf, AnchoredSystemPathBuf, RelativeUnixPathBuf};
+
+    use super::{FilterResolver, PackageInference, TargetSelector};
+    use crate::{
+        package_graph::PackageGraph,
+        package_json::PackageJson,
+        package_manager::PackageManager,
+        run::{scope::change_detector::PackageChangeDetector, task_id::ROOT_PKG_NAME},
+    };
+
+    fn get_name(name: &str) -> (Option<&str>, &str) {
+        if let Some(idx) = name.rfind('/') {
+            // check if the rightmost slash has an @
+            if let Some(idx) = name[..idx].find('@') {
+                return (Some(&name[..idx]), &name[idx + 1..]);
+            }
+
+            return (Some(&name[..idx]), &name[idx + 1..]);
+        }
+
+        (None, name)
+    }
+
+    fn reverse<T, U>(tuple: (T, U)) -> (U, T) {
+        let (a, b) = tuple;
+        (b, a)
+    }
+
+    /// Make a project resolver with the provided dependencies. Extras is for
+    /// packages that are not dependencies of any other package.
+    fn make_project<T: PackageChangeDetector>(
+        dependencies: &[(&str, &str)],
+        extras: &[&str],
+        package_inference: Option<PackageInference>,
+        change_detector: T,
+    ) -> super::FilterResolver<'static, T> {
+        let temp_folder = tempfile::tempdir().unwrap();
+        let turbo_root = Box::leak(Box::new(
+            AbsoluteSystemPathBuf::new(temp_folder.path().as_os_str().to_str().unwrap()).unwrap(),
+        ));
+
+        let packages = dependencies
+            .iter()
+            .flat_map(|(a, b)| vec![a, b])
+            .chain(extras.iter())
+            .collect::<HashSet<_>>();
+
+        let dependencies =
+            dependencies
+                .iter()
+                .fold(HashMap::<&str, Vec<&str>>::new(), |mut acc, (k, v)| {
+                    let k = get_name(k).1;
+                    let v = get_name(v).1;
+                    acc.entry(k).or_default().push(v);
+                    acc
+                });
+
+        let package_jsons = packages
+            .iter()
+            .map(|package_path| {
+                let (_path, name) = get_name(package_path);
+                (
+                    turbo_root
+                        .join_unix_path(RelativeUnixPathBuf::new(**package_path).unwrap())
+                        .unwrap(),
+                    PackageJson {
+                        name: Some(name.to_string()),
+                        dependencies: dependencies.get(name).map(|v| {
+                            v.iter()
+                                .map(|name| (name.to_string(), "*".to_string()))
+                                .collect()
+                        }),
+                        // path: Some(AnchoredSystemPathBuf::try_from(**package_path).unwrap()),
+                        ..Default::default()
+                    },
+                )
+            })
+            .collect();
+
+        let pkg_graph = Box::leak(Box::new(
+            PackageGraph::builder(turbo_root, Default::default())
+                .with_package_jsons(Some(package_jsons))
+                .with_package_manger(Some(PackageManager::Pnpm6))
+                .build()
+                .unwrap(),
+        ));
+
+        let scm = Box::leak(Box::new(turborepo_scm::SCM::new(turbo_root)));
+
+        let resolver = FilterResolver::<'static>::new_with_change_detector(
+            pkg_graph,
+            turbo_root,
+            package_inference,
+            scm,
+            change_detector,
+        );
+
+        resolver
+    }
+
+    #[test_case(
+        vec![
+            TargetSelector {
+                name_pattern: ROOT_PKG_NAME.to_string(),
+                ..Default::default()
+            }
+        ],
+        None,
+        &[ROOT_PKG_NAME] ;
+        "select root package"
+    )]
+    #[test_case(
+        vec![
+            TargetSelector {
+                exclude_self: true,
+                include_dependencies: true,
+                name_pattern: "project-1".to_string(),
+                ..Default::default()
+            }
+        ],
+        None,
+        &["project-2", "project-4"] ;
+        "select only package dependencies (excluding the package itself)"
+    )]
+    #[test_case(
+        vec![
+            TargetSelector {
+                exclude_self: false,
+                include_dependencies: true,
+                name_pattern: "project-1".to_string(),
+                ..Default::default()
+            }
+        ],
+        None,
+        &["project-1", "project-2", "project-4"] ;
+        "select package with dependencies"
+    )]
+    #[test_case(
+        vec![
+            TargetSelector {
+                exclude_self: true,
+                include_dependencies: true,
+                include_dependents: true,
+                name_pattern: "project-1".to_string(),
+                ..Default::default()
+            }
+        ],
+        None,
+        &["project-0", "project-1", "project-2", "project-4", "project-5"] ;
+        "select package with dependencies and dependents, including dependent
+    dependencies" )]
+    #[test_case(
+        vec![
+            TargetSelector {
+                include_dependents: true,
+                name_pattern: "project-2".to_string(),
+                ..Default::default()
+            }
+        ],
+        None,
+        &["project-1", "project-2", "project-0"] ;
+        "select package with dependents"
+    )]
+    #[test_case(
+        vec![
+            TargetSelector {
+                exclude_self: true,
+                include_dependents: true,
+                name_pattern: "project-2".to_string(),
+                ..Default::default()
+            }
+        ],
+        None,
+        &["project-0", "project-1"] ;
+        "select dependents excluding package itself"
+    )]
+    #[test_case(
+        vec![
+            TargetSelector {
+                exclude_self: true,
+                include_dependents: true,
+                name_pattern: "project-2".to_string(),
+                ..Default::default()
+            },
+            TargetSelector {
+                include_dependencies: true,
+                exclude_self: true,
+                name_pattern: "project-1".to_string(),
+                ..Default::default()
+            }
+        ],
+        None,
+        &["project-0", "project-1", "project-2", "project-4"] ;
+        "filter using two selectors: one selects dependencies another selects
+    dependents" )]
+    #[test_case(
+        vec![
+            TargetSelector {
+                name_pattern: "project-2".to_string(),
+                ..Default::default()
+            }
+        ],
+        None,
+        &["project-2"] ;
+        "select just a package by name"
+    )]
+    #[test_case(
+        vec![
+            TargetSelector {
+                parent_dir: AnchoredSystemPathBuf::try_from("packages/*").unwrap(),
+                ..Default::default()
+            }
+        ],
+        None,
+        &["project-0", "project-1"] ;
+        "select by parentDir using glob"
+    )]
+    #[test_case(
+        vec![
+            TargetSelector {
+                parent_dir: AnchoredSystemPathBuf::try_from("project-5/**").unwrap(),
+                ..Default::default()
+            }
+        ],
+        None,
+        &["project-5", "project-6"] ;
+        "select by parentDir using globstar"
+    )]
+    #[test_case(
+        vec![
+            TargetSelector {
+                parent_dir: AnchoredSystemPathBuf::try_from("project-5").unwrap(),
+                ..Default::default()
+            }
+        ],
+        None,
+        &["project-5"] ;
+        "select by parentDir with no glob"
+    )]
+    #[test_case(
+        vec![
+            TargetSelector {
+                exclude: true,
+                name_pattern: "project-1".to_string(),
+                ..Default::default()
+            }
+        ],
+        None,
+        &["project-0", "project-2", "project-3", "project-4", "project-5", "project-6"] ;
+        "select all packages except one"
+    )]
+    #[test_case(
+        vec![
+            TargetSelector {
+                parent_dir: AnchoredSystemPathBuf::try_from("packages/*").unwrap(),
+                ..Default::default()
+            },
+            TargetSelector {
+                exclude: true,
+                name_pattern: "*-1".to_string(),
+                ..Default::default()
+            }
+        ],
+        None,
+        &["project-0"] ;
+        "select by parentDir and exclude one package by pattern"
+    )]
+    #[test_case(
+        vec![
+            TargetSelector {
+                parent_dir: AnchoredSystemPathBuf::try_from(".").unwrap(),
+                ..Default::default()
+            }
+        ],
+        None,
+        &[ROOT_PKG_NAME] ;
+        "select root package by directory"
+    )]
+    #[test_case(
+        vec![],
+        Some(PackageInference{
+            package_name: None,
+            directory_root: AnchoredSystemPathBuf::try_from("packages").unwrap(),
+        }),
+        &["project-0", "project-1"] ;
+        "select packages directory"
+    )]
+    #[test_case(
+        vec![],
+        Some(PackageInference{
+            package_name: Some("project-0".to_string()),
+            directory_root: AnchoredSystemPathBuf::try_from("packages/project-0").unwrap(),
+        }),
+        &["project-0"] ;
+        "infer single package"
+    )]
+    #[test_case(
+        vec![],
+        Some(PackageInference{
+            package_name: Some("project-0".to_string()),
+            directory_root: AnchoredSystemPathBuf::try_from("packages/project-0/src").unwrap(),
+        }),
+        &["project-0"] ;
+        "infer single package from subdirectory"
+    )]
+    fn filter(
+        selectors: Vec<TargetSelector>,
+        package_inference: Option<PackageInference>,
+        expected: &[&str],
+    ) {
+        let resolver = make_project(
+            &[
+                ("packages/project-0", "packages/project-1"),
+                ("packages/project-0", "project-5"),
+                ("packages/project-1", "project-2"),
+                ("packages/project-1", "project-4"),
+            ],
+            &["project-3", "project-5/packages/project-6"],
+            package_inference,
+            TestChangeDetector::new(&[]),
+        );
+
+        let packages = resolver.get_filtered_packages(selectors).unwrap();
+
+        assert_eq!(packages, expected.iter().map(|s| s.to_string()).collect());
+    }
+
+    #[test]
+    fn match_exact() {
+        let resolver = make_project(
+            &[],
+            &["packages/@foo/bar", "packages/bar"],
+            None,
+            TestChangeDetector::new(&[]),
+        );
+        let packages = resolver
+            .get_filtered_packages(vec![TargetSelector {
+                name_pattern: "bar".to_string(),
+                ..Default::default()
+            }])
+            .unwrap();
+
+        assert_eq!(packages, vec!["bar".to_string()].into_iter().collect());
+    }
+
+    #[test]
+    fn match_scoped_package() {
+        let resolver = make_project(
+            &[],
+            &["packages/bar/@foo/bar"],
+            None,
+            TestChangeDetector::new(&[]),
+        );
+        let packages = resolver
+            .get_filtered_packages(vec![TargetSelector {
+                name_pattern: "bar".to_string(),
+                ..Default::default()
+            }])
+            .unwrap();
+
+        assert_eq!(packages, vec!["@foo/bar".to_string()].into_iter().collect());
+    }
+
+    #[test]
+    fn match_multiple_scoped() {
+        let resolver = make_project(
+            &[],
+            &["packages/@foo/bar", "packages/@types/bar"],
+            None,
+            TestChangeDetector::new(&[]),
+        );
+        let packages = resolver
+            .get_filtered_packages(vec![TargetSelector {
+                name_pattern: "bar".to_string(),
+                ..Default::default()
+            }])
+            .unwrap();
+
+        assert_eq!(packages, HashSet::new());
+    }
+
+    #[test_case(
+        vec![
+            TargetSelector {
+                from_ref: "HEAD~1".to_string(),
+                ..Default::default()
+            }
+        ],
+        &["package-1", "package-2", ROOT_PKG_NAME] ;
+        "all changed packages"
+    )]
+    #[test_case(
+        vec![
+            TargetSelector {
+                from_ref: "HEAD~1".to_string(),
+                parent_dir: AnchoredSystemPathBuf::try_from(".").unwrap(),
+                ..Default::default()
+            }
+        ],
+        &[ROOT_PKG_NAME] ;
+        "all changed packages with parent dir exact match"
+    )]
+    #[test_case(
+        vec![
+            TargetSelector {
+                from_ref: "HEAD~1".to_string(),
+                parent_dir: AnchoredSystemPathBuf::try_from("package-2").unwrap(),
+                ..Default::default()
+            }
+        ],
+        &["package-2"] ;
+        "changed packages in directory"
+    )]
+    #[test_case(
+        vec![
+            TargetSelector {
+                from_ref: "HEAD~1".to_string(),
+                name_pattern: "package-2*".to_string(),
+                ..Default::default()
+            }
+        ],
+        &["package-2"] ;
+        "changed packages matching pattern"
+    )]
+    #[test_case(
+        vec![
+            TargetSelector {
+                from_ref: "HEAD~1".to_string(),
+                name_pattern: "package-1".to_string(),
+                match_dependencies: true,
+                ..Default::default()
+            }
+        ],
+        &["package-1"] ;
+        "changed package was requested scope, and we're matching dependencies"
+    )]
+    #[test_case(
+        vec![
+            TargetSelector {
+                from_ref: "HEAD~2".to_string(),
+                ..Default::default()
+            }
+        ],
+        &["package-1", "package-2", "package-3", ROOT_PKG_NAME] ;
+        "older commit"
+    )]
+    #[test_case(
+        vec![
+            TargetSelector {
+                from_ref: "HEAD~2".to_string(),
+                to_ref_override: "HEAD~1".to_string(),
+                ..Default::default()
+            }
+        ],
+        &["package-3"] ;
+        "commit range"
+    )]
+    #[test_case(
+        vec![
+            TargetSelector {
+                from_ref: "HEAD~1".to_string(),
+                parent_dir:
+    AnchoredSystemPathBuf::try_from("package-*").unwrap(),
+    match_dependencies: true,             ..Default::default()
+            }
+        ],
+        &["package-1", "package-2"] ;
+        "match dependency subtree"
+    )]
+    fn scm(selectors: Vec<TargetSelector>, expected: &[&str]) {
+        let scm_resolver = TestChangeDetector::new(&[
+            ("HEAD~1", "HEAD", &["package-1", "package-2", ROOT_PKG_NAME]),
+            ("HEAD~2", "HEAD~1", &["package-3"]),
+            (
+                "HEAD~2",
+                "HEAD",
+                &["package-1", "package-2", "package-3", ROOT_PKG_NAME],
+            ),
+        ]);
+
+        let resolver = make_project(
+            &[("package-3", "package-20")],
+            &["package-1", "package-2"],
+            None,
+            scm_resolver,
+        );
+
+        let packages = resolver.get_filtered_packages(selectors).unwrap();
+        assert_eq!(packages, expected.iter().map(|s| s.to_string()).collect());
+    }
+
+    struct TestChangeDetector<'a>(HashMap<(&'a str, &'a str), HashSet<String>>);
+
+    impl<'a> TestChangeDetector<'a> {
+        fn new(pairs: &[(&'a str, &'a str, &[&'a str])]) -> Self {
+            let mut map = HashMap::new();
+            for (from, to, changed) in pairs {
+                map.insert(
+                    (*from, *to),
+                    changed.iter().map(|s| s.to_string()).collect(),
+                );
+            }
+
+            Self(map)
+        }
+    }
+
+    impl<'a> PackageChangeDetector for TestChangeDetector<'a> {
+        fn changed_packages(
+            &self,
+            from: &str,
+            to: &str,
+        ) -> Result<HashSet<String>, turborepo_scm::Error> {
+            Ok(self
+                .0
+                .get(&(from, to))
+                .map(|h| h.to_owned())
+                .expect("unsupported range"))
         }
     }
 }

--- a/crates/turborepo-lib/src/run/scope/filter.rs
+++ b/crates/turborepo-lib/src/run/scope/filter.rs
@@ -350,7 +350,7 @@ impl<'a, T: PackageChangeDetector> FilterResolver<'a, T> {
             } else {
                 let path = self
                     .turbo_root
-                    .join_unix_path(selector.parent_dir.to_unix().unwrap())
+                    .join_unix_path(selector.parent_dir.to_unix())
                     .unwrap();
                 let matcher = wax::Glob::new(path.as_str())?;
                 let p = self.turbo_root.resolve(&info.package_json_path);
@@ -416,7 +416,7 @@ impl<'a, T: PackageChangeDetector> FilterResolver<'a, T> {
 
         let path = self
             .turbo_root
-            .join_unix_path(selector.parent_dir.to_unix().unwrap())
+            .join_unix_path(selector.parent_dir.to_unix())
             .unwrap();
         let globber = wax::Glob::new(path.as_str()).unwrap();
 
@@ -461,7 +461,7 @@ impl<'a, T: PackageChangeDetector> FilterResolver<'a, T> {
             } else {
                 let path = self
                     .turbo_root
-                    .join_unix_path(selector.parent_dir.to_unix().unwrap())
+                    .join_unix_path(selector.parent_dir.to_unix())
                     .unwrap();
                 let globber = wax::Glob::new(path.as_str())?;
                 let packages = self.pkg_graph.workspaces();

--- a/crates/turborepo-lib/src/run/scope/filter.rs
+++ b/crates/turborepo-lib/src/run/scope/filter.rs
@@ -260,7 +260,7 @@ impl<'a, T: PackageChangeDetector> FilterResolver<'a, T> {
                 let node = package_graph::WorkspaceNode::Workspace(package.clone());
 
                 if selector.include_dependencies {
-                    let dependencies = self.pkg_graph.dependencies(&node);
+                    let dependencies = self.pkg_graph.immediate_dependencies(&node);
                     let dependencies = dependencies
                         .iter()
                         .flatten()
@@ -272,8 +272,8 @@ impl<'a, T: PackageChangeDetector> FilterResolver<'a, T> {
                 }
 
                 if selector.include_dependents {
-                    let dependents = self.pkg_graph.dependents(&node);
-                    for dependent in dependents.iter().flatten().map(|i| i.as_workspace()) {
+                    let dependents = self.pkg_graph.ancestors(&node);
+                    for dependent in dependents.iter().map(|i| i.as_workspace()) {
                         walked_dependents.insert(dependent.clone());
 
                         // get the dependent's dependencies
@@ -282,7 +282,7 @@ impl<'a, T: PackageChangeDetector> FilterResolver<'a, T> {
                                 package_graph::WorkspaceNode::Workspace(dependent.to_owned());
 
                             let dependent_dependencies =
-                                self.pkg_graph.dependencies(&dependent_node);
+                                self.pkg_graph.immediate_dependencies(&dependent_node);
 
                             let dependent_dependencies = dependent_dependencies
                                 .iter()
@@ -381,7 +381,7 @@ impl<'a, T: PackageChangeDetector> FilterResolver<'a, T> {
             }
 
             let workspace_node = package_graph::WorkspaceNode::Workspace(package.clone());
-            let dependencies = self.pkg_graph.dependencies(&workspace_node);
+            let dependencies = self.pkg_graph.immediate_dependencies(&workspace_node);
 
             for changed_package in &changed_packages {
                 if !selector.exclude_self && package.eq(changed_package) {

--- a/crates/turborepo-lib/src/run/scope/filter.rs
+++ b/crates/turborepo-lib/src/run/scope/filter.rs
@@ -361,7 +361,7 @@ impl<'a, T: PackageChangeDetector> FilterResolver<'a, T> {
                     .join_unix_path(selector.parent_dir.to_unix().unwrap())
                     .unwrap();
                 let matcher = wax::Glob::new(path.as_str())?;
-                let p = info.package_json_path.restore_anchor(self.turbo_root);
+                let p = self.turbo_root.resolve(&info.package_json_path);
                 let matches = matcher.is_match(p.as_std_path());
 
                 if matches {
@@ -459,7 +459,7 @@ impl<'a, T: PackageChangeDetector> FilterResolver<'a, T> {
                         .get(&package)
                         .ok_or(ResolutionError::MissingPackageInfo(package.clone()))?;
 
-                    let path = path.restore_anchor(self.turbo_root);
+                    let path = self.turbo_root.resolve(path);
                     if globber.is_match(path.as_std_path()) {
                         entry_packages.insert(package);
                     }
@@ -478,7 +478,7 @@ impl<'a, T: PackageChangeDetector> FilterResolver<'a, T> {
                 let globber = wax::Glob::new(path.as_str())?;
                 let packages = self.pkg_graph.workspaces();
                 for (name, _) in packages.filter(|(_name, info)| {
-                    let path = info.package_json_path.restore_anchor(self.turbo_root);
+                    let path = self.turbo_root.resolve(&info.package_json_path);
                     globber.is_match(path.as_std_path())
                 }) {
                     entry_packages.insert(name.to_string());

--- a/crates/turborepo-lib/src/run/scope/filter.rs
+++ b/crates/turborepo-lib/src/run/scope/filter.rs
@@ -1,5 +1,6 @@
 use tracing::debug;
 use turbopath::{AbsoluteSystemPath, AnchoredSystemPathBuf};
+use turborepo_scm::SCM;
 
 use crate::package_graph::{self, PackageGraph};
 
@@ -52,8 +53,25 @@ impl PackageInference {
     }
 }
 
-struct Resolver<'a> {
+pub struct Resolver<'a> {
     pkg_graph: &'a PackageGraph,
     turbo_root: &'a AbsoluteSystemPath,
     inference: Option<PackageInference>,
+    scm: &'a SCM,
+}
+
+impl<'a> Resolver<'a> {
+    pub(crate) fn new(
+        pkg_graph: &'a PackageGraph,
+        turbo_root: &'a AbsoluteSystemPath,
+        inference: Option<PackageInference>,
+        scm: &'a SCM,
+    ) -> Self {
+        Self {
+            pkg_graph,
+            turbo_root,
+            inference,
+            scm,
+        }
+    }
 }

--- a/crates/turborepo-lib/src/run/scope/filter.rs
+++ b/crates/turborepo-lib/src/run/scope/filter.rs
@@ -49,7 +49,7 @@ impl PackageInference {
                 // do so in a consistent manner
                 return Self {
                     package_name: Some(workspace_name.to_string()),
-                    directory_root: workspace_entry.package_json_path().clone(),
+                    directory_root: workspace_entry.package_json_path().to_owned(),
                 };
             }
             let inferred_path_is_between_root_and_pkg = full_inference_path.contains(&pkg_path);

--- a/crates/turborepo-lib/src/run/scope/filter.rs
+++ b/crates/turborepo-lib/src/run/scope/filter.rs
@@ -13,10 +13,7 @@ use super::{
     simple_glob::{Match, SimpleGlob},
     target_selector::{InvalidSelectorError, TargetSelector},
 };
-use crate::{
-    package_graph::{self, PackageGraph, WorkspaceName, WorkspaceNode},
-    run::task_id::ROOT_PKG_NAME,
-};
+use crate::package_graph::{self, PackageGraph, WorkspaceName};
 
 pub struct PackageInference {
     package_name: Option<String>,
@@ -916,14 +913,7 @@ mod test {
 
         assert_eq!(
             packages,
-            expected
-                .iter()
-                .map(|s| if ROOT_PKG_NAME.eq(*s) {
-                    WorkspaceName::Root
-                } else {
-                    WorkspaceName::Other(s.to_string())
-                })
-                .collect()
+            expected.iter().map(|s| WorkspaceName::from(*s)).collect()
         );
     }
 
@@ -1100,14 +1090,7 @@ mod test {
         let packages = resolver.get_filtered_packages(selectors).unwrap();
         assert_eq!(
             packages,
-            expected
-                .iter()
-                .map(|s| if ROOT_PKG_NAME.eq(*s) {
-                    WorkspaceName::Root
-                } else {
-                    WorkspaceName::Other(s.to_string())
-                })
-                .collect()
+            expected.iter().map(|s| WorkspaceName::from(*s)).collect()
         );
     }
 
@@ -1119,16 +1102,7 @@ mod test {
             for (from, to, changed) in pairs {
                 map.insert(
                     (*from, *to),
-                    changed
-                        .iter()
-                        .map(|s| {
-                            if ROOT_PKG_NAME.eq(*s) {
-                                WorkspaceName::Root
-                            } else {
-                                WorkspaceName::Other(s.to_string())
-                            }
-                        })
-                        .collect(),
+                    changed.iter().map(|s| WorkspaceName::from(*s)).collect(),
                 );
             }
 

--- a/crates/turborepo-lib/src/run/scope/filter.rs
+++ b/crates/turborepo-lib/src/run/scope/filter.rs
@@ -226,7 +226,7 @@ impl<'a, T: PackageChangeDetector> FilterResolver<'a, T> {
             self.pkg_graph
                 .workspaces()
                 // todo: a type-level way of dealing with non-root packages
-                .filter(|(name, _)| WorkspaceName::Root.eq(name)) // the root package has to be explicitly included
+                .filter(|(name, _)| !WorkspaceName::Root.eq(name)) // the root package has to be explicitly included
                 .map(|(name, _)| name.to_owned())
                 .collect()
         };
@@ -918,7 +918,11 @@ mod test {
             packages,
             expected
                 .iter()
-                .map(|s| WorkspaceName::Other(s.to_string()))
+                .map(|s| if ROOT_PKG_NAME.eq(*s) {
+                    WorkspaceName::Root
+                } else {
+                    WorkspaceName::Other(s.to_string())
+                })
                 .collect()
         );
     }
@@ -1098,7 +1102,11 @@ mod test {
             packages,
             expected
                 .iter()
-                .map(|s| crate::package_graph::WorkspaceName::Other(s.to_string()))
+                .map(|s| if ROOT_PKG_NAME.eq(*s) {
+                    WorkspaceName::Root
+                } else {
+                    WorkspaceName::Other(s.to_string())
+                })
                 .collect()
         );
     }
@@ -1113,7 +1121,13 @@ mod test {
                     (*from, *to),
                     changed
                         .iter()
-                        .map(|s| WorkspaceName::Other(s.to_string()))
+                        .map(|s| {
+                            if ROOT_PKG_NAME.eq(*s) {
+                                WorkspaceName::Root
+                            } else {
+                                WorkspaceName::Other(s.to_string())
+                            }
+                        })
                         .collect(),
                 );
             }

--- a/crates/turborepo-lib/src/run/scope/filter.rs
+++ b/crates/turborepo-lib/src/run/scope/filter.rs
@@ -1,7 +1,7 @@
 use tracing::debug;
 use turbopath::{AbsoluteSystemPath, AnchoredSystemPathBuf};
 
-use crate::package_graph;
+use crate::package_graph::{self, PackageGraph};
 
 pub struct PackageInference {
     package_name: Option<String>,
@@ -50,4 +50,10 @@ impl PackageInference {
             directory_root: pkg_inference_path.to_owned(),
         }
     }
+}
+
+struct Resolver<'a> {
+    pkg_graph: &'a PackageGraph,
+    turbo_root: &'a AbsoluteSystemPath,
+    inference: Option<PackageInference>,
 }

--- a/crates/turborepo-lib/src/run/scope/filter.rs
+++ b/crates/turborepo-lib/src/run/scope/filter.rs
@@ -647,7 +647,7 @@ mod test {
         if let Some(idx) = name.rfind('/') {
             // check if the rightmost slash has an @
             if let Some(idx) = name[..idx].find('@') {
-                return (Some(&name[..idx]), &name[idx + 1..]);
+                return (Some(&name[..idx - 1]), &name[idx..]);
             }
 
             return (Some(&name[..idx]), &name[idx + 1..]);
@@ -693,7 +693,7 @@ mod test {
         let package_jsons = packages
             .iter()
             .map(|package_path| {
-                let (_path, name) = get_name(package_path);
+                let (_, name) = get_name(package_path);
                 (
                     turbo_root
                         .join_unix_path(RelativeUnixPathBuf::new(**package_path).unwrap())
@@ -705,7 +705,6 @@ mod test {
                                 .map(|name| (name.to_string(), "*".to_string()))
                                 .collect()
                         }),
-                        // path: Some(AnchoredSystemPathBuf::try_from(**package_path).unwrap()),
                         ..Default::default()
                     },
                 )

--- a/crates/turborepo-lib/src/run/scope/mod.rs
+++ b/crates/turborepo-lib/src/run/scope/mod.rs
@@ -10,14 +10,17 @@ use filter::{FilterResolver, PackageInference};
 use turbopath::AbsoluteSystemPath;
 use turborepo_scm::SCM;
 
-use crate::{opts::ScopeOpts, package_graph::PackageGraph};
+use crate::{
+    opts::ScopeOpts,
+    package_graph::{PackageGraph, WorkspaceName},
+};
 
 pub fn resolve_packages(
     opts: &ScopeOpts,
     turbo_root: &AbsoluteSystemPath,
     pkg_graph: &PackageGraph,
     scm: &SCM,
-) -> Result<HashSet<String>> {
+) -> Result<HashSet<WorkspaceName>> {
     let pkg_inference = opts.pkg_inference_root.as_ref().map(|pkg_inference_path| {
         PackageInference::calculate(turbo_root, pkg_inference_path, pkg_graph)
     });

--- a/crates/turborepo-lib/src/run/scope/mod.rs
+++ b/crates/turborepo-lib/src/run/scope/mod.rs
@@ -20,6 +20,9 @@ pub fn resolve_packages(
         PackageInference::calculate(turbo_root, pkg_inference_path, pkg_graph)
     });
     let _resolver = Resolver::new(pkg_graph, turbo_root, pkg_inference, scm);
+    let mut filter_patterns = opts.filter_patterns.clone();
+    filter_patterns.extend(opts.legacy_filter.as_filter_pattern());
+    let is_all_packages = filter_patterns.is_empty() && opts.pkg_inference_root.is_none();
     warn!("resolve packages not implemented yet");
     Ok(HashSet::new())
 }

--- a/crates/turborepo-lib/src/run/scope/mod.rs
+++ b/crates/turborepo-lib/src/run/scope/mod.rs
@@ -1,6 +1,7 @@
 mod change_detector;
 mod filter;
 mod simple_glob;
+mod target_selector;
 
 use std::collections::HashSet;
 

--- a/crates/turborepo-lib/src/run/scope/mod.rs
+++ b/crates/turborepo-lib/src/run/scope/mod.rs
@@ -3,7 +3,7 @@ mod filter;
 use std::collections::HashSet;
 
 use anyhow::Result;
-use filter::PackageInference;
+use filter::{PackageInference, Resolver};
 use tracing::warn;
 use turbopath::AbsoluteSystemPath;
 use turborepo_scm::SCM;
@@ -14,11 +14,12 @@ pub fn resolve_packages(
     opts: &ScopeOpts,
     turbo_root: &AbsoluteSystemPath,
     pkg_graph: &PackageGraph,
-    _scm: &SCM,
+    scm: &SCM,
 ) -> Result<HashSet<String>> {
-    let _pkg_inference = opts.pkg_inference_root.as_ref().map(|pkg_inference_path| {
+    let pkg_inference = opts.pkg_inference_root.as_ref().map(|pkg_inference_path| {
         PackageInference::calculate(turbo_root, pkg_inference_path, pkg_graph)
     });
+    let _resolver = Resolver::new(pkg_graph, turbo_root, pkg_inference, scm);
     warn!("resolve packages not implemented yet");
     Ok(HashSet::new())
 }

--- a/crates/turborepo-lib/src/run/scope/mod.rs
+++ b/crates/turborepo-lib/src/run/scope/mod.rs
@@ -1,10 +1,11 @@
+mod change_detector;
 mod filter;
+mod simple_glob;
 
 use std::collections::HashSet;
 
 use anyhow::Result;
-use filter::{PackageInference, Resolver};
-use tracing::warn;
+use filter::{FilterResolver, PackageInference};
 use turbopath::AbsoluteSystemPath;
 use turborepo_scm::SCM;
 
@@ -19,10 +20,9 @@ pub fn resolve_packages(
     let pkg_inference = opts.pkg_inference_root.as_ref().map(|pkg_inference_path| {
         PackageInference::calculate(turbo_root, pkg_inference_path, pkg_graph)
     });
-    let _resolver = Resolver::new(pkg_graph, turbo_root, pkg_inference, scm);
-    let mut filter_patterns = opts.filter_patterns.clone();
-    filter_patterns.extend(opts.legacy_filter.as_filter_pattern());
-    let is_all_packages = filter_patterns.is_empty() && opts.pkg_inference_root.is_none();
-    warn!("resolve packages not implemented yet");
-    Ok(HashSet::new())
+
+    let filtered_packages = FilterResolver::new(opts, pkg_graph, turbo_root, pkg_inference, scm)
+        .resolve(&opts.get_filters())?;
+
+    Ok(filtered_packages)
 }

--- a/crates/turborepo-lib/src/run/scope/mod.rs
+++ b/crates/turborepo-lib/src/run/scope/mod.rs
@@ -5,18 +5,19 @@ use std::collections::HashSet;
 use anyhow::Result;
 use filter::PackageInference;
 use tracing::warn;
+use turbopath::AbsoluteSystemPath;
 use turborepo_scm::SCM;
 
-use crate::{commands::CommandBase, opts::ScopeOpts, package_graph};
+use crate::{opts::ScopeOpts, package_graph::PackageGraph};
 
 pub fn resolve_packages(
     opts: &ScopeOpts,
-    base: &CommandBase,
-    pkg_graph: &package_graph::PackageGraph,
+    turbo_root: &AbsoluteSystemPath,
+    pkg_graph: &PackageGraph,
     _scm: &SCM,
 ) -> Result<HashSet<String>> {
     let _pkg_inference = opts.pkg_inference_root.as_ref().map(|pkg_inference_path| {
-        PackageInference::calculate(&base.repo_root, pkg_inference_path, pkg_graph)
+        PackageInference::calculate(turbo_root, pkg_inference_path, pkg_graph)
     });
     warn!("resolve packages not implemented yet");
     Ok(HashSet::new())

--- a/crates/turborepo-lib/src/run/scope/simple_glob.rs
+++ b/crates/turborepo-lib/src/run/scope/simple_glob.rs
@@ -1,0 +1,87 @@
+use regex::Regex;
+
+/// A simple glob-like pattern that supports a subset of
+/// glob syntax for the purposes of string matching.
+/// If you are matching paths, use `turborepo_wax::glob::Glob` instead.
+pub enum SimpleGlob {
+    Regex(Regex),
+    String(String),
+    Any,
+}
+
+pub trait Match {
+    fn is_match(&self, s: &str) -> bool;
+}
+
+impl SimpleGlob {
+    pub fn new(pattern: &str) -> Result<Self, regex::Error> {
+        if pattern == "*" {
+            Ok(SimpleGlob::Any)
+        } else if pattern.contains('*') {
+            let regex = Regex::new(&format!("^{}$", pattern.replace('*', ".*")))?;
+            Ok(SimpleGlob::Regex(regex))
+        } else {
+            Ok(SimpleGlob::String(pattern.to_string()))
+        }
+    }
+}
+
+impl Match for SimpleGlob {
+    fn is_match(&self, s: &str) -> bool {
+        match self {
+            SimpleGlob::Regex(regex) => regex.is_match(s),
+            SimpleGlob::String(string) => string == s,
+            SimpleGlob::Any => true,
+        }
+    }
+}
+
+pub struct AnyGlob<T: Match>(Vec<T>);
+
+impl<T: Match> Match for AnyGlob<T> {
+    fn is_match(&self, s: &str) -> bool {
+        self.0.iter().any(|glob| glob.is_match(s))
+    }
+}
+
+pub struct NotGlob<T: Match>(T);
+
+impl<T: Match> Match for NotGlob<T> {
+    fn is_match(&self, s: &str) -> bool {
+        !self.0.is_match(s)
+    }
+}
+
+pub struct IncludeExcludeGlob<I: Match, E: Match> {
+    include: I,
+    exclude: E,
+}
+
+impl IncludeExcludeGlob<AnyGlob<SimpleGlob>, AnyGlob<SimpleGlob>> {
+    pub fn new_from_globs<'a>(
+        include: impl Iterator<Item = &'a dyn AsRef<&'a str>>,
+        exclude: impl Iterator<Item = &'a dyn AsRef<&'a str>>,
+        _include_default: bool,
+        _exclude_default: bool,
+    ) -> Self {
+        let include = AnyGlob(
+            include
+                .map(|glob| SimpleGlob::new(glob.as_ref()).unwrap())
+                .collect(),
+        );
+
+        let exclude = AnyGlob(
+            exclude
+                .map(|glob| SimpleGlob::new(glob.as_ref()).unwrap())
+                .collect(),
+        );
+
+        Self { include, exclude }
+    }
+}
+
+impl<T: Match, E: Match> Match for IncludeExcludeGlob<T, E> {
+    fn is_match(&self, s: &str) -> bool {
+        self.include.is_match(s) && !self.exclude.is_match(s)
+    }
+}

--- a/crates/turborepo-lib/src/run/scope/target_selector.rs
+++ b/crates/turborepo-lib/src/run/scope/target_selector.rs
@@ -258,7 +258,7 @@ mod test {
         let result = TargetSelector::from_str(raw_selector);
 
         match result {
-            Ok(got) => {
+            Ok(_got) => {
                 panic!("expected error when parsing {}", raw_selector);
             }
             Err(e) => {

--- a/crates/turborepo-lib/src/run/scope/target_selector.rs
+++ b/crates/turborepo-lib/src/run/scope/target_selector.rs
@@ -1,0 +1,285 @@
+use std::str::FromStr;
+
+use regex::Regex;
+use thiserror::Error;
+use turbopath::AnchoredSystemPathBuf;
+
+#[derive(Debug, Default, PartialEq)]
+pub struct TargetSelector {
+    pub include_dependencies: bool,
+    pub match_dependencies: bool,
+    pub include_dependents: bool,
+    pub exclude: bool,
+    pub exclude_self: bool,
+    pub follow_prod_deps_only: bool,
+    pub parent_dir: AnchoredSystemPathBuf,
+    pub name_pattern: String,
+    pub from_ref: String,
+    pub to_ref_override: String,
+    pub raw: String,
+}
+
+impl TargetSelector {
+    pub fn to_ref(&self) -> &str {
+        if self.to_ref_override.is_empty() {
+            "HEAD"
+        } else {
+            &self.to_ref_override
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn is_valid(&self) -> bool {
+        !self.from_ref.is_empty()
+            || self.parent_dir != AnchoredSystemPathBuf::default()
+            || !self.name_pattern.is_empty()
+    }
+}
+
+impl FromStr for TargetSelector {
+    type Err = InvalidSelectorError;
+
+    fn from_str(raw_selector: &str) -> Result<Self, Self::Err> {
+        let selector = raw_selector.strip_prefix('!');
+        let (exclude, selector) = match selector {
+            Some(selector) => (true, selector),
+            None => (false, raw_selector),
+        };
+
+        let mut exclude_self = false;
+        let include_dependencies = selector.strip_suffix("...");
+
+        let (include_dependencies, selector) = if let Some(selector) = include_dependencies {
+            (
+                true,
+                if let Some(selector) = selector.strip_suffix('^') {
+                    exclude_self = true;
+                    selector
+                } else {
+                    selector
+                },
+            )
+        } else {
+            (false, selector)
+        };
+
+        let include_dependents = selector.strip_prefix("...");
+        let (include_dependents, selector) = if let Some(selector) = include_dependents {
+            (
+                true,
+                if let Some(selector) = selector.strip_prefix('^') {
+                    exclude_self = true;
+                    selector
+                } else {
+                    selector
+                },
+            )
+        } else {
+            (false, selector)
+        };
+
+        let re = Regex::new(r"^(?P<name>[^.](?:[^{}\[\]]*[^{}\[\].])?)?(\{(?P<directory>[^}]*)})?(?P<commits>(?:\.{3})?\[[^\]]+\])?$").expect("valid");
+        let captures = re.captures(&selector);
+
+        let captures = match captures {
+            Some(captures) => captures,
+            None => {
+                return if let Some(relative_path) = is_selector_by_location(&selector) {
+                    Ok(TargetSelector {
+                        exclude,
+                        include_dependencies,
+                        include_dependents,
+                        parent_dir: relative_path?,
+                        raw: raw_selector.to_string(),
+                        ..Default::default()
+                    })
+                } else {
+                    Ok(TargetSelector {
+                        exclude,
+                        exclude_self,
+                        include_dependencies,
+                        include_dependents,
+                        name_pattern: selector.to_string(),
+                        raw: raw_selector.to_string(),
+                        ..Default::default()
+                    })
+                }
+            }
+        };
+
+        let mut pre_add_dependencies = false;
+
+        let name_pattern = captures
+            .name("name")
+            .map_or(String::new(), |m| m.as_str().to_string());
+
+        let mut parent_dir = AnchoredSystemPathBuf::default();
+
+        if let Some(directory) = captures.name("directory") {
+            let directory = directory.as_str().to_string();
+            if directory.is_empty() {
+                return Err(InvalidSelectorError::EmptyPathSpecification);
+            } else {
+                parent_dir = AnchoredSystemPathBuf::try_from(directory.as_str())
+                    .map_err(|_| InvalidSelectorError::InvalidAnchoredPath(directory))?;
+            }
+        }
+
+        let (from_ref, to_ref_override) = if let Some(commits) = captures.name("commits") {
+            let commits_str = if let Some(commits) = commits.as_str().strip_prefix("...") {
+                if parent_dir == AnchoredSystemPathBuf::default() && name_pattern.is_empty() {
+                    return Err(InvalidSelectorError::CantMatchDependencies);
+                }
+                pre_add_dependencies = true;
+                commits
+            } else {
+                commits.as_str()
+            };
+
+            // strip the square brackets
+            let inner_str = commits_str
+                .strip_prefix('[')
+                .and_then(|s| s.strip_suffix(']'));
+
+            if let Some(commits_str) = inner_str {
+                if let Some((a, b)) = commits_str.split_once("...") {
+                    (a.to_string(), b.to_string())
+                } else {
+                    (commits_str.to_string(), String::new())
+                }
+            } else {
+                (commits_str.to_string(), String::new())
+            }
+        } else {
+            Default::default()
+        };
+
+        Ok(TargetSelector {
+            from_ref,
+            to_ref_override,
+            exclude,
+            exclude_self,
+            include_dependencies,
+            include_dependents,
+            match_dependencies: pre_add_dependencies,
+            name_pattern,
+            parent_dir,
+            raw: raw_selector.to_string(),
+            ..Default::default()
+        })
+    }
+}
+
+#[derive(Debug, Error, PartialEq)]
+pub enum InvalidSelectorError {
+    #[error("cannot use match dependencies without specifying either a directory or package")]
+    CantMatchDependencies,
+    #[error("invalid anchored path: {0}")]
+    InvalidAnchoredPath(String),
+    #[error("empty path specification")]
+    EmptyPathSpecification,
+
+    #[error("selector \"{0}\" must have a reference, directory, or name pattern")]
+    InvalidSelector(String),
+}
+
+/// checks if the selector is a filesystem path
+pub fn is_selector_by_location(
+    raw_selector: &str,
+) -> Option<Result<AnchoredSystemPathBuf, InvalidSelectorError>> {
+    if !raw_selector.starts_with('.') {
+        return None;
+    }
+
+    // ., ./, or .\
+    if raw_selector.len() == 1
+        || raw_selector.chars().nth(1) == Some('/')
+        || raw_selector.chars().nth(1) == Some('\\')
+    {
+        return Some(
+            AnchoredSystemPathBuf::try_from(raw_selector)
+                .map_err(|_| InvalidSelectorError::InvalidAnchoredPath(raw_selector.to_string())),
+        );
+    }
+
+    if raw_selector.chars().nth(1) != Some('.') {
+        return None;
+    }
+
+    // .., ../, or ..\
+    if raw_selector.len() == 2
+        || raw_selector.chars().nth(2) == Some('/')
+        || raw_selector.chars().nth(2) == Some('\\')
+    {
+        return Some(
+            AnchoredSystemPathBuf::try_from(raw_selector)
+                .map_err(|_| InvalidSelectorError::InvalidAnchoredPath(raw_selector.to_string())),
+        );
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod test {
+    use std::str::FromStr;
+
+    use test_case::test_case;
+    use turbopath::AnchoredSystemPathBuf;
+
+    use super::TargetSelector;
+
+    #[test_case("foo", TargetSelector { name_pattern: "foo".to_string(), raw: "foo".to_string(), ..Default::default() }; "foo")]
+    #[test_case("foo...", TargetSelector { name_pattern: "foo".to_string(), raw: "foo...".to_string(), include_dependencies: true, ..Default::default() }; "foo dot dot dot")]
+    #[test_case("...foo", TargetSelector { name_pattern: "foo".to_string(), raw: "...foo".to_string(), include_dependents: true, ..Default::default() }; "dot dot dot foo")]
+    #[test_case("...foo...", TargetSelector { name_pattern: "foo".to_string(), raw: "...foo...".to_string(), include_dependents: true, include_dependencies: true, ..Default::default() }; "dot dot dot foo dot dot dot")]
+    #[test_case("foo^...", TargetSelector { name_pattern: "foo".to_string(), raw: "foo^...".to_string(), include_dependencies: true, exclude_self: true, ..Default::default() }; "foo caret dot dot dot")]
+    #[test_case("...^foo", TargetSelector { name_pattern: "foo".to_string(), raw: "...^foo".to_string(), include_dependents: true, exclude_self: true, ..Default::default() }; "dot dot dot caret foo")]
+    #[test_case("./foo", TargetSelector { raw: "./foo".to_string(), parent_dir: AnchoredSystemPathBuf::try_from("./foo").unwrap(), ..Default::default() }; "dot slash foo")]
+    #[test_case("../foo", TargetSelector { raw: "../foo".to_string(), parent_dir: AnchoredSystemPathBuf::try_from("../foo").unwrap(), ..Default::default() }; "dot dot slash foo")]
+    #[test_case("...{./foo}", TargetSelector { raw: "...{./foo}".to_string(), parent_dir: AnchoredSystemPathBuf::try_from("./foo").unwrap(), include_dependents: true, ..Default::default() }; "dot dot dot curly bracket foo")]
+    #[test_case(".", TargetSelector { raw: ".".to_string(), parent_dir: AnchoredSystemPathBuf::try_from(".").unwrap(), ..Default::default() }; "parent dir dot")]
+    #[test_case("..", TargetSelector { raw: "..".to_string(), parent_dir: AnchoredSystemPathBuf::try_from("..").unwrap(), ..Default::default() }; "parent dir dot dot")]
+    #[test_case("[master]", TargetSelector { raw: "[master]".to_string(), from_ref: "master".to_string(), ..Default::default() }; "square brackets master")]
+    #[test_case("[from...to]", TargetSelector { raw: "[from...to]".to_string(), from_ref: "from".to_string(), to_ref_override: "to".to_string(), ..Default::default() }; "[from...to]")]
+    #[test_case("{foo}[master]", TargetSelector { raw: "{foo}[master]".to_string(), from_ref: "master".to_string(), parent_dir: AnchoredSystemPathBuf::try_from("foo").unwrap(), ..Default::default() }; "{foo}[master]")]
+    #[test_case("pattern{foo}[master]", TargetSelector { raw: "pattern{foo}[master]".to_string(), from_ref: "master".to_string(), parent_dir: AnchoredSystemPathBuf::try_from("foo").unwrap(), name_pattern: "pattern".to_string(), ..Default::default() }; "pattern{foo}[master]")]
+    #[test_case("[master]...", TargetSelector { raw: "[master]...".to_string(), from_ref: "master".to_string(), include_dependencies: true, ..Default::default() }; "square brackets master dot dot dot")]
+    #[test_case("...[master]", TargetSelector { raw: "...[master]".to_string(), from_ref: "master".to_string(), include_dependents: true, ..Default::default() }; "dot dot dot master square brackets")]
+    #[test_case("...[master]...", TargetSelector { raw: "...[master]...".to_string(), from_ref: "master".to_string(), include_dependencies: true, include_dependents: true, ..Default::default() }; "dot dot dot master square brackets dot dot dot")]
+    #[test_case("...[from...to]...", TargetSelector { raw: "...[from...to]...".to_string(), from_ref: "from".to_string(), to_ref_override: "to".to_string(), include_dependencies: true, include_dependents: true, ..Default::default() }; "dot dot dot [from...to] dot dot dot")]
+    #[test_case("foo...[master]", TargetSelector { raw: "foo...[master]".to_string(), from_ref: "master".to_string(), name_pattern: "foo".to_string(), match_dependencies: true, ..Default::default() }; "foo...[master]")]
+    #[test_case("foo...[master]...", TargetSelector { raw: "foo...[master]...".to_string(), from_ref: "master".to_string(), name_pattern: "foo".to_string(), match_dependencies: true, include_dependencies: true, ..Default::default() }; "foo...[master] dot dot dot")]
+    #[test_case("{foo}...[master]", TargetSelector { raw: "{foo}...[master]".to_string(), from_ref: "master".to_string(), parent_dir: AnchoredSystemPathBuf::try_from("foo").unwrap(), match_dependencies: true, ..Default::default() }; "curly brackets foo...[master]")]
+    fn parse_target_selector(raw_selector: &str, want: TargetSelector) {
+        let result = TargetSelector::from_str(raw_selector);
+
+        match result {
+            Ok(got) => {
+                assert_eq!(
+                    got, want,
+                    "ParseTargetSelector() = {:?}, want {:?}",
+                    got, want
+                );
+            }
+            Err(e) => {
+                panic!("ParseTargetSelector() error = {:?}", e)
+            }
+        }
+    }
+
+    #[test_case("{}" ; "curly brackets")]
+    #[test_case("......[master]" ; "......[master]")]
+    fn parse_target_selector_invalid(raw_selector: &str) {
+        let result = TargetSelector::from_str(raw_selector);
+
+        match result {
+            Ok(got) => {
+                panic!("expected error when parsing {}", raw_selector);
+            }
+            Err(e) => {
+                println!("{:?}", e);
+            }
+        }
+    }
+}

--- a/crates/turborepo-lib/src/run/scope/target_selector.rs
+++ b/crates/turborepo-lib/src/run/scope/target_selector.rs
@@ -187,29 +187,21 @@ pub enum InvalidSelectorError {
 pub fn is_selector_by_location(
     raw_selector: &str,
 ) -> Option<Result<AnchoredSystemPathBuf, InvalidSelectorError>> {
-    let mut raw_selector_inner = raw_selector;
+    let exact_matches = [".", ".."];
+    let prefixes = ["./", ".\\", "../", "..\\"];
 
-    // detecting ./ and ../
-    for _ in 0..2 {
-        let Some(raw_selector_stripped) = raw_selector_inner.strip_prefix('.') else {
-            return None;
-        };
-
-        if raw_selector_stripped.is_empty()
-            || raw_selector_stripped.starts_with('/')
-            || raw_selector_stripped.starts_with('\\')
-        {
-            return Some(
-                AnchoredSystemPathBuf::try_from(raw_selector).map_err(|_| {
-                    InvalidSelectorError::InvalidAnchoredPath(raw_selector.to_string())
-                }),
-            );
-        }
-
-        raw_selector_inner = raw_selector_stripped;
+    if exact_matches.contains(&raw_selector)
+        || prefixes
+            .iter()
+            .any(|prefix| raw_selector.starts_with(prefix))
+    {
+        Some(
+            AnchoredSystemPathBuf::try_from(raw_selector)
+                .map_err(|_| InvalidSelectorError::InvalidAnchoredPath(raw_selector.to_string())),
+        )
+    } else {
+        None
     }
-
-    None
 }
 
 #[cfg(test)]

--- a/crates/turborepo-lib/src/run/scope/target_selector.rs
+++ b/crates/turborepo-lib/src/run/scope/target_selector.rs
@@ -79,12 +79,12 @@ impl FromStr for TargetSelector {
         };
 
         let re = Regex::new(r"^(?P<name>[^.](?:[^{}\[\]]*[^{}\[\].])?)?(\{(?P<directory>[^}]*)})?(?P<commits>(?:\.{3})?\[[^\]]+\])?$").expect("valid");
-        let captures = re.captures(&selector);
+        let captures = re.captures(selector);
 
         let captures = match captures {
             Some(captures) => captures,
             None => {
-                return if let Some(relative_path) = is_selector_by_location(&selector) {
+                return if let Some(relative_path) = is_selector_by_location(selector) {
                     Ok(TargetSelector {
                         exclude,
                         include_dependencies,

--- a/crates/turborepo-lockfiles/src/berry/mod.rs
+++ b/crates/turborepo-lockfiles/src/berry/mod.rs
@@ -6,6 +6,7 @@ mod ser;
 
 use std::{
     collections::{HashMap, HashSet},
+    io::{BufWriter, Write},
     iter,
     rc::Rc,
 };
@@ -546,6 +547,23 @@ impl Lockfile for BerryLockfile {
             .collect::<Result<Vec<_>, turbopath::PathError>>()?;
         patches.sort();
         Ok(patches)
+    }
+
+    fn global_change_key(&self) -> Vec<u8> {
+        let mut buf = vec![b'b', b'e', b'r', b'r', b'y', 0];
+        {
+            let mut writer = BufWriter::new(&mut buf);
+            writer.write(&self.data.metadata.version.to_be_bytes()[..]);
+            writer.write(
+                self.data
+                    .metadata
+                    .cache_key
+                    .as_deref()
+                    .unwrap_or("")
+                    .as_bytes(),
+            );
+        }
+        buf
     }
 }
 

--- a/crates/turborepo-lockfiles/src/berry/mod.rs
+++ b/crates/turborepo-lockfiles/src/berry/mod.rs
@@ -15,6 +15,7 @@ use de::SemverString;
 use identifiers::{Descriptor, Locator};
 use protocol_resolver::DescriptorResolver;
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 use thiserror::Error;
 use turbopath::RelativeUnixPathBuf;
 
@@ -551,18 +552,15 @@ impl Lockfile for BerryLockfile {
 
     fn global_change_key(&self) -> Vec<u8> {
         let mut buf = vec![b'b', b'e', b'r', b'r', b'y', 0];
-        {
-            let mut writer = BufWriter::new(&mut buf);
-            writer.write(&self.data.metadata.version.to_be_bytes()[..]);
-            writer.write(
-                self.data
-                    .metadata
-                    .cache_key
-                    .as_deref()
-                    .unwrap_or("")
-                    .as_bytes(),
-            );
-        }
+
+        serde_json::to_writer(
+            &mut buf,
+            &json!({
+                "version": &self.data.metadata.version,
+                "cache_key": &self.data.metadata.cache_key,
+            }),
+        );
+
         buf
     }
 }

--- a/crates/turborepo-lockfiles/src/berry/mod.rs
+++ b/crates/turborepo-lockfiles/src/berry/mod.rs
@@ -6,7 +6,6 @@ mod ser;
 
 use std::{
     collections::{HashMap, HashSet},
-    io::{BufWriter, Write},
     iter,
     rc::Rc,
 };
@@ -559,7 +558,8 @@ impl Lockfile for BerryLockfile {
                 "version": &self.data.metadata.version,
                 "cache_key": &self.data.metadata.cache_key,
             }),
-        );
+        )
+        .expect("writing to Vec cannot fail");
 
         buf
     }

--- a/crates/turborepo-lockfiles/src/lib.rs
+++ b/crates/turborepo-lockfiles/src/lib.rs
@@ -60,6 +60,8 @@ pub trait Lockfile {
     fn global_change_key(&self) -> Vec<u8>;
 }
 
+/// Takes a lockfile, and a map of package root paths -> (package name, version)
+/// and calcualtes the transitive closures for all of them
 pub fn all_transitive_closures<L: Lockfile + ?Sized>(
     lockfile: &L,
     workspaces: HashMap<String, HashMap<String, String>>,

--- a/crates/turborepo-lockfiles/src/lib.rs
+++ b/crates/turborepo-lockfiles/src/lib.rs
@@ -60,8 +60,8 @@ pub trait Lockfile {
     fn global_change_key(&self) -> Vec<u8>;
 }
 
-/// Takes a lockfile, and a map of package root paths -> (package name, version)
-/// and calcualtes the transitive closures for all of them
+/// Takes a lockfile, and a map of workspace directory paths -> (package name,
+/// version) and calculates the transitive closures for all of them
 pub fn all_transitive_closures<L: Lockfile + ?Sized>(
     lockfile: &L,
     workspaces: HashMap<String, HashMap<String, String>>,

--- a/crates/turborepo-lockfiles/src/lib.rs
+++ b/crates/turborepo-lockfiles/src/lib.rs
@@ -50,6 +50,14 @@ pub trait Lockfile {
     fn patches(&self) -> Result<Vec<RelativeUnixPathBuf>, Error> {
         Ok(Vec::new())
     }
+
+    /// Present a global change key which is compared against two lockfiles
+    ///
+    /// Impl notes: please prefix this key with some magic identifier
+    /// to prevent clashes. we are not worried about inter-version
+    /// compatibility so these keys don't need to be stable. They are
+    /// ephemeral.
+    fn global_change_key(&self) -> Vec<u8>;
 }
 
 pub fn all_transitive_closures<L: Lockfile + ?Sized>(

--- a/crates/turborepo-lockfiles/src/npm.rs
+++ b/crates/turborepo-lockfiles/src/npm.rs
@@ -1,4 +1,7 @@
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    io::{BufWriter, Write},
+};
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -134,6 +137,16 @@ impl Lockfile for NpmLockfile {
 
     fn encode(&self) -> Result<Vec<u8>, crate::Error> {
         Ok(serde_json::to_vec_pretty(&self)?)
+    }
+
+    fn global_change_key(&self) -> Vec<u8> {
+        let mut buf = vec![b'n', b'p', b'm', 0];
+        {
+            let mut writer = BufWriter::new(&mut buf);
+            writer.write_all(&self.lockfile_version.to_be_bytes()[..]);
+            serde_json::to_writer(writer, &self.other.get("requires"));
+        }
+        buf
     }
 }
 

--- a/crates/turborepo-lockfiles/src/npm.rs
+++ b/crates/turborepo-lockfiles/src/npm.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use serde_json::{json, Value};
 
 use super::{Error, Lockfile, Package};
 
@@ -141,11 +141,15 @@ impl Lockfile for NpmLockfile {
 
     fn global_change_key(&self) -> Vec<u8> {
         let mut buf = vec![b'n', b'p', b'm', 0];
-        {
-            let mut writer = BufWriter::new(&mut buf);
-            writer.write_all(&self.lockfile_version.to_be_bytes()[..]);
-            serde_json::to_writer(writer, &self.other.get("requires"));
-        }
+
+        serde_json::to_writer(
+            &mut buf,
+            &json!({
+                "requires": &self.other.get("requires"),
+                "version": &self.lockfile_version,
+            }),
+        );
+
         buf
     }
 }

--- a/crates/turborepo-lockfiles/src/npm.rs
+++ b/crates/turborepo-lockfiles/src/npm.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::HashMap,
-    io::{BufWriter, Write},
-};
+use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -148,7 +145,8 @@ impl Lockfile for NpmLockfile {
                 "requires": &self.other.get("requires"),
                 "version": &self.lockfile_version,
             }),
-        );
+        )
+        .expect("writing to Vec cannot fail");
 
         buf
     }

--- a/crates/turborepo-lockfiles/src/pnpm/data.rs
+++ b/crates/turborepo-lockfiles/src/pnpm/data.rs
@@ -410,7 +410,7 @@ impl crate::Lockfile for PnpmLockfile {
     }
 
     fn global_change_key(&self) -> Vec<u8> {
-        let mut buf = vec![b'y', b'a', b'r', b'n', 0];
+        let mut buf = vec![b'p', b'n', b'p', b'm', 0];
         {
             let mut writer = BufWriter::new(&mut buf);
             writer.write_all(self.lockfile_version.version.as_bytes());

--- a/crates/turborepo-lockfiles/src/pnpm/data.rs
+++ b/crates/turborepo-lockfiles/src/pnpm/data.rs
@@ -1,7 +1,4 @@
-use std::{
-    borrow::Cow,
-    io::{BufWriter, Write},
-};
+use std::borrow::Cow;
 
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -422,7 +419,8 @@ impl crate::Lockfile for PnpmLockfile {
                 "patched_deps": self.patched_dependencies,
                 "settings": self.settings,
             }),
-        );
+        )
+        .expect("writing to Vec cannot fail");
 
         buf
     }

--- a/crates/turborepo-lockfiles/src/yarn1/mod.rs
+++ b/crates/turborepo-lockfiles/src/yarn1/mod.rs
@@ -107,6 +107,11 @@ impl Lockfile for Yarn1Lockfile {
     fn encode(&self) -> Result<Vec<u8>, crate::Error> {
         Ok(self.to_string().into_bytes())
     }
+
+    fn global_change_key(&self) -> Vec<u8> {
+        // todo: need advice on impl for this
+        vec![]
+    }
 }
 
 pub fn yarn_subgraph(contents: &[u8], packages: &[String]) -> Result<Vec<u8>, crate::Error> {

--- a/crates/turborepo-lockfiles/src/yarn1/mod.rs
+++ b/crates/turborepo-lockfiles/src/yarn1/mod.rs
@@ -109,8 +109,7 @@ impl Lockfile for Yarn1Lockfile {
     }
 
     fn global_change_key(&self) -> Vec<u8> {
-        // todo: need advice on impl for this
-        vec![]
+        vec![b'y', b'a', b'r', b'n', 0]
     }
 }
 

--- a/crates/turborepo-paths/src/absolute_system_path.rs
+++ b/crates/turborepo-paths/src/absolute_system_path.rs
@@ -199,10 +199,6 @@ impl AbsoluteSystemPath {
         ))
     }
 
-    pub fn join_path(&self, path: &AnchoredSystemPath) -> AbsoluteSystemPathBuf {
-        AbsoluteSystemPathBuf(self.0.join(path))
-    }
-
     pub fn anchor(&self, path: &AbsoluteSystemPath) -> Result<AnchoredSystemPathBuf, PathError> {
         AnchoredSystemPathBuf::new(self, path)
     }

--- a/crates/turborepo-paths/src/absolute_system_path.rs
+++ b/crates/turborepo-paths/src/absolute_system_path.rs
@@ -199,6 +199,10 @@ impl AbsoluteSystemPath {
         ))
     }
 
+    pub fn join_path(&self, path: &AnchoredSystemPath) -> AbsoluteSystemPathBuf {
+        AbsoluteSystemPathBuf(self.0.join(path))
+    }
+
     pub fn anchor(&self, path: &AbsoluteSystemPath) -> Result<AnchoredSystemPathBuf, PathError> {
         AnchoredSystemPathBuf::new(self, path)
     }

--- a/crates/turborepo-paths/src/absolute_system_path.rs
+++ b/crates/turborepo-paths/src/absolute_system_path.rs
@@ -14,6 +14,7 @@ use std::{
 use camino::{Utf8Component, Utf8Components, Utf8Path, Utf8PathBuf};
 use fs_err as fs;
 use path_clean::PathClean;
+use wax::CandidatePath;
 
 use crate::{
     AbsoluteSystemPathBuf, AnchoredSystemPath, AnchoredSystemPathBuf, PathError, RelativeUnixPath,
@@ -352,6 +353,12 @@ impl AbsoluteSystemPath {
         fs::set_permissions(&self.0, permissions)?;
 
         Ok(())
+    }
+}
+
+impl<'a> From<&'a AbsoluteSystemPath> for CandidatePath<'a> {
+    fn from(value: &'a AbsoluteSystemPath) -> Self {
+        CandidatePath::from(value.0.as_std_path())
     }
 }
 

--- a/crates/turborepo-paths/src/anchored_system_path.rs
+++ b/crates/turborepo-paths/src/anchored_system_path.rs
@@ -73,16 +73,17 @@ impl AnchoredSystemPath {
         self.0.as_std_path()
     }
 
-    pub fn to_unix(&self) -> Result<RelativeUnixPathBuf, PathError> {
+    pub fn to_unix(&self) -> RelativeUnixPathBuf {
         #[cfg(unix)]
         {
-            return RelativeUnixPathBuf::new(self.0.as_str());
+            return RelativeUnixPathBuf::new(self.0.as_str())
+                .expect("anchored system path is relative");
         }
         #[cfg(not(unix))]
         {
             use crate::IntoUnix;
             let unix_buf = self.0.into_unix();
-            RelativeUnixPathBuf::new(unix_buf)
+            RelativeUnixPathBuf::new(unix_buf).expect("anchored system path is relative")
         }
     }
 }

--- a/crates/turborepo-paths/src/anchored_system_path.rs
+++ b/crates/turborepo-paths/src/anchored_system_path.rs
@@ -75,15 +75,15 @@ impl AnchoredSystemPath {
 
     pub fn to_unix(&self) -> RelativeUnixPathBuf {
         #[cfg(unix)]
-        {
-            return RelativeUnixPathBuf::new(self.0.as_str())
-                .expect("anchored system path is relative");
-        }
+        let buf = RelativeUnixPathBuf::new(self.0.as_str());
+
         #[cfg(not(unix))]
-        {
+        let buf = {
             use crate::IntoUnix;
             let unix_buf = self.0.into_unix();
-            RelativeUnixPathBuf::new(unix_buf).expect("anchored system path is relative")
-        }
+            RelativeUnixPathBuf::new(unix_buf)
+        };
+
+        buf.unwrap_or_else(|_| panic!("anchored system path is relative: {}", self.0.as_str()))
     }
 }

--- a/crates/turborepo-paths/src/anchored_system_path_buf.rs
+++ b/crates/turborepo-paths/src/anchored_system_path_buf.rs
@@ -8,10 +8,7 @@ use std::{
 use camino::{Utf8Component, Utf8Components, Utf8Path, Utf8PathBuf};
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    check_path, AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPath, PathError,
-    PathValidation,
-};
+use crate::{check_path, AbsoluteSystemPath, AnchoredSystemPath, PathError, PathValidation};
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Serialize, Deserialize)]
 pub struct AnchoredSystemPathBuf(pub(crate) Utf8PathBuf);

--- a/crates/turborepo-paths/src/anchored_system_path_buf.rs
+++ b/crates/turborepo-paths/src/anchored_system_path_buf.rs
@@ -201,7 +201,7 @@ impl AnchoredSystemPathBuf {
     }
 
     pub fn join(&self, other: &AnchoredSystemPathBuf) -> AnchoredSystemPathBuf {
-        Self(self.0.join(other.0.to_owned()))
+        Self(self.0.join(&other.0))
     }
 
     pub fn restore_anchor(&self, path: &AbsoluteSystemPath) -> AbsoluteSystemPathBuf {

--- a/crates/turborepo-paths/src/anchored_system_path_buf.rs
+++ b/crates/turborepo-paths/src/anchored_system_path_buf.rs
@@ -205,7 +205,7 @@ impl AnchoredSystemPathBuf {
     }
 
     pub fn restore_anchor(&self, path: &AbsoluteSystemPath) -> AbsoluteSystemPathBuf {
-        path.join_unix_path(self.to_unix().unwrap()).unwrap()
+        path.join_path(self)
     }
 }
 
@@ -287,5 +287,16 @@ mod tests {
             (Err(result), Err(expected)) => assert_eq!(result, expected),
             (result, expected) => panic!("Expected {:?}, got {:?}", expected, result),
         }
+    }
+
+    #[test]
+    fn test_restore_anchor() {
+        let root = AbsoluteSystemPathBuf::new("/a/b/c").unwrap();
+        let path = AnchoredSystemPathBuf::from_raw("d/e/f").unwrap();
+        let expected = AbsoluteSystemPathBuf::new("/a/b/c/d/e/f").unwrap();
+
+        let result = path.restore_anchor(&root);
+
+        assert_eq!(result, expected);
     }
 }

--- a/crates/turborepo-paths/src/anchored_system_path_buf.rs
+++ b/crates/turborepo-paths/src/anchored_system_path_buf.rs
@@ -201,7 +201,7 @@ impl AnchoredSystemPathBuf {
     }
 
     pub fn join(&self, other: &AnchoredSystemPath) -> AnchoredSystemPathBuf {
-        Self(self.0.join(&other))
+        Self(self.0.join(other))
     }
 }
 

--- a/crates/turborepo-paths/src/anchored_system_path_buf.rs
+++ b/crates/turborepo-paths/src/anchored_system_path_buf.rs
@@ -200,8 +200,8 @@ impl AnchoredSystemPathBuf {
         self.0.components()
     }
 
-    pub fn join(&self, other: &AnchoredSystemPathBuf) -> AnchoredSystemPathBuf {
-        Self(self.0.join(&other.0))
+    pub fn join(&self, other: &AnchoredSystemPath) -> AnchoredSystemPathBuf {
+        Self(self.0.join(&other))
     }
 
     pub fn restore_anchor(&self, path: &AbsoluteSystemPath) -> AbsoluteSystemPathBuf {

--- a/crates/turborepo-paths/src/anchored_system_path_buf.rs
+++ b/crates/turborepo-paths/src/anchored_system_path_buf.rs
@@ -8,7 +8,10 @@ use std::{
 use camino::{Utf8Component, Utf8Components, Utf8Path, Utf8PathBuf};
 use serde::{Deserialize, Serialize};
 
-use crate::{check_path, AbsoluteSystemPath, AnchoredSystemPath, PathError, PathValidation};
+use crate::{
+    check_path, AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPath, PathError,
+    PathValidation,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Serialize, Deserialize)]
 pub struct AnchoredSystemPathBuf(pub(crate) Utf8PathBuf);
@@ -195,6 +198,14 @@ impl AnchoredSystemPathBuf {
 
     pub fn components(&self) -> Utf8Components {
         self.0.components()
+    }
+
+    pub fn join(&self, other: &AnchoredSystemPathBuf) -> AnchoredSystemPathBuf {
+        Self(self.0.join(other.0.to_owned()))
+    }
+
+    pub fn restore_anchor(&self, path: &AbsoluteSystemPath) -> AbsoluteSystemPathBuf {
+        path.join_unix_path(self.to_unix().unwrap()).unwrap()
     }
 }
 

--- a/crates/turborepo-paths/src/anchored_system_path_buf.rs
+++ b/crates/turborepo-paths/src/anchored_system_path_buf.rs
@@ -203,10 +203,6 @@ impl AnchoredSystemPathBuf {
     pub fn join(&self, other: &AnchoredSystemPath) -> AnchoredSystemPathBuf {
         Self(self.0.join(&other))
     }
-
-    pub fn restore_anchor(&self, path: &AbsoluteSystemPath) -> AbsoluteSystemPathBuf {
-        path.join_path(self)
-    }
 }
 
 impl From<AnchoredSystemPathBuf> for PathBuf {
@@ -287,16 +283,5 @@ mod tests {
             (Err(result), Err(expected)) => assert_eq!(result, expected),
             (result, expected) => panic!("Expected {:?}, got {:?}", expected, result),
         }
-    }
-
-    #[test]
-    fn test_restore_anchor() {
-        let root = AbsoluteSystemPathBuf::new("/a/b/c").unwrap();
-        let path = AnchoredSystemPathBuf::from_raw("d/e/f").unwrap();
-        let expected = AbsoluteSystemPathBuf::new("/a/b/c/d/e/f").unwrap();
-
-        let result = path.restore_anchor(&root);
-
-        assert_eq!(result, expected);
     }
 }

--- a/crates/turborepo-scm/src/git.rs
+++ b/crates/turborepo-scm/src/git.rs
@@ -126,7 +126,6 @@ impl Git {
         turbo_root: &AbsoluteSystemPath,
         stdout: Vec<u8>,
     ) {
-        let turbo_root = turbo_root;
         let stdout = String::from_utf8(stdout).unwrap();
         for line in stdout.lines() {
             let path = RelativeUnixPath::new(line).unwrap();

--- a/crates/turborepo-scm/src/hash_object.rs
+++ b/crates/turborepo-scm/src/hash_object.rs
@@ -14,7 +14,7 @@ pub(crate) fn hash_objects(
             Ok(hash) => {
                 let package_relative_path =
                     AnchoredSystemPathBuf::relative_path_between(pkg_path, &full_file_path)
-                        .to_unix()?;
+                        .to_unix();
                 hashes.insert(package_relative_path, hash.to_string());
             }
             Err(e) => {

--- a/crates/turborepo-scm/src/hash_object.rs
+++ b/crates/turborepo-scm/src/hash_object.rs
@@ -85,7 +85,7 @@ mod test {
                 .collect();
 
             let git_to_pkg_path = git_root.anchor(pkg_path).unwrap();
-            let pkg_prefix = git_to_pkg_path.to_unix().unwrap();
+            let pkg_prefix = git_to_pkg_path.to_unix();
 
             let expected_hashes = GitHashes::from_iter(file_hashes);
             let mut hashes = GitHashes::new();
@@ -102,7 +102,7 @@ mod test {
 
         for (to_hash, pkg_path) in error_tests {
             let git_to_pkg_path = git_root.anchor(pkg_path).unwrap();
-            let pkg_prefix = git_to_pkg_path.to_unix().unwrap();
+            let pkg_prefix = git_to_pkg_path.to_unix();
 
             let to_hash = to_hash
                 .into_iter()

--- a/crates/turborepo-scm/src/manual.rs
+++ b/crates/turborepo-scm/src/manual.rs
@@ -40,7 +40,7 @@ pub(crate) fn hash_files(
             }
         };
         let hash = git_like_hash_file(&path, &metadata)?;
-        hashes.insert(file.to_unix()?, hash);
+        hashes.insert(file.to_unix(), hash);
     }
     Ok(hashes)
 }
@@ -94,7 +94,7 @@ pub(crate) fn get_package_file_hashes_from_processing_gitignore<S: AsRef<str>>(
         }
         let path = AbsoluteSystemPath::from_std_path(dirent.path())?;
         let relative_path = full_package_path.anchor(path)?;
-        let relative_path = relative_path.to_unix()?;
+        let relative_path = relative_path.to_unix();
         if let Some(include_pattern) = include_pattern.as_ref() {
             if !include_pattern.is_match(relative_path.as_str()) {
                 continue;

--- a/crates/turborepo-scm/src/manual.rs
+++ b/crates/turborepo-scm/src/manual.rs
@@ -170,7 +170,7 @@ mod tests {
         let (_tmp, turbo_root) = tmp_dir();
 
         let pkg_path = AnchoredSystemPathBuf::from_raw("child-dir/libA").unwrap();
-        let unix_pkg_path = pkg_path.to_unix().unwrap();
+        let unix_pkg_path = pkg_path.to_unix();
         let file_hash: Vec<(&str, &str, Option<&str>)> = vec![
             ("top-level-file", "top-level-file-contents", None),
             ("other-dir/other-dir-file", "other-dir-file-contents", None),

--- a/crates/turborepo-scm/src/package_deps.rs
+++ b/crates/turborepo-scm/src/package_deps.rs
@@ -81,7 +81,7 @@ impl Git {
     ) -> Result<GitHashes, Error> {
         let full_pkg_path = turbo_root.resolve(package_path);
         let git_to_pkg_path = self.root.anchor(&full_pkg_path)?;
-        let pkg_prefix = git_to_pkg_path.to_unix()?;
+        let pkg_prefix = git_to_pkg_path.to_unix();
         let mut hashes = self.git_ls_tree(&full_pkg_path)?;
         // Note: to_hash is *git repo relative*
         let to_hash = self.append_git_status(&full_pkg_path, &pkg_prefix, &mut hashes)?;
@@ -96,7 +96,7 @@ impl Git {
     ) -> Result<GitHashes, Error> {
         let mut hashes = GitHashes::new();
         let to_hash = files
-            .map(|f| self.root.anchor(process_relative_to.resolve(&f))?.to_unix())
+            .map(|f| Ok(self.root.anchor(process_relative_to.resolve(&f))?.to_unix()))
             .collect::<Result<Vec<_>, PathError>>()?;
         // Note: to_hash is *git repo relative*
         hash_objects(&self.root, process_relative_to, to_hash, &mut hashes)?;
@@ -110,7 +110,7 @@ impl Git {
         inputs: &[S],
     ) -> Result<GitHashes, Error> {
         let full_pkg_path = turbo_root.resolve(package_path);
-        let package_unix_path_buf = package_path.to_unix()?;
+        let package_unix_path_buf = package_path.to_unix();
         let package_unix_path = package_unix_path_buf.as_str();
 
         let mut inputs = inputs
@@ -156,7 +156,7 @@ impl Git {
         let to_hash = files
             .iter()
             .map(|entry| {
-                let path = self.root.anchor(entry)?.to_unix()?;
+                let path = self.root.anchor(entry)?.to_unix();
                 Ok(path)
             })
             .collect::<Result<Vec<_>, Error>>()?;


### PR DESCRIPTION
### Description

This ports over filter and scope to rust, roughly matching the go implementation with some minor deviations where it makes sense for rustiness. All the tests are ported as-is and should pass. Note that this adds a print line to the run stub which prints out the filtered packages.

### Testing Instructions

Two options. Run `cargo test` in the `turborepo-lib` package, or, to test out the real SCM implementation, run it on real projects by building it and performing prunes.

