### PR TITLE
Add `Send` bound to `T` in `Vc<T>` to make type error less cryptic

### DIFF
--- a/crates/turbo-tasks-macros/src/generic_type_macro.rs
+++ b/crates/turbo-tasks-macros/src/generic_type_macro.rs
@@ -6,7 +6,7 @@ use turbo_tasks_macros_shared::{get_type_ident, GenericTypeInput};
 use crate::value_macro::value_type_and_register;
 
 pub fn generic_type(input: TokenStream) -> TokenStream {
-    let input = parse_macro_input!(input as GenericTypeInput);
+    let mut input = parse_macro_input!(input as GenericTypeInput);
 
     for param in &input.generics.params {
         match param {
@@ -30,6 +30,17 @@ pub fn generic_type(input: TokenStream) -> TokenStream {
                     .error("const parameters are not supported in generic_type")
                     .emit();
             }
+        }
+    }
+
+    // Add Send bound to input generics.
+
+    for param in &mut input.generics.params {
+        match param {
+            GenericParam::Type(param) => {
+                param.bounds.push(syn::parse_quote! { std::marker::Send });
+            }
+            _ => {}
         }
     }
 

--- a/crates/turbo-tasks-macros/src/generic_type_macro.rs
+++ b/crates/turbo-tasks-macros/src/generic_type_macro.rs
@@ -36,11 +36,8 @@ pub fn generic_type(input: TokenStream) -> TokenStream {
     // Add Send bound to input generics.
 
     for param in &mut input.generics.params {
-        match param {
-            GenericParam::Type(param) => {
-                param.bounds.push(syn::parse_quote! { std::marker::Send });
-            }
-            _ => {}
+        if let GenericParam::Type(param) = param {
+            param.bounds.push(syn::parse_quote! { std::marker::Send });
         }
     }
 

--- a/crates/turbo-tasks-macros/src/value_impl_macro.rs
+++ b/crates/turbo-tasks-macros/src/value_impl_macro.rs
@@ -251,7 +251,7 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
                     #[doc(hidden)]
                     #[allow(non_camel_case_types)]
                     // #[turbo_tasks::async_trait]
-                    trait #inline_extension_trait_ident {
+                    trait #inline_extension_trait_ident: std::marker::Send {
                         #[allow(declare_interior_mutable_const)]
                         #[doc(hidden)]
                         const #native_function_ident: #native_function_ty;

--- a/crates/turbo-tasks-macros/src/value_trait_macro.rs
+++ b/crates/turbo-tasks-macros/src/value_trait_macro.rs
@@ -129,7 +129,7 @@ pub fn value_trait(args: TokenStream, input: TokenStream) -> TokenStream {
                 #[doc(hidden)]
                 #[allow(non_camel_case_types)]
                 // #[turbo_tasks::async_trait]
-                trait #inline_extension_trait_ident : std::marker::Send {
+                trait #inline_extension_trait_ident: std::marker::Send {
                     #[allow(declare_interior_mutable_const)]
                     const #native_function_ident: #native_function_ty;
                     #[allow(declare_interior_mutable_const)]

--- a/crates/turbo-tasks-macros/src/value_trait_macro.rs
+++ b/crates/turbo-tasks-macros/src/value_trait_macro.rs
@@ -129,7 +129,7 @@ pub fn value_trait(args: TokenStream, input: TokenStream) -> TokenStream {
                 #[doc(hidden)]
                 #[allow(non_camel_case_types)]
                 // #[turbo_tasks::async_trait]
-                trait #inline_extension_trait_ident {
+                trait #inline_extension_trait_ident : std::marker::Send {
                     #[allow(declare_interior_mutable_const)]
                     const #native_function_ident: #native_function_ty;
                     #[allow(declare_interior_mutable_const)]

--- a/crates/turbo-tasks-macros/src/value_trait_macro.rs
+++ b/crates/turbo-tasks-macros/src/value_trait_macro.rs
@@ -197,7 +197,7 @@ pub fn value_trait(args: TokenStream, input: TokenStream) -> TokenStream {
     let expanded = quote! {
         #[must_use]
         #(#attrs)*
-        #vis #trait_token #trait_ident: #(#supertraits)+*
+        #vis #trait_token #trait_ident: std::marker::Send + #(#supertraits)+*
         {
             #(#items)*
         }

--- a/crates/turbo-tasks/src/generics/index_map.rs
+++ b/crates/turbo-tasks/src/generics/index_map.rs
@@ -23,7 +23,11 @@ async fn index_map_is_empty(index_map: Vc<IndexMap<Vc<()>, Vc<()>>>) -> Result<V
     Ok(Vc::cell(index_map.is_empty()))
 }
 
-impl<K, V> Vc<IndexMap<Vc<K>, Vc<V>>> {
+impl<K, V> Vc<IndexMap<Vc<K>, Vc<V>>>
+where
+    K: Send,
+    V: Send,
+{
     /// See [`IndexMap::len`].
     pub fn len(self) -> Vc<usize> {
         index_map_len(Self::to_repr(self))
@@ -40,7 +44,11 @@ fn index_map_default() -> Vc<IndexMap<Vc<()>, Vc<()>>> {
     Vc::cell(Default::default())
 }
 
-impl<K, V> ValueDefault for IndexMap<Vc<K>, Vc<V>> {
+impl<K, V> ValueDefault for IndexMap<Vc<K>, Vc<V>>
+where
+    K: Send,
+    V: Send,
+{
     fn value_default() -> Vc<Self> {
         // Safety: `index_map_default` creates an empty map, which is a valid
         // representation of any index set of `Vc`.
@@ -60,7 +68,11 @@ async fn index_map_dbg_depth(
         .await
 }
 
-impl<K, V> ValueDebug for IndexMap<Vc<K>, Vc<V>> {
+impl<K, V> ValueDebug for IndexMap<Vc<K>, Vc<V>>
+where
+    K: Send,
+    V: Send,
+{
     fn dbg(self: Vc<Self>) -> Vc<ValueDebugString> {
         index_map_dbg_depth(Vc::<Self>::to_repr(self), usize::MAX)
     }

--- a/crates/turbo-tasks/src/generics/index_set.rs
+++ b/crates/turbo-tasks/src/generics/index_set.rs
@@ -43,7 +43,10 @@ fn index_set_default() -> Vc<IndexSet<Vc<()>>> {
     Vc::cell(Default::default())
 }
 
-impl<T> ValueDefault for IndexSet<Vc<T>> {
+impl<T> ValueDefault for IndexSet<Vc<T>>
+where
+    T: Send,
+{
     fn value_default() -> Vc<Self> {
         // Safety: `index_set_default` creates an empty set, which is a valid
         // representation of any index set of `Vc`.
@@ -63,7 +66,10 @@ async fn index_set_dbg_depth(
         .await
 }
 
-impl<T> ValueDebug for IndexSet<Vc<T>> {
+impl<T> ValueDebug for IndexSet<Vc<T>>
+where
+    T: Send,
+{
     fn dbg(self: Vc<Self>) -> Vc<ValueDebugString> {
         index_set_dbg_depth(Vc::<Self>::to_repr(self), usize::MAX)
     }

--- a/crates/turbo-tasks/src/generics/index_set.rs
+++ b/crates/turbo-tasks/src/generics/index_set.rs
@@ -23,7 +23,10 @@ async fn index_set_is_empty(index_set: Vc<IndexSet<Vc<()>>>) -> Result<Vc<bool>>
     Ok(Vc::cell(index_set.is_empty()))
 }
 
-impl<T> Vc<IndexSet<Vc<T>>> {
+impl<T> Vc<IndexSet<Vc<T>>>
+where
+    T: Send,
+{
     /// See [`IndexSet::len`].
     pub fn len(self) -> Vc<usize> {
         index_set_len(Self::to_repr(self))

--- a/crates/turbo-tasks/src/generics/option.rs
+++ b/crates/turbo-tasks/src/generics/option.rs
@@ -22,7 +22,10 @@ async fn option_is_some(option: Vc<Option<Vc<()>>>) -> Result<Vc<bool>> {
     Ok(Vc::cell(option.is_some()))
 }
 
-impl<T> Vc<Option<Vc<T>>> {
+impl<T> Vc<Option<Vc<T>>>
+where
+    T: Send,
+{
     /// See [`Option::is_none`].
     pub fn is_none(self) -> Vc<bool> {
         option_is_none(Self::to_repr(self))
@@ -39,7 +42,10 @@ fn option_default() -> Vc<Option<Vc<()>>> {
     Vc::cell(Default::default())
 }
 
-impl<T> ValueDefault for Option<Vc<T>> {
+impl<T> ValueDefault for Option<Vc<T>>
+where
+    T: Send,
+{
     fn value_default() -> Vc<Self> {
         // Safety: `option_default` creates a None variant, which is a valid
         // representation of any option of `Vc`.
@@ -59,7 +65,10 @@ async fn option_dbg_depth(
         .await
 }
 
-impl<T> ValueDebug for Option<Vc<T>> {
+impl<T> ValueDebug for Option<Vc<T>>
+where
+    T: Send,
+{
     fn dbg(self: Vc<Self>) -> Vc<ValueDebugString> {
         option_dbg_depth(Vc::<Self>::to_repr(self), usize::MAX)
     }

--- a/crates/turbo-tasks/src/generics/vec.rs
+++ b/crates/turbo-tasks/src/generics/vec.rs
@@ -22,7 +22,10 @@ async fn vec_is_empty(vec: Vc<Vec<Vc<()>>>) -> Result<Vc<bool>> {
     Ok(Vc::cell(vec.is_empty()))
 }
 
-impl<T> Vc<Vec<Vc<T>>> {
+impl<T> Vc<Vec<Vc<T>>>
+where
+    T: Send,
+{
     /// See [`Vec::len`].
     pub fn len(self) -> Vc<usize> {
         vec_len(Self::to_repr(self))
@@ -39,7 +42,10 @@ fn vec_default() -> Vc<Vec<Vc<()>>> {
     Vc::cell(Default::default())
 }
 
-impl<T> ValueDefault for Vec<Vc<T>> {
+impl<T> ValueDefault for Vec<Vc<T>>
+where
+    T: Send,
+{
     fn value_default() -> Vc<Self> {
         // Safety: `vec_default` creates an empty vector, which is a valid
         // representation of any vector of `Vc`s.
@@ -55,7 +61,10 @@ async fn vec_dbg_depth(vec: Vc<Vec<Vc<()>>>, depth: usize) -> Result<Vc<ValueDeb
         .await
 }
 
-impl<T> ValueDebug for Vec<Vc<T>> {
+impl<T> ValueDebug for Vec<Vc<T>>
+where
+    T: Send,
+{
     fn dbg(self: Vc<Self>) -> Vc<ValueDebugString> {
         vec_dbg_depth(Vc::<Self>::to_repr(self), usize::MAX)
     }

--- a/crates/turbo-tasks/src/manager.rs
+++ b/crates/turbo-tasks/src/manager.rs
@@ -341,6 +341,7 @@ impl<B: Backend + 'static> TurboTasks<B> {
     /// Creates a new root task
     pub fn spawn_root_task<T, F, Fut>(&self, functor: F) -> TaskId
     where
+        T: Send,
         F: Fn() -> Fut + Send + Sync + Clone + 'static,
         Fut: Future<Output = Result<Vc<T>>> + Send,
     {
@@ -361,6 +362,7 @@ impl<B: Backend + 'static> TurboTasks<B> {
     #[track_caller]
     pub fn spawn_once_task<T, Fut>(&self, future: Fut) -> TaskId
     where
+        T: Send,
         Fut: Future<Output = Result<Vc<T>>> + Send + 'static,
     {
         let id = self.backend.create_transient_task(
@@ -1398,7 +1400,7 @@ pub fn notify_scheduled_tasks() {
     with_turbo_tasks(|tt| tt.notify_scheduled_tasks())
 }
 
-pub fn emit<T: VcValueTrait>(collectible: Vc<T>) {
+pub fn emit<T: VcValueTrait + Send>(collectible: Vc<T>) {
     with_turbo_tasks(|tt| tt.emit_collectible(T::get_trait_type_id(), collectible.node))
 }
 

--- a/crates/turbo-tasks/src/raw_vc.rs
+++ b/crates/turbo-tasks/src/raw_vc.rs
@@ -436,7 +436,7 @@ impl<T: VcValueTrait> CollectiblesFuture<T> {
     }
 }
 
-impl<T: VcValueTrait> Future for CollectiblesFuture<T> {
+impl<T: VcValueTrait + Send> Future for CollectiblesFuture<T> {
     type Output = Result<AutoSet<Vc<T>>>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {

--- a/crates/turbo-tasks/src/task/task_input.rs
+++ b/crates/turbo-tasks/src/task/task_input.rs
@@ -167,7 +167,10 @@ where
     }
 }
 
-impl<T> TaskInput for Vc<T> {
+impl<T> TaskInput for Vc<T>
+where
+    T: Send,
+{
     fn try_from_concrete(input: &ConcreteTaskInput) -> Result<Self> {
         match input {
             ConcreteTaskInput::TaskCell(task, index) => Ok(Vc {

--- a/crates/turbo-tasks/src/task/task_output.rs
+++ b/crates/turbo-tasks/src/task/task_output.rs
@@ -15,7 +15,7 @@ pub trait TaskOutput {
 
 impl<T> TaskOutput for Vc<T>
 where
-    T: ?Sized,
+    T: ?Sized + Send,
 {
     type Return = Vc<T>;
 

--- a/crates/turbo-tasks/src/trait_ref.rs
+++ b/crates/turbo-tasks/src/trait_ref.rs
@@ -136,7 +136,7 @@ pub trait IntoTraitRef {
 
 impl<T> IntoTraitRef for Vc<T>
 where
-    T: VcValueTrait + ?Sized,
+    T: VcValueTrait + ?Sized + Send,
 {
     type ValueTrait = T;
 

--- a/crates/turbo-tasks/src/trait_ref.rs
+++ b/crates/turbo-tasks/src/trait_ref.rs
@@ -104,7 +104,7 @@ where
 
 impl<T> TraitRef<T>
 where
-    T: VcValueTrait + ?Sized,
+    T: VcValueTrait + ?Sized + Send,
 {
     /// Returns a new cell that points to a value that implements the value
     /// trait `T`.

--- a/crates/turbo-tasks/src/vc/mod.rs
+++ b/crates/turbo-tasks/src/vc/mod.rs
@@ -39,7 +39,7 @@ use crate::{
 #[must_use]
 pub struct Vc<T>
 where
-    T: ?Sized,
+    T: ?Sized + Send,
 {
     pub(crate) node: RawVc,
     #[doc(hidden)]

--- a/crates/turbo-tasks/src/vc/mod.rs
+++ b/crates/turbo-tasks/src/vc/mod.rs
@@ -401,7 +401,7 @@ where
     /// removing the need for a `Result` return type.
     pub async fn try_resolve_sidecast<K>(vc: Self) -> Result<Option<Vc<K>>, ResolveTypeError>
     where
-        K: VcValueTrait + ?Sized,
+        K: VcValueTrait + ?Sized + Send,
     {
         let raw_vc: RawVc = vc.node;
         let raw_vc = raw_vc
@@ -421,7 +421,7 @@ where
     pub async fn try_resolve_downcast<K>(vc: Self) -> Result<Option<Vc<K>>, ResolveTypeError>
     where
         K: Upcast<T>,
-        K: VcValueTrait + ?Sized,
+        K: VcValueTrait + ?Sized + Send,
     {
         let raw_vc: RawVc = vc.node;
         let raw_vc = raw_vc

--- a/crates/turbo-tasks/src/vc/mod.rs
+++ b/crates/turbo-tasks/src/vc/mod.rs
@@ -176,7 +176,7 @@ where
 #[doc(hidden)]
 impl<T> Deref for Vc<T>
 where
-    T: ?Sized,
+    T: ?Sized + Send,
 {
     type Target = VcDeref<T>;
 
@@ -190,14 +190,14 @@ where
     }
 }
 
-impl<T> Copy for Vc<T> where T: ?Sized {}
+impl<T> Copy for Vc<T> where T: ?Sized + Send {}
 
-unsafe impl<T> Send for Vc<T> where T: ?Sized {}
-unsafe impl<T> Sync for Vc<T> where T: ?Sized {}
+unsafe impl<T> Send for Vc<T> where T: ?Sized + Send {}
+unsafe impl<T> Sync for Vc<T> where T: ?Sized + Send {}
 
 impl<T> Clone for Vc<T>
 where
-    T: ?Sized,
+    T: ?Sized + Send,
 {
     fn clone(&self) -> Self {
         *self
@@ -206,7 +206,7 @@ where
 
 impl<T> core::hash::Hash for Vc<T>
 where
-    T: ?Sized,
+    T: ?Sized + Send,
 {
     fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
         self.node.hash(state);
@@ -215,18 +215,18 @@ where
 
 impl<T> PartialEq<Vc<T>> for Vc<T>
 where
-    T: ?Sized,
+    T: ?Sized + Send,
 {
     fn eq(&self, other: &Self) -> bool {
         self.node == other.node
     }
 }
 
-impl<T> Eq for Vc<T> where T: ?Sized {}
+impl<T> Eq for Vc<T> where T: ?Sized + Send {}
 
 impl<T> PartialOrd<Vc<T>> for Vc<T>
 where
-    T: ?Sized,
+    T: ?Sized + Send,
 {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         self.node.partial_cmp(&other.node)
@@ -235,7 +235,7 @@ where
 
 impl<T> Ord for Vc<T>
 where
-    T: ?Sized,
+    T: ?Sized + Send,
 {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.node.cmp(&other.node)
@@ -244,7 +244,7 @@ where
 
 impl<T> Serialize for Vc<T>
 where
-    T: ?Sized,
+    T: ?Sized + Send,
 {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         self.node.serialize(serializer)
@@ -253,7 +253,7 @@ where
 
 impl<'de, T> Deserialize<'de> for Vc<T>
 where
-    T: ?Sized,
+    T: ?Sized + Send,
 {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         Ok(Vc {
@@ -265,7 +265,10 @@ where
 
 // TODO(alexkirsz) This should not be implemented for Vc. Instead, users should
 // use the `ValueDebug` implementation to get a `D: Debug`.
-impl<T> std::fmt::Debug for Vc<T> {
+impl<T> std::fmt::Debug for Vc<T>
+where
+    T: Send,
+{
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Vc").field("node", &self.node).finish()
     }
@@ -294,7 +297,7 @@ where
 
 impl<T> Vc<T>
 where
-    T: ?Sized,
+    T: ?Sized + Send,
 {
     /// Connects the operation pointed to by this `Vc` to the current task.
     pub fn connect(vc: Self) {
@@ -337,7 +340,7 @@ where
     pub fn upcast<K>(vc: Self) -> Vc<K>
     where
         T: Upcast<K>,
-        K: VcValueTrait + ?Sized,
+        K: VcValueTrait + ?Sized + Send,
     {
         Vc {
             node: vc.node,
@@ -348,7 +351,7 @@ where
 
 impl<T> Vc<T>
 where
-    T: ?Sized,
+    T: ?Sized + Send,
 {
     /// Resolve the reference until it points to a cell directly.
     ///
@@ -386,7 +389,7 @@ where
 
 impl<T> Vc<T>
 where
-    T: VcValueTrait + ?Sized,
+    T: VcValueTrait + ?Sized + Send,
 {
     /// Attempts to sidecast the given `Vc<Box<dyn T>>` to a `Vc<Box<dyn K>>`.
     /// This operation also resolves the `Vc`.
@@ -453,7 +456,7 @@ where
 
 impl<T> CollectiblesSource for Vc<T>
 where
-    T: ?Sized,
+    T: ?Sized + Send,
 {
     fn take_collectibles<Vt: VcValueTrait>(self) -> CollectiblesFuture<Vt> {
         self.node.take_collectibles()
@@ -466,7 +469,7 @@ where
 
 impl<T> From<RawVc> for Vc<T>
 where
-    T: ?Sized,
+    T: ?Sized + Send,
 {
     fn from(node: RawVc) -> Self {
         Self {
@@ -478,7 +481,7 @@ where
 
 impl<T> TraceRawVcs for Vc<T>
 where
-    T: ?Sized,
+    T: ?Sized + Send,
 {
     fn trace_raw_vcs(&self, trace_context: &mut TraceRawVcsContext) {
         TraceRawVcs::trace_raw_vcs(&self.node, trace_context);
@@ -487,7 +490,7 @@ where
 
 impl<T> ValueDebugFormat for Vc<T>
 where
-    T: ?Sized,
+    T: ?Sized + Send,
     T: Upcast<Box<dyn ValueDebug>>,
 {
     fn value_debug_format(&self, depth: usize) -> ValueDebugFormatString {
@@ -534,11 +537,11 @@ where
     }
 }
 
-impl<T> Unpin for Vc<T> where T: ?Sized {}
+impl<T> Unpin for Vc<T> where T: ?Sized + Send {}
 
 impl<T> Default for Vc<T>
 where
-    T: ValueDefault,
+    T: ValueDefault + Send,
 {
     fn default() -> Self {
         T::value_default()

--- a/crates/turbo-tasks/src/vc/traits.rs
+++ b/crates/turbo-tasks/src/vc/traits.rs
@@ -47,9 +47,9 @@ where
 ///
 /// The implementor of this trait must ensure that `Self` implements the
 /// trait `T`.
-pub unsafe trait Dynamic<T>
+pub unsafe trait Dynamic<T>: Send
 where
-    T: VcValueTrait + ?Sized + Send,
+    T: VcValueTrait + ?Sized,
 {
 }
 

--- a/crates/turbo-tasks/src/vc/traits.rs
+++ b/crates/turbo-tasks/src/vc/traits.rs
@@ -34,9 +34,9 @@ pub trait VcValueTrait {
 ///
 /// The implementor of this trait must ensure that `Self` implements the
 /// trait `T`.
-pub unsafe trait Upcast<T>
+pub unsafe trait Upcast<T>: Send
 where
-    T: VcValueTrait + ?Sized,
+    T: VcValueTrait + ?Sized + Send,
 {
 }
 
@@ -49,7 +49,7 @@ where
 /// trait `T`.
 pub unsafe trait Dynamic<T>: Send
 where
-    T: VcValueTrait + ?Sized,
+    T: VcValueTrait + ?Sized + Send,
 {
 }
 

--- a/crates/turbo-tasks/src/vc/traits.rs
+++ b/crates/turbo-tasks/src/vc/traits.rs
@@ -49,7 +49,7 @@ where
 /// trait `T`.
 pub unsafe trait Dynamic<T>
 where
-    T: VcValueTrait + ?Sized,
+    T: VcValueTrait + ?Sized + Send,
 {
 }
 

--- a/crates/turbopack-core/src/chunk/evaluate.rs
+++ b/crates/turbopack-core/src/chunk/evaluate.rs
@@ -17,7 +17,7 @@ use crate::{
 #[turbo_tasks::value_trait]
 pub trait EvaluatableAsset: Asset + Module + ChunkableModule {}
 
-pub trait EvaluatableAssetExt {
+pub trait EvaluatableAssetExt: Send {
     fn to_evaluatable(
         self: Vc<Self>,
         asset_context: Vc<Box<dyn AssetContext>>,

--- a/crates/turbopack-core/src/chunk/mod.rs
+++ b/crates/turbopack-core/src/chunk/mod.rs
@@ -515,7 +515,7 @@ type ChunkItemToGraphNodesFuture<I: FromChunkableModule> =
 
 impl<I> Visit<ChunkContentGraphNode<Vc<I>>, ()> for ChunkContentVisit<Vc<I>>
 where
-    I: FromChunkableModule,
+    I: Send + FromChunkableModule,
 {
     type Edge = (
         Option<(Vc<Box<dyn Module>>, ChunkingType)>,

--- a/crates/turbopack-core/src/chunk/mod.rs
+++ b/crates/turbopack-core/src/chunk/mod.rs
@@ -338,7 +338,7 @@ async fn reference_to_graph_nodes<I>(
     )>,
 >
 where
-    I: FromChunkableModule,
+    I: Send + FromChunkableModule,
 {
     let Some(chunkable_module_reference) =
         Vc::try_resolve_downcast::<Box<dyn ChunkableModuleReference>>(reference).await?

--- a/crates/turbopack-core/src/chunk/mod.rs
+++ b/crates/turbopack-core/src/chunk/mod.rs
@@ -503,7 +503,7 @@ struct ChunkContentVisit<I> {
     _phantom: PhantomData<I>,
 }
 
-type ChunkItemToGraphNodesEdges<I> = impl Iterator<
+type ChunkItemToGraphNodesEdges<I: Send> = impl Iterator<
     Item = (
         Option<(Vc<Box<dyn Module>>, ChunkingType)>,
         ChunkContentGraphNode<Vc<I>>,

--- a/crates/turbopack-core/src/issue/mod.rs
+++ b/crates/turbopack-core/src/issue/mod.rs
@@ -744,7 +744,7 @@ where
     }
 }
 
-pub async fn handle_issues<T>(
+pub async fn handle_issues<T: Send>(
     source: Vc<T>,
     issue_reporter: Vc<Box<dyn IssueReporter>>,
     min_failing_severity: Vc<IssueSeverity>,

--- a/crates/turbopack-core/src/resolve/origin.rs
+++ b/crates/turbopack-core/src/resolve/origin.rs
@@ -30,7 +30,7 @@ pub trait ResolveOrigin {
 // TODO it would be nice if these methods can be moved to the trait to allow
 // overriding it, but currently we explicitly disallow it due to the way
 // transitions work. Maybe transitions should be decorators on ResolveOrigin?
-pub trait ResolveOriginExt {
+pub trait ResolveOriginExt: Send {
     /// Resolve to an asset from that origin. Custom resolve options can be
     /// passed. Otherwise provide `origin.resolve_options()` unmodified.
     fn resolve_asset(

--- a/crates/turbopack-core/src/version.rs
+++ b/crates/turbopack-core/src/version.rs
@@ -105,7 +105,7 @@ impl From<AssetContent> for Vc<Box<dyn VersionedContent>> {
     }
 }
 
-pub trait VersionedContentExt {
+pub trait VersionedContentExt: Send {
     fn versioned(self: Vc<Self>) -> Vc<Box<dyn VersionedContent>>;
 }
 

--- a/crates/turbopack-dev-server/src/source/mod.rs
+++ b/crates/turbopack-dev-server/src/source/mod.rs
@@ -420,7 +420,7 @@ pub trait ContentSource {
     }
 }
 
-pub trait ContentSourceExt {
+pub trait ContentSourceExt: Send {
     fn issue_file_path(
         self: Vc<Self>,
         file_path: Vc<FileSystemPath>,

--- a/crates/turbopack-dev-server/src/update/stream.rs
+++ b/crates/turbopack-dev-server/src/update/stream.rs
@@ -23,7 +23,7 @@ use crate::source::{resolve::ResolveSourceRequestResult, ProxyResult};
 
 type GetContentFn = Box<dyn Fn() -> Vc<ResolveSourceRequestResult> + Send + Sync>;
 
-async fn peek_issues<T>(source: Vc<T>) -> Result<Vec<ReadRef<PlainIssue>>> {
+async fn peek_issues<T: Send>(source: Vc<T>) -> Result<Vec<ReadRef<PlainIssue>>> {
     let captured = source.peek_issues_with_path().await?.await?;
 
     captured.get_plain_issues().await

--- a/crates/turbopack-ecmascript/src/chunk/item.rs
+++ b/crates/turbopack-ecmascript/src/chunk/item.rs
@@ -179,7 +179,7 @@ pub trait EcmascriptChunkItem: ChunkItem {
     fn chunking_context(self: Vc<Self>) -> Vc<Box<dyn EcmascriptChunkingContext>>;
 }
 
-pub trait EcmascriptChunkItemExt {
+pub trait EcmascriptChunkItemExt: Send {
     /// Returns the module id of this chunk item.
     fn id(self: Vc<Self>) -> Vc<ModuleId>;
 


### PR DESCRIPTION
### Description

Currently, the diagnostics for `T` in `Vc<T>` not implementing `Send` is too cryptic.

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->


Closes WEB-1498