### PR TITLE
fix: unify go rust error formatting

### DIFF
--- a/crates/turborepo-lib/src/lib.rs
+++ b/crates/turborepo-lib/src/lib.rs
@@ -30,7 +30,6 @@ mod shim;
 mod task_graph;
 mod tracing;
 
-use ::tracing::error;
 use anyhow::Result;
 pub use child::spawn_child;
 
@@ -58,7 +57,9 @@ pub fn main() -> Payload {
     match shim::run() {
         Ok(payload) => payload,
         Err(err) => {
-            error!("{}", err.to_string());
+            // This raw print matches the Go behavior, once we no longer care
+            // about matching formatting we should remove this.
+            println!("Turbo error: {err}");
             Payload::Rust(Err(err))
         }
     }

--- a/crates/turborepo-lib/src/tracing.rs
+++ b/crates/turborepo-lib/src/tracing.rs
@@ -170,11 +170,13 @@ where
 
         match *level {
             Level::ERROR => {
-                write_string::<Red, Black>(writer.by_ref(), self.is_ansi, level.as_str())
+                // The padding spaces are necessary to match the formatting of Go
+                write_string::<Red, Black>(writer.by_ref(), self.is_ansi, " ERROR ")
                     .and_then(|_| write_message::<Red, Default>(writer, self.is_ansi, event))
             }
             Level::WARN => {
-                write_string::<Yellow, Black>(writer.by_ref(), self.is_ansi, level.as_str())
+                // The padding spaces are necessary to match the formatting of Go
+                write_string::<Yellow, Black>(writer.by_ref(), self.is_ansi, " WARNING ")
                     .and_then(|_| write_message::<Yellow, Default>(writer, self.is_ansi, event))
             }
             Level::INFO => write_message::<Default, Default>(writer, self.is_ansi, event),

--- a/turborepo-tests/integration/tests/bad_flag.t
+++ b/turborepo-tests/integration/tests/bad_flag.t
@@ -3,7 +3,7 @@ Setup
 
 Bad flag should print misuse text
   $ ${TURBO} --bad-flag
-  ERROR unexpected argument '--bad-flag' found
+   ERROR  unexpected argument '--bad-flag' found
   
     note: to pass '--bad-flag' as a value, use '-- --bad-flag'
   
@@ -15,7 +15,7 @@ Bad flag should print misuse text
 
 Bad flag with an implied run command should display run flags
   $ ${TURBO} build --bad-flag
-  ERROR unexpected argument '--bad-flag' found
+   ERROR  unexpected argument '--bad-flag' found
   
     note: to pass '--bad-flag' as a value, use '-- --bad-flag'
   

--- a/turborepo-tests/integration/tests/command-version.t
+++ b/turborepo-tests/integration/tests/command-version.t
@@ -7,5 +7,5 @@ Test version matches that of version.txt
 
 TODO: resolve ambiguity
   $ ${TURBO} -v
-  ERROR No command specified
+  Turbo error: No command specified
   [1]

--- a/turborepo-tests/integration/tests/no_args.t
+++ b/turborepo-tests/integration/tests/no_args.t
@@ -67,7 +67,7 @@ Make sure exit code is 2 when no args are passed
   [1]
 
   $ ${TURBO} run
-  ERROR at least one task must be specified
+  Turbo error: at least one task must be specified
   [1]
 
 Run again with an environment variable that corresponds to a run argument and assert that

--- a/turborepo-tests/integration/tests/run-logging/log_prefix.t
+++ b/turborepo-tests/integration/tests/run-logging/log_prefix.t
@@ -61,7 +61,7 @@ Setup
 
 # Running with bogus option
   $ ${TURBO} run build --log-prefix=blah
-  ERROR invalid value 'blah' for '--log-prefix <LOG_PREFIX>'
+   ERROR  invalid value 'blah' for '--log-prefix <LOG_PREFIX>'
     [possible values: auto, none, task]
   
   For more information, try '--help'.
@@ -70,7 +70,7 @@ Setup
 
 # Running with missing value for option
   $ ${TURBO} run build --log-prefix
-  ERROR a value is required for '--log-prefix <LOG_PREFIX>' but none was supplied
+   ERROR  a value is required for '--log-prefix <LOG_PREFIX>' but none was supplied
     [possible values: auto, none, task]
   
   For more information, try '--help'.

--- a/turborepo-tests/integration/tests/run-logging/verbosity.t
+++ b/turborepo-tests/integration/tests/run-logging/verbosity.t
@@ -104,7 +104,7 @@ Verbosity level 2
 
 Make sure users can only use one verbosity flag
   $ ${TURBO} build -v --verbosity=1
-  ERROR the argument '-v...' cannot be used with '--verbosity <COUNT>'
+   ERROR  the argument '-v...' cannot be used with '--verbosity <COUNT>'
   
   Usage: turbo [OPTIONS] [COMMAND]
   
@@ -120,12 +120,12 @@ TURBO_LOG_VERBOSITY should be respoected
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .+ (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running command as global turbo (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::daemon::connector: looking for pid in lockfile: .+ (re)
-  ERROR unable to connect: daemon is not running
+  Turbo error: unable to connect: daemon is not running
   [1]
 
 verbosity overrides TURBO_LOG_VERBOSITY global setting
   $ TURBO_LOG_VERBOSITY=debug ${TURBO} daemon status -v
-  ERROR unable to connect: daemon is not running
+  Turbo error: unable to connect: daemon is not running
   [1]
 
 verbosity doesn't override TURBO_LOG_VERBOSITY package settings
@@ -136,5 +136,5 @@ verbosity doesn't override TURBO_LOG_VERBOSITY package settings
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .+ (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running command as global turbo (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::daemon::connector: looking for pid in lockfile: .+ (re)
-  ERROR unable to connect: daemon is not running
+  Turbo error: unable to connect: daemon is not running
   [1]


### PR DESCRIPTION
### Description

This PR changes the error formatting for our Rust codepath to match that of the Go codepath. The lines that we're specifically matching are:
 - our warn and error prefixes being padded: [source](https://github.com/vercel/turbo/blob/main/cli/internal/ui/ui.go#L25)
 - printing out the error instead of using a logger: [source](https://github.com/vercel/turbo/blob/main/cli/internal/cmd/root.go#L87)

### Testing Instructions

If stacked on top of #5789 then persistent task validation integration tests pass:
```
[1 olszewski@chriss-mbp] /Users/olszewski/code/vercel/turborepo/turborepo-tests/integration $ EXPERIMENTAL_RUST_CODEPATH=true .cram_env/bin/prysk --shell=bash tests/persistent_dependencies/1-topological.t
.
# Ran 1 tests, 0 skipped, 0 failed.
```

Closes TURBO-1255