### PR TITLE
fix(turborepo): Force all URLs to be normalized during login.

### DIFF
--- a/crates/turborepo-lib/src/config/mod.rs
+++ b/crates/turborepo-lib/src/config/mod.rs
@@ -37,6 +37,11 @@ pub enum Error {
          one"
     )]
     NoTurboJSON,
+    #[error(
+        "loginUrl is configured to \"{value}\", but cannot be a base URL. This happens in \
+         situations like using a `data:` URL."
+    )]
+    LoginUrlCannotBeABase { value: String },
     #[error(transparent)]
     SerdeJson(#[from] serde_json::Error),
     #[error(transparent)]


### PR DESCRIPTION
The login URL that we pass through via `webbrowser-rs` is not escaped. As a consequence, [in what appear to be extremely rare scenarios](https://github.com/amodm/webbrowser-rs/issues/75), some downstream parser is failing to correctly process the URL, resulting in broken behavior. (The linked upstream library does not appear to be the root cause of the problem, though it may be able to be defensive of this scenario.)

The URL we were using previously—though it isn't spec-compliant—isn't _truly_ ambiguous. The guilty parser should not have been tripped up by it.

This also takes the first steps toward aligning the login code paths with aims on dropping `--sso-team`.

Closes TURBO-1232