### PR TITLE
fix(turborepo): Make shim do complete package manager detection.

### DIFF
--- a/crates/turborepo-lib/src/shim.rs
+++ b/crates/turborepo-lib/src/shim.rs
@@ -317,8 +317,14 @@ impl LocalTurboState {
     // - `pnpm install`
     // - `npm install --install-strategy=linked`
     fn generate_linked_path(root_path: &AbsoluteSystemPath) -> Option<AbsoluteSystemPathBuf> {
-        let canonical_path =
-            fs_canonicalize(root_path.join_components(&["node_modules", "turbo", ".."])).ok()?;
+        let canonical_path = fs_canonicalize(
+            root_path
+                .as_path()
+                .join("node_modules")
+                .join("turbo")
+                .join(".."),
+        )
+        .ok()?;
 
         AbsoluteSystemPathBuf::try_from(canonical_path).ok()
     }


### PR DESCRIPTION
In 1.10.2 we introduced package manager detection into workspace existence detection. However, we did not include the `package.json` contents into the method call, which resulted in incomplete detection.

This updates that method call to include the `package.json` (if present) which gives us the correct behavior for package manager detection. This also pulls on a turbopath type thread to do some more migration.

The change that resulted in less-robust workspace detection:
https://github.com/vercel/turbo/commit/4e99d40db30d8584f140556a01986624b47dad60#diff-8459a232d027b507053b9df40feba72a5fdc6b1b08d5348140ab2ce9dd4d861e

Closes TURBO-1341