### PR TITLE
Add a FileSystemPathOption::none for cached cell reuse

### DIFF
--- a/crates/turbo-tasks-fs/src/lib.rs
+++ b/crates/turbo-tasks-fs/src/lib.rs
@@ -1120,7 +1120,7 @@ impl FileSystemPath {
                 Self::new_normalized(this.fs, path).resolve().await?,
             )))
         } else {
-            Ok(Vc::cell(None))
+            Ok(FileSystemPathOption::none())
         }
     }
 
@@ -1136,7 +1136,7 @@ impl FileSystemPath {
                 )));
             }
         }
-        Ok(Vc::cell(None))
+        Ok(FileSystemPathOption::none())
     }
 
     #[turbo_tasks::function]

--- a/crates/turbo-tasks-fs/src/lib.rs
+++ b/crates/turbo-tasks-fs/src/lib.rs
@@ -1022,6 +1022,14 @@ impl FileSystemPath {
 pub struct FileSystemPathOption(Option<Vc<FileSystemPath>>);
 
 #[turbo_tasks::value_impl]
+impl FileSystemPathOption {
+    #[turbo_tasks::function]
+    pub fn none() -> Vc<Self> {
+        Vc::cell(None)
+    }
+}
+
+#[turbo_tasks::value_impl]
 impl FileSystemPath {
     /// Create a new Vc<FileSystemPath> from a path withing a FileSystem. The
     /// /-separated path is expected to be already normalized (this is asserted

--- a/crates/turbopack-css/src/chunk/mod.rs
+++ b/crates/turbopack-css/src/chunk/mod.rs
@@ -90,7 +90,7 @@ impl CssChunk {
             while !*path.is_inside(current).await? {
                 let parent = current.parent().resolve().await?;
                 if parent == current {
-                    return Ok(Vc::cell(None));
+                    return Ok(FileSystemPathOption::none());
                 }
                 current = parent;
             }

--- a/crates/turbopack-ecmascript/src/chunk/mod.rs
+++ b/crates/turbopack-ecmascript/src/chunk/mod.rs
@@ -150,7 +150,7 @@ impl EcmascriptChunk {
             while !*path.is_inside_or_equal(current).await? {
                 let parent = current.parent().resolve().await?;
                 if parent == current {
-                    return Ok(Vc::cell(None));
+                    return Ok(FileSystemPathOption::none());
                 }
                 current = parent;
             }


### PR DESCRIPTION
### Description

Adds `FileSystemPathOption::none()`, which returns a stably cached cell to a `None` value.

### Testing Instructions


Closes WEB-1376
