### PR TITLE
fix(release): add capnproto to one more spot

### DIFF
--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -297,6 +297,9 @@ jobs:
           git config --global user.name 'Turbobot'
           git config --global user.email 'turbobot@vercel.com'
 
+      - name: Setup capnproto
+        uses: ./.github/actions/setup-capnproto
+
       - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@v3
         with:


### PR DESCRIPTION
### Description

We need capnproto in one more place - (see [prior run](https://github.com/vercel/turbo/actions/runs/6110532432/job/16585004421))

TODO: It looks like we're building the CLI twice on release when we don't need to. We build all the rust artifacts in their os/arch's and then for publish it looks like we build again and I don't _think_ we need to. But will investigate that after unblocking the release.
