### PR TITLE
fix(Turborepo): Update integration test for bad flag

### DIFF
--- a/turborepo-tests/integration/tests/bad_flag.t
+++ b/turborepo-tests/integration/tests/bad_flag.t
@@ -5,7 +5,7 @@ Bad flag should print misuse text
   $ ${TURBO} --bad-flag
    ERROR  unexpected argument '--bad-flag' found
   
-    note: to pass '--bad-flag' as a value, use '-- --bad-flag'
+    tip: to pass '--bad-flag' as a value, use '-- --bad-flag'
   
   Usage: turbo [OPTIONS] [COMMAND]
   
@@ -17,7 +17,7 @@ Bad flag with an implied run command should display run flags
   $ ${TURBO} build --bad-flag
    ERROR  unexpected argument '--bad-flag' found
   
-    note: to pass '--bad-flag' as a value, use '-- --bad-flag'
+    tip: to pass '--bad-flag' as a value, use '-- --bad-flag'
   
   Usage: turbo <--cache-dir <CACHE_DIR>|--cache-workers <CACHE_WORKERS>|--concurrency <CONCURRENCY>|--continue|--dry-run [<DRY_RUN>]|--single-package|--filter <FILTER>|--force [<FORCE>]|--framework-inference [<BOOL>]|--global-deps <GLOBAL_DEPS>|--graph [<GRAPH>]|--env-mode [<ENV_MODE>]|--ignore <IGNORE>|--include-dependencies|--no-cache|--no-daemon|--no-deps|--output-logs <OUTPUT_LOGS>|--log-order <LOG_ORDER>|--only|--parallel|--pkg-inference-root <PKG_INFERENCE_ROOT>|--profile <PROFILE>|--remote-only [<BOOL>]|--scope <SCOPE>|--since <SINCE>|--summarize [<SUMMARIZE>]|--log-prefix <LOG_PREFIX>|TASKS|PASS_THROUGH_ARGS|--experimental-space-id <EXPERIMENTAL_SPACE_ID>|--experimental-rust-codepath>
   


### PR DESCRIPTION
### Description

#5936 updated `clap`, which in turn broke one of our integration tests.

### Testing Instructions

Updated integration test, the difference is not super significant, just s/note/tip in an error message.

Closes TURBO-1328