### PR TITLE
fix: copy root json to full directory

### DIFF
--- a/crates/turborepo-lib/src/commands/prune.rs
+++ b/crates/turborepo-lib/src/commands/prune.rs
@@ -187,7 +187,7 @@ pub fn prune(
             prune.copy_file(&patch.to_system_path(), Some(CopyDestination::Docker))?;
         }
     } else {
-        prune.copy_file(package_json(), Some(CopyDestination::All))?;
+        prune.copy_file(package_json(), Some(CopyDestination::Docker))?;
     }
 
     Ok(())

--- a/crates/turborepo-lib/src/commands/prune.rs
+++ b/crates/turborepo-lib/src/commands/prune.rs
@@ -168,7 +168,7 @@ pub fn prune(
 
         let original = prune.root.resolve(package_json());
         let permissions = original.symlink_metadata()?.permissions();
-        let new_package_json_path = prune.out_directory.resolve(package_json());
+        let new_package_json_path = prune.full_directory.resolve(package_json());
         new_package_json_path.create_with_contents(&pruned_json_contents)?;
         #[cfg(unix)]
         new_package_json_path.set_mode(permissions.mode())?;
@@ -187,7 +187,7 @@ pub fn prune(
             prune.copy_file(&patch.to_system_path(), Some(CopyDestination::Docker))?;
         }
     } else {
-        prune.copy_file(package_json(), Some(CopyDestination::Docker))?;
+        prune.copy_file(package_json(), Some(CopyDestination::All))?;
     }
 
     Ok(())

--- a/turborepo-tests/integration/tests/prune/docker.t
+++ b/turborepo-tests/integration/tests/prune/docker.t
@@ -15,6 +15,13 @@ Make sure patches are part of the json output
   patches
   pnpm-lock.yaml
   pnpm-workspace.yaml
+Make sure patches are part of the json output
+  $ ls out/full
+  apps
+  packages
+  patches
+  pnpm-workspace.yaml
+  turbo.json
 Make sure that pnpm-workspace.yaml is in the top out directory
   $ ls out
   full

--- a/turborepo-tests/integration/tests/prune/docker.t
+++ b/turborepo-tests/integration/tests/prune/docker.t
@@ -18,6 +18,7 @@ Make sure patches are part of the json output
 Make sure patches are part of the json output
   $ ls out/full
   apps
+  package.json
   packages
   patches
   pnpm-workspace.yaml
@@ -26,7 +27,6 @@ Make sure that pnpm-workspace.yaml is in the top out directory
   $ ls out
   full
   json
-  package.json
   pnpm-lock.yaml
   pnpm-workspace.yaml
 


### PR DESCRIPTION
### Description

Fixes #5768

We were copying the root `package.json` into `out` and not `out/full` as intended if the `--docker` flag was used. This behavior would only appear if the root `package.json` contained patches the needed to be pruned. This PR gets us back to the Go behavior.

### Testing Instructions

Started also tracking the contents of `out/full` in an integration test


Closes TURBO-1227