### PR TITLE
add untracked trait reads

### DIFF
--- a/crates/turbo-tasks-testing/src/lib.rs
+++ b/crates/turbo-tasks-testing/src/lib.rs
@@ -122,6 +122,10 @@ impl TurboTasksCallApi for VcStorage {
 }
 
 impl TurboTasksApi for VcStorage {
+    fn pin(&self) -> Arc<dyn TurboTasksApi> {
+        self.this.upgrade().unwrap()
+    }
+
     fn invalidate(&self, _task: TaskId) {
         unreachable!()
     }

--- a/crates/turbo-tasks/src/trait_ref.rs
+++ b/crates/turbo-tasks/src/trait_ref.rs
@@ -130,6 +130,7 @@ pub trait IntoTraitRef {
     type Future: Future<Output = Result<<VcValueTraitCast<Self::ValueTrait> as VcCast>::Output>>;
 
     fn into_trait_ref(self) -> Self::Future;
+    fn into_trait_ref_untracked(self) -> Self::Future;
 }
 
 impl<T> IntoTraitRef for Vc<T>
@@ -142,5 +143,9 @@ where
 
     fn into_trait_ref(self) -> Self::Future {
         self.node.into_trait_read::<T>()
+    }
+
+    fn into_trait_ref_untracked(self) -> Self::Future {
+        self.node.into_trait_read_untracked::<T>()
     }
 }


### PR DESCRIPTION
### Description

* allows to call `into_trait_ref_untracked` similar to the value variant
* use ReadRawVcFuture everywhere
* remove duplicate notify_dependencies

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
