### PR TITLE
fix(turborepo): Process single-package independently.

### DIFF
--- a/crates/turborepo-lib/src/cli.rs
+++ b/crates/turborepo-lib/src/cli.rs
@@ -205,13 +205,11 @@ impl Args {
     pub fn new() -> Result<Self> {
         // We always pass --single-package in from the shim.
         // We need to omit it, and then add it in for run.
-        let arg_separator_position = std::env::args_os()
-            .find_position(|input_token| input_token == "--")
-            .map(|(index, _)| index);
+        let arg_separator_position =
+            std::env::args_os().position(|input_token| input_token == "--");
 
-        let single_package_position = std::env::args_os()
-            .find_position(|input_token| input_token == "--single-package")
-            .map(|(index, _)| index);
+        let single_package_position =
+            std::env::args_os().position(|input_token| input_token == "--single-package");
 
         let is_single_package = match (arg_separator_position, single_package_position) {
             (_, None) => false,


### PR DESCRIPTION
#6021 Removed the global `--single-package` flag, which was _backwards_-compatible. But for forward-compatibility we need to make sure that we don't try to parse it as an argument unless we're in `run`.

Closes TURBO-1401