### PR TITLE
Add support to integration tests for experimental rust codepath

### DIFF
--- a/cli/internal/turbostate/turbostate.go
+++ b/cli/internal/turbostate/turbostate.go
@@ -39,27 +39,28 @@ type RunPayload struct {
 	//   "foo" -> flag passed and file name attached: emit to file
 	// The mirror for this in Rust is `Option<String>` with the default value
 	// for the flag being `Some("")`.
-	Graph               *string  `json:"graph"`
-	Ignore              []string `json:"ignore"`
-	IncludeDependencies bool     `json:"include_dependencies"`
-	NoCache             bool     `json:"no_cache"`
-	NoDaemon            bool     `json:"no_daemon"`
-	NoDeps              bool     `json:"no_deps"`
-	Only                bool     `json:"only"`
-	OutputLogs          string   `json:"output_logs"`
-	LogOrder            string   `json:"log_order"`
-	PassThroughArgs     []string `json:"pass_through_args"`
-	Parallel            bool     `json:"parallel"`
-	Profile             string   `json:"profile"`
-	RemoteOnly          bool     `json:"remote_only"`
-	Scope               []string `json:"scope"`
-	Since               string   `json:"since"`
-	SinglePackage       bool     `json:"single_package"`
-	Summarize           bool     `json:"summarize"`
-	Tasks               []string `json:"tasks"`
-	PkgInferenceRoot    string   `json:"pkg_inference_root"`
-	LogPrefix           string   `json:"log_prefix"`
-	ExperimentalSpaceID string   `json:"experimental_space_id"`
+	Graph                    *string  `json:"graph"`
+	Ignore                   []string `json:"ignore"`
+	IncludeDependencies      bool     `json:"include_dependencies"`
+	NoCache                  bool     `json:"no_cache"`
+	NoDaemon                 bool     `json:"no_daemon"`
+	NoDeps                   bool     `json:"no_deps"`
+	Only                     bool     `json:"only"`
+	OutputLogs               string   `json:"output_logs"`
+	LogOrder                 string   `json:"log_order"`
+	PassThroughArgs          []string `json:"pass_through_args"`
+	Parallel                 bool     `json:"parallel"`
+	Profile                  string   `json:"profile"`
+	RemoteOnly               bool     `json:"remote_only"`
+	Scope                    []string `json:"scope"`
+	Since                    string   `json:"since"`
+	SinglePackage            bool     `json:"single_package"`
+	Summarize                bool     `json:"summarize"`
+	Tasks                    []string `json:"tasks"`
+	PkgInferenceRoot         string   `json:"pkg_inference_root"`
+	LogPrefix                string   `json:"log_prefix"`
+	ExperimentalSpaceID      string   `json:"experimental_space_id"`
+	ExperimentalRustCodepath bool     `json:"experimental_rust_codepath"`
 }
 
 // Command consists of the data necessary to run a command.

--- a/crates/turborepo-lib/src/cli.rs
+++ b/crates/turborepo-lib/src/cli.rs
@@ -539,8 +539,7 @@ pub struct RunArgs {
 
     /// Opt-in to the rust codepath for running turbo
     /// rather than using the go shim
-    #[cfg(feature = "run-stub")]
-    #[clap(long)]
+    #[clap(long, env, hide = true, default_value_t = false)]
     pub experimental_rust_codepath: bool,
 }
 
@@ -773,6 +772,9 @@ pub async fn run(
         }
         #[cfg(not(feature = "run-stub"))]
         Command::Run(args) => {
+            if args.experimental_rust_codepath {
+                warn!("rust codepath enabled, but not compiled with support");
+            }
             if args.tasks.is_empty() {
                 return Err(anyhow!("at least one task must be specified"));
             }

--- a/crates/turborepo-lib/src/cli.rs
+++ b/crates/turborepo-lib/src/cli.rs
@@ -5,7 +5,7 @@ use camino::Utf8PathBuf;
 use clap::{ArgAction, CommandFactory, Parser, Subcommand, ValueEnum};
 use clap_complete::{generate, Shell};
 use serde::{Deserialize, Serialize};
-use tracing::{debug, error};
+use tracing::{debug, error, warn};
 use turbopath::AbsoluteSystemPathBuf;
 use turborepo_ui::UI;
 

--- a/crates/turborepo-lib/src/cli.rs
+++ b/crates/turborepo-lib/src/cli.rs
@@ -5,7 +5,7 @@ use camino::Utf8PathBuf;
 use clap::{ArgAction, CommandFactory, Parser, Subcommand, ValueEnum};
 use clap_complete::{generate, Shell};
 use serde::{Deserialize, Serialize};
-use tracing::{debug, error, warn};
+use tracing::{debug, error};
 use turbopath::AbsoluteSystemPathBuf;
 use turborepo_ui::UI;
 
@@ -773,7 +773,7 @@ pub async fn run(
         #[cfg(not(feature = "run-stub"))]
         Command::Run(args) => {
             if args.experimental_rust_codepath {
-                warn!("rust codepath enabled, but not compiled with support");
+                tracing::warn!("rust codepath enabled, but not compiled with support");
             }
             if args.tasks.is_empty() {
                 return Err(anyhow!("at least one task must be specified"));

--- a/crates/turborepo-lib/src/commands/run.rs
+++ b/crates/turborepo-lib/src/commands/run.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error};
 
 use crate::{commands::CommandBase, run::Run};
 
@@ -9,7 +9,7 @@ pub async fn run(base: CommandBase) -> Result<()> {
     debug!("configured run struct: {:?}", run);
 
     match run.run().await {
-        Ok(code) => Ok(()),
+        Ok(_code) => Ok(()),
         Err(err) => {
             error!("run failed: {}", err);
             Err(err)

--- a/crates/turborepo-lib/src/commands/run.rs
+++ b/crates/turborepo-lib/src/commands/run.rs
@@ -1,16 +1,15 @@
 use anyhow::Result;
-use tracing::{error, info};
+use tracing::{debug, error, info, warn};
 
 use crate::{commands::CommandBase, run::Run};
 
-#[allow(dead_code)]
 pub async fn run(base: CommandBase) -> Result<()> {
-    info!("Executing run stub");
     let mut run = Run::new(base);
-    info!("configured run struct: {:?}", run);
+    debug!("using the experimental rust codepath");
+    debug!("configured run struct: {:?}", run);
 
     match run.run().await {
-        Ok(_) => Ok(()),
+        Ok(code) => Ok(()),
         Err(err) => {
             error!("run failed: {}", err);
             Err(err)

--- a/turborepo-tests/e2e/package.json
+++ b/turborepo-tests/e2e/package.json
@@ -1,7 +1,8 @@
 {
   "name": "turborepo-tests-e2e",
   "scripts": {
-    "test": "node -r esbuild-register index.ts"
+    "test": "node -r esbuild-register index.ts",
+    "test-rust-codepath": "EXPERIMENTAL_RUST_CODEPATH=true node -r esbuild-register index.ts"
   },
   "dependencies": {
     "esbuild": "^0.15.0",

--- a/turborepo-tests/e2e/package.json
+++ b/turborepo-tests/e2e/package.json
@@ -2,7 +2,7 @@
   "name": "turborepo-tests-e2e",
   "scripts": {
     "test": "node -r esbuild-register index.ts",
-    "test-rust-codepath": "EXPERIMENTAL_RUST_CODEPATH=true node -r esbuild-register index.ts"
+    "test:rust-codepath": "EXPERIMENTAL_RUST_CODEPATH=true node -r esbuild-register index.ts"
   },
   "dependencies": {
     "esbuild": "^0.15.0",

--- a/turborepo-tests/integration/package.json
+++ b/turborepo-tests/integration/package.json
@@ -3,6 +3,7 @@
   "scripts": {
     "test:setup": "./setup.sh",
     "test": "./test.sh",
+    "test:rust-codepath": "EXPERIMENTAL_RUST_CODEPATH=true ./test.sh",
     "test:interactive": ".cram_env/bin/prysk -i --shell=`which bash` tests",
     "test:parallel": ".cram_env/bin/pytest -n auto tests --prysk-shell=`which bash`",
     "pretest:parallel": ".cram_env/bin/pip3 install --quiet pytest \"prysk[pytest-plugin]\" pytest-xdist"

--- a/turborepo-tests/integration/tests/bad_flag.t
+++ b/turborepo-tests/integration/tests/bad_flag.t
@@ -19,7 +19,7 @@ Bad flag with an implied run command should display run flags
   
     note: to pass '--bad-flag' as a value, use '-- --bad-flag'
   
-  Usage: turbo <--cache-dir <CACHE_DIR>|--cache-workers <CACHE_WORKERS>|--concurrency <CONCURRENCY>|--continue|--dry-run [<DRY_RUN>]|--single-package|--filter <FILTER>|--force [<FORCE>]|--framework-inference [<BOOL>]|--global-deps <GLOBAL_DEPS>|--graph [<GRAPH>]|--env-mode [<ENV_MODE>]|--ignore <IGNORE>|--include-dependencies|--no-cache|--no-daemon|--no-deps|--output-logs <OUTPUT_LOGS>|--log-order <LOG_ORDER>|--only|--parallel|--pkg-inference-root <PKG_INFERENCE_ROOT>|--profile <PROFILE>|--remote-only [<BOOL>]|--scope <SCOPE>|--since <SINCE>|--summarize [<SUMMARIZE>]|--log-prefix <LOG_PREFIX>|TASKS|PASS_THROUGH_ARGS|--experimental-space-id <EXPERIMENTAL_SPACE_ID>>
+  Usage: turbo <--cache-dir <CACHE_DIR>|--cache-workers <CACHE_WORKERS>|--concurrency <CONCURRENCY>|--continue|--dry-run [<DRY_RUN>]|--single-package|--filter <FILTER>|--force [<FORCE>]|--framework-inference [<BOOL>]|--global-deps <GLOBAL_DEPS>|--graph [<GRAPH>]|--env-mode [<ENV_MODE>]|--ignore <IGNORE>|--include-dependencies|--no-cache|--no-daemon|--no-deps|--output-logs <OUTPUT_LOGS>|--log-order <LOG_ORDER>|--only|--parallel|--pkg-inference-root <PKG_INFERENCE_ROOT>|--profile <PROFILE>|--remote-only [<BOOL>]|--scope <SCOPE>|--since <SINCE>|--summarize [<SUMMARIZE>]|--log-prefix <LOG_PREFIX>|TASKS|PASS_THROUGH_ARGS|--experimental-space-id <EXPERIMENTAL_SPACE_ID>|--experimental-rust-codepath>
   
   For more information, try '--help'.
   


### PR DESCRIPTION
### Description

This PR adds some basic logging / flags to use the rust codepath. When the binary is compiled with the `run-stub` feature, the `--experimental-rust-codepath` flag (better used with the env var of the same name) will opt the run into using rust, rather than go.

This also adds commands to integration and e2e for this. Note that e2e tests (prysk) will probably fail. This is because we currently print a warning when the codepath is entered.

### Testing Instructions

```
cargo build --features run-stub
cd turborepo-tests/integration
pnpm i
pnpm run test:rust-codepath
```

Note: this is based on https://github.com/vercel/turbo/pull/5727 otherwise turbo fails during workspace enumeration.