### PR TITLE
feat(create-turbo): support package manager opt

### DIFF
--- a/packages/create-turbo/__tests__/index.test.ts
+++ b/packages/create-turbo/__tests__/index.test.ts
@@ -31,7 +31,7 @@ describe("create-turbo", () => {
     { packageManager: "pnpm" },
     { packageManager: "bun" },
   ])(
-    "outputs expected console messages when using $packageManager",
+    "outputs expected console messages when using $packageManager (option)",
     async ({ packageManager }) => {
       const { root } = useFixture({ fixture: `create-turbo` });
 
@@ -77,6 +77,78 @@ describe("create-turbo", () => {
           example: "default",
         }
       );
+
+      const expected = `${chalk.bold(
+        logger.turboGradient(">>> Success!")
+      )} Created a new Turborepo at "${path.relative(process.cwd(), root)}".`;
+
+      expect(mockConsole.log).toHaveBeenCalledWith(expected);
+      expect(mockConsole.log).toHaveBeenCalledWith(
+        "Inside that directory, you can run several commands:"
+      );
+
+      availableScripts.forEach((script) => {
+        expect(mockConsole.log).toHaveBeenCalledWith(
+          chalk.cyan(`  ${packageManager} run ${script}`)
+        );
+      });
+
+      mockAvailablePackageManagers.mockRestore();
+      mockCreateProject.mockRestore();
+      mockGetWorkspaceDetails.mockRestore();
+      mockExecSync.mockRestore();
+    }
+  );
+
+  test.each<{ packageManager: PackageManager }>([
+    { packageManager: "yarn" },
+    { packageManager: "npm" },
+    { packageManager: "pnpm" },
+    { packageManager: "bun" },
+  ])(
+    "outputs expected console messages when using $packageManager (arg)",
+    async ({ packageManager }) => {
+      const { root } = useFixture({ fixture: `create-turbo` });
+
+      const availableScripts = ["build", "test", "dev"];
+
+      const mockAvailablePackageManagers = jest
+        .spyOn(turboUtils, "getAvailablePackageManagers")
+        .mockResolvedValue({
+          npm: "8.19.2",
+          yarn: "1.22.10",
+          pnpm: "7.22.2",
+          bun: "1.0.1",
+        });
+
+      const mockCreateProject = jest
+        .spyOn(turboUtils, "createProject")
+        .mockResolvedValue({
+          cdPath: "",
+          hasPackageJson: true,
+          availableScripts,
+        });
+
+      const mockGetWorkspaceDetails = jest
+        .spyOn(turboWorkspaces, "getWorkspaceDetails")
+        .mockResolvedValue(
+          getWorkspaceDetailsMockReturnValue({
+            root,
+            packageManager,
+          })
+        );
+
+      const mockExecSync = jest
+        .spyOn(childProcess, "execSync")
+        .mockImplementation(() => {
+          return "success";
+        });
+
+      await create(root as CreateCommandArgument, undefined, {
+        manager: packageManager,
+        skipInstall: true,
+        example: "default",
+      });
 
       const expected = `${chalk.bold(
         logger.turboGradient(">>> Success!")

--- a/packages/create-turbo/src/cli.ts
+++ b/packages/create-turbo/src/cli.ts
@@ -3,7 +3,7 @@
 import http from "node:http";
 import https from "node:https";
 import chalk from "chalk";
-import { Command } from "commander";
+import { Command, Option } from "commander";
 import { logger } from "@turbo/utils";
 import { ProxyAgent } from "proxy-agent";
 import cliPkg from "../package.json";
@@ -21,9 +21,17 @@ const createTurboCli = new Command();
 createTurboCli
   .name(chalk.bold(logger.turboGradient("create-turbo")))
   .description("Create a new Turborepo")
-  .usage(`${chalk.bold("<project-directory> <package-manager>")} [options]`)
+  .usage(`${chalk.bold("<project-directory>")} [options]`)
   .argument("[project-directory]")
+  // TODO: argument is still provided (but removed from help)
+  // for backwards compatibility, remove this in the next major
   .argument("[package-manager]")
+  .addOption(
+    new Option(
+      "-m, --manager <package-manager>",
+      "Specify the package manager to use"
+    ).choices(["npm", "yarn", "pnpm", "bun"])
+  )
   .option(
     "--skip-install",
     "Do not run a package manager install after creating the project",

--- a/packages/create-turbo/src/commands/create/index.ts
+++ b/packages/create-turbo/src/commands/create/index.ts
@@ -56,13 +56,16 @@ const SCRIPTS_TO_DISPLAY: Record<string, string> = {
 
 export async function create(
   directory: CreateCommandArgument,
-  packageManager: CreateCommandArgument,
+  packageManagerCmd: CreateCommandArgument,
   opts: CreateCommandOptions
 ) {
-  const { skipInstall, skipTransforms } = opts;
+  const { manager: packageManagerOpt, skipInstall, skipTransforms } = opts;
   logger.log(chalk.bold(turboGradient(`\n>>> TURBOREPO\n`)));
   info(`Welcome to Turborepo! Let's get you set up with a new codebase.`);
   logger.log();
+
+  // if both the package manager option and command are provided, the option takes precedence
+  const packageManager = packageManagerOpt ?? packageManagerCmd;
 
   const [online, availablePackageManagers] = await Promise.all([
     isOnline(),

--- a/packages/create-turbo/src/commands/create/types.ts
+++ b/packages/create-turbo/src/commands/create/types.ts
@@ -1,6 +1,9 @@
+import type { PackageManager } from "@turbo/utils";
+
 export type CreateCommandArgument = string | undefined;
 
 export interface CreateCommandOptions {
+  manager?: PackageManager;
   skipInstall?: boolean;
   skipTransforms?: boolean;
   turboVersion?: string;


### PR DESCRIPTION
### Description

Support package manager as an option for `create-turbo`. Existing command is still available for backwards compatibility. If both are specified, option wins. 

Closes TURBO-1335