### PR TITLE
fix: persistent task concurrency check

### DIFF
--- a/crates/turborepo-lib/src/engine/mod.rs
+++ b/crates/turborepo-lib/src/engine/mod.rs
@@ -224,8 +224,8 @@ pub enum ValidateError {
         dependant: String,
     },
     #[error(
-        "You have {persistent_count} persistent tasks, but `turbo` is configured for concurrency \
-         of {concurrency}. Set --concurrency to at least {persistent_count}"
+        "You have {persistent_count} persistent tasks but `turbo` is configured for concurrency \
+         of {concurrency}. Set --concurrency to at least {}", persistent_count+1
     )]
     PersistentTasksExceedConcurrency {
         persistent_count: u32,

--- a/crates/turborepo-lib/src/opts.rs
+++ b/crates/turborepo-lib/src/opts.rs
@@ -147,7 +147,7 @@ fn parse_concurrency(concurrency_raw: &str) -> Result<u32> {
         };
     }
     match concurrency_raw.parse::<u32>() {
-        Ok(concurrency) if concurrency > 1 => Ok(concurrency),
+        Ok(concurrency) if concurrency >= 1 => Ok(concurrency),
         Ok(_) | Err(_) => Err(anyhow!(
             "invalid value for --concurrency CLI flag. This should be a positive integer greater \
              than or equal to 1: {}",


### PR DESCRIPTION
### Description

A minor error formatting change and `--concurrency` parsing logic change in order for us to match Go behavior.

### Testing Instructions

Integration test passes:

```
[1 olszewski@chriss-mbp] /Users/olszewski/code/vercel/turborepo/turborepo-tests/integration $ EXPERIMENTAL_RUST_CODEPATH=true .cram_env/bin/prysk --shell=bash tests/persistent_dependencies/10-too-many.t         
.
# Ran 1 tests, 0 skipped, 0 failed.
```


Closes TURBO-1268