### PR TITLE
fix: Update React version to 18.2.0 in UI package of 'basic' boilerplate

### DIFF
--- a/examples/basic/packages/ui/package.json
+++ b/examples/basic/packages/ui/package.json
@@ -13,7 +13,7 @@
     "@types/react-dom": "^18.2.0",
     "eslint": "^7.32.0",
     "eslint-config-custom": "workspace:*",
-    "react": "^17.0.2",
+    "react": "^18.2.0",
     "tsconfig": "workspace:*",
     "typescript": "^4.5.2"
   }


### PR DESCRIPTION
This commit addresses a dependency conflict related to React versions in the UI package of the 'basic' boilerplate. The conflict arose when installing the Material-UI (@mui/material) package.

### Description

Updated the React version in the UI package from 17.0.2 to 18.2.0 to align with the peer dependency requirements of Material-UI.

### Testing Instructions

1. Pull this branch locally and ensure you have the 'basic' boilerplate set up.
2. Navigate to the UI package directory.
3. Run the following command to install Material-UI package: **npm install @mui/material**
4. Verify that there are no errors or warnings related to dependency conflicts during the installation.

Closes #5761 