### PR TITLE
fix: use cargo groups for macos turbopack bench

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -946,12 +946,12 @@ jobs:
       - name: Build benchmarks for tests
         timeout-minutes: 120
         run: |
-          cargo test --benches --release --workspace --exclude turbopack-bench --no-run
+          cargo tp-bench-test --no-run
 
       - name: Run cargo test on benchmarks
         timeout-minutes: 120
         run: |
-          cargo test --benches --release --workspace --exclude turbopack-bench
+          cargo tp-bench-test
 
       - name: Build benchmarks for tests for other bundlers
         if: needs.determine_jobs.outputs.turbopack_bench == 'true'


### PR DESCRIPTION
### Description

Matches the changes to the ubuntu turbopack bench job made in https://github.com/vercel/turbo/pull/4623

### Testing Instructions

Confirm changed commands match the changes in #4623


Closes TURBO-1292