### PR TITLE
fix(with-tailwind): support .mjs import extension

### DIFF
--- a/examples/with-tailwind/packages/eslint-config-custom/library.js
+++ b/examples/with-tailwind/packages/eslint-config-custom/library.js
@@ -28,6 +28,9 @@ module.exports = {
       typescript: {
         project,
       },
+      node: {
+        extensions: [".mjs", ".js", ".jsx", ".ts", ".tsx"],
+      },
     },
   },
   ignorePatterns: ["node_modules/", "dist/"],

--- a/examples/with-tailwind/packages/eslint-config-custom/next.js
+++ b/examples/with-tailwind/packages/eslint-config-custom/next.js
@@ -32,6 +32,9 @@ module.exports = {
       typescript: {
         project,
       },
+      node: {
+        extensions: [".mjs", ".js", ".jsx", ".ts", ".tsx"],
+      },
     },
   },
   ignorePatterns: ["node_modules/", "dist/"],

--- a/examples/with-tailwind/packages/eslint-config-custom/react.js
+++ b/examples/with-tailwind/packages/eslint-config-custom/react.js
@@ -28,6 +28,9 @@ module.exports = {
       typescript: {
         project,
       },
+      node: {
+        extensions: [".mjs", ".js", ".jsx", ".ts", ".tsx"],
+      },
     },
   },
   ignorePatterns: ["node_modules/", "dist/", ".eslintrc.js", "**/*.css"],

--- a/examples/with-tailwind/packages/tsconfig/base.json
+++ b/examples/with-tailwind/packages/tsconfig/base.json
@@ -8,6 +8,7 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "allowImportingTsExtensions": true,
+    "noEmit": true,
     "inlineSources": false,
     "isolatedModules": true,
     "moduleResolution": "node",

--- a/examples/with-tailwind/packages/tsconfig/nextjs.json
+++ b/examples/with-tailwind/packages/tsconfig/nextjs.json
@@ -11,7 +11,6 @@
     "jsx": "preserve",
     "lib": ["dom", "dom.iterable", "esnext"],
     "module": "esnext",
-    "noEmit": true,
     "resolveJsonModule": true,
     "strict": false,
     "target": "es5"

--- a/examples/with-tailwind/turbo.json
+++ b/examples/with-tailwind/turbo.json
@@ -6,7 +6,9 @@
       "dependsOn": ["^build"],
       "outputs": ["dist/**", ".next/**", "!.next/cache/**"]
     },
-    "lint": {},
+    "lint": {
+      "dependsOn": ["^build"]
+    },
     "check-types": {},
     "dev": {
       "cache": false,


### PR DESCRIPTION
### Description

Fixes https://github.com/vercel/turbo/issues/5909

We're only bundling the `ui` package to `esm`, which creates an `.mjs` extension in `dist/` which the import resolver plugin apparently(?) doesn't resolve by default. 

Also, since we're linting based on TS types we need lint to depend on build. 


Closes TURBO-1314