### PR TITLE
Wire filewatching to daemon server

### DIFF
--- a/crates/turborepo-lib/src/commands/daemon.rs
+++ b/crates/turborepo-lib/src/commands/daemon.rs
@@ -1,8 +1,10 @@
 use std::time::Duration;
 
 use camino::Utf8PathBuf;
+use futures::FutureExt;
 use pidlock::PidlockError::AlreadyOwned;
 use time::{format_description, OffsetDateTime};
+use tokio::signal::ctrl_c;
 use tracing::{trace, warn};
 use turbopath::AbsoluteSystemPathBuf;
 
@@ -162,8 +164,23 @@ pub async fn daemon_server(
         .map_err(|_| DaemonError::InvalidTimeout(idle_time.to_owned()))
         .map(|d| Duration::from_nanos(d as u64))?;
 
-    let server = crate::daemon::DaemonServer::new(base, timeout, log_file)?;
-    let reason = server.serve().await;
+    // let server = crate::daemon::DaemonServer::new(base, timeout, log_file)?;
+    // let reason = server.serve().await;
+    let daemon_root = base.daemon_file_root();
+    let exit_signal = ctrl_c().map(|result| {
+        if let Err(e) = result {
+            tracing::error!("Error with signal handling: {}", e);
+        }
+        CloseReason::Interrupt
+    });
+    let reason = crate::daemon::serve(
+        &base.repo_root,
+        &daemon_root,
+        log_file,
+        timeout,
+        exit_signal,
+    )
+    .await;
 
     match reason {
         CloseReason::SocketOpenError(SocketOpenError::LockError(AlreadyOwned)) => {

--- a/crates/turborepo-lib/src/commands/daemon.rs
+++ b/crates/turborepo-lib/src/commands/daemon.rs
@@ -164,8 +164,6 @@ pub async fn daemon_server(
         .map_err(|_| DaemonError::InvalidTimeout(idle_time.to_owned()))
         .map(|d| Duration::from_nanos(d as u64))?;
 
-    // let server = crate::daemon::DaemonServer::new(base, timeout, log_file)?;
-    // let reason = server.serve().await;
     let daemon_root = base.daemon_file_root();
     let exit_signal = ctrl_c().map(|result| {
         if let Err(e) = result {

--- a/crates/turborepo-lib/src/commands/daemon.rs
+++ b/crates/turborepo-lib/src/commands/daemon.rs
@@ -173,8 +173,11 @@ pub async fn daemon_server(
         }
         CloseReason::Interrupt
     });
+    // TODO: be more methodical about this choice:
+    let cookie_dir = base.repo_root.join_component(".git");
     let reason = crate::daemon::serve(
         &base.repo_root,
+        cookie_dir,
         &daemon_root,
         log_file,
         timeout,

--- a/crates/turborepo-lib/src/daemon/endpoint.rs
+++ b/crates/turborepo-lib/src/daemon/endpoint.rs
@@ -41,7 +41,6 @@ pub async fn listen_socket(
 > {
     let pid_path = path.join_component("turbod.pid");
     let sock_path = path.join_component("turbod.sock");
-    println!("SOCK {}", sock_path);
     let mut lock = pidlock::Pidlock::new(pid_path.as_std_path().to_owned());
 
     trace!("acquiring pidlock");

--- a/crates/turborepo-lib/src/daemon/endpoint.rs
+++ b/crates/turborepo-lib/src/daemon/endpoint.rs
@@ -6,7 +6,7 @@ use futures::Stream;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tonic::transport::server::Connected;
 use tracing::{debug, trace};
-use turbopath::AbsoluteSystemPathBuf;
+use turbopath::AbsoluteSystemPath;
 
 #[derive(thiserror::Error, Debug)]
 pub enum SocketOpenError {
@@ -30,7 +30,7 @@ const WINDOWS_POLL_DURATION: Duration = Duration::from_millis(1);
 ///       code path to shut down the non-blocking polling
 #[tracing::instrument]
 pub async fn listen_socket(
-    path: AbsoluteSystemPathBuf,
+    path: &AbsoluteSystemPath,
     #[allow(unused)] running: Arc<AtomicBool>,
 ) -> Result<
     (
@@ -41,6 +41,7 @@ pub async fn listen_socket(
 > {
     let pid_path = path.join_component("turbod.pid");
     let sock_path = path.join_component("turbod.sock");
+    println!("SOCK {}", sock_path);
     let mut lock = pidlock::Pidlock::new(pid_path.as_std_path().to_owned());
 
     trace!("acquiring pidlock");
@@ -202,7 +203,7 @@ mod test {
         pid_path.create_with_contents("100000").unwrap();
 
         let running = Arc::new(AtomicBool::new(true));
-        let result = listen_socket(pid_path, running).await;
+        let result = listen_socket(&pid_path, running).await;
 
         // Note: PidLock doesn't implement Debug, so we can't unwrap_err()
 
@@ -232,7 +233,7 @@ mod test {
             .unwrap();
 
         let running = Arc::new(AtomicBool::new(true));
-        let result = listen_socket(pid_path, running).await;
+        let result = listen_socket(&pid_path, running).await;
 
         // Note: PidLock doesn't implement Debug, so we can't unwrap_err()
 

--- a/crates/turborepo-lib/src/daemon/mod.rs
+++ b/crates/turborepo-lib/src/daemon/mod.rs
@@ -7,7 +7,7 @@ mod server;
 
 pub use client::{DaemonClient, DaemonError};
 pub use connector::DaemonConnector;
-pub use server::{CloseReason, DaemonServer};
+pub use server::{serve, CloseReason};
 
 pub(crate) mod proto {
     tonic::include_proto!("turbodprotocol");

--- a/crates/turborepo-lib/src/daemon/server.rs
+++ b/crates/turborepo-lib/src/daemon/server.rs
@@ -16,54 +16,33 @@ use std::{
     collections::{HashMap, HashSet},
     sync::{
         atomic::{AtomicBool, Ordering},
-        Arc, Mutex as StdMutux,
+        Arc, Mutex,
     },
     time::{Duration, Instant},
 };
 
-use globwatch::{StopSource, Watcher};
+use futures::Future;
+use thiserror::Error;
 use tokio::{
     select,
-    signal::ctrl_c,
-    sync::{
-        oneshot::{self, Receiver, Sender},
-        Mutex,
-    },
+    sync::{oneshot, watch},
 };
 use tonic::transport::{NamedService, Server};
 use tower::ServiceBuilder;
-use tracing::{error, trace};
-use turbopath::AbsoluteSystemPathBuf;
+use tracing::{error, trace, warn};
+use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
+use turborepo_filewatch::{
+    cookie_jar::CookieJar,
+    globwatcher::{Error as GlobWatcherError, GlobSet, GlobWatcher},
+    FileSystemWatcher, WatchError,
+};
 
 use super::{
     bump_timeout::BumpTimeout,
     endpoint::SocketOpenError,
     proto::{self},
-    DaemonError,
 };
-use crate::{
-    commands::CommandBase, daemon::bump_timeout_layer::BumpTimeoutLayer, get_version,
-    globwatcher::HashGlobWatcher,
-};
-
-pub struct DaemonServer<T: Watcher> {
-    #[allow(dead_code)]
-    daemon_root: AbsoluteSystemPathBuf,
-    log_file: AbsoluteSystemPathBuf,
-
-    start_time: Instant,
-    #[allow(dead_code)]
-    timeout: Arc<BumpTimeout>,
-
-    watcher: Arc<HashGlobWatcher<T>>,
-    shutdown: Mutex<Option<Sender<()>>>,
-    #[allow(dead_code)]
-    shutdown_rx: Option<Receiver<()>>,
-
-    running: Arc<AtomicBool>,
-
-    times_saved: Arc<std::sync::Mutex<HashMap<String, u64>>>,
-}
+use crate::{daemon::bump_timeout_layer::BumpTimeoutLayer, get_version};
 
 #[derive(Debug)]
 #[allow(dead_code)]
@@ -76,116 +55,132 @@ pub enum CloseReason {
     SocketOpenError(SocketOpenError),
 }
 
-impl DaemonServer<notify::RecommendedWatcher> {
-    #[tracing::instrument(skip(base), fields(repo_root = %base.repo_root))]
-    pub fn new(
-        base: &CommandBase,
-        timeout: Duration,
-        log_file: AbsoluteSystemPathBuf,
-    ) -> Result<Self, DaemonError> {
-        let daemon_root = base.daemon_file_root();
-
-        let watcher = Arc::new(HashGlobWatcher::new(
-            &base.repo_root,
-            &daemon_root.join_component("flush"),
-        )?);
-
-        let (send_shutdown, recv_shutdown) = tokio::sync::oneshot::channel::<()>();
-
-        Ok(Self {
-            daemon_root,
-            log_file,
-
-            start_time: Instant::now(),
-            timeout: Arc::new(BumpTimeout::new(timeout)),
-
-            watcher,
-            shutdown: Mutex::new(Some(send_shutdown)),
-            shutdown_rx: Some(recv_shutdown),
-
-            running: Arc::new(AtomicBool::new(true)),
-            times_saved: Arc::new(StdMutux::new(HashMap::new())),
-        })
-    }
+struct FileWatching {
+    _watcher: FileSystemWatcher,
+    glob_watcher: GlobWatcher,
 }
 
-impl<T: Watcher> Drop for DaemonServer<T> {
-    fn drop(&mut self) {
-        self.running.store(false, Ordering::SeqCst);
-    }
+#[derive(Debug, Error)]
+enum RpcError {
+    #[error("deadline exceeded")]
+    DeadlineExceeded,
+    #[error("invalid glob: {0}")]
+    InvalidGlob(#[from] wax::BuildError),
+    #[error("globwatching failed: {0}")]
+    GlobWatching(#[from] GlobWatcherError),
+    #[error("filewatching unavailable")]
+    NoFileWatching,
 }
 
-impl<T: Watcher + Send + 'static> DaemonServer<T> {
-    /// Serve the daemon server, while also watching for filesystem changes.
-    #[tracing::instrument(skip(self))]
-    pub async fn serve(mut self) -> CloseReason {
-        let stop = StopSource::new();
-        let watcher = self.watcher.clone();
-        let watcher_fut = watcher.watch(stop.token());
-        tokio::pin!(watcher_fut);
-
-        let timer = self.timeout.clone();
-        let timeout_fut = timer.wait();
-
-        // if shutdown is available, then listen. otherwise just wait forever
-        let shutdown_rx = self.shutdown_rx.take();
-        let shutdown_fut = async move {
-            match shutdown_rx {
-                Some(rx) => {
-                    rx.await.ok();
-                }
-                None => {
-                    futures::pending!();
-                }
+impl From<RpcError> for tonic::Status {
+    fn from(value: RpcError) -> Self {
+        match value {
+            RpcError::DeadlineExceeded => {
+                tonic::Status::deadline_exceeded("failed to load filewatching in time")
             }
+            RpcError::InvalidGlob(e) => tonic::Status::invalid_argument(e.to_string()),
+            RpcError::GlobWatching(e) => tonic::Status::unavailable(e.to_string()),
+            RpcError::NoFileWatching => tonic::Status::unavailable("filewatching unavailable"),
+        }
+    }
+}
+
+async fn start_filewatching(
+    repo_root: AbsoluteSystemPathBuf,
+    watcher_tx: watch::Sender<Option<Arc<FileWatching>>>,
+) -> Result<(), WatchError> {
+    let watcher = FileSystemWatcher::new(&repo_root).await?;
+    // TODO: be more methodical about this choice:
+    let cookie_dir = repo_root.join_component(".git");
+    let cookie_jar = CookieJar::new(&cookie_dir, Duration::from_millis(100), watcher.subscribe());
+    let glob_watcher = GlobWatcher::new(&repo_root, cookie_jar, watcher.subscribe());
+    // We can ignore failures here, it means the server is shutting down and
+    // receivers have gone out of scope.
+    let _ = watcher_tx.send(Some(Arc::new(FileWatching {
+        _watcher: watcher,
+        glob_watcher,
+    })));
+    Ok(())
+}
+
+pub async fn serve<S>(
+    repo_root: &AbsoluteSystemPath,
+    daemon_root: &AbsoluteSystemPath,
+    log_file: AbsoluteSystemPathBuf,
+    timeout: Duration,
+    external_shutdown: S,
+) -> CloseReason
+where
+    S: Future<Output = CloseReason>,
+{
+    let watcher_repo_root = repo_root.to_owned();
+    let (watcher_tx, watcher_rx) = watch::channel(None);
+    let (trigger_shutdown, shutdown_signal) = {
+        let (tx, rx) = oneshot::channel::<()>();
+        (Arc::new(Mutex::new(Some(tx))), rx)
+    };
+
+    // watch receivers as a group own the filewatcher, which will exit when
+    // all references are dropped.
+    let fw_shutdown = trigger_shutdown.clone();
+    let fw_handle = tokio::task::spawn(async move {
+        if let Err(e) = start_filewatching(watcher_repo_root, watcher_tx).await {
+            fw_shutdown
+                .lock()
+                .expect("mutex poisoned")
+                .take()
+                .map(|tx| {
+                    error!("filewatching failed to start: {}", e);
+                    let _ = tx.send(());
+                });
+        }
+    });
+    let (exit_root_watch, root_watch_exit_signal) = oneshot::channel();
+    let watch_root_handle = tokio::task::spawn(watch_root(
+        watcher_rx.clone(),
+        repo_root.to_owned(),
+        trigger_shutdown.clone(),
+        root_watch_exit_signal,
+    ));
+
+    let bump_timeout = Arc::new(BumpTimeout::new(timeout));
+    let timeout_fut = bump_timeout.wait();
+
+    // when one of these futures complete, let the server gracefully shutdown
+    let (gprc_shutdown_tx, shutdown_reason) = oneshot::channel();
+    let shutdown_fut = async move {
+        select! {
+            _ = shutdown_signal => gprc_shutdown_tx.send(CloseReason::Shutdown).ok(),
+            _ = timeout_fut => gprc_shutdown_tx.send(CloseReason::Timeout).ok(),
+            reason = external_shutdown => gprc_shutdown_tx.send(reason).ok(),
         };
+    };
+    let running = Arc::new(AtomicBool::new(true));
 
-        // when one of these futures complete, let the server gracefully shutdown
-        let (shutdown_tx, shutdown_reason) = oneshot::channel();
-        let shutdown_fut = async move {
-            select! {
-                _ = shutdown_fut => shutdown_tx.send(CloseReason::Shutdown).ok(),
-                _ = timeout_fut => shutdown_tx.send(CloseReason::Timeout).ok(),
-                _ = ctrl_c() => shutdown_tx.send(CloseReason::Interrupt).ok(),
-            };
-        };
-
-        #[cfg(feature = "http")]
-        let server_fut = {
-            // set up grpc reflection
-            let efd = include_bytes!("file_descriptor_set.bin");
-            let reflection = tonic_reflection::server::Builder::configure()
-                .register_encoded_file_descriptor_set(efd)
-                .build()
-                .unwrap();
-
-            let service = ServiceBuilder::new()
-                .layer(BumpTimeoutLayer::new(self.timeout.clone()))
-                .service(crate::daemon::proto::turbod_server::TurbodServer::new(self));
-
-            Server::builder()
-                .add_service(reflection)
-                .add_service(service)
-                .serve_with_shutdown("127.0.0.1:5000".parse().unwrap(), shutdown_fut)
-        };
-
-        #[cfg(not(feature = "http"))]
-        let (_lock, server_fut) = {
-            let (lock, stream) = match crate::daemon::endpoint::listen_socket(
-                self.daemon_root.clone(),
-                self.running.clone(),
-            )
-            .await
-            {
-                Ok(val) => val,
-                Err(e) => return CloseReason::SocketOpenError(e),
-            };
+    let service = TurboGrpcService {
+        shutdown: trigger_shutdown,
+        watcher_rx,
+        times_saved: Arc::new(Mutex::new(HashMap::new())),
+        start_time: Instant::now(),
+        log_file,
+    };
+    let (_lock, server_fut) =
+        {
+            let (lock, stream) =
+                match crate::daemon::endpoint::listen_socket(daemon_root.clone(), running.clone())
+                    .await
+                {
+                    Ok(val) => val,
+                    Err(e) => panic!("{}", e), //return CloseReason::SocketOpenError(e),
+                };
 
             trace!("acquired connection stream for socket");
 
             let service = ServiceBuilder::new()
-                .layer(BumpTimeoutLayer::new(self.timeout.clone()))
-                .service(crate::daemon::proto::turbod_server::TurbodServer::new(self));
+                .layer(BumpTimeoutLayer::new(bump_timeout.clone()))
+                .service(crate::daemon::proto::turbod_server::TurbodServer::new(
+                    service,
+                ));
 
             (
                 lock,
@@ -194,35 +189,140 @@ impl<T: Watcher + Send + 'static> DaemonServer<T> {
                     .serve_with_incoming_shutdown(stream, shutdown_fut),
             )
         };
-        tokio::pin!(server_fut);
+    // Wait for the server to exit.
+    let _ = server_fut.await;
+    trace!("gRPC server exited");
+    running.store(false, Ordering::SeqCst);
+    // We expect to have a signal from the grpc server on what triggered the exit
+    let close_reason = shutdown_reason.await.unwrap_or(CloseReason::ServerClosed);
+    // Now that the server has exited, the TurboGrpcService instance should be
+    // dropped. The root watcher still has a reference to a receiver, keeping
+    // the filewatcher alive. We don't care if we fail to send, root watching
+    // may have exited already
+    let _ = exit_root_watch.send(());
+    let _ = watch_root_handle.await;
+    trace!("root watching exited");
+    let _ = fw_handle.await;
+    trace!("filewatching handle joined");
+    close_reason
+}
 
-        // necessary to make sure we don't try to poll the watcher_fut once it
-        // has completed
-        let mut watcher_done = false;
-        loop {
-            select! {
-                    _ = &mut server_fut => {
-                    return shutdown_reason.await.unwrap_or(CloseReason::ServerClosed);
-                },
-                watch_res = &mut watcher_fut, if !watcher_done => {
-                    match watch_res {
-                        Ok(()) => return CloseReason::WatcherClosed,
-                        Err(e) => {
-                            error!("Globwatch config error: {:?}", e);
-                            watcher_done = true;
-                        },
-                    }
-                },
+struct TurboGrpcService {
+    shutdown: Arc<Mutex<Option<oneshot::Sender<()>>>>,
+    watcher_rx: watch::Receiver<Option<Arc<FileWatching>>>,
+    times_saved: Arc<Mutex<HashMap<String, u64>>>,
+    start_time: Instant,
+    log_file: AbsoluteSystemPathBuf,
+}
+
+impl TurboGrpcService {
+    fn trigger_shutdown(&self) {
+        self.shutdown
+            .lock()
+            .expect("mutex poisoned")
+            .take()
+            .map(|s| s.send(()));
+    }
+
+    async fn wait_for_filewatching(&self) -> Result<Arc<FileWatching>, RpcError> {
+        let rx = self.watcher_rx.clone();
+        wait_for_filewatching(rx, Duration::from_millis(100)).await
+    }
+
+    async fn watch_globs(
+        &self,
+        hash: String,
+        output_globs: Vec<String>,
+        output_glob_exclusions: Vec<String>,
+        time_saved: u64,
+    ) -> Result<(), RpcError> {
+        let glob_set = GlobSet::from_raw(output_globs, output_glob_exclusions)?;
+        let fw = self.wait_for_filewatching().await?;
+        fw.glob_watcher.watch_globs(hash.clone(), glob_set).await?;
+        {
+            let mut times_saved = self.times_saved.lock().expect("times saved lock poisoned");
+            times_saved.insert(hash, time_saved);
+        }
+        Ok(())
+    }
+
+    async fn get_changed_outputs(
+        &self,
+        hash: String,
+        candidates: HashSet<String>,
+    ) -> Result<(HashSet<String>, u64), RpcError> {
+        let time_saved = {
+            let times_saved = self.times_saved.lock().expect("times saved lock poisoned");
+            times_saved.get(hash.as_str()).copied().unwrap_or_default()
+        };
+        let fw = self.wait_for_filewatching().await?;
+        let changed_globs = fw.glob_watcher.get_changed_globs(hash, candidates).await?;
+        Ok((changed_globs, time_saved))
+    }
+}
+
+async fn wait_for_filewatching(
+    mut rx: watch::Receiver<Option<Arc<FileWatching>>>,
+    timeout: Duration,
+) -> Result<Arc<FileWatching>, RpcError> {
+    if let Some(fw) = rx.borrow().as_ref().map(|fw| fw.clone()) {
+        return Ok(fw);
+    }
+    tokio::time::timeout(timeout, rx.changed())
+        .await
+        .map_err(|_| RpcError::DeadlineExceeded)? // timeout case
+        .map_err(|_| RpcError::NoFileWatching)?; // sender dropped with no receivers
+    let result = rx
+        .borrow()
+        .as_ref()
+        .map(|fw| fw.clone())
+        // This error should never happen, we got the change notification
+        // above, and we only ever go from None to Some filewatcher
+        .ok_or_else(|| RpcError::NoFileWatching)?;
+    Ok(result)
+}
+
+async fn watch_root(
+    filewatching_access: watch::Receiver<Option<Arc<FileWatching>>>,
+    root: AbsoluteSystemPathBuf,
+    trigger_shutdown: Arc<Mutex<Option<oneshot::Sender<()>>>>,
+    mut exit_signal: oneshot::Receiver<()>,
+) -> Result<(), WatchError> {
+    let mut recv_events = {
+        let Ok(fw) = wait_for_filewatching(filewatching_access, Duration::from_secs(5)).await
+        else {
+            return Ok(());
+        };
+
+        fw._watcher.subscribe()
+    };
+
+    loop {
+        // Ignore the outer layer of Result, if the sender has closed, filewatching has
+        // gone away and we can return.
+        select! {
+            _ = &mut exit_signal => return Ok(()),
+            event = recv_events.recv() => {
+                let Ok(event) = event else {
+                    return Ok(());
+                };
+                let should_trigger_shutdown = match event {
+                    Ok(event) if event.paths.iter().any(|p| p == (&root as &AbsoluteSystemPath)) => true,
+                    Ok(_) => false,
+                    Err(_) => true
+                };
+                if should_trigger_shutdown {
+                    warn!("Root watcher triggering shutdown");
+                    trigger_shutdown.lock().expect("mutex poisoned").take().map(|s| s.send(()));
+                    return Ok(());
+                }
             }
         }
-
-        // here the stop token is dropped, and the pid lock is dropped
-        // causing them to be cleaned up
     }
 }
 
 #[tonic::async_trait]
-impl<T: Watcher + Send + 'static> proto::turbod_server::Turbod for DaemonServer<T> {
+impl proto::turbod_server::Turbod for TurboGrpcService {
     async fn hello(
         &self,
         request: tonic::Request<proto::HelloRequest>,
@@ -243,7 +343,7 @@ impl<T: Watcher + Send + 'static> proto::turbod_server::Turbod for DaemonServer<
         &self,
         _request: tonic::Request<proto::ShutdownRequest>,
     ) -> Result<tonic::Response<proto::ShutdownResponse>, tonic::Status> {
-        self.shutdown.lock().await.take().map(|s| s.send(()));
+        self.trigger_shutdown();
 
         // if Some(Ok), then the server is shutting down now
         // if Some(Err), then the server is already shutting down
@@ -269,25 +369,14 @@ impl<T: Watcher + Send + 'static> proto::turbod_server::Turbod for DaemonServer<
     ) -> Result<tonic::Response<proto::NotifyOutputsWrittenResponse>, tonic::Status> {
         let inner = request.into_inner();
 
-        {
-            let mut times_saved = self.times_saved.lock().expect("times saved lock poisoned");
-            times_saved.insert(inner.hash.clone(), inner.time_saved);
-        }
-        match self
-            .watcher
-            .watch_globs(
-                Arc::new(inner.hash),
-                inner.output_globs,
-                inner.output_exclusion_globs,
-            )
-            .await
-        {
-            Ok(_) => Ok(tonic::Response::new(proto::NotifyOutputsWrittenResponse {})),
-            Err(e) => {
-                error!("failed to watch globs: {:?}", e);
-                Err(tonic::Status::internal("failed to watch globs"))
-            }
-        }
+        self.watch_globs(
+            inner.hash,
+            inner.output_globs,
+            inner.output_exclusion_globs,
+            inner.time_saved,
+        )
+        .await?;
+        Ok(tonic::Response::new(proto::NotifyOutputsWrittenResponse {}))
     }
 
     async fn get_changed_outputs(
@@ -295,47 +384,32 @@ impl<T: Watcher + Send + 'static> proto::turbod_server::Turbod for DaemonServer<
         request: tonic::Request<proto::GetChangedOutputsRequest>,
     ) -> Result<tonic::Response<proto::GetChangedOutputsResponse>, tonic::Status> {
         let inner = request.into_inner();
-        let hash = Arc::new(inner.hash);
-        let changed = self
-            .watcher
-            .changed_globs(&hash, HashSet::from_iter(inner.output_globs))
-            .await;
-
-        let time_saved = {
-            let times_saved = self.times_saved.lock().expect("times saved lock poisoned");
-            times_saved.get(hash.as_str()).copied().unwrap_or_default()
-        };
-
-        match changed {
-            Ok(changed) => Ok(tonic::Response::new(proto::GetChangedOutputsResponse {
-                changed_output_globs: changed.into_iter().collect(),
-                time_saved,
-            })),
-            Err(e) => {
-                error!("flush directory operation failed: {:?}", e);
-                Err(tonic::Status::internal("failed to watch flush directory"))
-            }
-        }
+        let (changed, time_saved) = self
+            .get_changed_outputs(inner.hash, HashSet::from_iter(inner.output_globs))
+            .await?;
+        Ok(tonic::Response::new(proto::GetChangedOutputsResponse {
+            changed_output_globs: changed.into_iter().collect(),
+            time_saved,
+        }))
     }
 }
 
-impl<T: Watcher> NamedService for DaemonServer<T> {
+impl NamedService for TurboGrpcService {
     const NAME: &'static str = "turborepo.Daemon";
 }
 
 #[cfg(test)]
 mod test {
     use std::{
-        assert_matches,
+        assert_matches::{self, assert_matches},
         time::{Duration, Instant},
     };
 
-    use tokio::select;
+    use futures::FutureExt;
+    use tokio::sync::oneshot;
     use turbopath::AbsoluteSystemPathBuf;
-    use turborepo_ui::UI;
 
-    use super::DaemonServer;
-    use crate::{commands::CommandBase, Args};
+    use crate::daemon::{server::serve, CloseReason};
 
     // the windows runner starts a new thread to accept uds requests,
     // so we need a multi-threaded runtime
@@ -343,41 +417,46 @@ mod test {
     #[tracing_test::traced_test]
     async fn lifecycle() {
         let tempdir = tempfile::tempdir().unwrap();
-        let path = AbsoluteSystemPathBuf::try_from(tempdir.path()).unwrap();
+        let path = AbsoluteSystemPathBuf::try_from(tempdir.path())
+            .unwrap()
+            .to_realpath()
+            .unwrap();
 
+        let repo_root = path.join_component("repo");
+        repo_root.create_dir_all().unwrap();
+        let daemon_root = path.join_component("daemon");
+        let log_file = daemon_root.join_component("log");
         tracing::info!("start");
 
-        let daemon = DaemonServer::new(
-            &CommandBase::new(
-                Args {
-                    ..Default::default()
-                },
-                path.clone(),
-                "test",
-                UI::new(true),
+        let pid_path = daemon_root.join_component("turbod.pid");
+
+        let (tx, rx) = oneshot::channel::<CloseReason>();
+        let exit_signal = rx.map(|_result| CloseReason::Interrupt);
+        let handle = tokio::task::spawn(async move {
+            let repo_root = repo_root;
+            let daemon_root = daemon_root;
+            serve(
+                &repo_root,
+                &daemon_root,
+                log_file,
+                Duration::from_secs(60 * 60),
+                exit_signal,
             )
-            .unwrap(),
-            Duration::from_secs(60 * 60),
-            path.clone(),
-        )
-        .unwrap();
+            .await
+        });
 
-        tracing::info!("server started");
+        tokio::time::sleep(Duration::from_millis(2000)).await;
+        assert!(pid_path.exists(), "pid file must be present");
+        // signal server exit
+        tx.send(CloseReason::Interrupt).unwrap();
+        handle.await.unwrap();
 
-        let pid_path = path.join_component("turbod.pid");
-        let sock_path = path.join_component("turbod.sock");
-
-        select! {
-            _ = daemon.serve() => panic!("must not close"),
-            _ = tokio::time::sleep(Duration::from_millis(10)) => (),
-        }
-
+        // The serve future should be dropped here, closing the server.
         tracing::info!("yay we are done");
 
         assert!(!pid_path.exists(), "pid file must be deleted");
-        assert!(!sock_path.exists(), "socket file must be deleted");
 
-        tracing::info!("and files cleaned up")
+        tracing::info!("and files cleaned up");
     }
 
     // the windows runner starts a new thread to accept uds requests,
@@ -386,27 +465,29 @@ mod test {
     #[tracing_test::traced_test]
     async fn timeout() {
         let tempdir = tempfile::tempdir().unwrap();
-        let path = AbsoluteSystemPathBuf::try_from(tempdir.path()).unwrap();
+        let path = AbsoluteSystemPathBuf::try_from(tempdir.path())
+            .unwrap()
+            .to_realpath()
+            .unwrap();
 
-        let daemon = DaemonServer::new(
-            &CommandBase::new(
-                Args {
-                    ..Default::default()
-                },
-                path.clone(),
-                "test",
-                UI::new(true),
-            )
-            .unwrap(),
-            Duration::from_millis(5),
-            path.clone(),
-        )
-        .unwrap();
+        let repo_root = path.join_component("repo");
+        repo_root.create_dir_all().unwrap();
+        let daemon_root = path.join_component("daemon");
+        let log_file = daemon_root.join_component("log");
 
-        let pid_path = path.join_component("turbod.pid");
+        let pid_path = daemon_root.join_component("turbod.pid");
 
         let now = Instant::now();
-        let close_reason = daemon.serve().await;
+        let (_tx, rx) = oneshot::channel::<CloseReason>();
+        let exit_signal = rx.map(|_result| CloseReason::Interrupt);
+        let close_reason = serve(
+            &repo_root,
+            &daemon_root,
+            log_file,
+            Duration::from_millis(5),
+            exit_signal,
+        )
+        .await;
 
         assert!(
             now.elapsed() >= Duration::from_millis(5),
@@ -418,5 +499,49 @@ mod test {
             "must close due to timeout"
         );
         assert!(!pid_path.exists(), "pid file must be deleted");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[tracing_test::traced_test]
+    async fn test_delete_root() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let path = AbsoluteSystemPathBuf::try_from(tempdir.path())
+            .unwrap()
+            .to_realpath()
+            .unwrap();
+
+        let repo_root = path.join_component("repo");
+        repo_root.create_dir_all().unwrap();
+        let daemon_root = path.join_component("daemon");
+        daemon_root.create_dir_all().unwrap();
+        let log_file = daemon_root.join_component("log");
+
+        let (_tx, rx) = oneshot::channel::<CloseReason>();
+        let exit_signal = rx.map(|_result| CloseReason::Interrupt);
+
+        let server_repo_root = repo_root.clone();
+        let handle = tokio::task::spawn(async move {
+            let repo_root = server_repo_root;
+            let daemon_root = daemon_root;
+            serve(
+                &repo_root,
+                &daemon_root,
+                log_file,
+                Duration::from_secs(60 * 60),
+                exit_signal,
+            )
+            .await
+        });
+
+        // give filewatching some time to bootstrap
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        // Remove the root
+        repo_root.remove_dir_all().unwrap();
+
+        let close_reason = tokio::time::timeout(Duration::from_secs(1), handle)
+            .await
+            .expect("no timeout")
+            .expect("server exited");
+        assert_matches!(close_reason, CloseReason::Shutdown);
     }
 }

--- a/crates/turborepo-lib/src/daemon/server.rs
+++ b/crates/turborepo-lib/src/daemon/server.rs
@@ -317,7 +317,9 @@ async fn watch_root(
                     return Ok(());
                 };
                 let should_trigger_shutdown = match event {
-                    Ok(event) if event.paths.iter().any(|p| p == (&root as &AbsoluteSystemPath)) => true,
+                    // filewatching can throw some weird events, so check that the root is actually gone
+                    // before triggering a shutdown
+                    Ok(event) if event.paths.iter().any(|p| p == (&root as &AbsoluteSystemPath)) => !root.exists(),
                     Ok(_) => false,
                     Err(_) => true
                 };


### PR DESCRIPTION
### Description

 - daemon asynchronously loads filewatching
 - filewatching errors and/or repo root being removed trigger server shutdown
 - filewatcher constructor is now fully asynchronous
 - running gRPC server is now a function call, rather than a struct to simplify ownership and lifecycle of filewatching-related tasks.

### Testing Instructions

Existing tests, plus an additional test at the server level for root deletion.

To be done before re-enabling rust daemon:
 - make an intelligent choice of cookie directory
 - verify timeout behavior so we don't block the client ever

Closes TURBO-1317