### PR TITLE
changed LandingPage component clipping title

### DIFF
--- a/docs/components/pages/landing/index.tsx
+++ b/docs/components/pages/landing/index.tsx
@@ -179,7 +179,7 @@ function LandingPage() {
       <main className="relative flex flex-col items-center justify-center w-full h-full  overflow-hidden [--geist-foreground:#fff] dark:[--geist-foreground:#000] [--gradient-stop-1:0px] [--gradient-stop-2:120px] sm:[--gradient-stop-1:0px] sm:[--gradient-stop-2:120px]">
         <Background />
         <FadeIn className="z-10 flex flex-col items-center justify-center w-full h-full">
-          <h1 className="mt-12 lg:!mt-20 mx-6 w-[300px] md:!w-full font-extrabold text-5xl lg:text-6xl  leading-tight xl:leading-snug text-center mb-4 bg-clip-text text-transparent bg-gradient-to-b from-black/80 to-black dark:from-white dark:to-[#AAAAAA]">
+          <h1 className="mt-12 lg:!mt-20 mx-6 w-[300px] md:!w-full font-extrabold text-5xl lg:text-6xl  leading-tight xl:leading-snug text-center pb-4 bg-clip-text text-transparent bg-gradient-to-b from-black/80 to-black dark:from-white dark:to-[#AAAAAA]">
             Make Ship Happen
           </h1>
           <p className="mx-6 text-xl max-h-[112px] md:max-h-[96px] w-[315px] md:w-[660px] md:text-2xl font-space-grotesk text-center text-[#666666] dark:text-[#888888]">


### PR DESCRIPTION
Fixed clipping title on landing page

### Description


Switched out "mb-4" with "pd-4" as the "bg-clip-text" was cutting out the lower half of letters of the main title when the screen width was in the range of 1000-1200px ish

See old below
![Screenshot 2023-09-12 22 45 14](https://github.com/vercel/turbo/assets/118931755/49c164d4-0e48-4952-b8d8-f4ff1ab504c2)


### Testing Instructions

Manually resize screen width to see no clipping.