### PR TITLE
fix(release): correct version script

### DIFF
--- a/packages/turbo/bump-version.js
+++ b/packages/turbo/bump-version.js
@@ -1,18 +1,26 @@
 #!/usr/bin/env node
 
 const fs = require("fs");
-const {
-  knownUnixlikePackages,
-  knownWindowsPackages,
-} = require("./node-platform");
-
 const pkg = require("./package.json");
+
 const file = require.resolve("./package.json");
+
+const knownWindowsPackages = {
+  "win32 arm64 LE": "turbo-windows-arm64",
+  "win32 x64 LE": "turbo-windows-64",
+};
+
+const knownUnixLikePackages = {
+  "darwin arm64 LE": "turbo-darwin-arm64",
+  "darwin x64 LE": "turbo-darwin-64",
+  "linux arm64 LE": "turbo-linux-arm64",
+  "linux x64 LE": "turbo-linux-64",
+};
 
 pkg.optionalDependencies = Object.fromEntries(
   Object.values({
     ...knownWindowsPackages,
-    ...knownUnixlikePackages,
+    ...knownUnixLikePackages,
   })
     .sort()
     .map((x) => [x, pkg.version])


### PR DESCRIPTION
### Description

We still need the platform / arch enums to update versions.

These were removed as part of https://github.com/vercel/turbo/pull/5695