### PR TITLE
chore: remove anyhow from task cache

### DIFF
--- a/crates/turborepo-lib/src/run/cache.rs
+++ b/crates/turborepo-lib/src/run/cache.rs
@@ -24,6 +24,12 @@ pub enum Error {
     Cache(#[from] turborepo_cache::CacheError),
 }
 
+impl Error {
+    pub fn is_cache_miss(&self) -> bool {
+        matches!(&self, Self::Cache(CacheError::CacheMiss))
+    }
+}
+
 pub struct RunCache {
     task_output_mode: Option<OutputLogsMode>,
     cache: AsyncCache,


### PR DESCRIPTION
### Description

In general we're trying to move away from anyhow. On a more operational level since a cache miss is reported as an error, keeping our own error variant where it's easy to check if it is a `CacheError::CacheMiss` without downcasting is preferable.

### Testing Instructions

`cargo check`
