### PR TITLE
chore: require lockfile implementations to be threadsafe

### DIFF
--- a/crates/turborepo-lockfiles/src/berry/mod.rs
+++ b/crates/turborepo-lockfiles/src/berry/mod.rs
@@ -7,7 +7,6 @@ mod ser;
 use std::{
     collections::{HashMap, HashSet},
     iter,
-    rc::Rc,
 };
 
 use de::SemverString;
@@ -40,11 +39,11 @@ pub enum Error {
 type Map<K, V> = std::collections::BTreeMap<K, V>;
 
 pub struct BerryLockfile {
-    data: Rc<LockfileData>,
+    data: LockfileData,
     resolutions: Map<Descriptor<'static>, Locator<'static>>,
     // A mapping from descriptors without protocols to a range with a protocol
     resolver: DescriptorResolver,
-    locator_package: Map<Locator<'static>, Rc<BerryPackage>>,
+    locator_package: Map<Locator<'static>, BerryPackage>,
     // Map of regular locators to patch locators that apply to them
     patches: Map<Locator<'static>, Locator<'static>>,
     // Descriptors that come from default package extensions that ship with berry
@@ -55,12 +54,12 @@ pub struct BerryLockfile {
 
 // This is the direct representation of the lockfile as it appears on disk.
 // More internal tracking is required for effectively altering the lockfile
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct LockfileData {
     #[serde(rename = "__metadata")]
     metadata: Metadata,
     #[serde(flatten)]
-    packages: Map<String, Rc<BerryPackage>>,
+    packages: Map<String, BerryPackage>,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Clone)]
@@ -137,7 +136,7 @@ impl BerryLockfile {
             .unwrap_or_default();
 
         let mut this = Self {
-            data: Rc::new(lockfile),
+            data: lockfile,
             resolutions: descriptor_locator,
             locator_package,
             resolver,

--- a/crates/turborepo-lockfiles/src/berry/ser.rs
+++ b/crates/turborepo-lockfiles/src/berry/ser.rs
@@ -187,8 +187,6 @@ fn wrap_string(s: &str) -> Cow<str> {
 
 #[cfg(test)]
 mod test {
-    use std::rc::Rc;
-
     use pretty_assertions::assert_eq;
 
     use super::*;
@@ -231,10 +229,10 @@ mod test {
             },
             packages: [(
                 long_key.clone(),
-                Rc::new(BerryPackage {
+                BerryPackage {
                     version: SemverString("1.2.3".to_string()),
                     ..Default::default()
-                }),
+                },
             )]
             .iter()
             .cloned()

--- a/crates/turborepo-lockfiles/src/lib.rs
+++ b/crates/turborepo-lockfiles/src/lib.rs
@@ -25,7 +25,7 @@ pub struct Package {
 // This trait will only be used when migrating the Go lockfile implementations
 // to Rust. Once the migration is complete we will leverage petgraph for doing
 // our graph calculations.
-pub trait Lockfile {
+pub trait Lockfile: Send + Sync {
     // Given a workspace, a package it imports and version returns the key, resolved
     // version, and if it was found
     fn resolve_package(


### PR DESCRIPTION
### Description

In order to safely share access to the `PackageGraph` between threads, we need all the types it holds to be threadsafe. The berry lockfile was the only part holding us back due to it's use of `Rc` to avoid cloning some data (this data was borrowed before we removed it's self referential nature).

Alternatives:
 - Not requiring `Lockfile` implementers to be `Send + Sync` and instead hold a `Box<dyn Lockfile + Send + Sync>`:  requiring lockfiles to be `Send + Sync` will allow us to parallelize the walking of the lockfile in the future
 - Replacing `Rc` usage with `Arc` usage in berry lockfile: For the `BerryPackage` struct clone it exactly once from the `LockfileData` struct, the cost of `Arc` seemed to outweigh the savings of avoiding that clone. The `Rc` around the `LockfileData` was only used to avoid cloning the entire lockfile struct when we pruned it via `turbo prune`. Since this only happens in `turbo prune` where FS operations make up the bulk of the runtime, I'm not concerned with this perf hit.

### Testing Instructions

Existing unit tests.
I used `cargo instruments --example berry_resolutions -t time` to see if this was any large perf hit and it seems this like maybe ~1ms.
