### PR TITLE
Use shallow references in `RebasedAsset`

### DIFF
--- a/crates/turbopack/src/rebase/mod.rs
+++ b/crates/turbopack/src/rebase/mod.rs
@@ -8,7 +8,7 @@ use turbopack_core::{
     ident::AssetIdent,
     module::Module,
     output::{OutputAsset, OutputAssets},
-    reference::all_referenced_modules,
+    reference::primary_referenced_modules,
 };
 
 /// Converts a [Module] graph into an [OutputAsset] graph by placing it into a
@@ -50,14 +50,11 @@ impl OutputAsset for RebasedAsset {
 
     #[turbo_tasks::function]
     async fn references(&self) -> Result<Vc<OutputAssets>> {
-        let mut references = Vec::new();
-        for &module in all_referenced_modules(self.source).await?.iter() {
-            references.push(Vc::upcast(RebasedAsset::new(
-                module,
-                self.input_dir,
-                self.output_dir,
-            )));
-        }
+        let modules = primary_referenced_modules(self.source).await?;
+        let references = modules
+            .iter()
+            .map(|module| Vc::upcast(RebasedAsset::new(*module, self.input_dir, self.output_dir)))
+            .collect();
         Ok(Vc::cell(references))
     }
 }


### PR DESCRIPTION
### Description

Changes `RebasedAsset::references()` to rebase only the directly referenced modules, allowing further rebasing to happen when their references are requested.

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->


Closes WEB-1379