### PR TITLE
feat(turborepo-auth): move logout function to crate

### DIFF
--- a/crates/turborepo-auth/src/lib.rs
+++ b/crates/turborepo-auth/src/lib.rs
@@ -9,10 +9,11 @@ use reqwest::Url;
 use serde::Deserialize;
 use thiserror::Error;
 use tokio::sync::OnceCell;
+use tracing::error;
 #[cfg(not(test))]
 use tracing::warn;
 use turborepo_api_client::APIClient;
-use turborepo_ui::{start_spinner, BOLD, CYAN, UI};
+use turborepo_ui::{start_spinner, BOLD, CYAN, GREY, UI};
 
 const DEFAULT_HOST_NAME: &str = "127.0.0.1";
 const DEFAULT_PORT: u16 = 9789;
@@ -28,6 +29,19 @@ pub enum Error {
          situations like using a `data:` URL."
     )]
     LoginUrlCannotBeABase { value: String },
+}
+
+pub fn logout<F>(ui: &UI, mut set_token: F) -> Result<()>
+where
+    F: FnMut() -> Result<()>,
+{
+    if let Err(err) = set_token() {
+        error!("could not logout. Something went wrong: {}", err);
+        return Err(err.into());
+    }
+
+    println!("{}", ui.apply(GREY.apply_to(">>> Logged out")));
+    Ok(())
 }
 
 pub async fn login<F>(

--- a/crates/turborepo-lib/src/commands/logout.rs
+++ b/crates/turborepo-lib/src/commands/logout.rs
@@ -1,15 +1,15 @@
 use anyhow::Result;
-use tracing::error;
-use turborepo_ui::GREY;
+use turborepo_auth::logout as auth_logout;
 
 use crate::commands::CommandBase;
 
 pub fn logout(base: &mut CommandBase) -> Result<()> {
-    if let Err(err) = base.user_config_mut()?.set_token(None) {
-        error!("could not logout. Something went wrong: {}", err);
-        return Err(err.into());
-    }
+    let ui = base.ui;
 
-    println!("{}", base.ui.apply(GREY.apply_to(">>> Logged out")));
-    Ok(())
+    // Passing a closure here while we figure out how to make turborepo-auth
+    // crate manage its own configuration for the path to the token.
+    let set_token =
+        || -> Result<(), anyhow::Error> { Ok(base.user_config_mut()?.set_token(None)?) };
+
+    auth_logout(&ui, set_token)
 }


### PR DESCRIPTION
This moves the function over to the crate.

It's kind of useless since the closure passed is what does the heavy lifting,
but there are a few moving parts to being able to fix this:

- `token_path` passed into login functions in #6034 should be reusable
- #5796 changes how the config on disk is set, so I want to wait for that.
- Figure out if we're going to build in a default config location into turborepo-auth

Closes TURBO-1373