### PR TITLE
fix(lockfile): use correct ffi method for global changes

### DIFF
--- a/cli/internal/ffi/ffi.go
+++ b/cli/internal/ffi/ffi.go
@@ -257,7 +257,7 @@ func GlobalChange(packageManager string, prevContents []byte, currContents []byt
 		CurrContents:   currContents,
 	}
 	reqBuf := Marshal(&req)
-	resBuf := C.patches(reqBuf)
+	resBuf := C.global_change(reqBuf)
 	reqBuf.Free()
 
 	resp := ffi_proto.GlobalChangeResponse{}


### PR DESCRIPTION
### Description

Sharp eyes @arlyon caught that this we weren't using the correct FFI function for checking for global lockfile changes.

This would cause a panic if it got hit since the response buffer wouldn't decode correctly.

### Testing Instructions

Eyes