### PR TITLE
Ensure process.env.TURBOPACK is always set

### DIFF
--- a/crates/turbopack-cli/src/contexts.rs
+++ b/crates/turbopack-cli/src/contexts.rs
@@ -177,6 +177,7 @@ pub fn get_client_asset_context(
 fn client_defines(node_env: &NodeEnv) -> Vc<CompileTimeDefines> {
     compile_time_defines!(
         process.turbopack = true,
+        process.env.TURBOPACK = true,
         process.env.NODE_ENV = node_env.to_string()
     )
     .cell()

--- a/crates/turbopack-tests/tests/execution.rs
+++ b/crates/turbopack-tests/tests/execution.rs
@@ -199,6 +199,7 @@ async fn run_test(resource: String) -> Result<Vc<RunTestResult>> {
         .defines(
             compile_time_defines!(
                 process.turbopack = true,
+                process.env.TURBOPACK = true,
                 process.env.NODE_ENV = "development",
             )
             .cell(),

--- a/crates/turbopack-tests/tests/snapshot.rs
+++ b/crates/turbopack-tests/tests/snapshot.rs
@@ -214,6 +214,7 @@ async fn run_test(resource: String) -> Result<Vc<FileSystemPath>> {
 
     let defines = compile_time_defines!(
         process.turbopack = true,
+        process.env.TURBOPACK = true,
         process.env.NODE_ENV = "development",
         DEFINED_VALUE = "value",
         DEFINED_TRUE = true,

--- a/crates/turbopack/src/evaluate_context.rs
+++ b/crates/turbopack/src/evaluate_context.rs
@@ -76,8 +76,12 @@ pub async fn node_evaluate_asset_context(
         transitions.unwrap_or_else(|| Vc::cell(Default::default())),
         CompileTimeInfo::builder(node_build_environment())
             .defines(
-                compile_time_defines!(process.turbopack = true, process.env.NODE_ENV = node_env,)
-                    .cell(),
+                compile_time_defines!(
+                    process.turbopack = true,
+                    process.env.NODE_ENV = node_env,
+                    process.env.TURBOPACK = true
+                )
+                .cell(),
             )
             .cell(),
         ModuleOptionsContext {


### PR DESCRIPTION
### Description

Related to https://github.com/vercel/next.js/pull/56496. Server Actions currently shows an error as it seems to use the react-dom-webpack version instead of react-dom-turbopack. This seems to be caused by the changes in https://github.com/vercel/next.js/pull/56438 which checks for `process.env.TURBOPACK` which is not always set currently, unlike `process.turbopack`. This PR adds it in the other places where `process.turbopack` is set.

<!--
  ✍️ Write a short summary of your work.
  If necessary, include relevant screenshots.
-->

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
