### PR TITLE
chore: make color selector usable with prefix ui

### DIFF
--- a/crates/turborepo-ui/src/color_selector.rs
+++ b/crates/turborepo-ui/src/color_selector.rs
@@ -4,7 +4,7 @@ use std::{
     sync::{Arc, OnceLock, RwLock},
 };
 
-use console::Style;
+use console::{Style, StyledObject};
 
 static COLORS: OnceLock<[Style; 5]> = OnceLock::new();
 
@@ -49,13 +49,13 @@ impl ColorSelector {
         color
     }
 
-    pub fn prefix_with_color(&self, cache_key: &str, prefix: &str) -> Cow<'static, str> {
+    pub fn prefix_with_color(&self, cache_key: &str, prefix: &str) -> StyledObject<String> {
         if prefix.is_empty() {
-            return "".into();
+            return Style::new().apply_to(String::new());
         }
 
         let style = self.color_for_key(cache_key);
-        style.apply_to(format!("{}: ", prefix)).to_string().into()
+        style.apply_to(format!("{}: ", prefix))
     }
 }
 


### PR DESCRIPTION
### Description

When I was hooking up the task cache to the visitor, I noticed that we wouldn't be able to use the output of `ColorSelector` with `PrefixUI` since `PrefixUI` [expects the styles to not be applied yet](https://github.com/vercel/turbo/blob/main/crates/turborepo-ui/src/prefixed.rs#L25). This PR changes the color selector to defer on applying the style until the prefix ui decides to write output.

### Testing Instructions

👀 


Closes TURBO-1294