### PR TITLE
fix(ci): remove build_turborepo dependency from JS and examples tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -335,7 +335,7 @@ jobs:
 
   turborepo_examples:
     name: Turborepo Examples
-    needs: [determine_jobs, build_turborepo]
+    needs: [determine_jobs]
     if: needs.determine_jobs.outputs.examples == 'true'
     timeout-minutes: 40
 
@@ -401,7 +401,7 @@ jobs:
     name: JS Package Tests
     timeout-minutes: 30
     if: needs.determine_jobs.outputs.turborepo_js == 'true'
-    needs: [determine_jobs, build_turborepo]
+    needs: [determine_jobs]
     runs-on: ${{ matrix.os.runner }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
JS and examples tests do not use a local build of the turbo binary, so we do not need to build it first. More importantly, becuase the build_turborepo job runs conditionally only when Go or Rust files are changed[^1], it prevents JS and examples tests from running when only examples or JS files have changed

This was introduced in #5665, but I think it should be safe to remove these parts. I will test:

- [x] https://github.com/vercel/turbo/pull/6067
- [x] https://github.com/vercel/turbo/pull/6068

Closes TURBO-1377

[^1]: The output is called `outputs.go`, but it is actually set to true when Go or Rust files change. I will fix this in https://github.com/vercel/turbo/pull/6069.