### PR TITLE
Fix clippy warnings / errors in filewatching code

### DIFF
--- a/crates/turborepo-filewatch/src/cookie_jar.rs
+++ b/crates/turborepo-filewatch/src/cookie_jar.rs
@@ -130,7 +130,7 @@ async fn watch_cookies(
                                     .expect("Non-absolute path from filewatching");
                                 if root.relation_to_path(abs_path) == PathRelation::Parent {
                                     if let Some(responder) = watches.cookies.remove(&path) {
-                                        if let Err(_) = responder.send(Ok(())) {
+                                        if responder.send(Ok(())).is_err() {
                                             // Note that cookie waiters will time out if they don't get a
                                             // response, so we don't necessarily
                                             // need to panic here, although we could decide to do that in the
@@ -151,7 +151,7 @@ async fn watch_cookies(
                         let resp = if is_closing { WatchError::Closed } else { e };
                         let mut watches = watches.lock().expect("mutex poisoned");
                         for (_, sender) in watches.cookies.drain() {
-                            if let Err(_) = sender.send(Err(resp.clone())) {
+                            if sender.send(Err(resp.clone())).is_err() {
                                 // Note that cookie waiters will time out if they don't get a response, so
                                 // we don't necessarily need to panic here, although
                                 // we could decide to do that in the future.

--- a/crates/turborepo-filewatch/src/fsevent.rs
+++ b/crates/turborepo-filewatch/src/fsevent.rs
@@ -14,6 +14,9 @@
 //! [ref]: https://developer.apple.com/library/mac/documentation/Darwin/Reference/FSEvents_Ref/
 
 #![allow(non_upper_case_globals, dead_code)]
+// bitflags! with a 0 value defined triggers this clippy error,
+// but we want to be able to define a value for fs::kFSEventStreamEventFlagNone
+#![allow(clippy::bad_bit_mask)]
 
 use std::{
     collections::HashMap,

--- a/crates/turborepo-filewatch/src/lib.rs
+++ b/crates/turborepo-filewatch/src/lib.rs
@@ -90,7 +90,7 @@ impl FileSystemWatcher {
         let watcher = run_watcher(&watch_root, send_file_events).unwrap();
         let (exit_ch, exit_signal) = tokio::sync::oneshot::channel();
         // Ensure we are ready to receive new events, not events for existing state
-        futures::executor::block_on(wait_for_cookie(&root, &mut recv_file_events))?;
+        futures::executor::block_on(wait_for_cookie(root, &mut recv_file_events))?;
         tokio::task::spawn(watch_events(
             watcher,
             watch_root,
@@ -233,7 +233,7 @@ fn watch_parents(root: &AbsoluteSystemPath, watcher: &mut Backend) -> Result<(),
 
 #[cfg(not(feature = "manual_recursive_watch"))]
 fn watch_recursively(root: &AbsoluteSystemPath, watcher: &mut Backend) -> Result<(), WatchError> {
-    watcher.watch(&root.as_std_path(), RecursiveMode::Recursive)?;
+    watcher.watch(root.as_std_path(), RecursiveMode::Recursive)?;
     Ok(())
 }
 


### PR DESCRIPTION
### Description

 - switch `if let Err(_) = ...` to `if ....is_err()`
 - drop unnecessary references
 - allow `bad_bit_mask` in `fsevents` because we want to be able to define a bitmask set to 0

### Testing Instructions

 - clippy


Closes TURBO-1306