### PR TITLE
Update HMR for next-api

### DIFF
--- a/crates/turbopack-cli/js/src/entry/client.ts
+++ b/crates/turbopack-cli/js/src/entry/client.ts
@@ -1,9 +1,14 @@
 import { connect } from "@vercel/turbopack-ecmascript-runtime/dev/client/hmr-client";
-import { connectHMR } from "@vercel/turbopack-ecmascript-runtime/dev/client/websocket";
+import {
+  connectHMR,
+  addMessageListener,
+  sendMessage,
+} from "@vercel/turbopack-ecmascript-runtime/dev/client/websocket";
 
 export function initializeHMR(options: { assetPrefix: string }) {
   connect({
-    assetPrefix: options.assetPrefix,
+    addMessageListener,
+    sendMessage,
   });
   connectHMR({
     assetPrefix: options.assetPrefix,

--- a/crates/turbopack-ecmascript-hmr-protocol/src/lib.rs
+++ b/crates/turbopack-ecmascript-hmr-protocol/src/lib.rs
@@ -27,12 +27,14 @@ impl Display for ResourceIdentifier {
 }
 
 #[derive(Deserialize)]
-#[serde(tag = "type", rename_all = "camelCase")]
+#[serde(tag = "type")]
 pub enum ClientMessage {
+    #[serde(rename = "turbopack-subscribe")]
     Subscribe {
         #[serde(flatten)]
         resource: ResourceIdentifier,
     },
+    #[serde(rename = "turbopack-unsubscribe")]
     Unsubscribe {
         #[serde(flatten)]
         resource: ResourceIdentifier,

--- a/crates/turbopack-ecmascript-runtime/js/package.json
+++ b/crates/turbopack-ecmascript-runtime/js/package.json
@@ -14,6 +14,7 @@
     "check:dev-runtime-none": "tsc -p src/dev/runtime/none"
   },
   "exports": {
+    ".": "./src/main.js",
     "./*": "./src/*.ts"
   },
   "dependencies": {

--- a/crates/turbopack-ecmascript-runtime/js/src/dev/client/hmr-client.ts
+++ b/crates/turbopack-ecmascript-runtime/js/src/dev/client/hmr-client.ts
@@ -12,12 +12,12 @@ export type ClientOptions = {
 
 export function connect({ addMessageListener, sendMessage }: ClientOptions) {
   addMessageListener((msg) => {
-    switch (msg.type) {
+    switch (msg.event) {
       case "turbopack-connected":
         handleSocketConnected(sendMessage);
         break;
       default:
-        handleSocketMessage(msg as ServerMessage);
+        handleSocketMessage(msg.data as ServerMessage);
         break;
     }
   });

--- a/crates/turbopack-ecmascript-runtime/js/src/dev/client/hmr-client.ts
+++ b/crates/turbopack-ecmascript-runtime/js/src/dev/client/hmr-client.ts
@@ -7,23 +7,22 @@ type SendMessage = typeof import("./websocket").sendMessage;
 
 export type ClientOptions = {
   assetPrefix: string;
-  addEventListener: typeof import("./websocket").addEventListener;
+  addMessageListener: typeof import("./websocket").addMessageListener;
   sendMessage: SendMessage;
 };
 
 // TURBOPACK CLient
 export function connect({
   assetPrefix,
-  addEventListener,
+  addMessageListener,
   sendMessage,
 }: ClientOptions) {
-  addEventListener((event) => {
-    switch (event.type) {
-      case "connected":
+  addMessageListener((msg) => {
+    switch (msg.type) {
+      case "turbopack-connected":
         handleSocketConnected(sendMessage);
         break;
-      case "message":
-        const msg: ServerMessage = JSON.parse(event.message.data);
+      default:
         handleSocketMessage(msg);
         break;
     }
@@ -495,7 +494,8 @@ export function setHooks(newHooks: typeof hooks) {
   Object.assign(hooks, newHooks);
 }
 
-function handleSocketMessage(msg: ServerMessage) {
+function handleSocketMessage(event: any) {
+  const msg = JSON.parse(event.data);
   sortIssues(msg.issues);
 
   const hasCriticalIssues = handleIssues(msg);

--- a/crates/turbopack-ecmascript-runtime/js/src/dev/client/hmr-client.ts
+++ b/crates/turbopack-ecmascript-runtime/js/src/dev/client/hmr-client.ts
@@ -3,20 +3,16 @@
 /// <reference path="../runtime/base/protocol.d.ts" />
 /// <reference path="../runtime/base/extensions.d.ts" />
 
+import type { WebSocketMessage } from "./websocket";
+
 type SendMessage = typeof import("./websocket").sendMessage;
 
 export type ClientOptions = {
-  assetPrefix: string;
   addMessageListener: typeof import("./websocket").addMessageListener;
   sendMessage: SendMessage;
 };
 
-// TURBOPACK CLient
-export function connect({
-  assetPrefix,
-  addMessageListener,
-  sendMessage,
-}: ClientOptions) {
+export function connect({ addMessageListener, sendMessage }: ClientOptions) {
   addMessageListener((msg) => {
     switch (msg.type) {
       case "turbopack-connected":
@@ -494,8 +490,7 @@ export function setHooks(newHooks: typeof hooks) {
   Object.assign(hooks, newHooks);
 }
 
-function handleSocketMessage(event: any) {
-  const msg = JSON.parse(event.data);
+function handleSocketMessage(msg: WebSocketMessage) {
   sortIssues(msg.issues);
 
   const hasCriticalIssues = handleIssues(msg);

--- a/crates/turbopack-ecmascript-runtime/js/src/dev/client/hmr-client.ts
+++ b/crates/turbopack-ecmascript-runtime/js/src/dev/client/hmr-client.ts
@@ -12,7 +12,7 @@ export type ClientOptions = {
 
 export function connect({ addMessageListener, sendMessage }: ClientOptions) {
   addMessageListener((msg) => {
-    switch (msg.event) {
+    switch (msg.type) {
       case "turbopack-connected":
         handleSocketConnected(sendMessage);
         break;

--- a/crates/turbopack-ecmascript-runtime/js/src/dev/client/hmr-client.ts
+++ b/crates/turbopack-ecmascript-runtime/js/src/dev/client/hmr-client.ts
@@ -71,13 +71,13 @@ function subscribeToUpdates(
   resource: ResourceIdentifier
 ): () => void {
   sendJSON(sendMessage, {
-    type: "subscribe",
+    type: "turbopack-subscribe",
     ...resource,
   });
 
   return () => {
     sendJSON(sendMessage, {
-      type: "unsubscribe",
+      type: "turbopack-unsubscribe",
       ...resource,
     });
   };

--- a/crates/turbopack-ecmascript-runtime/js/src/dev/client/hmr-client.ts
+++ b/crates/turbopack-ecmascript-runtime/js/src/dev/client/hmr-client.ts
@@ -3,8 +3,6 @@
 /// <reference path="../runtime/base/protocol.d.ts" />
 /// <reference path="../runtime/base/extensions.d.ts" />
 
-import type { WebSocketMessage } from "./websocket";
-
 type SendMessage = typeof import("./websocket").sendMessage;
 
 export type ClientOptions = {
@@ -19,7 +17,7 @@ export function connect({ addMessageListener, sendMessage }: ClientOptions) {
         handleSocketConnected(sendMessage);
         break;
       default:
-        handleSocketMessage(msg);
+        handleSocketMessage(msg as ServerMessage);
         break;
     }
   });
@@ -490,7 +488,7 @@ export function setHooks(newHooks: typeof hooks) {
   Object.assign(hooks, newHooks);
 }
 
-function handleSocketMessage(msg: WebSocketMessage) {
+function handleSocketMessage(msg: ServerMessage) {
   sortIssues(msg.issues);
 
   const hasCriticalIssues = handleIssues(msg);

--- a/crates/turbopack-ecmascript-runtime/js/src/dev/client/index.ts
+++ b/crates/turbopack-ecmascript-runtime/js/src/dev/client/index.ts
@@ -1,0 +1,2 @@
+export * from "./hmr-client";
+export * from "./websocket";

--- a/crates/turbopack-ecmascript-runtime/js/src/dev/client/websocket.ts
+++ b/crates/turbopack-ecmascript-runtime/js/src/dev/client/websocket.ts
@@ -17,7 +17,7 @@ function getSocketProtocol(assetPrefix: string): string {
   return protocol === "http:" ? "ws" : "wss";
 }
 
-type WebSocketMessage = Record<string, any> & {
+export type WebSocketMessage = Record<string, any> & {
   type: string;
 };
 

--- a/crates/turbopack-ecmascript-runtime/js/src/dev/client/websocket.ts
+++ b/crates/turbopack-ecmascript-runtime/js/src/dev/client/websocket.ts
@@ -1,7 +1,7 @@
 // Adapted from https://github.com/vercel/next.js/blob/canary/packages/next/client/dev/error-overlay/websocket.ts
 
 let source: WebSocket;
-const eventCallbacks: ((event: WebsocketEvent) => void)[] = [];
+const eventCallbacks: ((msg: WebSocketMessage) => void)[] = [];
 
 // TODO: add timeout again
 // let lastActivity = Date.now()
@@ -17,16 +17,11 @@ function getSocketProtocol(assetPrefix: string): string {
   return protocol === "http:" ? "ws" : "wss";
 }
 
-type WebsocketEvent =
-  | {
-      type: "connected";
-    }
-  | {
-      type: "message";
-      message: MessageEvent;
-    };
+type WebSocketMessage = Record<string, any> & {
+  type: string;
+};
 
-export function addEventListener(cb: (event: WebsocketEvent) => void) {
+export function addMessageListener(cb: (msg: WebSocketMessage) => void) {
   eventCallbacks.push(cb);
 }
 
@@ -51,10 +46,11 @@ export function connectHMR(options: HMROptions) {
     console.log("[HMR] connecting...");
 
     function handleOnline() {
+      const connected = {
+        type: "turbopack-connected",
+      };
       eventCallbacks.forEach((cb) => {
-        cb({
-          type: "connected",
-        });
+        cb(connected);
       });
 
       if (options.log) console.log("[HMR] connected");
@@ -64,11 +60,9 @@ export function connectHMR(options: HMROptions) {
     function handleMessage(event: MessageEvent) {
       // lastActivity = Date.now()
 
+      const message = JSON.parse(event.data);
       eventCallbacks.forEach((cb) => {
-        cb({
-          type: "message",
-          message: event,
-        });
+        cb(message);
       });
     }
 

--- a/crates/turbopack-ecmascript-runtime/js/src/dev/client/websocket.ts
+++ b/crates/turbopack-ecmascript-runtime/js/src/dev/client/websocket.ts
@@ -17,9 +17,14 @@ function getSocketProtocol(assetPrefix: string): string {
   return protocol === "http:" ? "ws" : "wss";
 }
 
-export type WebSocketMessage = Record<string, any> & {
-  type: string;
-};
+export type WebSocketMessage =
+  | {
+      event: "turbopack-connected";
+    }
+  | {
+      event: "turbopack-message";
+      data: Record<string, any>;
+    };
 
 export function addMessageListener(cb: (msg: WebSocketMessage) => void) {
   eventCallbacks.push(cb);
@@ -46,9 +51,7 @@ export function connectHMR(options: HMROptions) {
     console.log("[HMR] connecting...");
 
     function handleOnline() {
-      const connected = {
-        type: "turbopack-connected",
-      };
+      const connected = { event: "turbopack-connected" as const };
       eventCallbacks.forEach((cb) => {
         cb(connected);
       });
@@ -60,7 +63,10 @@ export function connectHMR(options: HMROptions) {
     function handleMessage(event: MessageEvent) {
       // lastActivity = Date.now()
 
-      const message = JSON.parse(event.data);
+      const message = {
+        event: "turbopack-message" as const,
+        data: JSON.parse(event.data),
+      };
       eventCallbacks.forEach((cb) => {
         cb(message);
       });

--- a/crates/turbopack-ecmascript-runtime/js/src/dev/client/websocket.ts
+++ b/crates/turbopack-ecmascript-runtime/js/src/dev/client/websocket.ts
@@ -19,10 +19,10 @@ function getSocketProtocol(assetPrefix: string): string {
 
 export type WebSocketMessage =
   | {
-      event: "turbopack-connected";
+      type: "turbopack-connected";
     }
   | {
-      event: "turbopack-message";
+      type: "turbopack-message";
       data: Record<string, any>;
     };
 
@@ -51,7 +51,7 @@ export function connectHMR(options: HMROptions) {
     console.log("[HMR] connecting...");
 
     function handleOnline() {
-      const connected = { event: "turbopack-connected" as const };
+      const connected = { type: "turbopack-connected" as const };
       eventCallbacks.forEach((cb) => {
         cb(connected);
       });
@@ -64,7 +64,7 @@ export function connectHMR(options: HMROptions) {
       // lastActivity = Date.now()
 
       const message = {
-        event: "turbopack-message" as const,
+        type: "turbopack-message" as const,
         data: JSON.parse(event.data),
       };
       eventCallbacks.forEach((cb) => {

--- a/crates/turbopack-ecmascript-runtime/js/src/dev/runtime/base/protocol.d.ts
+++ b/crates/turbopack-ecmascript-runtime/js/src/dev/runtime/base/protocol.d.ts
@@ -91,11 +91,11 @@ type ResourceIdentifier = {
 };
 
 type ClientMessageSubscribe = {
-  type: "subscribe";
+  type: "turbopack-subscribe";
 } & ResourceIdentifier;
 
 type ClientMessageUnsubscribe = {
-  type: "unsubscribe";
+  type: "turbopack-unsubscribe";
 } & ResourceIdentifier;
 
 type ClientMessage = ClientMessageSubscribe | ClientMessageUnsubscribe;

--- a/crates/turbopack-ecmascript-runtime/js/src/main.js
+++ b/crates/turbopack-ecmascript-runtime/js/src/main.js
@@ -1,0 +1,1 @@
+// required for NCC to work


### PR DESCRIPTION
### Description

This makes several changes to our HMR protocol to make play nicely with Next's already existing websocket and protocol:
1. Use a `turbopack-` prefix in our message's `type`
2. Allow any compatible `sendMessage` and `addMessageListener` implementation (so we can reuse Next's websocket handlers)
3. Create a new "dev client" entrypoint so that we can precompile with NCC
4. Receive a pre-parsed `data` from the websocket's `message.data` string.



### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->


Closes WEB-1452