### PR TITLE
Add project-specific lints with ast-grep

### DIFF
--- a/.config/ast-grep/rule-tests/__snapshots__/no-context-snapshot.yml
+++ b/.config/ast-grep/rule-tests/__snapshots__/no-context-snapshot.yml
@@ -1,0 +1,42 @@
+id: no-context
+snapshots:
+  "fn foo(context: ChunkingContext) -> u32 { 5 };":
+    labels:
+      - source: context
+        style: primary
+        start: 7
+        end: 14
+      - source: "context: ChunkingContext"
+        style: secondary
+        start: 7
+        end: 31
+  foo(|context| context):
+    labels:
+      - source: context
+        style: primary
+        start: 5
+        end: 12
+      - source: "|context|"
+        style: secondary
+        start: 4
+        end: 13
+  let context = ChunkingContext::new();:
+    labels:
+      - source: context
+        style: primary
+        start: 4
+        end: 11
+      - source: let context = ChunkingContext::new();
+        style: secondary
+        start: 0
+        end: 37
+  "struct Foo { context: Context };":
+    labels:
+      - source: context
+        style: primary
+        start: 13
+        end: 20
+      - source: "context: Context"
+        style: secondary
+        start: 13
+        end: 29

--- a/.config/ast-grep/rule-tests/no-context-test.yml
+++ b/.config/ast-grep/rule-tests/no-context-test.yml
@@ -1,0 +1,11 @@
+id: no-context
+valid:
+  - "let chunking_context = ChunkingContext::new();"
+  - "struct Foo { chunking_context: Context };"
+  - "foo(|chunking_context| context)"
+  - "fn foo(chunking_context: ChunkingContext) -> u32 { 5 };"
+invalid:
+  - "let context = ChunkingContext::new();"
+  - "struct Foo { context: Context };"
+  - "foo(|context| context)"
+  - "fn foo(context: ChunkingContext) -> u32 { 5 };"

--- a/.config/ast-grep/rules/no-context.yml
+++ b/.config/ast-grep/rules/no-context.yml
@@ -1,0 +1,20 @@
+id: no-context
+message: Don't name variables `context`.
+note: Use a more specific name, such as chunking_context, asset_context, etc.
+severity: warning
+language: Rust
+rule:
+  regex: \bcontext\b
+  any:
+    - all:
+        - inside:
+            any:
+              - kind: closure_parameters
+              - kind: parameter
+              - kind: function_type
+              - kind: let_declaration
+        - kind: identifier
+    - all:
+        - kind: field_identifier
+        - inside:
+            kind: field_declaration

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
+.config/ast-grep/rule-tests/__snapshots__/** linguist-generated=true
 crates/turbopack-tests/tests/snapshot/**/output/** linguist-generated=true
 crates/turborepo-lockfiles/fixtures/*.lock text eol=lf

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -518,6 +518,10 @@ jobs:
         run: |
           cargo groups clippy turborepo-libraries --features rustls-tls
 
+      - name: Run ast-grep lints
+        run: |
+          pnpm --package=@ast-grep/cli dlx ast-grep scan $(cargo groups list turborepo-libraries | awk '{ print $2 }' | tr '\n' ' ')
+
   turbopack_rust_check:
     needs: [determine_jobs]
     # We test dependency changes only on main
@@ -568,6 +572,10 @@ jobs:
       - name: Run cargo clippy
         run: |
           RUSTFLAGS="-D warnings -A deprecated" cargo groups clippy turbopack --features rustls-tls
+
+      - name: Run ast-grep lints
+        run: |
+          pnpm --package=@ast-grep/cli dlx ast-grep scan $(cargo groups list turbopack | awk '{ print $2 }' | tr '\n' ' ')
 
   next_dev_check:
     needs: [determine_jobs]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -520,7 +520,7 @@ jobs:
 
       - name: Run ast-grep lints
         run: |
-          pnpm --package=@ast-grep/cli dlx ast-grep scan $(cargo groups list turborepo-libraries | awk '{ print $2 }' | tr '\n' ' ')
+          npx --package @ast-grep/cli -- ast-grep scan $(cargo groups list turborepo-libraries | awk '{ print $2 }' | tr '\n' ' ')
 
   turbopack_rust_check:
     needs: [determine_jobs]
@@ -575,7 +575,7 @@ jobs:
 
       - name: Run ast-grep lints
         run: |
-          pnpm --package=@ast-grep/cli dlx ast-grep scan $(cargo groups list turbopack | awk '{ print $2 }' | tr '\n' ' ')
+          npx --package @ast-grep/cli -- ast-grep scan $(cargo groups list turbopack | awk '{ print $2 }' | tr '\n' ' ')
 
   next_dev_check:
     needs: [determine_jobs]

--- a/sgconfig.yml
+++ b/sgconfig.yml
@@ -1,0 +1,6 @@
+ruleDirs:
+  - .config/ast-grep/rules
+testConfigs:
+  - testDir: .config/ast-grep/rule-tests
+utilDirs:
+  - .config/ast-grep/rule-utils


### PR DESCRIPTION
ast-grep[0] is a tool that uses tree-sitter[1] and a pattern language to match against code using its ast. It implements code transformation, querying, and linting.

Since clippy isn't extensible for project-specific lints, this adds a first ast-grep lint disallowing `context` as a variable name. Currently it's set to warning as usage is addressed.

To run, install ast-grep, then run `ast-grep scan`. Example output:

```
warning[no-context]: Don't name variables `context`.
    ┌─ ./crates/turbopack-ecmascript-hmr-protocol/src/lib.rs:132:9
    │
132 │     pub context: &'a str,
    │     ----^^^^^^^---------
    │
    = Use a more specific name, such as chunking_context, asset_context, etc.
```

[0] https://ast-grep.github.io
[1] https://tree-sitter.github.io/tree-sitter/
