### PR TITLE
fix(Turborepo): Filter ancestor events before manual recursive watch

### DIFF
--- a/crates/turborepo-filewatch/src/lib.rs
+++ b/crates/turborepo-filewatch/src/lib.rs
@@ -3,7 +3,6 @@
 use std::{
     fmt::{Debug, Display},
     future::IntoFuture,
-    io,
     path::Path,
     result::Result,
     sync::Arc,
@@ -17,7 +16,7 @@ use fsevent::FsEventWatcher;
 use notify::event::EventKind;
 #[cfg(not(target_os = "macos"))]
 use notify::{Config, RecommendedWatcher};
-use notify::{ErrorKind, Event, EventHandler, RecursiveMode, Watcher};
+use notify::{Event, EventHandler, RecursiveMode, Watcher};
 use thiserror::Error;
 use tokio::sync::{broadcast, mpsc};
 use tracing::warn;
@@ -28,7 +27,11 @@ use turbopath::PathRelation;
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
 #[cfg(feature = "manual_recursive_watch")]
 use {
-    notify::event::{CreateKind, EventAttributes},
+    notify::{
+        event::{CreateKind, EventAttributes},
+        ErrorKind,
+    },
+    std::io,
     walkdir::WalkDir,
 };
 

--- a/crates/turborepo-filewatch/src/lib.rs
+++ b/crates/turborepo-filewatch/src/lib.rs
@@ -3,10 +3,11 @@
 use std::{
     fmt::{Debug, Display},
     future::IntoFuture,
+    io,
     path::Path,
     result::Result,
     sync::Arc,
-    time::Duration, io,
+    time::Duration,
 };
 
 // macos -> custom watcher impl in fsevents, no recursive watch, no watching ancestors
@@ -16,7 +17,7 @@ use fsevent::FsEventWatcher;
 use notify::event::EventKind;
 #[cfg(not(target_os = "macos"))]
 use notify::{Config, RecommendedWatcher};
-use notify::{Event, EventHandler, RecursiveMode, Watcher, ErrorKind};
+use notify::{ErrorKind, Event, EventHandler, RecursiveMode, Watcher};
 use thiserror::Error;
 use tokio::sync::{broadcast, mpsc};
 use tracing::warn;
@@ -268,11 +269,11 @@ fn manually_add_recursive_watches(
         let dir = dir?;
         if dir.file_type().is_dir() {
             match watcher.watch(dir.path(), RecursiveMode::NonRecursive) {
-                Ok(()) => {},
+                Ok(()) => {}
                 // If we try to watch a non-existent path, we can just skip
                 // it.
                 Err(e) if is_not_found(&e) => continue,
-                Err(e) => return Err(e.into())
+                Err(e) => return Err(e.into()),
             }
         }
         if let Some(sender) = sender.as_ref() {


### PR DESCRIPTION
### Description

 - filter events relative to our path before attempting manual recursive watching. This prevents us from adding unnecessary watches
 - ignore not-found errors when adding manual recursive watches. It's possible that a directory is added and removed faster than we can start watching it, in which case we don't care about it

### Testing Instructions

Existing test suite (was previously flaky on linux)


Closes TURBO-1308