### PR TITLE
Use shallow references in `any_content_changed_of_module`

### DIFF
--- a/crates/turbopack-core/src/changed.rs
+++ b/crates/turbopack-core/src/changed.rs
@@ -8,7 +8,7 @@ use crate::{
     asset::Asset,
     module::Module,
     output::{OutputAsset, OutputAssets},
-    reference::all_referenced_modules,
+    reference::primary_referenced_modules,
 };
 
 async fn get_referenced_output_assets(
@@ -20,7 +20,7 @@ async fn get_referenced_output_assets(
 async fn get_referenced_modules(
     parent: Vc<Box<dyn Module>>,
 ) -> Result<impl Iterator<Item = Vc<Box<dyn Module>>> + Send> {
-    Ok(all_referenced_modules(parent)
+    Ok(primary_referenced_modules(parent)
         .await?
         .clone_value()
         .into_iter())


### PR DESCRIPTION
### Description

Switches `get_referenced_modules` to use `primary_referenced_modules`, which only returns modules _directly_ referenced by this module. The old `all_referenced_modules` did its own recursive traversal of the module looking direct and transitively referenced modules, defeating the purpose of our `NonDeterministic().skip_duplicates()` graph traversal.

### Testing Instructions



Closes WEB-1378