### PR TITLE
feature(turborepo): `turborepo-ui` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9824,6 +9824,7 @@ dependencies = [
  "turborepo-fs",
  "turborepo-lockfiles",
  "turborepo-scm",
+ "turborepo-ui",
  "uds_windows",
  "url",
  "vercel-api-mock",
@@ -9869,6 +9870,21 @@ dependencies = [
  "turbopath",
  "wax",
  "which",
+]
+
+[[package]]
+name = "turborepo-ui"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "atty",
+ "console",
+ "indicatif",
+ "lazy_static",
+ "tempfile",
+ "thiserror",
+ "tracing",
+ "turbopath",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,7 +276,7 @@ dependencies = [
  "log",
  "parking",
  "polling",
- "rustix",
+ "rustix 0.37.19",
  "slab",
  "socket2",
  "waker-fn",
@@ -3480,13 +3480,12 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi 0.3.1",
- "io-lifetimes",
- "rustix",
+ "rustix 0.38.3",
  "windows-sys 0.48.0",
 ]
 
@@ -3908,6 +3907,12 @@ name = "linux-raw-sys"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
 
 [[package]]
 name = "lock_api"
@@ -5958,7 +5963,20 @@ dependencies = [
  "errno",
  "io-lifetimes",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.3.8",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac5ffa1efe7548069688cd7028f32591853cd7b5b756d41bcffd2353e4fc75b4"
+dependencies = [
+ "bitflags 2.3.3",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.5",
  "windows-sys 0.48.0",
 ]
 
@@ -8015,7 +8033,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "fastrand",
  "redox_syscall 0.3.5",
- "rustix",
+ "rustix 0.37.19",
  "windows-sys 0.48.0",
 ]
 
@@ -8054,7 +8072,7 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e6bf6f19e9f8ed8d4048dc22981458ebcf406d67e94cd422e5ecd73d63b3237"
 dependencies = [
- "rustix",
+ "rustix 0.37.19",
  "windows-sys 0.48.0",
 ]
 
@@ -9885,6 +9903,7 @@ dependencies = [
  "thiserror",
  "tracing",
  "turbopath",
+ "turborepo-ci",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,6 +139,7 @@ turborepo-ffi = { path = "crates/turborepo-ffi" }
 turborepo-fs = { path = "crates/turborepo-fs" }
 turborepo-lib = { path = "crates/turborepo-lib", default-features = false }
 turborepo-lockfiles = { path = "crates/turborepo-lockfiles" }
+turborepo-ui = { path = "crates/turborepo-ui" }
 turborepo-scm = { path = "crates/turborepo-scm" }
 wax = { path = "crates/turborepo-wax" }
 vercel-api-mock = { path = "crates/turborepo-vercel-api-mock" }

--- a/crates/turborepo-lib/Cargo.toml
+++ b/crates/turborepo-lib/Cargo.toml
@@ -102,10 +102,10 @@ turbo-updater = { workspace = true }
 turbopath = { workspace = true }
 turborepo-api-client = { workspace = true }
 turborepo-cache = { workspace = true }
+turborepo-ci = { workspace = true }
 turborepo-env = { workspace = true }
 turborepo-lockfiles = { workspace = true }
 turborepo-scm = { workspace = true }
-turborepo-ci = { workspace = true }
 turborepo-ui = { workspace = true }
 wax = { workspace = true }
 webbrowser = { workspace = true }

--- a/crates/turborepo-lib/Cargo.toml
+++ b/crates/turborepo-lib/Cargo.toml
@@ -105,6 +105,7 @@ turborepo-cache = { workspace = true }
 turborepo-env = { workspace = true }
 turborepo-lockfiles = { workspace = true }
 turborepo-scm = { workspace = true }
+turborepo-ci = { workspace = true }
 turborepo-ui = { workspace = true }
 wax = { workspace = true }
 webbrowser = { workspace = true }

--- a/crates/turborepo-lib/Cargo.toml
+++ b/crates/turborepo-lib/Cargo.toml
@@ -105,6 +105,7 @@ turborepo-cache = { workspace = true }
 turborepo-env = { workspace = true }
 turborepo-lockfiles = { workspace = true }
 turborepo-scm = { workspace = true }
+turborepo-ui = { workspace = true }
 wax = { workspace = true }
 webbrowser = { workspace = true }
 which = { workspace = true }

--- a/crates/turborepo-lib/src/cli.rs
+++ b/crates/turborepo-lib/src/cli.rs
@@ -7,6 +7,7 @@ use clap_complete::{generate, Shell};
 use serde::Serialize;
 use tracing::{debug, error};
 use turbopath::AbsoluteSystemPathBuf;
+use turborepo_ui::UI;
 
 #[cfg(feature = "run-stub")]
 use crate::commands::run;
@@ -15,7 +16,6 @@ use crate::{
     get_version,
     shim::{RepoMode, RepoState},
     tracing::TurboSubscriber,
-    ui::UI,
     Payload,
 };
 

--- a/crates/turborepo-lib/src/commands/info.rs
+++ b/crates/turborepo-lib/src/commands/info.rs
@@ -1,11 +1,11 @@
 use anyhow::Result;
+use turborepo_ui::GREY;
 
 use crate::{
     commands::CommandBase,
     package_graph::{PackageGraph, WorkspaceName, WorkspaceNode},
     package_json::PackageJson,
     package_manager::PackageManager,
-    ui::GREY,
 };
 
 pub fn run(base: &mut CommandBase, workspace: Option<&str>) -> Result<()> {

--- a/crates/turborepo-lib/src/commands/link.rs
+++ b/crates/turborepo-lib/src/commands/link.rs
@@ -17,14 +17,14 @@ use dirs_next::home_dir;
 #[cfg(test)]
 use rand::Rng;
 use turborepo_api_client::{APIClient, CachingStatus, Space, Team};
-
 #[cfg(not(test))]
-use crate::ui::CYAN;
+use turborepo_ui::CYAN;
+use turborepo_ui::{BOLD, GREY, UNDERLINE};
+
 use crate::{
     cli::LinkTarget,
     commands::CommandBase,
     config::{RawTurboJSON, SpacesJson},
-    ui::{BOLD, GREY, UNDERLINE},
 };
 
 #[derive(Clone)]
@@ -478,13 +478,13 @@ mod test {
     use tempfile::{NamedTempFile, TempDir};
     use tokio::sync::OnceCell;
     use turbopath::AbsoluteSystemPathBuf;
+    use turborepo_ui::UI;
     use vercel_api_mock::start_test_server;
 
     use crate::{
         cli::LinkTarget,
         commands::{link, CommandBase},
         config::{ClientConfigLoader, RawTurboJSON, RepoConfigLoader, UserConfigLoader},
-        ui::UI,
         Args,
     };
 

--- a/crates/turborepo-lib/src/commands/login.rs
+++ b/crates/turborepo-lib/src/commands/login.rs
@@ -11,6 +11,7 @@ use tokio::sync::OnceCell;
 use tracing::debug;
 #[cfg(not(test))]
 use tracing::warn;
+use turborepo_ui::{start_spinner, BOLD, CYAN, GREY, UNDERLINE};
 
 use crate::{
     commands::{
@@ -18,7 +19,6 @@ use crate::{
         CommandBase,
     },
     get_version,
-    ui::{start_spinner, BOLD, CYAN, GREY, UNDERLINE},
 };
 
 const DEFAULT_HOST_NAME: &str = "127.0.0.1";
@@ -305,6 +305,7 @@ mod test {
     use tempfile::{tempdir, NamedTempFile};
     use tokio::sync::OnceCell;
     use turbopath::AbsoluteSystemPathBuf;
+    use turborepo_ui::UI;
     use vercel_api_mock::start_test_server;
 
     use crate::{
@@ -314,7 +315,6 @@ mod test {
             CommandBase,
         },
         config::{ClientConfigLoader, RepoConfigLoader, UserConfigLoader},
-        ui::UI,
         Args,
     };
 

--- a/crates/turborepo-lib/src/commands/logout.rs
+++ b/crates/turborepo-lib/src/commands/logout.rs
@@ -1,7 +1,8 @@
 use anyhow::Result;
 use tracing::error;
+use turborepo_ui::GREY;
 
-use crate::{commands::CommandBase, ui::GREY};
+use crate::commands::CommandBase;
 
 pub fn logout(base: &mut CommandBase) -> Result<()> {
     if let Err(err) = base.user_config_mut()?.set_token(None) {

--- a/crates/turborepo-lib/src/commands/mod.rs
+++ b/crates/turborepo-lib/src/commands/mod.rs
@@ -5,13 +5,13 @@ use sha2::{Digest, Sha256};
 use tokio::sync::OnceCell;
 use turbopath::AbsoluteSystemPathBuf;
 use turborepo_api_client::APIClient;
+use turborepo_ui::UI;
 
 use crate::{
     config::{
         default_user_config_path, get_repo_config_path, ClientConfig, ClientConfigLoader,
         RepoConfig, RepoConfigLoader, UserConfig, UserConfigLoader,
     },
-    ui::UI,
     Args,
 };
 
@@ -176,8 +176,9 @@ impl CommandBase {
 mod test {
     use test_case::test_case;
     use turbopath::AbsoluteSystemPathBuf;
+    use turborepo_ui::UI;
 
-    use crate::{get_version, ui::UI};
+    use crate::get_version;
 
     #[cfg(not(target_os = "windows"))]
     #[test_case("/tmp/turborepo", "6e0cfa616f75a61c"; "basic example")]

--- a/crates/turborepo-lib/src/commands/prune.rs
+++ b/crates/turborepo-lib/src/commands/prune.rs
@@ -7,13 +7,13 @@ use tracing::trace;
 use turbopath::{
     AbsoluteSystemPathBuf, AnchoredSystemPath, AnchoredSystemPathBuf, RelativeUnixPath,
 };
+use turborepo_ui::BOLD;
 
 use super::CommandBase;
 use crate::{
     config::RawTurboJSON,
     package_graph::{PackageGraph, WorkspaceName, WorkspaceNode},
     package_json::PackageJson,
-    ui::BOLD,
 };
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/turborepo-lib/src/commands/unlink.rs
+++ b/crates/turborepo-lib/src/commands/unlink.rs
@@ -1,8 +1,9 @@
 use std::{fs, fs::File};
 
 use anyhow::{Context, Result};
+use turborepo_ui::GREY;
 
-use crate::{cli::LinkTarget, commands::CommandBase, config::RawTurboJSON, ui::GREY};
+use crate::{cli::LinkTarget, commands::CommandBase, config::RawTurboJSON};
 
 enum UnlinkSpacesResult {
     Unlinked,

--- a/crates/turborepo-lib/src/daemon/server.rs
+++ b/crates/turborepo-lib/src/daemon/server.rs
@@ -332,9 +332,10 @@ mod test {
 
     use tokio::select;
     use turbopath::AbsoluteSystemPathBuf;
+    use turborepo_ui::UI;
 
     use super::DaemonServer;
-    use crate::{commands::CommandBase, ui::UI, Args};
+    use crate::{commands::CommandBase, Args};
 
     // the windows runner starts a new thread to accept uds requests,
     // so we need a multi-threaded runtime

--- a/crates/turborepo-lib/src/lib.rs
+++ b/crates/turborepo-lib/src/lib.rs
@@ -20,7 +20,6 @@ mod run;
 mod shim;
 mod task_graph;
 mod tracing;
-mod ui;
 
 use ::tracing::error;
 use anyhow::Result;

--- a/crates/turborepo-lib/src/package_manager/mod.rs
+++ b/crates/turborepo-lib/src/package_manager/mod.rs
@@ -16,12 +16,12 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, RelativeUnixPath};
 use turborepo_lockfiles::Lockfile;
+use turborepo_ui::{UI, UNDERLINE};
 use wax::{Any, Glob, Pattern};
 
 use crate::{
     package_json::PackageJson,
     package_manager::{npm::NpmDetector, pnpm::PnpmDetector, yarn::YarnDetector},
-    ui::{UI, UNDERLINE},
 };
 
 #[derive(Debug, Deserialize)]

--- a/crates/turborepo-lib/src/run/global_hash.rs
+++ b/crates/turborepo-lib/src/run/global_hash.rs
@@ -4,8 +4,9 @@ use anyhow::Result;
 use turbopath::{AbsoluteSystemPath, RelativeUnixPathBuf};
 use turborepo_env::{BySource, DetailedMap, EnvironmentVariableMap};
 use turborepo_lockfiles::Lockfile;
+use turborepo_ui::UI;
 
-use crate::{cli::EnvMode, package_json::PackageJson, package_manager::PackageManager, ui::UI};
+use crate::{cli::EnvMode, package_json::PackageJson, package_manager::PackageManager};
 
 static DEFAULT_ENV_VARS: [&str; 1] = ["VERCEL_ANALYTICS_ID"];
 

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -4,6 +4,8 @@ mod global_hash;
 mod scope;
 pub mod task_id;
 
+use std::io::IsTerminal;
+
 use anyhow::{Context as ErrorContext, Result};
 use tracing::{debug, info};
 use turborepo_cache::{http::APIAuth, AsyncCache};
@@ -62,7 +64,8 @@ impl Run {
         }
 
         // There's some warning handling code in Go that I'm ignoring
-        if turborepo_ci::is_ci() && !std::io::stdout().is_terminal() && !opts.run_opts.no_daemon {
+        let is_ci_and_not_tty = turborepo_ci::is_ci() && !std::io::stdout().is_terminal();
+        if is_ci_and_not_tty && !opts.run_opts.no_daemon {
             info!("skipping turbod since we appear to be in a non-interactive context");
         } else if !opts.run_opts.no_daemon {
             let connector = DaemonConnector {

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -142,13 +142,13 @@ mod test {
     use anyhow::Result;
     use tempfile::tempdir;
     use turbopath::AbsoluteSystemPathBuf;
+    use turborepo_ui::UI;
 
     use crate::{
         cli::{Command, RunArgs},
         commands::CommandBase,
         get_version,
         run::Run,
-        ui::UI,
         Args,
     };
 

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -9,6 +9,7 @@ use tracing::{debug, info};
 use turborepo_cache::{http::APIAuth, AsyncCache};
 use turborepo_env::EnvironmentVariableMap;
 use turborepo_scm::SCM;
+use turborepo_ui::UI;
 
 use crate::{
     commands::CommandBase, config::TurboJson, daemon::DaemonConnector, manager::Manager,
@@ -61,7 +62,7 @@ impl Run {
         }
 
         // There's some warning handling code in Go that I'm ignoring
-        if self.base.ui.is_ci() && !opts.run_opts.no_daemon {
+        if UI::is_ci() && !opts.run_opts.no_daemon {
             info!("skipping turbod since we appear to be in a non-interactive context");
         } else if !opts.run_opts.no_daemon {
             let connector = DaemonConnector {

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -62,7 +62,7 @@ impl Run {
         }
 
         // There's some warning handling code in Go that I'm ignoring
-        if UI::is_ci() && !opts.run_opts.no_daemon {
+        if turborepo_ci::is_ci() && !std::io::stdout().is_terminal() && !opts.run_opts.no_daemon {
             info!("skipping turbod since we appear to be in a non-interactive context");
         } else if !opts.run_opts.no_daemon {
             let connector = DaemonConnector {

--- a/crates/turborepo-lib/src/shim.rs
+++ b/crates/turborepo-lib/src/shim.rs
@@ -17,10 +17,11 @@ use tiny_gradient::{GradientStr, RGB};
 use tracing::debug;
 use turbo_updater::check_for_updates;
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
+use turborepo_ui::UI;
 
 use crate::{
     cli, get_version, package_manager::WorkspaceGlobs, spawn_child, tracing::TurboSubscriber,
-    ui::UI, PackageManager, Payload,
+    PackageManager, Payload,
 };
 
 // all arguments that result in a stdout that much be directly parsable and

--- a/crates/turborepo-lib/src/tracing.rs
+++ b/crates/turborepo-lib/src/tracing.rs
@@ -22,8 +22,7 @@ use tracing_subscriber::{
     reload::{self, Error, Handle},
     EnvFilter, Layer, Registry,
 };
-
-use crate::ui::UI;
+use turborepo_ui::UI;
 
 type StdOutLog = Filtered<
     tracing_subscriber::fmt::Layer<Registry, DefaultFields, TurboFormatter>,

--- a/crates/turborepo-ui/Cargo.toml
+++ b/crates/turborepo-ui/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "turborepo-ui"
+version = "0.1.0"
+edition = "2021"
+license = "MPL-2.0"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[dev-dependencies]
+anyhow = { workspace = true }
+tempfile = { workspace = true }
+
+[dependencies]
+atty = { workspace = true }
+console = { workspace = true }
+indicatif = { workspace = true }
+lazy_static = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+turbopath = { workspace = true }

--- a/crates/turborepo-ui/Cargo.toml
+++ b/crates/turborepo-ui/Cargo.toml
@@ -17,3 +17,4 @@ lazy_static = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 turbopath = { workspace = true }
+turborepo-ci = { workspace = true }

--- a/crates/turborepo-ui/src/lib.rs
+++ b/crates/turborepo-ui/src/lib.rs
@@ -50,11 +50,6 @@ impl UI {
         Self { should_strip_ansi }
     }
 
-    // STUB
-    pub fn is_ci(&self) -> bool {
-        env::var("CI").is_ok()
-    }
-
     /// Infer the color choice from environment variables and checking if stdout
     /// is a tty
     pub fn infer() -> Self {

--- a/crates/turborepo-ui/src/lib.rs
+++ b/crates/turborepo-ui/src/lib.rs
@@ -1,6 +1,6 @@
 mod log_replayer;
 
-use std::{borrow::Cow, env, f64::consts::PI, io::IsTerminal, time::Duration};
+use std::{borrow::Cow, env, f64::consts::PI, time::Duration};
 
 use console::{Style, StyledObject};
 use indicatif::{ProgressBar, ProgressStyle};

--- a/crates/turborepo-ui/src/lib.rs
+++ b/crates/turborepo-ui/src/lib.rs
@@ -50,10 +50,6 @@ impl UI {
         Self { should_strip_ansi }
     }
 
-    pub fn is_ci() -> bool {
-        turborepo_ci::is_ci() && std::io::stdout().is_terminal()
-    }
-
     /// Infer the color choice from environment variables and checking if stdout
     /// is a tty
     pub fn infer() -> Self {

--- a/crates/turborepo-ui/src/lib.rs
+++ b/crates/turborepo-ui/src/lib.rs
@@ -1,6 +1,6 @@
 mod log_replayer;
 
-use std::{borrow::Cow, env, f64::consts::PI, time::Duration};
+use std::{borrow::Cow, env, f64::consts::PI, io::IsTerminal, time::Duration};
 
 use console::{Style, StyledObject};
 use indicatif::{ProgressBar, ProgressStyle};
@@ -48,6 +48,10 @@ pub struct UI {
 impl UI {
     pub fn new(should_strip_ansi: bool) -> Self {
         Self { should_strip_ansi }
+    }
+
+    pub fn is_ci() -> bool {
+        turborepo_ci::is_ci() && std::io::stdout().is_terminal()
     }
 
     /// Infer the color choice from environment variables and checking if stdout

--- a/crates/turborepo-ui/src/lib.rs
+++ b/crates/turborepo-ui/src/lib.rs
@@ -1,8 +1,19 @@
+mod log_replayer;
+
 use std::{borrow::Cow, env, f64::consts::PI, time::Duration};
 
 use console::{Style, StyledObject};
 use indicatif::{ProgressBar, ProgressStyle};
 use lazy_static::lazy_static;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("cannot read logs: {0}")]
+    CannotReadLogs(std::io::Error),
+    #[error("cannot write logs: {0}")]
+    CannotWriteLogs(std::io::Error),
+}
 
 pub fn start_spinner(message: &str) -> ProgressBar {
     let pb = ProgressBar::new_spinner();

--- a/crates/turborepo-ui/src/log_replayer.rs
+++ b/crates/turborepo-ui/src/log_replayer.rs
@@ -4,35 +4,39 @@ use std::{
     io::{BufRead, BufReader, Write},
 };
 
-use console::style;
 use tracing::{debug, warn};
 use turbopath::AbsoluteSystemPath;
 
 use crate::{Error, StyledObject, UI};
 
 #[allow(dead_code)]
-pub struct PrefixedUI<D: Display, W: Write> {
+pub struct PrefixedUI<D: Display + Clone, W: Write> {
     ui: UI,
     prefix: StyledObject<D>,
     output: W,
 }
 
 #[allow(dead_code)]
-impl<D: Display, W: Write> PrefixedUI<D, W> {
+impl<D: Display + Clone, W: Write> PrefixedUI<D, W> {
     pub fn new(ui: UI, prefix: StyledObject<D>, output: W) -> Self {
         Self { ui, prefix, output }
     }
 
-    pub fn output(&mut self, message: impl Into<String>) -> Result<(), Error> {
-        let message = style(format!("{} {}", self.prefix, message.into()));
-        writeln!(self.output, "{}", self.ui.apply(message)).map_err(Error::CannotWriteLogs)?;
+    pub fn output(&mut self, message: impl Display) -> Result<(), Error> {
+        writeln!(
+            self.output,
+            "{} {}",
+            self.ui.apply(self.prefix.clone()),
+            message
+        )
+        .map_err(Error::CannotWriteLogs)?;
 
         Ok(())
     }
 }
 
 #[allow(dead_code)]
-pub fn replay_logs<D: Display, W: Write>(
+pub fn replay_logs<D: Display + Clone, W: Write>(
     mut output: PrefixedUI<D, W>,
     log_file_name: &AbsoluteSystemPath,
 ) -> Result<(), Error> {

--- a/crates/turborepo-ui/src/log_replayer.rs
+++ b/crates/turborepo-ui/src/log_replayer.rs
@@ -10,7 +10,7 @@ use turbopath::AbsoluteSystemPath;
 use crate::{Error, StyledObject, UI};
 
 #[allow(dead_code)]
-pub struct PrefixedUI<D: Display + Clone, W: Write> {
+pub struct PrefixedUI<D, W> {
     ui: UI,
     prefix: StyledObject<D>,
     output: W,

--- a/crates/turborepo-ui/src/log_replayer.rs
+++ b/crates/turborepo-ui/src/log_replayer.rs
@@ -25,7 +25,7 @@ impl<D: Display + Clone, W: Write> PrefixedUI<D, W> {
     pub fn output(&mut self, message: impl Display) -> Result<(), Error> {
         writeln!(
             self.output,
-            "{} {}",
+            "{}{}",
             self.ui.apply(self.prefix.clone()),
             message
         )
@@ -84,8 +84,8 @@ mod tests {
 
         assert_eq!(
             String::from_utf8(output)?,
-            "\u{1b}[36m>\u{1b}[0m \n\u{1b}[36m>\u{1b}[0m one fish\n\u{1b}[36m>\u{1b}[0m two \
-             fish\n\u{1b}[36m>\u{1b}[0m red fish\n\u{1b}[36m>\u{1b}[0m blue fish\n"
+            "\u{1b}[36m>\u{1b}[0m\n\u{1b}[36m>\u{1b}[0mone fish\n\u{1b}[36m>\u{1b}[0mtwo \
+             fish\n\u{1b}[36m>\u{1b}[0mred fish\n\u{1b}[36m>\u{1b}[0mblue fish\n"
         );
 
         Ok(())

--- a/crates/turborepo-ui/src/log_replayer.rs
+++ b/crates/turborepo-ui/src/log_replayer.rs
@@ -9,6 +9,7 @@ use turbopath::AbsoluteSystemPath;
 
 use crate::{Error, StyledObject, UI};
 
+/// Writes to `output` with a prefix. The prefix is styled with `ui`.
 #[allow(dead_code)]
 pub struct PrefixedUI<D, W> {
     ui: UI,
@@ -22,6 +23,10 @@ impl<D: Display + Clone, W: Write> PrefixedUI<D, W> {
         Self { ui, prefix, output }
     }
 
+    /// Write `message` to `output` with the prefix. Note that this
+    /// does output the prefix when message is empty, unlike the Go
+    /// implementation. We do this because this behavior is what we actually
+    /// want for replaying logs.
     pub fn output(&mut self, message: impl Display) -> Result<(), Error> {
         writeln!(
             self.output,


### PR DESCRIPTION
### Description

I need some of the UI functionality in `turborepo-cache`, so I factored out the `turborepo-ui` crate to avoid circular dependencies.

I also added the log replayer code (which as far as I can tell does not need to be a function value since we don't use anything other than `defaultLogReplayer` in the Go code) and `PrefixedUI`.

### Testing Instructions

Wrote a simple test for log replayer.
