### PR TITLE
fix(create-turbo): add before commiting

### DIFF
--- a/packages/create-turbo/src/commands/create/index.ts
+++ b/packages/create-turbo/src/commands/create/index.ts
@@ -13,7 +13,7 @@ import {
   DownloadError,
   logger,
 } from "@turbo/utils";
-import { tryGitCommit, tryGitInit } from "../../utils/git";
+import { tryGitCommit, tryGitInit, tryGitAdd } from "../../utils/git";
 import { isOnline } from "../../utils/isOnline";
 import { transforms } from "../../transforms";
 import { TransformError } from "../../transforms/errors";
@@ -137,7 +137,10 @@ export async function create(
           },
           opts,
         });
+
         if (transformResult.result === "success") {
+          // add first to ensure any transforms that add new files are included
+          tryGitAdd();
           tryGitCommit(
             `feat(create-turbo): apply ${transformResult.name} transform`
           );

--- a/packages/create-turbo/src/utils/git.ts
+++ b/packages/create-turbo/src/utils/git.ts
@@ -89,6 +89,18 @@ export function tryGitCommit(message: string): boolean {
   }
 }
 
+export function tryGitAdd(): void {
+  try {
+    gitAddAll();
+  } catch (err) {
+    // do nothing
+  }
+}
+
+function gitAddAll() {
+  execSync("git add -A", { stdio: "ignore" });
+}
+
 function gitCommit(message: string) {
   execSync(
     `git commit --author="Turbobot <turbobot@vercel.com>" -am "${message}"`,


### PR DESCRIPTION
### Description

Noticed a minor issue in `create-turbo@canary` with our transforms. If the transform adds a file, it won't be committed. Not a major bug, but this should make sure we commit after every transform and don't miss any.  


Closes TURBO-1315