### PR TITLE
fix(workspaces): glob fix and refactor correction

### DIFF
--- a/packages/turbo-workspaces/src/commands/summary/index.ts
+++ b/packages/turbo-workspaces/src/commands/summary/index.ts
@@ -88,7 +88,7 @@ export async function summaryCommand(directory: SummaryCommandArgument) {
     Object.keys(workspacesByDirectory).forEach((dir, idx) => {
       renderDirectory({
         number: idx + 1,
-        workspaces: workspacesByDirectory[directory],
+        workspaces: workspacesByDirectory[dir],
         dir,
       });
     });

--- a/packages/turbo-workspaces/src/utils.ts
+++ b/packages/turbo-workspaces/src/utils.ts
@@ -168,6 +168,7 @@ function expandWorkspaces({
         onlyFiles: true,
         absolute: true,
         cwd: workspaceRoot,
+        ignore: ["**/node_modules/**"],
       });
     })
     .map((workspacePackageJson) => {


### PR DESCRIPTION
### Description

Fixes:
1. A minor issue introduced to `summary` during the lint refactor
2. An issue with workspace detection when using deep globs


Closes TURBO-1329