### PR TITLE
fix(Turborepo): Drop argument separator for yarn

### DIFF
--- a/cli/internal/packagemanager/berry.go
+++ b/cli/internal/packagemanager/berry.go
@@ -10,12 +10,13 @@ import (
 )
 
 var nodejsBerry = PackageManager{
-	Name:       "nodejs-berry",
-	Slug:       "yarn",
-	Command:    "yarn",
-	Specfile:   "package.json",
-	Lockfile:   "yarn.lock",
-	PackageDir: "node_modules",
+	Name:         "nodejs-berry",
+	Slug:         "yarn",
+	Command:      "yarn",
+	Specfile:     "package.json",
+	Lockfile:     "yarn.lock",
+	PackageDir:   "node_modules",
+	ArgSeparator: func(_userArgs []string) []string { return nil },
 
 	getWorkspaceGlobs: func(rootpath turbopath.AbsoluteSystemPath) ([]string, error) {
 		pkg, err := fs.ReadPackageJSON(rootpath.UntypedJoin("package.json"))

--- a/cli/internal/packagemanager/npm.go
+++ b/cli/internal/packagemanager/npm.go
@@ -15,7 +15,7 @@ var nodejsNpm = PackageManager{
 	Specfile:     "package.json",
 	Lockfile:     "package-lock.json",
 	PackageDir:   "node_modules",
-	ArgSeparator: []string{"--"},
+	ArgSeparator: func(_userArgs []string) []string { return []string{"--"} },
 
 	getWorkspaceGlobs: func(rootpath turbopath.AbsoluteSystemPath) ([]string, error) {
 		pkg, err := fs.ReadPackageJSON(rootpath.UntypedJoin("package.json"))

--- a/cli/internal/packagemanager/packagemanager.go
+++ b/cli/internal/packagemanager/packagemanager.go
@@ -40,7 +40,7 @@ type PackageManager struct {
 
 	// The separator that the Package Manger uses to identify arguments that
 	// should be passed through to the underlying script.
-	ArgSeparator []string
+	ArgSeparator func(userArgs []string) []string
 
 	// Return the list of workspace glob
 	getWorkspaceGlobs func(rootpath turbopath.AbsoluteSystemPath) ([]string, error)

--- a/cli/internal/packagemanager/pnpm.go
+++ b/cli/internal/packagemanager/pnpm.go
@@ -87,7 +87,7 @@ var nodejsPnpm = PackageManager{
 	// We are allowed to use nil here because ArgSeparator already has a type, so it's a typed nil,
 	// This could just as easily be []string{}, but the style guide says to prefer
 	// nil for empty slices.
-	ArgSeparator:               nil,
+	ArgSeparator:               func(_userArgs []string) []string { return nil },
 	WorkspaceConfigurationPath: "pnpm-workspace.yaml",
 
 	getWorkspaceGlobs: getPnpmWorkspaceGlobs,

--- a/cli/internal/packagemanager/pnpm6.go
+++ b/cli/internal/packagemanager/pnpm6.go
@@ -19,7 +19,7 @@ var nodejsPnpm6 = PackageManager{
 	Specfile:                   "package.json",
 	Lockfile:                   "pnpm-lock.yaml",
 	PackageDir:                 "node_modules",
-	ArgSeparator:               []string{"--"},
+	ArgSeparator:               func(_userArgs []string) []string { return []string{"--"} },
 	WorkspaceConfigurationPath: "pnpm-workspace.yaml",
 
 	getWorkspaceGlobs: getPnpmWorkspaceGlobs,

--- a/cli/internal/packagemanager/yarn.go
+++ b/cli/internal/packagemanager/yarn.go
@@ -18,13 +18,12 @@ func (e *NoWorkspacesFoundError) Error() string {
 }
 
 var nodejsYarn = PackageManager{
-	Name:         "nodejs-yarn",
-	Slug:         "yarn",
-	Command:      "yarn",
-	Specfile:     "package.json",
-	Lockfile:     "yarn.lock",
-	PackageDir:   "node_modules",
-	ArgSeparator: []string{"--"},
+	Name:       "nodejs-yarn",
+	Slug:       "yarn",
+	Command:    "yarn",
+	Specfile:   "package.json",
+	Lockfile:   "yarn.lock",
+	PackageDir: "node_modules",
 
 	getWorkspaceGlobs: func(rootpath turbopath.AbsoluteSystemPath) ([]string, error) {
 		pkg, err := fs.ReadPackageJSON(rootpath.UntypedJoin("package.json"))

--- a/cli/internal/packagemanager/yarn.go
+++ b/cli/internal/packagemanager/yarn.go
@@ -24,6 +24,17 @@ var nodejsYarn = PackageManager{
 	Specfile:   "package.json",
 	Lockfile:   "yarn.lock",
 	PackageDir: "node_modules",
+	ArgSeparator: func(userArgs []string) []string {
+		// Yarn warns and swallows a "--" token. If the user is passing "--", we need
+		// to prepend our own so that the user's doesn't get swallowed. If they are not
+		// passing their own, we don't need the "--" token and can avoid the warning.
+		for _, arg := range userArgs {
+			if arg == "--" {
+				return []string{"--"}
+			}
+		}
+		return nil
+	},
 
 	getWorkspaceGlobs: func(rootpath turbopath.AbsoluteSystemPath) ([]string, error) {
 		pkg, err := fs.ReadPackageJSON(rootpath.UntypedJoin("package.json"))

--- a/cli/internal/run/real_run.go
+++ b/cli/internal/run/real_run.go
@@ -451,7 +451,7 @@ func (ec *execContext) exec(ctx gocontext.Context, packageTask *nodes.PackageTas
 	argsactual := append([]string{"run"}, packageTask.Task)
 	if len(passThroughArgs) > 0 {
 		// This will be either '--' or a typed nil
-		argsactual = append(argsactual, ec.packageManager.ArgSeparator...)
+		argsactual = append(argsactual, ec.packageManager.ArgSeparator(passThroughArgs)...)
 		argsactual = append(argsactual, passThroughArgs...)
 	}
 


### PR DESCRIPTION
### Description

Since Yarn 1.0, the `--` is not required to pass arguments to scripts, and in fact produces a warning. Yarn [v1.0.0](https://github.com/yarnpkg/yarn/releases/tag/v1.0.0) was 6 years ago, so assuming it's safe to drop the separator

 - Change `ArgSeparator` to a function that returns `[]string`, rather than a field. The function accepts the list of user arguments so that `yarn` can determine whether or not to make use of `--`.

Fixes #5702 

### Testing Instructions

Existing test suite