### PR TITLE
ci: Adding mold as linker

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -56,6 +56,8 @@ runs:
       shell: bash
       run: echo "::add-matcher::${{ github.action_path }}/matchers.json"
 
+    - uses: rui314/setup-mold@v1
+
     - name: "Setup Rust Cache"
       uses: Swatinem/rust-cache@v2
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -222,8 +222,6 @@ jobs:
 
       - run: turbo run build --filter=cli --color --env-mode=strict --token=${{ secrets.TURBO_TOKEN }} --team=${{ vars.TURBO_TEAM }}
 
-      - run: readelf -p .comment target/debug/turbo
-
   go_lint:
     name: Go linting
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -222,6 +222,8 @@ jobs:
 
       - run: turbo run build --filter=cli --color --env-mode=strict --token=${{ secrets.TURBO_TOKEN }} --team=${{ vars.TURBO_TEAM }}
 
+      - run: readelf -p .comment target/debug/turbo
+
   go_lint:
     name: Go linting
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description

Just a minor perf improvement to use `mold` versus `ld` for linking.

### Testing Instructions

confirmed with `readelf` that we're using mold