### PR TITLE
chore(turborepo): Refactor globwatcher setup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2874,11 +2874,13 @@ dependencies = [
  "pin-project",
  "stop-token",
  "test-case",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tracing",
  "tracing-subscriber",
  "tracing-test",
+ "turbopath",
  "unic-segment",
  "walkdir",
 ]

--- a/crates/turborepo-globwatch/Cargo.toml
+++ b/crates/turborepo-globwatch/Cargo.toml
@@ -14,9 +14,11 @@ notify = "5.1"
 notify-debouncer-mini = { version = "0.2.1", default-features = false }
 pin-project = "1.0.12"
 stop-token = "0.7.0"
+thiserror = { workspace = true }
 tokio = { version = "1.25.0", features = ["sync"] }
 tokio-stream = "0.1.12"
 tracing = "0.1.37"
+turbopath = { workspace = true }
 unic-segment = "0.9.0"
 walkdir = "2.3.2"
 

--- a/crates/turborepo-globwatch/examples/cancel.rs
+++ b/crates/turborepo-globwatch/examples/cancel.rs
@@ -3,11 +3,13 @@ use std::{path::PathBuf, time::Duration};
 use futures::{join, StreamExt};
 use globwatch::GlobWatcher;
 use tracing::{info, info_span};
+use turbopath::AbsoluteSystemPathBuf;
 
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt::init();
-    let (watcher, config) = GlobWatcher::new("./flush".into()).unwrap();
+    let flush_dir = AbsoluteSystemPathBuf::from_cwd("./flush").unwrap();
+    let (watcher, config) = GlobWatcher::new(&flush_dir).unwrap();
     let stop = stop_token::StopSource::new();
     let mut stream = watcher.into_stream(stop.token());
 

--- a/crates/turborepo-globwatch/src/lib.rs
+++ b/crates/turborepo-globwatch/src/lib.rs
@@ -23,6 +23,7 @@
 use std::{
     collections::HashMap,
     fs::File,
+    io,
     path::{Path, PathBuf},
     sync::{
         atomic::{AtomicU64, Ordering},
@@ -30,24 +31,41 @@ use std::{
     },
 };
 
-use camino::Utf8PathBuf;
 use futures::{channel::oneshot, future::Either, FutureExt, Stream, StreamExt as _};
 use itertools::Itertools;
 use merge_streams::MergeStreams;
 pub use notify::{Event, Watcher};
 pub use stop_token::{stream::StreamExt, StopSource, StopToken, TimedOutError};
+use thiserror::Error;
 use tokio::sync::{
     mpsc::{UnboundedReceiver, UnboundedSender},
     watch,
 };
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::{error, event, span, trace, warn, Level};
+use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, PathError};
+
+/// WatchError wraps errors produced by GlobWatcher
+#[derive(Debug, Error)]
+pub enum WatchError {
+    // TODO: find a generic way to include the path in these errors
+    /// PathError wraps errors encountered dealing with paths while filewatching
+    #[error("Filewatching encountered a path error: {0}")]
+    PathError(#[from] PathError),
+    /// IO wraps IO errors encountered while attempting to watch the filesystem
+    #[error("Filewatching encountered an IO Error: {0}")]
+    IO(#[from] io::Error),
+    /// Backend wraps errors produced from the underlying filewatching
+    /// implementation.
+    #[error("Filewatching backend error: {0}")]
+    Backend(#[from] notify::Error),
+}
 
 /// A wrapper around notify that allows for glob-based watching.
 #[derive(Debug)]
 pub struct GlobWatcher {
     stream: UnboundedReceiver<Event>,
-    flush_dir: PathBuf,
+    flush_dir: AbsoluteSystemPathBuf,
 
     config: UnboundedReceiver<WatcherCommand>,
     setup_handle: tokio::task::JoinHandle<Result<(), notify::Error>>,
@@ -59,13 +77,12 @@ impl GlobWatcher {
     /// see the module-level documentation.
     #[tracing::instrument]
     pub fn new(
-        flush_dir: Utf8PathBuf,
-    ) -> Result<(Self, WatchConfig<notify::RecommendedWatcher>), notify::Error> {
+        flush_dir: &AbsoluteSystemPath,
+    ) -> Result<(Self, WatchConfig<notify::RecommendedWatcher>), WatchError> {
         let (send_event, receive_event) = tokio::sync::mpsc::unbounded_channel();
         let (send_config, receive_config) = tokio::sync::mpsc::unbounded_channel();
 
-        // even if this fails, we may still be able to continue
-        std::fs::create_dir_all(&flush_dir).ok();
+        flush_dir.create_dir_all()?;
         let flush_dir = flush_dir.canonicalize()?;
 
         let watcher = notify::recommended_watcher(move |event: Result<Event, notify::Error>| {
@@ -95,21 +112,20 @@ impl GlobWatcher {
         // so we just fire and forget a thread to do it in the
         // background, to cut our startup time in half.
         let flush = watcher.clone();
-        let path = flush_dir.as_path().to_owned();
+        let flush_watch_path = flush_dir.clone();
         let (setup_broadcaster, setup_receiver) = watch::channel(None);
         let setup_handle = tokio::task::spawn_blocking(move || {
-            if let Err(e) = flush
-                .lock()
-                .expect("only fails if poisoned")
-                .watch(&path, notify::RecursiveMode::Recursive)
-            {
+            if let Err(e) = flush.lock().expect("only fails if poisoned").watch(
+                flush_watch_path.as_std_path(),
+                notify::RecursiveMode::Recursive,
+            ) {
                 warn!("failed to watch flush dir: {}", e);
                 if setup_broadcaster.send(Some(false)).is_err() {
                     trace!("failed to notify failed flush watch");
                 }
                 Err(e)
             } else {
-                trace!("watching flush dir: {:?}", path);
+                trace!("watching flush dir: {:?}", flush_watch_path);
                 if setup_broadcaster.send(Some(true)).is_err() {
                     trace!("failed to notify successful flush watch");
                 }
@@ -233,7 +249,7 @@ impl GlobWatcher {
                             Either::Right(Ok(WatcherCommand::Flush(tx))) => {
                                 // create file in flush dir
                                 let flush_id = flush_id.fetch_add(1, Ordering::SeqCst);
-                                let flush_file = flush_dir.join(flush_id.to_string());
+                                let flush_file = flush_dir.join_component(&flush_id.to_string());
                                 if let Err(e) = File::create(flush_file) {
                                     warn!("failed to create flush file: {}", e);
                                 } else {

--- a/crates/turborepo-globwatch/src/lib.rs
+++ b/crates/turborepo-globwatch/src/lib.rs
@@ -83,7 +83,7 @@ impl GlobWatcher {
         let (send_config, receive_config) = tokio::sync::mpsc::unbounded_channel();
 
         flush_dir.create_dir_all()?;
-        let flush_dir = flush_dir.canonicalize()?;
+        let flush_dir = flush_dir.to_realpath()?;
 
         let watcher = notify::recommended_watcher(move |event: Result<Event, notify::Error>| {
             let span = span!(tracing::Level::TRACE, "watcher");

--- a/crates/turborepo-lib/src/daemon/client.rs
+++ b/crates/turborepo-lib/src/daemon/client.rs
@@ -7,7 +7,7 @@ use super::{
     connector::{DaemonConnector, DaemonConnectorError},
     endpoint::SocketOpenError,
 };
-use crate::get_version;
+use crate::{get_version, globwatcher::HashGlobSetupError};
 
 pub mod proto {
     tonic::include_proto!("turbodprotocol");
@@ -151,7 +151,7 @@ pub enum DaemonError {
     InvalidTimeout(String),
     /// The server is unable to start file watching.
     #[error("unable to start file watching")]
-    FileWatching(#[from] notify::Error),
+    SetupFileWatching(#[from] HashGlobSetupError),
 
     #[error("unable to display output: {0}")]
     DisplayError(#[from] serde_json::Error),

--- a/crates/turborepo-lib/src/daemon/server.rs
+++ b/crates/turborepo-lib/src/daemon/server.rs
@@ -86,8 +86,8 @@ impl DaemonServer<notify::RecommendedWatcher> {
         let daemon_root = base.daemon_file_root();
 
         let watcher = Arc::new(HashGlobWatcher::new(
-            base.repo_root.clone(),
-            daemon_root.join_component("flush").as_path().to_owned(),
+            &base.repo_root,
+            &daemon_root.join_component("flush"),
         )?);
 
         let (send_shutdown, recv_shutdown) = tokio::sync::oneshot::channel::<()>();

--- a/crates/turborepo-lib/src/globwatcher/mod.rs
+++ b/crates/turborepo-lib/src/globwatcher/mod.rs
@@ -5,14 +5,14 @@ use std::{
     time::Duration,
 };
 
-use camino::Utf8PathBuf;
 use futures::{stream::iter, StreamExt};
-use globwatch::{ConfigError, GlobWatcher, StopToken, WatchConfig, Watcher};
+use globwatch::{ConfigError, GlobWatcher, StopToken, WatchConfig, WatchError, Watcher};
 use itertools::Itertools;
 use notify::{EventKind, RecommendedWatcher};
+use thiserror::Error;
 use tokio::time::timeout;
 use tracing::{trace, warn};
-use turbopath::AbsoluteSystemPathBuf;
+use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, PathError};
 use wax::{Glob as WaxGlob, Pattern};
 
 // these aliases are for readability, but they're just strings. it may make
@@ -48,15 +48,28 @@ pub struct GlobSet {
     exclude: HashSet<Glob>,
 }
 
+#[derive(Debug, Error)]
+pub enum HashGlobSetupError {
+    #[error("failed to start tracking hash-globs {0}")]
+    WatchError(#[from] WatchError),
+    #[error("failed to calculate relative path for hash-glob watching ({1}): {0}")]
+    PathError(PathError, AbsoluteSystemPathBuf),
+}
+
 impl HashGlobWatcher<RecommendedWatcher> {
     #[tracing::instrument]
     pub fn new(
-        relative_to: AbsoluteSystemPathBuf,
-        flush_folder: Utf8PathBuf,
-    ) -> Result<Self, notify::Error> {
+        relative_to: &AbsoluteSystemPath,
+        flush_folder: &AbsoluteSystemPath,
+    ) -> Result<Self, HashGlobSetupError> {
         let (watcher, config) = GlobWatcher::new(flush_folder)?;
+        let relative_to = relative_to
+            .canonicalize()
+            .map_err(|e| HashGlobSetupError::PathError(e, relative_to.to_owned()))?
+            .as_std_path()
+            .to_owned();
         Ok(Self {
-            relative_to: relative_to.as_path().canonicalize()?,
+            relative_to,
             hash_globs: Default::default(),
             glob_statuses: Default::default(),
             watcher: Arc::new(Mutex::new(Some(watcher))),
@@ -357,16 +370,19 @@ fn clear_hash_globs(
 
 #[cfg(test)]
 mod test {
-    use std::{fs::File, sync::Arc, time::Duration};
+    use std::{sync::Arc, time::Duration};
 
-    use camino::Utf8PathBuf;
     use globwatch::StopSource;
     use tokio::time::timeout;
-    use turbopath::AbsoluteSystemPathBuf;
+    use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, RelativeUnixPathBuf};
 
-    fn setup() -> tempdir::TempDir {
-        let tmp = tempdir::TempDir::new("globwatch").unwrap();
+    fn temp_dir() -> (AbsoluteSystemPathBuf, tempfile::TempDir) {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = AbsoluteSystemPathBuf::try_from(tmp.path()).unwrap();
+        (path, tmp)
+    }
 
+    fn setup(tmp: &AbsoluteSystemPath) {
         let directories = ["my-pkg/dist/distChild", "my-pkg/.next/cache"];
 
         let files = [
@@ -377,28 +393,26 @@ mod test {
         ];
 
         for dir in directories.iter() {
-            std::fs::create_dir_all(tmp.path().join(dir)).unwrap();
+            let dir = RelativeUnixPathBuf::new(*dir).unwrap();
+            tmp.join_unix_path(&dir).unwrap().create_dir_all().unwrap();
         }
 
         for file in files.iter() {
-            std::fs::File::create(tmp.path().join(file)).unwrap();
+            let file = RelativeUnixPathBuf::new(*file).unwrap();
+            tmp.join_unix_path(&file)
+                .unwrap()
+                .create_with_contents("")
+                .unwrap();
         }
-
-        tmp
     }
 
     #[tokio::test]
     #[tracing_test::traced_test]
     async fn track_outputs() {
-        let dir = setup();
-        let flush = tempdir::TempDir::new("globwatch-flush").unwrap();
-        let watcher = Arc::new(
-            super::HashGlobWatcher::new(
-                AbsoluteSystemPathBuf::try_from(dir.path()).unwrap(),
-                Utf8PathBuf::try_from(flush.path().to_path_buf()).unwrap(),
-            )
-            .unwrap(),
-        );
+        let (dir, _) = temp_dir();
+        setup(&dir);
+        let (flush, _) = temp_dir();
+        let watcher = Arc::new(super::HashGlobWatcher::new(&dir, &flush).unwrap());
 
         let stop = StopSource::new();
 
@@ -432,7 +446,9 @@ mod test {
 
         // change a file that is neither included nor excluded
 
-        File::create(dir.path().join("my-pkg/irrelevant2")).unwrap();
+        dir.join_components(&["my-pkg", "irrelevant2"])
+            .create_with_contents("")
+            .unwrap();
         let changed = watcher
             .changed_globs(&hash, include.clone().into_iter().collect())
             .await
@@ -446,7 +462,9 @@ mod test {
 
         // change a file that is excluded
 
-        File::create(dir.path().join("my-pkg/.next/cache/next-file2")).unwrap();
+        dir.join_components(&["my-pkg", ".next", "cache", "next-file2"])
+            .create_with_contents("")
+            .unwrap();
         let changed = watcher
             .changed_globs(&hash, include.clone().into_iter().collect())
             .await
@@ -460,7 +478,9 @@ mod test {
 
         // change a file that is included
 
-        File::create(dir.path().join("my-pkg/dist/dist-file2")).unwrap();
+        dir.join_components(&["my-pkg", "dist", "dist-file2"])
+            .create_with_contents("")
+            .unwrap();
         let changed = watcher
             .changed_globs(&hash, include.clone().into_iter().collect())
             .await
@@ -475,7 +495,9 @@ mod test {
         // change a file that is included but with a subdirectory that is excluded
         // now both globs should be marked as changed
 
-        File::create(dir.path().join("my-pkg/.next/next-file2")).unwrap();
+        dir.join_components(&["my-pkg", ".next", "next-file2"])
+            .create_with_contents("")
+            .unwrap();
         let changed = watcher
             .changed_globs(&hash, include.clone().into_iter().collect())
             .await
@@ -502,15 +524,10 @@ mod test {
     #[tokio::test]
     #[tracing_test::traced_test]
     async fn test_multiple_hashes() {
-        let dir = setup();
-        let flush = tempdir::TempDir::new("globwatch-flush").unwrap();
-        let watcher = Arc::new(
-            super::HashGlobWatcher::new(
-                AbsoluteSystemPathBuf::try_from(dir.path()).unwrap(),
-                Utf8PathBuf::try_from(flush.path().to_path_buf()).unwrap(),
-            )
-            .unwrap(),
-        );
+        let (dir, _) = temp_dir();
+        setup(&dir);
+        let (flush, _) = temp_dir();
+        let watcher = Arc::new(super::HashGlobWatcher::new(&dir, &flush).unwrap());
 
         let stop = StopSource::new();
 
@@ -565,7 +582,9 @@ mod test {
 
         // make a change excluded in only one of the hashes
 
-        File::create(dir.path().join("my-pkg/.next/cache/next-file2")).unwrap();
+        dir.join_components(&["my-pkg", ".next", "cache", "next-file2"])
+            .create_with_contents("")
+            .unwrap();
         let changed = watcher
             .changed_globs(&hash1, globs1_inclusion.clone().into_iter().collect())
             .await
@@ -590,7 +609,9 @@ mod test {
 
         // make a change for the other hash
 
-        File::create(dir.path().join("my-pkg/.next/next-file2")).unwrap();
+        dir.join_components(&["my-pkg", ".next", "next-file2"])
+            .create_with_contents("")
+            .unwrap();
         let changed = watcher
             .changed_globs(&hash2, globs2_inclusion.clone().into_iter().collect())
             .await
@@ -620,15 +641,10 @@ mod test {
     #[tokio::test]
     #[tracing_test::traced_test]
     async fn watch_single_file() {
-        let dir = setup();
-        let flush = tempdir::TempDir::new("globwatch-flush").unwrap();
-        let watcher = Arc::new(
-            super::HashGlobWatcher::new(
-                AbsoluteSystemPathBuf::try_from(dir.path()).unwrap(),
-                Utf8PathBuf::try_from(flush.path().to_path_buf()).unwrap(),
-            )
-            .unwrap(),
-        );
+        let (dir, _) = temp_dir();
+        setup(&dir);
+        let (flush, _) = temp_dir();
+        let watcher = Arc::new(super::HashGlobWatcher::new(&dir, &flush).unwrap());
 
         let stop = StopSource::new();
 
@@ -646,7 +662,9 @@ mod test {
             .await
             .unwrap();
 
-        File::create(dir.path().join("my-pkg/.next/irrelevant")).unwrap();
+        dir.join_components(&["my-pkg", ".next", "irrelevant"])
+            .create_with_contents("")
+            .unwrap();
         let changed = watcher
             .changed_globs(&hash, inclusions.clone().into_iter().collect())
             .await
@@ -658,7 +676,9 @@ mod test {
             changed
         );
 
-        File::create(dir.path().join("my-pkg/.next/next-file")).unwrap();
+        dir.join_components(&["my-pkg", ".next", "next-file"])
+            .create_with_contents("")
+            .unwrap();
         let changed = watcher
             .changed_globs(&hash, inclusions.clone().into_iter().collect())
             .await
@@ -685,15 +705,10 @@ mod test {
     #[tokio::test]
     #[tracing_test::traced_test]
     async fn delete_root_kill_daemon() {
-        let dir = setup();
-        let flush = tempdir::TempDir::new("globwatch-flush").unwrap();
-        let watcher = Arc::new(
-            super::HashGlobWatcher::new(
-                AbsoluteSystemPathBuf::try_from(dir.path()).unwrap(),
-                Utf8PathBuf::try_from(flush.path().to_path_buf()).unwrap(),
-            )
-            .unwrap(),
-        );
+        let (dir, _) = temp_dir();
+        setup(&dir);
+        let (flush, _) = temp_dir();
+        let watcher = Arc::new(super::HashGlobWatcher::new(&dir, &flush).unwrap());
 
         let stop = StopSource::new();
 
@@ -704,7 +719,7 @@ mod test {
         let task = tokio::task::spawn(async move { task_watcher.watch(token).await });
         tokio::time::sleep(Duration::from_secs(3)).await;
         watcher.config.flush().await.unwrap();
-        std::fs::remove_dir_all(dir.path()).unwrap();
+        dir.remove_dir_all().unwrap();
 
         // it should shut down
         match timeout(Duration::from_secs(60), task).await {

--- a/crates/turborepo-lib/src/globwatcher/mod.rs
+++ b/crates/turborepo-lib/src/globwatcher/mod.rs
@@ -64,7 +64,7 @@ impl HashGlobWatcher<RecommendedWatcher> {
     ) -> Result<Self, HashGlobSetupError> {
         let (watcher, config) = GlobWatcher::new(flush_folder)?;
         let relative_to = relative_to
-            .canonicalize()
+            .to_realpath()
             .map_err(|e| HashGlobSetupError::PathError(e, relative_to.to_owned()))?
             .as_std_path()
             .to_owned();

--- a/crates/turborepo-lib/src/globwatcher/mod.rs
+++ b/crates/turborepo-lib/src/globwatcher/mod.rs
@@ -409,9 +409,9 @@ mod test {
     #[tokio::test]
     #[tracing_test::traced_test]
     async fn track_outputs() {
-        let (dir, _) = temp_dir();
+        let (dir, _tmp_dir) = temp_dir();
         setup(&dir);
-        let (flush, _) = temp_dir();
+        let (flush, _tmp_flush) = temp_dir();
         let watcher = Arc::new(super::HashGlobWatcher::new(&dir, &flush).unwrap());
 
         let stop = StopSource::new();
@@ -524,9 +524,9 @@ mod test {
     #[tokio::test]
     #[tracing_test::traced_test]
     async fn test_multiple_hashes() {
-        let (dir, _) = temp_dir();
+        let (dir, _tmp_dir) = temp_dir();
         setup(&dir);
-        let (flush, _) = temp_dir();
+        let (flush, _tmp_flush) = temp_dir();
         let watcher = Arc::new(super::HashGlobWatcher::new(&dir, &flush).unwrap());
 
         let stop = StopSource::new();
@@ -641,9 +641,9 @@ mod test {
     #[tokio::test]
     #[tracing_test::traced_test]
     async fn watch_single_file() {
-        let (dir, _) = temp_dir();
+        let (dir, _tmp_dir) = temp_dir();
         setup(&dir);
-        let (flush, _) = temp_dir();
+        let (flush, _tmp_flush) = temp_dir();
         let watcher = Arc::new(super::HashGlobWatcher::new(&dir, &flush).unwrap());
 
         let stop = StopSource::new();
@@ -705,9 +705,9 @@ mod test {
     #[tokio::test]
     #[tracing_test::traced_test]
     async fn delete_root_kill_daemon() {
-        let (dir, _) = temp_dir();
+        let (dir, _tmp_dir) = temp_dir();
         setup(&dir);
-        let (flush, _) = temp_dir();
+        let (flush, _tmp_flush) = temp_dir();
         let watcher = Arc::new(super::HashGlobWatcher::new(&dir, &flush).unwrap());
 
         let stop = StopSource::new();

--- a/crates/turborepo-paths/src/absolute_system_path.rs
+++ b/crates/turborepo-paths/src/absolute_system_path.rs
@@ -235,6 +235,11 @@ impl AbsoluteSystemPath {
         Ok(AbsoluteSystemPathBuf(cleaned_path))
     }
 
+    pub fn canonicalize(&self) -> Result<AbsoluteSystemPathBuf, PathError> {
+        let canonicalized = self.0.canonicalize_utf8()?;
+        Ok(AbsoluteSystemPathBuf(canonicalized))
+    }
+
     // note that this is *not* lstat. If this is a symlink, it
     // will return metadata for the target.
     pub fn stat(&self) -> Result<Metadata, PathError> {

--- a/crates/turborepo-paths/src/absolute_system_path.rs
+++ b/crates/turborepo-paths/src/absolute_system_path.rs
@@ -235,9 +235,9 @@ impl AbsoluteSystemPath {
         Ok(AbsoluteSystemPathBuf(cleaned_path))
     }
 
-    pub fn canonicalize(&self) -> Result<AbsoluteSystemPathBuf, PathError> {
-        let canonicalized = self.0.canonicalize_utf8()?;
-        Ok(AbsoluteSystemPathBuf(canonicalized))
+    pub fn to_realpath(&self) -> Result<AbsoluteSystemPathBuf, PathError> {
+        let realpath = dunce::canonicalize(&self.0)?;
+        Ok(AbsoluteSystemPathBuf(Utf8PathBuf::try_from(realpath)?))
     }
 
     // note that this is *not* lstat. If this is a symlink, it

--- a/crates/turborepo-paths/src/absolute_system_path_buf.rs
+++ b/crates/turborepo-paths/src/absolute_system_path_buf.rs
@@ -211,11 +211,6 @@ impl AbsoluteSystemPathBuf {
     pub fn extension(&self) -> Option<&str> {
         self.0.extension()
     }
-
-    pub fn to_realpath(&self) -> Result<Self, PathError> {
-        let realpath = dunce::canonicalize(&self.0)?;
-        Ok(Self(Utf8PathBuf::try_from(realpath)?))
-    }
 }
 
 impl TryFrom<PathBuf> for AbsoluteSystemPathBuf {


### PR DESCRIPTION
### Description

 - Plumb through path library usage
 - Start categorizing errors, avoid exposing underlying `notify::Error` (cc @nathanhammond for errors data point, we'll want to do more in the future)
 - Added `canonicalize` to `AbsoluteSystemPath` 

### Testing Instructions

Tests updated to use path library, otherwise unchanged