### PR TITLE
fix(turbo): remove trailing comma

### DIFF
--- a/packages/turbo/package.json
+++ b/packages/turbo/package.json
@@ -8,7 +8,7 @@
   "license": "MPL-2.0",
   "main": "./bin/turbo",
   "scripts": {
-    "postversion": "node bump-version.js",
+    "postversion": "node bump-version.js"
   },
   "bin": {
     "turbo": "./bin/turbo"


### PR DESCRIPTION
### Description

Trailing comma is read as invalid JSON depending on the parser. This was causing issues in `fs-extra`'s `readJsonSync`.