### PR TITLE
fix(example): basic example react version in ui package

### DIFF
--- a/examples/basic/packages/ui/package.json
+++ b/examples/basic/packages/ui/package.json
@@ -13,7 +13,7 @@
     "@types/react-dom": "^18.2.0",
     "eslint": "^7.32.0",
     "eslint-config-custom": "workspace:*",
-    "react": "^17.0.2",
+    "react": "^18.2.0",
     "tsconfig": "workspace:*",
     "typescript": "^4.5.2"
   }


### PR DESCRIPTION
### Description
This PR fixes the issue mentioned in https://github.com/vercel/turbo/issues/5756

<!--
  ✍️ Write a short summary of your work.
  If necessary, include relevant screenshots.
-->
Corrected version of react same as `web` and `docs` app so that we don't have to manually change react version while installing boiler plate on turbo

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->

- Install basic boiler plate of turbo app. UI package will use the same react version which is used by `web` and `docs` app
