### PR TITLE
fix: give name to package so that it works with rust codepath

### DIFF
--- a/crates/turbopack-tests/tests/execution/package.json
+++ b/crates/turbopack-tests/tests/execution/package.json
@@ -1,5 +1,6 @@
 {
   "private": true,
+  "name": "execution-test",
   "dependencies": {
     "expect": "29.5.0",
     "jest-circus": "29.5.0",


### PR DESCRIPTION
### Description

The rust codepath for turbo doesn't like nameless packages. This fixes that. 

### Testing Instructions

- compile turbo with rust run enabled (instructions are complicated for now, but will be easier shortly)
- error that a package.json doesn't have a name

Closes WEB-1381