### PR TITLE
fix(turborepo): Local turbo invocation

### DIFF
--- a/turborepo-tests/integration/tests/find_turbo/hard_mode.t
+++ b/turborepo-tests/integration/tests/find_turbo/hard_mode.t
@@ -3,10 +3,9 @@ Setup
   $ . ${TESTDIR}/setup.sh $(pwd)/subdir "hoisted"
   $ TESTROOT=$(pwd)
 
-When --skip-infer is used we use the current binary and output no global/local message
+When --skip-infer is used we use the current binary, not a local binary
   $ cd $TESTROOT/subdir
-  $ ${TURBO} --help --skip-infer -vv | head -n 2
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
+  $ ${TURBO} --help --skip-infer | grep "The build system that makes ship happen" | head -n 1
   The build system that makes ship happen
 
 It finds repo root and uses correct version
@@ -20,7 +19,7 @@ It finds repo root and uses correct version
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running local turbo binary in .*/hard_mode.t/subdir/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: supports_skip_infer_and_single_package true (re)
-  --skip-infer build --filter foo -vv --single-package --
+  --skip-infer build --filter foo -vv
 
 It respects cwd
   $ ${TESTDIR}/set_version.sh $TESTROOT "1.8.0"
@@ -33,7 +32,7 @@ It respects cwd
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running local turbo binary in .*/hard_mode.t/subdir/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: supports_skip_infer_and_single_package true (re)
-  --skip-infer build --filter foo -vv --single-package --
+  --skip-infer build --filter foo -vv --cwd .*/hard_mode.t/subdir (re)
 
 It respects cwd and finds repo root
   $ ${TESTDIR}/set_version.sh $TESTROOT "1.8.0"
@@ -46,4 +45,4 @@ It respects cwd and finds repo root
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running local turbo binary in .*/hard_mode.t/subdir/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: supports_skip_infer_and_single_package true (re)
-  --skip-infer build --filter foo -vv --single-package --
+  --skip-infer build --filter foo -vv --cwd .*/hard_mode.t/subdir/node_modules (re)

--- a/turborepo-tests/integration/tests/find_turbo/hoisted.t
+++ b/turborepo-tests/integration/tests/find_turbo/hoisted.t
@@ -12,8 +12,7 @@ Make sure we use local and do not pass --skip-infer to old binary
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running local turbo binary in .*/hoisted.t/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: supports_skip_infer_and_single_package false (re)
-  build --filter foo -vv --
-
+  build --filter foo -vv
 Make sure we use local and pass --skip-infer to newer binary
   $ ${TESTDIR}/set_version.sh $(pwd) "1.8.0"
   $ ${TURBO} build --filter foo -vv
@@ -24,4 +23,4 @@ Make sure we use local and pass --skip-infer to newer binary
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running local turbo binary in .*/hoisted.t/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: supports_skip_infer_and_single_package true (re)
-  --skip-infer build --filter foo -vv --single-package --
+  --skip-infer build --filter foo -vv

--- a/turborepo-tests/integration/tests/find_turbo/linked.t
+++ b/turborepo-tests/integration/tests/find_turbo/linked.t
@@ -14,8 +14,7 @@ Make sure we use local and do not pass --skip-infer to old binary
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running local turbo binary in .*/linked.t/node_modules/.pnpm/turbo-(darwin|linux|windows)-(64|arm64)@1.0.0/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: supports_skip_infer_and_single_package false (re)
-  build --filter foo -vv --
-
+  build --filter foo -vv
 Make sure we use local and pass --skip-infer to newer binary
   $ ${TESTDIR}/set_version.sh $(pwd) "1.8.0"
   $ ${TURBO} build --filter foo -vv
@@ -28,4 +27,4 @@ Make sure we use local and pass --skip-infer to newer binary
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running local turbo binary in .*/linked.t/node_modules/.pnpm/turbo-(darwin|linux|windows)-(64|arm64)@1.0.0/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: supports_skip_infer_and_single_package true (re)
-  --skip-infer build --filter foo -vv --single-package --
+  --skip-infer build --filter foo -vv

--- a/turborepo-tests/integration/tests/find_turbo/nested.t
+++ b/turborepo-tests/integration/tests/find_turbo/nested.t
@@ -13,8 +13,7 @@ Make sure we use local and do not pass --skip-infer to old binary
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running local turbo binary in .*/nested.t/node_modules/turbo/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: supports_skip_infer_and_single_package false (re)
-  build --filter foo -vv --
-
+  build --filter foo -vv
 Make sure we use local and pass --skip-infer to newer binary
   $ ${TESTDIR}/set_version.sh $(pwd) "1.8.0"
   $ ${TURBO} build --filter foo -vv
@@ -26,4 +25,4 @@ Make sure we use local and pass --skip-infer to newer binary
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running local turbo binary in .*/nested.t/node_modules/turbo/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: supports_skip_infer_and_single_package true (re)
-  --skip-infer build --filter foo -vv --single-package --
+  --skip-infer build --filter foo -vv

--- a/turborepo-tests/integration/tests/find_turbo/unplugged.t
+++ b/turborepo-tests/integration/tests/find_turbo/unplugged.t
@@ -14,8 +14,7 @@ Make sure we use local and do not pass --skip-infer to old binary
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running local turbo binary in .*/unplugged.t/.yarn/unplugged/turbo-(darwin|linux|windows)-(64|arm64)-npm-1.0.0-520925a700/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: supports_skip_infer_and_single_package false (re)
-  build --filter foo -vv --
-
+  build --filter foo -vv
 Make sure we use local and pass --skip-infer to newer binary
   $ ${TESTDIR}/set_version.sh $(pwd) "1.8.0"
   $ ${TURBO} build --filter foo -vv
@@ -28,4 +27,4 @@ Make sure we use local and pass --skip-infer to newer binary
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running local turbo binary in .*/unplugged.t/.yarn/unplugged/turbo-(darwin|linux|windows)-(64|arm64)-npm-1.0.0-520925a700/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: supports_skip_infer_and_single_package true (re)
-  --skip-infer build --filter foo -vv --single-package --
+  --skip-infer build --filter foo -vv

--- a/turborepo-tests/integration/tests/find_turbo/unplugged_env_moved.t
+++ b/turborepo-tests/integration/tests/find_turbo/unplugged_env_moved.t
@@ -15,8 +15,7 @@ Make sure we use local and do not pass --skip-infer to old binary
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running local turbo binary in .*/unplugged_env_moved.t/.moved/unplugged/turbo-(darwin|linux|windows)-(64|arm64)-npm-1.0.0-520925a700/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: supports_skip_infer_and_single_package false (re)
-  build --filter foo -vv --
-
+  build --filter foo -vv
 Make sure we use local and pass --skip-infer to newer binary
   $ ${TESTDIR}/set_version.sh $(pwd) "1.8.0"
   $ set -o allexport; source .env; set +o allexport;
@@ -30,4 +29,4 @@ Make sure we use local and pass --skip-infer to newer binary
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running local turbo binary in .*/unplugged_env_moved.t/.moved/unplugged/turbo-(darwin|linux|windows)-(64|arm64)-npm-1.0.0-520925a700/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: supports_skip_infer_and_single_package true (re)
-  --skip-infer build --filter foo -vv --single-package --
+  --skip-infer build --filter foo -vv

--- a/turborepo-tests/integration/tests/find_turbo/unplugged_moved.t
+++ b/turborepo-tests/integration/tests/find_turbo/unplugged_moved.t
@@ -14,8 +14,7 @@ Make sure we use local and do not pass --skip-infer to old binary
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running local turbo binary in .*/unplugged_moved.t/.moved/unplugged/turbo-(darwin|linux|windows)-(64|arm64)-npm-1.0.0-520925a700/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: supports_skip_infer_and_single_package false (re)
-  build --filter foo -vv --
-
+  build --filter foo -vv
 Make sure we use local and pass --skip-infer to newer binary
   $ ${TESTDIR}/set_version.sh $(pwd) "1.8.0"
   $ ${TURBO} build --filter foo -vv
@@ -28,4 +27,4 @@ Make sure we use local and pass --skip-infer to newer binary
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running local turbo binary in .*/unplugged_moved.t/.moved/unplugged/turbo-(darwin|linux|windows)-(64|arm64)-npm-1.0.0-520925a700/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: supports_skip_infer_and_single_package true (re)
-  --skip-infer build --filter foo -vv --single-package --
+  --skip-infer build --filter foo -vv

--- a/turborepo-tests/integration/tests/pkg-inference.t
+++ b/turborepo-tests/integration/tests/pkg-inference.t
@@ -2,15 +2,19 @@ Setup
   $ . ${TESTDIR}/../../helpers/setup.sh
   $ . ${TESTDIR}/_helpers/setup_monorepo.sh $(pwd)
 
-# Run as if called by global turbo (NEW)
+# Package inference does not find anything when run in the root.
+  $ ${TURBO} build --skip-infer --force | grep "Running build in 3 packages" | head -n 1
+  \xe2\x80\xa2 Running build in 3 packages (esc)
+
+# Package inference succeeds when `--skip-infer` is passed and in a directory.
   $ cd packages/util
   $ ${TURBO} build --skip-infer --force | grep "Running build in 1 packages" | head -n 1
   \xe2\x80\xa2 Running build in 1 packages (esc)
 
-# Does not run in a particular directory
+# Does package inference when `--cwd` is passed.
   $ ${TURBO} build --cwd $(pwd)/packages/util --force | grep "Running build in 1 packages" | head -n 1
   \xe2\x80\xa2 Running build in 1 packages (esc)
 
-# Run in a particular directory
+# Does package inference when local `turbo`` detection is skipped and `--cwd` is passed.
   $ ${TURBO} build --skip-infer --cwd $(pwd)/packages/util --force | grep "Running build in 1 packages" | head -n 1
   \xe2\x80\xa2 Running build in 1 packages (esc)

--- a/turborepo-tests/integration/tests/pkg-inference.t
+++ b/turborepo-tests/integration/tests/pkg-inference.t
@@ -2,19 +2,15 @@ Setup
   $ . ${TESTDIR}/../../helpers/setup.sh
   $ . ${TESTDIR}/_helpers/setup_monorepo.sh $(pwd)
 
-# Run as if called by global turbo
-  $ TURBO_INVOCATION_DIR=$(pwd)/packages/util ${TURBO} build --skip-infer
-  \xe2\x80\xa2 Packages in scope: util (esc)
+# Run as if called by global turbo (NEW)
+  $ cd packages/util
+  $ ${TURBO} build --skip-infer --force | grep "Running build in 1 packages" | head -n 1
   \xe2\x80\xa2 Running build in 1 packages (esc)
-  \xe2\x80\xa2 Remote caching disabled (esc)
-  util:build: cache miss, executing 76ab904c7ecb2d51
-  util:build: 
-  util:build: > build
-  util:build: > echo 'building'
-  util:build: 
-  util:build: building
-  
-   Tasks:    1 successful, 1 total
-  Cached:    0 cached, 1 total
-    Time:\s*[\.0-9]+m?s  (re)
-  
+
+# Does not run in a particular directory
+  $ ${TURBO} build --cwd $(pwd)/packages/util --force | grep "Running build in 3 packages" | head -n 1
+  \xe2\x80\xa2 Running build in 3 packages (esc)
+
+# Run in a particular directory
+  $ ${TURBO} build --skip-infer --cwd $(pwd)/packages/util --force | grep "Running build in 3 packages" | head -n 1
+  \xe2\x80\xa2 Running build in 3 packages (esc)

--- a/turborepo-tests/integration/tests/pkg-inference.t
+++ b/turborepo-tests/integration/tests/pkg-inference.t
@@ -8,9 +8,9 @@ Setup
   \xe2\x80\xa2 Running build in 1 packages (esc)
 
 # Does not run in a particular directory
-  $ ${TURBO} build --cwd $(pwd)/packages/util --force | grep "Running build in 3 packages" | head -n 1
-  \xe2\x80\xa2 Running build in 3 packages (esc)
+  $ ${TURBO} build --cwd $(pwd)/packages/util --force | grep "Running build in 1 packages" | head -n 1
+  \xe2\x80\xa2 Running build in 1 packages (esc)
 
 # Run in a particular directory
-  $ ${TURBO} build --skip-infer --cwd $(pwd)/packages/util --force | grep "Running build in 3 packages" | head -n 1
-  \xe2\x80\xa2 Running build in 3 packages (esc)
+  $ ${TURBO} build --skip-infer --cwd $(pwd)/packages/util --force | grep "Running build in 1 packages" | head -n 1
+  \xe2\x80\xa2 Running build in 1 packages (esc)


### PR DESCRIPTION
"Global" `turbo` should be doing _far_ less in terms of invoking "local" `turbo`. This PR makes that process _far_ less clever and simply reinvokes "local" at the same directory level, with the same arguments. This will make it _far_ easier to maintain compatibility.

As a consequence, the package inference root _always_ the current process's working directory, or `--cwd`. Then, the bugfix: when `--cwd` is passed we use that to calculate the inference root. It is no longer mutually exclusive.

Future work:
- We should also remove the (hidden) argument as it is no longer necessary, but that's the piece that is currently threading the value through everything all the way into Go, and would be a significant lift.
- Most of `ShimArgs` can now go away, but that's a bonus unnecessary refactor for this PR.

Review commit-by-commit with [`?w=1`](https://github.com/vercel/turbo/pull/6064/files?w=1)

Closes TURBO-1375