### PR TITLE
fix: snapshot test path canonicalization

### DIFF
--- a/crates/turbopack-tests/tests/snapshot.rs
+++ b/crates/turbopack-tests/tests/snapshot.rs
@@ -5,7 +5,7 @@ mod util;
 use std::{
     collections::{HashMap, HashSet, VecDeque},
     fs,
-    path::{Path, PathBuf},
+    path::PathBuf,
 };
 
 use anyhow::{bail, Context, Result};
@@ -165,7 +165,7 @@ async fn run(resource: PathBuf) -> Result<()> {
 
 #[turbo_tasks::function]
 async fn run_test(resource: String) -> Result<Vc<FileSystemPath>> {
-    let test_path = canonicalize(Path::new(&resource))?;
+    let test_path = canonicalize(&resource)?;
     assert!(test_path.exists(), "{} does not exist", resource);
     assert!(
         test_path.is_dir(),


### PR DESCRIPTION
### Description

#5582 did most of it, but was missing the execution tests

Closes WEB-1434