### PR TITLE
feat: hook up task cache

### DIFF
--- a/crates/turborepo-lib/src/run/cache.rs
+++ b/crates/turborepo-lib/src/run/cache.rs
@@ -348,4 +348,8 @@ impl TaskCache {
 
         Ok(())
     }
+
+    pub fn expanded_outputs(&self) -> &[AnchoredSystemPathBuf] {
+        &self.expanded_outputs
+    }
 }

--- a/crates/turborepo-lib/src/task_graph/visitor.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor.rs
@@ -13,9 +13,7 @@ use tokio::{process::Command, sync::mpsc};
 use tracing::{debug, error};
 use turbopath::AbsoluteSystemPath;
 use turborepo_env::{EnvironmentVariableMap, ResolvedEnvMode};
-use turborepo_ui::{
-    ColorSelector, OutputClient, OutputSink, OutputWriter, PrefixedUI, PrefixedWriter, UI,
-};
+use turborepo_ui::{ColorSelector, OutputClient, OutputSink, OutputWriter, PrefixedUI, UI};
 
 use crate::{
     cli::EnvMode,
@@ -208,18 +206,45 @@ impl<'a> Visitor<'a> {
             let workspace_directory = self.repo_root.resolve(workspace_dir);
             let errors = errors.clone();
             let task_id_for_display = self.display_task_id(&info);
+            let hash_tracker = self.task_hasher.task_hash_tracker();
 
             tasks.push(tokio::spawn(async move {
                 let task_id = info;
-                let _task_cache = task_cache;
+                let mut task_cache = task_cache;
                 let mut prefixed_ui =
                     Self::prefixed_ui(ui, is_github_actions, &output_client, pretty_prefix.clone());
+
+                match task_cache.restore_outputs(&mut prefixed_ui).await {
+                    Ok(_hit) => {
+                        // we need to set expanded outputs
+                        hash_tracker.insert_expanded_outputs(
+                            task_id,
+                            task_cache.expanded_outputs().to_vec(),
+                        );
+                        callback.send(Ok(())).ok();
+                        return;
+                    }
+                    Err(e) if e.is_cache_miss() => (),
+                    Err(e) => {
+                        prefixed_ui.error(format!("error fetching from cache: {e}"));
+                    }
+                }
 
                 let mut cmd = Command::new(package_manager.to_string());
                 cmd.args(["run", task_id.task()]);
                 cmd.current_dir(workspace_directory.as_path());
                 cmd.stdout(Stdio::piped());
                 cmd.stderr(Stdio::piped());
+
+                let mut stdout_writer =
+                    match task_cache.output_writer(pretty_prefix.clone(), output_client.stdout()) {
+                        Ok(w) => w,
+                        Err(e) => {
+                            error!("failed to capture outputs for \"{task_id}\": {e}");
+                            callback.send(Err(StopExecution)).ok();
+                            return;
+                        }
+                    };
 
                 let mut process = match manager.spawn(cmd, Duration::from_millis(500)) {
                     Some(Ok(child)) => child,
@@ -248,10 +273,7 @@ impl<'a> Visitor<'a> {
                 };
 
                 let exit_status = match process
-                    .wait_with_piped_outputs(
-                        PrefixedWriter::new(ui, pretty_prefix.clone(), output_client.stdout()),
-                        PrefixedWriter::new(ui, pretty_prefix.clone(), output_client.stderr()),
-                    )
+                    .wait_with_single_piped_output(&mut stdout_writer)
                     .await
                 {
                     Ok(Some(exit_status)) => exit_status,
@@ -275,6 +297,10 @@ impl<'a> Visitor<'a> {
                     // The task was successful, nothing special needs to happen.
                     ChildExit::Finished(Some(0)) => (),
                     ChildExit::Finished(Some(code)) => {
+                        // If there was an error, flush the buffered output
+                        if let Err(e) = task_cache.on_error(&mut prefixed_ui) {
+                            error!("error reading logs: {e}");
+                        }
                         let error =
                             TaskErrorCause::from_execution(process.label().to_string(), code);
                         if continue_on_error {
@@ -299,6 +325,20 @@ impl<'a> Visitor<'a> {
                         callback.send(Err(StopExecution)).ok();
                         return;
                     }
+                }
+
+                if let Err(e) = stdout_writer.flush() {
+                    error!("{e}");
+                } else if let Err(e) = task_cache
+                    .save_outputs(&mut prefixed_ui, Duration::from_secs(1))
+                    .await
+                {
+                    error!("error caching output: {e}");
+                } else {
+                    hash_tracker.insert_expanded_outputs(
+                        task_id.clone(),
+                        task_cache.expanded_outputs().to_vec(),
+                    );
                 }
 
                 if let Err(e) = output_client.finish() {

--- a/crates/turborepo-lib/test/scripts/hello_world_hello_moon.js
+++ b/crates/turborepo-lib/test/scripts/hello_world_hello_moon.js
@@ -1,0 +1,2 @@
+console.log("hello world");
+console.warn("hello moon");


### PR DESCRIPTION
### Description

This PR hooks up the task cache to task execution. 

The first commit adds a new method on child process that allows for both stdout/stderr to be written to a single write. If you see a better way to allow both streams to write to the same `Write` type please point it out, I don't love having two very similar methods.

Next commit actually hooks up the task cache during task execution.

Known issues:
 - The task execution code has gotten super cluttered. I do want to break up this function in the near future
 - Log replaying sometimes has issues. I've diffed the log files between the Rust and Go implementations and they end up in the file the same, but getting replayed there appears to be some issues.


### Testing Instructions

Use it!
```
[0 olszewski@chriss-mbp] /tmp/testing $ turbo_dev build --experimental-rust-codepath --force
web:build: cache bypass, force executing db159628c115329d
docs:build: cache bypass, force executing 5a3238fbb7af1c6a
docs:build: 
docs:build: > docs@1.0.0 build /private/tmp/testing/apps/docs
docs:build: > next build
docs:build: 
web:build: 
web:build: > web@1.0.0 build /private/tmp/testing/apps/web
web:build: > next build
web:build: 
docs:build: - info Creating an optimized production build...
web:build: - info Creating an optimized production build...
...
[0 olszewski@chriss-mbp] /tmp/testing $ turbo_dev build --experimental-rust-codepath
web:build: cache hit (outputs already on disk), suppressing logs db159628c115329d
docs:build: cache hit (outputs already on disk), suppressing logs 5a3238fbb7af1c6a
web:build: 
web:build: > web@1.0.0 build /private/tmp/testing/apps/web
web:build: > next build
web:build: 
web:build: - info Creating an optimized production build...
docs:build: 
docs:build: > docs@1.0.0 build /private/tmp/testing/apps/docs
docs:build: > next build
web:build: - info Compiled successfully
web:build: - info Linting and checking validity of types...
web:build: - info Collecting page data...
```


Closes TURBO-1432