### PR TITLE
chore: dedupe our lockfile names

### DIFF
--- a/crates/turborepo-lib/src/package_manager/mod.rs
+++ b/crates/turborepo-lib/src/package_manager/mod.rs
@@ -432,9 +432,9 @@ impl PackageManager {
 
     pub fn lockfile_name(&self) -> &'static str {
         match self {
-            PackageManager::Npm => "package-lock.json",
-            PackageManager::Pnpm | PackageManager::Pnpm6 => "pnpm-lock.yaml",
-            PackageManager::Yarn | PackageManager::Berry => "yarn.lock",
+            PackageManager::Npm => npm::LOCKFILE,
+            PackageManager::Pnpm | PackageManager::Pnpm6 => pnpm::LOCKFILE,
+            PackageManager::Yarn | PackageManager::Berry => yarn::LOCKFILE,
         }
     }
 


### PR DESCRIPTION
### Description

Noticed that I added new instances of the lockfile names in #5531 when they were already present in the package manager modules themselves.

This PR switches over to using those instead.

### Testing Instructions

👀 
