### PR TITLE
feat(Turborepo): Start implementing filewatching tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2873,6 +2873,7 @@ dependencies = [
  "notify-debouncer-mini",
  "pin-project",
  "stop-token",
+ "tempfile",
  "test-case",
  "thiserror",
  "tokio",

--- a/crates/turborepo-globwatch/Cargo.toml
+++ b/crates/turborepo-globwatch/Cargo.toml
@@ -23,6 +23,7 @@ unic-segment = "0.9.0"
 walkdir = "2.3.2"
 
 [dev-dependencies]
+tempfile = { workspace = true }
 test-case = "3.0.0"
 tokio = { version = "1.25.0", features = [
   "rt",

--- a/crates/turborepo-globwatch/src/lib.rs
+++ b/crates/turborepo-globwatch/src/lib.rs
@@ -354,6 +354,7 @@ impl<T: Watcher> WatchConfig<T> {
             .map_err(ConfigError::WatchError)
     }
 
+    /// add_root adds a *recursive* watch at a particular directory.
     pub async fn add_root(&self, root: &AbsoluteSystemPath) -> Result<(), ConfigError> {
         self.watcher
             .lock()

--- a/crates/turborepo-lib/src/globwatcher/mod.rs
+++ b/crates/turborepo-lib/src/globwatcher/mod.rs
@@ -37,7 +37,6 @@ pub struct HashGlobWatcher<T: Watcher> {
     /// maps a glob to the hashes for which this glob hasn't changed
     glob_statuses: Arc<Mutex<HashMap<Glob, HashSet<Hash>>>>,
 
-    #[allow(dead_code)]
     watcher: Arc<Mutex<Option<GlobWatcher>>>,
     config: WatchConfig<T>,
 }

--- a/crates/turborepo-paths/src/absolute_system_path.rs
+++ b/crates/turborepo-paths/src/absolute_system_path.rs
@@ -8,7 +8,7 @@ use std::{
     fmt,
     fs::{File, Metadata, OpenOptions, Permissions},
     io,
-    path::Path,
+    path::{Path, PathBuf},
 };
 
 use camino::{Utf8Component, Utf8Components, Utf8Path, Utf8PathBuf};
@@ -348,6 +348,20 @@ impl AbsoluteSystemPath {
         fs::set_permissions(&self.0, permissions)?;
 
         Ok(())
+    }
+}
+
+impl PartialEq<&AbsoluteSystemPath> for Path {
+    fn eq(&self, other: &&AbsoluteSystemPath) -> bool {
+        Utf8Path::from_path(self)
+            .map(|path| &other.0 == path)
+            .unwrap_or(false)
+    }
+}
+
+impl PartialEq<&AbsoluteSystemPath> for PathBuf {
+    fn eq(&self, other: &&AbsoluteSystemPath) -> bool {
+        self.as_path().eq(other)
     }
 }
 

--- a/crates/turborepo-paths/src/absolute_system_path.rs
+++ b/crates/turborepo-paths/src/absolute_system_path.rs
@@ -260,6 +260,10 @@ impl AbsoluteSystemPath {
         fs::remove_file(&self.0)
     }
 
+    pub fn rename(&self, other: &Self) -> Result<(), io::Error> {
+        fs::rename(self, other)
+    }
+
     pub fn components(&self) -> Utf8Components<'_> {
         self.0.components()
     }


### PR DESCRIPTION
### Description

 - Some light type aliasing for the filewatcher to make it more readable
 - Add `PartialEq` for `Path` and `PathBuf` to `AbsoluteSystemPath` to allow for comparisons
 - Add _some_ of the tests from Go's `filewatcher_test.go`. 
 - Add `add_root` to mirror Go's implementation. This will likely eventually take the place of `include` so that globs are moved up a layer.

Note that some significant restructuring of Rust filewatching is going to need to happen to get the rest of the Go tests moved over.

### Testing Instructions

Added new tests
