### PR TITLE
fix(turborepo): Better unlink Output

### DIFF
--- a/crates/turborepo-lib/src/commands/mod.rs
+++ b/crates/turborepo-lib/src/commands/mod.rs
@@ -74,18 +74,6 @@ impl CommandBase {
         Ok(self.repo_config.get_mut().unwrap())
     }
 
-    // NOTE: This deletes the repo config file. It does *not* remove the
-    // `RepoConfig` struct from `CommandBase`. This is fine because we
-    // currently do not have any commands that delete the repo config file
-    // and then attempt to read from it.
-    pub fn delete_repo_config_file(&mut self) -> Result<()> {
-        let repo_config_path = get_repo_config_path(self.repo_root.borrow());
-        if repo_config_path.exists() {
-            std::fs::remove_file(repo_config_path)?;
-        }
-        Ok(())
-    }
-
     fn user_config_init(&self) -> Result<UserConfig, ConfigError> {
         UserConfigLoader::new(default_user_config_path()?)
             .with_token(self.args.token.clone())

--- a/crates/turborepo-lib/src/commands/unlink.rs
+++ b/crates/turborepo-lib/src/commands/unlink.rs
@@ -14,20 +14,14 @@ fn unlink_remote_caching(base: &mut CommandBase) -> Result<()> {
     let repo_config: &mut crate::config::RepoConfig = base.repo_config_mut()?;
     let needs_disabling = repo_config.team_id().is_some() || repo_config.team_slug().is_some();
 
-    if needs_disabling {
-        base.repo_config_mut()?.set_team_id(None)?;
-
-        println!(
-            "{}",
-            base.ui.apply(GREY.apply_to("> Disabled Remote Caching"))
-        );
+    let output = if needs_disabling {
+        repo_config.set_team_id(None)?;
+        "> Disabled Remote Caching"
     } else {
-        println!(
-            "{}",
-            base.ui
-                .apply(GREY.apply_to("> No Remote Caching config found"))
-        );
-    }
+        "> No Remote Caching config found"
+    };
+
+    println!("{}", base.ui.apply(GREY.apply_to(output)));
 
     Ok(())
 }
@@ -38,27 +32,20 @@ fn unlink_spaces(base: &mut CommandBase) -> Result<()> {
         repo_config.space_team_id().is_some() || repo_config.space_team_slug().is_some();
 
     if needs_disabling {
-        base.repo_config_mut()?.set_space_team_id(None)?;
+        repo_config.set_space_team_id(None)?;
     }
 
     // Space config is _also_ in turbo.json.
     let result =
         remove_spaces_from_turbo_json(base).context("could not unlink. Something went wrong")?;
 
-    match (needs_disabling, result) {
-        (_, UnlinkSpacesResult::Unlinked) => {
-            println!("{}", base.ui.apply(GREY.apply_to("> Unlinked Spaces")));
-        }
-        (true, _) => {
-            println!("{}", base.ui.apply(GREY.apply_to("> Unlinked Spaces")));
-        }
-        (false, UnlinkSpacesResult::NoSpacesFound) => {
-            println!(
-                "{}",
-                base.ui.apply(GREY.apply_to("> No Spaces config found"))
-            );
-        }
-    }
+    let output = match (needs_disabling, result) {
+        (_, UnlinkSpacesResult::Unlinked) => "> Unlinked Spaces",
+        (true, _) => "> Unlinked Spaces",
+        (false, UnlinkSpacesResult::NoSpacesFound) => "> No Spaces config found",
+    };
+
+    println!("{}", base.ui.apply(GREY.apply_to(output)));
 
     Ok(())
 }


### PR DESCRIPTION
`turbo unlink` previously would delete the entire configuration file which is unnecessarily punishing, this switches to do the absolute minimum change to the file.

Closes TURBO-1225