### PR TITLE
Revert swc versions to one that doesn't use lightningcss

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,15 +616,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
-name = "base64-simd"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "781dd20c3aff0bd194fe7d2a977dd92f21c173891f3a03b677359e5fa457e5d5"
-dependencies = [
- "simd-abstraction",
-]
-
-[[package]]
 name = "better_scoped_tls"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -690,9 +681,9 @@ dependencies = [
 
 [[package]]
 name = "binding_macros"
-version = "0.56.10"
+version = "0.53.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7379c1a81786adc4a7a0bfe197be24402b1314bf7f0e0f45d10de767377aeac"
+checksum = "e03769a02fbae78c9eb429cec1089cd4ccf244f18cd3a616096245f6be377ac1"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -1392,26 +1383,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed3d0b5ff30645a68f35ece8cea4556ca14ef8a1651455f789a099a0513532a6"
 
 [[package]]
-name = "const-str"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21077772762a1002bb421c3af42ac1725fa56066bfc53d9a55bb79905df2aaf3"
-dependencies = [
- "const-str-proc-macro",
-]
-
-[[package]]
-name = "const-str-proc-macro"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e1e0fdd2e5d3041e530e1b21158aeeef8b5d0e306bc5c1e3d6cf0930d10e25a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "const_fn"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1821,33 +1792,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cssparser"
-version = "0.29.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93d03419cb5950ccfd3daf3ff1c7a36ace64609a1a8746d493df1ca0afde0fa"
-dependencies = [
- "cssparser-macros",
- "dtoa-short",
- "itoa",
- "matches",
- "phf",
- "proc-macro2",
- "quote",
- "smallvec",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "cssparser-macros"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
-dependencies = [
- "quote",
- "syn 2.0.25",
-]
-
-[[package]]
 name = "ctor"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2045,15 +1989,6 @@ name = "data-encoding"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
-
-[[package]]
-name = "data-url"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a30bfce702bcfa94e906ef82421f2c0e61c076ad76030c16ee5d2e9a32fe193"
-dependencies = [
- "matches",
-]
 
 [[package]]
 name = "dav1d"
@@ -2255,21 +2190,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88e3201db19ec4199af513d38c49fcbc5f8ca31d268f942e97324a826c9e9fdb"
 dependencies = [
  "nom",
-]
-
-[[package]]
-name = "dtoa"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
-
-[[package]]
-name = "dtoa-short"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbaceec3c6e4211c79e7b1800fb9680527106beb2f9c51904a3210c03a448c74"
-dependencies = [
- "dtoa",
 ]
 
 [[package]]
@@ -3985,41 +3905,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lightningcss"
-version = "1.0.0-alpha.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04f87dd0377974affb751fedb4d394b0fce51829227ec6afe4fa7d51eeb6383b"
-dependencies = [
- "ahash 0.7.6",
- "bitflags 2.3.3",
- "const-str",
- "cssparser",
- "dashmap",
- "data-encoding",
- "itertools",
- "lazy_static",
- "lightningcss-derive",
- "parcel_selectors",
- "parcel_sourcemap",
- "paste",
- "pathdiff",
- "rayon",
- "serde",
- "smallvec",
-]
-
-[[package]]
-name = "lightningcss-derive"
-version = "1.0.0-alpha.39"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80f9c05013e43faeef3f09a4c425f926b91a64fee540887a9857a5556b70ea5a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "link-cplusplus"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4135,12 +4020,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "matches"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
-
-[[package]]
 name = "matchit"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4167,9 +4046,9 @@ dependencies = [
 
 [[package]]
 name = "mdxjs"
-version = "0.1.15"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e097a5c85092b8b9c49c4cb97bb9aade29bf876e1dd7a6cfedb6a0224892493d"
+checksum = "334329b79f2a86b4e432a4f9911df72e4b7dff1164dfa3027bc7f91d60391d8f"
 dependencies = [
  "markdown",
  "serde",
@@ -4409,9 +4288,9 @@ dependencies = [
 
 [[package]]
 name = "modularize_imports"
-version = "0.38.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "207835c220baf4ce7535ae23f61b3ed1f8d08b57a6a8eb7803a5ec2bc3d689c6"
+checksum = "fadb4910d44f493d92d99c729efc7df7c183068023347e593b6acc35e301374a"
 dependencies = [
  "convert_case 0.5.0",
  "handlebars",
@@ -4949,12 +4828,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "outref"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f222829ae9293e33a9f5e9f440c6760a3d450a64affe1846486b140db81c1f4"
-
-[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4977,36 +4850,6 @@ dependencies = [
  "bytecount",
  "fnv",
  "unicode-width",
-]
-
-[[package]]
-name = "parcel_selectors"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b1aa68e6c4bf7a49302b9c711c880c1cc2a7dc5c5184042cc724e4124e0d95f"
-dependencies = [
- "bitflags 2.3.3",
- "cssparser",
- "fxhash",
- "log",
- "phf",
- "phf_codegen",
- "precomputed-hash",
- "smallvec",
-]
-
-[[package]]
-name = "parcel_sourcemap"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "485b74d7218068b2b7c0e3ff12fbc61ae11d57cb5d8224f525bd304c6be05bbb"
-dependencies = [
- "base64-simd",
- "data-url",
- "rkyv",
- "serde",
- "serde_json",
- "vlq",
 ]
 
 [[package]]
@@ -5171,16 +5014,6 @@ dependencies = [
  "phf_macros",
  "phf_shared",
  "proc-macro-hack",
-]
-
-[[package]]
-name = "phf_codegen"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb1c3a8bc4dd4e5cfce29b44ffc14bedd2ee294559a294e2a4d4c9e9a6a13cd"
-dependencies = [
- "phf_generator",
- "phf_shared",
 ]
 
 [[package]]
@@ -6685,15 +6518,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "simd-abstraction"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cadb29c57caadc51ff8346233b5cec1d240b68ce55cf1afc764818791876987"
-dependencies = [
- "outref",
-]
-
-[[package]]
 name = "simd-adler32"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6985,9 +6809,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "styled_components"
-version = "0.65.0"
+version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d73be0eacb8259fcbd1cd87d44a1084123860ae48f6fefa26ae594f52eff138"
+checksum = "bf847274a7e6a68723a5eec6543a7197805f8a72d086250ebb8bb33a92fd0204"
 dependencies = [
  "Inflector",
  "once_cell",
@@ -6999,13 +6823,11 @@ dependencies = [
 
 [[package]]
 name = "styled_jsx"
-version = "0.42.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "526a18566599c72e059bc99caa9498394b86f95d7043c2f79597eb31f597163f"
+checksum = "9250212c7494edb9d07261d449fe88f6797bd18486b791c76dceda9e12ba5f4c"
 dependencies = [
  "easy-error",
- "lightningcss",
- "parcel_selectors",
  "swc_core",
  "tracing",
 ]
@@ -7046,10 +6868,11 @@ dependencies = [
 
 [[package]]
 name = "swc"
-version = "0.265.10"
+version = "0.264.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca1e03e7be80a2eae021b23317936d1782998cba8447b56e8f9e13402366837"
+checksum = "ee55e78284e616507c3155942c774a75f42555a6ff26c8ddc391336e145de9ea"
 dependencies = [
+ "ahash 0.8.3",
  "anyhow",
  "base64 0.13.1",
  "dashmap",
@@ -7124,9 +6947,9 @@ dependencies = [
 
 [[package]]
 name = "swc_bundler"
-version = "0.219.8"
+version = "0.217.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a67bb31be024e911195c51dd8ea2a6b3f032d75862e1f81038bba80f67088f"
+checksum = "9db89958f46b03b8f39f29cc1c57426f33c9b41fd2917aedab68d62425ce17d5"
 dependencies = [
  "anyhow",
  "crc",
@@ -7170,11 +6993,10 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.32.1"
+version = "0.31.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c84742fc22df1c293da5354c1cc8a5b45a045e9dc941005c1fd9cb4e9bdabc1"
+checksum = "88d00f960c667c59c133f30492f4d07f26242fcf988a066d3871e6d3d838d528"
 dependencies = [
- "ahash 0.8.3",
  "anyhow",
  "ast_node",
  "atty",
@@ -7229,9 +7051,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "0.82.10"
+version = "0.79.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567897c2eaeebc497baa7d1c0047b9d1c807bb88b0b21039485252677d3a05c6"
+checksum = "0ee3a56f867f2fc26c13a7b3b9ef050cf408bf02b67ec4dc3befa43f72da4b90"
 dependencies = [
  "binding_macros",
  "swc",
@@ -7244,6 +7066,7 @@ dependencies = [
  "swc_css_compat",
  "swc_css_modules",
  "swc_css_parser",
+ "swc_css_prefixer",
  "swc_css_utils",
  "swc_css_visit",
  "swc_ecma_ast",
@@ -7273,9 +7096,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_ast"
-version = "0.139.1"
+version = "0.137.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fab824eff88884673de1d6b84cdb5d3d71c0b903fcef62a3ec1f44f40477433f"
+checksum = "3c2a453b258363999f37e77ad58f6e8c6158d5f15bd7239d2a9d95e018020037"
 dependencies = [
  "is-macro",
  "serde",
@@ -7286,9 +7109,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_codegen"
-version = "0.149.1"
+version = "0.147.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef989abd4b9ccf3caf6a4ab0ceb9f9e7d6a27c08585a20a7fc7b9db6c73a341"
+checksum = "8aeab66ab91e3315f080cf8d88ad9e78ba603e856f566939c8ddfff80950cf84"
 dependencies = [
  "auto_impl",
  "bitflags 2.3.3",
@@ -7316,9 +7139,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_compat"
-version = "0.25.1"
+version = "0.23.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ee1b2b77e7daaf389237ca2656df01cf8c1a6f2d9b158459921b202a661f8a"
+checksum = "c25d7c3063ce3e1c5968482c15fafb1485bf4c1abab068f13e4042465c026977"
 dependencies = [
  "bitflags 2.3.3",
  "once_cell",
@@ -7333,9 +7156,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_modules"
-version = "0.27.1"
+version = "0.25.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da600f86869cd8c6c47c906b92fef7293c4b560db265fd93bc1c8cf5ca8008a8"
+checksum = "c3680e550fa17a4f51e82f33e44485a95637867fb5f95033a138ae8d8d0e20a3"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -7349,9 +7172,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_parser"
-version = "0.148.1"
+version = "0.146.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b02a3c11508487249aa571a908e673c540191de97d5139bb78ab03188dd57e26"
+checksum = "9b0e2040634316eaf0a8c383c31eb3fb2e72ad0209aa3d1c09db424e29cef838"
 dependencies = [
  "lexical",
  "serde",
@@ -7361,10 +7184,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "swc_css_utils"
-version = "0.136.1"
+name = "swc_css_prefixer"
+version = "0.149.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eead47672e3c832e2e3fc3e523490c4822d80a7fc8c50e87a66f9ab7003b517"
+checksum = "246bd085111255b2deb090f04faeb3a1d3b9d5656b58d2d651019121f651c7b4"
+dependencies = [
+ "once_cell",
+ "preset_env_base",
+ "serde",
+ "serde_json",
+ "swc_atoms",
+ "swc_common",
+ "swc_css_ast",
+ "swc_css_utils",
+ "swc_css_visit",
+]
+
+[[package]]
+name = "swc_css_utils"
+version = "0.134.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed1c92974c6544e93f1b510a6666d8c507e4bbeb2d9ca53c2827eb304336b57"
 dependencies = [
  "once_cell",
  "serde",
@@ -7377,9 +7217,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_visit"
-version = "0.138.1"
+version = "0.136.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83f01449a09b8a87ab4bd2ea6cbaaf74e39f9bfba3842a2918e998c5f9b428a4"
+checksum = "a77e6528e4be03574d827a017b28b071cd3c1b63ecc0a9594d937eb372815889"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -7390,9 +7230,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.109.1"
+version = "0.107.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e063a1614daed3ea8be56e5dd8edb17003409088d2fc9ce4aca3378879812607"
+checksum = "e6528f3dd33e11eae9d7fe9fee4a79d5bbd211c74426ab2eec64dc82bd2eb74d"
 dependencies = [
  "bitflags 2.3.3",
  "bytecheck",
@@ -7409,9 +7249,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.144.2"
+version = "0.142.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c18a128504833fe3b7201d830271a12d71d76bb6472ede6f11677e98fca9eda"
+checksum = "933643517578f6c383fead24be0ba707c8548d43a9f80c46cc6972c5d7a0ab3a"
 dependencies = [
  "memchr",
  "num-bigint",
@@ -7441,9 +7281,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ext_transforms"
-version = "0.108.1"
+version = "0.106.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2544221560ee7f035946e93c6407b78f814b0220ae5e1d2a831cfb8418e4699a"
+checksum = "a9eda7699dc5b4e9e99b314441196b19ce1730e9d81fae725ff9e0f5c71ebd68"
 dependencies = [
  "phf",
  "swc_atoms",
@@ -7455,9 +7295,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_lints"
-version = "0.87.4"
+version = "0.85.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d69869bb58bf428c8392084d6ead64b164ddec2b979a03b9c6eb70fa617904a1"
+checksum = "eca995bed2e3d3731845dcdd7e6cfb3176ff620830aa1b7f4d935df184b413b0"
 dependencies = [
  "auto_impl",
  "dashmap",
@@ -7475,9 +7315,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_loader"
-version = "0.44.3"
+version = "0.43.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d30d2ee2ea9207263f723ac0fe701c7c22200e5bec13d3a9b9a9189e97931081"
+checksum = "4c6515f49c3c7dc162eaca6c4d6f711ad07e0e9ffe7df3d9a5ba938e6c0330de"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -7496,9 +7336,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "0.186.8"
+version = "0.184.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f07913f04dfe7baa6a608dea418e69f318518c661814ea2b4c6d355bc5a68fdb"
+checksum = "d4e038d1e0dcd15f74d9ef03a00a05ebd61aa2377e344af3ebc44f28bda5e41c"
 dependencies = [
  "arrayvec 0.7.2",
  "indexmap 1.9.3",
@@ -7531,9 +7371,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.139.1"
+version = "0.137.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e2abc67575c5fcc77cfb9b3eaaeb73bac2cac265504a1fc06a04d0ebbc4c53b"
+checksum = "5f95601ae9654b664a44154bd5186af106df8e7de2dfecad211b29dc90b84185"
 dependencies = [
  "either",
  "num-bigint",
@@ -7551,10 +7391,11 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "0.200.7"
+version = "0.198.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7890a174b923add0d1579b89145b7a6920e83886b688d59c7537e1c89f6c865"
+checksum = "7a137c955a99aafd2be3aef58ba68e02222d96364f7a3f99dda02f1557a45a2e"
 dependencies = [
+ "ahash 0.8.3",
  "anyhow",
  "dashmap",
  "indexmap 1.9.3",
@@ -7576,9 +7417,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_quote_macros"
-version = "0.50.1"
+version = "0.48.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3f02da9402e673522c0f47f2a2092d1389142d601a28a10b48f33a2648bd4f0"
+checksum = "c54d134c226248d209a3cb38fcf059f3613e104e94c552a362c920183d57ad9b"
 dependencies = [
  "anyhow",
  "pmutil",
@@ -7594,9 +7435,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_testing"
-version = "0.21.1"
+version = "0.20.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b776795afd44c8df3977391e239a8dedbe2139c5eeb1ea053c1e29314b6d8a7"
+checksum = "2fe5b4d4ce8851df5e0fe7599b5df70ba4504c26e996bdf12c81c08e330c94b2"
 dependencies = [
  "anyhow",
  "hex",
@@ -7607,9 +7448,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.223.6"
+version = "0.221.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d78c832cd4814a2d0a72f404181767cd3086af0dc711da8d250c2cbe09680ae"
+checksum = "b1fa03407af8c2bc6541aea9b62022f318b2d7f7c282e782f5398868d3948a5f"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -7627,9 +7468,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.132.4"
+version = "0.130.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b9cbdb2be485815eb755a0014b3c2a9008ba0c20634b9ccbdef78a79d76c1e"
+checksum = "42198e3909a6d852ebd88897267ee89323a8ebdbdb436ec60f48079f7c188018"
 dependencies = [
  "better_scoped_tls",
  "bitflags 2.3.3",
@@ -7651,9 +7492,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "0.121.4"
+version = "0.119.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2024092cf6ce2bccf714d1ee06f23dc719d7e1f8bf8c04da11abeff9288d1b"
+checksum = "e58867e9bdc687350717ac8cc83ab8be18172800a91ad7882bf5c0035d0d673e"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -7665,9 +7506,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "0.158.5"
+version = "0.156.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce98b4da27cec62683329e2c1c5fe7e1a43a44f7a0fe7c436a9cce42eb684917"
+checksum = "a20356107a3be02d78136e7d15e768e0734ee988d9dff656e9a9a544f760b279"
 dependencies = [
  "arrayvec 0.7.2",
  "indexmap 1.9.3",
@@ -7704,9 +7545,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "0.175.6"
+version = "0.173.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d8dad438bcb6ae3051e6a6da8e01c9606c997e9f6c57d8fedace63ee64e80b4"
+checksum = "6fc648bb839cbb26ab12a9d4378d716d29294d00bf8d1bb764200224100d00b8"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -7731,9 +7572,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.192.6"
+version = "0.190.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb010e3b1664539d63dc46866e4ec74c96c3044d5395260abc6a4163022d9a93"
+checksum = "e41b54418d67a43f10299ed434947b07e9eb487225fc81fa26b1d64781e27043"
 dependencies = [
  "dashmap",
  "indexmap 1.9.3",
@@ -7756,9 +7597,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "0.166.5"
+version = "0.164.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1244684381c23422ce7f1b9d9dc2541aa008cf5da5b9a3a9d74e5cf0c0b04867"
+checksum = "d90da5e5c6f756cfb33bde8a65f9e120882e558efc12d5e485660b68cb030cc0"
 dependencies = [
  "either",
  "rustc-hash",
@@ -7776,9 +7617,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.178.6"
+version = "0.176.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7634824044c431f80f6a5cdc7eb0568b08d8915c5da20427b36ffcf5759e26b"
+checksum = "541af7444d05aeb25552b9a894a553b57152442990947ac6d5635a337977bbfa"
 dependencies = [
  "base64 0.13.1",
  "dashmap",
@@ -7801,9 +7642,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_testing"
-version = "0.135.4"
+version = "0.133.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e044aa61ea8c86529be13263855d1b844983e84adc8bd119c51ccf4c810d725"
+checksum = "8ddad20242eba6b08f14fba779c8354612f3812008f63f0a2655fbcd17be0ced"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -7827,9 +7668,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.182.6"
+version = "0.180.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465158f5266c85c24bf602d8e314935651233328def7f49a5be2d0d57507b50c"
+checksum = "08e70b8deabd5f9a4425fa0c2e2fb60e3f15a40eedac2fecb45f35c89c2f9d32"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -7843,9 +7684,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_usage_analyzer"
-version = "0.18.2"
+version = "0.16.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89263934ddec01e3738cea970fdf6029b780ad4053d506eb84db9f56b2b95777"
+checksum = "2228a99cb5a110235b3e5b08ba55068ee8942ed24d440c91035f257870095a13"
 dependencies = [
  "indexmap 1.9.3",
  "rustc-hash",
@@ -7860,9 +7701,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.122.1"
+version = "0.120.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47f412679df4b7f28354b81acdf0fbf53816366019f21e5affc1482b868bda1d"
+checksum = "058e23023eab86b548b0488b84a4d490f8d2f5e1de6483d82e352218fd59ae31"
 dependencies = [
  "indexmap 1.9.3",
  "num_cpus",
@@ -7879,9 +7720,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.95.1"
+version = "0.93.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2774848b306e17fa280c598ecb192cc2c72a1163942b02d48606514336e9e7c5"
+checksum = "9abcc6c3255eea772716872d9c958abfe97b1f4658c7a9d1d9dc55eb7e6da254"
 dependencies = [
  "num-bigint",
  "serde",
@@ -7894,9 +7735,9 @@ dependencies = [
 
 [[package]]
 name = "swc_emotion"
-version = "0.41.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "055ee3fbd6b9bf4b05ab58dc03dc0f924505aa4394d1c1d57953788b4d6df632"
+checksum = "cf743905cbab16c3933907dc07fa8bb6ac68682da193ea336cddbebcd6bd219f"
 dependencies = [
  "base64 0.13.1",
  "byteorder",
@@ -7924,9 +7765,9 @@ dependencies = [
 
 [[package]]
 name = "swc_error_reporters"
-version = "0.16.1"
+version = "0.15.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c76b479ad1a69bec65b261354b8e2dec8ed0f9ed43c7b54ab053dc4923e1c90e"
+checksum = "19c5d3bfe85c5f3e50f5a604398ca6b0830a45344b602a53b153b46fe56d3f02"
 dependencies = [
  "anyhow",
  "miette 4.7.1",
@@ -7937,9 +7778,9 @@ dependencies = [
 
 [[package]]
 name = "swc_fast_graph"
-version = "0.20.1"
+version = "0.19.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2f7297cdefdb54d8d09e0294c1aec3826825b1feefd0c25978365aa7f447a1c"
+checksum = "f94ed8b5eb3ea3b932e5bbc32555ebb3d661eef94d7217b7aef6394b224807c0"
 dependencies = [
  "indexmap 1.9.3",
  "petgraph",
@@ -7949,9 +7790,9 @@ dependencies = [
 
 [[package]]
 name = "swc_graph_analyzer"
-version = "0.21.1"
+version = "0.20.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d20a18d45da54ba15698d5ce1f6a0a97684f4035922730393e98e47b44fc3573"
+checksum = "e57e24c2f183d4f9b6be8e5d871a9748ff5959a4c6912d4b9686c739d8f2abcf"
 dependencies = [
  "auto_impl",
  "petgraph",
@@ -7984,9 +7825,9 @@ dependencies = [
 
 [[package]]
 name = "swc_node_comments"
-version = "0.19.1"
+version = "0.18.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2b9597573f1ab8bae72329eef550d214ced0955c7a4f1b6b4ae5e216219e710"
+checksum = "da86e3f1e554fe14d69ffb7a22b6176476cde12eb363540506f37a112f766fca"
 dependencies = [
  "dashmap",
  "swc_atoms",
@@ -8009,9 +7850,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_proxy"
-version = "0.38.1"
+version = "0.36.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a76ccadcc63a459e096f332730b2d4e09548fc10e0be63df9f3bacecdf5332fe"
+checksum = "2bb75fb6cd712b8e5f8e2cf7d7ac9bbbdbd7e475af9de54842b97f2a02638d73"
 dependencies = [
  "better_scoped_tls",
  "rkyv",
@@ -8023,9 +7864,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_runner"
-version = "0.101.1"
+version = "0.98.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de5d17c23f3cde487d510d488fdc420a9150474536e0a525b933375ad8eb711d"
+checksum = "67a6eed4a31d6f11698321a7f48573fb5f31a1de5dc54b720c5ff00607e72274"
 dependencies = [
  "anyhow",
  "enumset",
@@ -8047,9 +7888,9 @@ dependencies = [
 
 [[package]]
 name = "swc_relay"
-version = "0.13.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44b92952f3d06147704b7044efbfe5ec1199f2f535de18bf6d59b12d2ad54e5a"
+checksum = "84156a35d2a71e325b0c0c64d5bda2ed9eeb194df49ea42a6de3793b648b413b"
 dependencies = [
  "once_cell",
  "regex",
@@ -8062,9 +7903,9 @@ dependencies = [
 
 [[package]]
 name = "swc_timer"
-version = "0.20.1"
+version = "0.19.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b740ce6b402ed04176bd28dc4f4f92c764fe0defe8437c2f3b6e1b5818b4e10c"
+checksum = "1cc8582db551c7e879fdd1939123eb02915c4e06510a5bfd44c3cc3e1a4957b8"
 dependencies = [
  "tracing",
 ]
@@ -8333,9 +8174,9 @@ dependencies = [
 
 [[package]]
 name = "testing"
-version = "0.34.1"
+version = "0.33.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc31f7f4a7baef94495386462c2a55caa0f0885b61b28c120f783132d14938ed"
+checksum = "1c722daaa5ad2208e7abd37aa92b4699bec2b053297859faecc5ccebf3bc7425"
 dependencies = [
  "ansi_term",
  "cargo_metadata",
@@ -10183,8 +10024,8 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
- "rand 0.8.5",
+ "cfg-if 0.1.10",
+ "rand 0.4.6",
  "static_assertions",
 ]
 
@@ -10498,12 +10339,6 @@ dependencies = [
  "thiserror",
  "tracing",
 ]
-
-[[package]]
-name = "vlq"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65dd7eed29412da847b0f78bcec0ac98588165988a8cfe41d4ea1d429f8ccfff"
 
 [[package]]
 name = "vte"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,8 +75,6 @@ lto = "off"
 [workspace.dependencies]
 async-recursion = "1.0.2"
 # Keep consistent with preset_env_base through swc_core
-# swc_ecma_loader = { version = "0.43.24", features = ["cache"] }
-
 browserslist-rs = { version = "0.12.2" }
 
 # Temporarily downgrading these to avoid breaking changes stemming from using

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,10 @@ mdxjs = "=0.1.14"
 modularize_imports = { version = "=0.33.0" }
 styled_components = { version = "=0.60.0" }
 styled_jsx = { version = "=0.37.0" }
-swc_core = { version = "=0.79.55", features = ["ecma_loader_lru", "ecma_loader_parking_lot"] }
+swc_core = { version = "=0.79.55", features = [
+  "ecma_loader_lru",
+  "ecma_loader_parking_lot",
+] }
 swc_emotion = { version = "=0.36.0" }
 swc_relay = { version = "=0.8.0" }
 testing = { version = "0.33.21" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,15 +75,20 @@ lto = "off"
 [workspace.dependencies]
 async-recursion = "1.0.2"
 # Keep consistent with preset_env_base through swc_core
+# swc_ecma_loader = { version = "0.43.24", features = ["cache"] }
+
 browserslist-rs = { version = "0.12.2" }
-mdxjs = { version = "0.1.15" }
-modularize_imports = { version = "0.38.0" }
-styled_components = { version = "0.65.0" }
-styled_jsx = { version = "0.42.0" }
-swc_core = { version = "0.82.10" }
-swc_emotion = { version = "0.41.0" }
-swc_relay = { version = "0.13.0" }
-testing = { version = "0.34.1" }
+
+# Temporarily downgrading these to avoid breaking changes stemming from using
+# lightning_css in later versions styled_jsx >= 0.37.0
+mdxjs = "=0.1.14"
+modularize_imports = { version = "=0.33.0" }
+styled_components = { version = "=0.60.0" }
+styled_jsx = { version = "=0.37.0" }
+swc_core = { version = "=0.79.55", features = ["ecma_loader_lru", "ecma_loader_parking_lot"] }
+swc_emotion = { version = "=0.36.0" }
+swc_relay = { version = "=0.8.0" }
+testing = { version = "0.33.21" }
 
 auto-hash-map = { path = "crates/turbo-tasks-auto-hash-map" }
 node-file-trace = { path = "crates/node-file-trace", default-features = false }

--- a/crates/turbopack-ecmascript-plugins/src/transform/directives/server_to_client_proxy.rs
+++ b/crates/turbopack-ecmascript-plugins/src/transform/directives/server_to_client_proxy.rs
@@ -31,7 +31,7 @@ pub fn create_proxy_module(transition_name: &str, target_import: &str) -> Progra
                 })],
                 src: Box::new(target_import.into()),
                 type_only: false,
-                with: Some(Box::new(ObjectLit {
+                asserts: Some(Box::new(ObjectLit {
                     span: DUMMY_SP,
                     props: vec![PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {
                         key: PropName::Ident(Ident::new(TURBOPACK_HELPER.into(), DUMMY_SP)),

--- a/crates/turbopack-ecmascript/src/parse.rs
+++ b/crates/turbopack-ecmascript/src/parse.rs
@@ -254,11 +254,11 @@ async fn parse_content(
                             decorators: true,
                             decorators_before_export: true,
                             export_default_from: true,
-                            import_attributes: true,
+                            import_assertions: true,
                             allow_super_outside_method: true,
                             allow_return_outside_function: true,
                             auto_accessors: true,
-                            explicit_resource_management: true,
+                            using_decl: true,
                         }),
                         EcmascriptModuleAssetType::Typescript
                         | EcmascriptModuleAssetType::TypescriptWithTypes => {

--- a/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/crates/turbopack-ecmascript/src/references/mod.rs
@@ -2602,7 +2602,7 @@ pub struct AstPath(#[turbo_tasks(trace_ignore)] Vec<AstParentKind>);
 pub static TURBOPACK_HELPER: &str = "__turbopackHelper";
 
 pub fn is_turbopack_helper_import(import: &ImportDecl) -> bool {
-    import.with.as_ref().map_or(false, |asserts| {
+    import.asserts.as_ref().map_or(false, |asserts| {
         asserts.props.iter().any(|assert| {
             assert
                 .as_prop()

--- a/crates/turbopack-ecmascript/src/tree_shake/graph.rs
+++ b/crates/turbopack-ecmascript/src/tree_shake/graph.rs
@@ -299,7 +299,7 @@ impl DepGraph {
                         specifiers,
                         src: Box::new(uri_of_module.clone().into()),
                         type_only: false,
-                        with: Some(Box::new(create_turbopack_chunk_id_assert(dep))),
+                        asserts: Some(Box::new(create_turbopack_chunk_id_assert(dep))),
                     })));
             }
 
@@ -334,7 +334,7 @@ impl DepGraph {
                                     )],
                                     src: None,
                                     type_only: false,
-                                    with: Some(Box::new(ObjectLit {
+                                    asserts: Some(Box::new(ObjectLit {
                                         span: DUMMY_SP,
                                         props: vec![assertion_prop],
                                     })),
@@ -787,7 +787,7 @@ impl DepGraph {
                         })],
                         src: None,
                         type_only: false,
-                        with: None,
+                        asserts: None,
                     })),
                     export: Some(export.clone()),
                     ..Default::default()

--- a/crates/turbopack-ecmascript/src/tree_shake/merge.rs
+++ b/crates/turbopack-ecmascript/src/tree_shake/merge.rs
@@ -49,7 +49,7 @@ where
                     // Try to prepend the content of module
 
                     let part_id = import
-                        .with
+                        .asserts
                         .as_deref()
                         .and_then(find_turbopack_chunk_id_in_asserts);
 

--- a/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/1/output.md
+++ b/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/1/output.md
@@ -370,22 +370,22 @@ graph TD
 # Modules (dev)
 ## Part 0
 ```js
-import { foobarCopy } from "entry.js" with {
+import { foobarCopy } from "entry.js" assert {
     __turbopack_chunk__: 9
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 11
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 5
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 8
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 10
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 6
 };
 "module evaluation";
@@ -396,13 +396,13 @@ console.log(foobarCopy);
 ```
 ## Part 1
 ```js
-import { foobar } from "entry.js" with {
+import { foobar } from "entry.js" assert {
     __turbopack_chunk__: 5
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 8
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 10
 };
 export { foobar };
@@ -410,7 +410,7 @@ export { foobar };
 ```
 ## Part 2
 ```js
-import { foo } from "entry.js" with {
+import { foo } from "entry.js" assert {
     __turbopack_chunk__: 6
 };
 export { foo };
@@ -418,16 +418,16 @@ export { foo };
 ```
 ## Part 3
 ```js
-import { internal } from "entry.js" with {
+import { internal } from "entry.js" assert {
     __turbopack_chunk__: 11
 };
-import { foobar } from "entry.js" with {
+import { foobar } from "entry.js" assert {
     __turbopack_chunk__: 5
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 8
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 10
 };
 export { external1 };
@@ -438,10 +438,10 @@ function external1() {
 ```
 ## Part 4
 ```js
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 6
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 9
 };
 export { external2 };
@@ -458,7 +458,7 @@ export { foobar };
 ```
 ## Part 6
 ```js
-import { foobar } from "entry.js" with {
+import { foobar } from "entry.js" assert {
     __turbopack_chunk__: 5
 };
 const foo = foobar;
@@ -473,10 +473,10 @@ export { bar };
 ```
 ## Part 8
 ```js
-import { bar } from "entry.js" with {
+import { bar } from "entry.js" assert {
     __turbopack_chunk__: 7
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 6
 };
 foobar += bar;
@@ -485,10 +485,10 @@ export { foobar };
 ```
 ## Part 9
 ```js
-import { foobar } from "entry.js" with {
+import { foobar } from "entry.js" assert {
     __turbopack_chunk__: 5
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 8
 };
 let foobarCopy = foobar;
@@ -497,10 +497,10 @@ export { foobarCopy };
 ```
 ## Part 10
 ```js
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 6
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 9
 };
 foobar += "foo";
@@ -509,13 +509,13 @@ export { foobar };
 ```
 ## Part 11
 ```js
-import { foobar } from "entry.js" with {
+import { foobar } from "entry.js" assert {
     __turbopack_chunk__: 5
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 8
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 10
 };
 import { upper } from "module";
@@ -551,10 +551,10 @@ console.log(foobarCopy);
 # Modules (prod)
 ## Part 0
 ```js
-import { foobar } from "entry.js" with {
+import { foobar } from "entry.js" assert {
     __turbopack_chunk__: 5
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 7
 };
 "module evaluation";
@@ -566,13 +566,13 @@ export { foobarCopy };
 ```
 ## Part 1
 ```js
-import { foobar } from "entry.js" with {
+import { foobar } from "entry.js" assert {
     __turbopack_chunk__: 5
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 7
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 8
 };
 export { foobar };
@@ -580,7 +580,7 @@ export { foobar };
 ```
 ## Part 2
 ```js
-import { foobar } from "entry.js" with {
+import { foobar } from "entry.js" assert {
     __turbopack_chunk__: 5
 };
 export { foo };
@@ -590,13 +590,13 @@ export { foo };
 ```
 ## Part 3
 ```js
-import { foobar } from "entry.js" with {
+import { foobar } from "entry.js" assert {
     __turbopack_chunk__: 5
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 7
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 8
 };
 export { external1 };
@@ -631,7 +631,7 @@ export { bar };
 ```
 ## Part 7
 ```js
-import { bar } from "entry.js" with {
+import { bar } from "entry.js" assert {
     __turbopack_chunk__: 6
 };
 foobar += bar;

--- a/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/2/output.md
+++ b/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/2/output.md
@@ -392,22 +392,22 @@ graph TD
 # Modules (dev)
 ## Part 0
 ```js
-import { foobarCopy } from "entry.js" with {
+import { foobarCopy } from "entry.js" assert {
     __turbopack_chunk__: 9
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 11
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 5
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 8
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 10
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 6
 };
 "module evaluation";
@@ -419,16 +419,16 @@ import "other";
 ```
 ## Part 1
 ```js
-import { internal } from "entry.js" with {
+import { internal } from "entry.js" assert {
     __turbopack_chunk__: 11
 };
-import { foobar } from "entry.js" with {
+import { foobar } from "entry.js" assert {
     __turbopack_chunk__: 5
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 8
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 10
 };
 export { external1 };
@@ -439,13 +439,13 @@ function external1() {
 ```
 ## Part 2
 ```js
-import { foobar } from "entry.js" with {
+import { foobar } from "entry.js" assert {
     __turbopack_chunk__: 5
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 8
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 10
 };
 export { foobar };
@@ -453,7 +453,7 @@ export { foobar };
 ```
 ## Part 3
 ```js
-import { foo } from "entry.js" with {
+import { foo } from "entry.js" assert {
     __turbopack_chunk__: 6
 };
 export { foo };
@@ -461,10 +461,10 @@ export { foo };
 ```
 ## Part 4
 ```js
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 6
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 9
 };
 export { external2 };
@@ -481,7 +481,7 @@ export { foobar };
 ```
 ## Part 6
 ```js
-import { foobar } from "entry.js" with {
+import { foobar } from "entry.js" assert {
     __turbopack_chunk__: 5
 };
 const foo = foobar;
@@ -496,10 +496,10 @@ export { bar };
 ```
 ## Part 8
 ```js
-import { bar } from "entry.js" with {
+import { bar } from "entry.js" assert {
     __turbopack_chunk__: 7
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 6
 };
 foobar += bar;
@@ -508,10 +508,10 @@ export { foobar };
 ```
 ## Part 9
 ```js
-import { foobar } from "entry.js" with {
+import { foobar } from "entry.js" assert {
     __turbopack_chunk__: 5
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 8
 };
 let foobarCopy = foobar;
@@ -520,10 +520,10 @@ export { foobarCopy };
 ```
 ## Part 10
 ```js
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 6
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 9
 };
 foobar += "foo";
@@ -532,13 +532,13 @@ export { foobar };
 ```
 ## Part 11
 ```js
-import { foobar } from "entry.js" with {
+import { foobar } from "entry.js" assert {
     __turbopack_chunk__: 5
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 8
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 10
 };
 import { upper } from "module";
@@ -575,10 +575,10 @@ console.log(foobarCopy);
 # Modules (prod)
 ## Part 0
 ```js
-import { foobar } from "entry.js" with {
+import { foobar } from "entry.js" assert {
     __turbopack_chunk__: 5
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 7
 };
 "module evaluation";
@@ -591,13 +591,13 @@ export { foobarCopy };
 ```
 ## Part 1
 ```js
-import { foobar } from "entry.js" with {
+import { foobar } from "entry.js" assert {
     __turbopack_chunk__: 5
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 7
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 8
 };
 export { external1 };
@@ -612,13 +612,13 @@ function internal() {
 ```
 ## Part 2
 ```js
-import { foobar } from "entry.js" with {
+import { foobar } from "entry.js" assert {
     __turbopack_chunk__: 5
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 7
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 8
 };
 export { foobar };
@@ -626,7 +626,7 @@ export { foobar };
 ```
 ## Part 3
 ```js
-import { foobar } from "entry.js" with {
+import { foobar } from "entry.js" assert {
     __turbopack_chunk__: 5
 };
 export { foo };
@@ -656,7 +656,7 @@ export { bar };
 ```
 ## Part 7
 ```js
-import { bar } from "entry.js" with {
+import { bar } from "entry.js" assert {
     __turbopack_chunk__: 6
 };
 foobar += bar;

--- a/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/3/output.md
+++ b/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/3/output.md
@@ -329,19 +329,19 @@ graph TD
 # Modules (dev)
 ## Part 0
 ```js
-import { c1_3 } from "entry.js" with {
+import { c1_3 } from "entry.js" assert {
     __turbopack_chunk__: 4
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 6
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 7
 };
-import { c2_2 } from "entry.js" with {
+import { c2_2 } from "entry.js" assert {
     __turbopack_chunk__: 5
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 8
 };
 "module evaluation";
@@ -351,7 +351,7 @@ c2_2();
 ```
 ## Part 1
 ```js
-import { c1_1 } from "entry.js" with {
+import { c1_1 } from "entry.js" assert {
     __turbopack_chunk__: 4
 };
 export { c1_1 };
@@ -359,7 +359,7 @@ export { c1_1 };
 ```
 ## Part 2
 ```js
-import { c1_3 } from "entry.js" with {
+import { c1_3 } from "entry.js" assert {
     __turbopack_chunk__: 4
 };
 export { c1_3 };
@@ -367,7 +367,7 @@ export { c1_3 };
 ```
 ## Part 3
 ```js
-import { c2_2 } from "entry.js" with {
+import { c2_2 } from "entry.js" assert {
     __turbopack_chunk__: 5
 };
 export { c2_2 };
@@ -375,10 +375,10 @@ export { c2_2 };
 ```
 ## Part 4
 ```js
-import { d1 } from "entry.js" with {
+import { d1 } from "entry.js" assert {
     __turbopack_chunk__: 6
 };
-import { d2 } from "entry.js" with {
+import { d2 } from "entry.js" assert {
     __turbopack_chunk__: 7
 };
 function c1_1() {
@@ -394,7 +394,7 @@ function c1_3() {
 ```
 ## Part 5
 ```js
-import { d3 } from "entry.js" with {
+import { d3 } from "entry.js" assert {
     __turbopack_chunk__: 8
 };
 function c2_1() {
@@ -454,10 +454,10 @@ c2_2();
 # Modules (prod)
 ## Part 0
 ```js
-import { c1_3 } from "entry.js" with {
+import { c1_3 } from "entry.js" assert {
     __turbopack_chunk__: 4
 };
-import { c2_2 } from "entry.js" with {
+import { c2_2 } from "entry.js" assert {
     __turbopack_chunk__: 5
 };
 "module evaluation";
@@ -467,7 +467,7 @@ c2_2();
 ```
 ## Part 1
 ```js
-import { c1_1 } from "entry.js" with {
+import { c1_1 } from "entry.js" assert {
     __turbopack_chunk__: 4
 };
 export { c1_1 };
@@ -475,7 +475,7 @@ export { c1_1 };
 ```
 ## Part 2
 ```js
-import { c1_3 } from "entry.js" with {
+import { c1_3 } from "entry.js" assert {
     __turbopack_chunk__: 4
 };
 export { c1_3 };
@@ -483,7 +483,7 @@ export { c1_3 };
 ```
 ## Part 3
 ```js
-import { c2_2 } from "entry.js" with {
+import { c2_2 } from "entry.js" assert {
     __turbopack_chunk__: 5
 };
 export { c2_2 };
@@ -491,10 +491,10 @@ export { c2_2 };
 ```
 ## Part 4
 ```js
-import { d1 } from "entry.js" with {
+import { d1 } from "entry.js" assert {
     __turbopack_chunk__: 6
 };
-import { d2 } from "entry.js" with {
+import { d2 } from "entry.js" assert {
     __turbopack_chunk__: 7
 };
 function c1_1() {
@@ -510,7 +510,7 @@ function c1_3() {
 ```
 ## Part 5
 ```js
-import { d3 } from "entry.js" with {
+import { d3 } from "entry.js" assert {
     __turbopack_chunk__: 8
 };
 function c2_1() {

--- a/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/complex/output.md
+++ b/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/complex/output.md
@@ -402,13 +402,13 @@ graph TD
 # Modules (dev)
 ## Part 0
 ```js
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 8
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 11
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 13
 };
 "module evaluation";
@@ -416,7 +416,7 @@ import "entry.js" with {
 ```
 ## Part 1
 ```js
-import { dogRef } from "entry.js" with {
+import { dogRef } from "entry.js" assert {
     __turbopack_chunk__: 5
 };
 export { dogRef };
@@ -424,7 +424,7 @@ export { dogRef };
 ```
 ## Part 2
 ```js
-import { cat } from "entry.js" with {
+import { cat } from "entry.js" assert {
     __turbopack_chunk__: 14
 };
 export { cat };
@@ -432,7 +432,7 @@ export { cat };
 ```
 ## Part 3
 ```js
-import { cat } from "entry.js" with {
+import { cat } from "entry.js" assert {
     __turbopack_chunk__: 14
 };
 export { initialCat };
@@ -442,19 +442,19 @@ export { initialCat };
 ```
 ## Part 4
 ```js
-import { cat } from "entry.js" with {
+import { cat } from "entry.js" assert {
     __turbopack_chunk__: 14
 };
-import { dog } from "entry.js" with {
+import { dog } from "entry.js" assert {
     __turbopack_chunk__: 6
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 7
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 10
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 12
 };
 export { getChimera };
@@ -465,22 +465,22 @@ function getChimera() {
 ```
 ## Part 5
 ```js
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 13
 };
-import { dog } from "entry.js" with {
+import { dog } from "entry.js" assert {
     __turbopack_chunk__: 6
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 7
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 10
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 12
 };
-import { getDog } from "entry.js" with {
+import { getDog } from "entry.js" assert {
     __turbopack_chunk__: 9
 };
 function setDog(newDog) {
@@ -508,10 +508,10 @@ export { dog };
 ```
 ## Part 8
 ```js
-import { dog } from "entry.js" with {
+import { dog } from "entry.js" assert {
     __turbopack_chunk__: 6
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 7
 };
 console.log(dog);
@@ -519,16 +519,16 @@ console.log(dog);
 ```
 ## Part 9
 ```js
-import { dog } from "entry.js" with {
+import { dog } from "entry.js" assert {
     __turbopack_chunk__: 6
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 7
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 10
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 12
 };
 function getDog() {
@@ -538,7 +538,7 @@ function getDog() {
 ```
 ## Part 10
 ```js
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 8
 };
 dog += "!";
@@ -547,16 +547,16 @@ export { dog };
 ```
 ## Part 11
 ```js
-import { dog } from "entry.js" with {
+import { dog } from "entry.js" assert {
     __turbopack_chunk__: 6
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 7
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 10
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 8
 };
 console.log(dog);
@@ -564,7 +564,7 @@ console.log(dog);
 ```
 ## Part 12
 ```js
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 11
 };
 dog += "!";
@@ -573,22 +573,22 @@ export { dog };
 ```
 ## Part 13
 ```js
-import { dog } from "entry.js" with {
+import { dog } from "entry.js" assert {
     __turbopack_chunk__: 6
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 7
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 10
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 12
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 8
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 11
 };
 console.log(dog);
@@ -619,16 +619,16 @@ console.log(dog);
 # Modules (prod)
 ## Part 0
 ```js
-import { dog } from "entry.js" with {
+import { dog } from "entry.js" assert {
     __turbopack_chunk__: 5
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 6
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 7
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 8
 };
 "module evaluation";
@@ -639,16 +639,16 @@ console.log(dog);
 ```
 ## Part 1
 ```js
-import { dog } from "entry.js" with {
+import { dog } from "entry.js" assert {
     __turbopack_chunk__: 5
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 6
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 7
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 8
 };
 export { dogRef };
@@ -668,7 +668,7 @@ export { dogRef };
 ```
 ## Part 2
 ```js
-import { cat } from "entry.js" with {
+import { cat } from "entry.js" assert {
     __turbopack_chunk__: 9
 };
 export { cat };
@@ -676,7 +676,7 @@ export { cat };
 ```
 ## Part 3
 ```js
-import { cat } from "entry.js" with {
+import { cat } from "entry.js" assert {
     __turbopack_chunk__: 9
 };
 export { initialCat };
@@ -686,19 +686,19 @@ export { initialCat };
 ```
 ## Part 4
 ```js
-import { cat } from "entry.js" with {
+import { cat } from "entry.js" assert {
     __turbopack_chunk__: 9
 };
-import { dog } from "entry.js" with {
+import { dog } from "entry.js" assert {
     __turbopack_chunk__: 5
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 6
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 7
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 8
 };
 export { getChimera };

--- a/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/simple/output.md
+++ b/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/simple/output.md
@@ -129,7 +129,7 @@ graph TD
 ```
 ## Part 1
 ```js
-import { dog } from "entry.js" with {
+import { dog } from "entry.js" assert {
     __turbopack_chunk__: 3
 };
 export { DOG };
@@ -139,7 +139,7 @@ export { DOG };
 ```
 ## Part 2
 ```js
-import { dog } from "entry.js" with {
+import { dog } from "entry.js" assert {
     __turbopack_chunk__: 3
 };
 export { CHIMERA };
@@ -168,7 +168,7 @@ export { dog };
 ```
 ## Part 1
 ```js
-import { dog } from "entry.js" with {
+import { dog } from "entry.js" assert {
     __turbopack_chunk__: 3
 };
 export { DOG };
@@ -178,7 +178,7 @@ export { DOG };
 ```
 ## Part 2
 ```js
-import { dog } from "entry.js" with {
+import { dog } from "entry.js" assert {
     __turbopack_chunk__: 3
 };
 export { CHIMERA };

--- a/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/test-config-1/output.md
+++ b/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/test-config-1/output.md
@@ -370,22 +370,22 @@ graph TD
 # Modules (dev)
 ## Part 0
 ```js
-import { foobarCopy } from "entry.js" with {
+import { foobarCopy } from "entry.js" assert {
     __turbopack_chunk__: 9
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 11
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 5
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 8
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 10
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 6
 };
 "module evaluation";
@@ -396,13 +396,13 @@ console.log(foobarCopy);
 ```
 ## Part 1
 ```js
-import { foobar } from "entry.js" with {
+import { foobar } from "entry.js" assert {
     __turbopack_chunk__: 5
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 8
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 10
 };
 export { foobar };
@@ -410,7 +410,7 @@ export { foobar };
 ```
 ## Part 2
 ```js
-import { foo } from "entry.js" with {
+import { foo } from "entry.js" assert {
     __turbopack_chunk__: 6
 };
 export { foo };
@@ -418,16 +418,16 @@ export { foo };
 ```
 ## Part 3
 ```js
-import { internal } from "entry.js" with {
+import { internal } from "entry.js" assert {
     __turbopack_chunk__: 11
 };
-import { foobar } from "entry.js" with {
+import { foobar } from "entry.js" assert {
     __turbopack_chunk__: 5
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 8
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 10
 };
 export { external1 };
@@ -438,10 +438,10 @@ function external1() {
 ```
 ## Part 4
 ```js
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 6
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 9
 };
 export { external2 };
@@ -458,7 +458,7 @@ export { foobar };
 ```
 ## Part 6
 ```js
-import { foobar } from "entry.js" with {
+import { foobar } from "entry.js" assert {
     __turbopack_chunk__: 5
 };
 const foo = foobar;
@@ -473,10 +473,10 @@ export { bar };
 ```
 ## Part 8
 ```js
-import { bar } from "entry.js" with {
+import { bar } from "entry.js" assert {
     __turbopack_chunk__: 7
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 6
 };
 foobar += bar;
@@ -485,10 +485,10 @@ export { foobar };
 ```
 ## Part 9
 ```js
-import { foobar } from "entry.js" with {
+import { foobar } from "entry.js" assert {
     __turbopack_chunk__: 5
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 8
 };
 let foobarCopy = foobar;
@@ -497,10 +497,10 @@ export { foobarCopy };
 ```
 ## Part 10
 ```js
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 6
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 9
 };
 foobar += "foo";
@@ -509,13 +509,13 @@ export { foobar };
 ```
 ## Part 11
 ```js
-import { foobar } from "entry.js" with {
+import { foobar } from "entry.js" assert {
     __turbopack_chunk__: 5
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 8
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 10
 };
 import { upper } from "module";
@@ -551,10 +551,10 @@ console.log(foobarCopy);
 # Modules (prod)
 ## Part 0
 ```js
-import { foobar } from "entry.js" with {
+import { foobar } from "entry.js" assert {
     __turbopack_chunk__: 5
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 7
 };
 "module evaluation";
@@ -566,13 +566,13 @@ export { foobarCopy };
 ```
 ## Part 1
 ```js
-import { foobar } from "entry.js" with {
+import { foobar } from "entry.js" assert {
     __turbopack_chunk__: 5
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 7
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 8
 };
 export { foobar };
@@ -580,7 +580,7 @@ export { foobar };
 ```
 ## Part 2
 ```js
-import { foobar } from "entry.js" with {
+import { foobar } from "entry.js" assert {
     __turbopack_chunk__: 5
 };
 export { foo };
@@ -590,13 +590,13 @@ export { foo };
 ```
 ## Part 3
 ```js
-import { foobar } from "entry.js" with {
+import { foobar } from "entry.js" assert {
     __turbopack_chunk__: 5
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 7
 };
-import "entry.js" with {
+import "entry.js" assert {
     __turbopack_chunk__: 8
 };
 export { external1 };
@@ -631,7 +631,7 @@ export { bar };
 ```
 ## Part 7
 ```js
-import { bar } from "entry.js" with {
+import { bar } from "entry.js" assert {
     __turbopack_chunk__: 6
 };
 foobar += bar;


### PR DESCRIPTION
Using lightningcss results in a breaking change to Next.js, so let's revert swc for now.


Closes WEB-1524