### PR TITLE
fix(turborepo): Remove automatic linking.

### DIFF
--- a/crates/turborepo-lib/src/commands/login.rs
+++ b/crates/turborepo-lib/src/commands/login.rs
@@ -10,16 +10,9 @@ use serde::Deserialize;
 use tokio::sync::OnceCell;
 #[cfg(not(test))]
 use tracing::warn;
-use turborepo_ui::{start_spinner, BOLD, CYAN, GREY, UNDERLINE};
+use turborepo_ui::{start_spinner, BOLD, CYAN};
 
-use crate::{
-    commands::{
-        link::{verify_caching_enabled, REMOTE_CACHING_INFO, REMOTE_CACHING_URL},
-        CommandBase,
-    },
-    config::Error,
-    get_version,
-};
+use crate::{commands::CommandBase, config::Error};
 
 const DEFAULT_HOST_NAME: &str = "127.0.0.1";
 const DEFAULT_PORT: u16 = 9789;
@@ -48,11 +41,11 @@ pub async fn sso_login(base: &mut CommandBase, sso_team: &str) -> Result<()> {
     let spinner = start_spinner("Waiting for your authorization...");
     direct_user_to_url(login_url.as_str());
 
-    let verification_token = Arc::new(OnceCell::new());
-    run_sso_one_shot_server(DEFAULT_PORT, verification_token.clone()).await?;
+    let token_cell = Arc::new(OnceCell::new());
+    run_sso_one_shot_server(DEFAULT_PORT, token_cell.clone()).await?;
     spinner.finish_and_clear();
 
-    let token = verification_token
+    let token = token_cell
         .get()
         .ok_or_else(|| anyhow!("no token auth token found"))?;
 
@@ -76,37 +69,16 @@ pub async fn sso_login(base: &mut CommandBase, sso_team: &str) -> Result<()> {
         )))
     );
 
-    if let Some(team_id) = verified_user.team_id {
-        verify_caching_enabled(&api_client, &team_id, &verified_user.token, None).await?;
-        base.repo_config_mut()?.set_team_id(Some(team_id))?;
-        println!(
-            "{}
-
-{}
-  For more info, see {}
-
+    println!(
+        "{}
 {}
 ",
-            base.ui
-                .apply(CYAN.apply_to(format!("Remote Caching enabled for {}", sso_team))),
-            REMOTE_CACHING_INFO,
-            base.ui.apply(UNDERLINE.apply_to(REMOTE_CACHING_URL)),
-            base.ui
-                .apply(GREY.apply_to("To disable Remote Caching, run `npx turbo unlink`"))
-        )
-    } else {
-        println!(
-            "{}
-{}
-",
-            base.ui.apply(
-                CYAN.apply_to(
-                    "To connect to your Remote Cache, run the following in any turborepo:"
-                )
-            ),
-            base.ui.apply(BOLD.apply_to("`npx turbo link`"))
-        );
-    }
+        base.ui.apply(
+            CYAN.apply_to("To connect to your Remote Cache, run the following in any turborepo:")
+        ),
+        base.ui.apply(BOLD.apply_to("`npx turbo link`"))
+    );
+
     Ok(())
 }
 
@@ -149,6 +121,7 @@ pub async fn login(base: &mut CommandBase) -> Result<()> {
     .await?;
 
     spinner.finish_and_clear();
+
     let token = token_cell
         .get()
         .ok_or_else(|| anyhow!("Failed to get token"))?;

--- a/crates/turborepo-lib/src/commands/login.rs
+++ b/crates/turborepo-lib/src/commands/login.rs
@@ -409,10 +409,6 @@ mod test {
             base.user_config().unwrap().token().unwrap(),
             vercel_api_mock::EXPECTED_TOKEN
         );
-        assert_eq!(
-            base.repo_config().unwrap().team_id().unwrap(),
-            vercel_api_mock::EXPECTED_SSO_TEAM_ID
-        );
     }
 
     #[test]


### PR DESCRIPTION
The automatic `link` (which only occurs for `--sso-team`) does not account for the fact that `login` is a one-time, global operation, which can be run from _anywhere_ because of global `turbo`.

This means that, _wherever_ you run `turbo login --sso-team` you get a `.turbo/config.json` generated relative to `cwd`.

The preferred method for automatically handling linking should be storing the remote cache configuration inside of `turbo.json`—which makes this automatic `link` step irrelevant and enables us to test for cache connectivity during runs and know concretely whether or not the exhibited behavior is intentional.

First step: remove the clearly buggy `link` implementation.

Review in whitespace-only mode: https://github.com/vercel/turbo/pull/5776/files?w=1

Closes TURBO-1234