### PR TITLE
libwebp-sys: 0.9.2 -> 0.9.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3964,9 +3964,9 @@ dependencies = [
 
 [[package]]
 name = "libwebp-sys"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5df1e76f0acef0058aa2164ccf74e610e716e7f9eeb3ee2283de7d43659d823"
+checksum = "0c94b08ea3ec9eedea0fa779848e7fa183dc52aa60882488828883503faf630f"
 dependencies = [
  "cc",
  "glob",


### PR DESCRIPTION
### Description

libwebp-sys 0.9.3 includes the fix for CVE-2023-4863.

Changes:
https://github.com/NoXF/libwebp-sys/compare/0bdfce41a6776ddca7f946c6a39a2cfdba70d986...41698c4d1ee85ecd6e985b03c23bd1f5de2e44bd
<!--
  ✍️ Write a short summary of your work.
  If necessary, include relevant screenshots.
-->

### Testing Instructions

No functional changes expected for turbo.