### PR TITLE
fix: missing autoprefixer package in with-tailwind example

### DIFF
--- a/examples/with-tailwind/packages/ui/package.json
+++ b/examples/with-tailwind/packages/ui/package.json
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "@types/react": "^18.2.5",
+    "autoprefixer": "^10.4.13",
     "eslint-config-custom": "workspace:*",
     "postcss": "^8.4.20",
     "react": "^18.2.0",

--- a/examples/with-tailwind/pnpm-lock.yaml
+++ b/examples/with-tailwind/pnpm-lock.yaml
@@ -144,6 +144,9 @@ importers:
       '@types/react':
         specifier: ^18.2.5
         version: 18.2.21
+      autoprefixer:
+        specifier: ^10.4.13
+        version: 10.4.15(postcss@8.4.28)
       eslint-config-custom:
         specifier: workspace:*
         version: link:../eslint-config-custom


### PR DESCRIPTION
### Description

In `with-tailwind` example, the `autoprefixer` package is missing from `package.json` file even though it is used in `postcss.config.js`

