### PR TITLE
feature(turborepo): Port Async Cache and Cache Multiplexer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9771,6 +9771,7 @@ dependencies = [
  "turbo-updater",
  "turbopath",
  "turborepo-api-client",
+ "turborepo-cache",
  "turborepo-env",
  "turborepo-fs",
  "turborepo-lockfiles",

--- a/cli/internal/cache/cache.go
+++ b/cli/internal/cache/cache.go
@@ -115,9 +115,6 @@ func (o *Opts) resolveCacheDir(repoRoot turbopath.AbsoluteSystemPath) turbopath.
 	return DefaultLocation(repoRoot)
 }
 
-var _remoteOnlyHelp = `Ignore the local filesystem cache for all tasks. Only
-allow reading and caching artifacts using the remote cache.`
-
 // New creates a new cache
 func New(opts Opts, repoRoot turbopath.AbsoluteSystemPath, client client, recorder analytics.Recorder, onCacheRemoved OnCacheRemoved) (Cache, error) {
 	c, err := newSyncCache(opts, repoRoot, client, recorder, onCacheRemoved)
@@ -143,7 +140,7 @@ func newSyncCache(opts Opts, repoRoot turbopath.AbsoluteSystemPath, client clien
 	// Further, since the httpCache can be removed at runtime, we need to insert a noopCache
 	// as a backup if you are configured to have *just* an httpCache.
 	//
-	// This is reduced from (!useFsCache && !useHTTPCache) || (!useFsCache & useHTTPCache)
+	// This is reduced from (!useFsCache && !useHTTPCache) || (!useFsCache && useHTTPCache)
 	useNoopCache := !useFsCache
 
 	// Build up an array of cache implementations, we can only ever have 1 or 2.

--- a/crates/turborepo-api-client/src/lib.rs
+++ b/crates/turborepo-api-client/src/lib.rs
@@ -3,12 +3,12 @@
 #![feature(error_generic_member_access)]
 #![deny(clippy::all)]
 
-use std::env;
+use std::{backtrace::Backtrace, env};
 
 use lazy_static::lazy_static;
 use regex::Regex;
 pub use reqwest::Response;
-use reqwest::{Method, RequestBuilder};
+use reqwest::{Method, RequestBuilder, StatusCode};
 use serde::{Deserialize, Serialize};
 use turborepo_ci::{is_ci, Vendor};
 use url::Url;
@@ -132,6 +132,12 @@ pub struct UserResponse {
 pub struct PreflightResponse {
     location: Url,
     allow_authorization_header: bool,
+}
+
+#[derive(Deserialize)]
+struct ApiError {
+    code: String,
+    message: String,
 }
 
 pub struct APIClient {
@@ -317,11 +323,47 @@ impl APIClient {
             request_builder = request_builder.header("x-artifact-tag", tag);
         }
 
-        retry::make_retryable_request(request_builder)
-            .await?
-            .error_for_status()?;
+        let response = retry::make_retryable_request(request_builder).await?;
 
+        if response.status() == StatusCode::FORBIDDEN {
+            return Err(Self::handle_403(response).await);
+        }
+
+        response.error_for_status()?;
         Ok(())
+    }
+
+    async fn handle_403(response: Response) -> Error {
+        let api_error: ApiError = match response.json().await {
+            Ok(api_error) => api_error,
+            Err(e) => return Error::ReqwestError(e),
+        };
+
+        if let Some(status_string) = api_error.code.strip_prefix("remote_caching_") {
+            let status = match status_string {
+                "disabled" => CachingStatus::Disabled,
+                "enabled" => CachingStatus::Enabled,
+                "over_limit" => CachingStatus::OverLimit,
+                "paused" => CachingStatus::Paused,
+                _ => {
+                    return Error::UnknownCachingStatus(
+                        status_string.to_string(),
+                        Backtrace::capture(),
+                    )
+                }
+            };
+
+            Error::CacheDisabled {
+                status,
+                message: api_error.message,
+            }
+        } else {
+            Error::UnknownStatus {
+                code: api_error.code,
+                message: api_error.message,
+                backtrace: Backtrace::capture(),
+            }
+        }
     }
 
     pub async fn fetch_artifact(
@@ -330,9 +372,8 @@ impl APIClient {
         token: &str,
         team_id: &str,
         team_slug: Option<&str>,
-        use_preflight: bool,
     ) -> Result<Response> {
-        self.get_artifact(hash, token, team_id, team_slug, use_preflight, Method::GET)
+        self.get_artifact(hash, token, team_id, team_slug, Method::GET)
             .await
     }
 
@@ -342,9 +383,8 @@ impl APIClient {
         token: &str,
         team_id: &str,
         team_slug: Option<&str>,
-        use_preflight: bool,
     ) -> Result<Response> {
-        self.get_artifact(hash, token, team_id, team_slug, use_preflight, Method::HEAD)
+        self.get_artifact(hash, token, team_id, team_slug, Method::HEAD)
             .await
     }
 
@@ -354,13 +394,12 @@ impl APIClient {
         token: &str,
         team_id: &str,
         team_slug: Option<&str>,
-        use_preflight: bool,
         method: Method,
     ) -> Result<Response> {
         let mut request_url = self.make_url(&format!("/v8/artifacts/{}", hash));
         let mut allow_auth = true;
 
-        if use_preflight {
+        if self.use_preflight {
             let preflight_response = self
                 .do_preflight(token, &request_url, "GET", "Authorization, User-Agent")
                 .await?;
@@ -380,11 +419,13 @@ impl APIClient {
 
         request_builder = Self::add_team_params(request_builder, team_id, team_slug);
 
-        let response = retry::make_retryable_request(request_builder)
-            .await?
-            .error_for_status()?;
+        let response = retry::make_retryable_request(request_builder).await?;
 
-        Ok(response)
+        if response.status() == StatusCode::FORBIDDEN {
+            Err(Self::handle_403(response).await)
+        } else {
+            Ok(response.error_for_status()?)
+        }
     }
 
     pub async fn do_preflight(

--- a/crates/turborepo-api-client/src/lib.rs
+++ b/crates/turborepo-api-client/src/lib.rs
@@ -135,7 +135,7 @@ pub struct PreflightResponse {
 }
 
 #[derive(Deserialize)]
-struct ApiError {
+struct APIError {
     code: String,
     message: String,
 }
@@ -334,7 +334,7 @@ impl APIClient {
     }
 
     async fn handle_403(response: Response) -> Error {
-        let api_error: ApiError = match response.json().await {
+        let api_error: APIError = match response.json().await {
             Ok(api_error) => api_error,
             Err(e) => return Error::ReqwestError(e),
         };

--- a/crates/turborepo-cache/Cargo.toml
+++ b/crates/turborepo-cache/Cargo.toml
@@ -25,6 +25,7 @@ bytes.workspace = true
 camino = { workspace = true }
 chrono = { workspace = true }
 dunce = { workspace = true }
+futures = { workspace = true }
 hex = { workspace = true }
 hmac = "0.12.1"
 lazy_static = { workspace = true }

--- a/crates/turborepo-cache/src/async_cache.rs
+++ b/crates/turborepo-cache/src/async_cache.rs
@@ -68,7 +68,9 @@ impl AsyncCache {
         self.real_cache.exists(key, team_id, team_slug).await
     }
 
-    // Mostly used for testing to ensure that the workers resolve
+    // Used for testing to ensure that the workers resolve
+    // before checking the cache.
+    #[cfg(test)]
     pub async fn wait(&mut self) {
         while let Some(worker) = self.workers.next().await {
             let _ = worker;

--- a/crates/turborepo-cache/src/async_cache.rs
+++ b/crates/turborepo-cache/src/async_cache.rs
@@ -17,7 +17,7 @@ impl AsyncCache {
         &mut self,
         anchor: &AbsoluteSystemPath,
         key: &str,
-        files: Vec<AnchoredSystemPathBuf>,
+        files: &[AnchoredSystemPathBuf],
         duration: u32,
         token: &str,
     ) {

--- a/crates/turborepo-cache/src/async_cache.rs
+++ b/crates/turborepo-cache/src/async_cache.rs
@@ -5,7 +5,7 @@ use tokio::task::JoinHandle;
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPathBuf};
 use turborepo_api_client::APIClient;
 
-use crate::{multiplexer::CacheMultiplexer, CacheError, CacheOpts, CacheResponse};
+use crate::{http::APIAuth, multiplexer::CacheMultiplexer, CacheError, CacheOpts, CacheResponse};
 
 pub struct AsyncCache {
     workers: FuturesUnordered<JoinHandle<()>>,
@@ -18,11 +18,10 @@ impl AsyncCache {
         opts: &CacheOpts,
         repo_root: &AbsoluteSystemPath,
         api_client: APIClient,
-        team_id: &str,
-        token: &str,
+        api_auth: Option<APIAuth>,
     ) -> Result<AsyncCache, CacheError> {
         let max_workers = opts.workers.try_into().expect("usize is smaller than u32");
-        let real_cache = CacheMultiplexer::new(opts, repo_root, api_client, team_id, token)?;
+        let real_cache = CacheMultiplexer::new(opts, repo_root, api_client, api_auth)?;
 
         Ok(AsyncCache {
             workers: FuturesUnordered::new(),
@@ -69,9 +68,276 @@ impl AsyncCache {
         self.real_cache.exists(key, team_id, team_slug).await
     }
 
+    // Mostly used for testing to ensure that the workers resolve
+    pub async fn wait(&mut self) {
+        while let Some(worker) = self.workers.next().await {
+            let _ = worker;
+        }
+    }
+
     pub async fn shutdown(self) {
         for worker in self.workers {
             let _ = worker.await;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::assert_matches::assert_matches;
+
+    use anyhow::Result;
+    use futures::future::try_join_all;
+    use tempfile::tempdir;
+    use turbopath::AbsoluteSystemPathBuf;
+    use turborepo_api_client::APIClient;
+    use vercel_api_mock::start_test_server;
+
+    use crate::{
+        http::APIAuth,
+        test_cases::{get_test_cases, TestCase},
+        AsyncCache, CacheError, CacheOpts, CacheResponse, CacheSource, RemoteCacheOpts,
+    };
+
+    #[tokio::test]
+    async fn test_async_cache() -> Result<()> {
+        let port = port_scanner::request_open_port().unwrap();
+        let handle = tokio::spawn(start_test_server(port));
+
+        try_join_all(get_test_cases().into_iter().map(|test_case| async {
+            let test_case = test_case;
+            round_trip_test_with_both_caches(&test_case, port).await?;
+            round_trip_test_without_remote_cache(&test_case).await?;
+            round_trip_test_without_fs(&test_case, port).await
+        }))
+        .await?;
+
+        handle.abort();
+        Ok(())
+    }
+
+    async fn round_trip_test_without_fs(test_case: &TestCase, port: u16) -> Result<()> {
+        let repo_root = tempdir()?;
+        let repo_root_path = AbsoluteSystemPathBuf::try_from(repo_root.path())?;
+        test_case.initialize(&repo_root_path)?;
+
+        let hash = format!("{}-no-fs", test_case.hash);
+
+        let opts = CacheOpts {
+            override_dir: None,
+            skip_remote: false,
+            skip_filesystem: true,
+            workers: 10,
+            remote_cache_opts: Some(RemoteCacheOpts {
+                team_id: "my-team".to_string(),
+                signature: false,
+            }),
+        };
+
+        let api_client = APIClient::new(&format!("http://localhost:{}", port), 200, "2.0.0", true)?;
+        let api_auth = Some(APIAuth {
+            team_id: "my-team-id".to_string(),
+            token: "my-token".to_string(),
+        });
+        let mut async_cache = AsyncCache::new(&opts, &repo_root_path, api_client, api_auth)?;
+
+        // Ensure that the cache is empty
+        let response = async_cache.exists(&hash, "my-team-id", None).await;
+
+        assert_matches!(response, Err(CacheError::CacheMiss));
+
+        // Add test case
+        async_cache
+            .put(
+                repo_root_path.clone(),
+                hash.clone(),
+                test_case.files.iter().map(|f| f.path.clone()).collect(),
+                test_case.duration,
+            )
+            .await;
+
+        // Wait for async cache to process
+        async_cache.wait().await;
+
+        let fs_cache_path = repo_root_path.join_components(&[
+            "node_modules",
+            ".cache",
+            "turbo",
+            &format!("{}.tar.zst", hash),
+        ]);
+
+        // Confirm that fs cache file does *not* exist
+        assert!(!fs_cache_path.exists());
+
+        let response = async_cache.exists(&hash, "my-team-id", None).await?;
+
+        // Confirm that we fetch from remote cache and not local.
+        assert_eq!(
+            response,
+            CacheResponse {
+                source: CacheSource::Remote,
+                time_saved: test_case.duration
+            }
+        );
+
+        Ok(())
+    }
+
+    async fn round_trip_test_without_remote_cache(test_case: &TestCase) -> Result<()> {
+        let repo_root = tempdir()?;
+        let repo_root_path = AbsoluteSystemPathBuf::try_from(repo_root.path())?;
+        test_case.initialize(&repo_root_path)?;
+
+        let hash = format!("{}-no-remote", test_case.hash);
+
+        let opts = CacheOpts {
+            override_dir: None,
+            skip_remote: true,
+            skip_filesystem: false,
+            workers: 10,
+            remote_cache_opts: Some(RemoteCacheOpts {
+                team_id: "my-team".to_string(),
+                signature: false,
+            }),
+        };
+
+        // Initialize client with invalid API url to ensure that we don't hit the
+        // network
+        let api_client = APIClient::new("http://example.com", 200, "2.0.0", true)?;
+        let api_auth = Some(APIAuth {
+            team_id: "my-team-id".to_string(),
+            token: "my-token".to_string(),
+        });
+        let mut async_cache = AsyncCache::new(&opts, &repo_root_path, api_client, api_auth)?;
+
+        // Ensure that the cache is empty
+        let response = async_cache.exists(&hash, "my-team-id", None).await;
+
+        assert_matches!(response, Err(CacheError::CacheMiss));
+
+        // Add test case
+        async_cache
+            .put(
+                repo_root_path.clone(),
+                hash.clone(),
+                test_case.files.iter().map(|f| f.path.clone()).collect(),
+                test_case.duration,
+            )
+            .await;
+
+        // Wait for async cache to process
+        async_cache.wait().await;
+
+        let fs_cache_path = repo_root_path.join_components(&[
+            "node_modules",
+            ".cache",
+            "turbo",
+            &format!("{}.tar.zst", hash),
+        ]);
+
+        // Confirm that fs cache file exists
+        assert!(fs_cache_path.exists());
+
+        let response = async_cache.exists(&hash, "my-team-id", None).await?;
+
+        // Confirm that we fetch from local cache first.
+        assert_eq!(
+            response,
+            CacheResponse {
+                source: CacheSource::Local,
+                time_saved: test_case.duration
+            }
+        );
+
+        // Remove fs cache file
+        fs_cache_path.remove_file()?;
+
+        let response = async_cache.exists(&hash, "my-team-id", None).await;
+
+        // Confirm that we get a cache miss
+        assert_matches!(response, Err(CacheError::CacheMiss));
+
+        Ok(())
+    }
+
+    async fn round_trip_test_with_both_caches(test_case: &TestCase, port: u16) -> Result<()> {
+        let repo_root = tempdir()?;
+        let repo_root_path = AbsoluteSystemPathBuf::try_from(repo_root.path())?;
+        test_case.initialize(&repo_root_path)?;
+
+        let hash = format!("{}-both", test_case.hash);
+
+        let opts = CacheOpts {
+            override_dir: None,
+            skip_remote: false,
+            skip_filesystem: false,
+            workers: 10,
+            remote_cache_opts: Some(RemoteCacheOpts {
+                team_id: "my-team".to_string(),
+                signature: false,
+            }),
+        };
+
+        let api_client = APIClient::new(&format!("http://localhost:{}", port), 200, "2.0.0", true)?;
+        let api_auth = Some(APIAuth {
+            team_id: "my-team-id".to_string(),
+            token: "my-token".to_string(),
+        });
+        let mut async_cache = AsyncCache::new(&opts, &repo_root_path, api_client, api_auth)?;
+
+        // Ensure that the cache is empty
+        let response = async_cache.exists(&hash, "my-team-id", None).await;
+
+        assert_matches!(response, Err(CacheError::CacheMiss));
+
+        // Add test case
+        async_cache
+            .put(
+                repo_root_path.clone(),
+                hash.clone(),
+                test_case.files.iter().map(|f| f.path.clone()).collect(),
+                test_case.duration,
+            )
+            .await;
+
+        // Wait for async cache to process
+        async_cache.wait().await;
+
+        let fs_cache_path = repo_root_path.join_components(&[
+            "node_modules",
+            ".cache",
+            "turbo",
+            &format!("{}.tar.zst", hash),
+        ]);
+
+        // Confirm that fs cache file exists
+        assert!(fs_cache_path.exists());
+
+        let response = async_cache.exists(&hash, "my-team-id", None).await?;
+
+        // Confirm that we fetch from local cache first.
+        assert_eq!(
+            response,
+            CacheResponse {
+                source: CacheSource::Local,
+                time_saved: test_case.duration
+            }
+        );
+
+        // Remove fs cache file
+        fs_cache_path.remove_file()?;
+
+        let response = async_cache.exists(&hash, "my-team-id", None).await?;
+
+        // Confirm that we still can fetch from remote cache
+        assert_eq!(
+            response,
+            CacheResponse {
+                source: CacheSource::Remote,
+                time_saved: test_case.duration
+            }
+        );
+
+        Ok(())
     }
 }

--- a/crates/turborepo-cache/src/async_cache.rs
+++ b/crates/turborepo-cache/src/async_cache.rs
@@ -1,44 +1,77 @@
-use std::future::Future;
+use std::sync::Arc;
 
 use futures::{stream::FuturesUnordered, StreamExt};
 use tokio::task::JoinHandle;
-use turbopath::{AbsoluteSystemPath, AnchoredSystemPathBuf};
+use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPathBuf};
+use turborepo_api_client::APIClient;
 
-use crate::multiplexer::CacheMultiplexer;
+use crate::{multiplexer::CacheMultiplexer, CacheError, CacheOpts, CacheResponse};
 
-struct AsyncCache {
+pub struct AsyncCache {
     workers: FuturesUnordered<JoinHandle<()>>,
     max_workers: usize,
-    real_cache: CacheMultiplexer,
+    real_cache: Arc<CacheMultiplexer>,
 }
 
 impl AsyncCache {
+    pub fn new(
+        opts: &CacheOpts,
+        repo_root: &AbsoluteSystemPath,
+        api_client: APIClient,
+        team_id: &str,
+        token: &str,
+    ) -> Result<AsyncCache, CacheError> {
+        let max_workers = opts.workers.try_into().expect("usize is smaller than u32");
+        let real_cache = CacheMultiplexer::new(opts, repo_root, api_client, team_id, token)?;
+
+        Ok(AsyncCache {
+            workers: FuturesUnordered::new(),
+            real_cache: Arc::new(real_cache),
+            max_workers,
+        })
+    }
+
     pub async fn put(
         &mut self,
-        anchor: &AbsoluteSystemPath,
-        key: &str,
-        files: &[AnchoredSystemPathBuf],
+        anchor: AbsoluteSystemPathBuf,
+        key: String,
+        files: Vec<AnchoredSystemPathBuf>,
         duration: u32,
-        token: &str,
     ) {
         if self.workers.len() >= self.max_workers {
-            self.workers.next().await.unwrap();
+            let _ = self.workers.next().await.unwrap();
         }
 
+        let real_cache = self.real_cache.clone();
+
         let fut = tokio::spawn(async move {
-            let _ = self
-                .real_cache
-                .put(&anchor, &key, files, duration, token)
-                .await;
+            let _ = real_cache.put(&anchor, &key, &files, duration).await;
         });
         self.workers.push(fut);
     }
 
-    pub fn new(real_cache: CacheMultiplexer, max_workers: usize) -> AsyncCache {
-        AsyncCache {
-            workers: FuturesUnordered::new(),
-            real_cache,
-            max_workers,
+    pub async fn fetch(
+        &mut self,
+        anchor: &AbsoluteSystemPath,
+        key: &str,
+        team_id: &str,
+        team_slug: Option<&str>,
+    ) -> Result<(CacheResponse, Vec<AnchoredSystemPathBuf>), CacheError> {
+        self.real_cache.fetch(anchor, key, team_id, team_slug).await
+    }
+
+    pub async fn exists(
+        &mut self,
+        key: &str,
+        team_id: &str,
+        team_slug: Option<&str>,
+    ) -> Result<CacheResponse, CacheError> {
+        self.real_cache.exists(key, team_id, team_slug).await
+    }
+
+    pub async fn shutdown(self) {
+        for worker in self.workers {
+            let _ = worker.await;
         }
     }
 }

--- a/crates/turborepo-cache/src/async_cache.rs
+++ b/crates/turborepo-cache/src/async_cache.rs
@@ -1,0 +1,44 @@
+use std::future::Future;
+
+use futures::{stream::FuturesUnordered, StreamExt};
+use tokio::task::JoinHandle;
+use turbopath::{AbsoluteSystemPath, AnchoredSystemPathBuf};
+
+use crate::multiplexer::CacheMultiplexer;
+
+struct AsyncCache {
+    workers: FuturesUnordered<JoinHandle<()>>,
+    max_workers: usize,
+    real_cache: CacheMultiplexer,
+}
+
+impl AsyncCache {
+    pub async fn put(
+        &mut self,
+        anchor: &AbsoluteSystemPath,
+        key: &str,
+        files: Vec<AnchoredSystemPathBuf>,
+        duration: u32,
+        token: &str,
+    ) {
+        if self.workers.len() >= self.max_workers {
+            self.workers.next().await.unwrap();
+        }
+
+        let fut = tokio::spawn(async move {
+            let _ = self
+                .real_cache
+                .put(&anchor, &key, files, duration, token)
+                .await;
+        });
+        self.workers.push(fut);
+    }
+
+    pub fn new(real_cache: CacheMultiplexer, max_workers: usize) -> AsyncCache {
+        AsyncCache {
+            workers: FuturesUnordered::new(),
+            real_cache,
+            max_workers,
+        }
+    }
+}

--- a/crates/turborepo-cache/src/async_cache.rs
+++ b/crates/turborepo-cache/src/async_cache.rs
@@ -136,7 +136,7 @@ mod tests {
             }),
         };
 
-        let api_client = APIClient::new(&format!("http://localhost:{}", port), 200, "2.0.0", true)?;
+        let api_client = APIClient::new(format!("http://localhost:{}", port), 200, "2.0.0", true)?;
         let api_auth = Some(APIAuth {
             team_id: "my-team-id".to_string(),
             token: "my-token".to_string(),
@@ -280,7 +280,7 @@ mod tests {
             }),
         };
 
-        let api_client = APIClient::new(&format!("http://localhost:{}", port), 200, "2.0.0", true)?;
+        let api_client = APIClient::new(format!("http://localhost:{}", port), 200, "2.0.0", true)?;
         let api_auth = Some(APIAuth {
             team_id: "my-team-id".to_string(),
             token: "my-token".to_string(),

--- a/crates/turborepo-cache/src/cache_archive/create.rs
+++ b/crates/turborepo-cache/src/cache_archive/create.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use tar::{EntryType, Header};
-use turbopath::{AbsoluteSystemPath, AnchoredSystemPath, RelativeUnixPathBuf};
+use turbopath::{AbsoluteSystemPath, AnchoredSystemPath};
 
 use crate::CacheError;
 

--- a/crates/turborepo-cache/src/cache_archive/restore.rs
+++ b/crates/turborepo-cache/src/cache_archive/restore.rs
@@ -341,7 +341,7 @@ mod tests {
         for (tar_bytes, is_compressed) in
             [(&uncompressed_tar[..], false), (&compressed_tar[..], true)]
         {
-            let mut cache_reader = CacheReader::from_reader(&tar_bytes[..], is_compressed)?;
+            let mut cache_reader = CacheReader::from_reader(tar_bytes, is_compressed)?;
             let output_dir = tempdir()?;
             let output_dir_path = output_dir.path().to_string_lossy();
             let anchor = AbsoluteSystemPath::new(&output_dir_path)?;
@@ -364,7 +364,7 @@ mod tests {
         for (tar_bytes, is_compressed) in
             [(&uncompressed_tar[..], false), (&compressed_tar[..], true)]
         {
-            let mut cache_reader = CacheReader::from_reader(&tar_bytes[..], is_compressed)?;
+            let mut cache_reader = CacheReader::from_reader(tar_bytes, is_compressed)?;
             let output_dir = tempdir()?;
             let output_dir_path = output_dir.path().to_string_lossy();
             let anchor = AbsoluteSystemPath::new(&output_dir_path)?;

--- a/crates/turborepo-cache/src/cache_archive/restore_regular.rs
+++ b/crates/turborepo-cache/src/cache_archive/restore_regular.rs
@@ -31,7 +31,6 @@ pub fn restore_regular(
         open_options.mode(header.mode()?);
     }
 
-    println!("resolved path: {}", resolved_path);
     let mut file = open_options.open(resolved_path.as_path())?;
     io::copy(entry, &mut file)?;
 

--- a/crates/turborepo-cache/src/fs.rs
+++ b/crates/turborepo-cache/src/fs.rs
@@ -181,12 +181,8 @@ mod test {
             .expect_err("Expected cache miss");
         assert_matches!(expected_miss, CacheError::CacheMiss);
 
-        cache.put(
-            repo_root_path,
-            &test_case.hash,
-            test_case.duration,
-            test_case.files.iter().map(|f| f.path.clone()).collect(),
-        )?;
+        let files: Vec<_> = test_case.files.iter().map(|f| f.path.clone()).collect();
+        cache.put(repo_root_path, &test_case.hash, &files, test_case.duration)?;
 
         let expected_hit = cache.exists(&test_case.hash)?;
         assert_eq!(

--- a/crates/turborepo-cache/src/fs.rs
+++ b/crates/turborepo-cache/src/fs.rs
@@ -127,7 +127,7 @@ impl FSCache {
         let mut cache_item = CacheWriter::create(&cache_path)?;
 
         for file in files {
-            cache_item.add_file(anchor, &file)?;
+            cache_item.add_file(anchor, file)?;
         }
 
         let metadata_path = self
@@ -174,17 +174,17 @@ mod test {
         let repo_root_path = AbsoluteSystemPath::from_std_path(repo_root.path())?;
         test_case.initialize(repo_root_path)?;
 
-        let cache = FSCache::new(None, &repo_root_path)?;
+        let cache = FSCache::new(None, repo_root_path)?;
 
         let expected_miss = cache
-            .exists(&test_case.hash)
+            .exists(test_case.hash)
             .expect_err("Expected cache miss");
         assert_matches!(expected_miss, CacheError::CacheMiss);
 
         let files: Vec<_> = test_case.files.iter().map(|f| f.path.clone()).collect();
-        cache.put(repo_root_path, &test_case.hash, &files, test_case.duration)?;
+        cache.put(repo_root_path, test_case.hash, &files, test_case.duration)?;
 
-        let expected_hit = cache.exists(&test_case.hash)?;
+        let expected_hit = cache.exists(test_case.hash)?;
         assert_eq!(
             expected_hit,
             CacheResponse {
@@ -193,7 +193,7 @@ mod test {
             }
         );
 
-        let (status, files) = cache.fetch(&repo_root_path, &test_case.hash)?;
+        let (status, files) = cache.fetch(repo_root_path, test_case.hash)?;
         assert_eq!(
             status,
             CacheResponse {

--- a/crates/turborepo-cache/src/fs.rs
+++ b/crates/turborepo-cache/src/fs.rs
@@ -9,7 +9,7 @@ use crate::{
     CacheError, CacheResponse, CacheSource,
 };
 
-pub struct FsCache {
+pub struct FSCache {
     cache_directory: AbsoluteSystemPathBuf,
 }
 
@@ -26,7 +26,7 @@ impl CacheMetadata {
     }
 }
 
-impl FsCache {
+impl FSCache {
     fn resolve_cache_dir(
         repo_root: &AbsoluteSystemPath,
         override_dir: Option<&Utf8Path>,
@@ -45,7 +45,7 @@ impl FsCache {
         let cache_directory = Self::resolve_cache_dir(repo_root, override_dir);
         cache_directory.create_dir_all()?;
 
-        Ok(FsCache { cache_directory })
+        Ok(FSCache { cache_directory })
     }
 
     pub fn fetch(
@@ -174,7 +174,7 @@ mod test {
         let repo_root_path = AbsoluteSystemPath::from_std_path(repo_root.path())?;
         test_case.initialize(repo_root_path)?;
 
-        let cache = FsCache::new(None, &repo_root_path)?;
+        let cache = FSCache::new(None, &repo_root_path)?;
 
         let expected_miss = cache
             .exists(&test_case.hash)

--- a/crates/turborepo-cache/src/fs.rs
+++ b/crates/turborepo-cache/src/fs.rs
@@ -87,7 +87,7 @@ impl FsCache {
         ))
     }
 
-    fn exists(&self, hash: &str) -> Result<CacheResponse, CacheError> {
+    pub(crate) fn exists(&self, hash: &str) -> Result<CacheResponse, CacheError> {
         let uncompressed_cache_path = self
             .cache_directory
             .join_component(&format!("{}.tar", hash));

--- a/crates/turborepo-cache/src/http.rs
+++ b/crates/turborepo-cache/src/http.rs
@@ -80,7 +80,7 @@ impl HTTPCache {
     ) -> Result<(), CacheError> {
         let mut cache_archive = CacheWriter::from_writer(writer, true)?;
         for file in files {
-            cache_archive.add_file(anchor, &file)?;
+            cache_archive.add_file(anchor, file)?;
         }
 
         Ok(())

--- a/crates/turborepo-cache/src/http.rs
+++ b/crates/turborepo-cache/src/http.rs
@@ -9,39 +9,43 @@ use crate::{
     CacheError, CacheOpts, CacheResponse, CacheSource,
 };
 
-pub struct HttpCache {
+pub struct HTTPCache {
     client: APIClient,
     signer_verifier: Option<ArtifactSignatureAuthenticator>,
     repo_root: AbsoluteSystemPathBuf,
     token: String,
 }
 
-impl HttpCache {
+pub struct APIAuth {
+    pub team_id: String,
+    pub token: String,
+}
+
+impl HTTPCache {
     pub fn new(
         client: APIClient,
         opts: &CacheOpts,
         repo_root: AbsoluteSystemPathBuf,
-        team_id: &str,
-        token: &str,
-    ) -> HttpCache {
+        api_auth: APIAuth,
+    ) -> HTTPCache {
         let signer_verifier = if opts
             .remote_cache_opts
             .as_ref()
             .map_or(false, |remote_cache_opts| remote_cache_opts.signature)
         {
             Some(ArtifactSignatureAuthenticator {
-                team_id: team_id.as_bytes().to_vec(),
+                team_id: api_auth.team_id.as_bytes().to_vec(),
                 secret_key_override: None,
             })
         } else {
             None
         };
 
-        HttpCache {
+        HTTPCache {
             client,
             signer_verifier,
             repo_root,
-            token: token.to_string(),
+            token: api_auth.token,
         }
     }
 
@@ -191,22 +195,28 @@ mod test {
     use vercel_api_mock::start_test_server;
 
     use crate::{
-        http::HttpCache,
+        http::{APIAuth, HTTPCache},
         test_cases::{get_test_cases, TestCase},
         CacheOpts, CacheSource,
     };
 
     #[tokio::test]
     async fn test_http_cache() -> Result<()> {
-        try_join_all(get_test_cases().into_iter().map(round_trip_test)).await?;
-
-        Ok(())
-    }
-
-    async fn round_trip_test(test_case: TestCase) -> Result<()> {
         let port = port_scanner::request_open_port().unwrap();
         let handle = tokio::spawn(start_test_server(port));
 
+        try_join_all(
+            get_test_cases()
+                .into_iter()
+                .map(|test_case| round_trip_test(test_case, port)),
+        )
+        .await?;
+
+        handle.abort();
+        Ok(())
+    }
+
+    async fn round_trip_test(test_case: TestCase, port: u16) -> Result<()> {
         let repo_root = tempdir()?;
         let repo_root_path = AbsoluteSystemPathBuf::try_from(repo_root.path())?;
         test_case.initialize(&repo_root_path)?;
@@ -219,27 +229,24 @@ mod test {
 
         let api_client = APIClient::new(&format!("http://localhost:{}", port), 200, "2.0.0", true)?;
         let opts = CacheOpts::default();
-        let team_id = "my-team";
-        let token = "my-token";
+        let api_auth = APIAuth {
+            team_id: "my-team".to_string(),
+            token: "my-token".to_string(),
+        };
 
-        let cache = HttpCache::new(api_client, opts, repo_root_path.to_owned(), team_id, token);
+        let cache = HTTPCache::new(api_client, &opts, repo_root_path.to_owned(), api_auth);
 
+        let anchored_files: Vec<_> = files.iter().map(|f| f.path.clone()).collect();
         cache
-            .put(
-                &repo_root_path,
-                hash,
-                files.iter().map(|f| f.path.clone()).collect(),
-                duration,
-                "",
-            )
+            .put(&repo_root_path, hash, &anchored_files, duration)
             .await?;
 
-        let cache_response = cache.exists(hash, "", "", None, false).await?;
+        let cache_response = cache.exists(hash, "", None).await?;
 
         assert_eq!(cache_response.time_saved, duration);
         assert_eq!(cache_response.source, CacheSource::Remote);
 
-        let (cache_response, received_files) = cache.retrieve(hash, "", "", None).await?;
+        let (cache_response, received_files) = cache.fetch(hash, "", None).await?;
         assert_eq!(cache_response.time_saved, duration);
 
         for (test_file, received_file) in files.iter().zip(received_files) {
@@ -248,7 +255,6 @@ mod test {
             assert_eq!(std::fs::read_to_string(file_path)?, test_file.contents);
         }
 
-        handle.abort();
         Ok(())
     }
 }

--- a/crates/turborepo-cache/src/http.rs
+++ b/crates/turborepo-cache/src/http.rs
@@ -72,7 +72,7 @@ impl HttpCache {
         &self,
         writer: impl Write,
         anchor: &AbsoluteSystemPath,
-        files: Vec<AnchoredSystemPathBuf>,
+        files: &[AnchoredSystemPathBuf],
     ) -> Result<(), CacheError> {
         let mut cache_archive = CacheWriter::from_writer(writer, true)?;
         for file in files {

--- a/crates/turborepo-cache/src/lib.rs
+++ b/crates/turborepo-cache/src/lib.rs
@@ -1,17 +1,22 @@
 #![feature(error_generic_member_access)]
 #![feature(provide_any)]
 #![feature(assert_matches)]
+#![feature(box_patterns)]
 #![deny(clippy::all)]
 
+mod async_cache;
 pub mod cache_archive;
 pub mod fs;
 pub mod http;
+mod multiplexer;
 pub mod signature_authentication;
 #[cfg(test)]
 mod test_cases;
 
 use std::{backtrace, backtrace::Backtrace};
 
+use camino::Utf8Path;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::signature_authentication::SignatureError;
@@ -79,4 +84,19 @@ pub enum CacheSource {
 pub struct CacheResponse {
     source: CacheSource,
     time_saved: u32,
+}
+
+#[derive(Debug, Default)]
+pub struct CacheOpts<'a> {
+    override_dir: Option<&'a Utf8Path>,
+    skip_remote: bool,
+    skip_filesystem: bool,
+    workers: u32,
+    pub(crate) remote_cache_opts: Option<RemoteCacheOpts>,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RemoteCacheOpts {
+    team_id: String,
+    signature: bool,
 }

--- a/crates/turborepo-cache/src/lib.rs
+++ b/crates/turborepo-cache/src/lib.rs
@@ -15,6 +15,7 @@ mod test_cases;
 
 use std::{backtrace, backtrace::Backtrace};
 
+pub use async_cache::AsyncCache;
 use camino::Utf8Path;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -88,11 +89,11 @@ pub struct CacheResponse {
 
 #[derive(Debug, Default)]
 pub struct CacheOpts<'a> {
-    override_dir: Option<&'a Utf8Path>,
-    skip_remote: bool,
-    skip_filesystem: bool,
-    workers: u32,
-    pub(crate) remote_cache_opts: Option<RemoteCacheOpts>,
+    pub override_dir: Option<&'a Utf8Path>,
+    pub skip_remote: bool,
+    pub skip_filesystem: bool,
+    pub workers: u32,
+    pub remote_cache_opts: Option<RemoteCacheOpts>,
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/turborepo-cache/src/multiplexer.rs
+++ b/crates/turborepo-cache/src/multiplexer.rs
@@ -1,0 +1,92 @@
+use camino::Utf8Path;
+use futures::future::join;
+use tracing::warn;
+use turbopath::{AbsoluteSystemPath, AnchoredSystemPathBuf};
+use turborepo_api_client::APIClient;
+
+use crate::{fs::FsCache, http::HttpCache, CacheError, CacheOpts};
+
+pub struct CacheMultiplexer {
+    fs: Option<FsCache>,
+    http: Option<HttpCache>,
+}
+
+impl CacheMultiplexer {
+    pub fn new(
+        opts: CacheOpts,
+        override_dir: Option<&Utf8Path>,
+        repo_root: &AbsoluteSystemPath,
+        api_client: APIClient,
+        team_id: &str,
+        token: &str,
+    ) -> Result<Self, CacheError> {
+        let use_fs_cache = !opts.skip_filesystem;
+        let use_http_cache = !opts.skip_remote;
+        // Since the above two flags are not mutually exclusive it is possible to
+        // configure yourself out of having a cache. We should tell you about it
+        // but we shouldn't fail your build for that reason.
+        //
+        // Further, since the httpCache can be removed at runtime, we need to insert a
+        // noopCache as a backup if you are configured to have *just* an
+        // httpCache.
+        //
+        if !use_fs_cache && !use_http_cache {
+            warn!("no caches are enabled");
+        }
+
+        let fs_cache = use_fs_cache
+            .then(|| FsCache::new(override_dir, repo_root))
+            .transpose()?;
+
+        let http_cache = use_http_cache
+            .then(|| HttpCache::new(api_client, opts, repo_root.to_owned(), team_id, token));
+
+        Ok(CacheMultiplexer {
+            fs: fs_cache,
+            http: http_cache,
+        })
+    }
+
+    pub async fn put(
+        &mut self,
+        anchor: &AbsoluteSystemPath,
+        key: &str,
+        files: Vec<AnchoredSystemPathBuf>,
+        duration: u32,
+        token: &str,
+    ) -> Result<(), CacheError> {
+        let (http_result, fs_result) = match (&self.http, &self.fs) {
+            (Some(http), Some(fs)) => {
+                let (http_result, fs_result) = join(
+                    http.put(anchor, key, &files, duration, token),
+                    fs.put(anchor, key, &files, duration),
+                )
+                .await;
+
+                (Some(http_result), Some(fs_result))
+            }
+            (None, Some(fs)) => {
+                let fs_result = fs.put(anchor, key, &files, duration).await;
+                (None, Some(fs_result))
+            }
+            (Some(http), None) => {
+                let http_result = http.put(anchor, key, &files, duration, token).await;
+                (Some(http_result), None)
+            }
+            (None, None) => return Ok(()),
+        };
+
+        if let Some(Err(http_err)) = http_result {
+            if let Err(CacheError::ApiClientError(
+                box turborepo_api_client::Error::CacheDisabled { .. },
+                ..,
+            )) = http_err
+            {
+                warn!("failed to put to http cache: cache disabled");
+                self.http = None;
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/crates/turborepo-cache/src/multiplexer.rs
+++ b/crates/turborepo-cache/src/multiplexer.rs
@@ -72,12 +72,12 @@ impl CacheMultiplexer {
     ) -> Result<(), CacheError> {
         self.fs
             .as_ref()
-            .map(|fs| fs.put(anchor, key, &files, duration))
+            .map(|fs| fs.put(anchor, key, files, duration))
             .transpose()?;
 
         let http_result = match self.get_http_cache() {
             Some(http) => {
-                let http_result = http.put(anchor, key, &files, duration).await;
+                let http_result = http.put(anchor, key, files, duration).await;
 
                 Some(http_result)
             }

--- a/crates/turborepo-cache/src/signature_authentication.rs
+++ b/crates/turborepo-cache/src/signature_authentication.rs
@@ -25,9 +25,9 @@ pub enum SignatureError {
 
 #[derive(Debug)]
 pub struct ArtifactSignatureAuthenticator {
-    team_id: Vec<u8>,
+    pub(crate) team_id: Vec<u8>,
     // An override for testing purposes (to avoid env var race conditions)
-    secret_key_override: Option<Vec<u8>>,
+    pub(crate) secret_key_override: Option<Vec<u8>>,
 }
 
 impl ArtifactSignatureAuthenticator {

--- a/crates/turborepo-cache/src/test_cases.rs
+++ b/crates/turborepo-cache/src/test_cases.rs
@@ -10,7 +10,7 @@ impl TestFile {
     pub fn create(&self, repo_root: &AbsoluteSystemPath) -> Result<()> {
         let file_path = repo_root.resolve(&self.path);
         std::fs::create_dir_all(file_path.parent().unwrap())?;
-        std::fs::write(file_path, &self.contents)?;
+        std::fs::write(file_path, self.contents)?;
 
         Ok(())
     }

--- a/crates/turborepo-lib/Cargo.toml
+++ b/crates/turborepo-lib/Cargo.toml
@@ -101,6 +101,7 @@ tracing.workspace = true
 turbo-updater = { workspace = true }
 turbopath = { workspace = true }
 turborepo-api-client = { workspace = true }
+turborepo-cache = { workspace = true }
 turborepo-env = { workspace = true }
 turborepo-lockfiles = { workspace = true }
 turborepo-scm = { workspace = true }

--- a/crates/turborepo-lib/src/cli.rs
+++ b/crates/turborepo-lib/src/cli.rs
@@ -414,7 +414,7 @@ pub enum GenerateCommand {
 pub struct RunArgs {
     /// Override the filesystem cache directory.
     #[clap(long)]
-    pub cache_dir: Option<String>,
+    pub cache_dir: Option<Utf8PathBuf>,
     /// Set the number of concurrent cache operations (default 10)
     #[clap(long, default_value_t = 10)]
     pub cache_workers: u32,

--- a/crates/turborepo-lib/src/cli.rs
+++ b/crates/turborepo-lib/src/cli.rs
@@ -994,7 +994,7 @@ mod test {
             Args {
                 command: Some(Command::Run(Box::new(RunArgs {
                     tasks: vec!["build".to_string()],
-                    cache_dir: Some("foobar".to_string()),
+                    cache_dir: Some(Utf8PathBuf::from("foobar")),
                     ..get_default_run_args()
                 }))),
                 ..Args::default()

--- a/crates/turborepo-lib/src/commands/mod.rs
+++ b/crates/turborepo-lib/src/commands/mod.rs
@@ -143,7 +143,7 @@ impl CommandBase {
         &self.args
     }
 
-    pub fn api_client(&mut self) -> Result<APIClient> {
+    pub fn api_client(&self) -> Result<APIClient> {
         let repo_config = self.repo_config()?;
         let client_config = self.client_config()?;
         let args = self.args();

--- a/crates/turborepo-lib/src/config/turbo.rs
+++ b/crates/turborepo-lib/src/config/turbo.rs
@@ -6,10 +6,10 @@ use std::{
 use camino::Utf8Path;
 use serde::{Deserialize, Serialize};
 use turbopath::{AbsoluteSystemPath, RelativeUnixPathBuf};
+use turborepo_cache::RemoteCacheOpts;
 
 use crate::{
     config::Error,
-    opts::RemoteCacheOpts,
     package_json::PackageJson,
     run::task_id::{get_package_task_from_id, is_package_task, root_task_id},
     task_graph::{

--- a/crates/turborepo-lib/src/opts.rs
+++ b/crates/turborepo-lib/src/opts.rs
@@ -1,7 +1,9 @@
 #![allow(dead_code)]
 use anyhow::{anyhow, Result};
+use camino::Utf8Path;
 use serde::{Deserialize, Serialize};
 use turbopath::AnchoredSystemPathBuf;
+use turborepo_cache::CacheOpts;
 
 use crate::{
     cli::{Command, DryRunMode, EnvMode, LogPrefix, RunArgs},
@@ -17,32 +19,6 @@ pub struct Opts<'a> {
     pub scope_opts: ScopeOpts,
 }
 
-#[derive(Debug, Default)]
-pub struct CacheOpts<'a> {
-    override_dir: Option<&'a str>,
-    skip_remote: bool,
-    skip_filesystem: bool,
-    workers: u32,
-    pub(crate) remote_cache_opts: Option<RemoteCacheOpts>,
-}
-
-impl<'a> From<&'a RunArgs> for CacheOpts<'a> {
-    fn from(run_args: &'a RunArgs) -> Self {
-        CacheOpts {
-            override_dir: run_args.cache_dir.as_deref(),
-            skip_filesystem: run_args.remote_only,
-            workers: run_args.cache_workers,
-            ..CacheOpts::default()
-        }
-    }
-}
-
-#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct RemoteCacheOpts {
-    team_id: String,
-    signature: bool,
-}
-
 impl<'a> TryFrom<&'a Args> for Opts<'a> {
     type Error = anyhow::Error;
 
@@ -53,6 +29,7 @@ impl<'a> TryFrom<&'a Args> for Opts<'a> {
         let run_opts = RunOpts::try_from(run_args.as_ref())?;
         let cache_opts = CacheOpts::from(run_args.as_ref());
         let scope_opts = ScopeOpts::try_from(run_args.as_ref())?;
+
         Ok(Self {
             run_opts,
             cache_opts,
@@ -170,5 +147,16 @@ impl<'a> TryFrom<&'a RunArgs> for ScopeOpts {
             .map(AnchoredSystemPathBuf::from_raw)
             .transpose()?;
         Ok(Self { pkg_inference_root })
+    }
+}
+
+impl<'a> From<&'a RunArgs> for CacheOpts<'a> {
+    fn from(run_args: &'a RunArgs) -> Self {
+        CacheOpts {
+            override_dir: run_args.cache_dir.as_deref(),
+            skip_filesystem: run_args.remote_only,
+            workers: run_args.cache_workers,
+            ..CacheOpts::default()
+        }
     }
 }

--- a/crates/turborepo-lib/src/opts.rs
+++ b/crates/turborepo-lib/src/opts.rs
@@ -1,7 +1,4 @@
-#![allow(dead_code)]
 use anyhow::{anyhow, Result};
-use camino::Utf8Path;
-use serde::{Deserialize, Serialize};
 use turbopath::AnchoredSystemPathBuf;
 use turborepo_cache::CacheOpts;
 

--- a/crates/turborepo-lib/src/run/scope/filter.rs
+++ b/crates/turborepo-lib/src/run/scope/filter.rs
@@ -20,7 +20,7 @@ impl PackageInference {
         pkg_graph: &package_graph::PackageGraph,
     ) -> Self {
         debug!(
-            "Using {} as a basis for selecting pacakges",
+            "Using {} as a basis for selecting packages",
             pkg_inference_path
         );
         let full_inference_path = turbo_root.resolve(pkg_inference_path);

--- a/crates/turborepo-vercel-api-mock/src/lib.rs
+++ b/crates/turborepo-vercel-api-mock/src/lib.rs
@@ -153,20 +153,18 @@ pub async fn start_test_server(port: u16) -> Result<()> {
         .route(
             "/v8/artifacts/:hash",
             head(|Path(hash): Path<String>| async move {
-                let duration = head_durations_ref
-                    .lock()
-                    .await
-                    .get(&hash)
-                    .cloned()
-                    .unwrap_or(0);
                 let mut headers = HeaderMap::new();
+
+                let Some(duration) = head_durations_ref.lock().await.get(&hash).cloned() else {
+                    return (StatusCode::NOT_FOUND, headers);
+                };
 
                 headers.insert(
                     "x-artifact-duration",
                     HeaderValue::from_str(&duration.to_string()).unwrap(),
                 );
 
-                headers
+                (StatusCode::OK, headers)
             }),
         )
         .route(


### PR DESCRIPTION
### Description

Ported both of these and connected to the run outline. I eschewed using a trait because the function signatures are not identical between `fs` and `http`, plus it's only two caches so there's no need for too much abstraction.

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
