### PR TITLE
chore: remove pass through env from experimental fields

### DIFF
--- a/crates/turborepo-lib/src/config/turbo.rs
+++ b/crates/turborepo-lib/src/config/turbo.rs
@@ -745,9 +745,7 @@ mod tests {
                 "DependsOn".to_string()
             ].into_iter().collect(),
             experimental_fields: HashSet::new(),
-            experimental: TaskDefinitionExperiments {
-                pass_through_env: vec![],
-            },
+            experimental: TaskDefinitionExperiments {},
             task_definition: TaskDefinitionHashable {
                 dot_env: vec![RelativeUnixPathBuf::new("package/a/.env").unwrap()],
                 env: vec!["OS".to_string()],

--- a/crates/turborepo-lib/src/task_graph/mod.rs
+++ b/crates/turborepo-lib/src/task_graph/mod.rs
@@ -22,9 +22,7 @@ pub struct BookkeepingTaskDefinition {
 // experimental. We keep these separated so we can compute a global hash without
 // these.
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
-pub struct TaskDefinitionExperiments {
-    pub(crate) pass_through_env: Vec<String>,
-}
+pub struct TaskDefinitionExperiments {}
 
 // TaskOutputs represents the patterns for including and excluding files from
 // outputs


### PR DESCRIPTION
### Description

I noticed we had `pass_through_env` listed in both the experimental and hashable fields on the Rust side. We only populate the hashable variant so this PR just removes the experimental variant to match the Go version.

### Testing Instructions

Compare with the [Go struct](https://github.com/vercel/turbo/blob/main/cli/internal/fs/turbo_json.go#L136)
