### PR TITLE
fix: pin thiserror to <1.0.45 which requires updating the toolchain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8466,18 +8466,18 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.48"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6d7a740b8a666a7e828dd00da9c0dc290dff53154ea77ac109281de90589b7"
+checksum = "611040a08a0439f8248d1990b111c95baa9c704c805fa1f62104b39655fd7f90"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.48"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
+checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -226,7 +226,8 @@ sourcemap = "6.0.2"
 syn = "1.0.107"
 tempfile = "3.3.0"
 test-case = "3.0.0"
-thiserror = "1.0.38"
+# pinned due to 1.0.45 requiring toolchain update
+thiserror = "<1.0.45"
 tiny-gradient = "0.1.0"
 tokio = "1.25.0"
 tokio-util = { version = "0.7.7", features = ["io"] }


### PR DESCRIPTION
### Description

The latest thiserror uses certain apis that aren't available to us without a toolchain update.
 
https://github.com/dtolnay/thiserror/pull/246/files

Pin the version instead

### Testing Instructions

Should be covered by existing test suite
