### PR TITLE
Update turbopack daily tests env

### DIFF
--- a/.github/workflows/nextjs-integration-test.yml
+++ b/.github/workflows/nextjs-integration-test.yml
@@ -83,7 +83,7 @@ jobs:
         run: |
           ls $NEXT_TEST_SKIP_RETRY_MANIFEST
           sudo npx playwright install-deps && pnpm playwright install
-          NEXT_TEST_MODE=dev node run-tests.js -g ${{ matrix.group }}/3 -c ${TEST_CONCURRENCY} --type development
+          NEXT_TEST_MODE=dev TURBOPACK=1 node run-tests.js -g ${{ matrix.group }}/3 -c ${TEST_CONCURRENCY} --type development
           ls test/turbopack-test-junit-report
         # It is currently expected to fail some of next.js integration test, do not fail CI check.
         continue-on-error: true
@@ -124,7 +124,7 @@ jobs:
       - name: Run test/integration
         run: |
           sudo npx playwright install-deps && pnpm playwright install
-          node run-tests.js -g ${{ matrix.group }}/12 -c ${TEST_CONCURRENCY} --type integration
+          TURBOPACK=1 node run-tests.js -g ${{ matrix.group }}/12 -c ${TEST_CONCURRENCY} --type integration
           ls test/turbopack-test-junit-report
         continue-on-error: true
         env:


### PR DESCRIPTION
### Description

Ensures the TURBOPACK env is always explicitly set before running tests

x-ref: [slack thread](https://vercel.slack.com/archives/C04KC8A53T7/p1696278216418089)

### Testing Instructions

Test run verifying this fix can be seen here https://github.com/vercel/turbo/actions/runs/6386995577/job/17334817140
