### PR TITLE
Turbopack: Sort env vars for compatibility

### DIFF
--- a/crates/turbo-tasks-env/src/command_line.rs
+++ b/crates/turbo-tasks-env/src/command_line.rs
@@ -1,9 +1,7 @@
-use std::env;
-
 use indexmap::IndexMap;
 use turbo_tasks::Vc;
 
-use crate::{EnvMap, ProcessEnv, GLOBAL_ENV_LOCK};
+use crate::{sorted_env_vars, EnvMap, ProcessEnv, GLOBAL_ENV_LOCK};
 
 /// Load the environment variables defined via command line.
 #[turbo_tasks::value]
@@ -20,7 +18,7 @@ impl CommandLineProcessEnv {
 /// Clones the current env vars into a IndexMap.
 fn env_snapshot() -> IndexMap<String, String> {
     let _lock = GLOBAL_ENV_LOCK.lock().unwrap();
-    env::vars().collect::<IndexMap<_, _>>()
+    sorted_env_vars()
 }
 
 #[turbo_tasks::value_impl]

--- a/crates/turbo-tasks-env/src/dotenv.rs
+++ b/crates/turbo-tasks-env/src/dotenv.rs
@@ -25,7 +25,7 @@ impl DotenvProcessEnv {
 
     #[turbo_tasks::function]
     pub async fn read_prior(self: Vc<Self>) -> Result<Vc<EnvMap>> {
-        let this: turbo_tasks::ReadRef<DotenvProcessEnv> = self.await?;
+        let this = self.await?;
         match this.prior {
             None => Ok(EnvMap::empty()),
             Some(p) => Ok(p.read_all()),

--- a/crates/turbo-tasks-env/src/dotenv.rs
+++ b/crates/turbo-tasks-env/src/dotenv.rs
@@ -5,7 +5,7 @@ use indexmap::IndexMap;
 use turbo_tasks::{ValueToString, Vc};
 use turbo_tasks_fs::{FileContent, FileSystemPath};
 
-use crate::{EnvMap, ProcessEnv, GLOBAL_ENV_LOCK};
+use crate::{sorted_env_vars, EnvMap, ProcessEnv, GLOBAL_ENV_LOCK};
 
 /// Load the environment variables defined via a dotenv file, with an
 /// optional prior state that we can lookup already defined variables
@@ -25,7 +25,7 @@ impl DotenvProcessEnv {
 
     #[turbo_tasks::function]
     pub async fn read_prior(self: Vc<Self>) -> Result<Vc<EnvMap>> {
-        let this = self.await?;
+        let this: turbo_tasks::ReadRef<DotenvProcessEnv> = self.await?;
         match this.prior {
             None => Ok(EnvMap::empty()),
             Some(p) => Ok(p.read_all()),
@@ -47,7 +47,7 @@ impl DotenvProcessEnv {
                 // Unfortunately, dotenvy only looks up variable references from the global env.
                 // So we must mutate while we process. Afterwards, we can restore the initial
                 // state.
-                let initial = env::vars().collect();
+                let initial = sorted_env_vars();
 
                 restore_env(&initial, &prior, &lock);
 
@@ -56,7 +56,7 @@ impl DotenvProcessEnv {
                 // var, it'll be ignored.
                 res = dotenv::from_read(f.read()).map(|e| e.load());
 
-                vars = env::vars().collect();
+                vars = sorted_env_vars();
                 restore_env(&vars, &initial, &lock);
             }
 

--- a/crates/turbo-tasks-env/src/lib.rs
+++ b/crates/turbo-tasks-env/src/lib.rs
@@ -57,6 +57,12 @@ pub trait ProcessEnv {
     }
 }
 
+pub fn sorted_env_vars() -> IndexMap<String, String> {
+    let mut vars = env::vars().collect::<IndexMap<_, _>>();
+    vars.sort_keys();
+    vars
+}
+
 #[turbo_tasks::function]
 pub async fn case_insensitive_read(map: Vc<EnvMap>, name: String) -> Result<Vc<Option<String>>> {
     Ok(Vc::cell(

--- a/crates/turbopack-env/src/asset.rs
+++ b/crates/turbopack-env/src/asset.rs
@@ -42,10 +42,7 @@ impl Source for ProcessEnvAsset {
 impl Asset for ProcessEnvAsset {
     #[turbo_tasks::function]
     async fn content(&self) -> Result<Vc<AssetContent>> {
-        let mut env = (*self.env.read_all().await?).clone();
-        // Sort keys for compatibility across platforms (e.g. Windows returns sorted
-        // environment variables)
-        env.sort_keys();
+        let env = self.env.read_all().await?;
 
         // TODO: In SSR, we use the native process.env, which can only contain string
         // values. We need to inject literal values (to emulate webpack's
@@ -53,7 +50,7 @@ impl Asset for ProcessEnvAsset {
         let mut code = RopeBuilder::default();
         code += "const env = process.env = {...process.env};\n\n";
 
-        for (name, val) in &env {
+        for (name, val) in &*env {
             // It's assumed the env has passed through an EmbeddableProcessEnv, so the value
             // is ready to be directly embedded. Values _after_ an embeddable
             // env can be used to inject live code into the output.

--- a/crates/turbopack-tests/tests/snapshot/env/env/output/crates_turbopack-tests_tests_snapshot_env_env_input__env__env_b53fce.js
+++ b/crates/turbopack-tests/tests/snapshot/env/env/output/crates_turbopack-tests_tests_snapshot_env_env_input__env__env_b53fce.js
@@ -5,10 +5,10 @@
 const env = process.env = {
     ...process.env
 };
+env["ALLFOOBAR"] = foobarfoobar;
+env["BARFOO"] = barfoo;
 env["FOO"] = foo;
 env["FOOBAR"] = foobar;
-env["BARFOO"] = barfoo;
-env["ALLFOOBAR"] = foobarfoobar;
 
 }.call(this) }),
 }]);

--- a/crates/turbopack-tests/tests/snapshot/env/env/output/crates_turbopack-tests_tests_snapshot_env_env_input__env__env_b53fce.js.map
+++ b/crates/turbopack-tests/tests/snapshot/env/env/output/crates_turbopack-tests_tests_snapshot_env_env_input__env__env_b53fce.js.map
@@ -1,6 +1,6 @@
 {
   "version": 3,
   "sections": [
-    {"offset": {"line": 4, "column": 0}, "map": {"version":3,"sources":["/turbopack/[project]/crates/turbopack-tests/tests/snapshot/env/env/input/.env/.env.js"],"sourcesContent":["const env = process.env = {...process.env};\n\nenv[\"FOO\"] = foo;\nenv[\"FOOBAR\"] = foobar;\nenv[\"BARFOO\"] = barfoo;\nenv[\"ALLFOOBAR\"] = foobarfoobar;\n"],"names":[],"mappings":"AAAA,MAAM,MAAM,QAAQ,GAAG,GAAG;IAAC,GAAG,QAAQ,GAAG;AAAA;AAEzC,GAAG,CAAC,MAAM,GAAG;AACb,GAAG,CAAC,SAAS,GAAG;AAChB,GAAG,CAAC,SAAS,GAAG;AAChB,GAAG,CAAC,YAAY,GAAG"}},
+    {"offset": {"line": 4, "column": 0}, "map": {"version":3,"sources":["/turbopack/[project]/crates/turbopack-tests/tests/snapshot/env/env/input/.env/.env.js"],"sourcesContent":["const env = process.env = {...process.env};\n\nenv[\"ALLFOOBAR\"] = foobarfoobar;\nenv[\"BARFOO\"] = barfoo;\nenv[\"FOO\"] = foo;\nenv[\"FOOBAR\"] = foobar;\n"],"names":[],"mappings":"AAAA,MAAM,MAAM,QAAQ,GAAG,GAAG;IAAC,GAAG,QAAQ,GAAG;AAAA;AAEzC,GAAG,CAAC,YAAY,GAAG;AACnB,GAAG,CAAC,SAAS,GAAG;AAChB,GAAG,CAAC,MAAM,GAAG;AACb,GAAG,CAAC,SAAS,GAAG"}},
     {"offset": {"line": 11, "column": 0}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}}]
 }


### PR DESCRIPTION
Windows sorts the environment variables returned, breaking snapshot tests.
