### PR TITLE
refactor(Turborepo): Extract LocalTurboState from RepoState

### DIFF
--- a/crates/turborepo-lib/src/shim.rs
+++ b/crates/turborepo-lib/src/shim.rs
@@ -1,7 +1,7 @@
 use std::{
     env,
     fs::{self},
-    path::{Path, PathBuf},
+    path::PathBuf,
     process,
     process::Stdio,
     time::Duration,
@@ -12,7 +12,7 @@ use camino::Utf8PathBuf;
 use const_format::formatcp;
 use dunce::canonicalize as fs_canonicalize;
 use semver::Version;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use tiny_gradient::{GradientStr, RGB};
 use tracing::debug;
 use turbo_updater::check_for_updates;
@@ -188,13 +188,13 @@ impl ShimArgs {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum RepoMode {
     SinglePackage,
     MultiPackage,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct YarnRc {
     pnp_unplugged_folder: Utf8PathBuf,
@@ -208,7 +208,7 @@ impl Default for YarnRc {
     }
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug)]
 pub struct TurboState {
     bin_path: Option<PathBuf>,
     version: &'static str,
@@ -286,7 +286,7 @@ impl TurboState {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug)]
 pub struct LocalTurboState {
     bin_path: PathBuf,
     version: String,
@@ -377,7 +377,7 @@ impl LocalTurboState {
     //
     // In spite of that, the only known unsupported local invocation is Yarn/Berry <
     // 2.1 PnP
-    pub fn infer(root_path: &AbsoluteSystemPathBuf) -> Option<Self> {
+    pub fn infer(root_path: &AbsoluteSystemPath) -> Option<Self> {
         let platform_package_name = TurboState::platform_package_name();
         let binary_name = TurboState::binary_name();
 
@@ -423,13 +423,16 @@ impl LocalTurboState {
 
         None
     }
+
+    fn supports_skip_infer_and_single_package(&self) -> bool {
+        turbo_version_has_shim(&self.version)
+    }
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone)]
 pub struct RepoState {
     pub root: AbsoluteSystemPathBuf,
     pub mode: RepoMode,
-    pub local_turbo_state: Option<LocalTurboState>,
 }
 
 #[derive(Debug)]
@@ -525,7 +528,6 @@ impl RepoState {
 
             // If there is only one potential root, that's the winner.
             if check_roots.peek().is_none() {
-                let local_turbo_state = LocalTurboState::infer(&current.path);
                 return Ok(Self {
                     root: current.path.clone(),
                     mode: if current.workspace_globs.is_some() {
@@ -533,7 +535,6 @@ impl RepoState {
                     } else {
                         RepoMode::SinglePackage
                     },
-                    local_turbo_state,
                 });
 
             // More than one potential root. See if we can stop at the first.
@@ -541,11 +542,9 @@ impl RepoState {
             // and set the mode properly in the else and it would still work.
             } else if current.workspace_globs.is_some() {
                 // If the closest one has workspaces then we stop there.
-                let local_turbo_state = LocalTurboState::infer(&current.path);
                 return Ok(Self {
                     root: current.path.clone(),
                     mode: RepoMode::MultiPackage,
-                    local_turbo_state,
                 });
 
             // More than one potential root.
@@ -555,22 +554,18 @@ impl RepoState {
             } else {
                 for ancestor_infer in check_roots {
                     if ancestor_infer.is_workspace_root_of(&current.path) {
-                        let local_turbo_state = LocalTurboState::infer(&ancestor_infer.path);
                         return Ok(Self {
                             root: ancestor_infer.path.clone(),
                             mode: RepoMode::MultiPackage,
-                            local_turbo_state,
                         });
                     }
                 }
 
                 // We have eliminated RepoMode::MultiPackage as an option.
                 // We must exhaustively check before this becomes the answer.
-                let local_turbo_state = LocalTurboState::infer(&current.path);
                 return Ok(Self {
                     root: current.path.clone(),
                     mode: RepoMode::SinglePackage,
-                    local_turbo_state,
                 });
             }
         }
@@ -590,122 +585,120 @@ impl RepoState {
         let potential_turbo_roots = RepoState::generate_potential_turbo_roots(reference_dir);
         RepoState::process_potential_turbo_roots(potential_turbo_roots)
     }
+}
 
-    /// Attempts to run correct turbo by finding nearest package.json,
-    /// then finding local turbo installation. If the current binary is the
-    /// local turbo installation, then we run current turbo. Otherwise we
-    /// kick over to the local turbo installation.
-    ///
-    /// # Arguments
-    ///
-    /// * `turbo_state`: state for current execution
-    ///
-    /// returns: Result<i32, Error>
-    fn run_correct_turbo(
-        self,
-        shim_args: ShimArgs,
-        subscriber: &TurboSubscriber,
-        ui: UI,
-    ) -> Result<Payload> {
-        if let Some(LocalTurboState { bin_path, version }) = &self.local_turbo_state {
-            try_check_for_updates(&shim_args, version);
-            let canonical_local_turbo = fs_canonicalize(bin_path)?;
-            Ok(Payload::Rust(
-                self.spawn_local_turbo(&canonical_local_turbo, shim_args),
-            ))
-        } else {
-            try_check_for_updates(&shim_args, get_version());
-            // cli::run checks for this env var, rather than an arg, so that we can support
-            // calling old versions without passing unknown flags.
-            env::set_var(
-                cli::INVOCATION_DIR_ENV_VAR,
-                shim_args.invocation_dir.as_path(),
+/// Attempts to run correct turbo by finding nearest package.json,
+/// then finding local turbo installation. If the current binary is the
+/// local turbo installation, then we run current turbo. Otherwise we
+/// kick over to the local turbo installation.
+///
+/// # Arguments
+///
+/// * `turbo_state`: state for current execution
+///
+/// returns: Result<i32, Error>
+fn run_correct_turbo(
+    repo_state: RepoState,
+    shim_args: ShimArgs,
+    subscriber: &TurboSubscriber,
+    ui: UI,
+) -> Result<Payload> {
+    if let Some(turbo_state) = LocalTurboState::infer(&repo_state.root) {
+        try_check_for_updates(&shim_args, &turbo_state.version);
+        Ok(Payload::Rust(spawn_local_turbo(
+            &repo_state,
+            turbo_state,
+            shim_args,
+        )))
+    } else {
+        try_check_for_updates(&shim_args, get_version());
+        // cli::run checks for this env var, rather than an arg, so that we can support
+        // calling old versions without passing unknown flags.
+        env::set_var(
+            cli::INVOCATION_DIR_ENV_VAR,
+            shim_args.invocation_dir.as_path(),
+        );
+        debug!("Running command as global turbo");
+        cli::run(Some(repo_state), subscriber, ui)
+    }
+}
+
+fn spawn_local_turbo(
+    repo_state: &RepoState,
+    local_turbo_state: LocalTurboState,
+    mut shim_args: ShimArgs,
+) -> Result<i32> {
+    let local_turbo_path = fs_canonicalize(&local_turbo_state.bin_path)?;
+    debug!(
+        "Running local turbo binary in {}\n",
+        local_turbo_path.display()
+    );
+
+    let supports_skip_infer_and_single_package =
+        local_turbo_state.supports_skip_infer_and_single_package();
+    let already_has_single_package_flag = shim_args
+        .remaining_turbo_args
+        .contains(&"--single-package".to_string());
+    let should_add_single_package_flag = repo_state.mode == RepoMode::SinglePackage
+        && !already_has_single_package_flag
+        && supports_skip_infer_and_single_package;
+
+    debug!(
+        "supports_skip_infer_and_single_package {:?}",
+        supports_skip_infer_and_single_package
+    );
+    let cwd = fs_canonicalize(&repo_state.root)?;
+    let mut raw_args: Vec<_> = if supports_skip_infer_and_single_package {
+        vec!["--skip-infer".to_string()]
+    } else {
+        Vec::new()
+    };
+
+    raw_args.append(&mut shim_args.remaining_turbo_args);
+
+    // We add this flag after the raw args to avoid accidentally passing it
+    // as a global flag instead of as a run flag.
+    if should_add_single_package_flag {
+        raw_args.push("--single-package".to_string());
+    }
+
+    raw_args.push("--".to_string());
+    raw_args.append(&mut shim_args.forwarded_args);
+
+    // We spawn a process that executes the local turbo
+    // that we've found in node_modules/.bin/turbo.
+    let mut command = process::Command::new(local_turbo_path);
+    command
+        .args(&raw_args)
+        // rather than passing an argument that local turbo might not understand, set
+        // an environment variable that can be optionally used
+        .env(
+            cli::INVOCATION_DIR_ENV_VAR,
+            shim_args.invocation_dir.as_path(),
+        )
+        .current_dir(cwd)
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit());
+
+    let child = spawn_child(command)?;
+
+    let exit_status = child.wait()?;
+    let exit_code = exit_status.code().unwrap_or_else(|| {
+        debug!("go-turbo failed to report exit code");
+        #[cfg(unix)]
+        {
+            use std::os::unix::process::ExitStatusExt;
+            let signal = exit_status.signal();
+            let core_dumped = exit_status.core_dumped();
+            debug!(
+                "go-turbo caught signal {:?}. Core dumped? {}",
+                signal, core_dumped
             );
-            debug!("Running command as global turbo");
-            cli::run(Some(self), subscriber, ui)
         }
-    }
+        2
+    });
 
-    fn local_turbo_supports_skip_infer_and_single_package(&self) -> Result<bool> {
-        if let Some(LocalTurboState { version, .. }) = &self.local_turbo_state {
-            Ok(turbo_version_has_shim(version))
-        } else {
-            Ok(false)
-        }
-    }
-
-    fn spawn_local_turbo(&self, local_turbo_path: &Path, mut shim_args: ShimArgs) -> Result<i32> {
-        debug!(
-            "Running local turbo binary in {}\n",
-            local_turbo_path.display()
-        );
-
-        let supports_skip_infer_and_single_package =
-            self.local_turbo_supports_skip_infer_and_single_package()?;
-        let already_has_single_package_flag = shim_args
-            .remaining_turbo_args
-            .contains(&"--single-package".to_string());
-        let should_add_single_package_flag = self.mode == RepoMode::SinglePackage
-            && !already_has_single_package_flag
-            && supports_skip_infer_and_single_package;
-
-        debug!(
-            "supports_skip_infer_and_single_package {:?}",
-            supports_skip_infer_and_single_package
-        );
-        let cwd = fs_canonicalize(&self.root)?;
-        let mut raw_args: Vec<_> = if supports_skip_infer_and_single_package {
-            vec!["--skip-infer".to_string()]
-        } else {
-            Vec::new()
-        };
-
-        raw_args.append(&mut shim_args.remaining_turbo_args);
-
-        // We add this flag after the raw args to avoid accidentally passing it
-        // as a global flag instead of as a run flag.
-        if should_add_single_package_flag {
-            raw_args.push("--single-package".to_string());
-        }
-
-        raw_args.push("--".to_string());
-        raw_args.append(&mut shim_args.forwarded_args);
-
-        // We spawn a process that executes the local turbo
-        // that we've found in node_modules/.bin/turbo.
-        let mut command = process::Command::new(local_turbo_path);
-        command
-            .args(&raw_args)
-            // rather than passing an argument that local turbo might not understand, set
-            // an environment variable that can be optionally used
-            .env(
-                cli::INVOCATION_DIR_ENV_VAR,
-                shim_args.invocation_dir.as_path(),
-            )
-            .current_dir(cwd)
-            .stdout(Stdio::inherit())
-            .stderr(Stdio::inherit());
-
-        let child = spawn_child(command)?;
-
-        let exit_status = child.wait()?;
-        let exit_code = exit_status.code().unwrap_or_else(|| {
-            debug!("go-turbo failed to report exit code");
-            #[cfg(unix)]
-            {
-                use std::os::unix::process::ExitStatusExt;
-                let signal = exit_status.signal();
-                let core_dumped = exit_status.core_dumped();
-                debug!(
-                    "go-turbo caught signal {:?}. Core dumped? {}",
-                    signal, core_dumped
-                );
-            }
-            2
-        });
-
-        Ok(exit_code)
-    }
+    Ok(exit_code)
 }
 
 /// Checks for `TURBO_BINARY_PATH` variable. If it is set,
@@ -773,7 +766,7 @@ pub fn run() -> Result<Payload> {
     match RepoState::infer(&args.cwd) {
         Ok(repo_state) => {
             debug!("Repository Root: {}", repo_state.root);
-            repo_state.run_correct_turbo(args, &subscriber, ui)
+            run_correct_turbo(repo_state, args, &subscriber, ui)
         }
         Err(err) => {
             // If we cannot infer, we still run global turbo. This allows for global

--- a/turborepo-tests/integration/tests/find_turbo/hard_mode.t
+++ b/turborepo-tests/integration/tests/find_turbo/hard_mode.t
@@ -14,9 +14,9 @@ It finds repo root and uses correct version
   $ cd $TESTROOT/subdir/node_modules
   $ ${TURBO} build --filter foo -vv
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/hard_mode.t/subdir (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Local turbo path: .*/hard_mode.t/subdir/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Local turbo version: 1.8.0 (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/hard_mode.t/subdir (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running local turbo binary in .*/hard_mode.t/subdir/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: supports_skip_infer_and_single_package true (re)
@@ -27,9 +27,9 @@ It respects cwd
   $ cd $TESTROOT
   $ ${TURBO} build --filter foo -vv --cwd ${TESTROOT}/subdir
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/hard_mode.t/subdir (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Local turbo path: .*/hard_mode.t/subdir/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Local turbo version: 1.8.0 (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/hard_mode.t/subdir (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running local turbo binary in .*/hard_mode.t/subdir/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: supports_skip_infer_and_single_package true (re)
@@ -40,9 +40,9 @@ It respects cwd and finds repo root
   $ cd $TESTROOT
   $ ${TURBO} build --filter foo -vv --cwd ${TESTROOT}/subdir/node_modules
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/hard_mode.t/subdir (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Local turbo path: .*/hard_mode.t/subdir/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Local turbo version: 1.8.0 (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/hard_mode.t/subdir (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running local turbo binary in .*/hard_mode.t/subdir/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: supports_skip_infer_and_single_package true (re)

--- a/turborepo-tests/integration/tests/find_turbo/hoisted.t
+++ b/turborepo-tests/integration/tests/find_turbo/hoisted.t
@@ -6,9 +6,9 @@ Make sure we use local and do not pass --skip-infer to old binary
   $ ${TESTDIR}/set_version.sh $(pwd) "1.0.0"
   $ ${TURBO} build --filter foo -vv
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/hoisted.t (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Local turbo path: .*/hoisted.t/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Local turbo version: 1.0.0 (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/hoisted.t (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running local turbo binary in .*/hoisted.t/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: supports_skip_infer_and_single_package false (re)
@@ -18,9 +18,9 @@ Make sure we use local and pass --skip-infer to newer binary
   $ ${TESTDIR}/set_version.sh $(pwd) "1.8.0"
   $ ${TURBO} build --filter foo -vv
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/hoisted.t (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Local turbo path: .*/hoisted.t/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Local turbo version: 1.8.0 (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/hoisted.t (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running local turbo binary in .*/hoisted.t/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: supports_skip_infer_and_single_package true (re)

--- a/turborepo-tests/integration/tests/find_turbo/linked.t
+++ b/turborepo-tests/integration/tests/find_turbo/linked.t
@@ -6,11 +6,11 @@ Make sure we use local and do not pass --skip-infer to old binary
   $ ${TESTDIR}/set_version.sh $(pwd) "1.0.0"
   $ ${TURBO} build --filter foo -vv
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/linked.t (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .*/linked.t/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .*/linked.t/node_modules/turbo/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Local turbo path: .*/linked.t/node_modules/.pnpm/turbo-(darwin|linux|windows)-(64|arm64)@1.0.0/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Local turbo version: 1.0.0 (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/linked.t (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running local turbo binary in .*/linked.t/node_modules/.pnpm/turbo-(darwin|linux|windows)-(64|arm64)@1.0.0/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: supports_skip_infer_and_single_package false (re)
@@ -20,11 +20,11 @@ Make sure we use local and pass --skip-infer to newer binary
   $ ${TESTDIR}/set_version.sh $(pwd) "1.8.0"
   $ ${TURBO} build --filter foo -vv
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/linked.t (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .*/linked.t/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .*/linked.t/node_modules/turbo/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Local turbo path: .*/linked.t/node_modules/.pnpm/turbo-(darwin|linux|windows)-(64|arm64)@1.0.0/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Local turbo version: 1.8.0 (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/linked.t (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running local turbo binary in .*/linked.t/node_modules/.pnpm/turbo-(darwin|linux|windows)-(64|arm64)@1.0.0/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: supports_skip_infer_and_single_package true (re)

--- a/turborepo-tests/integration/tests/find_turbo/nested.t
+++ b/turborepo-tests/integration/tests/find_turbo/nested.t
@@ -6,10 +6,10 @@ Make sure we use local and do not pass --skip-infer to old binary
   $ ${TESTDIR}/set_version.sh $(pwd) "1.0.0"
   $ ${TURBO} build --filter foo -vv
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/nested.t (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .*/nested.t/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Local turbo path: .*/nested.t/node_modules/turbo/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Local turbo version: 1.0.0 (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/nested.t (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running local turbo binary in .*/nested.t/node_modules/turbo/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: supports_skip_infer_and_single_package false (re)
@@ -19,10 +19,10 @@ Make sure we use local and pass --skip-infer to newer binary
   $ ${TESTDIR}/set_version.sh $(pwd) "1.8.0"
   $ ${TURBO} build --filter foo -vv
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/nested.t (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .*/nested.t/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Local turbo path: .*/nested.t/node_modules/turbo/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Local turbo version: 1.8.0 (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/nested.t (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running local turbo binary in .*/nested.t/node_modules/turbo/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: supports_skip_infer_and_single_package true (re)

--- a/turborepo-tests/integration/tests/find_turbo/unplugged.t
+++ b/turborepo-tests/integration/tests/find_turbo/unplugged.t
@@ -6,11 +6,11 @@ Make sure we use local and do not pass --skip-infer to old binary
   $ ${TESTDIR}/set_version.sh $(pwd) "1.0.0"
   $ ${TURBO} build --filter foo -vv
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/unplugged.t (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .*/unplugged.t/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .*/unplugged.t/node_modules/turbo/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Local turbo path: .*/unplugged.t/.yarn/unplugged/turbo-(darwin|linux|windows)-(64|arm64)-npm-1.0.0-520925a700/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Local turbo version: 1.0.0 (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/unplugged.t (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running local turbo binary in .*/unplugged.t/.yarn/unplugged/turbo-(darwin|linux|windows)-(64|arm64)-npm-1.0.0-520925a700/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: supports_skip_infer_and_single_package false (re)
@@ -20,11 +20,11 @@ Make sure we use local and pass --skip-infer to newer binary
   $ ${TESTDIR}/set_version.sh $(pwd) "1.8.0"
   $ ${TURBO} build --filter foo -vv
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/unplugged.t (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .*/unplugged.t/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .*/unplugged.t/node_modules/turbo/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Local turbo path: .*/unplugged.t/.yarn/unplugged/turbo-(darwin|linux|windows)-(64|arm64)-npm-1.0.0-520925a700/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Local turbo version: 1.8.0 (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/unplugged.t (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running local turbo binary in .*/unplugged.t/.yarn/unplugged/turbo-(darwin|linux|windows)-(64|arm64)-npm-1.0.0-520925a700/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: supports_skip_infer_and_single_package true (re)

--- a/turborepo-tests/integration/tests/find_turbo/unplugged_env_moved.t
+++ b/turborepo-tests/integration/tests/find_turbo/unplugged_env_moved.t
@@ -7,11 +7,11 @@ Make sure we use local and do not pass --skip-infer to old binary
   $ set -o allexport; source .env; set +o allexport;
   $ ${TURBO} build --filter foo -vv
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/unplugged_env_moved.t (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .*/unplugged_env_moved.t/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .*/unplugged_env_moved.t/node_modules/turbo/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Local turbo path: .*/unplugged_env_moved.t/.moved/unplugged/turbo-(darwin|linux|windows)-(64|arm64)-npm-1.0.0-520925a700/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Local turbo version: 1.0.0 (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/unplugged_env_moved.t (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running local turbo binary in .*/unplugged_env_moved.t/.moved/unplugged/turbo-(darwin|linux|windows)-(64|arm64)-npm-1.0.0-520925a700/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: supports_skip_infer_and_single_package false (re)
@@ -22,11 +22,11 @@ Make sure we use local and pass --skip-infer to newer binary
   $ set -o allexport; source .env; set +o allexport;
   $ ${TURBO} build --filter foo -vv
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/unplugged_env_moved.t (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .*/unplugged_env_moved.t/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .*/unplugged_env_moved.t/node_modules/turbo/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Local turbo path: .*/unplugged_env_moved.t/.moved/unplugged/turbo-(darwin|linux|windows)-(64|arm64)-npm-1.0.0-520925a700/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Local turbo version: 1.8.0 (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/unplugged_env_moved.t (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running local turbo binary in .*/unplugged_env_moved.t/.moved/unplugged/turbo-(darwin|linux|windows)-(64|arm64)-npm-1.0.0-520925a700/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: supports_skip_infer_and_single_package true (re)

--- a/turborepo-tests/integration/tests/find_turbo/unplugged_moved.t
+++ b/turborepo-tests/integration/tests/find_turbo/unplugged_moved.t
@@ -6,11 +6,11 @@ Make sure we use local and do not pass --skip-infer to old binary
   $ ${TESTDIR}/set_version.sh $(pwd) "1.0.0"
   $ ${TURBO} build --filter foo -vv
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/unplugged_moved.t (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .*/unplugged_moved.t/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .*/unplugged_moved.t/node_modules/turbo/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Local turbo path: .*/unplugged_moved.t/.moved/unplugged/turbo-(darwin|linux|windows)-(64|arm64)-npm-1.0.0-520925a700/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Local turbo version: 1.0.0 (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/unplugged_moved.t (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running local turbo binary in .*/unplugged_moved.t/.moved/unplugged/turbo-(darwin|linux|windows)-(64|arm64)-npm-1.0.0-520925a700/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: supports_skip_infer_and_single_package false (re)
@@ -20,11 +20,11 @@ Make sure we use local and pass --skip-infer to newer binary
   $ ${TESTDIR}/set_version.sh $(pwd) "1.8.0"
   $ ${TURBO} build --filter foo -vv
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/unplugged_moved.t (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .*/unplugged_moved.t/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .*/unplugged_moved.t/node_modules/turbo/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Local turbo path: .*/unplugged_moved.t/.moved/unplugged/turbo-(darwin|linux|windows)-(64|arm64)-npm-1.0.0-520925a700/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Local turbo version: 1.8.0 (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/unplugged_moved.t (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running local turbo binary in .*/unplugged_moved.t/.moved/unplugged/turbo-(darwin|linux|windows)-(64|arm64)-npm-1.0.0-520925a700/node_modules/turbo-(darwin|linux|windows)-(64|arm64)/bin/turbo (re)
   
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: supports_skip_infer_and_single_package true (re)

--- a/turborepo-tests/integration/tests/inference/has_workspaces.t
+++ b/turborepo-tests/integration/tests/inference/has_workspaces.t
@@ -4,9 +4,9 @@ Setup
 
   $ cd $TARGET_DIR && ${TURBO} run build --filter=nothing -vv
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/has_workspaces\.t (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running command as global turbo (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::cli: pkg_inference_root set to "" (re)
   [-0-9:.TWZ+]+ \[DEBUG] turbo: Found go binary at "[\-\w\/]+" (re)
@@ -27,9 +27,9 @@ Setup
   
   $ cd $TARGET_DIR/apps/web && ${TURBO} run build --filter=nothing -vv
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/has_workspaces\.t (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running command as global turbo (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::cli: pkg_inference_root set to "apps/web" (re)
   [-0-9:.TWZ+]+ \[DEBUG] turbo: Found go binary at "[\-\w\/]+" (re)
@@ -51,9 +51,9 @@ Setup
   
   $ cd $TARGET_DIR/crates && ${TURBO} run build --filter=nothing -vv
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/has_workspaces\.t (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running command as global turbo (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::cli: pkg_inference_root set to "crates" (re)
   [-0-9:.TWZ+]+ \[DEBUG] turbo: Found go binary at "[\-\w\/]+" (re)
@@ -75,9 +75,9 @@ Setup
   
   $ cd $TARGET_DIR/crates/super-crate/tests/test-package && ${TURBO} run build --filter=nothing -vv
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/has_workspaces\.t (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running command as global turbo (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::cli: pkg_inference_root set to "crates/super-crate/tests/test-package" (re)
   [-0-9:.TWZ+]+ \[DEBUG] turbo: Found go binary at "[\-\w\/]+" (re)
@@ -99,9 +99,9 @@ Setup
   
   $ cd $TARGET_DIR/packages/ui-library/src && ${TURBO} run build --filter=nothing -vv
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/has_workspaces\.t (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running command as global turbo (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::cli: pkg_inference_root set to "packages/ui-library/src" (re)
   [-0-9:.TWZ+]+ \[DEBUG] turbo: Found go binary at "[\-\w\/]+" (re)

--- a/turborepo-tests/integration/tests/inference/nested_workspaces.t
+++ b/turborepo-tests/integration/tests/inference/nested_workspaces.t
@@ -4,9 +4,9 @@ Setup
 
   $ cd $TARGET_DIR/outer && ${TURBO} run build --filter=nothing -vv
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/nested_workspaces/outer (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running command as global turbo (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::cli: pkg_inference_root set to "" (re)
   [-0-9:.TWZ+]+ \[DEBUG] turbo: Found go binary at "[\-\w\/]+" (re)
@@ -27,9 +27,9 @@ Setup
   
   $ cd $TARGET_DIR/outer/apps && ${TURBO} run build --filter=nothing -vv
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/nested_workspaces/outer (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running command as global turbo (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::cli: pkg_inference_root set to "apps" (re)
   [-0-9:.TWZ+]+ \[DEBUG] turbo: Found go binary at "[\-\w\/]+" (re)
@@ -51,9 +51,9 @@ Setup
   
   $ cd $TARGET_DIR/outer/inner && ${TURBO} run build --filter=nothing -vv
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/nested_workspaces/outer/inner (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running command as global turbo (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::cli: pkg_inference_root set to "" (re)
   [-0-9:.TWZ+]+ \[DEBUG] turbo: Found go binary at "[\-\w\/]+" (re)
@@ -74,9 +74,9 @@ Setup
   
   $ cd $TARGET_DIR/outer/inner/apps && ${TURBO} run build --filter=nothing -vv
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/nested_workspaces/outer/inner (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running command as global turbo (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::cli: pkg_inference_root set to "apps" (re)
   [-0-9:.TWZ+]+ \[DEBUG] turbo: Found go binary at "[\-\w\/]+" (re)
@@ -98,9 +98,9 @@ Setup
   
   $ cd $TARGET_DIR/outer/inner-no-turbo && ${TURBO} run build --filter=nothing -vv
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/nested_workspaces/outer (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running command as global turbo (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::cli: pkg_inference_root set to "inner-no-turbo" (re)
   [-0-9:.TWZ+]+ \[DEBUG] turbo: Found go binary at "[\-\w\/]+" (re)
@@ -122,9 +122,9 @@ Setup
   
   $ cd $TARGET_DIR/outer/inner-no-turbo/apps && ${TURBO} run build --filter=nothing -vv
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/nested_workspaces/outer (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running command as global turbo (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::cli: pkg_inference_root set to "inner-no-turbo/apps" (re)
   [-0-9:.TWZ+]+ \[DEBUG] turbo: Found go binary at "[\-\w\/]+" (re)
@@ -146,9 +146,9 @@ Setup
   
   $ cd $TARGET_DIR/outer-no-turbo && ${TURBO} run build --filter=nothing -vv
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/nested_workspaces/outer-no-turbo (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running command as global turbo (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::cli: pkg_inference_root set to "" (re)
   [-0-9:.TWZ+]+ \[DEBUG] turbo: Found go binary at "[\-\w\/]+" (re)
@@ -161,9 +161,9 @@ Setup
 
   $ cd $TARGET_DIR/outer-no-turbo/apps && ${TURBO} run build --filter=nothing -vv
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/nested_workspaces/outer-no-turbo (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running command as global turbo (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::cli: pkg_inference_root set to "apps" (re)
   [-0-9:.TWZ+]+ \[DEBUG] turbo: Found go binary at "[\-\w\/]+" (re)
@@ -176,9 +176,9 @@ Setup
 
   $ cd $TARGET_DIR/outer-no-turbo/inner && ${TURBO} run build --filter=nothing -vv
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/nested_workspaces/outer-no-turbo/inner (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running command as global turbo (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::cli: pkg_inference_root set to "" (re)
   [-0-9:.TWZ+]+ \[DEBUG] turbo: Found go binary at "[\-\w\/]+" (re)
@@ -199,9 +199,9 @@ Setup
   
   $ cd $TARGET_DIR/outer-no-turbo/inner/apps && ${TURBO} run build --filter=nothing -vv
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/nested_workspaces/outer-no-turbo/inner (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running command as global turbo (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::cli: pkg_inference_root set to "apps" (re)
   [-0-9:.TWZ+]+ \[DEBUG] turbo: Found go binary at "[\-\w\/]+" (re)
@@ -223,9 +223,9 @@ Setup
   
   $ cd $TARGET_DIR/outer-no-turbo/inner-no-turbo && ${TURBO} run build --filter=nothing -vv
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/nested_workspaces/outer-no-turbo/inner-no-turbo (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running command as global turbo (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::cli: pkg_inference_root set to "" (re)
   [-0-9:.TWZ+]+ \[DEBUG] turbo: Found go binary at "[\-\w\/]+" (re)
@@ -238,9 +238,9 @@ Setup
 
   $ cd $TARGET_DIR/outer-no-turbo/inner-no-turbo/apps && ${TURBO} run build --filter=nothing -vv
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/nested_workspaces/outer-no-turbo/inner-no-turbo (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running command as global turbo (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::cli: pkg_inference_root set to "apps" (re)
   [-0-9:.TWZ+]+ \[DEBUG] turbo: Found go binary at "[\-\w\/]+" (re)

--- a/turborepo-tests/integration/tests/inference/no_workspaces.t
+++ b/turborepo-tests/integration/tests/inference/no_workspaces.t
@@ -4,9 +4,9 @@ Setup
 
   $ cd $TARGET_DIR && ${TURBO} run build --filter=nothing -vv
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/no_workspaces (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running command as global turbo (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::cli: pkg_inference_root set to "" (re)
   [-0-9:.TWZ+]+ \[DEBUG] turbo: Found go binary at "[\-\w\/]+" (re)
@@ -26,9 +26,9 @@ Setup
   
   $ cd $TARGET_DIR/parent && ${TURBO} run build --filter=nothing -vv
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/no_workspaces/parent (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running command as global turbo (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::cli: pkg_inference_root set to "" (re)
   [-0-9:.TWZ+]+ \[DEBUG] turbo: Found go binary at "[\-\w\/]+" (re)
@@ -48,9 +48,9 @@ Setup
   
   $ cd $TARGET_DIR/parent/child && ${TURBO} run build --filter=nothing -vv
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/no_workspaces/parent/child (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running command as global turbo (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::cli: pkg_inference_root set to "" (re)
   [-0-9:.TWZ+]+ \[DEBUG] turbo: Found go binary at "[\-\w\/]+" (re)

--- a/turborepo-tests/integration/tests/run-logging/verbosity.t
+++ b/turborepo-tests/integration/tests/run-logging/verbosity.t
@@ -39,9 +39,9 @@ Verbosity level 1
 Verbosity level 2
   $ ${TURBO} build -vv --filter=util --force
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .* (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running command as global turbo (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::cli: pkg_inference_root set to "" (re)
   [-0-9:.TWZ+]+ \[DEBUG] turbo: Found go binary at "[\-\w\/]+" (re)
@@ -71,9 +71,9 @@ Verbosity level 2
   
   $ ${TURBO} build --verbosity=2 --filter=util --force
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .* (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running command as global turbo (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::cli: pkg_inference_root set to "" (re)
   [-0-9:.TWZ+]+ \[DEBUG] turbo: Found go binary at "[\-\w\/]+" (re)
@@ -115,9 +115,9 @@ Make sure users can only use one verbosity flag
 TURBO_LOG_VERBOSITY should be respoected
   $ TURBO_LOG_VERBOSITY=debug ${TURBO} daemon status
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .+ (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .+ (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .+ (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .+ (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .+ (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .+ (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running command as global turbo (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::daemon::connector: looking for pid in lockfile: .+ (re)
   Turbo error: unable to connect: daemon is not running
@@ -131,9 +131,9 @@ verbosity overrides TURBO_LOG_VERBOSITY global setting
 verbosity doesn't override TURBO_LOG_VERBOSITY package settings
   $ TURBO_LOG_VERBOSITY=turborepo_lib=debug ${TURBO} daemon status -v
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .+ (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .+ (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .+ (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .+ (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .+ (re)
+  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .+ (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running command as global turbo (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::daemon::connector: looking for pid in lockfile: .+ (re)
   Turbo error: unable to connect: daemon is not running


### PR DESCRIPTION
### Description

Step 1 of several in moving inference code into its own package, separate from CLI code. 
Separates `RepoState` and `LocalTurboState`. `RepoState` does not need to own a `LocalTurboState`, and this gets `RepoState` inference closer to being independent of turbo.

### Testing Instructions

Existing test suite. Note integration test changes to verbose log output. We now identify the repository root before checking for any local `turbo` binaries


Closes TURBO-1381