### PR TITLE
fix: upgrading go to support windows

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -11,7 +11,7 @@ runs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.20
+        go-version: "1.20"
         cache: true
         cache-dependency-path: cli/go.sum
 

--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -11,7 +11,7 @@ runs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18
+        go-version: 1.20
         cache: true
         cache-dependency-path: cli/go.sum
 

--- a/cli/cmd/turbo/main.go
+++ b/cli/cmd/turbo/main.go
@@ -10,7 +10,6 @@ import (
 	"github.com/vercel/turbo/cli/internal/turbostate"
 )
 
-// Touching file to force cache miss
 func main() {
 	if len(os.Args) != 2 {
 		fmt.Printf("go-turbo is expected to be invoked via turbo")

--- a/cli/cmd/turbo/main.go
+++ b/cli/cmd/turbo/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/vercel/turbo/cli/internal/turbostate"
 )
 
+// Touching file to force cache miss
 func main() {
 	if len(os.Args) != 2 {
 		fmt.Printf("go-turbo is expected to be invoked via turbo")


### PR DESCRIPTION
### Description

Due to the latest `windows-2022` runner image no longer including a "built from source" Go binary, we're running into https://github.com/golang/go/issues/51007

Luckily as of `1.20` Go is no longer shipping these precompiled object files so we will hopefully not run into the issues.

### Testing Instructions

CI


Closes TURBO-1344