### PR TITLE
fix: use bash for shell when building turbo

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -221,6 +221,7 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - run: turbo run build --filter=cli --color --env-mode=strict --token=${{ secrets.TURBO_TOKEN }} --team=${{ vars.TURBO_TEAM }}
+        shell: bash
 
   go_lint:
     name: Go linting
@@ -277,6 +278,7 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - run: turbo run test --filter=cli --color
+        shell: bash
 
   go_integration:
     name: Go Integration Tests

--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -18,6 +18,7 @@ import (
 	"github.com/vercel/turbo/cli/internal/util"
 )
 
+// A comment that should force a rebuild, DO NOT LET CHRIS COMMIT THIS
 func initializeOutputFiles(helper *cmdutil.Helper, parsedArgs *turbostate.ParsedArgsFromRust) error {
 	if parsedArgs.Trace != "" {
 		cleanup, err := createTraceFile(parsedArgs.Trace)


### PR DESCRIPTION
### Description

TODO

### Testing Instructions

TODO

Closes TURBO-1343