### PR TITLE
fix: don't execute tasks when calculating task hashes

### DIFF
--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -487,7 +487,8 @@ impl<'a> Run<'a> {
             true,
             self.processes.clone(),
             &self.base.repo_root,
-        );
+        )
+        .dry_run();
 
         visitor.visit(engine.clone()).await?;
         let task_hash_tracker = visitor.into_task_hash_tracker();

--- a/crates/turborepo-lib/src/task_graph/visitor.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor.rs
@@ -42,6 +42,7 @@ pub struct Visitor<'a> {
     ui: UI,
     manager: ProcessManager,
     repo_root: &'a AbsoluteSystemPath,
+    dry: bool,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -101,6 +102,7 @@ impl<'a> Visitor<'a> {
             ui,
             manager,
             repo_root,
+            dry: false,
         }
     }
 
@@ -180,6 +182,10 @@ impl<'a> Visitor<'a> {
             )?;
 
             debug!("task {} hash is {}", info, task_hash);
+            if self.dry {
+                callback.send(Ok(())).ok();
+                continue;
+            }
 
             let task_cache =
                 self.run_cache
@@ -386,6 +392,11 @@ impl<'a> Visitor<'a> {
 
     pub fn into_task_hash_tracker(self) -> TaskHashTrackerState {
         self.task_hasher.into_task_hash_tracker_state()
+    }
+
+    pub fn dry_run(mut self) -> Self {
+        self.dry = true;
+        self
     }
 }
 


### PR DESCRIPTION
### Description

Issues with spawning tasks were causing task hashes to diverge. This is an issue that should be addressed, but it should not effect the task hashing comparison.

Furthermore, we don't want to be executing the tasks twice once in Go and once in Rust.

### Testing Instructions

`pnpm test` in the e2e directory


Closes TURBO-1415