### PR TITLE
chore(labels): consolidate issue labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/0-turborepo-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/0-turborepo-bug-report.yml
@@ -1,7 +1,7 @@
 name: Turborepo Bug Report
 description: Create a bug report for the Turborepo team
 title: "[turborepo] "
-labels: ["kind: bug", "area: turborepo", "needs: triage"]
+labels: ["kind: bug", "owned-by: turborepo", "needs: triage"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/1-turbopack-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-turbopack-bug-report.yml
@@ -3,7 +3,7 @@
 name: Turbopack Bug Report
 description: Create a bug report for the Turbopack team
 title: "[turbopack] "
-labels: ["kind: bug", "area: turbopack", "needs: triage"]
+labels: ["kind: bug", "owned-by: web-tooling", "needs: triage"]
 body:
   - type: markdown
     attributes:

--- a/.github/turbo-orchestrator.yml
+++ b/.github/turbo-orchestrator.yml
@@ -30,7 +30,7 @@
 
 labeler:
   labels:
-    # teams
+    # owned-by
     - label: "owned-by: turborepo"
       when:
         isAnyFileOwnedByMatch: '@vercel\/turbo-oss'
@@ -39,10 +39,10 @@ labeler:
         isAnyFileOwnedByMatch: '@vercel\/web-tooling'
 
     # created-by
-    - label: "created-by: web-tooling team"
+    - label: "created-by: web-tooling"
       when:
         isPRAuthorMatch: "^(alexkirsz|Brooooooklyn|ForsakenHarmony|jridgewell|kdy1|kwonoj|padmaia|sokra|wbinnssmith)$"
-    - label: "created-by: turborepo team"
+    - label: "created-by: turborepo"
       when:
         isPRAuthorMatch: "^(gsoltis|gaspar09|nathanhammond|tknickman|mehulkar|chris-olszewski|NicholasLYang|arlyon)$"
 


### PR DESCRIPTION
### Description

_The last label related PR._ 

This makes sure we're using the same **team** labels for both issues and pull requests. 

It has always bothered me that labels get: `area: [team]` while pull requests would get `team: [team]`. 

This is now consolidated to only the `owned-by: [team]` label for both issues and pull requests. 

We also now include a `created-by: [team]` label.

