### PR TITLE
fix(turbo-ignore): Quote the filter argument.

### DIFF
--- a/packages/turbo-ignore/__tests__/ignore.test.ts
+++ b/packages/turbo-ignore/__tests__/ignore.test.ts
@@ -42,7 +42,7 @@ describe("turboIgnore()", () => {
     turboIgnore("test-workspace", {});
 
     expect(mockExec).toHaveBeenCalledWith(
-      "npx turbo run build --filter=test-workspace...[HEAD^] --dry=json",
+      `npx turbo run build --filter="test-workspace...[HEAD^]" --dry=json`,
       expect.anything(),
       expect.anything()
     );
@@ -75,7 +75,7 @@ describe("turboIgnore()", () => {
     turboIgnore("test-workspace", {});
 
     expect(mockExec).toHaveBeenCalledWith(
-      "npx turbo run build --filter=test-workspace...[HEAD^] --dry=json",
+      `npx turbo run build --filter="test-workspace...[HEAD^]" --dry=json`,
       expect.anything(),
       expect.anything()
     );
@@ -120,7 +120,7 @@ describe("turboIgnore()", () => {
     turboIgnore("test-workspace", {});
 
     expect(mockExec).toHaveBeenCalledWith(
-      "npx turbo run build --filter=test-workspace...[too-far-back] --dry=json",
+      `npx turbo run build --filter="test-workspace...[too-far-back]" --dry=json`,
       expect.anything(),
       expect.anything()
     );
@@ -158,7 +158,7 @@ describe("turboIgnore()", () => {
     turboIgnore("test-workspace", { fallback: "HEAD^" });
 
     expect(mockExec).toHaveBeenCalledWith(
-      "npx turbo run build --filter=test-workspace...[HEAD^] --dry=json",
+      `npx turbo run build --filter="test-workspace...[HEAD^]" --dry=json`,
       expect.anything(),
       expect.anything()
     );
@@ -268,7 +268,7 @@ describe("turboIgnore()", () => {
         'Inferred "test-app" as workspace from "package.json"',
         'Using "build" as the task as it was unspecified',
         `Found previous deployment ("last-deployed-sha") for "test-app" on branch "my-branch"`,
-        "Analyzing results of `npx turbo run build --filter=test-app...[last-deployed-sha] --dry=json`",
+        'Analyzing results of `npx turbo run build --filter="test-app...[last-deployed-sha]" --dry=json`',
         "This project and its dependencies are not affected",
         () => expect.stringContaining("⏭ Ignoring the change"),
       ],
@@ -312,7 +312,7 @@ describe("turboIgnore()", () => {
         'Inferred "test-app" as workspace from "package.json"',
         'Using "workspace#build" as the task from the arguments',
         'Found previous deployment ("last-deployed-sha") for "test-app" on branch "my-branch"',
-        'Analyzing results of `npx turbo run "workspace#build" --filter=test-app...[last-deployed-sha] --dry=json`',
+        'Analyzing results of `npx turbo run "workspace#build" --filter="test-app...[last-deployed-sha]" --dry=json`',
         'This commit affects "test-app"',
         () => expect.stringContaining("✓ Proceeding with deployment"),
       ],
@@ -353,7 +353,7 @@ describe("turboIgnore()", () => {
         'Inferred "test-app" as workspace from "package.json"',
         'Using "build" as the task as it was unspecified',
         'Found previous deployment ("last-deployed-sha") for "test-app" on branch "my-branch"',
-        "Analyzing results of `npx turbo run build --filter=test-app...[last-deployed-sha] --dry=json`",
+        'Analyzing results of `npx turbo run build --filter="test-app...[last-deployed-sha]" --dry=json`',
         'This commit affects "test-app" and 1 dependency (ui)',
         () => expect.stringContaining("✓ Proceeding with deployment"),
       ],
@@ -394,7 +394,7 @@ describe("turboIgnore()", () => {
         'Inferred "test-app" as workspace from "package.json"',
         'Using "build" as the task as it was unspecified',
         'Found previous deployment ("last-deployed-sha") for "test-app" on branch "my-branch"',
-        "Analyzing results of `npx turbo run build --filter=test-app...[last-deployed-sha] --dry=json`",
+        'Analyzing results of `npx turbo run build --filter="test-app...[last-deployed-sha]" --dry=json`',
         'This commit affects "test-app" and 2 dependencies (ui, tsconfig)',
         () => expect.stringContaining("✓ Proceeding with deployment"),
       ],
@@ -445,7 +445,7 @@ describe("turboIgnore()", () => {
         'Using "workspace#build" as the task from the arguments',
         'Previous deployment ("last-deployed-sha") for "test-app" on branch "my-branch" is unreachable.',
         "Falling back to ref HEAD^2",
-        'Analyzing results of `npx turbo run "workspace#build" --filter=test-app...[HEAD^2] --dry=json`',
+        'Analyzing results of `npx turbo run "workspace#build" --filter="test-app...[HEAD^2]" --dry=json`',
         'This commit affects "test-app"',
         () => expect.stringContaining("✓ Proceeding with deployment"),
       ],
@@ -471,13 +471,13 @@ describe("turboIgnore()", () => {
     turboIgnore(undefined, { directory: "__fixtures__/app" });
 
     expect(mockExec).toHaveBeenCalledWith(
-      "npx turbo run build --filter=test-app...[HEAD^] --dry=json",
+      `npx turbo run build --filter="test-app...[HEAD^]" --dry=json`,
       expect.anything(),
       expect.anything()
     );
     validateLogs(
       [
-        "Failed to parse JSON output from `npx turbo run build --filter=test-app...[HEAD^] --dry=json`.",
+        'Failed to parse JSON output from `npx turbo run build --filter="test-app...[HEAD^]" --dry=json`.',
       ],
       mockConsole.error,
       { prefix: "≫  " }
@@ -504,13 +504,13 @@ describe("turboIgnore()", () => {
     turboIgnore(undefined, { directory: "__fixtures__/app" });
 
     expect(mockExec).toHaveBeenCalledWith(
-      "npx turbo run build --filter=test-app...[HEAD^] --dry=json",
+      `npx turbo run build --filter="test-app...[HEAD^]" --dry=json`,
       expect.anything(),
       expect.anything()
     );
     validateLogs(
       [
-        "Failed to parse JSON output from `npx turbo run build --filter=test-app...[HEAD^] --dry=json`.",
+        'Failed to parse JSON output from `npx turbo run build --filter="test-app...[HEAD^]" --dry=json`.',
       ],
       mockConsole.error,
       { prefix: "≫  " }
@@ -594,7 +594,7 @@ describe("turboIgnore()", () => {
         'Using "build" as the task as it was unspecified',
         "Conflicting commit messages found: [vercel deploy] and [vercel skip]",
         `Found previous deployment ("last-deployed-sha") for "test-app" on branch "my-branch"`,
-        "Analyzing results of `npx turbo run build --filter=test-app...[last-deployed-sha] --dry=json`",
+        'Analyzing results of `npx turbo run build --filter="test-app...[last-deployed-sha]" --dry=json`',
         "This project and its dependencies are not affected",
         () => expect.stringContaining("⏭ Ignoring the change"),
       ],
@@ -624,7 +624,7 @@ describe("turboIgnore()", () => {
     turboIgnore(undefined, { directory: "__fixtures__/app", maxBuffer: 1024 });
 
     expect(mockExec).toHaveBeenCalledWith(
-      "npx turbo run build --filter=test-app...[HEAD^] --dry=json",
+      `npx turbo run build --filter="test-app...[HEAD^]" --dry=json`,
       expect.objectContaining({ maxBuffer: 1024 }),
       expect.anything()
     );

--- a/packages/turbo-ignore/src/ignore.ts
+++ b/packages/turbo-ignore/src/ignore.ts
@@ -93,7 +93,7 @@ export function turboIgnore(
   }
 
   // Build, and execute the command
-  const command = `npx turbo run ${task} --filter=${workspace}...[${comparison.ref}] --dry=json`;
+  const command = `npx turbo run ${task} --filter="${workspace}...[${comparison.ref}]" --dry=json`;
   info(`Analyzing results of \`${command}\``);
 
   const execOptions: { cwd: string; maxBuffer?: number } = {


### PR DESCRIPTION
It's possible that the filter argument that is being passed into `child_process.exec` can be interpreted differently in some shells. This quotes the argument to reduce the chances of that occurring.

Possibly fixes #6058.

Closes TURBO-1418