### PR TITLE
fix: avoid panic during task cache construction

### DIFF
--- a/crates/turborepo-lib/src/run/cache.rs
+++ b/crates/turborepo-lib/src/run/cache.rs
@@ -59,25 +59,8 @@ impl RunCache {
         let task_dir = self.repo_root.resolve(workspace_dir);
         let log_file_path =
             task_dir.join_components(&[".turbo", &format!("turbo-{}.log", task_id.task())]);
-        let hashable_outputs = task_definition.hashable_outputs(&task_id);
-        let mut repo_relative_globs = TaskOutputs {
-            inclusions: Vec::with_capacity(hashable_outputs.inclusions.len()),
-            exclusions: Vec::with_capacity(hashable_outputs.exclusions.len()),
-        };
-
-        for output in hashable_outputs.inclusions {
-            let inclusion_glob = task_dir.join_component(&output);
-            repo_relative_globs
-                .inclusions
-                .push(inclusion_glob.to_string());
-        }
-
-        for output in hashable_outputs.exclusions {
-            let exclusion_glob = task_dir.join_component(&output);
-            repo_relative_globs
-                .exclusions
-                .push(exclusion_glob.to_string());
-        }
+        let repo_relative_globs =
+            task_definition.repo_relative_hashable_outputs(&task_id, workspace_dir);
 
         let mut task_output_mode = task_definition.output_mode;
         if let Some(task_output_mode_override) = self.task_output_mode {

--- a/crates/turborepo-lib/src/task_graph/mod.rs
+++ b/crates/turborepo-lib/src/task_graph/mod.rs
@@ -197,22 +197,25 @@ impl TaskDefinition {
         task_name: &TaskId,
         workspace_dir: &AnchoredSystemPath,
     ) -> TaskOutputs {
-        let mut repo_relative_globs = self.hashable_outputs(task_name);
-
-        let repo_relative_glob = |glob: &str| -> String {
+        let make_glob_repo_relative = |glob: &str| -> String {
             let mut repo_relative_glob = workspace_dir.to_string();
             repo_relative_glob.push(std::path::MAIN_SEPARATOR);
             repo_relative_glob.push_str(glob);
             repo_relative_glob
         };
 
+        // At this point repo_relative_globs are still workspace relative, but
+        // the processing in the rest of the function converts this to be repo
+        // relative.
+        let mut repo_relative_globs = self.hashable_outputs(task_name);
+
         for input in repo_relative_globs.inclusions.iter_mut() {
-            let relative_input = repo_relative_glob(input.as_str());
+            let relative_input = make_glob_repo_relative(input.as_str());
             *input = relative_input;
         }
 
         for output in repo_relative_globs.exclusions.iter_mut() {
-            let relative_output = repo_relative_glob(output.as_str());
+            let relative_output = make_glob_repo_relative(output.as_str());
             *output = relative_output;
         }
 

--- a/crates/turborepo-lib/src/task_graph/mod.rs
+++ b/crates/turborepo-lib/src/task_graph/mod.rs
@@ -282,7 +282,11 @@ mod test {
         };
 
         let task_id = TaskId::new("foo", "build");
-        let workspace_dir = AnchoredSystemPath::new("apps/foo").unwrap();
+        let workspace_dir = AnchoredSystemPath::new(match cfg!(windows) {
+            true => "apps\\foo",
+            false => "apps/foo",
+        })
+        .unwrap();
 
         let relative_outputs = task_defn.repo_relative_hashable_outputs(&task_id, workspace_dir);
         let relative_prefix = match cfg!(windows) {

--- a/crates/turborepo-lib/src/task_graph/mod.rs
+++ b/crates/turborepo-lib/src/task_graph/mod.rs
@@ -3,7 +3,7 @@ mod visitor;
 use std::collections::{HashMap, HashSet};
 
 use serde::{Deserialize, Serialize};
-use turbopath::RelativeUnixPathBuf;
+use turbopath::{AnchoredSystemPath, RelativeUnixPathBuf};
 pub use visitor::{Error, Visitor};
 
 use crate::{
@@ -192,6 +192,33 @@ impl TaskDefinition {
         hashable
     }
 
+    pub fn repo_relative_hashable_outputs(
+        &self,
+        task_name: &TaskId,
+        workspace_dir: &AnchoredSystemPath,
+    ) -> TaskOutputs {
+        let mut repo_relative_globs = self.hashable_outputs(task_name);
+
+        let repo_relative_glob = |glob: &str| -> String {
+            let mut repo_relative_glob = workspace_dir.to_string();
+            repo_relative_glob.push(std::path::MAIN_SEPARATOR);
+            repo_relative_glob.push_str(glob);
+            repo_relative_glob
+        };
+
+        for input in repo_relative_globs.inclusions.iter_mut() {
+            let relative_input = repo_relative_glob(input.as_str());
+            *input = relative_input;
+        }
+
+        for output in repo_relative_globs.exclusions.iter_mut() {
+            let relative_output = repo_relative_glob(output.as_str());
+            *output = relative_output;
+        }
+
+        repo_relative_globs
+    }
+
     // merge accepts a BookkeepingTaskDefinitions and
     // merges it into TaskDefinition. It uses the bookkeeping
     // defined_fields to determine which fields should be overwritten and when
@@ -235,5 +262,42 @@ impl FromIterator<BookkeepingTaskDefinition> for TaskDefinition {
                 def.merge(other);
                 def
             })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    #[test]
+    fn test_relative_output_globs() {
+        let task_defn = TaskDefinition {
+            outputs: TaskOutputs {
+                inclusions: vec![".next/**/*".to_string()],
+                exclusions: vec![".next/bad-file".to_string()],
+            },
+            ..Default::default()
+        };
+
+        let task_id = TaskId::new("foo", "build");
+        let workspace_dir = AnchoredSystemPath::new("apps/foo").unwrap();
+
+        let relative_outputs = task_defn.repo_relative_hashable_outputs(&task_id, workspace_dir);
+        let relative_prefix = match cfg!(windows) {
+            true => "apps\\foo\\",
+            false => "apps/foo/",
+        };
+        assert_eq!(
+            relative_outputs,
+            TaskOutputs {
+                inclusions: vec![
+                    format!("{relative_prefix}.next/**/*"),
+                    format!("{relative_prefix}.turbo/turbo-build.log"),
+                ],
+                exclusions: vec![format!("{relative_prefix}.next/bad-file")],
+            }
+        );
     }
 }


### PR DESCRIPTION
### Description

When hooking up the task graph visitor to the task cache I hit a [failing debug assertion](https://github.com/vercel/turbo/blob/main/crates/turborepo-paths/src/absolute_system_path.rs#L179). This was triggered by the the [join we perform](https://github.com/vercel/turbo/blob/main/crates/turborepo-lib/src/run/cache.rs#L69) in the task graph construction.

This PR:
 - We join anchored workspace directory instead of the resolved absolute system path. [This now matches Go](https://github.com/vercel/turbo/blob/main/cli/internal/runcache/runcache.go#L313)
 - Moves this logic into it's own method so it can be tested without an entire `RunCache` instance
 - Removes an unnecessary cloning of the `TaskOutput` object

I'll note that this *probably* isn't what we want to do in the future as we're joining anchored system paths with globs that will [most definitely contain relative unix paths](https://github.com/vercel/turbo/blob/main/cli/internal/nodes/packagetask.go#L38). On windows this results in globs like `apps\web\.turbo/turbo-build.log`. I do want to fix this, but since that would be a behavior change in both Go&Rust, it belongs in its own PR.

### Testing Instructions

Moved code that panicked to it's own method and added a unit test that would exercise it.
