### PR TITLE
chore: minor task cache changes

### DIFF
--- a/crates/turborepo-lib/src/run/cache.rs
+++ b/crates/turborepo-lib/src/run/cache.rs
@@ -52,12 +52,13 @@ impl RunCache {
         self: &Arc<Self>,
         // TODO: Group these in a struct
         task_definition: &TaskDefinition,
-        task_dir: &AbsoluteSystemPath,
+        workspace_dir: &AnchoredSystemPath,
         task_id: TaskId<'static>,
-        log_file: &AnchoredSystemPath,
         hash: &str,
     ) -> TaskCache {
-        let log_file_path = self.repo_root.resolve(log_file);
+        let task_dir = self.repo_root.resolve(workspace_dir);
+        let log_file_path =
+            task_dir.join_components(&[".turbo", &format!("turbo-{}.log", task_id.task())]);
         let hashable_outputs = task_definition.hashable_outputs(&task_id);
         let mut repo_relative_globs = TaskOutputs {
             inclusions: Vec::with_capacity(hashable_outputs.inclusions.len()),

--- a/crates/turborepo-lib/src/run/cache.rs
+++ b/crates/turborepo-lib/src/run/cache.rs
@@ -115,7 +115,7 @@ pub struct TaskCache {
 }
 
 impl TaskCache {
-    fn replay_log_file(
+    pub fn replay_log_file(
         &self,
         prefixed_ui: &mut PrefixedUI<impl Write>,
     ) -> Result<(), anyhow::Error> {
@@ -126,7 +126,7 @@ impl TaskCache {
         Ok(())
     }
 
-    fn on_error(&self, prefixed_ui: &mut PrefixedUI<impl Write>) -> Result<(), anyhow::Error> {
+    pub fn on_error(&self, prefixed_ui: &mut PrefixedUI<impl Write>) -> Result<(), anyhow::Error> {
         if self.task_output_mode == OutputLogsMode::ErrorsOnly {
             prefixed_ui.output(format!(
                 "cache miss, executing {}",
@@ -138,7 +138,7 @@ impl TaskCache {
         Ok(())
     }
 
-    fn output_writer<W: Write>(
+    pub fn output_writer<W: Write>(
         &self,
         prefix: StyledObject<String>,
         writer: W,
@@ -163,7 +163,7 @@ impl TaskCache {
         Ok(log_writer)
     }
 
-    async fn restore_outputs(
+    pub async fn restore_outputs(
         &mut self,
         team_id: &str,
         team_slug: Option<&str>,

--- a/crates/turborepo-lib/src/run/cache.rs
+++ b/crates/turborepo-lib/src/run/cache.rs
@@ -1,4 +1,4 @@
-use std::{io::Write, rc::Rc};
+use std::{io::Write, sync::Arc};
 
 use console::StyledObject;
 use tracing::{debug, log::warn};
@@ -49,7 +49,7 @@ impl RunCache {
     }
 
     pub fn task_cache(
-        self: &Rc<Self>,
+        self: &Arc<Self>,
         // TODO: Group these in a struct
         task_definition: &TaskDefinition,
         task_dir: &AbsoluteSystemPath,
@@ -102,7 +102,7 @@ impl RunCache {
 
 pub struct TaskCache {
     expanded_outputs: Vec<AnchoredSystemPathBuf>,
-    run_cache: Rc<RunCache>,
+    run_cache: Arc<RunCache>,
     repo_relative_globs: TaskOutputs,
     hash: String,
     task_output_mode: OutputLogsMode,

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -4,13 +4,13 @@ mod cache;
 mod global_hash;
 mod scope;
 pub mod task_id;
-
 use std::{
     io::{BufWriter, IsTerminal},
     sync::Arc,
 };
 
 use anyhow::{anyhow, Context as ErrorContext, Result};
+pub use cache::{RunCache, TaskCache};
 use itertools::Itertools;
 use tracing::{debug, info};
 use turbopath::AbsoluteSystemPathBuf;
@@ -29,7 +29,7 @@ use crate::{
     opts::{GraphOpts, Opts},
     package_graph::{PackageGraph, WorkspaceName},
     package_json::PackageJson,
-    run::{cache::RunCache, global_hash::get_global_hash_inputs},
+    run::global_hash::get_global_hash_inputs,
     task_graph::Visitor,
 };
 


### PR DESCRIPTION
### Description

This PR can be reviewed by commit and contains the following changes:
 - Changing use of `Rc` into `Arc` in `TaskCache`, this allows us to send the task cache across tokio tasks.
 - Alterations to the task cache constructor: the `task_dir`/`workspace_dir` that we get from the package graph will be a repo_root anchored system path and we can derive the log file path from the information that is already sent in instead of [calculating it elsewhere like we do in Go](https://github.com/vercel/turbo/blob/main/cli/internal/graph/graph.go#L239).
 - Make `RunCache`/`TaskCache` accessible to the rest of the crate along with the so that the task graph visitor can operate on them. The changes to the visibility of the methods on `TaskCache` now match the Go implementation.

### Testing Instructions

Primarily 👀 as these are just minor changes to allow for the task cache to be used by the task graph visitor

Closes TURBO-1285