### PR TITLE
Chunking Refactor Step 1

### DIFF
--- a/crates/turbopack-build/src/chunking_context.rs
+++ b/crates/turbopack-build/src/chunking_context.rs
@@ -8,7 +8,7 @@ use turbo_tasks::{
 };
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
-    chunk::{Chunk, ChunkableModule, ChunkingContext, Chunks, EvaluatableAssets},
+    chunk::{Chunk, ChunkableModuleExt, ChunkingContext, Chunks, EvaluatableAssets},
     environment::Environment,
     ident::AssetIdent,
     module::Module,

--- a/crates/turbopack-build/src/ecmascript/node/content.rs
+++ b/crates/turbopack-build/src/ecmascript/node/content.rs
@@ -6,6 +6,7 @@ use turbo_tasks::{TryJoinIterExt, Value, Vc};
 use turbo_tasks_fs::File;
 use turbopack_core::{
     asset::AssetContent,
+    chunk::ChunkItemExt,
     code_builder::{Code, CodeBuilder},
     output::OutputAsset,
     source_map::{GenerateSourceMap, OptionSourceMap},

--- a/crates/turbopack-build/src/ecmascript/node/entry/chunk.rs
+++ b/crates/turbopack-build/src/ecmascript/node/entry/chunk.rs
@@ -6,16 +6,13 @@ use turbo_tasks::{ValueToString, Vc};
 use turbo_tasks_fs::{File, FileSystemPath};
 use turbopack_core::{
     asset::{Asset, AssetContent},
-    chunk::{ChunkingContext, EvaluatableAssets},
+    chunk::{ChunkItemExt, ChunkableModule, ChunkingContext, EvaluatableAssets},
     code_builder::{Code, CodeBuilder},
     ident::AssetIdent,
     output::{OutputAsset, OutputAssets},
     source_map::{GenerateSourceMap, OptionSourceMap, SourceMapAsset},
 };
-use turbopack_ecmascript::{
-    chunk::{EcmascriptChunkItemExt, EcmascriptChunkPlaceable},
-    utils::StringifyJs,
-};
+use turbopack_ecmascript::{chunk::EcmascriptChunkPlaceable, utils::StringifyJs};
 
 use super::runtime::EcmascriptBuildNodeRuntimeChunk;
 use crate::BuildChunkingContext;

--- a/crates/turbopack-cli/src/build/mod.rs
+++ b/crates/turbopack-cli/src/build/mod.rs
@@ -14,7 +14,7 @@ use turbopack_build::{BuildChunkingContext, MinifyType};
 use turbopack_cli_utils::issue::{ConsoleUi, LogOptions};
 use turbopack_core::{
     asset::Asset,
-    chunk::{ChunkableModule, ChunkingContext, EvaluatableAssets},
+    chunk::{ChunkableModule, ChunkableModuleExt, ChunkingContext, EvaluatableAssets},
     environment::{BrowserEnvironment, Environment, ExecutionEnvironment},
     issue::{handle_issues, IssueReporter, IssueSeverity},
     module::Module,

--- a/crates/turbopack-core/src/chunk/mod.rs
+++ b/crates/turbopack-core/src/chunk/mod.rs
@@ -102,6 +102,11 @@ pub trait ChunkableModule: Module + Asset {
             }),
         )
     }
+
+    fn as_chunk_item(
+        self: Vc<Self>,
+        chunking_context: Vc<Box<dyn ChunkingContext>>,
+    ) -> Vc<Box<dyn ChunkItem>>;
 }
 
 #[turbo_tasks::value(transparent)]

--- a/crates/turbopack-css/src/asset.rs
+++ b/crates/turbopack-css/src/asset.rs
@@ -112,19 +112,6 @@ impl Asset for CssModuleAsset {
 #[turbo_tasks::value_impl]
 impl ChunkableModule for CssModuleAsset {
     #[turbo_tasks::function]
-    fn as_chunk(
-        self: Vc<Self>,
-        chunking_context: Vc<Box<dyn ChunkingContext>>,
-        availability_info: Value<AvailabilityInfo>,
-    ) -> Vc<Box<dyn Chunk>> {
-        Vc::upcast(CssChunk::new(
-            chunking_context,
-            Vc::upcast(self),
-            availability_info,
-        ))
-    }
-
-    #[turbo_tasks::function]
     fn as_chunk_item(
         self: Vc<Self>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
@@ -173,6 +160,15 @@ impl ChunkItem for CssModuleChunkItem {
     #[turbo_tasks::function]
     async fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
         Vc::upcast(self.chunking_context)
+    }
+
+    #[turbo_tasks::function]
+    fn as_chunk(&self, availability_info: Value<AvailabilityInfo>) -> Vc<Box<dyn Chunk>> {
+        Vc::upcast(CssChunk::new(
+            self.chunking_context,
+            Vc::upcast(self.module),
+            availability_info,
+        ))
     }
 }
 

--- a/crates/turbopack-css/src/asset.rs
+++ b/crates/turbopack-css/src/asset.rs
@@ -123,6 +123,14 @@ impl ChunkableModule for CssModuleAsset {
             availability_info,
         ))
     }
+
+    #[turbo_tasks::function]
+    fn as_chunk_item(
+        self: Vc<Self>,
+        chunking_context: Vc<Box<dyn ChunkingContext>>,
+    ) -> Vc<Box<dyn turbopack_core::chunk::ChunkItem>> {
+        todo!();
+    }
 }
 
 #[turbo_tasks::value_impl]
@@ -194,7 +202,7 @@ impl CssChunkItem for CssModuleChunkItem {
                     {
                         imports.push(CssImport::Internal(
                             import_ref,
-                            placeable.as_chunk_item(chunking_context),
+                            CssChunkPlaceable::as_chunk_item(placeable, chunking_context),
                         ));
                     }
                 }
@@ -210,9 +218,10 @@ impl CssChunkItem for CssModuleChunkItem {
                     if let Some(placeable) =
                         Vc::try_resolve_downcast::<Box<dyn CssChunkPlaceable>>(module).await?
                     {
-                        imports.push(CssImport::Composes(
-                            placeable.as_chunk_item(chunking_context),
-                        ));
+                        imports.push(CssImport::Composes(CssChunkPlaceable::as_chunk_item(
+                            placeable,
+                            chunking_context,
+                        )));
                     }
                 }
             }

--- a/crates/turbopack-css/src/asset.rs
+++ b/crates/turbopack-css/src/asset.rs
@@ -129,7 +129,10 @@ impl ChunkableModule for CssModuleAsset {
         self: Vc<Self>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Vc<Box<dyn turbopack_core::chunk::ChunkItem>> {
-        todo!();
+        Vc::upcast(CssModuleChunkItem::cell(CssModuleChunkItem {
+            module: self,
+            chunking_context,
+        }))
     }
 }
 

--- a/crates/turbopack-css/src/chunk/mod.rs
+++ b/crates/turbopack-css/src/chunk/mod.rs
@@ -12,7 +12,7 @@ use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{
         availability_info::AvailabilityInfo, chunk_content, chunk_content_split, Chunk,
-        ChunkContentResult, ChunkItem, ChunkableModule, ChunkingContext, Chunks,
+        ChunkContentResult, ChunkItem, ChunkItemExt, ChunkableModule, ChunkingContext, Chunks,
         FromChunkableModule, ModuleId, OutputChunk, OutputChunkRuntimeInfo,
     },
     code_builder::{Code, CodeBuilder},
@@ -142,11 +142,15 @@ impl CssChunkContent {
         let mut body = CodeBuilder::default();
         let mut external_imports = IndexSet::new();
         for entry in this.main_entries.await?.iter() {
-            let entry_item = CssChunkPlaceable::as_chunk_item(*entry, this.chunking_context);
+            let entry_item = entry.as_chunk_item(this.chunking_context);
 
-            // TODO(WEB-1261)
-            for external_import in expand_imports(&mut body, entry_item).await? {
-                external_imports.insert(external_import.await?.to_owned());
+            if let Some(css_item) =
+                Vc::try_resolve_downcast::<Box<dyn CssChunkItem>>(entry_item).await?
+            {
+                // TODO(WEB-1261)
+                for external_import in expand_imports(&mut body, css_item).await? {
+                    external_imports.insert(external_import.await?.to_owned());
+                }
             }
         }
 
@@ -323,7 +327,7 @@ impl OutputChunk for CssChunk {
             .main_entries
             .await?
             .iter()
-            .map(|&entry| CssChunkPlaceable::as_chunk_item(entry, self.chunking_context))
+            .map(|&entry| entry.as_chunk_item(self.chunking_context))
             .collect();
         let included_ids = entries_chunk_items
             .iter()
@@ -332,7 +336,12 @@ impl OutputChunk for CssChunk {
         let imports_chunk_items: Vec<_> = entries_chunk_items
             .iter()
             .map(|&chunk_item| async move {
-                Ok(chunk_item
+                let Some(css_item) =
+                    Vc::try_resolve_downcast::<Box<dyn CssChunkItem>>(chunk_item).await?
+                else {
+                    return Ok(vec![]);
+                };
+                Ok(css_item
                     .content()
                     .await?
                     .imports
@@ -492,13 +501,9 @@ impl CssChunkContext {
     }
 }
 
+// TODO: remove
 #[turbo_tasks::value_trait]
-pub trait CssChunkPlaceable: ChunkableModule + Module + Asset {
-    fn as_chunk_item(
-        self: Vc<Self>,
-        chunking_context: Vc<Box<dyn ChunkingContext>>,
-    ) -> Vc<Box<dyn CssChunkItem>>;
-}
+pub trait CssChunkPlaceable: ChunkableModule + Module + Asset {}
 
 #[turbo_tasks::value(transparent)]
 pub struct CssChunkPlaceables(Vec<Vc<Box<dyn CssChunkPlaceable>>>);
@@ -523,7 +528,7 @@ pub trait CssChunkItem: ChunkItem {
     fn content(self: Vc<Self>) -> Vc<CssChunkItemContent>;
     fn chunking_context(self: Vc<Self>) -> Vc<Box<dyn ChunkingContext>>;
     fn id(self: Vc<Self>) -> Vc<ModuleId> {
-        CssChunkContext::of(self.chunking_context()).chunk_item_id(self)
+        CssChunkContext::of(CssChunkItem::chunking_context(self)).chunk_item_id(self)
     }
 }
 
@@ -536,10 +541,10 @@ impl FromChunkableModule for Box<dyn CssChunkItem> {
         if let Some(placeable) =
             Vc::try_resolve_downcast::<Box<dyn CssChunkPlaceable>>(asset).await?
         {
-            return Ok(Some(CssChunkPlaceable::as_chunk_item(
-                placeable,
-                chunking_context,
-            )));
+            let item = placeable.as_chunk_item(chunking_context);
+            if let Some(css_item) = Vc::try_resolve_downcast::<Box<dyn CssChunkItem>>(item).await? {
+                return Ok(Some(css_item));
+            }
         }
         Ok(None)
     }

--- a/crates/turbopack-css/src/chunk/mod.rs
+++ b/crates/turbopack-css/src/chunk/mod.rs
@@ -142,7 +142,7 @@ impl CssChunkContent {
         let mut body = CodeBuilder::default();
         let mut external_imports = IndexSet::new();
         for entry in this.main_entries.await?.iter() {
-            let entry_item = entry.as_chunk_item(this.chunking_context);
+            let entry_item = CssChunkPlaceable::as_chunk_item(*entry, this.chunking_context);
 
             // TODO(WEB-1261)
             for external_import in expand_imports(&mut body, entry_item).await? {
@@ -323,7 +323,7 @@ impl OutputChunk for CssChunk {
             .main_entries
             .await?
             .iter()
-            .map(|&entry| entry.as_chunk_item(self.chunking_context))
+            .map(|&entry| CssChunkPlaceable::as_chunk_item(entry, self.chunking_context))
             .collect();
         let included_ids = entries_chunk_items
             .iter()
@@ -536,7 +536,10 @@ impl FromChunkableModule for Box<dyn CssChunkItem> {
         if let Some(placeable) =
             Vc::try_resolve_downcast::<Box<dyn CssChunkPlaceable>>(asset).await?
         {
-            return Ok(Some(placeable.as_chunk_item(chunking_context)));
+            return Ok(Some(CssChunkPlaceable::as_chunk_item(
+                placeable,
+                chunking_context,
+            )));
         }
         Ok(None)
     }

--- a/crates/turbopack-css/src/module_asset.rs
+++ b/crates/turbopack-css/src/module_asset.rs
@@ -222,6 +222,14 @@ impl ChunkableModule for ModuleCssAsset {
             availability_info,
         ))
     }
+
+    #[turbo_tasks::function]
+    fn as_chunk_item(
+        self: Vc<Self>,
+        chunking_context: Vc<Box<dyn ChunkingContext>>,
+    ) -> Vc<Box<dyn turbopack_core::chunk::ChunkItem>> {
+        todo!();
+    }
 }
 
 #[turbo_tasks::value_impl]
@@ -338,7 +346,12 @@ impl EcmascriptChunkItem for ModuleChunkItem {
                         let placeable: Vc<Box<dyn EcmascriptChunkPlaceable>> =
                             Vc::upcast(css_module);
 
-                        let module_id = placeable.as_chunk_item(self.chunking_context).id().await?;
+                        let module_id = EcmascriptChunkPlaceable::as_chunk_item(
+                            placeable,
+                            self.chunking_context,
+                        )
+                        .id()
+                        .await?;
                         let module_id = StringifyJs(&*module_id);
                         let original_name = StringifyJs(&original_name);
                         exported_class_names.push(format! {

--- a/crates/turbopack-css/src/module_asset.rs
+++ b/crates/turbopack-css/src/module_asset.rs
@@ -212,19 +212,6 @@ impl ModuleCssAsset {
 #[turbo_tasks::value_impl]
 impl ChunkableModule for ModuleCssAsset {
     #[turbo_tasks::function]
-    fn as_chunk(
-        self: Vc<Self>,
-        chunking_context: Vc<Box<dyn ChunkingContext>>,
-        availability_info: Value<AvailabilityInfo>,
-    ) -> Vc<Box<dyn Chunk>> {
-        Vc::upcast(EcmascriptChunk::new(
-            chunking_context,
-            Vc::upcast(self),
-            availability_info,
-        ))
-    }
-
-    #[turbo_tasks::function]
     async fn as_chunk_item(
         self: Vc<Self>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
@@ -287,6 +274,15 @@ impl ChunkItem for ModuleChunkItem {
     #[turbo_tasks::function]
     async fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
         Vc::upcast(self.chunking_context)
+    }
+
+    #[turbo_tasks::function]
+    fn as_chunk(&self, availability_info: Value<AvailabilityInfo>) -> Vc<Box<dyn Chunk>> {
+        Vc::upcast(EcmascriptChunk::new(
+            Vc::upcast(self.chunking_context),
+            Vc::upcast(self.module),
+            availability_info,
+        ))
     }
 }
 

--- a/crates/turbopack-css/src/module_asset.rs
+++ b/crates/turbopack-css/src/module_asset.rs
@@ -230,7 +230,7 @@ impl ChunkableModule for ModuleCssAsset {
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<Box<dyn turbopack_core::chunk::ChunkItem>>> {
         let chunking_context =
-            Vc::try_resolve_sidecast::<Box<dyn EcmascriptChunkingContext>>(chunking_context)
+            Vc::try_resolve_downcast::<Box<dyn EcmascriptChunkingContext>>(chunking_context)
                 .await?
                 .context(
                     "chunking context must impl EcmascriptChunkingContext to use ModuleCssAsset",

--- a/crates/turbopack-dev-server/src/html.rs
+++ b/crates/turbopack-dev-server/src/html.rs
@@ -5,7 +5,7 @@ use turbo_tasks_fs::{File, FileSystemPath};
 use turbo_tasks_hash::{encode_hex, Xxh3Hash64Hasher};
 use turbopack_core::{
     asset::{Asset, AssetContent},
-    chunk::{ChunkableModule, ChunkingContext, EvaluatableAssets},
+    chunk::{ChunkableModule, ChunkableModuleExt, ChunkingContext, EvaluatableAssets},
     ident::AssetIdent,
     output::{OutputAsset, OutputAssets},
     version::{Version, VersionedContent},

--- a/crates/turbopack-dev/src/chunking_context.rs
+++ b/crates/turbopack-dev/src/chunking_context.rs
@@ -6,7 +6,7 @@ use turbo_tasks::{
 };
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
-    chunk::{Chunk, ChunkableModule, ChunkingContext, Chunks, EvaluatableAssets},
+    chunk::{Chunk, ChunkableModuleExt, ChunkingContext, Chunks, EvaluatableAssets},
     environment::Environment,
     ident::AssetIdent,
     module::Module,

--- a/crates/turbopack-dev/src/ecmascript/content_entry.rs
+++ b/crates/turbopack-dev/src/ecmascript/content_entry.rs
@@ -5,7 +5,7 @@ use indexmap::IndexMap;
 use tracing::{info_span, Instrument};
 use turbo_tasks::{ReadRef, TryJoinIterExt, Value, ValueToString, Vc};
 use turbopack_core::{
-    chunk::{availability_info::AvailabilityInfo, ChunkItem, ModuleId},
+    chunk::{availability_info::AvailabilityInfo, ChunkItem, ChunkItemExt, ModuleId},
     code_builder::{Code, CodeBuilder},
     error::PrettyPrintError,
     issue::{code_gen::CodeGenerationIssue, IssueExt, IssueSeverity},

--- a/crates/turbopack-dev/src/ecmascript/evaluate/chunk.rs
+++ b/crates/turbopack-dev/src/ecmascript/evaluate/chunk.rs
@@ -7,7 +7,10 @@ use turbo_tasks::{ReadRef, TryJoinIterExt, Value, ValueToString, Vc};
 use turbo_tasks_fs::File;
 use turbopack_core::{
     asset::{Asset, AssetContent},
-    chunk::{Chunk, ChunkData, ChunkingContext, ChunksData, EvaluatableAssets, ModuleId},
+    chunk::{
+        Chunk, ChunkData, ChunkItemExt, ChunkableModule, ChunkingContext, ChunksData,
+        EvaluatableAssets, ModuleId,
+    },
     code_builder::{Code, CodeBuilder},
     ident::AssetIdent,
     module::Module,
@@ -15,7 +18,7 @@ use turbopack_core::{
     source_map::{GenerateSourceMap, OptionSourceMap, SourceMapAsset},
 };
 use turbopack_ecmascript::{
-    chunk::{EcmascriptChunkData, EcmascriptChunkItemExt, EcmascriptChunkPlaceable},
+    chunk::{EcmascriptChunkData, EcmascriptChunkPlaceable},
     utils::StringifyJs,
 };
 use turbopack_ecmascript_runtime::RuntimeType;

--- a/crates/turbopack-ecmascript/src/chunk/context.rs
+++ b/crates/turbopack-ecmascript/src/chunk/context.rs
@@ -1,8 +1,5 @@
-use anyhow::Result;
-use turbo_tasks::{ValueToString, Vc};
-use turbopack_core::chunk::{ChunkItem, ChunkingContext, ModuleId};
-
-use super::item::EcmascriptChunkItem;
+use turbo_tasks::Vc;
+use turbopack_core::chunk::ChunkingContext;
 
 /// [`EcmascriptChunkingContext`] must be implemented by [`ChunkingContext`]
 /// implementors that want to operate on [`EcmascriptChunk`]s.
@@ -12,17 +9,5 @@ pub trait EcmascriptChunkingContext: ChunkingContext {
     /// the `__turbopack_refresh__` argument.
     fn has_react_refresh(self: Vc<Self>) -> Vc<bool> {
         Vc::cell(false)
-    }
-
-    async fn chunk_item_id(
-        self: Vc<Self>,
-        chunk_item: Vc<Box<dyn EcmascriptChunkItem>>,
-    ) -> Result<Vc<ModuleId>> {
-        let layer = self.layer();
-        let mut ident = chunk_item.asset_ident();
-        if !layer.await?.is_empty() {
-            ident = ident.with_modifier(layer)
-        }
-        Ok(ModuleId::String(ident.to_string().await?.clone_value()).cell())
     }
 }

--- a/crates/turbopack-ecmascript/src/chunk/item.rs
+++ b/crates/turbopack-ecmascript/src/chunk/item.rs
@@ -262,7 +262,9 @@ impl FromChunkableModule for Box<dyn EcmascriptChunkItem> {
             return Ok(None);
         };
 
-        Ok(Some(placeable.as_chunk_item(context)))
+        Ok(Some(EcmascriptChunkPlaceable::as_chunk_item(
+            placeable, context,
+        )))
     }
 
     async fn from_async_asset(

--- a/crates/turbopack-ecmascript/src/chunk/item.rs
+++ b/crates/turbopack-ecmascript/src/chunk/item.rs
@@ -7,7 +7,7 @@ use turbo_tasks_fs::rope::Rope;
 use turbopack_core::{
     chunk::{
         availability_info::AvailabilityInfo, available_modules::AvailableAssets, ChunkItem,
-        ChunkableModule, ChunkingContext, FromChunkableModule, ModuleId,
+        ChunkItemExt, ChunkableModule, ChunkingContext, FromChunkableModule,
     },
     code_builder::{Code, CodeBuilder},
     error::PrettyPrintError,
@@ -180,9 +180,6 @@ pub trait EcmascriptChunkItem: ChunkItem {
 }
 
 pub trait EcmascriptChunkItemExt: Send {
-    /// Returns the module id of this chunk item.
-    fn id(self: Vc<Self>) -> Vc<ModuleId>;
-
     /// Generates the module factory for this chunk item.
     fn code(self: Vc<Self>, availability_info: Value<AvailabilityInfo>) -> Vc<Code>;
 }
@@ -191,12 +188,6 @@ impl<T> EcmascriptChunkItemExt for T
 where
     T: Upcast<Box<dyn EcmascriptChunkItem>>,
 {
-    /// Returns the module id of this chunk item.
-    fn id(self: Vc<Self>) -> Vc<ModuleId> {
-        let chunk_item = Vc::upcast(self);
-        chunk_item.chunking_context().chunk_item_id(chunk_item)
-    }
-
     /// Generates the module factory for this chunk item.
     fn code(self: Vc<Self>, availability_info: Value<AvailabilityInfo>) -> Vc<Code> {
         module_factory_with_code_generation_issue(Vc::upcast(self), availability_info)
@@ -255,16 +246,13 @@ impl FromChunkableModule for Box<dyn EcmascriptChunkItem> {
             return Ok(None);
         };
 
-        let Some(context) =
-            Vc::try_resolve_sidecast::<Box<dyn EcmascriptChunkingContext>>(chunking_context)
-                .await?
+        let item = placeable.as_chunk_item(Vc::upcast(chunking_context));
+        let Some(ecmascript_item) =
+            Vc::try_resolve_sidecast::<Box<dyn EcmascriptChunkItem>>(item).await?
         else {
             return Ok(None);
         };
-
-        Ok(Some(EcmascriptChunkPlaceable::as_chunk_item(
-            placeable, context,
-        )))
+        Ok(Some(ecmascript_item))
     }
 
     async fn from_async_asset(

--- a/crates/turbopack-ecmascript/src/chunk/item.rs
+++ b/crates/turbopack-ecmascript/src/chunk/item.rs
@@ -286,7 +286,10 @@ impl FromChunkableModule for Box<dyn EcmascriptChunkItem> {
 
         let manifest_asset =
             ManifestChunkAsset::new(module, context, Value::new(next_availability_info));
-        Ok(Some(Vc::upcast(ManifestLoaderItem::new(manifest_asset))))
+        Ok(Some(Vc::upcast(ManifestLoaderItem::new(
+            manifest_asset,
+            chunking_context,
+        ))))
     }
 }
 

--- a/crates/turbopack-ecmascript/src/chunk/item.rs
+++ b/crates/turbopack-ecmascript/src/chunk/item.rs
@@ -248,7 +248,7 @@ impl FromChunkableModule for Box<dyn EcmascriptChunkItem> {
 
         let item = placeable.as_chunk_item(Vc::upcast(chunking_context));
         let Some(ecmascript_item) =
-            Vc::try_resolve_sidecast::<Box<dyn EcmascriptChunkItem>>(item).await?
+            Vc::try_resolve_downcast::<Box<dyn EcmascriptChunkItem>>(item).await?
         else {
             return Ok(None);
         };
@@ -261,7 +261,7 @@ impl FromChunkableModule for Box<dyn EcmascriptChunkItem> {
         availability_info: Value<AvailabilityInfo>,
     ) -> Result<Option<Vc<Self>>> {
         let Some(context) =
-            Vc::try_resolve_sidecast::<Box<dyn EcmascriptChunkingContext>>(chunking_context)
+            Vc::try_resolve_downcast::<Box<dyn EcmascriptChunkingContext>>(chunking_context)
                 .await?
         else {
             return Ok(None);

--- a/crates/turbopack-ecmascript/src/chunk/mod.rs
+++ b/crates/turbopack-ecmascript/src/chunk/mod.rs
@@ -14,7 +14,8 @@ use turbo_tasks_fs::FileSystemPathOption;
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{
-        availability_info::AvailabilityInfo, Chunk, ChunkItem, ChunkingContext, Chunks, ModuleIds,
+        availability_info::AvailabilityInfo, Chunk, ChunkItem, ChunkItemExt, ChunkableModule,
+        ChunkingContext, Chunks, ModuleIds,
     },
     ident::AssetIdent,
     introspect::{
@@ -165,7 +166,7 @@ impl EcmascriptChunk {
             .main_entries
             .await?
             .iter()
-            .map(|&entry| entry.as_chunk_item(this.chunking_context).id())
+            .map(|&entry| entry.as_chunk_item(Vc::upcast(this.chunking_context)).id())
             .collect();
         Ok(Vc::cell(entries))
     }

--- a/crates/turbopack-ecmascript/src/chunk/mod.rs
+++ b/crates/turbopack-ecmascript/src/chunk/mod.rs
@@ -77,7 +77,7 @@ impl EcmascriptChunk {
         availability_info: Value<AvailabilityInfo>,
     ) -> Result<Vc<Self>> {
         let Some(context) =
-            Vc::try_resolve_sidecast::<Box<dyn EcmascriptChunkingContext>>(chunking_context)
+            Vc::try_resolve_downcast::<Box<dyn EcmascriptChunkingContext>>(chunking_context)
                 .await?
         else {
             bail!("Ecmascript chunking context not found");
@@ -97,7 +97,7 @@ impl EcmascriptChunk {
         main_entry: Vc<Box<dyn EcmascriptChunkPlaceable>>,
     ) -> Result<Vc<Self>> {
         let Some(context) =
-            Vc::try_resolve_sidecast::<Box<dyn EcmascriptChunkingContext>>(chunking_context)
+            Vc::try_resolve_downcast::<Box<dyn EcmascriptChunkingContext>>(chunking_context)
                 .await?
         else {
             bail!("Ecmascript chunking context not found");

--- a/crates/turbopack-ecmascript/src/chunk/placeable.rs
+++ b/crates/turbopack-ecmascript/src/chunk/placeable.rs
@@ -1,15 +1,10 @@
 use turbo_tasks::Vc;
 use turbopack_core::{asset::Asset, chunk::ChunkableModule, module::Module};
 
-use super::{item::EcmascriptChunkItem, EcmascriptChunkingContext};
 use crate::references::{async_module::OptionAsyncModule, esm::EsmExports};
 
 #[turbo_tasks::value_trait]
 pub trait EcmascriptChunkPlaceable: ChunkableModule + Module + Asset {
-    fn as_chunk_item(
-        self: Vc<Self>,
-        chunking_context: Vc<Box<dyn EcmascriptChunkingContext>>,
-    ) -> Vc<Box<dyn EcmascriptChunkItem>>;
     fn get_exports(self: Vc<Self>) -> Vc<EcmascriptExports>;
     fn get_async_module(self: Vc<Self>) -> Vc<OptionAsyncModule> {
         Vc::cell(None)

--- a/crates/turbopack-ecmascript/src/chunk_group_files_asset.rs
+++ b/crates/turbopack-ecmascript/src/chunk_group_files_asset.rs
@@ -5,8 +5,8 @@ use turbo_tasks_fs::{File, FileSystemPath};
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{
-        availability_info::AvailabilityInfo, Chunk, ChunkItem, ChunkableModule, ChunkingContext,
-        EvaluatableAssets,
+        availability_info::AvailabilityInfo, Chunk, ChunkItem, ChunkableModule, ChunkableModuleExt,
+        ChunkingContext, EvaluatableAssets,
     },
     ident::AssetIdent,
     introspect::{
@@ -90,19 +90,6 @@ impl Asset for ChunkGroupFilesAsset {
 
 #[turbo_tasks::value_impl]
 impl ChunkableModule for ChunkGroupFilesAsset {
-    #[turbo_tasks::function]
-    fn as_chunk(
-        self: Vc<Self>,
-        chunking_context: Vc<Box<dyn ChunkingContext>>,
-        availability_info: Value<AvailabilityInfo>,
-    ) -> Vc<Box<dyn Chunk>> {
-        Vc::upcast(EcmascriptChunk::new(
-            chunking_context,
-            Vc::upcast(self),
-            availability_info,
-        ))
-    }
-
     #[turbo_tasks::function]
     async fn as_chunk_item(
         self: Vc<Self>,
@@ -237,6 +224,15 @@ impl ChunkItem for ChunkGroupFilesChunkItem {
     #[turbo_tasks::function]
     async fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
         Vc::upcast(self.chunking_context)
+    }
+
+    #[turbo_tasks::function]
+    fn as_chunk(&self, availability_info: Value<AvailabilityInfo>) -> Vc<Box<dyn Chunk>> {
+        Vc::upcast(EcmascriptChunk::new(
+            Vc::upcast(self.chunking_context),
+            Vc::upcast(self.inner),
+            availability_info,
+        ))
     }
 }
 

--- a/crates/turbopack-ecmascript/src/chunk_group_files_asset.rs
+++ b/crates/turbopack-ecmascript/src/chunk_group_files_asset.rs
@@ -102,6 +102,14 @@ impl ChunkableModule for ChunkGroupFilesAsset {
             availability_info,
         ))
     }
+
+    #[turbo_tasks::function]
+    fn as_chunk_item(
+        self: Vc<Self>,
+        chunking_context: Vc<Box<dyn ChunkingContext>>,
+    ) -> Vc<Box<dyn turbopack_core::chunk::ChunkItem>> {
+        todo!();
+    }
 }
 
 #[turbo_tasks::value_impl]

--- a/crates/turbopack-ecmascript/src/chunk_group_files_asset.rs
+++ b/crates/turbopack-ecmascript/src/chunk_group_files_asset.rs
@@ -110,7 +110,7 @@ impl ChunkableModule for ChunkGroupFilesAsset {
     ) -> Result<Vc<Box<dyn turbopack_core::chunk::ChunkItem>>> {
         let this = self.await?;
         let chunking_context =
-            Vc::try_resolve_sidecast::<Box<dyn EcmascriptChunkingContext>>(chunking_context)
+            Vc::try_resolve_downcast::<Box<dyn EcmascriptChunkingContext>>(chunking_context)
                 .await?
                 .context(
                     "chunking context must impl EcmascriptChunkingContext to use \

--- a/crates/turbopack-ecmascript/src/chunk_group_files_asset.rs
+++ b/crates/turbopack-ecmascript/src/chunk_group_files_asset.rs
@@ -130,22 +130,6 @@ impl ChunkableModule for ChunkGroupFilesAsset {
 #[turbo_tasks::value_impl]
 impl EcmascriptChunkPlaceable for ChunkGroupFilesAsset {
     #[turbo_tasks::function]
-    async fn as_chunk_item(
-        self: Vc<Self>,
-        chunking_context: Vc<Box<dyn EcmascriptChunkingContext>>,
-    ) -> Result<Vc<Box<dyn EcmascriptChunkItem>>> {
-        let this = self.await?;
-        Ok(Vc::upcast(
-            ChunkGroupFilesChunkItem {
-                chunking_context,
-                client_root: this.client_root,
-                inner: self,
-            }
-            .cell(),
-        ))
-    }
-
-    #[turbo_tasks::function]
     fn get_exports(&self) -> Vc<EcmascriptExports> {
         EcmascriptExports::Value.cell()
     }
@@ -248,6 +232,11 @@ impl ChunkItem for ChunkGroupFilesChunkItem {
                 .map(Vc::upcast)
                 .collect(),
         ))
+    }
+
+    #[turbo_tasks::function]
+    async fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
+        Vc::upcast(self.chunking_context)
     }
 }
 

--- a/crates/turbopack-ecmascript/src/lib.rs
+++ b/crates/turbopack-ecmascript/src/lib.rs
@@ -415,6 +415,14 @@ impl ChunkableModule for EcmascriptModuleAsset {
             availability_info,
         ))
     }
+
+    #[turbo_tasks::function]
+    fn as_chunk_item(
+        self: Vc<Self>,
+        chunking_context: Vc<Box<dyn ChunkingContext>>,
+    ) -> Vc<Box<dyn turbopack_core::chunk::ChunkItem>> {
+        todo!();
+    }
 }
 
 #[turbo_tasks::value_impl]

--- a/crates/turbopack-ecmascript/src/lib.rs
+++ b/crates/turbopack-ecmascript/src/lib.rs
@@ -404,19 +404,6 @@ impl Asset for EcmascriptModuleAsset {
 #[turbo_tasks::value_impl]
 impl ChunkableModule for EcmascriptModuleAsset {
     #[turbo_tasks::function]
-    fn as_chunk(
-        self: Vc<Self>,
-        chunking_context: Vc<Box<dyn ChunkingContext>>,
-        availability_info: Value<AvailabilityInfo>,
-    ) -> Vc<Box<dyn Chunk>> {
-        Vc::upcast(EcmascriptChunk::new(
-            chunking_context,
-            Vc::upcast(self),
-            availability_info,
-        ))
-    }
-
-    #[turbo_tasks::function]
     async fn as_chunk_item(
         self: Vc<Self>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
@@ -498,6 +485,15 @@ impl ChunkItem for ModuleChunkItem {
     #[turbo_tasks::function]
     async fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
         Vc::upcast(self.chunking_context)
+    }
+
+    #[turbo_tasks::function]
+    fn as_chunk(&self, availability_info: Value<AvailabilityInfo>) -> Vc<Box<dyn Chunk>> {
+        Vc::upcast(EcmascriptChunk::new(
+            Vc::upcast(self.chunking_context),
+            Vc::upcast(self.module),
+            availability_info,
+        ))
     }
 }
 

--- a/crates/turbopack-ecmascript/src/lib.rs
+++ b/crates/turbopack-ecmascript/src/lib.rs
@@ -422,7 +422,7 @@ impl ChunkableModule for EcmascriptModuleAsset {
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<Box<dyn ChunkItem>>> {
         let chunking_context =
-            Vc::try_resolve_sidecast::<Box<dyn EcmascriptChunkingContext>>(chunking_context)
+            Vc::try_resolve_downcast::<Box<dyn EcmascriptChunkingContext>>(chunking_context)
                 .await?
                 .context(
                     "chunking context must impl EcmascriptChunkingContext to use \

--- a/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
+++ b/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
@@ -137,7 +137,7 @@ impl ChunkableModule for ManifestChunkAsset {
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<Box<dyn turbopack_core::chunk::ChunkItem>>> {
         let chunking_context =
-            Vc::try_resolve_sidecast::<Box<dyn EcmascriptChunkingContext>>(chunking_context)
+            Vc::try_resolve_downcast::<Box<dyn EcmascriptChunkingContext>>(chunking_context)
                 .await?
                 .context(
                     "chunking context must impl EcmascriptChunkingContext to use \

--- a/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
+++ b/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
@@ -131,6 +131,14 @@ impl ChunkableModule for ManifestChunkAsset {
             availability_info,
         ))
     }
+
+    #[turbo_tasks::function]
+    fn as_chunk_item(
+        self: Vc<Self>,
+        chunking_context: Vc<Box<dyn ChunkingContext>>,
+    ) -> Vc<Box<dyn turbopack_core::chunk::ChunkItem>> {
+        todo!();
+    }
 }
 
 #[turbo_tasks::value_impl]

--- a/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
+++ b/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
@@ -11,8 +11,7 @@ use turbopack_core::{
 
 use super::chunk_item::ManifestChunkItem;
 use crate::chunk::{
-    EcmascriptChunk, EcmascriptChunkItem, EcmascriptChunkPlaceable, EcmascriptChunkingContext,
-    EcmascriptExports,
+    EcmascriptChunk, EcmascriptChunkPlaceable, EcmascriptChunkingContext, EcmascriptExports,
 };
 
 #[turbo_tasks::function]
@@ -156,20 +155,6 @@ impl ChunkableModule for ManifestChunkAsset {
 
 #[turbo_tasks::value_impl]
 impl EcmascriptChunkPlaceable for ManifestChunkAsset {
-    #[turbo_tasks::function]
-    async fn as_chunk_item(
-        self: Vc<Self>,
-        chunking_context: Vc<Box<dyn EcmascriptChunkingContext>>,
-    ) -> Result<Vc<Box<dyn EcmascriptChunkItem>>> {
-        Ok(Vc::upcast(
-            ManifestChunkItem {
-                chunking_context,
-                manifest: self,
-            }
-            .cell(),
-        ))
-    }
-
     #[turbo_tasks::function]
     fn get_exports(&self) -> Vc<EcmascriptExports> {
         EcmascriptExports::Value.cell()

--- a/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
+++ b/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
@@ -2,7 +2,10 @@ use anyhow::{Context, Result};
 use turbo_tasks::{Value, Vc};
 use turbopack_core::{
     asset::{Asset, AssetContent},
-    chunk::{availability_info::AvailabilityInfo, Chunk, ChunkableModule, ChunkingContext},
+    chunk::{
+        availability_info::AvailabilityInfo, Chunk, ChunkableModule, ChunkableModuleExt,
+        ChunkingContext,
+    },
     ident::AssetIdent,
     module::Module,
     output::OutputAssets,
@@ -10,9 +13,7 @@ use turbopack_core::{
 };
 
 use super::chunk_item::ManifestChunkItem;
-use crate::chunk::{
-    EcmascriptChunk, EcmascriptChunkPlaceable, EcmascriptChunkingContext, EcmascriptExports,
-};
+use crate::chunk::{EcmascriptChunkPlaceable, EcmascriptChunkingContext, EcmascriptExports};
 
 #[turbo_tasks::function]
 fn modifier() -> Vc<String> {
@@ -118,19 +119,6 @@ impl Asset for ManifestChunkAsset {
 
 #[turbo_tasks::value_impl]
 impl ChunkableModule for ManifestChunkAsset {
-    #[turbo_tasks::function]
-    fn as_chunk(
-        self: Vc<Self>,
-        chunking_context: Vc<Box<dyn ChunkingContext>>,
-        availability_info: Value<AvailabilityInfo>,
-    ) -> Vc<Box<dyn Chunk>> {
-        Vc::upcast(EcmascriptChunk::new(
-            chunking_context,
-            Vc::upcast(self),
-            availability_info,
-        ))
-    }
-
     #[turbo_tasks::function]
     async fn as_chunk_item(
         self: Vc<Self>,

--- a/crates/turbopack-ecmascript/src/manifest/chunk_item.rs
+++ b/crates/turbopack-ecmascript/src/manifest/chunk_item.rs
@@ -1,8 +1,11 @@
 use anyhow::Result;
 use indoc::formatdoc;
-use turbo_tasks::{TryJoinIterExt, Vc};
+use turbo_tasks::{TryJoinIterExt, Value, Vc};
 use turbopack_core::{
-    chunk::{ChunkData, ChunkItem, ChunkingContext, ChunksData},
+    chunk::{
+        availability_info::AvailabilityInfo, Chunk, ChunkData, ChunkItem, ChunkingContext,
+        ChunksData,
+    },
     ident::AssetIdent,
     module::Module,
     reference::{ModuleReferences, SingleOutputAssetReference},
@@ -11,8 +14,8 @@ use turbopack_core::{
 use super::chunk_asset::ManifestChunkAsset;
 use crate::{
     chunk::{
-        data::EcmascriptChunkData, EcmascriptChunkItem, EcmascriptChunkItemContent,
-        EcmascriptChunkingContext,
+        data::EcmascriptChunkData, EcmascriptChunk, EcmascriptChunkItem,
+        EcmascriptChunkItemContent, EcmascriptChunkingContext,
     },
     utils::StringifyJs,
 };
@@ -95,5 +98,14 @@ impl ChunkItem for ManifestChunkItem {
     #[turbo_tasks::function]
     async fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
         Vc::upcast(self.chunking_context)
+    }
+
+    #[turbo_tasks::function]
+    fn as_chunk(&self, availability_info: Value<AvailabilityInfo>) -> Vc<Box<dyn Chunk>> {
+        Vc::upcast(EcmascriptChunk::new(
+            Vc::upcast(self.chunking_context),
+            Vc::upcast(self.manifest),
+            availability_info,
+        ))
     }
 }

--- a/crates/turbopack-ecmascript/src/manifest/chunk_item.rs
+++ b/crates/turbopack-ecmascript/src/manifest/chunk_item.rs
@@ -91,4 +91,9 @@ impl ChunkItem for ManifestChunkItem {
 
         Ok(Vc::cell(references))
     }
+
+    #[turbo_tasks::function]
+    async fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
+        Vc::upcast(self.chunking_context)
+    }
 }

--- a/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -8,7 +8,8 @@ use swc_core::{
 use turbo_tasks::{Value, ValueToString, Vc};
 use turbopack_core::{
     chunk::{
-        ChunkableModuleReference, ChunkingContext, ChunkingType, ChunkingTypeOption, ModuleId,
+        ChunkItemExt, ChunkableModule, ChunkableModuleReference, ChunkingContext, ChunkingType,
+        ChunkingTypeOption, ModuleId,
     },
     issue::{IssueSeverity, OptionIssueSource},
     module::Module,
@@ -23,7 +24,7 @@ use turbopack_core::{
 
 use crate::{
     analyzer::imports::ImportAnnotations,
-    chunk::{item::EcmascriptChunkItemExt, EcmascriptChunkPlaceable, EcmascriptChunkingContext},
+    chunk::{EcmascriptChunkPlaceable, EcmascriptChunkingContext},
     code_gen::{CodeGenerateable, CodeGeneration},
     create_visitor, magic_identifier,
     references::util::{request_to_string, throw_module_not_found_expr},
@@ -233,7 +234,10 @@ impl CodeGenerateable for EsmAssetReference {
             if let Some(ident) = referenced_asset.get_ident().await? {
                 match &*referenced_asset {
                     ReferencedAsset::Some(asset) => {
-                        let id = asset.as_chunk_item(chunking_context).id().await?;
+                        let id = asset
+                            .as_chunk_item(Vc::upcast(chunking_context))
+                            .id()
+                            .await?;
                         visitors.push(create_visitor!(visit_mut_program(program: &mut Program) {
                             let stmt = quote!(
                                 "var $name = __turbopack_import__($id);" as Stmt,

--- a/crates/turbopack-ecmascript/src/references/esm/url.rs
+++ b/crates/turbopack-ecmascript/src/references/esm/url.rs
@@ -5,7 +5,9 @@ use swc_core::{
 };
 use turbo_tasks::{Value, ValueToString, Vc};
 use turbopack_core::{
-    chunk::{ChunkableModuleReference, ChunkingType, ChunkingTypeOption},
+    chunk::{
+        ChunkItemExt, ChunkableModule, ChunkableModuleReference, ChunkingType, ChunkingTypeOption,
+    },
     environment::Rendering,
     issue::{code_gen::CodeGenerationIssue, IssueExt, IssueSeverity, IssueSource},
     reference::ModuleReference,
@@ -15,7 +17,7 @@ use turbopack_core::{
 
 use super::base::ReferencedAsset;
 use crate::{
-    chunk::{item::EcmascriptChunkItemExt, EcmascriptChunkPlaceable, EcmascriptChunkingContext},
+    chunk::EcmascriptChunkingContext,
     code_gen::{CodeGenerateable, CodeGeneration},
     create_visitor,
     references::AstPath,
@@ -151,7 +153,10 @@ impl CodeGenerateable for UrlAssetReference {
             ReferencedAsset::Some(asset) => {
                 // We rewrite the first `new URL()` arguments to be a require() of the chunk
                 // item, which exports the static asset path to the linked file.
-                let id = asset.as_chunk_item(chunking_context).id().await?;
+                let id = asset
+                    .as_chunk_item(Vc::upcast(chunking_context))
+                    .id()
+                    .await?;
 
                 visitors.push(
                     create_visitor!(ast_path, visit_mut_expr(new_expr: &mut Expr) {

--- a/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
+++ b/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
@@ -7,8 +7,8 @@ use swc_core::{
 use turbo_tasks::{debug::ValueDebug, Value, Vc};
 use turbopack_core::{
     chunk::{
-        availability_info::AvailabilityInfo, ChunkableModule, ChunkingContext, FromChunkableModule,
-        ModuleId,
+        availability_info::AvailabilityInfo, ChunkItemExt, ChunkableModule, ChunkingContext,
+        FromChunkableModule, ModuleId,
     },
     issue::{code_gen::CodeGenerationIssue, IssueExt, IssueSeverity},
     resolve::{
@@ -17,10 +17,7 @@ use turbopack_core::{
 };
 
 use super::util::{request_to_string, throw_module_not_found_expr};
-use crate::{
-    chunk::{item::EcmascriptChunkItemExt, EcmascriptChunkItem},
-    utils::module_id_to_lit,
-};
+use crate::{chunk::EcmascriptChunkItem, utils::module_id_to_lit};
 
 /// A mapping from a request pattern (e.g. "./module", `./images/${name}.png`)
 /// to corresponding module ids. The same pattern can map to multiple module ids

--- a/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -1,6 +1,6 @@
 use std::{collections::VecDeque, sync::Arc};
 
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use indexmap::IndexMap;
 use swc_core::{
     common::DUMMY_SP,
@@ -388,11 +388,28 @@ impl ChunkableModule for RequireContextAsset {
     }
 
     #[turbo_tasks::function]
-    fn as_chunk_item(
+    async fn as_chunk_item(
         self: Vc<Self>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
-    ) -> Vc<Box<dyn turbopack_core::chunk::ChunkItem>> {
-        todo!();
+    ) -> Result<Vc<Box<dyn turbopack_core::chunk::ChunkItem>>> {
+        let chunking_context =
+            Vc::try_resolve_sidecast::<Box<dyn EcmascriptChunkingContext>>(chunking_context)
+                .await?
+                .context(
+                    "chunking context must impl EcmascriptChunkingContext to use \
+                     RequireContextAsset",
+                )?;
+        let this = self.await?;
+        Ok(Vc::upcast(
+            RequireContextChunkItem {
+                chunking_context,
+                inner: self,
+
+                origin: this.origin,
+                map: this.map,
+            }
+            .cell(),
+        ))
     }
 }
 

--- a/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -282,7 +282,7 @@ impl CodeGenerateable for RequireContextAssetReference {
         &self,
         chunking_context: Vc<Box<dyn EcmascriptChunkingContext>>,
     ) -> Result<Vc<CodeGeneration>> {
-        let chunk_item = self.inner.as_chunk_item(chunking_context);
+        let chunk_item = EcmascriptChunkPlaceable::as_chunk_item(self.inner, chunking_context);
         let module_id = chunk_item.id().await?.clone_value();
 
         let mut visitors = Vec::new();
@@ -385,6 +385,14 @@ impl ChunkableModule for RequireContextAsset {
             Vc::upcast(self),
             availability_info,
         ))
+    }
+
+    #[turbo_tasks::function]
+    fn as_chunk_item(
+        self: Vc<Self>,
+        chunking_context: Vc<Box<dyn ChunkingContext>>,
+    ) -> Vc<Box<dyn turbopack_core::chunk::ChunkItem>> {
+        todo!();
     }
 }
 

--- a/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -393,7 +393,7 @@ impl ChunkableModule for RequireContextAsset {
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<Box<dyn turbopack_core::chunk::ChunkItem>>> {
         let chunking_context =
-            Vc::try_resolve_sidecast::<Box<dyn EcmascriptChunkingContext>>(chunking_context)
+            Vc::try_resolve_downcast::<Box<dyn EcmascriptChunkingContext>>(chunking_context)
                 .await?
                 .context(
                     "chunking context must impl EcmascriptChunkingContext to use \

--- a/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -375,19 +375,6 @@ impl Asset for RequireContextAsset {
 #[turbo_tasks::value_impl]
 impl ChunkableModule for RequireContextAsset {
     #[turbo_tasks::function]
-    fn as_chunk(
-        self: Vc<Self>,
-        chunking_context: Vc<Box<dyn ChunkingContext>>,
-        availability_info: Value<AvailabilityInfo>,
-    ) -> Vc<Box<dyn Chunk>> {
-        Vc::upcast(EcmascriptChunk::new(
-            chunking_context,
-            Vc::upcast(self),
-            availability_info,
-        ))
-    }
-
-    #[turbo_tasks::function]
     async fn as_chunk_item(
         self: Vc<Self>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
@@ -526,5 +513,14 @@ impl ChunkItem for RequireContextChunkItem {
     #[turbo_tasks::function]
     async fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
         Vc::upcast(self.chunking_context)
+    }
+
+    #[turbo_tasks::function]
+    fn as_chunk(&self, availability_info: Value<AvailabilityInfo>) -> Vc<Box<dyn Chunk>> {
+        Vc::upcast(EcmascriptChunk::new(
+            Vc::upcast(self.chunking_context),
+            Vc::upcast(self.inner),
+            availability_info,
+        ))
     }
 }

--- a/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -12,8 +12,7 @@ use turbopack_core::{
 use super::{chunk_item::EcmascriptModulePartChunkItem, get_part_id, split_module, SplitResult};
 use crate::{
     chunk::{
-        EcmascriptChunk, EcmascriptChunkItem, EcmascriptChunkPlaceable, EcmascriptChunkingContext,
-        EcmascriptExports,
+        EcmascriptChunk, EcmascriptChunkPlaceable, EcmascriptChunkingContext, EcmascriptExports,
     },
     references::analyze_ecmascript_module,
     AnalyzeEcmascriptModuleResult, EcmascriptModuleAsset,
@@ -108,20 +107,6 @@ impl Asset for EcmascriptModulePartAsset {
 
 #[turbo_tasks::value_impl]
 impl EcmascriptChunkPlaceable for EcmascriptModulePartAsset {
-    #[turbo_tasks::function]
-    async fn as_chunk_item(
-        self: Vc<Self>,
-        chunking_context: Vc<Box<dyn EcmascriptChunkingContext>>,
-    ) -> Result<Vc<Box<dyn EcmascriptChunkItem>>> {
-        Ok(Vc::upcast(
-            EcmascriptModulePartChunkItem {
-                module: self,
-                chunking_context,
-            }
-            .cell(),
-        ))
-    }
-
     #[turbo_tasks::function]
     async fn get_exports(self: Vc<Self>) -> Result<Vc<EcmascriptExports>> {
         Ok(self.analyze().await?.exports)

--- a/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -1,8 +1,8 @@
 use anyhow::{bail, Context, Result};
-use turbo_tasks::{Value, Vc};
+use turbo_tasks::Vc;
 use turbopack_core::{
     asset::{Asset, AssetContent},
-    chunk::{availability_info::AvailabilityInfo, Chunk, ChunkableModule, ChunkingContext},
+    chunk::{ChunkableModule, ChunkingContext},
     ident::AssetIdent,
     module::Module,
     reference::{ModuleReferences, SingleModuleReference},
@@ -11,9 +11,7 @@ use turbopack_core::{
 
 use super::{chunk_item::EcmascriptModulePartChunkItem, get_part_id, split_module, SplitResult};
 use crate::{
-    chunk::{
-        EcmascriptChunk, EcmascriptChunkPlaceable, EcmascriptChunkingContext, EcmascriptExports,
-    },
+    chunk::{EcmascriptChunkPlaceable, EcmascriptChunkingContext, EcmascriptExports},
     references::analyze_ecmascript_module,
     AnalyzeEcmascriptModuleResult, EcmascriptModuleAsset,
 };
@@ -115,19 +113,6 @@ impl EcmascriptChunkPlaceable for EcmascriptModulePartAsset {
 
 #[turbo_tasks::value_impl]
 impl ChunkableModule for EcmascriptModulePartAsset {
-    #[turbo_tasks::function]
-    async fn as_chunk(
-        self: Vc<Self>,
-        chunking_context: Vc<Box<dyn ChunkingContext>>,
-        availability_info: Value<AvailabilityInfo>,
-    ) -> Vc<Box<dyn Chunk>> {
-        Vc::upcast(EcmascriptChunk::new(
-            chunking_context,
-            Vc::upcast(self),
-            availability_info,
-        ))
-    }
-
     #[turbo_tasks::function]
     async fn as_chunk_item(
         self: Vc<Self>,

--- a/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -144,11 +144,24 @@ impl ChunkableModule for EcmascriptModulePartAsset {
     }
 
     #[turbo_tasks::function]
-    fn as_chunk_item(
+    async fn as_chunk_item(
         self: Vc<Self>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
-    ) -> Vc<Box<dyn turbopack_core::chunk::ChunkItem>> {
-        todo!();
+    ) -> Result<Vc<Box<dyn turbopack_core::chunk::ChunkItem>>> {
+        let chunking_context =
+            Vc::try_resolve_sidecast::<Box<dyn EcmascriptChunkingContext>>(chunking_context)
+                .await?
+                .context(
+                    "chunking context must impl EcmascriptChunkingContext to use \
+                     EcmascriptModulePartAsset",
+                )?;
+        Ok(Vc::upcast(
+            EcmascriptModulePartChunkItem {
+                module: self,
+                chunking_context,
+            }
+            .cell(),
+        ))
     }
 }
 

--- a/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -142,6 +142,14 @@ impl ChunkableModule for EcmascriptModulePartAsset {
             availability_info,
         ))
     }
+
+    #[turbo_tasks::function]
+    fn as_chunk_item(
+        self: Vc<Self>,
+        chunking_context: Vc<Box<dyn ChunkingContext>>,
+    ) -> Vc<Box<dyn turbopack_core::chunk::ChunkItem>> {
+        todo!();
+    }
 }
 
 #[turbo_tasks::value_impl]

--- a/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -134,7 +134,7 @@ impl ChunkableModule for EcmascriptModulePartAsset {
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<Box<dyn turbopack_core::chunk::ChunkItem>>> {
         let chunking_context =
-            Vc::try_resolve_sidecast::<Box<dyn EcmascriptChunkingContext>>(chunking_context)
+            Vc::try_resolve_downcast::<Box<dyn EcmascriptChunkingContext>>(chunking_context)
                 .await?
                 .context(
                     "chunking context must impl EcmascriptChunkingContext to use \

--- a/crates/turbopack-ecmascript/src/tree_shake/chunk_item.rs
+++ b/crates/turbopack-ecmascript/src/tree_shake/chunk_item.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use turbo_tasks::{Value, Vc};
 use turbopack_core::{
-    chunk::{availability_info::AvailabilityInfo, ChunkItem, ChunkingContext},
+    chunk::{availability_info::AvailabilityInfo, Chunk, ChunkItem, ChunkingContext},
     ident::AssetIdent,
     module::Module,
     reference::ModuleReferences,
@@ -10,8 +10,8 @@ use turbopack_core::{
 use super::{asset::EcmascriptModulePartAsset, part_of_module, split_module};
 use crate::{
     chunk::{
-        placeable::EcmascriptChunkPlaceable, EcmascriptChunkItem, EcmascriptChunkItemContent,
-        EcmascriptChunkingContext,
+        placeable::EcmascriptChunkPlaceable, EcmascriptChunk, EcmascriptChunkItem,
+        EcmascriptChunkItemContent, EcmascriptChunkingContext,
     },
     EcmascriptModuleContent,
 };
@@ -90,5 +90,14 @@ impl ChunkItem for EcmascriptModulePartChunkItem {
     #[turbo_tasks::function]
     async fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
         Vc::upcast(self.chunking_context)
+    }
+
+    #[turbo_tasks::function]
+    fn as_chunk(&self, availability_info: Value<AvailabilityInfo>) -> Vc<Box<dyn Chunk>> {
+        Vc::upcast(EcmascriptChunk::new(
+            Vc::upcast(self.chunking_context),
+            Vc::upcast(self.module),
+            availability_info,
+        ))
     }
 }

--- a/crates/turbopack-ecmascript/src/tree_shake/chunk_item.rs
+++ b/crates/turbopack-ecmascript/src/tree_shake/chunk_item.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use turbo_tasks::{Value, Vc};
 use turbopack_core::{
-    chunk::{availability_info::AvailabilityInfo, ChunkItem},
+    chunk::{availability_info::AvailabilityInfo, ChunkItem, ChunkingContext},
     ident::AssetIdent,
     module::Module,
     reference::ModuleReferences,
@@ -85,5 +85,10 @@ impl ChunkItem for EcmascriptModulePartChunkItem {
     #[turbo_tasks::function]
     async fn asset_ident(&self) -> Result<Vc<AssetIdent>> {
         Ok(self.module.ident())
+    }
+
+    #[turbo_tasks::function]
+    async fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
+        Vc::upcast(self.chunking_context)
     }
 }

--- a/crates/turbopack-json/src/lib.rs
+++ b/crates/turbopack-json/src/lib.rs
@@ -66,19 +66,6 @@ impl Asset for JsonModuleAsset {
 #[turbo_tasks::value_impl]
 impl ChunkableModule for JsonModuleAsset {
     #[turbo_tasks::function]
-    fn as_chunk(
-        self: Vc<Self>,
-        chunking_context: Vc<Box<dyn ChunkingContext>>,
-        availability_info: Value<AvailabilityInfo>,
-    ) -> Vc<Box<dyn Chunk>> {
-        Vc::upcast(EcmascriptChunk::new(
-            chunking_context,
-            Vc::upcast(self),
-            availability_info,
-        ))
-    }
-
-    #[turbo_tasks::function]
     async fn as_chunk_item(
         self: Vc<Self>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
@@ -125,6 +112,15 @@ impl ChunkItem for JsonChunkItem {
     #[turbo_tasks::function]
     async fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
         Vc::upcast(self.chunking_context)
+    }
+
+    #[turbo_tasks::function]
+    fn as_chunk(&self, availability_info: Value<AvailabilityInfo>) -> Vc<Box<dyn Chunk>> {
+        Vc::upcast(EcmascriptChunk::new(
+            Vc::upcast(self.chunking_context),
+            Vc::upcast(self.module),
+            availability_info,
+        ))
     }
 }
 

--- a/crates/turbopack-json/src/lib.rs
+++ b/crates/turbopack-json/src/lib.rs
@@ -99,17 +99,6 @@ impl ChunkableModule for JsonModuleAsset {
 #[turbo_tasks::value_impl]
 impl EcmascriptChunkPlaceable for JsonModuleAsset {
     #[turbo_tasks::function]
-    fn as_chunk_item(
-        self: Vc<Self>,
-        chunking_context: Vc<Box<dyn EcmascriptChunkingContext>>,
-    ) -> Vc<Box<dyn EcmascriptChunkItem>> {
-        Vc::upcast(JsonChunkItem::cell(JsonChunkItem {
-            module: self,
-            chunking_context,
-        }))
-    }
-
-    #[turbo_tasks::function]
     fn get_exports(&self) -> Vc<EcmascriptExports> {
         EcmascriptExports::Value.cell()
     }
@@ -131,6 +120,11 @@ impl ChunkItem for JsonChunkItem {
     #[turbo_tasks::function]
     fn references(&self) -> Vc<ModuleReferences> {
         self.module.references()
+    }
+
+    #[turbo_tasks::function]
+    async fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
+        Vc::upcast(self.chunking_context)
     }
 }
 

--- a/crates/turbopack-json/src/lib.rs
+++ b/crates/turbopack-json/src/lib.rs
@@ -77,6 +77,14 @@ impl ChunkableModule for JsonModuleAsset {
             availability_info,
         ))
     }
+
+    #[turbo_tasks::function]
+    fn as_chunk_item(
+        self: Vc<Self>,
+        chunking_context: Vc<Box<dyn ChunkingContext>>,
+    ) -> Vc<Box<dyn turbopack_core::chunk::ChunkItem>> {
+        todo!();
+    }
 }
 
 #[turbo_tasks::value_impl]

--- a/crates/turbopack-json/src/lib.rs
+++ b/crates/turbopack-json/src/lib.rs
@@ -84,7 +84,7 @@ impl ChunkableModule for JsonModuleAsset {
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<Box<dyn turbopack_core::chunk::ChunkItem>>> {
         let chunking_context =
-            Vc::try_resolve_sidecast::<Box<dyn EcmascriptChunkingContext>>(chunking_context)
+            Vc::try_resolve_downcast::<Box<dyn EcmascriptChunkingContext>>(chunking_context)
                 .await?
                 .context(
                     "chunking context must impl EcmascriptChunkingContext to use JsonModuleAsset",

--- a/crates/turbopack-mdx/src/lib.rs
+++ b/crates/turbopack-mdx/src/lib.rs
@@ -207,7 +207,7 @@ impl ChunkableModule for MdxModuleAsset {
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<Box<dyn turbopack_core::chunk::ChunkItem>>> {
         let chunking_context =
-            Vc::try_resolve_sidecast::<Box<dyn EcmascriptChunkingContext>>(chunking_context)
+            Vc::try_resolve_downcast::<Box<dyn EcmascriptChunkingContext>>(chunking_context)
                 .await?
                 .context(
                     "chunking context must impl EcmascriptChunkingContext to use MdxModuleAsset",
@@ -278,7 +278,7 @@ impl EcmascriptChunkItem for MdxChunkItem {
         let item = into_ecmascript_module_asset(&self.module)
             .await?
             .as_chunk_item(Vc::upcast(self.chunking_context));
-        let ecmascript_item = Vc::try_resolve_sidecast::<Box<dyn EcmascriptChunkItem>>(item)
+        let ecmascript_item = Vc::try_resolve_downcast::<Box<dyn EcmascriptChunkItem>>(item)
             .await?
             .context("MdxChunkItem must generate an EcmascriptChunkItem")?;
         Ok(ecmascript_item.content())

--- a/crates/turbopack-mdx/src/lib.rs
+++ b/crates/turbopack-mdx/src/lib.rs
@@ -200,6 +200,14 @@ impl ChunkableModule for MdxModuleAsset {
             availability_info,
         ))
     }
+
+    #[turbo_tasks::function]
+    fn as_chunk_item(
+        self: Vc<Self>,
+        chunking_context: Vc<Box<dyn ChunkingContext>>,
+    ) -> Vc<Box<dyn turbopack_core::chunk::ChunkItem>> {
+        todo!();
+    }
 }
 
 #[turbo_tasks::value_impl]
@@ -264,10 +272,11 @@ impl EcmascriptChunkItem for MdxChunkItem {
     /// apply all of the ecma transforms
     #[turbo_tasks::function]
     async fn content(&self) -> Result<Vc<EcmascriptChunkItemContent>> {
-        Ok(into_ecmascript_module_asset(&self.module)
-            .await?
-            .as_chunk_item(self.chunking_context)
-            .content())
+        Ok(EcmascriptChunkPlaceable::as_chunk_item(
+            into_ecmascript_module_asset(&self.module).await?,
+            self.chunking_context,
+        )
+        .content())
     }
 }
 

--- a/crates/turbopack-mdx/src/lib.rs
+++ b/crates/turbopack-mdx/src/lib.rs
@@ -189,19 +189,6 @@ impl Asset for MdxModuleAsset {
 #[turbo_tasks::value_impl]
 impl ChunkableModule for MdxModuleAsset {
     #[turbo_tasks::function]
-    fn as_chunk(
-        self: Vc<Self>,
-        chunking_context: Vc<Box<dyn ChunkingContext>>,
-        availability_info: Value<AvailabilityInfo>,
-    ) -> Vc<Box<dyn Chunk>> {
-        Vc::upcast(EcmascriptChunk::new(
-            chunking_context,
-            Vc::upcast(self),
-            availability_info,
-        ))
-    }
-
-    #[turbo_tasks::function]
     async fn as_chunk_item(
         self: Vc<Self>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
@@ -261,6 +248,15 @@ impl ChunkItem for MdxChunkItem {
     #[turbo_tasks::function]
     async fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
         Vc::upcast(self.chunking_context)
+    }
+
+    #[turbo_tasks::function]
+    fn as_chunk(&self, availability_info: Value<AvailabilityInfo>) -> Vc<Box<dyn Chunk>> {
+        Vc::upcast(EcmascriptChunk::new(
+            Vc::upcast(self.chunking_context),
+            Vc::upcast(self.module),
+            availability_info,
+        ))
     }
 }
 

--- a/crates/turbopack-node/src/evaluate.rs
+++ b/crates/turbopack-node/src/evaluate.rs
@@ -22,7 +22,7 @@ use turbo_tasks_fs::{
 };
 use turbopack_core::{
     asset::AssetContent,
-    chunk::{ChunkableModule, ChunkingContext, EvaluatableAsset, EvaluatableAssets},
+    chunk::{ChunkableModuleExt, ChunkingContext, EvaluatableAsset, EvaluatableAssets},
     context::AssetContext,
     file_source::FileSource,
     ident::AssetIdent,

--- a/crates/turbopack-node/src/lib.rs
+++ b/crates/turbopack-node/src/lib.rs
@@ -17,7 +17,7 @@ use turbo_tasks_env::ProcessEnv;
 use turbo_tasks_fs::{to_sys_path, File, FileSystemPath};
 use turbopack_core::{
     asset::{Asset, AssetContent},
-    chunk::{ChunkableModule, ChunkingContext, EvaluatableAsset, EvaluatableAssets},
+    chunk::{ChunkableModuleExt, ChunkingContext, EvaluatableAsset, EvaluatableAssets},
     module::Module,
     output::{OutputAsset, OutputAssetsSet},
     source_map::GenerateSourceMap,

--- a/crates/turbopack-static/src/lib.rs
+++ b/crates/turbopack-static/src/lib.rs
@@ -125,18 +125,6 @@ impl ChunkableModule for StaticModuleAsset {
 #[turbo_tasks::value_impl]
 impl EcmascriptChunkPlaceable for StaticModuleAsset {
     #[turbo_tasks::function]
-    fn as_chunk_item(
-        self: Vc<Self>,
-        chunking_context: Vc<Box<dyn EcmascriptChunkingContext>>,
-    ) -> Vc<Box<dyn EcmascriptChunkItem>> {
-        Vc::upcast(ModuleChunkItem::cell(ModuleChunkItem {
-            module: self,
-            chunking_context,
-            static_asset: self.static_asset(Vc::upcast(chunking_context)),
-        }))
-    }
-
-    #[turbo_tasks::function]
     fn get_exports(&self) -> Vc<EcmascriptExports> {
         EcmascriptExports::Value.into()
     }
@@ -214,6 +202,11 @@ impl ChunkItem for ModuleChunkItem {
                 self.static_asset.ident().to_string().await?
             )),
         ))]))
+    }
+
+    #[turbo_tasks::function]
+    async fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
+        Vc::upcast(self.chunking_context)
     }
 }
 

--- a/crates/turbopack-static/src/lib.rs
+++ b/crates/turbopack-static/src/lib.rs
@@ -102,6 +102,14 @@ impl ChunkableModule for StaticModuleAsset {
             availability_info,
         ))
     }
+
+    #[turbo_tasks::function]
+    fn as_chunk_item(
+        self: Vc<Self>,
+        chunking_context: Vc<Box<dyn ChunkingContext>>,
+    ) -> Vc<Box<dyn turbopack_core::chunk::ChunkItem>> {
+        todo!();
+    }
 }
 
 #[turbo_tasks::value_impl]

--- a/crates/turbopack-static/src/lib.rs
+++ b/crates/turbopack-static/src/lib.rs
@@ -91,19 +91,6 @@ impl Asset for StaticModuleAsset {
 #[turbo_tasks::value_impl]
 impl ChunkableModule for StaticModuleAsset {
     #[turbo_tasks::function]
-    fn as_chunk(
-        self: Vc<Self>,
-        chunking_context: Vc<Box<dyn ChunkingContext>>,
-        availability_info: Value<AvailabilityInfo>,
-    ) -> Vc<Box<dyn Chunk>> {
-        Vc::upcast(EcmascriptChunk::new(
-            chunking_context,
-            Vc::upcast(self),
-            availability_info,
-        ))
-    }
-
-    #[turbo_tasks::function]
     async fn as_chunk_item(
         self: Vc<Self>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
@@ -207,6 +194,15 @@ impl ChunkItem for ModuleChunkItem {
     #[turbo_tasks::function]
     async fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
         Vc::upcast(self.chunking_context)
+    }
+
+    #[turbo_tasks::function]
+    fn as_chunk(&self, availability_info: Value<AvailabilityInfo>) -> Vc<Box<dyn Chunk>> {
+        Vc::upcast(EcmascriptChunk::new(
+            Vc::upcast(self.chunking_context),
+            Vc::upcast(self.module),
+            availability_info,
+        ))
     }
 }
 

--- a/crates/turbopack-static/src/lib.rs
+++ b/crates/turbopack-static/src/lib.rs
@@ -109,7 +109,7 @@ impl ChunkableModule for StaticModuleAsset {
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<Box<dyn turbopack_core::chunk::ChunkItem>>> {
         let chunking_context =
-            Vc::try_resolve_sidecast::<Box<dyn EcmascriptChunkingContext>>(chunking_context)
+            Vc::try_resolve_downcast::<Box<dyn EcmascriptChunkingContext>>(chunking_context)
                 .await?
                 .context(
                     "chunking context must impl EcmascriptChunkingContext to use StaticModuleAsset",

--- a/crates/turbopack-tests/tests/snapshot.rs
+++ b/crates/turbopack-tests/tests/snapshot.rs
@@ -29,7 +29,10 @@ use turbopack::{
 use turbopack_build::{BuildChunkingContext, MinifyType};
 use turbopack_core::{
     asset::Asset,
-    chunk::{ChunkableModule, ChunkingContext, EvaluatableAssetExt, EvaluatableAssets},
+    chunk::{
+        ChunkableModule, ChunkableModuleExt, ChunkingContext, EvaluatableAssetExt,
+        EvaluatableAssets,
+    },
     compile_time_defines,
     compile_time_info::CompileTimeInfo,
     context::AssetContext,

--- a/crates/turbopack-wasm/src/module_asset.rs
+++ b/crates/turbopack-wasm/src/module_asset.rs
@@ -115,19 +115,6 @@ impl Asset for WebAssemblyModuleAsset {
 #[turbo_tasks::value_impl]
 impl ChunkableModule for WebAssemblyModuleAsset {
     #[turbo_tasks::function]
-    fn as_chunk(
-        self: Vc<Self>,
-        chunking_context: Vc<Box<dyn ChunkingContext>>,
-        availability_info: Value<AvailabilityInfo>,
-    ) -> Vc<Box<dyn Chunk>> {
-        Vc::upcast(EcmascriptChunk::new(
-            chunking_context,
-            Vc::upcast(self),
-            availability_info,
-        ))
-    }
-
-    #[turbo_tasks::function]
     async fn as_chunk_item(
         self: Vc<Self>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
@@ -206,6 +193,15 @@ impl ChunkItem for ModuleChunkItem {
     #[turbo_tasks::function]
     async fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
         Vc::upcast(self.chunking_context)
+    }
+
+    #[turbo_tasks::function]
+    fn as_chunk(&self, availability_info: Value<AvailabilityInfo>) -> Vc<Box<dyn Chunk>> {
+        Vc::upcast(EcmascriptChunk::new(
+            Vc::upcast(self.chunking_context),
+            Vc::upcast(self.module),
+            availability_info,
+        ))
     }
 }
 

--- a/crates/turbopack-wasm/src/module_asset.rs
+++ b/crates/turbopack-wasm/src/module_asset.rs
@@ -126,6 +126,14 @@ impl ChunkableModule for WebAssemblyModuleAsset {
             availability_info,
         ))
     }
+
+    #[turbo_tasks::function]
+    fn as_chunk_item(
+        self: Vc<Self>,
+        chunking_context: Vc<Box<dyn ChunkingContext>>,
+    ) -> Vc<Box<dyn turbopack_core::chunk::ChunkItem>> {
+        todo!();
+    }
 }
 
 #[turbo_tasks::value_impl]
@@ -188,7 +196,8 @@ impl ChunkItem for ModuleChunkItem {
 
     #[turbo_tasks::function]
     async fn references(&self) -> Result<Vc<ModuleReferences>> {
-        let loader = self.module.loader().as_chunk_item(self.chunking_context);
+        let loader =
+            EcmascriptChunkPlaceable::as_chunk_item(self.module.loader(), self.chunking_context);
 
         Ok(loader.references())
     }
@@ -213,10 +222,10 @@ impl EcmascriptChunkItem for ModuleChunkItem {
     ) -> Result<Vc<EcmascriptChunkItemContent>> {
         let loader_asset = self.module.loader();
 
-        let chunk_item_content = loader_asset
-            .as_chunk_item(self.chunking_context)
-            .content_with_availability_info(availability_info)
-            .await?;
+        let chunk_item_content =
+            EcmascriptChunkPlaceable::as_chunk_item(loader_asset, self.chunking_context)
+                .content_with_availability_info(availability_info)
+                .await?;
 
         Ok(EcmascriptChunkItemContent {
             options: EcmascriptChunkItemOptions {

--- a/crates/turbopack-wasm/src/module_asset.rs
+++ b/crates/turbopack-wasm/src/module_asset.rs
@@ -133,7 +133,7 @@ impl ChunkableModule for WebAssemblyModuleAsset {
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<Box<dyn turbopack_core::chunk::ChunkItem>>> {
         let chunking_context =
-            Vc::try_resolve_sidecast::<Box<dyn EcmascriptChunkingContext>>(chunking_context)
+            Vc::try_resolve_downcast::<Box<dyn EcmascriptChunkingContext>>(chunking_context)
                 .await?
                 .context(
                     "chunking context must impl EcmascriptChunkingContext to use \
@@ -229,7 +229,7 @@ impl EcmascriptChunkItem for ModuleChunkItem {
         let loader_asset = self.module.loader();
         let item = loader_asset.as_chunk_item(Vc::upcast(self.chunking_context));
 
-        let ecmascript_item = Vc::try_resolve_sidecast::<Box<dyn EcmascriptChunkItem>>(item)
+        let ecmascript_item = Vc::try_resolve_downcast::<Box<dyn EcmascriptChunkItem>>(item)
             .await?
             .context("EcmascriptModuleAsset must implement EcmascriptChunkItem")?;
 

--- a/crates/turbopack-wasm/src/raw.rs
+++ b/crates/turbopack-wasm/src/raw.rs
@@ -91,7 +91,7 @@ impl ChunkableModule for RawWebAssemblyModuleAsset {
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<Box<dyn turbopack_core::chunk::ChunkItem>>> {
         let chunking_context =
-            Vc::try_resolve_sidecast::<Box<dyn EcmascriptChunkingContext>>(chunking_context)
+            Vc::try_resolve_downcast::<Box<dyn EcmascriptChunkingContext>>(chunking_context)
                 .await?
                 .context(
                     "chunking context must impl EcmascriptChunkingContext to use \

--- a/crates/turbopack-wasm/src/raw.rs
+++ b/crates/turbopack-wasm/src/raw.rs
@@ -73,19 +73,6 @@ impl Asset for RawWebAssemblyModuleAsset {
 #[turbo_tasks::value_impl]
 impl ChunkableModule for RawWebAssemblyModuleAsset {
     #[turbo_tasks::function]
-    fn as_chunk(
-        self: Vc<Self>,
-        chunking_context: Vc<Box<dyn ChunkingContext>>,
-        availability_info: Value<AvailabilityInfo>,
-    ) -> Vc<Box<dyn Chunk>> {
-        Vc::upcast(EcmascriptChunk::new(
-            chunking_context,
-            Vc::upcast(self),
-            availability_info,
-        ))
-    }
-
-    #[turbo_tasks::function]
     async fn as_chunk_item(
         self: Vc<Self>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
@@ -144,6 +131,15 @@ impl ChunkItem for RawModuleChunkItem {
     #[turbo_tasks::function]
     async fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
         Vc::upcast(self.chunking_context)
+    }
+
+    #[turbo_tasks::function]
+    fn as_chunk(&self, availability_info: Value<AvailabilityInfo>) -> Vc<Box<dyn Chunk>> {
+        Vc::upcast(EcmascriptChunk::new(
+            Vc::upcast(self.chunking_context),
+            Vc::upcast(self.module),
+            availability_info,
+        ))
     }
 }
 

--- a/crates/turbopack-wasm/src/raw.rs
+++ b/crates/turbopack-wasm/src/raw.rs
@@ -111,21 +111,6 @@ impl ChunkableModule for RawWebAssemblyModuleAsset {
 #[turbo_tasks::value_impl]
 impl EcmascriptChunkPlaceable for RawWebAssemblyModuleAsset {
     #[turbo_tasks::function]
-    fn as_chunk_item(
-        self: Vc<Self>,
-        chunking_context: Vc<Box<dyn EcmascriptChunkingContext>>,
-    ) -> Vc<Box<dyn EcmascriptChunkItem>> {
-        Vc::upcast(
-            RawModuleChunkItem {
-                module: self,
-                chunking_context,
-                wasm_asset: self.wasm_asset(Vc::upcast(chunking_context)),
-            }
-            .cell(),
-        )
-    }
-
-    #[turbo_tasks::function]
     fn get_exports(self: Vc<Self>) -> Vc<EcmascriptExports> {
         EcmascriptExports::Value.cell()
     }
@@ -154,6 +139,11 @@ impl ChunkItem for RawModuleChunkItem {
                 self.wasm_asset.ident().to_string().await?
             )),
         ))]))
+    }
+
+    #[turbo_tasks::function]
+    async fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
+        Vc::upcast(self.chunking_context)
     }
 }
 

--- a/crates/turbopack-wasm/src/raw.rs
+++ b/crates/turbopack-wasm/src/raw.rs
@@ -84,6 +84,14 @@ impl ChunkableModule for RawWebAssemblyModuleAsset {
             availability_info,
         ))
     }
+
+    #[turbo_tasks::function]
+    fn as_chunk_item(
+        self: Vc<Self>,
+        chunking_context: Vc<Box<dyn ChunkingContext>>,
+    ) -> Vc<Box<dyn turbopack_core::chunk::ChunkItem>> {
+        todo!();
+    }
 }
 
 #[turbo_tasks::value_impl]


### PR DESCRIPTION
### Description

This is the first step of refactoring the chunking. In the end we want to avoid creating chunks from modules directly, but enforce everything going through the ChunkingContext to be chunked. This allows us to replace the existing chunking algorithm with a much more efficient one that avoid duplication between chunks in first place and doesn't require a post-chunking optimization.

This change moves a few methods around.

* `Module::as_chunk` is moved to `ChunkItem::as_chunk` as temporary intermediate state.
* `EcmascriptPlaceable::as_chunk_item` is moved to `ChunkableModule::as_chunk_item`. This generalizes the concept of converting a Module into a ChunkItem

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->


Closes WEB-1714