### PR TITLE
Update `swc_core` to `v0.82.10`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -690,9 +690,9 @@ dependencies = [
 
 [[package]]
 name = "binding_macros"
-version = "0.56.4"
+version = "0.56.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4706d0a47d57797314dc7d333fd7457e25ad9dc5061dba6326e160e0c54af6"
+checksum = "d7379c1a81786adc4a7a0bfe197be24402b1314bf7f0e0f45d10de767377aeac"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -4169,9 +4169,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "5486aed0026218e61b8a01d5fbd5a0a134649abb71a0e53b7bc088529dced86e"
 
 [[package]]
 name = "memmap2"
@@ -4400,9 +4400,9 @@ dependencies = [
 
 [[package]]
 name = "modularize_imports"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b96a1660a2857b51dfb91b50c5ca36690fbe3b2002bec7a4e602e7086a4b14"
+checksum = "207835c220baf4ce7535ae23f61b3ed1f8d08b57a6a8eb7803a5ec2bc3d689c6"
 dependencies = [
  "convert_case 0.5.0",
  "handlebars",
@@ -6945,9 +6945,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "styled_components"
-version = "0.64.0"
+version = "0.65.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfba2853ec3b9dbbc252f51278216b005789960ef7435d147794b82928a5e210"
+checksum = "6d73be0eacb8259fcbd1cd87d44a1084123860ae48f6fefa26ae594f52eff138"
 dependencies = [
  "Inflector",
  "once_cell",
@@ -6959,9 +6959,9 @@ dependencies = [
 
 [[package]]
 name = "styled_jsx"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41307dd2ef3c21f87bf1549d9cc78b65378f113edaa678f080898413b06b3386"
+checksum = "526a18566599c72e059bc99caa9498394b86f95d7043c2f79597eb31f597163f"
 dependencies = [
  "easy-error",
  "lightningcss",
@@ -7006,9 +7006,9 @@ dependencies = [
 
 [[package]]
 name = "swc"
-version = "0.265.4"
+version = "0.265.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ba53e3f02aa1a84dce2fa765b2388d1d50c61ca54b63882e3e368149e488905"
+checksum = "0ca1e03e7be80a2eae021b23317936d1782998cba8447b56e8f9e13402366837"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
@@ -7084,9 +7084,9 @@ dependencies = [
 
 [[package]]
 name = "swc_bundler"
-version = "0.219.3"
+version = "0.219.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a09dc06bca10155b807e3810325299bc5a57ca83d7ebe7bbc8ccac5f85b8cc2b"
+checksum = "e3a67bb31be024e911195c51dd8ea2a6b3f032d75862e1f81038bba80f67088f"
 dependencies = [
  "anyhow",
  "crc",
@@ -7130,9 +7130,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39cb7fcd56655c8ae7dcf2344f0be6cbff4d9c7cb401fe3ec8e56e1de8dfe582"
+checksum = "9c84742fc22df1c293da5354c1cc8a5b45a045e9dc941005c1fd9cb4e9bdabc1"
 dependencies = [
  "ahash 0.8.3",
  "anyhow",
@@ -7189,9 +7189,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "0.82.4"
+version = "0.82.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "749bc45ec3e42e70a167ecacbb6f0beacbf34c1050729404abd216df05b37f12"
+checksum = "567897c2eaeebc497baa7d1c0047b9d1c807bb88b0b21039485252677d3a05c6"
 dependencies = [
  "binding_macros",
  "swc",
@@ -7233,9 +7233,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_ast"
-version = "0.139.0"
+version = "0.139.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b183736d78583b5261e690833b0e8a1d5acee4ad99142d0e3aabdec10795fc5"
+checksum = "fab824eff88884673de1d6b84cdb5d3d71c0b903fcef62a3ec1f44f40477433f"
 dependencies = [
  "is-macro",
  "serde",
@@ -7246,9 +7246,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_codegen"
-version = "0.149.0"
+version = "0.149.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c4a9af319764a33a6e7daf99a2d0f979d7f06e72e8a01947eec607cb46ddf7d"
+checksum = "aef989abd4b9ccf3caf6a4ab0ceb9f9e7d6a27c08585a20a7fc7b9db6c73a341"
 dependencies = [
  "auto_impl",
  "bitflags 2.3.3",
@@ -7276,9 +7276,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_compat"
-version = "0.25.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c506282116236260f189f8f1eddd2ed582e52aac57e184dd9812d92a80915dd9"
+checksum = "a1ee1b2b77e7daaf389237ca2656df01cf8c1a6f2d9b158459921b202a661f8a"
 dependencies = [
  "bitflags 2.3.3",
  "once_cell",
@@ -7293,9 +7293,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_modules"
-version = "0.27.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1a4caa2e6e5166ffb3e1d5400f261edad555dfdc3380371fe578ab496499ed8"
+checksum = "da600f86869cd8c6c47c906b92fef7293c4b560db265fd93bc1c8cf5ca8008a8"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -7309,9 +7309,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_parser"
-version = "0.148.0"
+version = "0.148.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c09f1b12f73eb425a38b2ecace95069e024da7bdf6c0b35ac9f0999c7d36bf"
+checksum = "b02a3c11508487249aa571a908e673c540191de97d5139bb78ab03188dd57e26"
 dependencies = [
  "lexical",
  "serde",
@@ -7322,9 +7322,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_utils"
-version = "0.136.0"
+version = "0.136.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f2bb1a683a9ca9106a2c93c7266221f4e9d3ab85eb3eaee4ed78ea3b4dc820b"
+checksum = "3eead47672e3c832e2e3fc3e523490c4822d80a7fc8c50e87a66f9ab7003b517"
 dependencies = [
  "once_cell",
  "serde",
@@ -7337,9 +7337,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_visit"
-version = "0.138.0"
+version = "0.138.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52bde5bd8d92d993a3c69c809b51fadec06bb1c3c325fb951b79b481a74fd30a"
+checksum = "83f01449a09b8a87ab4bd2ea6cbaaf74e39f9bfba3842a2918e998c5f9b428a4"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -7350,9 +7350,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.109.0"
+version = "0.109.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bc2286cedd688a68f214faa1c19bb5cceab7c9c54d0cbe3273e4c1704e38f69"
+checksum = "e063a1614daed3ea8be56e5dd8edb17003409088d2fc9ce4aca3378879812607"
 dependencies = [
  "bitflags 2.3.3",
  "bytecheck",
@@ -7369,9 +7369,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.144.0"
+version = "0.144.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aabe6ed186d4398ffd54c79b1fcc465b9055202de6609a04c31a3fb5f446990b"
+checksum = "5c18a128504833fe3b7201d830271a12d71d76bb6472ede6f11677e98fca9eda"
 dependencies = [
  "memchr",
  "num-bigint",
@@ -7401,9 +7401,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ext_transforms"
-version = "0.108.0"
+version = "0.108.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57eb7bbfbd7d0b4c2d5abf6936efb16d5a228508246a19795d59c849dbff073e"
+checksum = "2544221560ee7f035946e93c6407b78f814b0220ae5e1d2a831cfb8418e4699a"
 dependencies = [
  "phf",
  "swc_atoms",
@@ -7415,9 +7415,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_lints"
-version = "0.87.1"
+version = "0.87.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb54a7bb321f20e4dd71c0161771ec14911786c3f0d8104284d44f1bdaa2fa4c"
+checksum = "d69869bb58bf428c8392084d6ead64b164ddec2b979a03b9c6eb70fa617904a1"
 dependencies = [
  "auto_impl",
  "dashmap",
@@ -7435,9 +7435,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_loader"
-version = "0.44.2"
+version = "0.44.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7d7c322462657ae27ac090a2c89f7e456c94416284a2f5ecf66c43a6a3c19d1"
+checksum = "d30d2ee2ea9207263f723ac0fe701c7c22200e5bec13d3a9b9a9189e97931081"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -7456,9 +7456,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "0.186.3"
+version = "0.186.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4071694a8b9afd5940373a397c2d6950c02d26f737856eb5a929f87d7ea01932"
+checksum = "f07913f04dfe7baa6a608dea418e69f318518c661814ea2b4c6d355bc5a68fdb"
 dependencies = [
  "arrayvec 0.7.2",
  "indexmap 1.9.3",
@@ -7491,9 +7491,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.139.0"
+version = "0.139.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eab46cb863bc5cd61535464e07e5b74d5f792fa26a27b9f6fd4c8daca9903b7"
+checksum = "1e2abc67575c5fcc77cfb9b3eaaeb73bac2cac265504a1fc06a04d0ebbc4c53b"
 dependencies = [
  "either",
  "num-bigint",
@@ -7511,9 +7511,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "0.200.3"
+version = "0.200.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da923c29abf6c935a1cbc3cdf1efbee21024b4cc1cd9f79b6f6b90adeb586831"
+checksum = "d7890a174b923add0d1579b89145b7a6920e83886b688d59c7537e1c89f6c865"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -7536,9 +7536,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_quote_macros"
-version = "0.50.0"
+version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdf676875aea532ce2c4cd479f89de52e0590048d71ec1790c8fe99f33788216"
+checksum = "d3f02da9402e673522c0f47f2a2092d1389142d601a28a10b48f33a2648bd4f0"
 dependencies = [
  "anyhow",
  "pmutil",
@@ -7554,9 +7554,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_testing"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8924413a32153210ddac17ad92e69e1533063304e549c56cf16010224d489e29"
+checksum = "0b776795afd44c8df3977391e239a8dedbe2139c5eeb1ea053c1e29314b6d8a7"
 dependencies = [
  "anyhow",
  "hex",
@@ -7567,9 +7567,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.223.2"
+version = "0.223.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f57bbdb1ca4a5a57f1be992bd50f6d586888cf0cb1ef1a67a9a7e6d7bf1d7e59"
+checksum = "8d78c832cd4814a2d0a72f404181767cd3086af0dc711da8d250c2cbe09680ae"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -7587,9 +7587,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.132.1"
+version = "0.132.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc48b51ff538b700104c32212b0db4ee690284f82e50b71da341db426a348e98"
+checksum = "82b9cbdb2be485815eb755a0014b3c2a9008ba0c20634b9ccbdef78a79d76c1e"
 dependencies = [
  "better_scoped_tls",
  "bitflags 2.3.3",
@@ -7611,9 +7611,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "0.121.1"
+version = "0.121.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d45c3d98505d52e19251b0828c7bda7323f6fb2428bb42e3d1a1b8ce9dd87bc"
+checksum = "ca2024092cf6ce2bccf714d1ee06f23dc719d7e1f8bf8c04da11abeff9288d1b"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -7625,9 +7625,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "0.158.2"
+version = "0.158.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744c207b919037553dde9b3f88ed66cc5605434b6c71a32efd33b47e1d224a20"
+checksum = "ce98b4da27cec62683329e2c1c5fe7e1a43a44f7a0fe7c436a9cce42eb684917"
 dependencies = [
  "arrayvec 0.7.2",
  "indexmap 1.9.3",
@@ -7664,9 +7664,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "0.175.2"
+version = "0.175.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e69c8e0600fd654a1d86577018b6a593acacf32d7d24dd23ddda3ea1daa81099"
+checksum = "9d8dad438bcb6ae3051e6a6da8e01c9606c997e9f6c57d8fedace63ee64e80b4"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -7691,9 +7691,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.192.2"
+version = "0.192.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "946f11d85fb68b6076a54ee5712013365fb17a97460204cbb8d0713ec76211fb"
+checksum = "cb010e3b1664539d63dc46866e4ec74c96c3044d5395260abc6a4163022d9a93"
 dependencies = [
  "dashmap",
  "indexmap 1.9.3",
@@ -7716,9 +7716,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "0.166.2"
+version = "0.166.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80c294ae4768d92e1d9b23ccb99fae11253b76e80697a34183dd5809f207c3e1"
+checksum = "1244684381c23422ce7f1b9d9dc2541aa008cf5da5b9a3a9d74e5cf0c0b04867"
 dependencies = [
  "either",
  "rustc-hash",
@@ -7736,9 +7736,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.178.2"
+version = "0.178.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87a268903e394caca4abe23a33b4f6198ad16269fa8e2888f1f7a9b9c457b08d"
+checksum = "b7634824044c431f80f6a5cdc7eb0568b08d8915c5da20427b36ffcf5759e26b"
 dependencies = [
  "base64 0.13.1",
  "dashmap",
@@ -7761,9 +7761,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_testing"
-version = "0.135.1"
+version = "0.135.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0a4dd31f47817b37b9cf4c128b14fe4e74639d997fb752a56b4d0b0ae871c6"
+checksum = "6e044aa61ea8c86529be13263855d1b844983e84adc8bd119c51ccf4c810d725"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -7787,9 +7787,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.182.2"
+version = "0.182.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63087ac08b6696480196efaf58383a591fc84bb851c2c367593fbae5cb514b37"
+checksum = "465158f5266c85c24bf602d8e314935651233328def7f49a5be2d0d57507b50c"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -7803,9 +7803,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_usage_analyzer"
-version = "0.18.0"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1369f8a761b9a3b929eb482b8467eb0bc6f842c26aa49043409f8fafbfaf7f58"
+checksum = "89263934ddec01e3738cea970fdf6029b780ad4053d506eb84db9f56b2b95777"
 dependencies = [
  "indexmap 1.9.3",
  "rustc-hash",
@@ -7820,9 +7820,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.122.0"
+version = "0.122.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11006a3398ffd4693c4d3b0a1b1a5030edbdc04228159f5301120a6178144708"
+checksum = "47f412679df4b7f28354b81acdf0fbf53816366019f21e5affc1482b868bda1d"
 dependencies = [
  "indexmap 1.9.3",
  "num_cpus",
@@ -7839,9 +7839,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.95.0"
+version = "0.95.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f628ec196e76e67892441e14eef2e423a738543d32bffdabfeec20c29582117"
+checksum = "2774848b306e17fa280c598ecb192cc2c72a1163942b02d48606514336e9e7c5"
 dependencies = [
  "num-bigint",
  "serde",
@@ -7854,9 +7854,9 @@ dependencies = [
 
 [[package]]
 name = "swc_emotion"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7a80eb046e114d6af3e78c28ab870d1de411d91ba4ba2e9caca07627d3f4580"
+checksum = "055ee3fbd6b9bf4b05ab58dc03dc0f924505aa4394d1c1d57953788b4d6df632"
 dependencies = [
  "base64 0.13.1",
  "byteorder",
@@ -7884,9 +7884,9 @@ dependencies = [
 
 [[package]]
 name = "swc_error_reporters"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6530d0def50c33d14064a43837b7e3c1fe8716ee6c3495a478835793caae2c97"
+checksum = "c76b479ad1a69bec65b261354b8e2dec8ed0f9ed43c7b54ab053dc4923e1c90e"
 dependencies = [
  "anyhow",
  "miette 4.7.1",
@@ -7897,9 +7897,9 @@ dependencies = [
 
 [[package]]
 name = "swc_fast_graph"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a407fff2eb5ce3bee7513bdd9531a7be0285bc1213500b6d98ad235428d94cce"
+checksum = "e2f7297cdefdb54d8d09e0294c1aec3826825b1feefd0c25978365aa7f447a1c"
 dependencies = [
  "indexmap 1.9.3",
  "petgraph",
@@ -7909,9 +7909,9 @@ dependencies = [
 
 [[package]]
 name = "swc_graph_analyzer"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90b996222612382d0d297d0315f5eedc5a830c37e62476c69774884633d31177"
+checksum = "d20a18d45da54ba15698d5ce1f6a0a97684f4035922730393e98e47b44fc3573"
 dependencies = [
  "auto_impl",
  "petgraph",
@@ -7944,9 +7944,9 @@ dependencies = [
 
 [[package]]
 name = "swc_node_comments"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73cee5dededc1e0d19e53dd0a41a343a43e21ed9b62c3df0fdd5801c11533bc9"
+checksum = "b2b9597573f1ab8bae72329eef550d214ced0955c7a4f1b6b4ae5e216219e710"
 dependencies = [
  "dashmap",
  "swc_atoms",
@@ -7969,9 +7969,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_proxy"
-version = "0.38.0"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d3777c28430000db35867b0de49cecdc36519d27045e7d027ef041954bba846"
+checksum = "a76ccadcc63a459e096f332730b2d4e09548fc10e0be63df9f3bacecdf5332fe"
 dependencies = [
  "better_scoped_tls",
  "rkyv",
@@ -7983,9 +7983,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_runner"
-version = "0.101.0"
+version = "0.101.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "050db3c5c80d26bcd6a375d569882fbffa505091f86b19140257fed98b515783"
+checksum = "de5d17c23f3cde487d510d488fdc420a9150474536e0a525b933375ad8eb711d"
 dependencies = [
  "anyhow",
  "enumset",
@@ -8007,9 +8007,9 @@ dependencies = [
 
 [[package]]
 name = "swc_relay"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec6ff3ce67b7e798e5213b0a58d43d9890a3a821851946d411207467d3d97b44"
+checksum = "44b92952f3d06147704b7044efbfe5ec1199f2f535de18bf6d59b12d2ad54e5a"
 dependencies = [
  "once_cell",
  "regex",
@@ -8022,9 +8022,9 @@ dependencies = [
 
 [[package]]
 name = "swc_timer"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95c548665c811d1c5def583d3d6ca0291e5397122c0de6362bb201cc2de8beff"
+checksum = "b740ce6b402ed04176bd28dc4f4f92c764fe0defe8437c2f3b6e1b5818b4e10c"
 dependencies = [
  "tracing",
 ]
@@ -8293,9 +8293,9 @@ dependencies = [
 
 [[package]]
 name = "testing"
-version = "0.34.0"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b199c2fbfc063718d1599d6caaa67868f130c39152bb00baf9534237b1037585"
+checksum = "dc31f7f4a7baef94495386462c2a55caa0f0885b61b28c120f783132d14938ed"
 dependencies = [
  "ansi_term",
  "cargo_metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,13 +77,13 @@ async-recursion = "1.0.2"
 # Keep consistent with preset_env_base through swc_core
 browserslist-rs = { version = "0.12.2" }
 mdxjs = { version = "0.1.15" }
-modularize_imports = { version = "0.37.0" }
-styled_components = { version = "0.64.0" }
-styled_jsx = { version = "0.41.0" }
-swc_core = { version = "0.82.4" }
-swc_emotion = { version = "0.40.0" }
-swc_relay = { version = "0.12.0" }
-testing = { version = "0.34.0" }
+modularize_imports = { version = "0.38.0" }
+styled_components = { version = "0.65.0" }
+styled_jsx = { version = "0.42.0" }
+swc_core = { version = "0.82.10" }
+swc_emotion = { version = "0.41.0" }
+swc_relay = { version = "0.13.0" }
+testing = { version = "0.34.1" }
 
 auto-hash-map = { path = "crates/turbo-tasks-auto-hash-map" }
 node-file-trace = { path = "crates/node-file-trace", default-features = false }


### PR DESCRIPTION
### Description

I need newer version of SWC crates because of https://github.com/vercel/next.js/pull/54653

### Testing Instructions

Let's look at the CI of the next.js counterpart


Closes WEB-1487