### PR TITLE
feat: port output control

### DIFF
--- a/crates/turborepo-ui/src/lib.rs
+++ b/crates/turborepo-ui/src/lib.rs
@@ -1,5 +1,6 @@
 mod color_selector;
 mod logs;
+mod output;
 mod prefixed;
 
 use std::{borrow::Cow, env, f64::consts::PI, time::Duration};
@@ -12,6 +13,7 @@ use thiserror::Error;
 pub use crate::{
     color_selector::ColorSelector,
     logs::{replay_logs, LogWriter},
+    output::{OutputClient, OutputClientBehavior, OutputSink, OutputWriter},
     prefixed::{PrefixedUI, PrefixedWriter},
 };
 

--- a/crates/turborepo-ui/src/logs.rs
+++ b/crates/turborepo-ui/src/logs.rs
@@ -155,11 +155,13 @@ mod tests {
     fn test_replay_logs() -> Result<()> {
         let ui = UI::new(false);
         let mut output = Vec::new();
+        let mut err = Vec::new();
         let mut prefixed_ui = PrefixedUI::new(
             ui,
             CYAN.apply_to(">".to_string()),
             BOLD.apply_to(">!".to_string()),
             &mut output,
+            &mut err,
         );
         let dir = tempdir()?;
         let log_file_path = AbsoluteSystemPathBuf::try_from(dir.path().join("test.txt"))?;

--- a/crates/turborepo-ui/src/output.rs
+++ b/crates/turborepo-ui/src/output.rs
@@ -1,0 +1,324 @@
+use std::{
+    borrow::Cow,
+    cell::RefCell,
+    io::{self, Write},
+    sync::{Arc, Mutex},
+};
+
+/// OutputSink represent a sink for outputs that can be written to from multiple
+/// threads through the use of Loggers.
+pub struct OutputSink<W> {
+    writers: Arc<Mutex<SinkWriters<W>>>,
+}
+
+struct SinkWriters<W> {
+    out: W,
+    err: W,
+}
+
+/// OutputClient allows for multiple threads to write to the same OutputSink
+pub struct OutputClient<W> {
+    behavior: OutputClientBehavior,
+    buffer: Option<RefCell<Vec<SinkBytes<'static>>>>,
+    writers: Arc<Mutex<SinkWriters<W>>>,
+}
+
+pub struct OutputWriter<'a, W> {
+    logger: &'a OutputClient<W>,
+    destination: Destination,
+}
+
+/// Enum for controlling the behavior of the client
+#[derive(Debug, Clone, Copy)]
+pub enum OutputClientBehavior {
+    /// Every line sent to the client will get immediately sent to the sink
+    Passthrough,
+    /// Every line sent to the client will get immediately sent to the sink,
+    /// but a buffer will be built up as well and returned when finish is called
+    InMemoryBuffer,
+    // Every line sent to the client will get tracked in the buffer only being
+    // sent to the sink once finish is called.
+    Grouped,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum Destination {
+    Stdout,
+    Stderr,
+}
+
+#[derive(Debug, Clone)]
+struct SinkBytes<'a> {
+    buffer: Cow<'a, [u8]>,
+    destination: Destination,
+}
+
+impl<W: Write> OutputSink<W> {
+    /// Produces a new sink with the corresponding out and err writers
+    pub fn new(out: W, err: W) -> Self {
+        Self {
+            writers: Arc::new(Mutex::new(SinkWriters { out, err })),
+        }
+    }
+
+    /// Produces a new client that will send all bytes that it receives to the
+    /// underlying sink. Behavior of how these bytes are sent is controlled
+    /// by the behavior parameter. Note that OutputClient intentionally doesn't
+    /// implement Sync as if you want to write to the same sink
+    /// from multiple threads, then you should create a logger for each thread.
+    pub fn logger(&self, behavior: OutputClientBehavior) -> OutputClient<W> {
+        let buffer = match behavior {
+            OutputClientBehavior::Passthrough => None,
+            OutputClientBehavior::InMemoryBuffer | OutputClientBehavior::Grouped => {
+                Some(RefCell::new(Vec::new()))
+            }
+        };
+        let writers = self.writers.clone();
+        OutputClient {
+            behavior,
+            buffer,
+            writers,
+        }
+    }
+}
+
+impl<W: Write> OutputClient<W> {
+    /// A writer that will write to the underlying sink's out writer according
+    /// to this client's behavior.
+    pub fn stdout(&self) -> OutputWriter<W> {
+        OutputWriter {
+            logger: self,
+            destination: Destination::Stdout,
+        }
+    }
+
+    /// A writer that will write to the underlying sink's err writer according
+    /// to this client's behavior.
+    pub fn stderr(&self) -> OutputWriter<W> {
+        OutputWriter {
+            logger: self,
+            destination: Destination::Stderr,
+        }
+    }
+
+    /// Consume the client and flush any bytes to the underlying sink if
+    /// necessary
+    pub fn finish(self) -> io::Result<Option<Vec<u8>>> {
+        let Self {
+            behavior,
+            buffer,
+            writers,
+        } = self;
+        let buffers = buffer.map(|cell| cell.into_inner());
+
+        if matches!(behavior, OutputClientBehavior::Grouped) {
+            let buffers = buffers
+                .as_ref()
+                .expect("grouped logging requires buffer to be present");
+            // We hold the mutex until we write all of the bytes associated for the client
+            // to ensure that the bytes aren't interspersed.
+            let mut writers = writers.lock().expect("lock poisoned");
+            for SinkBytes {
+                buffer,
+                destination,
+            } in buffers
+            {
+                let writer = match destination {
+                    Destination::Stdout => &mut writers.out,
+                    Destination::Stderr => &mut writers.err,
+                };
+                writer.write_all(buffer)?;
+            }
+        }
+
+        Ok(buffers.map(|buffers| {
+            // TODO: it might be worth the list traversal to calculate length so we do a
+            // single allocation
+            let mut bytes = Vec::new();
+            for SinkBytes { buffer, .. } in buffers {
+                bytes.extend_from_slice(&buffer[..]);
+            }
+            bytes
+        }))
+    }
+
+    fn handle_bytes(&self, bytes: SinkBytes) -> io::Result<usize> {
+        if matches!(
+            self.behavior,
+            OutputClientBehavior::InMemoryBuffer | OutputClientBehavior::Grouped
+        ) {
+            let bytes = SinkBytes {
+                destination: bytes.destination,
+                buffer: bytes.buffer.to_vec().into(),
+            };
+            self.add_bytes_to_buffer(bytes);
+        }
+        if matches!(
+            self.behavior,
+            OutputClientBehavior::Passthrough | OutputClientBehavior::InMemoryBuffer
+        ) {
+            self.write_bytes(bytes)
+        } else {
+            // If we only wrote to the buffer, then we consider it a successful write
+            Ok(bytes.buffer.len())
+        }
+    }
+
+    fn write_bytes(&self, bytes: SinkBytes) -> io::Result<usize> {
+        let SinkBytes {
+            buffer: line,
+            destination,
+        } = bytes;
+        let mut writers = self.writers.lock().expect("writer lock poisoned");
+        let writer = match destination {
+            Destination::Stdout => &mut writers.out,
+            Destination::Stderr => &mut writers.err,
+        };
+        writer.write(&line)
+    }
+
+    fn add_bytes_to_buffer(&self, bytes: SinkBytes<'static>) {
+        let buffer = self
+            .buffer
+            .as_ref()
+            .expect("attempted to add line to nil buffer");
+        buffer.borrow_mut().push(bytes);
+    }
+}
+
+impl<'a, W: Write> Write for OutputWriter<'a, W> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.logger.handle_bytes(SinkBytes {
+            buffer: buf.into(),
+            destination: self.destination,
+        })
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        // No buffer held by the logger writer so flush is a noop
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_loggers_from_multiple_threads() {
+        let sink = OutputSink::new(Vec::new(), Vec::new());
+        let pass_thru_logger = sink.logger(OutputClientBehavior::Passthrough);
+        let buffer_logger = sink.logger(OutputClientBehavior::InMemoryBuffer);
+        std::thread::scope(|s| {
+            s.spawn(move || {
+                let mut out = pass_thru_logger.stdout();
+                let mut err = pass_thru_logger.stderr();
+                writeln!(&mut out, "task 1: out").unwrap();
+                writeln!(&mut err, "task 1: err").unwrap();
+                assert!(pass_thru_logger.finish().unwrap().is_none());
+            });
+            s.spawn(move || {
+                let mut out = buffer_logger.stdout();
+                let mut err = buffer_logger.stderr();
+                writeln!(&mut out, "task 2: out").unwrap();
+                writeln!(&mut err, "task 2: err").unwrap();
+                assert_eq!(
+                    buffer_logger.finish().unwrap().unwrap(),
+                    b"task 2: out\ntask 2: err\n"
+                );
+            });
+        });
+        let SinkWriters { out, err } = Arc::into_inner(sink.writers).unwrap().into_inner().unwrap();
+        let out = String::from_utf8(out).unwrap();
+        let err = String::from_utf8(err).unwrap();
+        for line in out.lines() {
+            assert!(line.ends_with(": out"));
+        }
+        for line in err.lines() {
+            assert!(line.ends_with(": err"));
+        }
+    }
+
+    #[test]
+    fn test_pass_thru() -> io::Result<()> {
+        let sink = OutputSink::new(Vec::new(), Vec::new());
+        let logger = sink.logger(OutputClientBehavior::Passthrough);
+
+        let mut out = logger.stdout();
+
+        writeln!(&mut out, "output for 1")?;
+        assert_eq!(
+            sink.writers.lock().unwrap().out.as_slice(),
+            b"output for 1\n",
+            "pass thru should end up in sink immediately"
+        );
+        assert!(
+            logger.finish()?.is_none(),
+            "pass through logs shouldn't keep a buffer"
+        );
+        assert_eq!(
+            sink.writers.lock().unwrap().out.as_slice(),
+            b"output for 1\n",
+            "pass thru shouldn't alter sink on finish"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_buffer() -> io::Result<()> {
+        let sink = OutputSink::new(Vec::new(), Vec::new());
+        let logger = sink.logger(OutputClientBehavior::InMemoryBuffer);
+
+        let mut out = logger.stdout();
+
+        writeln!(&mut out, "output for 1")?;
+        assert_eq!(
+            sink.writers.lock().unwrap().out.as_slice(),
+            b"output for 1\n",
+            "buffer should end up in sink immediately"
+        );
+        assert_eq!(
+            logger.finish()?.unwrap(),
+            b"output for 1\n",
+            "buffer should return buffer"
+        );
+        assert_eq!(
+            sink.writers.lock().unwrap().out.as_slice(),
+            b"output for 1\n",
+            "buffer shouldn't alter sink on finish"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_grouped_logs() -> io::Result<()> {
+        let sink = OutputSink::new(Vec::new(), Vec::new());
+        let group1_logger = sink.logger(OutputClientBehavior::Grouped);
+        let group2_logger = sink.logger(OutputClientBehavior::Grouped);
+
+        let mut group1_out = group1_logger.stdout();
+        let mut group2_out = group2_logger.stdout();
+        let mut group2_err = group2_logger.stderr();
+
+        writeln!(&mut group2_out, "output for 2")?;
+        writeln!(&mut group1_out, "output for 1")?;
+        let group1_logs = group1_logger
+            .finish()?
+            .expect("grouped logs should have buffer");
+        writeln!(&mut group2_err, "warning for 2")?;
+        let group2_logs = group2_logger
+            .finish()?
+            .expect("grouped logs should have buffer");
+
+        assert_eq!(group1_logs, b"output for 1\n");
+        assert_eq!(group2_logs, b"output for 2\nwarning for 2\n");
+
+        let SinkWriters { out, err } = Arc::into_inner(sink.writers).unwrap().into_inner().unwrap();
+        assert_eq!(out, b"output for 1\noutput for 2\n");
+        assert_eq!(err, b"warning for 2\n");
+
+        Ok(())
+    }
+}

--- a/crates/turborepo-ui/src/output.rs
+++ b/crates/turborepo-ui/src/output.rs
@@ -147,6 +147,8 @@ impl<W: Write> OutputClient<W> {
             self.behavior,
             OutputClientBehavior::InMemoryBuffer | OutputClientBehavior::Grouped
         ) {
+            // This reconstruction is necessary to change the type of bytes from
+            // SinkBytes<'a> to SinkBytes<'static>
             let bytes = SinkBytes {
                 destination: bytes.destination,
                 buffer: bytes.buffer.to_vec().into(),

--- a/crates/turborepo-ui/tests/threads.rs
+++ b/crates/turborepo-ui/tests/threads.rs
@@ -35,12 +35,16 @@ fn test_can_write_from_threads() {
 
     assert!(err.is_empty(), "nothing wrote to stderr");
     assert_eq!(
-        String::from_utf8(task1_logfile.read().unwrap()).unwrap(),
-        "hello from foo\n"
+        String::from_utf8(task1_logfile.read().unwrap())
+            .unwrap()
+            .trim(),
+        "hello from foo"
     );
     assert_eq!(
-        String::from_utf8(task2_logfile.read().unwrap()).unwrap(),
-        "hello from bar\n"
+        String::from_utf8(task2_logfile.read().unwrap())
+            .unwrap()
+            .trim(),
+        "hello from bar"
     );
 
     let output = String::from_utf8(out).unwrap();

--- a/crates/turborepo-ui/tests/threads.rs
+++ b/crates/turborepo-ui/tests/threads.rs
@@ -1,0 +1,110 @@
+use std::{
+    io::{self, BufRead, BufReader, Write},
+    process::{Command, Stdio},
+};
+
+use console::Style;
+use turbopath::AbsoluteSystemPath;
+use turborepo_ui::{
+    LogWriter, OutputClient, OutputClientBehavior, OutputSink, PrefixedUI, PrefixedWriter, UI,
+};
+
+#[test]
+fn test_can_write_from_threads() {
+    // Construct our output sink and clients
+    let mut out = Vec::new();
+    let mut err = Vec::new();
+    let sink = OutputSink::new(&mut out, &mut err);
+
+    let task1_client = sink.logger(OutputClientBehavior::Grouped);
+    let task2_client = sink.logger(OutputClientBehavior::Grouped);
+
+    // Setup the log files used by the tasks
+    let log_dir = tempfile::tempdir().unwrap();
+    let abs_log_dir = AbsoluteSystemPath::from_std_path(log_dir.path()).unwrap();
+    let task1_logfile = abs_log_dir.join_component("task1.txt");
+    let task2_logfile = abs_log_dir.join_component("task2.txt");
+
+    // Spawn two tasks that will produce output
+    std::thread::scope(|s| {
+        let task1_logfile = &task1_logfile;
+        let task2_logfile = &task2_logfile;
+        s.spawn(move || echo_task("foo", task1_client, task1_logfile));
+        s.spawn(move || echo_task("bar", task2_client, task2_logfile));
+    });
+
+    assert!(err.is_empty(), "nothing wrote to stderr");
+    assert_eq!(
+        String::from_utf8(task1_logfile.read().unwrap()).unwrap(),
+        "hello from foo\n"
+    );
+    assert_eq!(
+        String::from_utf8(task2_logfile.read().unwrap()).unwrap(),
+        "hello from bar\n"
+    );
+
+    let output = String::from_utf8(out).unwrap();
+    let lines = output.lines().collect::<Vec<_>>();
+    assert_eq!(lines.len(), 4, "the two tasks should output two lines each");
+
+    let first_task = lines[0].split(' ').next().unwrap();
+    assert_eq!(lines[0], format!("{first_task} > running {first_task}"));
+    assert_eq!(lines[1], format!("{first_task} > hello from {first_task}"));
+    let second_task = lines[2].split(' ').next().unwrap();
+    assert_eq!(lines[2], format!("{second_task} > running {second_task}"));
+    assert_eq!(
+        lines[3],
+        format!("{second_task} > hello from {second_task}")
+    );
+}
+
+fn echo_task(
+    task_name: &'static str,
+    client: OutputClient<impl Write>,
+    log_file: &AbsoluteSystemPath,
+) -> io::Result<()> {
+    // Construct the prefix UI used by turbo to write output
+    // this output will not appear in a task's log file.
+    let output_prefix = Style::new().apply_to(format!("{task_name} > "));
+    let warn_prefix = Style::new().apply_to(format!("{task_name} warning > "));
+    let ui = UI::new(true);
+    let mut prefix_ui = PrefixedUI::new(
+        ui,
+        output_prefix.clone(),
+        warn_prefix,
+        client.stdout(),
+        client.stderr(),
+    );
+
+    prefix_ui.output(format!("running {task_name}"));
+
+    // Construct the task logger that will write to the output sink as well as the
+    // log file
+    let mut task_logger = LogWriter::default();
+    task_logger.with_log_file(log_file).unwrap();
+    task_logger.with_prefixed_writer(PrefixedWriter::new(ui, output_prefix, client.stdout()));
+
+    let mut cmd = Command::new("echo");
+    cmd.args(["hello", "from", task_name]);
+    cmd.stdout(Stdio::piped());
+
+    let mut process = cmd.spawn().unwrap();
+    let stdout = process.stdout.take().unwrap();
+
+    // Read the process output and send it to the task logger
+    let mut buf = String::new();
+    let mut reader = BufReader::new(stdout);
+    while let Ok(n) = reader.read_line(&mut buf) {
+        if n == 0 {
+            break;
+        } else {
+            write!(task_logger, "{buf}").unwrap();
+        }
+        buf.clear();
+    }
+    process.wait()?;
+
+    client.finish()?;
+
+    Ok(())
+}


### PR DESCRIPTION
### Description

This is a port of what we do in Go for controlling writing to stdout/stderr. This abstraction will be used in conjunction with `PrefixedUI` and `LogWriter` to achieve the same behavior as Go.

In Go we achieve this behavior with a variety of wrapper structs around stdout and stderr that implement `io.Write`:
![graph](https://github.com/vercel/turbo/assets/4131117/49247730-eeb1-4b95-8533-743f212a9127)

In Rust we combine all the the nodes from "concurrent ui" on down and expose `OutputWriter` which implements `io::Write` which can then be wrapped in either of the other structs this crate provides. This roughly translates to [these lines in Go](https://github.com/vercel/turbo/blob/main/cli/internal/run/real_run.go#L212-L235)

Notes:
 - Currently this we wrap the underlying output writers in an `Arc<Mutex>` to allow them to be written to from multiple threads. This matches the behavior in Go, but in the future if we find we have too much contention with the mutex, we could try switching to a mpsc channel.
 - This PR also includes adding a separate writer for errors to `PrefixedUI` to match the Go implementation.

### Testing Instructions

Added unit tests for the new `output` module as well as an integration test that displays how `turbo` will use all of these modules together to achieve the same behavior as we have in Go. The integration test models how we use these components in Go: [prefix ui](https://github.com/vercel/turbo/blob/main/cli/internal/run/real_run.go#L412-L418) and [task writer](https://github.com/vercel/turbo/blob/main/cli/internal/run/real_run.go#L412-L418)


Closes TURBO-1312