### PR TITLE
feat: show all persistent task validation errors

### DIFF
--- a/cli/internal/core/engine.go
+++ b/cli/internal/core/engine.go
@@ -454,12 +454,12 @@ func (e *Engine) AddDep(fromTaskID string, toTaskID string) error {
 // ValidatePersistentDependencies checks if any task dependsOn persistent tasks and throws
 // an error if that task is actually implemented
 func (e *Engine) ValidatePersistentDependencies(graph *graph.CompleteGraph, concurrency int) error {
-	var validationError error
+	var validationErrors []string
 	persistentCount := 0
 
 	// Adding in a lock because otherwise walking the graph can introduce a data race
 	// (reproducible with `go test -race`)
-	var sema = util.NewSemaphore(1)
+	var mu sync.Mutex
 
 	errs := e.TaskGraph.Walk(func(v dag.Vertex) error {
 		vertexName := dag.VertexName(v) // vertexName is a taskID
@@ -468,12 +468,6 @@ func (e *Engine) ValidatePersistentDependencies(graph *graph.CompleteGraph, conc
 		if strings.Contains(vertexName, ROOT_NODE_NAME) {
 			return nil
 		}
-
-		// Aquire a lock, because otherwise walking this group can cause a race condition
-		// writing to the same validationError var defined outside the Walk(). This shows
-		// up when running tests with the `-race` flag.
-		sema.Acquire()
-		defer sema.Release()
 
 		currentTaskDefinition, currentTaskExists := e.completeGraph.TaskDefinitions[vertexName]
 		if currentTaskExists && currentTaskDefinition.Persistent {
@@ -511,11 +505,16 @@ func (e *Engine) ValidatePersistentDependencies(graph *graph.CompleteGraph, conc
 
 			// If both conditions are true set a value and break out of checking the dependencies
 			if depTaskDefinition.Persistent && hasScript {
-				validationError = fmt.Errorf(
+				// Aquire a lock, because otherwise walking this group can cause a race condition
+				// writing to the same validationErrors var defined outside the Walk(). This shows
+				// up when running tests with the `-race` flag.
+				mu.Lock()
+				defer mu.Unlock()
+				validationErrors = append(validationErrors, fmt.Sprintf(
 					"\"%s\" is a persistent task, \"%s\" cannot depend on it",
 					util.GetTaskId(packageName, taskName),
 					util.GetTaskId(currentPackageName, currentTaskName),
-				)
+				))
 
 				break
 			}
@@ -528,8 +527,9 @@ func (e *Engine) ValidatePersistentDependencies(graph *graph.CompleteGraph, conc
 		return fmt.Errorf("Validation failed: %v", err)
 	}
 
-	if validationError != nil {
-		return validationError
+	if len(validationErrors) > 0 {
+		sort.Strings(validationErrors)
+		return fmt.Errorf("%s", strings.Join(validationErrors, "\n"))
 	} else if persistentCount >= concurrency {
 		return fmt.Errorf("You have %v persistent tasks but `turbo` is configured for concurrency of %v. Set --concurrency to at least %v", persistentCount, concurrency, persistentCount+1)
 	}

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -184,7 +184,11 @@ impl Run {
             .map_err(|errors| {
                 anyhow!(
                     "error preparing engine: Invalid persistent task configuration:\n{}",
-                    errors.into_iter().join("\n")
+                    errors
+                        .into_iter()
+                        .map(|e| e.to_string())
+                        .sorted()
+                        .join("\n")
                 )
             })?;
 

--- a/turborepo-tests/integration/tests/persistent_dependencies/3-workspace-specific.t
+++ b/turborepo-tests/integration/tests/persistent_dependencies/3-workspace-specific.t
@@ -19,7 +19,9 @@
 # The regex match is liberal, because the build task from either workspace can throw the error
   $ ${TURBO} run build
    ERROR  run failed: error preparing engine: Invalid persistent task configuration:
-  "pkg-a#dev" is a persistent task, .*-a#build" cannot depend on it (re)
+  "pkg-a#dev" is a persistent task, "app-a#build" cannot depend on it
+  "pkg-a#dev" is a persistent task, "pkg-a#build" cannot depend on it
   Turbo error: error preparing engine: Invalid persistent task configuration:
-  "pkg-a#dev" is a persistent task, .*-a#build" cannot depend on it (re)
+  "pkg-a#dev" is a persistent task, "app-a#build" cannot depend on it
+  "pkg-a#dev" is a persistent task, "pkg-a#build" cannot depend on it
   [1]


### PR DESCRIPTION
### Description

This PR changes the Go behavior of persistent task validation to match how I ported it in Rust. I know I should probably change the Rust to match the Go instead, but the Rust port offers a better UX as it displays *all* persistent task validation errors and is deterministic. Previously in Go we were dependent on which invalid task we encountered first in the graph walk.

### Testing Instructions

Updated integration test passes both Go and Rust implementation
```
[0 olszewski@chriss-mbp] /Users/olszewski/code/vercel/turborepo/turborepo-tests/integration $ EXPERIMENTAL_RUST_CODEPATH=true .cram_env/bin/prysk --shell=bash tests/persistent_dependencies/3-workspace-specific.t
.
# Ran 1 tests, 0 skipped, 0 failed.
[0 olszewski@chriss-mbp] /Users/olszewski/code/vercel/turborepo/turborepo-tests/integration $ EXPERIMENTAL_RUST_CODEPATH=false .cram_env/bin/prysk --shell=bash tests/persistent_dependencies/3-workspace-specific.t
.
# Ran 1 tests, 0 skipped, 0 failed.
```
