### PR TITLE
fix(turborepo): Windows platform detection

### DIFF
--- a/.github/actions/setup-turborepo-environment/action.yml
+++ b/.github/actions/setup-turborepo-environment/action.yml
@@ -43,5 +43,5 @@ runs:
       shell: bash
       run: |
         VERSION=$(npm view turbo --json | jq -r '.versions | last')
-        echo "Latest pubblished version: $VERSION"
+        echo "Latest published version: $VERSION"
         npm i -g turbo@$VERSION

--- a/packages/turbo/bin/turbo
+++ b/packages/turbo/bin/turbo
@@ -66,7 +66,12 @@ function getBinaryPath() {
   // The only place where the binary can be at this point is `require.resolve`-able
   // relative to this package as it should be installed as an optional dependency.
 
-  const { platform, arch } = process;
+  let { platform, arch } = process;
+  // Node uses `win32` but we want to use `windows` for consistency with
+  // our package naming conventions (i.e. `turbo-windows-64`).
+  if (platform === "win32") {
+    platform = "windows";
+  }
   const resolvedArch = arch === 'x64' ? '64' : arch;
   const ext = platform === 'windows' ? '.exe' : '';
 


### PR DESCRIPTION
### Description

In our new `turbo` script we look for `windows` as a platform name, but node returns `win32` by default. Added a quick fix to convert `win32` to `windows` since we already use `windows` in multiple places like our package names.

### Testing Instructions

