### PR TITLE
chore: remove silent flag

### DIFF
--- a/crates/turborepo-lib/src/opts.rs
+++ b/crates/turborepo-lib/src/opts.rs
@@ -273,6 +273,14 @@ impl<'a> From<&'a RunArgs> for CacheOpts<'a> {
     }
 }
 
+impl<'a> RunOpts<'a> {
+    pub fn should_redirect_stderr_to_stdout(&self) -> bool {
+        // If we're running on Github Actions, force everything to stdout
+        // so as not to have out-of-order log lines
+        matches!(self.log_order, ResolvedLogOrder::Grouped) && self.is_github_actions
+    }
+}
+
 impl ScopeOpts {
     pub fn get_filters(&self) -> Vec<String> {
         [

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -265,6 +265,7 @@ impl<'a> Run<'a> {
             &global_hash,
             global_env_mode,
             self.base.ui,
+            false,
         );
 
         visitor.visit(engine.clone()).await?;

--- a/crates/turborepo-lib/src/task_graph/visitor.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor.rs
@@ -35,8 +35,6 @@ pub struct Visitor<'a> {
     sink: OutputSink<StdWriter>,
     color_cache: ColorSelector,
     ui: UI,
-    // For testing purposes we need to be able to silence the output
-    silent: bool,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -92,7 +90,6 @@ impl<'a> Visitor<'a> {
             sink,
             color_cache,
             ui,
-            silent: false,
         }
     }
 


### PR DESCRIPTION
### Description

In #5966 the `silent` and `quiet` flag was added to the run outline. This PR strips that out in favor of two alternatives controls for disabling output:
 - Adding a [`LevelFilter::OFF`](https://docs.rs/tracing/latest/tracing/level_filters/struct.LevelFilter.html#associatedconstant.OFF) for logging statements that come from tracing macros
 - A new variant to the UI that sends any bytes to a noop writer for logs that come from usage of `ui` struct in the task graph visitor

These should be the only two methods we use to write output and this refactor allows us to set these once and forget about them instead of passing around and checking the `bool` throughout the codebase.


### Testing Instructions

`cargo check` and eyes. Real testing will come in #5851 where these were used.

Closes TURBO-1347