### PR TITLE
feat: use prefixed ui in task graph visitor

### DIFF
--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -129,6 +129,9 @@ func optsFromArgs(args *turbostate.ParsedArgsFromRust) (*Opts, error) {
 }
 
 func configureRun(base *cmdutil.CmdBase, opts *Opts, signalWatcher *signals.Watcher) *run {
+	// TODO: We currently don't respect the user's input if they ask for task prefixes on
+	// GitHub Actions and forcibly strip tasks from their logs even if they specify
+	// that they want it. This should be fixed in Go and Rust at the same time.
 	if opts.runOpts.LogOrder == "auto" && ci.Constant() == "GITHUB_ACTIONS" {
 		opts.runOpts.LogOrder = "grouped"
 		opts.runOpts.LogPrefix = "none"

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -260,6 +260,7 @@ impl Run {
             &env_at_execution_start,
             &global_hash,
             global_env_mode,
+            self.base.ui,
         );
 
         visitor.visit(engine.clone()).await?;


### PR DESCRIPTION
### Description

Various plumbing changes that allow us to construct a prefixed UI instance for each task. This instance is necessary for interaction with the task cache.

Reviewer Notes:
Each commit is a fairly simple addition/change to the visitor and can be reviewed on its own.

### Testing Instructions

Observe that colors are displayed when running tasks with the run stub still:
<img width="592" alt="Screenshot 2023-09-11 at 2 25 08 PM" src="https://github.com/vercel/turbo/assets/4131117/558f6114-435a-49dd-b8ac-3885ee281d43">



Closes TURBO-1322