### PR TITLE
chore(turbo): disable deployments for pages

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "git": {
+    "deploymentEnabled": {
+      "benchmark-data": false,
+      "gh-pages": false
+    }
+  }
+}


### PR DESCRIPTION
### Description

`gh-pages` and `benchmark-data` have completely different directory structures, and all preview deploys on Vercel always fail for these branches (because app directories don't exist). Clean this up by stopping the auto deploys. 

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
