### PR TITLE
fix(lint): set vscode config for pnpm examples

### DIFF
--- a/packages/create-turbo/package.json
+++ b/packages/create-turbo/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "chalk": "2.4.2",
     "commander": "^10.0.0",
-    "fs-extra": "^10.1.0",
+    "fs-extra": "^11.1.1",
     "inquirer": "^8.0.0",
     "proxy-agent": "^6.2.2",
     "rimraf": "^3.0.2",

--- a/packages/create-turbo/src/transforms/index.ts
+++ b/packages/create-turbo/src/transforms/index.ts
@@ -1,6 +1,7 @@
 import { transform as packageManagerTransform } from "./package-manager";
 import { transform as officialStarter } from "./official-starter";
 import { transform as gitIgnoreTransform } from "./git-ignore";
+import { transform as pnpmEslintTransform } from "./pnpm-eslint";
 import type { TransformInput, TransformResult } from "./types";
 
 /**
@@ -10,4 +11,5 @@ export const transforms: Array<(args: TransformInput) => TransformResult> = [
   officialStarter,
   gitIgnoreTransform,
   packageManagerTransform,
+  pnpmEslintTransform,
 ];

--- a/packages/create-turbo/src/transforms/pnpm-eslint.ts
+++ b/packages/create-turbo/src/transforms/pnpm-eslint.ts
@@ -1,0 +1,32 @@
+import { writeJson, mkdir } from "fs-extra";
+import type { TransformInput, TransformResult } from "./types";
+
+const meta = {
+  name: "pnpm-eslint",
+};
+
+const VSCODE_ESLINT_CONFIG = {
+  "eslint.workingDirectories": [{ mode: "auto" }],
+};
+
+export async function transform(args: TransformInput): TransformResult {
+  const { project, prompts } = args;
+  const { packageManager } = prompts;
+
+  if (packageManager?.name === "pnpm") {
+    // write the settings directory
+    await mkdir(`${project.paths.root}/.vscode`, { recursive: true });
+    // write .vscode settings =- required for eslint plugin for work with pnpm workspaces
+    await writeJson(
+      `${project.paths.root}/.vscode/settings.json`,
+      VSCODE_ESLINT_CONFIG,
+      {
+        spaces: 2,
+      }
+    );
+  } else {
+    return { result: "not-applicable", ...meta };
+  }
+
+  return { result: "success", ...meta };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -444,8 +444,8 @@ importers:
         specifier: ^10.0.0
         version: 10.0.0
       fs-extra:
-        specifier: ^10.1.0
-        version: 10.1.0
+        specifier: ^11.1.1
+        version: 11.1.1
       inquirer:
         specifier: ^8.0.0
         version: 8.2.4


### PR DESCRIPTION
### Description

> `[{ "mode": "auto" }]` (since 2.0.0): instructs ESLint to infer a working directory based on the location of package.json, .eslintignore and .eslintrc* files. 

Fixes https://github.com/vercel/turbo/issues/5817
