### PR TITLE
chore: disable clippy checks on fsevents

### DIFF
--- a/crates/turborepo-filewatch/src/cookie_jar.rs
+++ b/crates/turborepo-filewatch/src/cookie_jar.rs
@@ -130,7 +130,7 @@ async fn watch_cookies(
                                     .expect("Non-absolute path from filewatching");
                                 if root.relation_to_path(abs_path) == PathRelation::Parent {
                                     if let Some(responder) = watches.cookies.remove(&path) {
-                                        if let Err(_) = responder.send(Ok(())) {
+                                        if responder.send(Ok(())).is_err() {
                                             // Note that cookie waiters will time out if they don't get a
                                             // response, so we don't necessarily
                                             // need to panic here, although we could decide to do that in the
@@ -151,7 +151,7 @@ async fn watch_cookies(
                         let resp = if is_closing { WatchError::Closed } else { e };
                         let mut watches = watches.lock().expect("mutex poisoned");
                         for (_, sender) in watches.cookies.drain() {
-                            if let Err(_) = sender.send(Err(resp.clone())) {
+                            if sender.send(Err(resp.clone())).is_err() {
                                 // Note that cookie waiters will time out if they don't get a response, so
                                 // we don't necessarily need to panic here, although
                                 // we could decide to do that in the future.

--- a/crates/turborepo-filewatch/src/lib.rs
+++ b/crates/turborepo-filewatch/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(clippy::all)]
 #![feature(assert_matches)]
 
 use std::{
@@ -91,7 +92,7 @@ impl FileSystemWatcher {
         let watcher = run_watcher(&watch_root, send_file_events).unwrap();
         let (exit_ch, exit_signal) = tokio::sync::oneshot::channel();
         // Ensure we are ready to receive new events, not events for existing state
-        futures::executor::block_on(wait_for_cookie(&root, &mut recv_file_events))?;
+        futures::executor::block_on(wait_for_cookie(root, &mut recv_file_events))?;
         tokio::task::spawn(watch_events(
             watcher,
             watch_root,
@@ -234,7 +235,7 @@ fn watch_parents(root: &AbsoluteSystemPath, watcher: &mut Backend) -> Result<(),
 
 #[cfg(not(feature = "manual_recursive_watch"))]
 fn watch_recursively(root: &AbsoluteSystemPath, watcher: &mut Backend) -> Result<(), WatchError> {
-    watcher.watch(&root.as_std_path(), RecursiveMode::Recursive)?;
+    watcher.watch(root.as_std_path(), RecursiveMode::Recursive)?;
     Ok(())
 }
 

--- a/crates/turborepo-filewatch/src/lib.rs
+++ b/crates/turborepo-filewatch/src/lib.rs
@@ -151,7 +151,7 @@ async fn watch_events(
                         {
                             if event.kind == EventKind::Create(CreateKind::Folder) {
                                 for new_path in &event.paths {
-                                    if let Err(err) = manually_add_recursive_watches(&new_path, &mut watcher, Some(&broadcast_sender)) {
+                                    if let Err(err) = manually_add_recursive_watches(new_path, &mut watcher, Some(&broadcast_sender)) {
                                         warn!("encountered error watching filesystem {}", err);
                                         break 'outer;
                                     }

--- a/crates/turborepo-filewatch/src/lib.rs
+++ b/crates/turborepo-filewatch/src/lib.rs
@@ -33,6 +33,7 @@ use {
 
 mod cookie_jar;
 #[cfg(target_os = "macos")]
+#[allow(clippy::all)]
 mod fsevent;
 
 #[cfg(not(target_os = "macos"))]


### PR DESCRIPTION
### Description

Since we just vendor the `fsevent` module, I want to disable clippy from running on it. We could also fix up all of the lints, but that is slightly more invasive. 

I have my rust-analyzer check command set to `cargo clippy` so I get all clippy warnings and for whatever reason, one of the clippy warnings in `fsevent` prevented compiler errors from showing up in my editor.

### Testing Instructions

`cargo clippy` on `turborepo-lib` now doesn't hard fail.


Closes TURBO-1305