### PR TITLE
fix: deny clippy errors in filewatching crate

### DIFF
--- a/crates/turborepo-filewatch/src/lib.rs
+++ b/crates/turborepo-filewatch/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(clippy::all)]
 #![feature(assert_matches)]
 
 use std::{
@@ -149,7 +150,7 @@ async fn watch_events(
                         {
                             if event.kind == EventKind::Create(CreateKind::Folder) {
                                 for new_path in &event.paths {
-                                    if let Err(err) = manually_add_recursive_watches(&new_path, &mut watcher, Some(&broadcast_sender)) {
+                                    if let Err(err) = manually_add_recursive_watches(new_path, &mut watcher, Some(&broadcast_sender)) {
                                         warn!("encountered error watching filesystem {}", err);
                                         break 'outer;
                                     }


### PR DESCRIPTION
### Description

#5891 fixed some clippy warnings, but it didn't deny any additional clippy warnings. This PR makes all clippy warnings into failures. In doing this, another unnecessary reference lint was uncovered.

### Testing Instructions
Add back the `&` removed in this PR and verify that `cargo clippy --no-default-features --features macos_fsevent --features watch_ancestors --features manual_recursive_watch` results in a failure.



Closes TURBO-1307