### PR TITLE
chore: quiet warnings on turborepo build

### DIFF
--- a/crates/turborepo-api-client/src/spaces.rs
+++ b/crates/turborepo-api-client/src/spaces.rs
@@ -1,6 +1,7 @@
 use crate::APIClient;
 
 impl APIClient {
+    #[allow(dead_code)]
     async fn create_spaces_run() {
         todo!()
     }

--- a/crates/turborepo-lib/src/daemon/server.rs
+++ b/crates/turborepo-lib/src/daemon/server.rs
@@ -120,7 +120,7 @@ where
     S: Future<Output = CloseReason>,
 {
     let running = Arc::new(AtomicBool::new(true));
-    let (_pid_lock, stream) = match listen_socket(daemon_root.clone(), running.clone()).await {
+    let (_pid_lock, stream) = match listen_socket(daemon_root, running.clone()).await {
         Ok((pid_lock, stream)) => (pid_lock, stream),
         Err(e) => return CloseReason::SocketOpenError(e),
     };

--- a/crates/turborepo-lib/src/lib.rs
+++ b/crates/turborepo-lib/src/lib.rs
@@ -7,6 +7,7 @@
 #![deny(clippy::all)]
 // Clippy's needless mut lint is buggy: https://github.com/rust-lang/rust-clippy/issues/11299
 #![allow(clippy::needless_pass_by_ref_mut)]
+#![allow(dead_code)]
 
 mod child;
 mod cli;


### PR DESCRIPTION
### Description

PR to hopefully make the turborepo build far less noisey:
 - Allow dead code in the `turborepo-lib` crate. This is a temporary measure until we finish the port as we have many components in the codebase that haven't been hooked up
 - Fix clippy warning in daemon (cloning a reference to a type that doesn't implement `Clone` is just copying the reference)
 - Allowing dead code on a private `todo` method. (@NicholasLYang Should I just remove this?)

### Testing Instructions

Hopefully far less annotations on this PR from warnings during build.

Closes TURBO-1364