### PR TITLE
fix(turborepo): API naming and dep graph

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -16,11 +16,11 @@ tr-run = "run -p turbo"
 tr-test = "groups test turborepo"
 tr-check = "groups check turborepo"
 # Builds all test code to check for compiler errors before running
-tp-pre-test = "nextest run --no-run --workspace --release --exclude turbo --exclude turborepo-* --exclude turbopath --exclude vercel-api-mock --exclude wax --exclude globwalk --exclude globwatch --exclude pidlock"
-tp-test = "nextest run --workspace --release --no-fail-fast --exclude turbo --exclude turborepo-* --exclude turbopath --exclude vercel-api-mock --exclude wax --exclude globwalk --exclude globwatch --exclude pidlock"
-tp-bench-test = "test --benches --workspace --release --no-fail-fast --exclude turbopack-bench --exclude turbo --exclude turborepo-* --exclude turbopath --exclude vercel-api-mock --exclude wax --exclude globwalk --exclude globwatch --exclude pidlock"
-tp-check = "check --workspace --exclude turbo --exclude turborepo-* --exclude turbopath --exclude vercel-api-mock --exclude wax --exclude globwalk --exclude globwatch --exclude pidlock"
-tp-clippy = "clippy --workspace --exclude turbo --exclude turborepo-* --exclude turbopath --exclude vercel-api-mock --exclude wax --exclude globwalk --exclude globwatch --exclude pidlock"
+tp-pre-test = "nextest run --no-run --workspace --release --exclude turbo --exclude turborepo-* --exclude turbopath --exclude wax --exclude globwalk --exclude globwatch --exclude pidlock"
+tp-test = "nextest run --workspace --release --no-fail-fast --exclude turbo --exclude turborepo-* --exclude turbopath --exclude wax --exclude globwalk --exclude globwatch --exclude pidlock"
+tp-bench-test = "test --benches --workspace --release --no-fail-fast --exclude turbopack-bench --exclude turbo --exclude turborepo-* --exclude turbopath --exclude wax --exclude globwalk --exclude globwatch --exclude pidlock"
+tp-check = "check --workspace --exclude turbo --exclude turborepo-* --exclude turbopath --exclude wax --exclude globwalk --exclude globwatch --exclude pidlock"
+tp-clippy = "clippy --workspace --exclude turbo --exclude turborepo-* --exclude turbopath --exclude wax --exclude globwalk --exclude globwatch --exclude pidlock"
 
 [target.'cfg(all())']
 rustflags = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9676,8 +9676,8 @@ dependencies = [
  "thiserror",
  "tokio",
  "turborepo-ci",
+ "turborepo-vercel-api-mock",
  "url",
- "vercel-api-mock",
 ]
 
 [[package]]
@@ -9711,7 +9711,7 @@ dependencies = [
  "turbopath",
  "turborepo-api-client",
  "turborepo-ui",
- "vercel-api-mock",
+ "turborepo-vercel-api-mock",
  "zstd",
 ]
 
@@ -9849,9 +9849,9 @@ dependencies = [
  "turborepo-lockfiles",
  "turborepo-scm",
  "turborepo-ui",
+ "turborepo-vercel-api-mock",
  "uds_windows",
  "url",
- "vercel-api-mock",
  "wax",
  "webbrowser",
  "which",
@@ -9910,6 +9910,21 @@ dependencies = [
  "tracing",
  "turbopath",
  "turborepo-ci",
+]
+
+[[package]]
+name = "turborepo-vercel-api-mock"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "axum",
+ "axum-macros",
+ "axum-server",
+ "futures-util",
+ "port_scanner",
+ "tempfile",
+ "tokio",
+ "turborepo-api-client",
 ]
 
 [[package]]
@@ -10168,21 +10183,6 @@ name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-
-[[package]]
-name = "vercel-api-mock"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "axum",
- "axum-macros",
- "axum-server",
- "futures-util",
- "port_scanner",
- "tempfile",
- "tokio",
- "turborepo-api-client",
-]
 
 [[package]]
 name = "vergen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9676,6 +9676,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "turborepo-ci",
+ "turborepo-vercel-api",
  "turborepo-vercel-api-mock",
  "url",
 ]
@@ -9849,6 +9850,7 @@ dependencies = [
  "turborepo-lockfiles",
  "turborepo-scm",
  "turborepo-ui",
+ "turborepo-vercel-api",
  "turborepo-vercel-api-mock",
  "uds_windows",
  "url",
@@ -9913,6 +9915,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "turborepo-vercel-api"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "serde",
+ "url",
+]
+
+[[package]]
 name = "turborepo-vercel-api-mock"
 version = "0.1.0"
 dependencies = [
@@ -9924,7 +9935,7 @@ dependencies = [
  "port_scanner",
  "tempfile",
  "tokio",
- "turborepo-api-client",
+ "turborepo-vercel-api",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,6 +142,7 @@ turborepo-lockfiles = { path = "crates/turborepo-lockfiles" }
 turborepo-ui = { path = "crates/turborepo-ui" }
 turborepo-scm = { path = "crates/turborepo-scm" }
 wax = { path = "crates/turborepo-wax" }
+turborepo-vercel-api = { path = "crates/turborepo-vercel-api" }
 turborepo-vercel-api-mock = { path = "crates/turborepo-vercel-api-mock" }
 
 # Be careful when selecting tls backend, including change default tls backend.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,7 +142,7 @@ turborepo-lockfiles = { path = "crates/turborepo-lockfiles" }
 turborepo-ui = { path = "crates/turborepo-ui" }
 turborepo-scm = { path = "crates/turborepo-scm" }
 wax = { path = "crates/turborepo-wax" }
-vercel-api-mock = { path = "crates/turborepo-vercel-api-mock" }
+turborepo-vercel-api-mock = { path = "crates/turborepo-vercel-api-mock" }
 
 # Be careful when selecting tls backend, including change default tls backend.
 # If you changed, must verify with ALL build targets with next-swc to ensure

--- a/crates/turborepo-api-client/Cargo.toml
+++ b/crates/turborepo-api-client/Cargo.toml
@@ -24,4 +24,5 @@ serde = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 turborepo-ci = { workspace = true }
+turborepo-vercel-api = { workspace = true }
 url = { workspace = true }

--- a/crates/turborepo-api-client/Cargo.toml
+++ b/crates/turborepo-api-client/Cargo.toml
@@ -11,7 +11,7 @@ rustls-tls = ["reqwest/rustls-tls"]
 
 [dev-dependencies]
 port_scanner = { workspace = true }
-vercel-api-mock = { workspace = true }
+turborepo-vercel-api-mock = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/turborepo-api-client/src/lib.rs
+++ b/crates/turborepo-api-client/src/lib.rs
@@ -9,8 +9,11 @@ use lazy_static::lazy_static;
 use regex::Regex;
 pub use reqwest::Response;
 use reqwest::{Method, RequestBuilder, StatusCode};
-use serde::{Deserialize, Serialize};
 use turborepo_ci::{is_ci, Vendor};
+use turborepo_vercel_api::{
+    APIError, CachingStatus, CachingStatusResponse, PreflightResponse, SpacesResponse, Team,
+    TeamsResponse, UserResponse, VerificationResponse, VerifiedSsoUser,
+};
 use url::Url;
 
 pub use crate::error::{Error, Result};
@@ -21,123 +24,6 @@ mod retry;
 lazy_static! {
     static ref AUTHORIZATION_REGEX: Regex =
         Regex::new(r"(?i)(?:^|,) *authorization *(?:,|$)").unwrap();
-}
-
-#[derive(Debug, Clone, Deserialize)]
-pub struct VerifiedSsoUser {
-    pub token: String,
-    pub team_id: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct VerificationResponse {
-    pub token: String,
-    pub team_id: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum CachingStatus {
-    Disabled,
-    Enabled,
-    OverLimit,
-    Paused,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CachingStatusResponse {
-    pub status: CachingStatus,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ArtifactResponse {
-    pub duration: u64,
-    pub expected_tag: Option<String>,
-    pub body: Vec<u8>,
-}
-
-/// Membership is the relationship between the logged-in user and a particular
-/// team
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Membership {
-    role: Role,
-}
-
-impl Membership {
-    #[allow(dead_code)]
-    pub fn new(role: Role) -> Self {
-        Self { role }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "UPPERCASE")]
-pub enum Role {
-    Member,
-    Owner,
-    Viewer,
-    Developer,
-    Billing,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Team {
-    pub id: String,
-    pub slug: String,
-    pub name: String,
-    #[serde(rename = "createdAt")]
-    pub created_at: u64,
-    pub created: chrono::DateTime<chrono::Utc>,
-    pub membership: Membership,
-}
-
-impl Team {
-    pub fn is_owner(&self) -> bool {
-        matches!(self.membership.role, Role::Owner)
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Space {
-    pub id: String,
-    pub name: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TeamsResponse {
-    pub teams: Vec<Team>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SpacesResponse {
-    pub spaces: Vec<Space>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct User {
-    pub id: String,
-    pub username: String,
-    pub email: String,
-    pub name: Option<String>,
-    #[serde(rename = "createdAt")]
-    pub created_at: Option<u64>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct UserResponse {
-    pub user: User,
-}
-
-pub struct PreflightResponse {
-    location: Url,
-    allow_authorization_header: bool,
-}
-
-#[derive(Deserialize)]
-struct APIError {
-    code: String,
-    message: String,
 }
 
 pub struct APIClient {

--- a/crates/turborepo-api-client/src/lib.rs
+++ b/crates/turborepo-api-client/src/lib.rs
@@ -509,7 +509,7 @@ impl APIClient {
 #[cfg(test)]
 mod test {
     use anyhow::Result;
-    use vercel_api_mock::start_test_server;
+    use turborepo_vercel_api_mock::start_test_server;
 
     use crate::APIClient;
 

--- a/crates/turborepo-cache/Cargo.toml
+++ b/crates/turborepo-cache/Cargo.toml
@@ -17,7 +17,7 @@ libc = "0.2.146"
 port_scanner = { workspace = true }
 tempfile = { workspace = true }
 test-case = { workspace = true }
-vercel-api-mock = { workspace = true }
+turborepo-vercel-api-mock = { workspace = true }
 
 [dependencies]
 base64 = "0.21.0"

--- a/crates/turborepo-cache/src/async_cache.rs
+++ b/crates/turborepo-cache/src/async_cache.rs
@@ -93,7 +93,7 @@ mod tests {
     use tempfile::tempdir;
     use turbopath::AbsoluteSystemPathBuf;
     use turborepo_api_client::APIClient;
-    use vercel_api_mock::start_test_server;
+    use turborepo_vercel_api_mock::start_test_server;
 
     use crate::{
         http::APIAuth,

--- a/crates/turborepo-cache/src/http.rs
+++ b/crates/turborepo-cache/src/http.rs
@@ -192,7 +192,7 @@ mod test {
     use tempfile::tempdir;
     use turbopath::AbsoluteSystemPathBuf;
     use turborepo_api_client::APIClient;
-    use vercel_api_mock::start_test_server;
+    use turborepo_vercel_api_mock::start_test_server;
 
     use crate::{
         http::{APIAuth, HTTPCache},

--- a/crates/turborepo-lib/Cargo.toml
+++ b/crates/turborepo-lib/Cargo.toml
@@ -82,6 +82,7 @@ tonic = { version = "0.8.3", features = ["transport"] }
 tonic-reflection = { version = "0.6.0", optional = true }
 tower = "0.4.13"
 turborepo-fs = { path = "../turborepo-fs" }
+turborepo-vercel-api = { path = "../turborepo-vercel-api" }
 uds_windows = "1.0.2"
 url = "2.3.1"
 

--- a/crates/turborepo-lib/Cargo.toml
+++ b/crates/turborepo-lib/Cargo.toml
@@ -30,7 +30,7 @@ tempfile = { workspace = true }
 test-case = { workspace = true }
 tracing-test = { version = "0.2.4", features = ["no-env-filter"] }
 tracing.workspace = true
-vercel-api-mock = { workspace = true }
+turborepo-vercel-api-mock = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true, features = ["backtrace"] }

--- a/crates/turborepo-lib/src/commands/link.rs
+++ b/crates/turborepo-lib/src/commands/link.rs
@@ -466,7 +466,7 @@ mod test {
     use tempfile::{NamedTempFile, TempDir};
     use turbopath::AbsoluteSystemPathBuf;
     use turborepo_ui::UI;
-    use vercel_api_mock::start_test_server;
+    use turborepo_vercel_api_mock::start_test_server;
 
     use crate::{
         cli::LinkTarget,
@@ -520,8 +520,8 @@ mod test {
         handle.abort();
         let team_id = base.repo_config().unwrap().team_id();
         assert!(
-            team_id == Some(vercel_api_mock::EXPECTED_USER_ID)
-                || team_id == Some(vercel_api_mock::EXPECTED_TEAM_ID)
+            team_id == Some(turborepo_vercel_api_mock::EXPECTED_USER_ID)
+                || team_id == Some(turborepo_vercel_api_mock::EXPECTED_TEAM_ID)
         );
 
         Ok(())
@@ -586,7 +586,7 @@ mod test {
         let turbo_json: RawTurboJSON = serde_json::from_str(&turbo_json_contents).unwrap();
         assert_eq!(
             turbo_json.experimental_spaces.unwrap().id.unwrap(),
-            vercel_api_mock::EXPECTED_SPACE_ID
+            turborepo_vercel_api_mock::EXPECTED_SPACE_ID
         );
     }
 }

--- a/crates/turborepo-lib/src/commands/link.rs
+++ b/crates/turborepo-lib/src/commands/link.rs
@@ -16,10 +16,11 @@ use dialoguer::{theme::ColorfulTheme, Confirm};
 use dirs_next::home_dir;
 #[cfg(test)]
 use rand::Rng;
-use turborepo_api_client::{APIClient, CachingStatus, Space, Team};
+use turborepo_api_client::APIClient;
 #[cfg(not(test))]
 use turborepo_ui::CYAN;
 use turborepo_ui::{BOLD, GREY, UNDERLINE};
+use turborepo_vercel_api::{CachingStatus, Space, Team};
 
 use crate::{cli::LinkTarget, commands::CommandBase, rewrite_json};
 

--- a/crates/turborepo-lib/src/commands/login.rs
+++ b/crates/turborepo-lib/src/commands/login.rs
@@ -177,7 +177,7 @@ async fn run_login_one_shot_server(
     login_token: Arc<OnceCell<String>>,
 ) -> Result<()> {
     login_token
-        .set(vercel_api_mock::EXPECTED_TOKEN.to_string())
+        .set(turborepo_vercel_api_mock::EXPECTED_TOKEN.to_string())
         .unwrap();
     Ok(())
 }
@@ -297,7 +297,7 @@ mod test {
     use tempfile::{tempdir, NamedTempFile};
     use turbopath::AbsoluteSystemPathBuf;
     use turborepo_ui::UI;
-    use vercel_api_mock::start_test_server;
+    use turborepo_vercel_api_mock::start_test_server;
 
     use crate::{
         commands::{
@@ -352,7 +352,7 @@ mod test {
 
         assert_eq!(
             base.user_config().unwrap().token().unwrap(),
-            vercel_api_mock::EXPECTED_TOKEN
+            turborepo_vercel_api_mock::EXPECTED_TOKEN
         );
     }
 
@@ -399,7 +399,7 @@ mod test {
             version: "",
         };
 
-        login::sso_login(&mut base, vercel_api_mock::EXPECTED_SSO_TEAM_SLUG)
+        login::sso_login(&mut base, turborepo_vercel_api_mock::EXPECTED_SSO_TEAM_SLUG)
             .await
             .unwrap();
 
@@ -407,7 +407,7 @@ mod test {
 
         assert_eq!(
             base.user_config().unwrap().token().unwrap(),
-            vercel_api_mock::EXPECTED_TOKEN
+            turborepo_vercel_api_mock::EXPECTED_TOKEN
         );
     }
 

--- a/crates/turborepo-vercel-api-mock/Cargo.toml
+++ b/crates/turborepo-vercel-api-mock/Cargo.toml
@@ -15,4 +15,4 @@ futures-util = "0.3.28"
 port_scanner = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
-turborepo-api-client = { workspace = true }
+turborepo-vercel-api = { workspace = true }

--- a/crates/turborepo-vercel-api-mock/Cargo.toml
+++ b/crates/turborepo-vercel-api-mock/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "vercel-api-mock"
+name = "turborepo-vercel-api-mock"
 version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"

--- a/crates/turborepo-vercel-api-mock/src/lib.rs
+++ b/crates/turborepo-vercel-api-mock/src/lib.rs
@@ -11,7 +11,7 @@ use axum::{
 };
 use futures_util::StreamExt;
 use tokio::sync::Mutex;
-use turborepo_api_client::{
+use turborepo_vercel_api::{
     CachingStatus, CachingStatusResponse, Membership, Role, Space, SpacesResponse, Team,
     TeamsResponse, User, UserResponse, VerificationResponse,
 };

--- a/crates/turborepo-vercel-api-mock/src/main.rs
+++ b/crates/turborepo-vercel-api-mock/src/main.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use vercel_api_mock::start_test_server;
+use turborepo_vercel_api_mock::start_test_server;
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/crates/turborepo-vercel-api/Cargo.toml
+++ b/crates/turborepo-vercel-api/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "turborepo-vercel-api"
+version = "0.1.0"
+edition = "2021"
+license = "MPL-2.0"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+chrono = { workspace = true, features = ["serde"] }
+serde = { workspace = true }
+url = { workspace = true }

--- a/crates/turborepo-vercel-api/src/lib.rs
+++ b/crates/turborepo-vercel-api/src/lib.rs
@@ -1,0 +1,119 @@
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct VerifiedSsoUser {
+    pub token: String,
+    pub team_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VerificationResponse {
+    pub token: String,
+    pub team_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CachingStatus {
+    Disabled,
+    Enabled,
+    OverLimit,
+    Paused,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CachingStatusResponse {
+    pub status: CachingStatus,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ArtifactResponse {
+    pub duration: u64,
+    pub expected_tag: Option<String>,
+    pub body: Vec<u8>,
+}
+
+/// Membership is the relationship between the logged-in user and a particular
+/// team
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Membership {
+    role: Role,
+}
+
+impl Membership {
+    #[allow(dead_code)]
+    pub fn new(role: Role) -> Self {
+        Self { role }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum Role {
+    Member,
+    Owner,
+    Viewer,
+    Developer,
+    Billing,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Team {
+    pub id: String,
+    pub slug: String,
+    pub name: String,
+    #[serde(rename = "createdAt")]
+    pub created_at: u64,
+    pub created: chrono::DateTime<chrono::Utc>,
+    pub membership: Membership,
+}
+
+impl Team {
+    pub fn is_owner(&self) -> bool {
+        matches!(self.membership.role, Role::Owner)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Space {
+    pub id: String,
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TeamsResponse {
+    pub teams: Vec<Team>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SpacesResponse {
+    pub spaces: Vec<Space>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct User {
+    pub id: String,
+    pub username: String,
+    pub email: String,
+    pub name: Option<String>,
+    #[serde(rename = "createdAt")]
+    pub created_at: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UserResponse {
+    pub user: User,
+}
+
+pub struct PreflightResponse {
+    pub location: Url,
+    pub allow_authorization_header: bool,
+}
+
+#[derive(Deserialize)]
+pub struct APIError {
+    pub code: String,
+    pub message: String,
+}


### PR DESCRIPTION
Previously we had a cycle in our dependencies; this hoists the API definitions out of API Client into their own crate `turborepo-vercel-api` so that both `turborepo-vercel-api-mock` and `turborepo-api-client` can consume them.

This is part of incremental progress for enabling iteration on API.

Closes TURBO-1271