### PR TITLE
Update `context` property in JS to match serialized Rust type

### DIFF
--- a/crates/turbopack-ecmascript-runtime/js/src/dev/runtime/base/protocol.d.ts
+++ b/crates/turbopack-ecmascript-runtime/js/src/dev/runtime/base/protocol.d.ts
@@ -127,7 +127,7 @@ type IssueSource = {
 
 type Issue = {
   severity: IssueSeverity;
-  context: string;
+  file_path: string;
   category: string;
 
   title: string;


### PR DESCRIPTION
This was updated in Rust in #5661
