### PR TITLE
Add index.ts to packages/database root

### DIFF
--- a/examples/with-prisma/packages/database/index.ts
+++ b/examples/with-prisma/packages/database/index.ts
@@ -1,0 +1,1 @@
+export * from './src'


### PR DESCRIPTION
### Description

<!--
I noticed that the 'prisma' import in 'web/app/page.tsx' couldn't be located, as it was previously exported from the 'src' directory within the 'database' package. To resolve this issue, I have exported it from the 'index.ts' file in the root directory.
-->

### Testing Instructions

<!--
Go into the  examples/with-prisma, install the dependencies in the apps/web to confirm that there is no error for
the prisma import. 
-->
