### PR TITLE
Turbopack: detect `spawn(process.argv[0], ['-e', ...])`

### DIFF
--- a/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -1370,6 +1370,10 @@ impl JsValue {
                         "process",
                         "The Node.js process module: https://nodejs.org/api/process.html",
                     ),
+                    WellKnownObjectKind::NodeProcessArgv => (
+                        "process.argv",
+                        "The Node.js process.argv property: https://nodejs.org/api/process.html#processargv",
+                    ),
                     WellKnownObjectKind::NodeProcessEnv => (
                         "process.env",
                         "The Node.js process.env property: https://nodejs.org/api/process.html#processenv",
@@ -2960,6 +2964,7 @@ pub enum WellKnownObjectKind {
     OsModule,
     OsModuleDefault,
     NodeProcess,
+    NodeProcessArgv,
     NodeProcessEnv,
     NodePreGyp,
     NodeExpressApp,
@@ -2978,6 +2983,7 @@ impl WellKnownObjectKind {
             Self::ChildProcess => Some(&["child_process"]),
             Self::OsModule => Some(&["os"]),
             Self::NodeProcess => Some(&["process"]),
+            Self::NodeProcessArgv => Some(&["process", "argv"]),
             Self::NodeProcessEnv => Some(&["process", "env"]),
             Self::NodeBuffer => Some(&["Buffer"]),
             Self::RequireCache => Some(&["require", "cache"]),

--- a/crates/turbopack-ecmascript/src/analyzer/well_known.rs
+++ b/crates/turbopack-ecmascript/src/analyzer/well_known.rs
@@ -666,6 +666,7 @@ pub fn child_process_module_member(kind: WellKnownObjectKind, prop: JsValue) -> 
         (WellKnownObjectKind::ChildProcess, Some("default")) => {
             JsValue::WellKnownObject(WellKnownObjectKind::ChildProcessDefault)
         }
+
         _ => JsValue::unknown(
             JsValue::member(
                 Box::new(JsValue::WellKnownObject(WellKnownObjectKind::ChildProcess)),
@@ -714,6 +715,7 @@ async fn node_process_member(
             .as_str()
             .into(),
         Some("cwd") => JsValue::WellKnownFunction(WellKnownFunctionKind::ProcessCwd),
+        Some("argv") => JsValue::WellKnownObject(WellKnownObjectKind::NodeProcessArgv),
         Some("env") => JsValue::WellKnownObject(WellKnownObjectKind::NodeProcessEnv),
         _ => JsValue::unknown(
             JsValue::member(

--- a/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/crates/turbopack-ecmascript/src/references/mod.rs
@@ -27,6 +27,7 @@ use constant_condition::{ConstantCondition, ConstantConditionValue};
 use constant_value::ConstantValue;
 use indexmap::IndexSet;
 use lazy_static::lazy_static;
+use num_traits::Zero;
 use parking_lot::Mutex;
 use regex::Regex;
 use swc_core::{
@@ -39,6 +40,7 @@ use swc_core::{
     },
     ecma::{
         ast::*,
+        atoms::Atom,
         visit::{
             fields::{AssignExprField, ExprField, PatField, PatOrExprField},
             AstParentKind, AstParentNodeRef, VisitAstPath, VisitWithPath,
@@ -87,7 +89,8 @@ use super::{
         graph::{create_graph, Effect},
         linker::link,
         well_known::replace_well_known,
-        JsValue, ObjectPart, WellKnownFunctionKind, WellKnownObjectKind,
+        ConstantValue as JsConstantValue, JsValue, ObjectPart, WellKnownFunctionKind,
+        WellKnownObjectKind,
     },
     errors,
     parse::{parse, ParseResult},
@@ -107,7 +110,7 @@ use crate::{
         imports::{ImportedSymbol, Reexport},
         parse_require_context,
         top_level_await::has_top_level_await,
-        ModuleValue, RequireContextValue,
+        ConstantNumber, ConstantString, ModuleValue, RequireContextValue,
     },
     chunk::EcmascriptExports,
     code_gen::{
@@ -1306,6 +1309,12 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
         }
         JsValue::WellKnownFunction(WellKnownFunctionKind::ChildProcessSpawnMethod(name)) => {
             let args = linked_args(args).await?;
+
+            // Is this specifically `spawn(process.argv[0], ['-e', ...])`?
+            if is_invoking_node_process_eval(&args) {
+                return Ok(());
+            }
+
             if !args.is_empty() {
                 let mut show_dynamic_warning = false;
                 let pat = js_value_to_pattern(&args[0]);
@@ -2697,4 +2706,50 @@ fn detect_dynamic_export(p: &Program) -> DetectedDynamicExportType {
     } else {
         DetectedDynamicExportType::None
     }
+}
+
+/// Detects whether a list of arguments is specifically
+/// `(process.argv[0], ['-e', ...])`. This is useful for detecting if a node
+/// process is being spawned to interpret a string of JavaScript code, and does
+/// not require static analysis.
+fn is_invoking_node_process_eval(args: &[JsValue]) -> bool {
+    if args.len() < 2 {
+        return false;
+    }
+
+    if let JsValue::Member(_, obj, constant) = &args[0] {
+        // Is the first argument to spawn `process.argv[]`?
+        if let (
+            box JsValue::WellKnownObject(WellKnownObjectKind::NodeProcessArgv),
+            box JsValue::Constant(JsConstantValue::Num(ConstantNumber(num))),
+        ) = (obj, constant)
+        {
+            // Is it specifically `process.argv[0]`?
+            if num.is_zero() {
+                if let JsValue::Array {
+                    total_nodes: _,
+                    items,
+                    mutable: _,
+                } = &args[1]
+                {
+                    // Is `-e` one of the arguments passed to the program?
+                    if items.iter().any(|e| {
+                        if let JsValue::Constant(JsConstantValue::Str(ConstantString::Word(arg))) =
+                            e
+                        {
+                            arg == "-e"
+                        } else {
+                            false
+                        }
+                    }) {
+                        // If so, this is likely spawning node to evaluate a string, and
+                        // does not need to be statically analyzed.
+                        return true;
+                    }
+                }
+            }
+        }
+    }
+
+    false
 }

--- a/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/input/index.js
+++ b/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/input/index.js
@@ -1,0 +1,3 @@
+import { spawn } from "child_process";
+
+let x = spawn(process.argv[0], ["-e", "console.log('foo');"]);

--- a/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/input/node_modules/child_process/index.js
+++ b/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/input/node_modules/child_process/index.js
@@ -1,0 +1,3 @@
+export function spawn(cmd, args) {
+  //
+}

--- a/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/options.json
+++ b/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/options.json
@@ -1,0 +1,3 @@
+{
+    "environment": "NodeJs"
+}

--- a/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/output/134fc_child_process_index_64e768.js
+++ b/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/output/134fc_child_process_index_64e768.js
@@ -1,0 +1,15 @@
+(globalThis.TURBOPACK = globalThis.TURBOPACK || []).push(["output/134fc_child_process_index_64e768.js", {
+
+"[project]/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/input/node_modules/child_process/index.js (ecmascript)": (({ r: __turbopack_require__, f: __turbopack_require_context__, i: __turbopack_import__, s: __turbopack_esm__, v: __turbopack_export_value__, n: __turbopack_export_namespace__, c: __turbopack_cache__, l: __turbopack_load__, j: __turbopack_dynamic__, g: global, __dirname, x: __turbopack_external_require__, y: __turbopack_external_import__, k: __turbopack_refresh__ }) => (() => {
+
+__turbopack_esm__({
+    "spawn": ()=>spawn
+});
+function spawn(cmd, args) {
+//
+}
+
+})()),
+}]);
+
+//# sourceMappingURL=134fc_child_process_index_64e768.js.map

--- a/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/output/134fc_child_process_index_64e768.js.map
+++ b/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/output/134fc_child_process_index_64e768.js.map
@@ -1,0 +1,6 @@
+{
+  "version": 3,
+  "sections": [
+    {"offset": {"line": 4, "column": 0}, "map": {"version":3,"sources":["/turbopack/[project]/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/input/node_modules/child_process/index.js"],"sourcesContent":["export function spawn(cmd, args) {\n  //\n}\n"],"names":[],"mappings":";;;AAAO,SAAS,MAAM,GAAG,EAAE,IAAI;AAC7B,EAAE;AACJ"}},
+    {"offset": {"line": 10, "column": 0}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}}]
+}

--- a/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/output/crates_turbopack-tests_tests_snapshot_node_spawn_node_eval_input_index_a238f1.js
+++ b/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/output/crates_turbopack-tests_tests_snapshot_node_spawn_node_eval_input_index_a238f1.js
@@ -1,0 +1,12 @@
+(globalThis.TURBOPACK = globalThis.TURBOPACK || []).push([
+    "output/crates_turbopack-tests_tests_snapshot_node_spawn_node_eval_input_index_a238f1.js",
+    {},
+]);
+(globalThis.TURBOPACK_CHUNK_LISTS = globalThis.TURBOPACK_CHUNK_LISTS || []).push({
+  "path": "output/crates_turbopack-tests_tests_snapshot_node_spawn_node_eval_input_index_a238f1.js",
+  "chunks": [
+    "output/crates_turbopack-tests_tests_snapshot_node_spawn_node_eval_input_index_b53fce.js",
+    "output/134fc_child_process_index_64e768.js"
+  ],
+  "source": "entry"
+});

--- a/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/output/crates_turbopack-tests_tests_snapshot_node_spawn_node_eval_input_index_b53fce.js
+++ b/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/output/crates_turbopack-tests_tests_snapshot_node_spawn_node_eval_input_index_b53fce.js
@@ -1,0 +1,16 @@
+(globalThis.TURBOPACK = globalThis.TURBOPACK || []).push(["output/crates_turbopack-tests_tests_snapshot_node_spawn_node_eval_input_index_b53fce.js", {
+
+"[project]/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/input/index.js (ecmascript)": (({ r: __turbopack_require__, f: __turbopack_require_context__, i: __turbopack_import__, s: __turbopack_esm__, v: __turbopack_export_value__, n: __turbopack_export_namespace__, c: __turbopack_cache__, l: __turbopack_load__, j: __turbopack_dynamic__, g: global, __dirname, x: __turbopack_external_require__, y: __turbopack_external_import__, k: __turbopack_refresh__ }) => (() => {
+
+var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$node$2f$spawn_node_eval$2f$input$2f$node_modules$2f$child_process$2f$index$2e$js__$28$ecmascript$29$__ = __turbopack_import__("[project]/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/input/node_modules/child_process/index.js (ecmascript)");
+"__TURBOPACK__ecmascript__hoisting__location__";
+;
+let x = __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$node$2f$spawn_node_eval$2f$input$2f$node_modules$2f$child_process$2f$index$2e$js__$28$ecmascript$29$__["spawn"](process.argv[0], [
+    "-e",
+    "console.log('foo');"
+]);
+
+})()),
+}]);
+
+//# sourceMappingURL=crates_turbopack-tests_tests_snapshot_node_spawn_node_eval_input_index_b53fce.js.map

--- a/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/output/crates_turbopack-tests_tests_snapshot_node_spawn_node_eval_input_index_b53fce.js.map
+++ b/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/output/crates_turbopack-tests_tests_snapshot_node_spawn_node_eval_input_index_b53fce.js.map
@@ -1,0 +1,6 @@
+{
+  "version": 3,
+  "sections": [
+    {"offset": {"line": 4, "column": 0}, "map": {"version":3,"sources":["/turbopack/[project]/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/input/index.js"],"sourcesContent":["import { spawn } from \"child_process\";\n\nlet x = spawn(process.argv[0], [\"-e\", \"console.log('foo');\"]);\n"],"names":[],"mappings":";;;AAEA,IAAI,IAAI,qNAAM,QAAQ,IAAI,CAAC,EAAE,EAAE;IAAC;IAAM;CAAsB"}},
+    {"offset": {"line": 11, "column": 0}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}}]
+}

--- a/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/output/crates_turbopack-tests_tests_snapshot_node_spawn_node_eval_input_index_e27a00.js
+++ b/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/output/crates_turbopack-tests_tests_snapshot_node_spawn_node_eval_input_index_e27a00.js
@@ -1,0 +1,6 @@
+(globalThis.TURBOPACK = globalThis.TURBOPACK || []).push([
+    "output/crates_turbopack-tests_tests_snapshot_node_spawn_node_eval_input_index_e27a00.js",
+    {},
+    {"otherChunks":[{"path":"output/crates_turbopack-tests_tests_snapshot_node_spawn_node_eval_input_index_b53fce.js","included":["[project]/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/input/index.js (ecmascript)"]},{"path":"output/134fc_child_process_index_64e768.js","included":["[project]/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/input/node_modules/child_process/index.js (ecmascript)"]}],"runtimeModuleIds":["[project]/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/input/index.js (ecmascript)"]}
+]);
+// Dummy runtime

--- a/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/output/crates_turbopack-tests_tests_snapshot_node_spawn_node_eval_input_index_e27a00.js.map
+++ b/crates/turbopack-tests/tests/snapshot/node/spawn_node_eval/output/crates_turbopack-tests_tests_snapshot_node_spawn_node_eval_input_index_e27a00.js.map
@@ -1,0 +1,4 @@
+{
+  "version": 3,
+  "sections": []
+}


### PR DESCRIPTION
This detects a specific pattern for invoking a node process to evaluate a string of JavaScript code. Since a filepath can't (or shouldn't) be passed here, this exempts it from static analysis.

This pattern is used by the package `xmlhttprequest-ssl`, which is required transitively by socket.io-client: https://github.com/mjwwit/node-XMLHttpRequest/blob/b0271d5e52692d9f48da6088b27d5bf2a6f50d86/lib/XMLHttpRequest.js#L544

Fixes WEB-1554
Resolves vercel/next.js#54787

Test Plan:
- Added snapshot test
- Manual test with a project using socket.io-client
