### PR TITLE
add warning when multiple package managers may impact inference

### DIFF
--- a/crates/turborepo-lib/src/cli.rs
+++ b/crates/turborepo-lib/src/cli.rs
@@ -654,7 +654,7 @@ pub async fn run(
         run_args.single_package = run_args.single_package
             || repo_state
                 .as_ref()
-                .map(|repo_state| matches!(repo_state.mode, RepoMode::SinglePackage))
+                .map(|repo_state| matches!(repo_state.get_mode(), RepoMode::SinglePackage))
                 .unwrap_or(false);
         // If this is a run command, and we know the actual invocation path, set the
         // inference root, as long as the user hasn't overridden the cwd

--- a/crates/turborepo-lib/src/shim.rs
+++ b/crates/turborepo-lib/src/shim.rs
@@ -499,7 +499,7 @@ fn spawn_local_turbo(
     let already_has_single_package_flag = shim_args
         .remaining_turbo_args
         .contains(&"--single-package".to_string());
-    let should_add_single_package_flag = repo_state.mode == RepoMode::SinglePackage
+    let should_add_single_package_flag = repo_state.get_mode() == RepoMode::SinglePackage
         && !already_has_single_package_flag
         && supports_skip_infer_and_single_package;
 


### PR DESCRIPTION
### Description

Adds a small warning when multiple package managers are detected in the same repo. This interferes with package inference and may cause repositories to be reported as single-package when they are not.

### Testing Instructions

Create a repo with both a package-lock.json and a yarn.lock and observe a new warning log line.


Closes TURBO-1353