### PR TITLE
docs(ci-github-actions): fix indent 

### DIFF
--- a/docs/pages/repo/docs/ci/github-actions.mdx
+++ b/docs/pages/repo/docs/ci/github-actions.mdx
@@ -56,35 +56,35 @@ Create file called `.github/workflows/ci.yml` in your repository with the follow
 
     jobs:
       build:
-          name: Build and Test
-          timeout-minutes: 15
-          runs-on: ubuntu-latest
-          # To use Remote Caching, uncomment the next lines and follow the steps below.
-          # env:
-          #  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-          #  TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-          #  TURBO_REMOTE_ONLY: true
+        name: Build and Test
+        timeout-minutes: 15
+        runs-on: ubuntu-latest
+        # To use Remote Caching, uncomment the next lines and follow the steps below.
+        # env:
+        #  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+        #  TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+        #  TURBO_REMOTE_ONLY: true
 
-          steps:
-            - name: Check out code
-              uses: actions/checkout@v3
-              with:
-                fetch-depth: 2
+        steps:
+          - name: Check out code
+            uses: actions/checkout@v3
+            with:
+              fetch-depth: 2
 
-            - name: Setup Node.js environment
-              uses: actions/setup-node@v3
-              with:
-                node-version: 18
-                cache: 'npm'
+          - name: Setup Node.js environment
+            uses: actions/setup-node@v3
+            with:
+              node-version: 18
+              cache: 'npm'
 
-            - name: Install dependencies
-              run: npm install
+          - name: Install dependencies
+            run: npm install
 
-            - name: Build
-              run: npm run build
+          - name: Build
+            run: npm run build
 
-            - name: Test
-              run: npm run test
+          - name: Test
+            run: npm run test
     ```
 
   </Tab>
@@ -100,34 +100,34 @@ Create file called `.github/workflows/ci.yml` in your repository with the follow
 
     jobs:
       build:
-          name: Build and Test
-          timeout-minutes: 15
-          runs-on: ubuntu-latest
-          # To use Remote Caching, uncomment the next lines and follow the steps below.
-          # env:
-          #  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-          #  TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+        name: Build and Test
+        timeout-minutes: 15
+        runs-on: ubuntu-latest
+        # To use Remote Caching, uncomment the next lines and follow the steps below.
+        # env:
+        #  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+        #  TURBO_TEAM: ${{ vars.TURBO_TEAM }}
 
-          steps:
-            - name: Check out code
-              uses: actions/checkout@v3
-              with:
-                fetch-depth: 2
+        steps:
+          - name: Check out code
+            uses: actions/checkout@v3
+            with:
+              fetch-depth: 2
 
-            - name: Setup Node.js environment
-              uses: actions/setup-node@v3
-              with:
-                node-version: 18
-                cache: 'yarn'
+          - name: Setup Node.js environment
+            uses: actions/setup-node@v3
+            with:
+              node-version: 18
+              cache: 'yarn'
 
-            - name: Install dependencies
-              run: yarn
+          - name: Install dependencies
+            run: yarn
 
-            - name: Build
-              run: yarn build
+          - name: Build
+            run: yarn build
 
-            - name: Test
-              run: yarn test
+          - name: Test
+            run: yarn test
     ```
 
   </Tab>
@@ -143,38 +143,38 @@ Create file called `.github/workflows/ci.yml` in your repository with the follow
 
     jobs:
       build:
-          name: Build and Test
-          timeout-minutes: 15
-          runs-on: ubuntu-latest
-          # To use Remote Caching, uncomment the next lines and follow the steps below.
-          # env:
-          #  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-          #  TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+        name: Build and Test
+        timeout-minutes: 15
+        runs-on: ubuntu-latest
+        # To use Remote Caching, uncomment the next lines and follow the steps below.
+        # env:
+        #  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+        #  TURBO_TEAM: ${{ vars.TURBO_TEAM }}
 
-          steps:
-            - name: Check out code
-              uses: actions/checkout@v3
-              with:
-                fetch-depth: 2
+        steps:
+          - name: Check out code
+            uses: actions/checkout@v3
+            with:
+              fetch-depth: 2
 
-            - uses: pnpm/action-setup@v2.0.1
-              with:
-                version: 6.32.2
+          - uses: pnpm/action-setup@v2.0.1
+            with:
+              version: 6.32.2
 
-            - name: Setup Node.js environment
-              uses: actions/setup-node@v3
-              with:
-                node-version: 18
-                cache: 'pnpm'
+          - name: Setup Node.js environment
+            uses: actions/setup-node@v3
+            with:
+              node-version: 18
+              cache: 'pnpm'
 
-            - name: Install dependencies
-              run: pnpm install
+          - name: Install dependencies
+            run: pnpm install
 
-            - name: Build
-              run: pnpm build
+          - name: Build
+            run: pnpm build
 
-            - name: Test
-              run: pnpm test
+          - name: Test
+            run: pnpm test
     ```
 
   </Tab>


### PR DESCRIPTION
### Description

On the npm tab the indent looks right, but it seems to me that that wasn't the case for the yarn and pnpm tabs. I think this fixes it! :)

I found out while C&P'ing the yarn one to use in a project.

### Testing Instructions

Build the docs and check that the indent looks good now for the yarn and pnpm tabs.
