### PR TITLE
Update ContextCondition::InPath to match exact path

### DIFF
--- a/crates/turbopack/src/condition.rs
+++ b/crates/turbopack/src/condition.rs
@@ -54,7 +54,10 @@ impl ContextCondition {
                     .await
             }
             ContextCondition::Not(condition) => condition.matches(path).await.map(|b| !b),
-            ContextCondition::InPath(other_path) => Ok(path.is_inside_ref(&*other_path.await?)),
+            ContextCondition::InPath(other_path) => {
+                let other_path = &*other_path.await?;
+                Ok(path == other_path || path.is_inside_ref(other_path))
+            }
             ContextCondition::InDirectory(dir) => Ok(path.path.starts_with(&format!("{dir}/"))
                 || path.path.contains(&format!("/{dir}/"))
                 || path.path.ends_with(&format!("/{dir}"))


### PR DESCRIPTION
### Description

Updates the `ContextCondition::InPath` matching code to also accept the exact path as "in".

| InPath              | `InPath("/foo/bar")` | `InPath("/foo/bar/baz.js`") |
|---------------------|----------------------|-----------------------------|
| `"/foo/bar"`        | `false` -> `true`    | `false`                     |
| `"/foo/bar.js"`     | `false`              | `false`                     |
| `"/foo/bar/baz.js"` | `true`               | `false` -> `true`           |

This change is necessary to fix our `ResolveOptions` when the Next.js entrypoint templates import the special `@vercel/turbopack/pages/_app` module, which is import mapped to the user's `/pages/_app` file. If the user is using `.ts` (or similar `.tsx`, etc) extensions, we need to ensure that the default `ResolveOptions` allows this import to find the file.

But without this change, we won't be able to prevent the [foreign_code_context_condition](https://github.com/vercel/next.js/blob/85d30b62db4606bf56a6a9533494c9e14d55e1cc/packages/next-swc/crates/next-core/src/util.rs#L83-L101) rule from altering our `ResolveOptions` to only import `.js`/`.json`/`.node` files.

### Testing Instructions



Closes WEB-1544