### PR TITLE
chore(ci): Only run examples CI on examples changes or version bump

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,6 +68,13 @@ jobs:
             Cargo.*
             rust-toolchain
 
+      - name: Turborepo version changes
+        id: turborepo_version
+        uses: technote-space/get-diff-action@v6
+        with:
+          PATTERNS: |
+            version.txt
+
       - name: Rust related changes
         id: rust
         uses: technote-space/get-diff-action@v6
@@ -188,7 +195,7 @@ jobs:
       turborepo_build: ${{ steps.ci.outputs.diff != '' || steps.turborepo_go.outputs.diff != '' || steps.turborepo_rust.outputs.diff != '' }}
       turborepo_e2e: ${{ steps.ci.outputs.diff != '' || steps.turborepo_go.outputs.diff != '' || steps.turborepo_rust.outputs.diff != ''  || steps.turborepo_e2e.outputs.diff != '' }}
       go_integration: ${{ steps.ci.outputs.diff != '' || steps.turborepo_go.outputs.diff != '' || steps.turborepo_rust.outputs.diff != ''  || steps.turborepo_integration.outputs.diff != '' }}
-      examples: ${{ steps.ci.outputs.diff != '' || steps.turborepo_go.outputs.diff != '' || steps.turborepo_rust.outputs.diff != '' || steps.examples.outputs.diff != '' }}
+      examples: ${{ steps.ci.outputs.diff != '' || steps.examples.outputs.diff != '' || steps.turborepo_version.outputs.diff != '' }}
       turborepo_js: ${{ steps.ci.outputs.diff != '' || steps.turborepo_js.outputs.diff != '' }}
       format: ${{ steps.ci.outputs.diff != '' || steps.format.outputs.diff != '' }}
       push: ${{ steps.ci.outputs.diff != '' || github.event_name == 'push' }}


### PR DESCRIPTION


### Description

We currently run examples on all code changes, which is not necessary since examples run on the released turbo, not the current code. This PR changes the CI to only run when the examples code is changed, when CI changes, or when a new version of turborepo is released.

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->


Closes TURBO-1396