### PR TITLE
fix: take reference of run cache opts

### DIFF
--- a/crates/turborepo-lib/src/run/cache.rs
+++ b/crates/turborepo-lib/src/run/cache.rs
@@ -31,7 +31,7 @@ impl RunCache {
     pub fn new(
         cache: AsyncCache,
         repo_root: &AbsoluteSystemPath,
-        opts: RunCacheOpts,
+        opts: &RunCacheOpts,
         color_selector: ColorSelector,
         daemon_client: Option<DaemonClient<DaemonConnector>>,
         ui: UI,

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -198,7 +198,7 @@ impl Run {
         let _runcache = RunCache::new(
             async_cache,
             &self.base.repo_root,
-            opts.runcache_opts,
+            &opts.runcache_opts,
             color_selector,
             daemon,
             self.base.ui,


### PR DESCRIPTION
### Description

Currently constructing a run cache takes ownership of the run cache opts struct which partially moves `opts` making it unusable for the rest of run. Taking ownership is unnecessary since all of the types that get saved by `RunCache` implement `Copy` and can be easily copied.

### Testing Instructions

It compiles 😄 


Closes TURBO-1238