### PR TITLE
feat(Turborepo): Create a filewatching crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9751,6 +9751,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "turborepo-filewatch"
+version = "0.1.0"
+dependencies = [
+ "notify 4.0.17",
+]
+
+[[package]]
 name = "turborepo-fs"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9795,7 +9795,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "dashmap",
- "futures",
  "notify 6.0.1",
  "notify-debouncer-full",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9802,6 +9802,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "turbopath",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2400,6 +2400,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "file-id"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13be71e6ca82e91bc0cb862bebaac0b2d1924a5a1d970c822b2f98b63fda8c3"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4532,6 +4541,36 @@ dependencies = [
  "mio 0.8.6",
  "walkdir",
  "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "notify"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5738a2795d57ea20abec2d6d76c6081186709c0024187cd5977265eda6598b51"
+dependencies = [
+ "bitflags 1.3.2",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys 4.1.0",
+ "inotify 0.9.6",
+ "kqueue",
+ "libc",
+ "mio 0.8.6",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "notify-debouncer-full"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "416969970ec751a5d702a88c6cd19ac1332abe997fce43f96db0418550426241"
+dependencies = [
+ "file-id",
+ "notify 6.0.1",
+ "parking_lot",
+ "walkdir",
 ]
 
 [[package]]
@@ -9754,7 +9793,15 @@ dependencies = [
 name = "turborepo-filewatch"
 version = "0.1.0"
 dependencies = [
- "notify 4.0.17",
+ "anyhow",
+ "dashmap",
+ "futures",
+ "notify 6.0.1",
+ "notify-debouncer-full",
+ "tempfile",
+ "thiserror",
+ "tokio",
+ "turbopath",
 ]
 
 [[package]]
@@ -9851,6 +9898,7 @@ dependencies = [
  "turborepo-cache",
  "turborepo-ci",
  "turborepo-env",
+ "turborepo-filewatch",
  "turborepo-fs",
  "turborepo-lockfiles",
  "turborepo-scm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2410,13 +2410,13 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.21"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cbc844cecaee9d4443931972e1289c8ff485cb4cc2767cb03ca139ed6885153"
+checksum = "d4029edd3e734da6fe05b6cd7bd2960760a616bd2ddd0d59a0124746d6272af0"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall 0.2.16",
+ "redox_syscall 0.3.5",
  "windows-sys 0.48.0",
 ]
 
@@ -4545,20 +4545,21 @@ dependencies = [
 
 [[package]]
 name = "notify"
-version = "6.0.1"
+version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5738a2795d57ea20abec2d6d76c6081186709c0024187cd5977265eda6598b51"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.3.3",
  "crossbeam-channel",
  "filetime",
  "fsevent-sys 4.1.0",
  "inotify 0.9.6",
  "kqueue",
  "libc",
+ "log",
  "mio 0.8.6",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4568,7 +4569,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "416969970ec751a5d702a88c6cd19ac1332abe997fce43f96db0418550426241"
 dependencies = [
  "file-id",
- "notify 6.0.1",
+ "notify 6.1.1",
  "parking_lot",
  "walkdir",
 ]
@@ -9794,8 +9795,12 @@ name = "turborepo-filewatch"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bitflags 1.3.2",
  "dashmap",
- "notify 6.0.1",
+ "fsevent-sys 4.1.0",
+ "itertools",
+ "libc",
+ "notify 6.1.1",
  "notify-debouncer-full",
  "tempfile",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9806,6 +9806,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tracing",
  "turbopath",
  "walkdir",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9798,6 +9798,7 @@ dependencies = [
  "bitflags 1.3.2",
  "dashmap",
  "fsevent-sys 4.1.0",
+ "futures",
  "itertools",
  "libc",
  "notify 6.1.1",

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -41,11 +41,11 @@ go-turbo$(EXT): $(GENERATED_FILES) $(SRC_FILES) go.mod turborepo-ffi-install
 
 .PHONY: turborepo-ffi-install
 turborepo-ffi-install: turborepo-ffi turborepo-ffi-copy-bindings
-	cp ../crates/turborepo-ffi/target/debug/libturborepo_ffi.a ./internal/ffi/libturborepo_ffi_$(GOOS)_$(GOARCH).a
+	cp ../crates/turborepo-ffi/target/x86_64-unknown-linux-musl/debug/libturborepo_ffi.a ./internal/ffi/libturborepo_ffi_$(GOOS)_$(GOARCH).a
 
 .PHONY: turborepo-ffi
 turborepo-ffi:
-	cd ../crates/turborepo-ffi && cargo build --target-dir ./target
+	cd ../crates/turborepo-ffi && cargo build --target x86_64-unknown-linux-musl --target-dir ./target
 
 .PHONY: turborepo-ffi-copy-bindings
 turborepo-ffi-copy-bindings:
@@ -337,4 +337,3 @@ fixture-%:
 	rm -rf testbed
 	mkdir -p testbed
 	../turborepo-tests/integration/tests/_helpers/setup_monorepo.sh ./testbed $($@_FIXTURE)
-

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -41,11 +41,11 @@ go-turbo$(EXT): $(GENERATED_FILES) $(SRC_FILES) go.mod turborepo-ffi-install
 
 .PHONY: turborepo-ffi-install
 turborepo-ffi-install: turborepo-ffi turborepo-ffi-copy-bindings
-	cp ../crates/turborepo-ffi/target/x86_64-unknown-linux-musl/debug/libturborepo_ffi.a ./internal/ffi/libturborepo_ffi_$(GOOS)_$(GOARCH).a
+	cp ../crates/turborepo-ffi/target/debug/libturborepo_ffi.a ./internal/ffi/libturborepo_ffi_$(GOOS)_$(GOARCH).a
 
 .PHONY: turborepo-ffi
 turborepo-ffi:
-	cd ../crates/turborepo-ffi && cargo build --target x86_64-unknown-linux-musl --target-dir ./target
+	cd ../crates/turborepo-ffi && cargo build --target-dir ./target
 
 .PHONY: turborepo-ffi-copy-bindings
 turborepo-ffi-copy-bindings:
@@ -337,3 +337,4 @@ fixture-%:
 	rm -rf testbed
 	mkdir -p testbed
 	../turborepo-tests/integration/tests/_helpers/setup_monorepo.sh ./testbed $($@_FIXTURE)
+

--- a/crates/turborepo-filewatch/Cargo.toml
+++ b/crates/turborepo-filewatch/Cargo.toml
@@ -6,4 +6,14 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-notify = "4.0.17"
+anyhow = { workspace = true }
+dashmap = { workspace = true }
+futures = { version = "0.3.26" }
+notify = "6.0.1"
+notify-debouncer-full = { version = "0.2.0", default-features = false }
+thiserror = "1.0.38"
+tokio = { workspace = true, features = ["full", "time"] }
+turbopath = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/turborepo-filewatch/Cargo.toml
+++ b/crates/turborepo-filewatch/Cargo.toml
@@ -14,6 +14,7 @@ notify-debouncer-full = { version = "0.2.0", default-features = false }
 thiserror = "1.0.38"
 tokio = { workspace = true, features = ["full", "time"] }
 turbopath = { workspace = true }
+walkdir = "2.3.3"
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/turborepo-filewatch/Cargo.toml
+++ b/crates/turborepo-filewatch/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2021"
 [dependencies]
 anyhow = { workspace = true }
 dashmap = { workspace = true }
-futures = { version = "0.3.26" }
 notify = "6.0.1"
 notify-debouncer-full = { version = "0.2.0", default-features = false }
 thiserror = "1.0.38"

--- a/crates/turborepo-filewatch/Cargo.toml
+++ b/crates/turborepo-filewatch/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "turborepo-filewatch"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+notify = "4.0.17"

--- a/crates/turborepo-filewatch/Cargo.toml
+++ b/crates/turborepo-filewatch/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 anyhow = { workspace = true }
 dashmap = { workspace = true }
+futures = { version = "0.3.26" }
 itertools = { workspace = true }
 notify = "6.0.1"
 notify-debouncer-full = { version = "0.2.0", default-features = false }

--- a/crates/turborepo-filewatch/Cargo.toml
+++ b/crates/turborepo-filewatch/Cargo.toml
@@ -35,3 +35,4 @@ tempfile = { workspace = true }
 default = ["macos_fsevent"]
 macos_fsevent = ["fsevent-sys"]
 watch_recursively = []
+watch_ancestors = []

--- a/crates/turborepo-filewatch/Cargo.toml
+++ b/crates/turborepo-filewatch/Cargo.toml
@@ -35,5 +35,5 @@ tempfile = { workspace = true }
 [features]
 default = ["macos_fsevent"]
 macos_fsevent = ["fsevent-sys"]
-watch_recursively = []
+manual_recursive_watch = []
 watch_ancestors = []

--- a/crates/turborepo-filewatch/Cargo.toml
+++ b/crates/turborepo-filewatch/Cargo.toml
@@ -15,6 +15,7 @@ notify = "6.0.1"
 notify-debouncer-full = { version = "0.2.0", default-features = false }
 thiserror = "1.0.38"
 tokio = { workspace = true, features = ["full", "time"] }
+tracing = "0.1.37"
 turbopath = { workspace = true }
 walkdir = "2.3.3"
 

--- a/crates/turborepo-filewatch/Cargo.toml
+++ b/crates/turborepo-filewatch/Cargo.toml
@@ -34,3 +34,4 @@ tempfile = { workspace = true }
 [features]
 default = ["macos_fsevent"]
 macos_fsevent = ["fsevent-sys"]
+watch_recursively = []

--- a/crates/turborepo-filewatch/Cargo.toml
+++ b/crates/turborepo-filewatch/Cargo.toml
@@ -2,6 +2,7 @@
 name = "turborepo-filewatch"
 version = "0.1.0"
 edition = "2021"
+license = "MPL-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/turborepo-filewatch/Cargo.toml
+++ b/crates/turborepo-filewatch/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 anyhow = { workspace = true }
 dashmap = { workspace = true }
+itertools = { workspace = true }
 notify = "6.0.1"
 notify-debouncer-full = { version = "0.2.0", default-features = false }
 thiserror = "1.0.38"
@@ -15,5 +16,19 @@ tokio = { workspace = true, features = ["full", "time"] }
 turbopath = { workspace = true }
 walkdir = "2.3.3"
 
+[target."cfg(target_os=\"macos\")".dependencies.fsevent-sys]
+optional = true
+version = "4"
+
+[dependencies.bitflags]
+version = "1.0.4"
+
+[dependencies.libc]
+version = "0.2.4"
+
 [dev-dependencies]
 tempfile = { workspace = true }
+
+[features]
+default = ["macos_fsevent"]
+macos_fsevent = ["fsevent-sys"]

--- a/crates/turborepo-filewatch/build.rs
+++ b/crates/turborepo-filewatch/build.rs
@@ -1,7 +1,7 @@
 fn main() {
     #[cfg(target_os = "linux")]
     {
-        println!("cargo:rustc-cfg=feature=\"watch_recursively\"");
+        println!("cargo:rustc-cfg=feature=\"manual_recursive_watch\"");
         println!("cargo:rustc-cfg=feature=\"watch_ancestors\"");
     }
     #[cfg(target_os = "windows")]

--- a/crates/turborepo-filewatch/build.rs
+++ b/crates/turborepo-filewatch/build.rs
@@ -1,0 +1,11 @@
+fn main() {
+    #[cfg(target_os = "linux")]
+    {
+        println!("cargo:rustc-cfg=feature=\"watch_recursively\"");
+        println!("cargo:rustc-cfg=feature=\"watch_ancestors\"");
+    }
+    #[cfg(target_os = "windows")]
+    {
+        println!("cargo:rustc-cfg=feature=\"watch_ancestors\"");
+    }
+}

--- a/crates/turborepo-filewatch/src/fsevent.rs
+++ b/crates/turborepo-filewatch/src/fsevent.rs
@@ -423,14 +423,14 @@ impl FsEventWatcher {
         // stream, and will be freed when the stream is closed. This means we
         // will leak the context if we panic before reacing
         // `FSEventStreamRelease`.
-        let context = Box::into_raw(Box::new(StreamContextInfo {
+        let stream_context_info = Box::into_raw(Box::new(StreamContextInfo {
             event_handler: self.event_handler.clone(),
             recursive_info: self.recursive_info.clone(),
         }));
 
         let stream_context = fs::FSEventStreamContext {
             version: 0,
-            info: context as *mut libc::c_void,
+            info: stream_context_info as *mut libc::c_void,
             retain: None,
             release: Some(release_context),
             copy_description: None,

--- a/crates/turborepo-filewatch/src/fsevent.rs
+++ b/crates/turborepo-filewatch/src/fsevent.rs
@@ -1,0 +1,630 @@
+//! Watcher implementation for Darwin's FSEvents API
+//!
+//! The FSEvents API provides a mechanism to notify clients about directories
+//! they ought to re-scan in order to keep their internal data structures
+//! up-to-date with respect to the true state of the file system. (For example,
+//! when files or directories are created, modified, or removed.) It sends these
+//! notifications "in bulk", possibly notifying the client of changes to several
+//! directories in a single callback.
+//!
+//! For more information see the [FSEvents API reference][ref].
+//!
+//! TODO: document event translation
+//!
+//! [ref]: https://developer.apple.com/library/mac/documentation/Darwin/Reference/FSEvents_Ref/
+
+#![allow(non_upper_case_globals, dead_code)]
+
+use std::{
+    collections::HashMap,
+    ffi::CStr,
+    fmt,
+    os::raw,
+    path::{Path, PathBuf},
+    ptr,
+    sync::{Arc, Mutex},
+    thread,
+};
+
+use fsevent_sys as fs;
+use fsevent_sys::core_foundation as cf;
+use notify::{Config, Error, EventHandler, RecursiveMode, Result, Watcher};
+
+use crate::event::*;
+
+type Sender<T> = std::sync::mpsc::Sender<T>;
+
+bitflags::bitflags! {
+  #[repr(C)]
+  struct StreamFlags: u32 {
+    const NONE = fs::kFSEventStreamEventFlagNone;
+    const MUST_SCAN_SUBDIRS = fs::kFSEventStreamEventFlagMustScanSubDirs;
+    const USER_DROPPED = fs::kFSEventStreamEventFlagUserDropped;
+    const KERNEL_DROPPED = fs::kFSEventStreamEventFlagKernelDropped;
+    const IDS_WRAPPED = fs::kFSEventStreamEventFlagEventIdsWrapped;
+    const HISTORY_DONE = fs::kFSEventStreamEventFlagHistoryDone;
+    const ROOT_CHANGED = fs::kFSEventStreamEventFlagRootChanged;
+    const MOUNT = fs::kFSEventStreamEventFlagMount;
+    const UNMOUNT = fs::kFSEventStreamEventFlagUnmount;
+    const ITEM_CREATED = fs::kFSEventStreamEventFlagItemCreated;
+    const ITEM_REMOVED = fs::kFSEventStreamEventFlagItemRemoved;
+    const INODE_META_MOD = fs::kFSEventStreamEventFlagItemInodeMetaMod;
+    const ITEM_RENAMED = fs::kFSEventStreamEventFlagItemRenamed;
+    const ITEM_MODIFIED = fs::kFSEventStreamEventFlagItemModified;
+    const FINDER_INFO_MOD = fs::kFSEventStreamEventFlagItemFinderInfoMod;
+    const ITEM_CHANGE_OWNER = fs::kFSEventStreamEventFlagItemChangeOwner;
+    const ITEM_XATTR_MOD = fs::kFSEventStreamEventFlagItemXattrMod;
+    const IS_FILE = fs::kFSEventStreamEventFlagItemIsFile;
+    const IS_DIR = fs::kFSEventStreamEventFlagItemIsDir;
+    const IS_SYMLINK = fs::kFSEventStreamEventFlagItemIsSymlink;
+    const OWN_EVENT = fs::kFSEventStreamEventFlagOwnEvent;
+    const IS_HARDLINK = fs::kFSEventStreamEventFlagItemIsHardlink;
+    const IS_LAST_HARDLINK = fs::kFSEventStreamEventFlagItemIsLastHardlink;
+    const ITEM_CLONED = fs::kFSEventStreamEventFlagItemCloned;
+  }
+}
+
+/// FSEvents-based `Watcher` implementation
+pub struct FsEventWatcher {
+    paths: cf::CFMutableArrayRef,
+    since_when: fs::FSEventStreamEventId,
+    latency: cf::CFTimeInterval,
+    flags: fs::FSEventStreamCreateFlags,
+    event_handler: Arc<Mutex<dyn EventHandler>>,
+    runloop: Option<(cf::CFRunLoopRef, thread::JoinHandle<()>)>,
+    recursive_info: HashMap<PathBuf, bool>,
+}
+
+impl fmt::Debug for FsEventWatcher {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("FsEventWatcher")
+            .field("paths", &self.paths)
+            .field("since_when", &self.since_when)
+            .field("latency", &self.latency)
+            .field("flags", &self.flags)
+            .field("event_handler", &Arc::as_ptr(&self.event_handler))
+            .field("runloop", &self.runloop)
+            .field("recursive_info", &self.recursive_info)
+            .finish()
+    }
+}
+
+// CFMutableArrayRef is a type alias to *mut libc::c_void, so FsEventWatcher is
+// not Send/Sync automatically. It's Send because the pointer is not used in
+// other threads.
+unsafe impl Send for FsEventWatcher {}
+
+// It's Sync because all methods that change the mutable state use `&mut self`.
+unsafe impl Sync for FsEventWatcher {}
+
+fn translate_flags(flags: StreamFlags, precise: bool) -> Vec<Event> {
+    let mut evs = Vec::new();
+
+    // «Denotes a sentinel event sent to mark the end of the "historical" events
+    // sent as a result of specifying a `sinceWhen` value in the FSEvents.Create
+    // call that created this event stream. After invoking the client's callback
+    // with all the "historical" events that occurred before now, the client's
+    // callback will be invoked with an event where the HistoryDone flag is set.
+    // The client should ignore the path supplied in this callback.»
+    // — https://www.mbsplugins.eu/FSEventsNextEvent.shtml
+    //
+    // As a result, we just stop processing here and return an empty vec, which
+    // will ignore this completely and not emit any Events whatsoever.
+    if flags.contains(StreamFlags::HISTORY_DONE) {
+        return evs;
+    }
+
+    // FSEvents provides two possible hints as to why events were dropped,
+    // however documentation on what those mean is scant, so we just pass them
+    // through in the info attr field. The intent is clear enough, and the
+    // additional information is provided if the user wants it.
+    if flags.contains(StreamFlags::MUST_SCAN_SUBDIRS) {
+        let e = Event::new(EventKind::Other).set_flag(Flag::Rescan);
+        evs.push(if flags.contains(StreamFlags::USER_DROPPED) {
+            e.set_info("rescan: user dropped")
+        } else if flags.contains(StreamFlags::KERNEL_DROPPED) {
+            e.set_info("rescan: kernel dropped")
+        } else {
+            e
+        });
+    }
+
+    // In imprecise mode, let's not even bother parsing the kind of the event
+    // except for the above very special events.
+    if !precise {
+        evs.push(Event::new(EventKind::Any));
+        return evs;
+    }
+
+    // This is most likely a rename or a removal. We assume rename but may want
+    // to figure out if it was a removal some way later (TODO). To denote the
+    // special nature of the event, we add an info string.
+    if flags.contains(StreamFlags::ROOT_CHANGED) {
+        evs.push(
+            Event::new(EventKind::Modify(ModifyKind::Name(RenameMode::From)))
+                .set_info("root changed"),
+        );
+    }
+
+    // A path was mounted at the event path; we treat that as a create.
+    if flags.contains(StreamFlags::MOUNT) {
+        evs.push(Event::new(EventKind::Create(CreateKind::Other)).set_info("mount"));
+    }
+
+    // A path was unmounted at the event path; we treat that as a remove.
+    if flags.contains(StreamFlags::UNMOUNT) {
+        evs.push(Event::new(EventKind::Remove(RemoveKind::Other)).set_info("mount"));
+    }
+
+    if flags.contains(StreamFlags::ITEM_CREATED) {
+        evs.push(if flags.contains(StreamFlags::IS_DIR) {
+            Event::new(EventKind::Create(CreateKind::Folder))
+        } else if flags.contains(StreamFlags::IS_FILE) {
+            Event::new(EventKind::Create(CreateKind::File))
+        } else {
+            let e = Event::new(EventKind::Create(CreateKind::Other));
+            if flags.contains(StreamFlags::IS_SYMLINK) {
+                e.set_info("is: symlink")
+            } else if flags.contains(StreamFlags::IS_HARDLINK) {
+                e.set_info("is: hardlink")
+            } else if flags.contains(StreamFlags::ITEM_CLONED) {
+                e.set_info("is: clone")
+            } else {
+                Event::new(EventKind::Create(CreateKind::Any))
+            }
+        });
+    }
+
+    if flags.contains(StreamFlags::ITEM_REMOVED) {
+        evs.push(if flags.contains(StreamFlags::IS_DIR) {
+            Event::new(EventKind::Remove(RemoveKind::Folder))
+        } else if flags.contains(StreamFlags::IS_FILE) {
+            Event::new(EventKind::Remove(RemoveKind::File))
+        } else {
+            let e = Event::new(EventKind::Remove(RemoveKind::Other));
+            if flags.contains(StreamFlags::IS_SYMLINK) {
+                e.set_info("is: symlink")
+            } else if flags.contains(StreamFlags::IS_HARDLINK) {
+                e.set_info("is: hardlink")
+            } else if flags.contains(StreamFlags::ITEM_CLONED) {
+                e.set_info("is: clone")
+            } else {
+                Event::new(EventKind::Remove(RemoveKind::Any))
+            }
+        });
+    }
+
+    // FSEvents provides no mechanism to associate the old and new sides of a
+    // rename event.
+    if flags.contains(StreamFlags::ITEM_RENAMED) {
+        evs.push(Event::new(EventKind::Modify(ModifyKind::Name(
+            RenameMode::Any,
+        ))));
+    }
+
+    // This is only described as "metadata changed", but it may be that it's
+    // only emitted for some more precise subset of events... if so, will need
+    // amending, but for now we have an Any-shaped bucket to put it in.
+    if flags.contains(StreamFlags::INODE_META_MOD) {
+        evs.push(Event::new(EventKind::Modify(ModifyKind::Metadata(
+            MetadataKind::Any,
+        ))));
+    }
+
+    if flags.contains(StreamFlags::FINDER_INFO_MOD) {
+        evs.push(
+            Event::new(EventKind::Modify(ModifyKind::Metadata(MetadataKind::Other)))
+                .set_info("meta: finder info"),
+        );
+    }
+
+    if flags.contains(StreamFlags::ITEM_CHANGE_OWNER) {
+        evs.push(Event::new(EventKind::Modify(ModifyKind::Metadata(
+            MetadataKind::Ownership,
+        ))));
+    }
+
+    if flags.contains(StreamFlags::ITEM_XATTR_MOD) {
+        evs.push(Event::new(EventKind::Modify(ModifyKind::Metadata(
+            MetadataKind::Extended,
+        ))));
+    }
+
+    // This is specifically described as a data change, which we take to mean
+    // is a content change.
+    if flags.contains(StreamFlags::ITEM_MODIFIED) {
+        evs.push(Event::new(EventKind::Modify(ModifyKind::Data(
+            DataChange::Content,
+        ))));
+    }
+
+    if flags.contains(StreamFlags::OWN_EVENT) {
+        for ev in &mut evs {
+            *ev = std::mem::take(ev).set_process_id(std::process::id());
+        }
+    }
+
+    evs
+}
+
+struct StreamContextInfo {
+    event_handler: Arc<Mutex<dyn EventHandler>>,
+    recursive_info: HashMap<PathBuf, bool>,
+}
+
+// Free the context when the stream created by `FSEventStreamCreate` is
+// released.
+extern "C" fn release_context(info: *const libc::c_void) {
+    // Safety:
+    // - The [documentation] for `FSEventStreamContext` states that `release` is
+    //   only called when the stream is deallocated, so it is safe to convert `info`
+    //   back into a box and drop it.
+    //
+    // [docs]: https://developer.apple.com/documentation/coreservices/fseventstreamcontext?language=objc
+    unsafe {
+        drop(Box::from_raw(
+            info as *const StreamContextInfo as *mut StreamContextInfo,
+        ));
+    }
+}
+
+extern "C" {
+    /// Indicates whether the run loop is waiting for an event.
+    fn CFRunLoopIsWaiting(runloop: cf::CFRunLoopRef) -> cf::Boolean;
+}
+
+impl FsEventWatcher {
+    fn from_event_handler(event_handler: Arc<Mutex<dyn EventHandler>>) -> Result<Self> {
+        println!("CREATING");
+        Ok(FsEventWatcher {
+            paths: unsafe {
+                cf::CFArrayCreateMutable(cf::kCFAllocatorDefault, 0, &cf::kCFTypeArrayCallBacks)
+            },
+            since_when: fs::kFSEventStreamEventIdSinceNow,
+            latency: 0.01,
+            flags: fs::kFSEventStreamCreateFlagFileEvents
+                | fs::kFSEventStreamCreateFlagNoDefer
+                | fs::kFSEventStreamCreateFlagWatchRoot,
+            event_handler,
+            runloop: None,
+            recursive_info: HashMap::new(),
+        })
+    }
+
+    fn watch_inner(&mut self, path: &Path, recursive_mode: RecursiveMode) -> Result<()> {
+        self.stop();
+        let result = self.append_path(path, recursive_mode);
+        // ignore return error: may be empty path list
+        let _ = self.run();
+        result
+    }
+
+    fn unwatch_inner(&mut self, path: &Path) -> Result<()> {
+        self.stop();
+        let result = self.remove_path(path);
+        // ignore return error: may be empty path list
+        let _ = self.run();
+        result
+    }
+
+    #[inline]
+    fn is_running(&self) -> bool {
+        self.runloop.is_some()
+    }
+
+    fn stop(&mut self) {
+        if !self.is_running() {
+            return;
+        }
+
+        if let Some((runloop, thread_handle)) = self.runloop.take() {
+            unsafe {
+                let runloop = runloop as *mut raw::c_void;
+
+                while CFRunLoopIsWaiting(runloop) == 0 {
+                    thread::yield_now();
+                }
+
+                cf::CFRunLoopStop(runloop);
+            }
+
+            // Wait for the thread to shut down.
+            thread_handle.join().expect("thread to shut down");
+        }
+    }
+
+    fn remove_path(&mut self, path: &Path) -> Result<()> {
+        let str_path = path.to_str().unwrap();
+        unsafe {
+            let mut err: cf::CFErrorRef = ptr::null_mut();
+            let cf_path = cf::str_path_to_cfstring_ref(str_path, &mut err);
+            if cf_path.is_null() {
+                cf::CFRelease(err as cf::CFRef);
+                return Err(Error::watch_not_found().add_path(path.into()));
+            }
+
+            let mut to_remove = Vec::new();
+            for idx in 0..cf::CFArrayGetCount(self.paths) {
+                let item = cf::CFArrayGetValueAtIndex(self.paths, idx);
+                if cf::CFStringCompare(item, cf_path, cf::kCFCompareCaseInsensitive)
+                    == cf::kCFCompareEqualTo
+                {
+                    to_remove.push(idx);
+                }
+            }
+
+            cf::CFRelease(cf_path);
+
+            for idx in to_remove.iter().rev() {
+                cf::CFArrayRemoveValueAtIndex(self.paths, *idx);
+            }
+        }
+        let p = if let Ok(canonicalized_path) = path.canonicalize() {
+            canonicalized_path
+        } else {
+            path.to_owned()
+        };
+        match self.recursive_info.remove(&p) {
+            Some(_) => Ok(()),
+            None => Err(Error::watch_not_found()),
+        }
+    }
+
+    // https://github.com/thibaudgg/rb-fsevent/blob/master/ext/fsevent_watch/main.c
+    fn append_path(&mut self, path: &Path, recursive_mode: RecursiveMode) -> Result<()> {
+        if !path.exists() {
+            return Err(Error::path_not_found().add_path(path.into()));
+        }
+        let canonical_path = path.to_path_buf().canonicalize()?;
+        let str_path = path.to_str().unwrap();
+        unsafe {
+            let mut err: cf::CFErrorRef = ptr::null_mut();
+            let cf_path = cf::str_path_to_cfstring_ref(str_path, &mut err);
+            if cf_path.is_null() {
+                // Most likely the directory was deleted, or permissions changed,
+                // while the above code was running.
+                cf::CFRelease(err as cf::CFRef);
+                return Err(Error::path_not_found().add_path(path.into()));
+            }
+            cf::CFArrayAppendValue(self.paths, cf_path);
+            cf::CFRelease(cf_path);
+        }
+        let is_recursive = matches!(recursive_mode, RecursiveMode::Recursive);
+        self.recursive_info.insert(canonical_path, is_recursive);
+        Ok(())
+    }
+
+    fn run(&mut self) -> Result<()> {
+        if unsafe { cf::CFArrayGetCount(self.paths) } == 0 {
+            // TODO: Reconstruct and add paths to error
+            return Err(Error::path_not_found());
+        }
+
+        // We need to associate the stream context with our callback in order to
+        // propagate events to the rest of the system. This will be owned by the
+        // stream, and will be freed when the stream is closed. This means we
+        // will leak the context if we panic before reacing
+        // `FSEventStreamRelease`.
+        let context = Box::into_raw(Box::new(StreamContextInfo {
+            event_handler: self.event_handler.clone(),
+            recursive_info: self.recursive_info.clone(),
+        }));
+
+        let stream_context = fs::FSEventStreamContext {
+            version: 0,
+            info: context as *mut libc::c_void,
+            retain: None,
+            release: Some(release_context),
+            copy_description: None,
+        };
+
+        let stream = unsafe {
+            fs::FSEventStreamCreate(
+                cf::kCFAllocatorDefault,
+                callback,
+                &stream_context,
+                self.paths,
+                self.since_when,
+                self.latency,
+                self.flags,
+            )
+        };
+
+        // Wrapper to help send CFRef types across threads.
+        struct CFSendWrapper(cf::CFRef);
+
+        // Safety:
+        // - According to the Apple documentation, it's safe to move `CFRef`s across threads.
+        //   https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/Multithreading/ThreadSafetySummary/ThreadSafetySummary.html
+        unsafe impl Send for CFSendWrapper {}
+
+        // move into thread
+        let stream = CFSendWrapper(stream);
+
+        // channel to pass runloop around
+        let (rl_tx, rl_rx) = std::sync::mpsc::channel();
+
+        let thread_handle = thread::Builder::new()
+            .name("notify-rs fsevents loop".to_string())
+            .spawn(move || {
+                let _ = &stream;
+                let stream = stream.0;
+
+                unsafe {
+                    let cur_runloop = cf::CFRunLoopGetCurrent();
+
+                    fs::FSEventStreamScheduleWithRunLoop(
+                        stream,
+                        cur_runloop,
+                        cf::kCFRunLoopDefaultMode,
+                    );
+                    fs::FSEventStreamStart(stream);
+
+                    // the calling to CFRunLoopRun will be terminated by CFRunLoopStop call in
+                    // drop()
+                    rl_tx
+                        .send(CFSendWrapper(cur_runloop))
+                        .expect("Unable to send runloop to watcher");
+
+                    cf::CFRunLoopRun();
+                    fs::FSEventStreamStop(stream);
+                    fs::FSEventStreamInvalidate(stream);
+                    fs::FSEventStreamRelease(stream);
+                }
+            })?;
+        // block until runloop has been sent
+        self.runloop = Some((rl_rx.recv().unwrap().0, thread_handle));
+
+        Ok(())
+    }
+
+    fn configure_raw_mode(&mut self, _config: Config, tx: Sender<Result<bool>>) {
+        tx.send(Ok(false))
+            .expect("configuration channel disconnect");
+    }
+}
+
+extern "C" fn callback(
+    stream_ref: fs::FSEventStreamRef,
+    info: *mut libc::c_void,
+    num_events: libc::size_t,                        // size_t numEvents
+    event_paths: *mut libc::c_void,                  // void *eventPaths
+    event_flags: *const fs::FSEventStreamEventFlags, // const FSEventStreamEventFlags eventFlags[]
+    event_ids: *const fs::FSEventStreamEventId,      // const FSEventStreamEventId eventIds[]
+) {
+    unsafe {
+        callback_impl(
+            stream_ref,
+            info,
+            num_events,
+            event_paths,
+            event_flags,
+            event_ids,
+        )
+    }
+}
+
+unsafe fn callback_impl(
+    _stream_ref: fs::FSEventStreamRef,
+    info: *mut libc::c_void,
+    num_events: libc::size_t,                        // size_t numEvents
+    event_paths: *mut libc::c_void,                  // void *eventPaths
+    event_flags: *const fs::FSEventStreamEventFlags, // const FSEventStreamEventFlags eventFlags[]
+    _event_ids: *const fs::FSEventStreamEventId,     // const FSEventStreamEventId eventIds[]
+) {
+    let event_paths = event_paths as *const *const libc::c_char;
+    let info = info as *const StreamContextInfo;
+    let event_handler = &(*info).event_handler;
+
+    for p in 0..num_events {
+        let path = CStr::from_ptr(*event_paths.add(p))
+            .to_str()
+            .expect("Invalid UTF8 string.");
+        let path = PathBuf::from(path);
+
+        let flag = *event_flags.add(p);
+        let orig = flag;
+        let flag = StreamFlags::from_bits(flag).unwrap_or_else(|| {
+            panic!("Unable to decode StreamFlags: {}", flag);
+        });
+
+        let mut handle_event = false;
+        for (p, r) in &(*info).recursive_info {
+            if path.starts_with(p) {
+                if *r || &path == p {
+                    handle_event = true;
+                    break;
+                } else if let Some(parent_path) = path.parent() {
+                    if parent_path == p {
+                        handle_event = true;
+                        break;
+                    }
+                }
+            }
+        }
+
+        if !handle_event {
+            continue;
+        }
+
+        println!("EEVV {} {} ({})", path.display(), orig as u32, p);
+        for ev in translate_flags(flag, true).into_iter() {
+            // TODO: precise
+            let ev = ev.add_path(path.clone());
+            let mut event_handler = event_handler.lock().expect("lock not to be poisoned");
+            event_handler.handle_event(Ok(ev));
+        }
+    }
+}
+
+impl Watcher for FsEventWatcher {
+    /// Create a new watcher.
+    fn new<F: EventHandler>(event_handler: F, _config: Config) -> Result<Self> {
+        Self::from_event_handler(Arc::new(Mutex::new(event_handler)))
+    }
+
+    fn watch(&mut self, path: &Path, recursive_mode: RecursiveMode) -> Result<()> {
+        self.watch_inner(path, recursive_mode)
+    }
+
+    fn unwatch(&mut self, path: &Path) -> Result<()> {
+        self.unwatch_inner(path)
+    }
+
+    fn configure(&mut self, config: Config) -> Result<bool> {
+        let (tx, rx) = std::sync::mpsc::channel();
+        self.configure_raw_mode(config, tx);
+        rx.recv()
+            .map_err(|err| Error::generic(&format!("internal channel disconnect: {:?}", err)))?
+    }
+
+    fn kind() -> crate::WatcherKind {
+        crate::WatcherKind::Fsevent
+    }
+}
+
+impl Drop for FsEventWatcher {
+    fn drop(&mut self) {
+        self.stop();
+        unsafe {
+            cf::CFRelease(self.paths);
+        }
+    }
+}
+
+#[test]
+fn test_fsevent_watcher_drop() {
+    use std::time::Duration;
+
+    use super::*;
+
+    let dir = tempfile::tempdir().unwrap();
+
+    let (tx, rx) = std::sync::mpsc::channel();
+
+    {
+        let mut watcher = FsEventWatcher::new(tx, Default::default()).unwrap();
+        watcher.watch(dir.path(), RecursiveMode::Recursive).unwrap();
+        thread::sleep(Duration::from_millis(2000));
+        //println!("is running -> {}", watcher.is_running());
+
+        thread::sleep(Duration::from_millis(1000));
+        watcher.unwatch(dir.path()).unwrap();
+        //println!("is running -> {}", watcher.is_running());
+    }
+
+    thread::sleep(Duration::from_millis(1000));
+
+    for res in rx {
+        let e = res.unwrap();
+        println!("debug => {:?} {:?}", e.kind, e.paths);
+    }
+
+    println!("in test: {} works", file!());
+}
+
+#[test]
+fn test_steam_context_info_send_and_sync() {
+    fn check_send<T: Send + Sync>() {}
+    check_send::<StreamContextInfo>();
+}

--- a/crates/turborepo-filewatch/src/lib.rs
+++ b/crates/turborepo-filewatch/src/lib.rs
@@ -1,0 +1,61 @@
+#[derive(Default)]
+struct DiskWatcher {
+    watcher: Mutex<Option<RecommendedWatcher>>,
+    /// Keeps track of which directories are currently watched. This is only
+    /// used on a OS that doesn't support recursive watching.
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    watching: dashmap::DashSet<PathBuf>,
+}
+
+impl DiskWatcher {
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    fn restore_if_watching(&self, dir_path: &Path, root_path: &Path) -> Result<()> {
+        if self.watching.contains(dir_path) {
+            let mut watcher = self.watcher.lock().unwrap();
+            self.start_watching(&mut watcher, dir_path, root_path)?;
+        }
+        Ok(())
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    fn ensure_watching(&self, dir_path: &Path, root_path: &Path) -> Result<()> {
+        if self.watching.contains(dir_path) {
+            return Ok(());
+        }
+        let mut watcher = self.watcher.lock().unwrap();
+        if self.watching.insert(dir_path.to_path_buf()) {
+            self.start_watching(&mut watcher, dir_path, root_path)?;
+        }
+        Ok(())
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    fn start_watching(
+        &self,
+        watcher: &mut std::sync::MutexGuard<Option<RecommendedWatcher>>,
+        dir_path: &Path,
+        root_path: &Path,
+    ) -> Result<()> {
+        if let Some(watcher) = watcher.as_mut() {
+            let mut path = dir_path;
+            while let Err(err) = watcher.watch(path, RecursiveMode::NonRecursive) {
+                if path == root_path {
+                    return Err(err).context(format!(
+                        "Unable to watch {} (tried up to {})",
+                        dir_path.display(),
+                        path.display()
+                    ));
+                }
+                let Some(parent_path) = path.parent() else {
+                    return Err(err).context(format!(
+                        "Unable to watch {} (tried up to {})",
+                        dir_path.display(),
+                        path.display()
+                    ));
+                };
+                path = parent_path;
+            }
+        }
+        Ok(())
+    }
+}

--- a/crates/turborepo-filewatch/src/lib.rs
+++ b/crates/turborepo-filewatch/src/lib.rs
@@ -4,14 +4,15 @@ use std::{
     path::{Path, PathBuf},
     fmt::Debug,
     thread,
-    time::Duration, future::IntoFuture
+    time::{Duration, Instant}, future::IntoFuture
 };
-use notify::event::CreateKind;
+use notify::event::{CreateKind, EventAttributes};
 //use notify::{watcher, DebouncedEvent, RecommendedWatcher, RecursiveMode, Watcher};
 use notify_debouncer_full::{notify::*, new_debouncer, DebounceEventResult, DebouncedEvent, Debouncer, FileIdMap};
 use thiserror::Error;
 use tokio::{sync::{broadcast, mpsc}, task::JoinHandle};
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
+use walkdir::WalkDir;
 
 #[derive(Default)]
 struct DiskWatcher {
@@ -27,7 +28,9 @@ enum WatchError {
     #[error("filewatching backend error: {0}")]
     Notify(#[from] notify::Error),
     #[error("filewatching stopped")]
-    Stopped(#[from] std::sync::mpsc::RecvError)
+    Stopped(#[from] std::sync::mpsc::RecvError),
+    #[error("enumerating recursive watch: {0}")]
+    WalkDir(#[from] walkdir::Error)
 }
 
 // impl DiskWatcher {
@@ -104,18 +107,20 @@ impl FileSystemWatcher {
             let mut exit_signal = exit_signal;
             loop {
                 tokio::select! {
-                    _ = &mut exit_signal => { println!("exit ch dropped"); return Ok(()); },
+                    _ = &mut exit_signal => { println!("exit ch dropped"); return Ok::<(), WatchError>(()); },
                     Some(event) = recv_file_events.recv().into_future() => {
                         //let event = recv_file_events.recv()?;
                         match event {
                             Ok(events) => {
                                 for event in events {
+                                    let time = event.time;
                                     println!("event {:?}", event);
                                     #[cfg(not(any(target_os = "macos", target_os = "windows")))]
                                     if event.event.kind == EventKind::Create(CreateKind::Folder) {
                                         for new_path in &event.event.paths {
                                             println!("new {}", new_path.display());
-                                            debouncer.watcher().watch(&new_path, RecursiveMode::NonRecursive)?;
+                                            //debouncer.watcher().watch(&new_path, RecursiveMode::Recursive)?;
+                                            watch_recursively(&new_path, debouncer.watcher(), Some((time, &broadcast_sender)))?;
                                         }
                                     }
                                     // we don't care if we fail to send, it just means no one is currently watching
@@ -142,6 +147,34 @@ impl FileSystemWatcher {
     }
 }
 
+fn watch_recursively(root: &Path, watcher: &mut RecommendedWatcher, sender: Option<(Instant, &broadcast::Sender<DebouncedEvent>)>) -> Result<(), WatchError> {
+    for dir in WalkDir::new(root).follow_links(false).into_iter() {
+        let dir = dir?;
+        if dir.file_type().is_dir() {
+            watcher.watch(dir.path(), RecursiveMode::NonRecursive)?;
+        }
+        if let Some((instant, sender)) = sender.as_ref() {
+            let create_kind = if dir.file_type().is_dir() {
+                CreateKind::Folder
+            } else {
+                CreateKind::File
+            };
+            let event = DebouncedEvent {
+                event: Event {
+                    paths: vec![dir.path().to_owned()],
+                    kind: EventKind::Create(create_kind),
+                    attrs: EventAttributes::default()
+                },
+                time: *instant
+            };
+            // It's ok if we fail to send, it means we're shutting down
+            let _ = sender.send(event);
+        }
+        println!("ADD {}", dir.path().display());
+    }
+    Ok(())
+}
+
 fn run_watcher(root: &AbsoluteSystemPath, sender: mpsc::Sender<DebounceEventResult>) -> Result<Debouncer<RecommendedWatcher, FileIdMap>, WatchError> {
     //let (tx, recv) = mpsc::channel();
     let mut debouncer = new_debouncer(Duration::from_millis(1), None, move |res| {
@@ -155,15 +188,20 @@ fn run_watcher(root: &AbsoluteSystemPath, sender: mpsc::Sender<DebounceEventResu
     #[cfg(any(target_os = "macos", target_os = "windows"))]
     debouncer.watcher().watch(&root_path, RecursiveMode::Recursive)?;
     #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-    debouncer.watcher().watch(root.as_std_path(), RecursiveMode::NonRecursive)?;
+    //debouncer.watcher().watch(root.as_std_path(), RecursiveMode::Recursive)?;
+    // Don't synthesize initial events
+    watch_recursively(root.as_std_path(), debouncer.watcher(), None)?;
     Ok(debouncer)
 }
 
 #[cfg(test)]
 mod test {
-    use std::time::Duration;
+    use std::{time::Duration, sync::atomic::AtomicUsize};
 
-    use turbopath::AbsoluteSystemPathBuf;
+    use notify::{EventKind, event::CreateKind};
+    use notify_debouncer_full::DebouncedEvent;
+    use tokio::sync::broadcast;
+    use turbopath::{AbsoluteSystemPathBuf, AbsoluteSystemPath};
 
     use crate::FileSystemWatcher;
 
@@ -180,5 +218,102 @@ mod test {
 
         let event = tokio::time::timeout(Duration::from_millis(2000), events_channel.recv()).await.unwrap();
         println!("test event {:?}", event);
+    }
+
+    fn temp_dir() -> (AbsoluteSystemPathBuf, tempfile::TempDir) {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = AbsoluteSystemPathBuf::try_from(tmp.path()).unwrap();
+        (path, tmp)
+    }
+
+    async fn expect_filesystem_event(recv: &mut broadcast::Receiver<DebouncedEvent>, expected_path: &AbsoluteSystemPath, expected_event: EventKind) {
+        println!("WAIT FOR {}", expected_path);
+        'outer: loop {
+            let event = tokio::time::timeout(Duration::from_millis(1000), recv.recv())
+                .await
+                .expect("timed out waiting for filesystem event")
+                .expect("sender was dropped");
+            for path in event.event.paths {
+                if path == expected_path && event.event.kind == expected_event {
+                    break 'outer;
+                } else {
+                    println!("{}, {:?}", path.display(), event.event.kind);
+                }
+            }
+        }
+    }
+
+    static WATCH_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+    async fn expect_watching(recv: &mut broadcast::Receiver<DebouncedEvent>, dirs: &[&AbsoluteSystemPath]) {
+        for dir in dirs {
+            let count = WATCH_COUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            let filename = dir.join_component(format!("test-{}", count).as_str());
+            println!("WRITING {}", filename);
+            filename.create_with_contents("hello").unwrap();
+
+            expect_filesystem_event(recv, &filename, EventKind::Create(CreateKind::File))
+                .await;
+        }
+    }
+
+    #[tokio::test]
+    async fn test_file_watching() {
+        // Directory layout:
+        // <repoRoot>/
+        //	 .git/
+        //   node_modules/
+        //     some-dep/
+        //   parent/
+        //     child/
+        let (repo_root, _tmp_repo_root) = temp_dir();
+        let repo_root = repo_root.to_realpath().unwrap();
+
+        repo_root.join_component(".git").create_dir_all().unwrap();
+        repo_root
+            .join_components(&["node_modules", "some-dep"])
+            .create_dir_all()
+            .unwrap();
+        let parent_path = repo_root.join_component("parent");
+        let child_path = parent_path.join_component("child");
+        child_path.create_dir_all().unwrap();
+        let sibling_path = parent_path.join_component("sibling");
+        sibling_path.create_dir_all().unwrap();
+
+        let watcher = FileSystemWatcher::new(&repo_root);
+        let mut recv = watcher.subscribe();
+
+        expect_watching(&mut recv, &[&repo_root, &parent_path, &child_path]).await;
+        let foo_path = child_path.join_component("foo");
+        foo_path.create_with_contents("hello").unwrap();
+        expect_filesystem_event(&mut recv, &foo_path, EventKind::Create(CreateKind::File)).await;
+
+        let deep_path = sibling_path.join_components(&["deep", "path"]);
+        deep_path.create_dir_all().unwrap();
+        expect_filesystem_event(
+            &mut recv,
+            &sibling_path.join_component("deep"),
+            EventKind::Create(CreateKind::Folder),
+        )
+        .await;
+        expect_filesystem_event(
+            &mut recv,
+            &deep_path,
+            EventKind::Create(CreateKind::Folder),
+        )
+        .await;
+        expect_watching(
+            &mut recv,
+            &[
+                &repo_root,
+                &parent_path,
+                &child_path,
+                &deep_path,
+                &sibling_path.join_component("deep"),
+            ],
+        )
+        .await;
+
+        // TODO: implement default filtering (.git, node_modules)
     }
 }

--- a/crates/turborepo-filewatch/src/lib.rs
+++ b/crates/turborepo-filewatch/src/lib.rs
@@ -1,3 +1,18 @@
+use std::{
+    result::Result,
+    sync::{Arc, Mutex},
+    path::{Path, PathBuf},
+    fmt::Debug,
+    thread,
+    time::Duration, future::IntoFuture
+};
+use notify::event::CreateKind;
+//use notify::{watcher, DebouncedEvent, RecommendedWatcher, RecursiveMode, Watcher};
+use notify_debouncer_full::{notify::*, new_debouncer, DebounceEventResult, DebouncedEvent, Debouncer, FileIdMap};
+use thiserror::Error;
+use tokio::{sync::{broadcast, mpsc}, task::JoinHandle};
+use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
+
 #[derive(Default)]
 struct DiskWatcher {
     watcher: Mutex<Option<RecommendedWatcher>>,
@@ -7,55 +22,163 @@ struct DiskWatcher {
     watching: dashmap::DashSet<PathBuf>,
 }
 
-impl DiskWatcher {
-    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-    fn restore_if_watching(&self, dir_path: &Path, root_path: &Path) -> Result<()> {
-        if self.watching.contains(dir_path) {
-            let mut watcher = self.watcher.lock().unwrap();
-            self.start_watching(&mut watcher, dir_path, root_path)?;
-        }
-        Ok(())
-    }
+#[derive(Debug, Error)]
+enum WatchError {
+    #[error("filewatching backend error: {0}")]
+    Notify(#[from] notify::Error),
+    #[error("filewatching stopped")]
+    Stopped(#[from] std::sync::mpsc::RecvError)
+}
 
-    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-    fn ensure_watching(&self, dir_path: &Path, root_path: &Path) -> Result<()> {
-        if self.watching.contains(dir_path) {
-            return Ok(());
-        }
-        let mut watcher = self.watcher.lock().unwrap();
-        if self.watching.insert(dir_path.to_path_buf()) {
-            self.start_watching(&mut watcher, dir_path, root_path)?;
-        }
-        Ok(())
-    }
+// impl DiskWatcher {
+//     #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+//     fn restore_if_watching(&self, dir_path: &Path, root_path: &Path) -> Result<()> {
+//         if self.watching.contains(dir_path) {
+//             let mut watcher = self.watcher.lock().unwrap();
+//             self.start_watching(&mut watcher, dir_path, root_path)?;
+//         }
+//         Ok(())
+//     }
 
-    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-    fn start_watching(
-        &self,
-        watcher: &mut std::sync::MutexGuard<Option<RecommendedWatcher>>,
-        dir_path: &Path,
-        root_path: &Path,
-    ) -> Result<()> {
-        if let Some(watcher) = watcher.as_mut() {
-            let mut path = dir_path;
-            while let Err(err) = watcher.watch(path, RecursiveMode::NonRecursive) {
-                if path == root_path {
-                    return Err(err).context(format!(
-                        "Unable to watch {} (tried up to {})",
-                        dir_path.display(),
-                        path.display()
-                    ));
+//     #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+//     fn ensure_watching(&self, dir_path: &Path, root_path: &Path) -> Result<()> {
+//         if self.watching.contains(dir_path) {
+//             return Ok(());
+//         }
+//         let mut watcher = self.watcher.lock().unwrap();
+//         if self.watching.insert(dir_path.to_path_buf()) {
+//             self.start_watching(&mut watcher, dir_path, root_path)?;
+//         }
+//         Ok(())
+//     }
+
+//     #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+//     fn start_watching(
+//         &self,
+//         watcher: &mut std::sync::MutexGuard<Option<RecommendedWatcher>>,
+//         dir_path: &Path,
+//         root_path: &Path,
+//     ) -> Result<()> {
+//         if let Some(watcher) = watcher.as_mut() {
+//             let mut path = dir_path;
+//             while let Err(err) = watcher.watch(path, RecursiveMode::NonRecursive) {
+//                 if path == root_path {
+//                     return Err(err).context(format!(
+//                         "Unable to watch {} (tried up to {})",
+//                         dir_path.display(),
+//                         path.display()
+//                     ));
+//                 }
+//                 let Some(parent_path) = path.parent() else {
+//                     return Err(err).context(format!(
+//                         "Unable to watch {} (tried up to {})",
+//                         dir_path.display(),
+//                         path.display()
+//                     ));
+//                 };
+//                 path = parent_path;
+//             }
+//         }
+//         Ok(())
+//     }
+// }
+
+struct FileSystemWatcher {
+    sender: broadcast::Sender<DebouncedEvent>,
+    exit_ch: tokio::sync::oneshot::Sender<()>
+    //watcher: Arc<Mutex<RecommendedWatcher>>,
+}
+
+impl FileSystemWatcher {
+    pub fn new(root: &AbsoluteSystemPath) -> Self {
+
+        let (sender, _) = broadcast::channel(1024);
+        let (send_file_events, mut recv_file_events) = mpsc::channel(1024);
+        let watch_root = root.to_owned();
+        let broadcast_sender = sender.clone();
+        let debouncer = run_watcher(&watch_root, send_file_events).unwrap();
+        println!("watching {}", &watch_root);
+        let (exit_ch, exit_signal) = tokio::sync::oneshot::channel();
+        tokio::task::spawn(async move {
+            let mut debouncer = debouncer;
+            let mut exit_signal = exit_signal;
+            loop {
+                tokio::select! {
+                    _ = &mut exit_signal => { println!("exit ch dropped"); return Ok(()); },
+                    Some(event) = recv_file_events.recv().into_future() => {
+                        //let event = recv_file_events.recv()?;
+                        match event {
+                            Ok(events) => {
+                                for event in events {
+                                    println!("event {:?}", event);
+                                    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+                                    if event.event.kind == EventKind::Create(CreateKind::Folder) {
+                                        for new_path in &event.event.paths {
+                                            println!("new {}", new_path.display());
+                                            debouncer.watcher().watch(&new_path, RecursiveMode::NonRecursive)?;
+                                        }
+                                    }
+                                    // we don't care if we fail to send, it just means no one is currently watching
+                                    let _ = broadcast_sender.send(event);
+                                }
+                            },
+                            Err(errors) => {
+                                println!("errors {:?}", errors);
+                                panic!("uh oh")
+                            }
+                        }
+                    }
                 }
-                let Some(parent_path) = path.parent() else {
-                    return Err(err).context(format!(
-                        "Unable to watch {} (tried up to {})",
-                        dir_path.display(),
-                        path.display()
-                    ));
-                };
-                path = parent_path;
             }
+        });
+        Self {
+            sender,
+            exit_ch
         }
-        Ok(())
+    }
+
+    pub fn subscribe(&self) -> broadcast::Receiver<DebouncedEvent> {
+        self.sender.subscribe()
+    }
+}
+
+fn run_watcher(root: &AbsoluteSystemPath, sender: mpsc::Sender<DebounceEventResult>) -> Result<Debouncer<RecommendedWatcher, FileIdMap>, WatchError> {
+    //let (tx, recv) = mpsc::channel();
+    let mut debouncer = new_debouncer(Duration::from_millis(1), None, move |res| {
+        futures::executor::block_on(async {
+            // It's ok if we fail to send, it means we're shutting down
+            let _ = sender.send(res).await;
+        })
+    })?;
+
+    //let mut watcher = watcher(sender, Duration::from_millis(1))?;
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    debouncer.watcher().watch(&root_path, RecursiveMode::Recursive)?;
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    debouncer.watcher().watch(root.as_std_path(), RecursiveMode::NonRecursive)?;
+    Ok(debouncer)
+}
+
+#[cfg(test)]
+mod test {
+    use std::time::Duration;
+
+    use turbopath::AbsoluteSystemPathBuf;
+
+    use crate::FileSystemWatcher;
+
+    #[tokio::test]
+    async fn test_hello() {
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPathBuf::try_from(tmp_dir.path()).unwrap();
+
+        let watcher = FileSystemWatcher::new(&root);
+        let mut events_channel = watcher.subscribe();
+
+        println!("writing");
+        root.join_component("foo").create_with_contents("hello world").unwrap();
+
+        let event = tokio::time::timeout(Duration::from_millis(2000), events_channel.recv()).await.unwrap();
+        println!("test event {:?}", event);
     }
 }

--- a/crates/turborepo-filewatch/src/lib.rs
+++ b/crates/turborepo-filewatch/src/lib.rs
@@ -1,7 +1,11 @@
 use std::{fmt::Debug, future::IntoFuture, result::Result, time::Duration};
 
-use itertools::Itertools;
-use notify::{RecursiveMode, Watcher};
+#[cfg(target_os = "macos")]
+use fsevent::FsEventWatcher;
+use notify::{
+    event::{CreateKind, EventAttributes},
+    Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher,
+};
 use notify_debouncer_full::{
     DebounceEventHandler, DebounceEventResult, DebouncedEvent, Debouncer, FileIdMap,
 };
@@ -298,26 +302,6 @@ mod test {
     use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
 
     use crate::FileSystemWatcher;
-
-    #[tokio::test]
-    async fn test_hello() {
-        let tmp_dir = tempfile::tempdir().unwrap();
-        let root = AbsoluteSystemPathBuf::try_from(tmp_dir.path())
-            .unwrap()
-            .to_realpath()
-            .unwrap();
-
-        let watcher = FileSystemWatcher::new(&root).unwrap();
-        let mut events_channel = watcher.subscribe();
-
-        root.join_component("foo")
-            .create_with_contents("hello world")
-            .unwrap();
-
-        let event = tokio::time::timeout(Duration::from_millis(2000), events_channel.recv())
-            .await
-            .unwrap();
-    }
 
     fn temp_dir() -> (AbsoluteSystemPathBuf, tempfile::TempDir) {
         let tmp = tempfile::tempdir().unwrap();

--- a/crates/turborepo-filewatch/src/lib.rs
+++ b/crates/turborepo-filewatch/src/lib.rs
@@ -187,8 +187,11 @@ fn filter_relevant(root: &AbsoluteSystemPath, event: &mut Event) {
     let is_modify_existing = matches!(event.kind, EventKind::Remove(_) | EventKind::Modify(_));
 
     event.paths.retain_mut(|path| {
-        match root.relation_to_path(&path) {
-            PathRelation::Incomparable => panic!("Non-absolute path from filewatching"),
+        let abs_path: &AbsoluteSystemPath = path
+            .as_path()
+            .try_into()
+            .expect("Non-absolute path from filewatching");
+        match root.relation_to_path(abs_path) {
             // An irrelevant path, probably from a non-recursive watch of a parent directory
             PathRelation::Divergent => false,
             // A path contained in the root

--- a/crates/turborepo-filewatch/src/lib.rs
+++ b/crates/turborepo-filewatch/src/lib.rs
@@ -2,36 +2,31 @@ use std::{fmt::Debug, future::IntoFuture, result::Result, time::Duration};
 
 #[cfg(target_os = "macos")]
 use fsevent::FsEventWatcher;
-use notify::{
-    event::{CreateKind, EventAttributes},
-    Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher,
-};
-use notify_debouncer_full::{
-    DebounceEventHandler, DebounceEventResult, DebouncedEvent, Debouncer, FileIdMap,
-};
+use notify::{RecursiveMode, Watcher};
+use notify_debouncer_full::{DebounceEventResult, DebouncedEvent, Debouncer, FileIdMap};
 use thiserror::Error;
 use tokio::sync::{broadcast, mpsc};
 use turbopath::AbsoluteSystemPath;
-// macos -> custom watcher impl in fsevents, no recursive watch, no watching ancestors
-#[cfg(target_os = "macos")]
-use {fsevent::FsEventWatcher, notify_debouncer_full::new_debouncer_opt};
-#[cfg(not(target_os = "macos"))]
-use {notify::RecommendedWatcher, notify_debouncer_full::new_debouncer, turbopath::PathRelation};
 // windows -> no recursive watch, watch ancestors
 // linux -> recursive watch, watch ancestors
-#[cfg(target_os = "linux")]
+#[cfg(feature = "watch_ancestors")]
+use turbopath::PathRelation;
+// macos -> custom watcher impl in fsevents, no recursive watch, no watching ancestors
+#[cfg(target_os = "macos")]
 use {
-    notify::{
-        event::{
-            Event, EventKind, {CreateKind, EventAttributes},
-        },
-        RecommendedWatcher,
+    fsevent::FsEventWatcher,
+    notify_debouncer_full::{new_debouncer_opt, DebounceEventHandler},
+};
+#[cfg(feature = "watch_recursively")]
+use {
+    notify::event::{
+        Event, EventKind, {CreateKind, EventAttributes},
     },
-    notify_debouncer_full::new_debouncer,
     std::{path::Path, time::Instant},
-    turbopath::PathRelation,
     walkdir::WalkDir,
 };
+#[cfg(not(target_os = "macos"))]
+use {notify::RecommendedWatcher, notify_debouncer_full::new_debouncer};
 
 #[cfg(target_os = "macos")]
 mod fsevent;

--- a/crates/turborepo-filewatch/src/lib.rs
+++ b/crates/turborepo-filewatch/src/lib.rs
@@ -160,6 +160,7 @@ fn run_watcher(
     Ok(debouncer)
 }
 
+#[cfg(target_os = "macos")]
 fn make_debouncer<F: DebounceEventHandler>(
     event_handler: F,
 ) -> Result<Debouncer<Backend, FileIdMap>, notify::Error> {

--- a/crates/turborepo-filewatch/src/lib.rs
+++ b/crates/turborepo-filewatch/src/lib.rs
@@ -121,16 +121,8 @@ async fn watch_events(
         tokio::select! {
             _ = &mut exit_signal => break 'outer,
             Some(event) = recv_file_events.recv().into_future() => {
-                match event {
-                    Ok(event) => {
-                        // we don't care if we fail to send, it just means no one is currently watching
-                        let _ = broadcast_sender.send(Ok(event));
-                    },
-                    Err(error) => {
-                        // we don't care if we fail to send, it just means no one is currently watching
-                        let _ = broadcast_sender.send(Err(NotifyError::from(error)));
-                    }
-                }
+                // we don't care if we fail to send, it just means no one is currently watching
+                let _ = broadcast_sender.send(event.map_err(NotifyError::from));
             }
         }
     }

--- a/crates/turborepo-filewatch/src/lib.rs
+++ b/crates/turborepo-filewatch/src/lib.rs
@@ -6,6 +6,7 @@ use std::{
     time::{Duration, Instant},
 };
 
+#[cfg(target_os = "macos")]
 use fsevent::FsEventWatcher;
 use itertools::Itertools;
 use notify::{
@@ -13,8 +14,8 @@ use notify::{
     Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher,
 };
 use notify_debouncer_full::{
-    new_debouncer_opt, DebounceEventHandler, DebounceEventResult, DebouncedEvent, Debouncer,
-    FileIdMap,
+    new_bouncer, new_debouncer_opt, DebounceEventHandler, DebounceEventResult, DebouncedEvent,
+    Debouncer, FileIdMap,
 };
 use thiserror::Error;
 use tokio::sync::{broadcast, mpsc};

--- a/crates/turborepo-filewatch/src/lib.rs
+++ b/crates/turborepo-filewatch/src/lib.rs
@@ -105,7 +105,7 @@ async fn watch_events(
     mut recv_file_events: mpsc::Receiver<DebounceEventResult>,
     exit_signal: tokio::sync::oneshot::Receiver<()>,
     broadcast_sender: broadcast::Sender<Result<DebouncedEvent, Vec<NotifyError>>>,
-) -> Result<(), WatchError> {
+) {
     let mut exit_signal = exit_signal;
     'outer: loop {
         tokio::select! {
@@ -126,7 +126,6 @@ async fn watch_events(
             }
         }
     }
-    Ok::<(), WatchError>(())
 }
 
 #[cfg(any(feature = "watch_ancestors", feature = "watch_recursively"))]
@@ -137,7 +136,7 @@ async fn watch_events(
     mut recv_file_events: mpsc::Receiver<DebounceEventResult>,
     exit_signal: tokio::sync::oneshot::Receiver<()>,
     broadcast_sender: broadcast::Sender<Result<DebouncedEvent, Vec<NotifyError>>>,
-) -> Result<(), WatchError> {
+) {
     let mut exit_signal = exit_signal;
     'outer: loop {
         tokio::select! {
@@ -169,7 +168,6 @@ async fn watch_events(
             }
         }
     }
-    Ok::<(), WatchError>(())
 }
 
 // Since we're manually watching the parent directories, we need

--- a/crates/turborepo-filewatch/src/lib.rs
+++ b/crates/turborepo-filewatch/src/lib.rs
@@ -250,18 +250,6 @@ mod test {
         (path, tmp)
     }
 
-    // async fn expect_filesystem_event(
-    //     recv: &mut broadcast::Receiver<DebouncedEvent>,
-    //     expected_path: &AbsoluteSystemPath,
-    //     expected_event: EventKind,
-    // ) { 'outer: loop { let event =
-    //   tokio::time::timeout(Duration::from_millis(3000), recv.recv()) .await
-    //   .expect("timed out waiting for filesystem event") .expect("sender was
-    //   dropped"); println!("event {:?}", event); for path in event.event.paths {
-    //   if path == expected_path && event.event.kind == expected_event { break
-    //   'outer; } } }
-    // }
-
     macro_rules! expect_filesystem_event {
         ($recv:ident, $expected_path:expr, $pattern:pat) => {
             'outer: loop {
@@ -516,7 +504,7 @@ mod test {
         // Create symlink during file watching
         let symlink_path = repo_root.join_component("symlink");
         symlink_path.symlink_to_dir(child_path.as_str()).unwrap();
-        expect_filesystem_event!(recv, symlink_path, EventKind::Create(CreateKind::Other));
+        expect_filesystem_event!(recv, symlink_path, EventKind::Create(_));
 
         // we expect that events in the symlinked directory will be raised with the
         // original path
@@ -560,7 +548,7 @@ mod test {
 
         // Delete symlink during file watching
         symlink_path.remove().unwrap();
-        expect_filesystem_event!(recv, symlink_path, EventKind::Remove(RemoveKind::Other));
+        expect_filesystem_event!(recv, symlink_path, EventKind::Remove(_));
     }
 
     #[tokio::test]

--- a/crates/turborepo-filewatch/src/lib.rs
+++ b/crates/turborepo-filewatch/src/lib.rs
@@ -1,5 +1,7 @@
 use std::{fmt::Debug, future::IntoFuture, result::Result, time::Duration};
 
+#[cfg(any(feature = "watch_recursively", feature = "watch_ancestors"))]
+use notify::event::EventKind;
 use notify::{RecursiveMode, Watcher};
 use notify_debouncer_full::{DebounceEventResult, DebouncedEvent, Debouncer, FileIdMap};
 use thiserror::Error;
@@ -18,9 +20,7 @@ use {
 };
 #[cfg(feature = "watch_recursively")]
 use {
-    notify::event::{
-        Event, EventKind, {CreateKind, EventAttributes},
-    },
+    notify::event::{CreateKind, Event, EventAttributes},
     std::{path::Path, time::Instant},
     walkdir::WalkDir,
 };
@@ -287,10 +287,7 @@ async fn wait_for_cookie(
 mod test {
     use std::{sync::atomic::AtomicUsize, time::Duration};
 
-    use notify::{
-        event::{ModifyKind, RenameMode},
-        EventKind,
-    };
+    use notify::{event::ModifyKind, EventKind};
     use notify_debouncer_full::DebouncedEvent;
     use tokio::sync::broadcast;
     use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};

--- a/crates/turborepo-filewatch/src/lib.rs
+++ b/crates/turborepo-filewatch/src/lib.rs
@@ -1,7 +1,5 @@
 use std::{fmt::Debug, future::IntoFuture, result::Result, time::Duration};
 
-#[cfg(target_os = "macos")]
-use fsevent::FsEventWatcher;
 use notify::{RecursiveMode, Watcher};
 use notify_debouncer_full::{DebounceEventResult, DebouncedEvent, Debouncer, FileIdMap};
 use thiserror::Error;
@@ -15,6 +13,7 @@ use turbopath::PathRelation;
 #[cfg(target_os = "macos")]
 use {
     fsevent::FsEventWatcher,
+    itertools::Itertools,
     notify_debouncer_full::{new_debouncer_opt, DebounceEventHandler},
 };
 #[cfg(feature = "watch_recursively")]

--- a/crates/turborepo-filewatch/src/lib.rs
+++ b/crates/turborepo-filewatch/src/lib.rs
@@ -14,7 +14,7 @@ use notify::{
     Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher,
 };
 use notify_debouncer_full::{
-    new_bouncer, new_debouncer_opt, DebounceEventHandler, DebounceEventResult, DebouncedEvent,
+    new_debouncer, new_debouncer_opt, DebounceEventHandler, DebounceEventResult, DebouncedEvent,
     Debouncer, FileIdMap,
 };
 use thiserror::Error;

--- a/crates/turborepo-lib/Cargo.toml
+++ b/crates/turborepo-lib/Cargo.toml
@@ -87,6 +87,7 @@ url = "2.3.1"
 
 camino = "1.1.4"
 const_format = "0.2.30"
+turborepo-filewatch = { path = "../turborepo-filewatch" }
 globwalk = { version = "0.1.0", path = "../turborepo-globwalk" }
 go-parse-duration = "0.1.1"
 is-terminal = "0.4.7"

--- a/crates/turborepo-lib/Cargo.toml
+++ b/crates/turborepo-lib/Cargo.toml
@@ -87,7 +87,6 @@ url = "2.3.1"
 
 camino = "1.1.4"
 const_format = "0.2.30"
-turborepo-filewatch = { path = "../turborepo-filewatch" }
 globwalk = { version = "0.1.0", path = "../turborepo-globwalk" }
 go-parse-duration = "0.1.1"
 is-terminal = "0.4.7"
@@ -106,6 +105,7 @@ turborepo-api-client = { workspace = true }
 turborepo-cache = { workspace = true }
 turborepo-ci = { workspace = true }
 turborepo-env = { workspace = true }
+turborepo-filewatch = { path = "../turborepo-filewatch" }
 turborepo-lockfiles = { workspace = true }
 turborepo-scm = { workspace = true }
 turborepo-ui = { workspace = true }

--- a/crates/turborepo-paths/src/absolute_system_path.rs
+++ b/crates/turborepo-paths/src/absolute_system_path.rs
@@ -359,6 +359,18 @@ impl AbsoluteSystemPath {
 impl<'a> From<&'a AbsoluteSystemPath> for CandidatePath<'a> {
     fn from(value: &'a AbsoluteSystemPath) -> Self {
         CandidatePath::from(value.0.as_std_path())
+}
+
+impl PartialEq<AbsoluteSystemPath> for Path {
+    fn eq(&self, other: &AbsoluteSystemPath) -> bool {
+        Utf8Path::from_path(self)
+            .map(|path| &other.0 == path)
+            .unwrap_or(false)
+    }
+}
+
+impl PartialEq<AbsoluteSystemPath> for PathBuf {
+        self.as_path().eq(other)
     }
 }
 

--- a/crates/turborepo-paths/src/absolute_system_path.rs
+++ b/crates/turborepo-paths/src/absolute_system_path.rs
@@ -8,7 +8,7 @@ use std::{
     fmt,
     fs::{File, Metadata, OpenOptions, Permissions},
     io,
-    path::Path,
+    path::{Path, PathBuf},
 };
 
 use camino::{Utf8Component, Utf8Components, Utf8Path, Utf8PathBuf};
@@ -359,6 +359,20 @@ impl AbsoluteSystemPath {
 impl<'a> From<&'a AbsoluteSystemPath> for CandidatePath<'a> {
     fn from(value: &'a AbsoluteSystemPath) -> Self {
         CandidatePath::from(value.0.as_std_path())
+    }
+}
+
+impl PartialEq<&AbsoluteSystemPath> for Path {
+    fn eq(&self, other: &&AbsoluteSystemPath) -> bool {
+        Utf8Path::from_path(self)
+            .map(|path| &other.0 == path)
+            .unwrap_or(false)
+    }
+}
+
+impl PartialEq<&AbsoluteSystemPath> for PathBuf {
+    fn eq(&self, other: &&AbsoluteSystemPath) -> bool {
+        self.as_path().eq(other)
     }
 }
 

--- a/crates/turborepo-paths/src/absolute_system_path.rs
+++ b/crates/turborepo-paths/src/absolute_system_path.rs
@@ -29,7 +29,7 @@ pub enum PathRelation {
     // e.g. /a vs /a/b
     Parent,
     // e.g. /a/b vs /a
-    Child
+    Child,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -281,6 +281,10 @@ impl AbsoluteSystemPath {
         fs::remove_file(&self.0)
     }
 
+    pub fn remove_dir(&self) -> Result<(), io::Error> {
+        fs::remove_dir(&self.0)
+    }
+
     pub fn components(&self) -> Utf8Components<'_> {
         self.0.components()
     }
@@ -337,9 +341,13 @@ impl AbsoluteSystemPath {
         loop {
             match (self_components.next(), other_components.next()) {
                 // Non-matching component, the paths diverge
-                (Some(self_component), Some(other_component)) if self_component != other_component => return PathRelation::Divergent,
+                (Some(self_component), Some(other_component))
+                    if self_component != other_component =>
+                {
+                    return PathRelation::Divergent
+                }
                 // A matching component, continue iterating
-                (Some(_), Some(_))  => {},
+                (Some(_), Some(_)) => {}
                 // We've reached the end of a possible parent without hitting a
                 // non-matching component. Return Parent.
                 (None, _) => return PathRelation::Parent,

--- a/crates/turborepo-paths/src/absolute_system_path.rs
+++ b/crates/turborepo-paths/src/absolute_system_path.rs
@@ -157,6 +157,10 @@ impl AbsoluteSystemPath {
         fs::remove_dir_all(&self.0)
     }
 
+    pub fn rename(&self, other: &Self) -> Result<(), io::Error> {
+        fs::rename(&self.0, &other.0)
+    }
+
     pub fn extension(&self) -> Option<&str> {
         self.0.extension()
     }

--- a/crates/turborepo-paths/src/absolute_system_path.rs
+++ b/crates/turborepo-paths/src/absolute_system_path.rs
@@ -363,6 +363,7 @@ impl AbsoluteSystemPath {
 impl<'a> From<&'a AbsoluteSystemPath> for CandidatePath<'a> {
     fn from(value: &'a AbsoluteSystemPath) -> Self {
         CandidatePath::from(value.0.as_std_path())
+    }
 }
 
 impl PartialEq<AbsoluteSystemPath> for Path {
@@ -374,6 +375,7 @@ impl PartialEq<AbsoluteSystemPath> for Path {
 }
 
 impl PartialEq<AbsoluteSystemPath> for PathBuf {
+    fn eq(&self, other: &AbsoluteSystemPath) -> bool {
         self.as_path().eq(other)
     }
 }

--- a/crates/turborepo-paths/src/absolute_system_path.rs
+++ b/crates/turborepo-paths/src/absolute_system_path.rs
@@ -106,7 +106,7 @@ impl AbsoluteSystemPath {
         Ok(Self::new_unchecked(path))
     }
 
-    pub(crate) fn new_unchecked<'a>(path: &'a Utf8Path) -> &'a Self {
+    pub(crate) fn new_unchecked(path: &Utf8Path) -> &Self {
         unsafe { &*(path as *const Utf8Path as *const Self) }
     }
 
@@ -591,13 +591,10 @@ mod tests {
         let abs_path = AbsoluteSystemPathBuf::try_from(root)
             .unwrap()
             .join_components(abs_path_components);
-        let other_path = other_components.iter().fold(
-            PathBuf::from_str(root).unwrap(),
-            |mut current, component| {
-                current.push(component);
-                current
-            },
-        );
+        let other_path = AbsoluteSystemPathBuf::try_from(root)
+            .unwrap()
+            .join_components(other_components);
+
         let relation = abs_path.relation_to_path(&other_path);
         assert_eq!(relation, expected);
     }

--- a/crates/turborepo-paths/src/absolute_system_path_buf.rs
+++ b/crates/turborepo-paths/src/absolute_system_path_buf.rs
@@ -237,6 +237,14 @@ impl TryFrom<&Path> for AbsoluteSystemPathBuf {
     }
 }
 
+impl TryFrom<&str> for AbsoluteSystemPathBuf {
+    type Error = PathError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::new(Utf8PathBuf::from(value))
+    }
+}
+
 impl From<AbsoluteSystemPathBuf> for PathBuf {
     fn from(path: AbsoluteSystemPathBuf) -> Self {
         path.0.into_std_path_buf()

--- a/crates/turborepo-paths/src/lib.rs
+++ b/crates/turborepo-paths/src/lib.rs
@@ -56,6 +56,8 @@ pub enum PathError {
     InvalidUnicode(String),
     #[error("Failed to convert path")]
     FromPathBufError(#[from] camino::FromPathBufError),
+    #[error("Failed to convert path")]
+    FromPathError(#[from] camino::FromPathError),
     #[error("path is malformed: {0}")]
     MalformedPath(String),
     #[error("Path is not safe for windows: {0}")]

--- a/crates/turborepo-paths/src/lib.rs
+++ b/crates/turborepo-paths/src/lib.rs
@@ -38,7 +38,7 @@ mod relative_unix_path_buf;
 
 use std::io;
 
-pub use absolute_system_path::AbsoluteSystemPath;
+pub use absolute_system_path::{AbsoluteSystemPath, PathRelation};
 pub use absolute_system_path_buf::AbsoluteSystemPathBuf;
 pub use anchored_system_path::AnchoredSystemPath;
 pub use anchored_system_path_buf::AnchoredSystemPathBuf;


### PR DESCRIPTION
### Description

 - Port `filewatcher.go`, `backend.go`, and `backend_darwin.go` functionality to Rust
 - copy the `fsevents` implementation of `notify::Watcher` from `notify`, modify it to be device-relative and to watch ancestors.

This PR adds a separate crate, rather than refactor the existing implementation. My intention is to layer on a port of `cookie.go`, as well as `globwatcher.go`, and wire it up to the daemon server. It is not currently wired up to anything, it is exercised via tests.

Filewatching notes: this crate exposes two features, `watch_recursively` and `watch_ancestors`. The former manually adds a watch to every directory in the tree that we are watching. The latter manually adds a non-recursive watch to every ancestor that we have permission to watch. Linux enables both, Windows enables `watch_ancestors`, and macos enables neither.

### Testing Instructions

 - new tests added, port of `filewatcher_test.go`
Note that one test is disabled for windows: renaming a parent directory of the repository root

Closes TURBO-1231