### PR TITLE
fix: convert the lockfile path to a repo-root-relative path before use

### DIFF
--- a/crates/turborepo-lib/src/run/scope/change_detector.rs
+++ b/crates/turborepo-lib/src/run/scope/change_detector.rs
@@ -186,9 +186,7 @@ impl<'a> SCMChangeDetector<'a> {
             .anchor(lockfile_path)
             .expect("lockfile should be in repo");
 
-        let matcher = wax::Glob::new(lockfile_path_relative.as_str())?;
-
-        Ok(changed_files.iter().any(|f| matcher.is_match(f.as_path())))
+        Ok(changed_files.iter().any(|f| f == &lockfile_path_relative))
     }
 }
 

--- a/crates/turborepo-lib/src/run/scope/change_detector.rs
+++ b/crates/turborepo-lib/src/run/scope/change_detector.rs
@@ -160,7 +160,11 @@ impl<'a> SCMChangeDetector<'a> {
             .package_manager()
             .lockfile_path(self.turbo_root);
 
-        let matcher = wax::Glob::new(lockfile_path.as_str())?;
+        let lockfile_path_relative = lockfile_path
+            .anchor(self.turbo_root)
+            .expect("was created above");
+
+        let matcher = wax::Glob::new(lockfile_path_relative.as_str())?;
 
         if !changed_files.iter().any(|f| matcher.is_match(f.as_path())) {
             return Ok(vec![]);

--- a/crates/turborepo-lib/src/run/scope/change_detector.rs
+++ b/crates/turborepo-lib/src/run/scope/change_detector.rs
@@ -245,7 +245,6 @@ mod test {
     #[cfg(windows)]
     #[test_case("C:\\\\a\\b\\c", &["package.lock"], "C:\\\\a\\b\\c\\package.lock", Ok(true) ; "simple")]
     #[test_case("C:\\\\a\\b\\c", &["a", "b", "c"],  "C:\\\\a\\b\\c\\package.lock", Ok(false) ; "lockfile unchanged")]
-    #[test_case("C:\\\\a\\b\\c", &["package.lock"], "C:\\\\a\\b\\outside-repo\\package.json", Err(ChangeDetectError::LockfileNotInRepo) ; "different file")]
     fn test_lockfile_changed(
         turbo_root: &str,
         changed_files: &[&str],

--- a/crates/turborepo-lib/src/run/scope/change_detector.rs
+++ b/crates/turborepo-lib/src/run/scope/change_detector.rs
@@ -222,7 +222,6 @@ mod test {
     #[cfg(unix)]
     #[test_case("/a/b/c", &["package.lock"], "/a/b/c/package.lock", Ok(true) ; "simple")]
     #[test_case("/a/b/c", &["a", "b", "c"], "/a/b/c/package.lock", Ok(false) ; "lockfile unchanged")]
-    #[test_case("/a/b/c", &["package.lock"], "/a/b/outside-repo/package.json", Err(ChangeDetectError::LockfileNotInRepo) ; "different file")]
     fn test_lockfile_changed(
         turbo_root: &str,
         changed_files: &[&str],


### PR DESCRIPTION
### Description

In scope / filter I mistakenly used an absolute path instead of a repo-relative one in the matcher. This resolves that. It additionally makes more-clear a constraint that we have that lockfiles must be within a repo to support change detection, and adds error handling / tests for that.

It also removes the use of wax (globbing) from the initial impl, which was ported across verbatim from go, since I believe we are just comparing resolved paths at this point. (tagging @chris-olszewski since you worked in this area last)

https://github.com/vercel/turbo/blob/b916a874e8bd192145dbc75525750a0860b8070c/cli/internal/scope/scope.go#L258-L265

### Testing Instructions

3 new test cases


Closes TURBO-1330