### PR TITLE
chore(docs): use correct npm flag in installation docs

### DIFF
--- a/docs/pages/repo/docs/installing.mdx
+++ b/docs/pages/repo/docs/installing.mdx
@@ -63,7 +63,7 @@ of the repository:
 <Tabs items={['npm', 'yarn', 'pnpm']} storageKey="selected-pkg-manager">
   <Tab>
     ```bash
-    npm install turbo --dev
+    npm install turbo --save-dev
     ```
   </Tab>
   <Tab>


### PR DESCRIPTION
### Description

In the ["Per Repository" installation instructions](https://turbo.build/repo/docs/installing#install-per-repository) `--dev` is suggested as the npm flag to install as a dev dependency. The correct flag is `--save-dev` - using `--dev` will trigger a warning and install it as a normal dependency. I suspect this bled over from the yarn instructions ✌️ 

### Testing Instructions

Gonna go out on a limb and say this isn't necessary here.
