### PR TITLE
Keep a copy of current integration test results in known location

### DIFF
--- a/.github/workflows/upload-nextjs-integration-test-results.yml
+++ b/.github/workflows/upload-nextjs-integration-test-results.yml
@@ -23,6 +23,10 @@ jobs:
         with:
           ref: nextjs-integration-test-data
 
+      - name: Git pull
+        run: |
+          git pull --depth=1 --no-tags origin nextjs-integration-test-data
+
       # First, grab test results into `test-results/main` directory from artifact stored by `next-integration-test`.
       - name: Grab test results
         uses: actions/download-artifact@v3
@@ -51,10 +55,6 @@ jobs:
           mv -fvn test-results/main/failed-test-path-list.json test-results/${{ env.RESULT_SUBPATH }}/failed-test-path-list.json
           ls -al ./test-results
           ls -al ./test-results/${{ env.RESULT_SUBPATH }}
-
-      - name: Git pull
-        run: |
-          git pull --depth=1 --no-tags origin nextjs-integration-test-data
 
       - name: Push data to branch
         uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/upload-nextjs-integration-test-results.yml
+++ b/.github/workflows/upload-nextjs-integration-test-results.yml
@@ -41,13 +41,13 @@ jobs:
           echo "SHA_SHORT=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
           echo "RESULT_SUBPATH=$(if ${{ inputs.is_main_branch }}; then echo 'main'; else echo ${{ env.NEXTJS_VERSION }}; fi)" >> $GITHUB_ENV
 
-      # Rename test results to `${date}-${nextjs-version}-${sha-short}.json`.
+      # Copy test results to `${date}-${nextjs-version}-${sha-short}.json`.
       # If workflow is not coming from main branch update, then we need to move test results to subpath `/${nextjs-version}`.
       - name: Congifure subpath
         run: |
           echo "Configured test result subpath for ${{ env.RESULT_SUBPATH }} / ${{ env.NEXTJS_VERSION }} / ${{ env.SHA_SHORT }}"
           mkdir -p test-results/${{ env.RESULT_SUBPATH }}
-          mv -v test-results/main/nextjs-test-results.json test-results/${{ env.RESULT_SUBPATH }}/$(date '+%Y%m%d%H%M')-${{ env.NEXTJS_VERSION }}-${{ env.SHA_SHORT }}.json
+          cp -v test-results/main/nextjs-test-results.json test-results/${{ env.RESULT_SUBPATH }}/$(date '+%Y%m%d%H%M')-${{ env.NEXTJS_VERSION }}-${{ env.SHA_SHORT }}.json
           mv -fvn test-results/main/failed-test-path-list.json test-results/${{ env.RESULT_SUBPATH }}/failed-test-path-list.json
           ls -al ./test-results
           ls -al ./test-results/${{ env.RESULT_SUBPATH }}


### PR DESCRIPTION
### Description

A very small change so that we keep a copy of the Next.js integration test results in a known location. We'll continue to have a copy of the results with a unique identifier, but having a known location allows me to easily download the JSON for syncing the results back to the Next.js CI suite.

### Testing Instructions



Closes WEB-1629