### PR TITLE
test(ci): update datadog-ci

### DIFF
--- a/.github/workflows/nextjs-integration-test.yml
+++ b/.github/workflows/nextjs-integration-test.yml
@@ -215,19 +215,15 @@ jobs:
       - name: Download test reports artifact
         id: download-test-reports
         uses: actions/download-artifact@v3
-        continue-on-error: true
         with:
           name: Test trace reports
           path: test
       - name: Upload test trace to datadog
-        continue-on-error: true
         run: |
-          npm install -g junit-report-merger@6.0.2 @datadog/datadog-ci @aws-sdk/property-provider
-          jrm ./nextjs-test-result-junit.xml "test/**/*.xml"
+          npm install -g @datadog/datadog-ci@2.18.1
           ls -al ./test/*.xml
-          ls -al ./*.xml
           # We'll tag this to the Turbopack service, not the next.js
-          DD_ENV=ci datadog-ci junit upload --tags test.type:turbopack.daily --service Turbopack ./nextjs-test-result-junit.xml
+          DD_ENV=ci datadog-ci junit upload --tags test.type:turbopack.daily --service Turbopack test
 
       # For the debugging purpose, upload the test trace to github artifact.
       # So we can manually analyze test reports.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1048,7 +1048,7 @@ jobs:
         env:
           DATADOG_API_KEY: ${{ secrets.DD_KEY_TURBOPACK }}
         run: |
-          npm install -g @datadog/datadog-ci @aws-sdk/property-provider
+          npm install -g @datadog/datadog-ci@2.18.1
           # Query raw benchmark output, create key:value pairs for each benchmark entries.
           # The generated key name is compact format the path of the benchmark entry, i.e
           # `base.hmr_to_commit.CSR.1000.mean`
@@ -1407,7 +1407,7 @@ jobs:
           node-version: 18
 
       - name: Install datadog
-        run: npm install -g @datadog/datadog-ci
+        run: npm install -g @datadog/datadog-ci@2.18.1
 
       - name: Download test results
         uses: actions/download-artifact@v3


### PR DESCRIPTION
### Description

Two updates to fix datadog reporting

- update datadog-ci dep to specific version to remove dependency workaround
- remove `merging` step, let datadog-ci handles concurrent update for the multiple test results report