### PR TITLE
fix: make color selector threadsafe

### DIFF
--- a/crates/turborepo-ui/src/color_selector.rs
+++ b/crates/turborepo-ui/src/color_selector.rs
@@ -1,9 +1,6 @@
 use std::{
     collections::HashMap,
-    sync::{
-        atomic::{AtomicUsize, Ordering},
-        OnceLock,
-    },
+    sync::{Arc, Mutex, OnceLock, RwLock},
 };
 
 use console::Style;
@@ -26,26 +23,32 @@ pub fn get_terminal_package_colors() -> &'static [Style; 5] {
 /// Shared between tasks so allows for concurrent access.
 #[derive(Default)]
 pub struct ColorSelector {
-    idx: AtomicUsize,
-    cache: HashMap<String, Style>,
+    inner: Arc<RwLock<ColorSelectorInner>>,
+}
+
+#[derive(Default)]
+struct ColorSelectorInner {
+    idx: usize,
+    cache: HashMap<String, &'static Style>,
 }
 
 impl ColorSelector {
-    pub fn color_for_key(&mut self, key: &str) -> Style {
-        if let Some(style) = self.cache.get(key) {
-            return style.clone();
+    pub fn color_for_key(&self, key: &str) -> &'static Style {
+        if let Some(style) = self.inner.read().expect("lock poisoned").color(key) {
+            return style;
         }
 
-        let colors = get_terminal_package_colors();
-
-        let idx = self.idx.fetch_add(1, Ordering::Relaxed);
-        let color = colors[idx % colors.len()].clone();
-        self.cache.insert(key.to_string(), color.clone());
+        let color = {
+            self.inner
+                .write()
+                .expect("lock poisoned")
+                .insert_color(key.to_string())
+        };
 
         color
     }
 
-    pub fn prefix_with_color(&mut self, cache_key: &str, prefix: &str) -> String {
+    pub fn prefix_with_color(&self, cache_key: &str, prefix: &str) -> String {
         if prefix.is_empty() {
             return "".into();
         }
@@ -55,16 +58,58 @@ impl ColorSelector {
     }
 }
 
+impl ColorSelectorInner {
+    fn color(&self, key: &str) -> Option<&'static Style> {
+        self.cache.get(key).copied()
+    }
+
+    fn insert_color(&mut self, key: String) -> &'static Style {
+        let colors = get_terminal_package_colors();
+        let chosen_color = &colors[self.idx % colors.len()];
+        // A color might have been chosen by the time we get to inserting
+        self.cache.entry(key).or_insert_with(|| {
+            // If a color hasn't been chosen, then we increment the index
+            self.idx += 1;
+            chosen_color
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use std::thread;
 
     #[test]
     fn test_color_selector() {
-        let mut selector = super::ColorSelector::default();
+        let selector = super::ColorSelector::default();
         let color1 = selector.color_for_key("key1");
         let color2 = selector.color_for_key("key2");
         let color3 = selector.color_for_key("key1");
         assert_eq!(color1, color3);
         assert_ne!(color1, color2);
+    }
+
+    #[test]
+    fn test_multithreaded_selector() {
+        let selector = super::ColorSelector::default();
+        thread::scope(|s| {
+            s.spawn(|| {
+                let color = selector.color_for_key("key1");
+                assert_eq!(color, selector.color_for_key("key1"));
+            });
+            s.spawn(|| {
+                let color = selector.color_for_key("key2");
+                assert_eq!(color, selector.color_for_key("key2"));
+            });
+            s.spawn(|| {
+                let color1 = selector.color_for_key("key1");
+                let color2 = selector.color_for_key("key2");
+                assert_eq!(color1, selector.color_for_key("key1"));
+                assert_eq!(color2, selector.color_for_key("key2"));
+                assert_ne!(color1, color2);
+            });
+        });
+        // We only inserted 2 keys so next index should be 2
+        assert_eq!(selector.inner.read().unwrap().idx, 2);
     }
 }

--- a/crates/turborepo-ui/src/color_selector.rs
+++ b/crates/turborepo-ui/src/color_selector.rs
@@ -112,4 +112,13 @@ mod tests {
         // We only inserted 2 keys so next index should be 2
         assert_eq!(selector.inner.read().unwrap().idx, 2);
     }
+
+    #[test]
+    fn test_color_selector_wraps_around() {
+        let selector = super::ColorSelector::default();
+        for key in &["1", "2", "3", "4", "5", "6"] {
+            selector.color_for_key(key);
+        }
+        assert_eq!(selector.color_for_key("1"), selector.color_for_key("6"));
+    }
 }


### PR DESCRIPTION
### Description

As mentioned in the review of #5707 the implementation of `ColorSelector` wasn't threadsafe and could only be used by multiple threads if wrapped in an `Arc<Mutex<>>`. 

This PR hides the inner mutability of `ColorSelector` by wrapping the inner state in a `Arc<RwLock<>>`. If this seems like overly complex for the color selector we can use a mutex like in Go.

### Testing Instructions

Added unit test that uses the color selector from multiple threads. I also added a test for making sure we wrap around correctly.
