### PR TITLE
chore(ci): Use better named outputs for triggering turborepo_build job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -183,7 +183,8 @@ jobs:
       turbopack_typescript: ${{ steps.ci.outputs.diff != '' || steps.turbopack_typescript.outputs.diff != '' }}
       turborepo_rust: ${{ steps.ci.outputs.diff != '' || steps.turborepo_rust.outputs.diff != '' }}
       turbopack_bench: ${{ steps.ci.outputs.diff != '' || steps.turbopack_bench.outputs.diff != '' }}
-      go: ${{ steps.ci.outputs.diff != '' || steps.turborepo_go.outputs.diff != '' || steps.turborepo_rust.outputs.diff != '' }}
+      go: ${{ steps.ci.outputs.diff != '' || steps.turborepo_go.outputs.diff != ''}}
+      turborepo_build: ${{ steps.ci.outputs.diff != '' || steps.turborepo_go.outputs.diff != '' || steps.turborepo_rust.outputs.diff != '' }}
       turborepo_e2e: ${{ steps.ci.outputs.diff != '' || steps.turborepo_go.outputs.diff != '' || steps.turborepo_rust.outputs.diff != ''  || steps.turborepo_e2e.outputs.diff != '' }}
       go_integration: ${{ steps.ci.outputs.diff != '' || steps.turborepo_go.outputs.diff != '' || steps.turborepo_rust.outputs.diff != ''  || steps.turborepo_integration.outputs.diff != '' }}
       examples: ${{ steps.ci.outputs.diff != '' || steps.turborepo_go.outputs.diff != '' || steps.turborepo_rust.outputs.diff != '' || steps.examples.outputs.diff != '' }}
@@ -196,6 +197,8 @@ jobs:
 
   build_turborepo:
     name: Build Turborepo
+    needs: determine_jobs
+    if: needs.determine_jobs.outputs.turborepo_build == 'true'
     runs-on: ${{ matrix.os.runner }}
     strategy:
       fail-fast: false
@@ -207,8 +210,6 @@ jobs:
             runner: macos-latest
           - name: windows
             runner: windows-latest
-    needs: determine_jobs
-    if: needs.determine_jobs.outputs.go == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -183,7 +183,8 @@ jobs:
       turbopack_typescript: ${{ steps.ci.outputs.diff != '' || steps.turbopack_typescript.outputs.diff != '' }}
       turborepo_rust: ${{ steps.ci.outputs.diff != '' || steps.turborepo_rust.outputs.diff != '' }}
       turbopack_bench: ${{ steps.ci.outputs.diff != '' || steps.turbopack_bench.outputs.diff != '' }}
-      go: ${{ steps.ci.outputs.diff != '' || steps.turborepo_go.outputs.diff != ''}}
+      turborepo_go_unit: ${{ steps.ci.outputs.diff != '' || steps.turborepo_go.outputs.diff != '' || steps.turborepo_rust.outputs.diff != '' }}
+      turborepo_go_lint: ${{ steps.ci.outputs.diff != '' || steps.turborepo_go.outputs.diff != ''}}
       turborepo_build: ${{ steps.ci.outputs.diff != '' || steps.turborepo_go.outputs.diff != '' || steps.turborepo_rust.outputs.diff != '' }}
       turborepo_e2e: ${{ steps.ci.outputs.diff != '' || steps.turborepo_go.outputs.diff != '' || steps.turborepo_rust.outputs.diff != ''  || steps.turborepo_e2e.outputs.diff != '' }}
       go_integration: ${{ steps.ci.outputs.diff != '' || steps.turborepo_go.outputs.diff != '' || steps.turborepo_rust.outputs.diff != ''  || steps.turborepo_integration.outputs.diff != '' }}
@@ -227,7 +228,7 @@ jobs:
     name: Go linting
     runs-on: ubuntu-latest
     needs: determine_jobs
-    if: needs.determine_jobs.outputs.go == 'true'
+    if: needs.determine_jobs.outputs.turborepo_go_lint == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -256,7 +257,7 @@ jobs:
   go_unit:
     name: Go Unit Tests
     needs: determine_jobs
-    if: needs.determine_jobs.outputs.go == 'true'
+    if: needs.determine_jobs.outputs.turborepo_go_unit == 'true'
     timeout-minutes: 45
     runs-on: ${{ matrix.os.runner }}
     strategy:


### PR DESCRIPTION
- Changes the name of the output that is used to trigger a build of turborepo. Both Rust and Go changes trigger this output to be set to true, so naming the output `outputs.go` didn't work
- Do not set `outputs.go` when Rust files change. After this PR, only Go linting and Unit tests rely on this output, so it is appropriate for them to only run when Go files have changed.

Closes TURBO-1380