### PR TITLE
fix: pin cargo sweep

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -69,7 +69,7 @@ runs:
     - name: "Install cargo-sweep"
       uses: taiki-e/install-action@v2
       with:
-        tool: cargo-sweep,cargo-groups
+        tool: cargo-sweep@0.6.2,cargo-groups
 
     - name: "Run cargo-sweep"
       uses: ./.github/actions/cargo-sweep


### PR DESCRIPTION
### Description

It seems that the recent `cargo-sweep` updates might've [broken our setup](https://github.com/vercel/turbo/actions/runs/6422868444/job/17440769096?pr=6112#step:13:5). This PR pins the previous version.

### Testing Instructions

CI Passes
