### PR TITLE
fix(Turborepo): Add typescript peer dep as dev dep

### DIFF
--- a/examples/basic/packages/eslint-config-custom/package.json
+++ b/examples/basic/packages/eslint-config-custom/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "devDependencies": {
     "@vercel/style-guide": "^5.0.0",
-    "eslint-config-turbo": "^1.10.12"
+    "eslint-config-turbo": "^1.10.12",
+    "typescript": "^4.5.3"
   }
 }

--- a/examples/basic/pnpm-lock.yaml
+++ b/examples/basic/pnpm-lock.yaml
@@ -103,6 +103,9 @@ importers:
       eslint-config-turbo:
         specifier: ^1.10.12
         version: 1.10.12(eslint@8.48.0)
+      typescript:
+        specifier: ^4.5.3
+        version: 4.9.5
 
   packages/tsconfig: {}
 


### PR DESCRIPTION
### Description

 - `eslint-config-custom` has a transitive peer dep on typescript which wasn't being provided. Promoted it to a dev dependency so that it is present

### Testing Instructions

Existing examples tests

Closes TURBO-1340