### PR TITLE
chore(types): consolidate packagejson type

### DIFF
--- a/packages/turbo-gen/src/commands/workspace/prompts.ts
+++ b/packages/turbo-gen/src/commands/workspace/prompts.ts
@@ -4,11 +4,15 @@ import inquirer from "inquirer";
 import { minimatch } from "minimatch";
 import validName from "validate-npm-package-name";
 import type { Project, Workspace } from "@turbo/workspaces";
-import { validateDirectory, logger } from "@turbo/utils";
+import {
+  validateDirectory,
+  logger,
+  type DependencyGroups,
+  type PackageJson,
+} from "@turbo/utils";
 import { getWorkspaceStructure } from "../../utils/getWorkspaceStructure";
 import type { WorkspaceType } from "../../generators/types";
 import { getWorkspaceList } from "../../utils/getWorkspaceList";
-import type { DependencyGroups, PackageJson } from "../../types";
 
 export async function name({
   override,

--- a/packages/turbo-gen/src/generators/copy.ts
+++ b/packages/turbo-gen/src/generators/copy.ts
@@ -2,10 +2,14 @@ import path from "path";
 import fs from "fs-extra";
 import chalk from "chalk";
 import { CopyFilterAsync } from "fs-extra";
-import { createProject, logger } from "@turbo/utils";
+import {
+  createProject,
+  logger,
+  type DependencyGroups,
+  type PackageJson,
+} from "@turbo/utils";
 import { gatherAddRequirements } from "../utils/gatherAddRequirements";
 import type { TurboGeneratorArguments } from "./types";
-import { DependencyGroups, PackageJson } from "../types";
 
 export async function generate({ project, opts }: TurboGeneratorArguments) {
   const { name, type, location, source, dependencies } =

--- a/packages/turbo-gen/src/generators/empty.ts
+++ b/packages/turbo-gen/src/generators/empty.ts
@@ -1,10 +1,9 @@
 import path from "path";
 import fs from "fs-extra";
 import chalk from "chalk";
-import { logger } from "@turbo/utils";
+import { logger, type PackageJson, type DependencyGroups } from "@turbo/utils";
 import { gatherAddRequirements } from "../utils/gatherAddRequirements";
 import type { TurboGeneratorArguments } from "./types";
-import type { PackageJson, DependencyGroups } from "../types";
 
 export async function generate({ project, opts }: TurboGeneratorArguments) {
   const { name, location, dependencies } = await gatherAddRequirements({

--- a/packages/turbo-gen/src/types.ts
+++ b/packages/turbo-gen/src/types.ts
@@ -1,22 +1,4 @@
 import type * as PlopTypes from "node-plop";
 
-interface DependencyGroups {
-  dependencies?: Record<string, string>;
-  devDependencies?: Record<string, string>;
-  peerDependencies?: Record<string, string>;
-  optionalDependencies?: Record<string, string>;
-}
-
-interface PackageJson extends DependencyGroups {
-  name: string;
-  version: string;
-  private?: boolean;
-  description?: string;
-  workspaces?: Array<string> | Record<string, Array<string>>;
-  main?: string;
-  module?: string;
-  exports?: object;
-  scripts?: Record<string, string>;
-}
-
-export type { PlopTypes, DependencyGroups, PackageJson };
+// re-export types to include them in the published package
+export type { PlopTypes };

--- a/packages/turbo-utils/src/getTurboConfigs.ts
+++ b/packages/turbo-utils/src/getTurboConfigs.ts
@@ -1,10 +1,12 @@
 import fs from "fs";
 import path from "path";
-import { getTurboRoot } from "./getTurboRoot";
 import yaml from "js-yaml";
 import { sync } from "fast-glob";
 import { Schema } from "@turbo/types";
 import JSON5 from "json5";
+
+import { getTurboRoot } from "./getTurboRoot";
+import type { PackageJson } from "./types";
 
 const ROOT_GLOB = "turbo.json";
 const ROOT_WORKSPACE_GLOB = "package.json";
@@ -24,11 +26,6 @@ export type TurboConfig = {
 };
 
 export type TurboConfigs = Array<TurboConfig>;
-
-interface PackageJson {
-  turbo?: Schema;
-  workspaces?: { packages: Array<string> } | Array<string>;
-}
 
 interface Options {
   cache?: boolean;

--- a/packages/turbo-utils/src/index.ts
+++ b/packages/turbo-utils/src/index.ts
@@ -30,3 +30,4 @@ export type {
   TurboConfigs,
   WorkspaceConfig,
 } from "./getTurboConfigs";
+export * from "./types";

--- a/packages/turbo-utils/src/types.ts
+++ b/packages/turbo-utils/src/types.ts
@@ -1,0 +1,25 @@
+import { Schema } from "@turbo/types";
+
+export type DependencyList = Record<string, string>;
+
+export interface DependencyGroups {
+  dependencies?: DependencyList;
+  devDependencies?: DependencyList;
+  peerDependencies?: DependencyList;
+  optionalDependencies?: DependencyList;
+}
+
+export interface PackageJson extends DependencyGroups {
+  name: string;
+  version: string;
+  description?: string;
+  private?: boolean;
+  packageManager?: string;
+  // there can be more in here, but we only care about packages
+  workspaces?: Array<string> | { packages: Array<string> };
+  main?: string;
+  module?: string;
+  exports?: object;
+  scripts?: Record<string, string>;
+  turbo?: Schema;
+}

--- a/packages/turbo-workspaces/__tests__/managers.test.ts
+++ b/packages/turbo-workspaces/__tests__/managers.test.ts
@@ -2,7 +2,7 @@ import path from "path";
 import { setupTestFixtures } from "@turbo/test-utils";
 import { Logger } from "../src/logger";
 import MANAGERS from "../src/managers";
-import { PackageJson } from "../src/types";
+import type { PackageJson } from "@turbo/utils";
 import fs from "fs-extra";
 import {
   generateDetectMatrix,

--- a/packages/turbo-workspaces/src/types.ts
+++ b/packages/turbo-workspaces/src/types.ts
@@ -36,22 +36,6 @@ export type Workspace = {
 
 export type WorkspaceInfo = Pick<Workspace, "name" | "description">;
 
-export type DependencyList = Record<string, string>;
-
-export type PackageJsonDependencies = {
-  dependencies?: DependencyList;
-  devDependencies?: DependencyList;
-  peerDependencies?: DependencyList;
-  optionalDependencies?: DependencyList;
-};
-
-export type PackageJson = PackageJsonDependencies & {
-  name?: string;
-  description?: string;
-  workspaces?: { packages: Array<string> } | Array<string>;
-  packageManager?: string;
-};
-
 export type DetectArgs = {
   workspaceRoot: string;
 };

--- a/packages/turbo-workspaces/src/updateDependencies.ts
+++ b/packages/turbo-workspaces/src/updateDependencies.ts
@@ -1,14 +1,8 @@
 import fs from "fs-extra";
 import chalk from "chalk";
 import path from "path";
-import {
-  Project,
-  Workspace,
-  DependencyList,
-  PackageManagerDetails,
-  Options,
-  PackageJsonDependencies,
-} from "./types";
+import type { DependencyList, DependencyGroups } from "@turbo/utils";
+import { Project, Workspace, PackageManagerDetails, Options } from "./types";
 import { Logger } from "./logger";
 import { getPackageJson } from "./utils";
 
@@ -65,14 +59,14 @@ export default function updateDependencies({
   });
 
   // collect stats as we go for consolidated output at the end
-  const stats: Record<keyof PackageJsonDependencies, Array<string>> = {
+  const stats: Record<keyof DependencyGroups, Array<string>> = {
     dependencies: [],
     devDependencies: [],
     peerDependencies: [],
     optionalDependencies: [],
   };
 
-  const allDependencyKeys: Array<keyof PackageJsonDependencies> = [
+  const allDependencyKeys: Array<keyof DependencyGroups> = [
     "dependencies",
     "devDependencies",
     "peerDependencies",
@@ -93,7 +87,7 @@ export default function updateDependencies({
     }
   });
 
-  const toLog = (key: keyof PackageJsonDependencies) => {
+  const toLog = (key: keyof DependencyGroups) => {
     const total = stats[key].length;
     if (total > 0) {
       return `${chalk.green(total.toString())} ${key}`;

--- a/packages/turbo-workspaces/src/utils.ts
+++ b/packages/turbo-workspaces/src/utils.ts
@@ -2,13 +2,8 @@ import fs from "fs-extra";
 import path from "path";
 import glob from "fast-glob";
 import yaml from "js-yaml";
-import {
-  PackageJson,
-  PackageManager,
-  Project,
-  Workspace,
-  WorkspaceInfo,
-} from "./types";
+import { PackageManager, Project, Workspace, WorkspaceInfo } from "./types";
+import type { PackageJson } from "@turbo/utils";
 import { ConvertError } from "./errors";
 
 // adapted from https://github.com/nodejs/corepack/blob/cae770694e62f15fed33dd8023649d77d96023c1/sources/specUtils.ts#L14


### PR DESCRIPTION
### Description

Consolidate to a single definition of `PackageJson` to ensure no more of the alternate `workspace` format bugs sneak in again.

This type is in `@turbo/utils` instead of `@turbo/types` to keep the latter lean and mean for sharing only the turbo config type.


Closes TURBO-1223