### PR TITLE
fix: allow multiple threads to share hash tracker

### DIFF
--- a/crates/turborepo-env/src/lib.rs
+++ b/crates/turborepo-env/src/lib.rs
@@ -48,7 +48,7 @@ impl EnvironmentVariableMap {
 }
 
 // BySource contains a map of environment variables broken down by the source
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Clone)]
 pub struct BySource {
     pub explicit: EnvironmentVariableMap,
     pub matching: EnvironmentVariableMap,
@@ -57,7 +57,7 @@ pub struct BySource {
 // DetailedMap contains the composite and the detailed maps of environment
 // variables All is used as a taskhash input (taskhash.CalculateTaskHash)
 // BySource is used by dry runs and run summaries
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Clone)]
 pub struct DetailedMap {
     pub all: EnvironmentVariableMap,
     pub by_source: BySource,

--- a/crates/turborepo-lib/src/task_graph/visitor.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor.rs
@@ -21,8 +21,7 @@ use crate::{
         task_id::{self, TaskId},
         RunCache,
     },
-    task_hash,
-    task_hash::{PackageInputsHashes, TaskHashTracker, TaskHasher},
+    task_hash::{self, PackageInputsHashes, TaskHashTracker, TaskHashTrackerState, TaskHasher},
 };
 
 // This holds the whole world
@@ -273,8 +272,8 @@ impl<'a> Visitor<'a> {
         prefixed_ui
     }
 
-    pub fn into_task_hash_tracker(self) -> TaskHashTracker {
-        self.task_hasher.into_task_hash_tracker()
+    pub fn into_task_hash_tracker(self) -> TaskHashTrackerState {
+        self.task_hasher.into_task_hash_tracker_state()
     }
 }
 


### PR DESCRIPTION
### Description

When executing a task, it might need to update the hash tracker with:
 - cache status
 - expanded output globs
or it might need to query the env vars.

Since task execution happens on multiple threads we need to ensure that the state portion can be shared between threads. This is achieved with a good ol' `Arc<Mutex>` around the mutable state. In Go we do the same thing, but with a `RWLock`, this can be ported in the future if we find that there's enough contention for the mutex. (I'm currently unconvinced this is necessary considering how infrequently reads happen)

I'm holding off on the cache status portion of the hash tracker since that depends on run summary code and I don't want to conflict with #5833 

### Testing Instructions

New test ensures that we can share the underlying state between threads since it is `Send + Sync`.


Closes TURBO-1350