### PR TITLE
Rearranging style-guide imports

### DIFF
--- a/examples/basic/packages/eslint-config-custom/next.js
+++ b/examples/basic/packages/eslint-config-custom/next.js
@@ -14,8 +14,8 @@ const project = resolve(process.cwd(), "tsconfig.json");
 module.exports = {
   extends: [
     "@vercel/style-guide/eslint/node",
-    "@vercel/style-guide/eslint/typescript",
     "@vercel/style-guide/eslint/browser",
+    "@vercel/style-guide/eslint/typescript",
     "@vercel/style-guide/eslint/react",
     "@vercel/style-guide/eslint/next",
     "eslint-config-turbo",


### PR DESCRIPTION
Fixing linting errors in Next.js applications using import alias.

### Description

I installed a brand new turborepo setup, and added following to the tsconfig.json for the default web Next.js app included. 

 ```
   "paths": {
      "@/*": ["./*"]
    }
```

Which results in following error:

`Unable to resolve path to module '@/components/test'.eslint(import/no-unresolved)`

If I look at the eslint configuration, it should already resolve the tsconfig import. I then tried to toggle some of the style-guides, and it seems that the order in which they are imported has an impact on the `import/no-unresolved` configuration.

https://github.com/vercel/turbo/assets/52371939/f881c25b-7270-4f4c-8449-202989158cd1


<!--
  ✍️ Write a short summary of your work.
  If necessary, include relevant screenshots.
-->

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->

Create a brand new turborepo and test path alias. Then reorder the style-guide imports under `packages > eslint-config-custom > next.js` moving `"@vercel/style-guide/eslint/browser"` after `"@vercel/style-guide/eslint/node"`. Restart eslint server. and everything works. No linting errors.