### PR TITLE
feature(turborepo): Spaces gets its own API client.

### DIFF
--- a/cli/internal/cmdutil/cmdutil.go
+++ b/cli/internal/cmdutil/cmdutil.go
@@ -155,7 +155,7 @@ func (h *Helper) GetCmdBase(executionState *turbostate.ExecutionState) (*CmdBase
 		return nil, err
 	}
 	apiClientConfig := executionState.APIClientConfig
-	spacesApiClientConfig := executionState.SpacesAPIClientConfig
+	spacesAPIClientConfig := executionState.SpacesAPIClientConfig
 
 	apiClient := client.NewClient(
 		apiClientConfig,
@@ -164,7 +164,7 @@ func (h *Helper) GetCmdBase(executionState *turbostate.ExecutionState) (*CmdBase
 	)
 
 	spacesClient := client.NewClient(
-		spacesApiClientConfig,
+		spacesAPIClientConfig,
 		logger,
 		h.TurboVersion,
 	)

--- a/cli/internal/cmdutil/cmdutil.go
+++ b/cli/internal/cmdutil/cmdutil.go
@@ -155,6 +155,7 @@ func (h *Helper) GetCmdBase(executionState *turbostate.ExecutionState) (*CmdBase
 		return nil, err
 	}
 	apiClientConfig := executionState.APIClientConfig
+	spacesApiClientConfig := executionState.SpacesAPIClientConfig
 
 	apiClient := client.NewClient(
 		apiClientConfig,
@@ -162,24 +163,32 @@ func (h *Helper) GetCmdBase(executionState *turbostate.ExecutionState) (*CmdBase
 		h.TurboVersion,
 	)
 
+	spacesClient := client.NewClient(
+		spacesApiClientConfig,
+		logger,
+		h.TurboVersion,
+	)
+
 	return &CmdBase{
-		UI:           terminal,
-		UIFactory:    uiFactory,
-		Logger:       logger,
-		RepoRoot:     repoRoot,
-		APIClient:    apiClient,
-		TurboVersion: h.TurboVersion,
+		UI:              terminal,
+		UIFactory:       uiFactory,
+		Logger:          logger,
+		RepoRoot:        repoRoot,
+		APIClient:       apiClient,
+		SpacesAPIClient: spacesClient,
+		TurboVersion:    h.TurboVersion,
 	}, nil
 }
 
 // CmdBase encompasses configured components common to all turbo commands.
 type CmdBase struct {
-	UI           cli.Ui
-	UIFactory    ui.Factory
-	Logger       hclog.Logger
-	RepoRoot     turbopath.AbsoluteSystemPath
-	APIClient    *client.APIClient
-	TurboVersion string
+	UI              cli.Ui
+	UIFactory       ui.Factory
+	Logger          hclog.Logger
+	RepoRoot        turbopath.AbsoluteSystemPath
+	APIClient       *client.APIClient
+	SpacesAPIClient *client.APIClient
+	TurboVersion    string
 }
 
 // LogError prints an error to the UI

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -368,6 +368,7 @@ func (r *run) run(ctx gocontext.Context, targets []string, executionState *turbo
 		rs.Opts.scopeOpts.PackageInferenceRoot,
 		r.base.TurboVersion,
 		r.base.APIClient,
+		r.base.SpacesAPIClient,
 		rs.Opts.runOpts,
 		packagesInScope,
 		globalEnvMode,

--- a/cli/internal/runsummary/run_summary.go
+++ b/cli/internal/runsummary/run_summary.go
@@ -77,6 +77,7 @@ func NewRunSummary(
 	repoPath turbopath.RelativeSystemPath,
 	turboVersion string,
 	apiClient *client.APIClient,
+	spacesClient *client.APIClient,
 	runOpts util.RunOpts,
 	packages []string,
 	globalEnvMode util.EnvMode,
@@ -121,7 +122,7 @@ func NewRunSummary(
 		synthesizedCommand: synthesizedCommand,
 	}
 
-	rsm.spacesClient = newSpacesClient(spaceID, apiClient)
+	rsm.spacesClient = newSpacesClient(spaceID, spacesClient)
 	if rsm.spacesClient.enabled {
 		go rsm.spacesClient.start()
 		payload := newSpacesRunCreatePayload(&rsm)

--- a/cli/internal/turbostate/turbostate.go
+++ b/cli/internal/turbostate/turbostate.go
@@ -92,9 +92,10 @@ type ParsedArgsFromRust struct {
 
 // ExecutionState is the entire state of a turbo execution that is passed from the Rust shim.
 type ExecutionState struct {
-	APIClientConfig APIClientConfig    `json:"api_client_config"`
-	PackageManager  string             `json:"package_manager"`
-	CLIArgs         ParsedArgsFromRust `json:"cli_args"`
+	APIClientConfig       APIClientConfig    `json:"api_client_config"`
+	SpacesAPIClientConfig APIClientConfig    `json:"spaces_api_client_config"`
+	PackageManager        string             `json:"package_manager"`
+	CLIArgs               ParsedArgsFromRust `json:"cli_args"`
 }
 
 // APIClientConfig holds the authentication and endpoint details for the API client

--- a/crates/turborepo-lib/src/commands/link.rs
+++ b/crates/turborepo-lib/src/commands/link.rs
@@ -247,6 +247,11 @@ pub async fn link(
                 )
             })?;
 
+            fs::create_dir_all(base.repo_root.join_component(".turbo"))
+                .context("could not create .turbo directory")?;
+            base.repo_config_mut()?
+                .set_space_team_id(Some(team_id.to_string()))?;
+
             println!(
                 "
     {} {} linked to {}

--- a/crates/turborepo-lib/src/execution_state.rs
+++ b/crates/turborepo-lib/src/execution_state.rs
@@ -8,12 +8,25 @@ use crate::{
 #[derive(Debug, Serialize)]
 pub struct ExecutionState<'a> {
     pub api_client_config: APIClientConfig<'a>,
+    pub spaces_api_client_config: SpacesAPIClientConfig<'a>,
     package_manager: PackageManager,
     pub cli_args: &'a Args,
 }
 
 #[derive(Debug, Serialize, Default)]
 pub struct APIClientConfig<'a> {
+    // Comes from user config, i.e. $XDG_CONFIG_HOME/turborepo/config.json
+    pub token: Option<&'a str>,
+    // Comes from repo config, i.e. ./.turbo/config.json
+    pub team_id: Option<&'a str>,
+    pub team_slug: Option<&'a str>,
+    pub api_url: &'a str,
+    pub use_preflight: bool,
+    pub timeout: u64,
+}
+
+#[derive(Debug, Serialize, Default)]
+pub struct SpacesAPIClientConfig<'a> {
     // Comes from user config, i.e. $XDG_CONFIG_HOME/turborepo/config.json
     pub token: Option<&'a str>,
     // Comes from repo config, i.e. ./.turbo/config.json
@@ -49,8 +62,18 @@ impl<'a> TryFrom<&'a CommandBase> for ExecutionState<'a> {
             timeout: client_config.remote_cache_timeout(),
         };
 
+        let spaces_api_client_config = SpacesAPIClientConfig {
+            token: user_config.token(),
+            team_id: repo_config.space_team_id(),
+            team_slug: repo_config.space_team_slug(),
+            api_url: repo_config.space_api_url(),
+            use_preflight: args.preflight,
+            timeout: client_config.remote_cache_timeout(),
+        };
+
         Ok(ExecutionState {
             api_client_config,
+            spaces_api_client_config,
             package_manager,
             cli_args: base.args(),
         })


### PR DESCRIPTION
Supersedes #5561 

Write and use a configuration for a Spaces API client. It's not graceful, but allows for isolated configuration.

Review ignoring whitespace: https://github.com/vercel/turbo/pull/5674/files?w=1