### PR TITLE
docs: update webpack docs to reflect latest next.js api

### DIFF
--- a/docs/pages/pack/docs/features/customizing-turbopack.mdx
+++ b/docs/pages/pack/docs/features/customizing-turbopack.mdx
@@ -21,7 +21,7 @@ If you need loader support beyond what's built in, many webpack loaders already 
 - Only loaders that return JavaScript code are supported. Loaders that transform files like stylesheets or images are not currently supported.
 - Options passed to webpack loaders must be plain JavaScript primitives, objects, and arrays. For example, it's not possible to pass `require()`d plugin modules as option values.
 
-As of Next 13.2, configuring webpack loaders is possible for Next.js apps through an experimental option in `next.config.js`. `turbo.loaders` can be set as a mapping of file extensions to a list of package names or `{loader, options}` pairs:
+As of Next 13.2, configuring webpack loaders is possible for Next.js apps through an experimental option in `next.config.js`. `turbo.rules` can be set as a mapping of file globs to a list of package names or `{loader, options}` pairs:
 
 ```js filename="next.config.js"
 module.exports = {
@@ -45,7 +45,9 @@ module.exports = {
 }
 ```
 
-Note: Prior to Next.js version 13.4.4, this config was named `experimental.turbo.loaders`.
+<Callout type="info">
+  Note: Prior to Next.js version 13.4.4, `experimental.turbo.rules` was named `experimental.turbo.loaders`.
+</Callout>
 
 If you need to pass something like the result of importing an external package as a loader option, it's possible to wrap the webpack loader with your own, specifying options there. **This is an interim solution and should not be necessary in the future.** This loader wraps `@mdx-js/loader` and configures the `rehypePrism` rehype plugin:
 

--- a/docs/pages/pack/docs/features/customizing-turbopack.mdx
+++ b/docs/pages/pack/docs/features/customizing-turbopack.mdx
@@ -27,9 +27,9 @@ As of Next 13.2, configuring webpack loaders is possible for Next.js apps throug
 module.exports = {
   experimental: {
     turbo: {
-      loaders: {
+      rules: {
         // Option format
-        '.md': [
+        '*.md': [
           {
             loader: '@mdx-js/loader',
             options: {
@@ -38,12 +38,14 @@ module.exports = {
           },
         ],
         // Option-less format
-        '.mdx': ['@mdx-js/loader'],
+        '*.mdx': ['@mdx-js/loader'],
       },
     },
   },
 }
 ```
+
+Note: Prior to Next.js version 13.4.4, this config was named `experimental.turbo.loaders`.
 
 If you need to pass something like the result of importing an external package as a loader option, it's possible to wrap the webpack loader with your own, specifying options there. **This is an interim solution and should not be necessary in the future.** This loader wraps `@mdx-js/loader` and configures the `rehypePrism` rehype plugin:
 
@@ -70,7 +72,7 @@ Then, configure Next.js to load the wrapper loader:
 module.exports = {
   experimental: {
     turbo: {
-      loaders: {
+      rules: {
         '.mdx': ['./my-mdx-loader'],
       },
     },

--- a/docs/pages/pack/docs/features/customizing-turbopack.mdx
+++ b/docs/pages/pack/docs/features/customizing-turbopack.mdx
@@ -46,7 +46,7 @@ module.exports = {
 ```
 
 <Callout type="info">
-  Note: Prior to Next.js version 13.4.4, `experimental.turbo.rules` was named `experimental.turbo.loaders`.
+  Note: Prior to Next.js version 13.4.4, `experimental.turbo.rules` was named `experimental.turbo.loaders` and only accepted file extensions like `.mdx` instead of `*.mdx`.
 </Callout>
 
 If you need to pass something like the result of importing an external package as a loader option, it's possible to wrap the webpack loader with your own, specifying options there. **This is an interim solution and should not be necessary in the future.** This loader wraps `@mdx-js/loader` and configures the `rehypePrism` rehype plugin:
@@ -75,7 +75,7 @@ module.exports = {
   experimental: {
     turbo: {
       rules: {
-        '.mdx': ['./my-mdx-loader'],
+        '*.mdx': ['./my-mdx-loader'],
       },
     },
   },


### PR DESCRIPTION
### Description

Updates docs to reflect changes in https://github.com/vercel/next.js/pull/49535/files

<!--
  ✍️ Write a short summary of your work.
  If necessary, include relevant screenshots.
-->

### Testing Instructions
QA "Customizing Turbopack" Docs