### PR TITLE
Extract as_chunk into shared ChunkType trait

### DIFF
--- a/crates/turbopack-css/src/asset.rs
+++ b/crates/turbopack-css/src/asset.rs
@@ -7,13 +7,11 @@ use swc_core::{
         visit::{VisitMutWith, VisitMutWithPath},
     },
 };
-use turbo_tasks::{TryJoinIterExt, Value, ValueToString, Vc};
+use turbo_tasks::{TryJoinIterExt, ValueToString, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     asset::{Asset, AssetContent},
-    chunk::{
-        availability_info::AvailabilityInfo, Chunk, ChunkItem, ChunkableModule, ChunkingContext,
-    },
+    chunk::{ChunkItem, ChunkType, ChunkableModule, ChunkingContext},
     context::AssetContext,
     ident::AssetIdent,
     module::Module,
@@ -23,7 +21,7 @@ use turbopack_core::{
 };
 
 use crate::{
-    chunk::{CssChunk, CssChunkItem, CssChunkItemContent, CssChunkPlaceable, CssImport},
+    chunk::{CssChunkItem, CssChunkItemContent, CssChunkPlaceable, CssChunkType, CssImport},
     code_gen::CodeGenerateable,
     parse::{parse_css, ParseCss, ParseCssResult, ParseCssResultSourceMap},
     path_visitor::ApplyVisitors,
@@ -163,12 +161,13 @@ impl ChunkItem for CssModuleChunkItem {
     }
 
     #[turbo_tasks::function]
-    fn as_chunk(&self, availability_info: Value<AvailabilityInfo>) -> Vc<Box<dyn Chunk>> {
-        Vc::upcast(CssChunk::new(
-            self.chunking_context,
-            Vc::upcast(self.module),
-            availability_info,
-        ))
+    fn ty(&self) -> Vc<Box<dyn ChunkType>> {
+        Vc::upcast(Vc::<CssChunkType>::default())
+    }
+
+    #[turbo_tasks::function]
+    fn module(&self) -> Vc<Box<dyn Module>> {
+        Vc::upcast(self.module)
     }
 }
 

--- a/crates/turbopack-css/src/module_asset.rs
+++ b/crates/turbopack-css/src/module_asset.rs
@@ -11,10 +11,7 @@ use turbo_tasks::{Value, ValueToString, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     asset::{Asset, AssetContent},
-    chunk::{
-        availability_info::AvailabilityInfo, Chunk, ChunkItem, ChunkItemExt, ChunkableModule,
-        ChunkingContext,
-    },
+    chunk::{ChunkItem, ChunkItemExt, ChunkType, ChunkableModule, ChunkingContext},
     context::AssetContext,
     ident::AssetIdent,
     issue::{Issue, IssueExt, IssueSeverity},
@@ -26,8 +23,8 @@ use turbopack_core::{
 };
 use turbopack_ecmascript::{
     chunk::{
-        EcmascriptChunk, EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkPlaceable,
-        EcmascriptChunkingContext, EcmascriptExports,
+        EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkPlaceable,
+        EcmascriptChunkType, EcmascriptChunkingContext, EcmascriptExports,
     },
     utils::StringifyJs,
     ParseResultSourceMap,
@@ -277,12 +274,13 @@ impl ChunkItem for ModuleChunkItem {
     }
 
     #[turbo_tasks::function]
-    fn as_chunk(&self, availability_info: Value<AvailabilityInfo>) -> Vc<Box<dyn Chunk>> {
-        Vc::upcast(EcmascriptChunk::new(
-            Vc::upcast(self.chunking_context),
-            Vc::upcast(self.module),
-            availability_info,
-        ))
+    fn ty(&self) -> Vc<Box<dyn ChunkType>> {
+        Vc::upcast(Vc::<EcmascriptChunkType>::default())
+    }
+
+    #[turbo_tasks::function]
+    fn module(&self) -> Vc<Box<dyn Module>> {
+        Vc::upcast(self.module)
     }
 }
 

--- a/crates/turbopack-ecmascript/src/chunk/chunk_type.rs
+++ b/crates/turbopack-ecmascript/src/chunk/chunk_type.rs
@@ -1,0 +1,40 @@
+use anyhow::{Context, Result};
+use turbo_tasks::{Value, ValueDefault, Vc};
+use turbopack_core::chunk::{availability_info::AvailabilityInfo, Chunk, ChunkItem, ChunkType};
+
+use super::{EcmascriptChunk, EcmascriptChunkPlaceable};
+
+#[derive(Default)]
+#[turbo_tasks::value]
+pub struct EcmascriptChunkType {}
+
+#[turbo_tasks::value_impl]
+impl ChunkType for EcmascriptChunkType {
+    #[turbo_tasks::function]
+    async fn as_chunk(
+        &self,
+        chunk_item: Vc<Box<dyn ChunkItem>>,
+        availability_info: Value<AvailabilityInfo>,
+    ) -> Result<Vc<Box<dyn Chunk>>> {
+        let placeable =
+            Vc::try_resolve_sidecast::<Box<dyn EcmascriptChunkPlaceable>>(chunk_item.module())
+                .await?
+                .context(
+                    "Module must implmement EcmascriptChunkPlaceable to be used as a EcmaScript \
+                     Chunk",
+                )?;
+        Ok(Vc::upcast(EcmascriptChunk::new(
+            chunk_item.chunking_context(),
+            placeable,
+            availability_info,
+        )))
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl ValueDefault for EcmascriptChunkType {
+    #[turbo_tasks::function]
+    fn value_default() -> Vc<Self> {
+        Self::default().cell()
+    }
+}

--- a/crates/turbopack-ecmascript/src/chunk/mod.rs
+++ b/crates/turbopack-ecmascript/src/chunk/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod chunk_type;
 pub(crate) mod content;
 pub(crate) mod context;
 pub(crate) mod data;
@@ -30,6 +31,7 @@ use turbopack_core::{
 
 use self::content::ecmascript_chunk_content;
 pub use self::{
+    chunk_type::EcmascriptChunkType,
     content::EcmascriptChunkContent,
     context::EcmascriptChunkingContext,
     data::EcmascriptChunkData,

--- a/crates/turbopack-ecmascript/src/chunk_group_files_asset.rs
+++ b/crates/turbopack-ecmascript/src/chunk_group_files_asset.rs
@@ -1,12 +1,12 @@
 use anyhow::{Context, Result};
 use indexmap::IndexSet;
-use turbo_tasks::{TryJoinIterExt, Value, ValueToString, Vc};
+use turbo_tasks::{TryJoinIterExt, ValueToString, Vc};
 use turbo_tasks_fs::{File, FileSystemPath};
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{
-        availability_info::AvailabilityInfo, Chunk, ChunkItem, ChunkableModule, ChunkingContext,
-        ChunkingContextExt, EvaluatableAssets,
+        ChunkItem, ChunkType, ChunkableModule, ChunkingContext, ChunkingContextExt,
+        EvaluatableAssets,
     },
     ident::AssetIdent,
     introspect::{
@@ -22,8 +22,8 @@ use turbopack_core::{
 
 use crate::{
     chunk::{
-        EcmascriptChunk, EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkPlaceable,
-        EcmascriptChunkingContext, EcmascriptExports,
+        EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkPlaceable,
+        EcmascriptChunkType, EcmascriptChunkingContext, EcmascriptExports,
     },
     utils::StringifyJs,
     EcmascriptModuleAsset,
@@ -227,12 +227,13 @@ impl ChunkItem for ChunkGroupFilesChunkItem {
     }
 
     #[turbo_tasks::function]
-    fn as_chunk(&self, availability_info: Value<AvailabilityInfo>) -> Vc<Box<dyn Chunk>> {
-        Vc::upcast(EcmascriptChunk::new(
-            Vc::upcast(self.chunking_context),
-            Vc::upcast(self.inner),
-            availability_info,
-        ))
+    fn ty(&self) -> Vc<Box<dyn ChunkType>> {
+        Vc::upcast(Vc::<EcmascriptChunkType>::default())
+    }
+
+    #[turbo_tasks::function]
+    fn module(&self) -> Vc<Box<dyn Module>> {
+        Vc::upcast(self.inner)
     }
 }
 

--- a/crates/turbopack-ecmascript/src/lib.rs
+++ b/crates/turbopack-ecmascript/src/lib.rs
@@ -54,8 +54,8 @@ use turbo_tasks_fs::{rope::Rope, FileSystemPath};
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{
-        availability_info::AvailabilityInfo, Chunk, ChunkItem, ChunkableModule, ChunkingContext,
-        EvaluatableAsset,
+        availability_info::AvailabilityInfo, Chunk, ChunkItem, ChunkType, ChunkableModule,
+        ChunkingContext, EvaluatableAsset,
     },
     compile_time_info::CompileTimeInfo,
     context::AssetContext,
@@ -68,7 +68,7 @@ use turbopack_core::{
 };
 
 use self::{
-    chunk::{EcmascriptChunkItemContent, EcmascriptExports},
+    chunk::{EcmascriptChunkItemContent, EcmascriptChunkType, EcmascriptExports},
     code_gen::{CodeGen, CodeGenerateableWithAvailabilityInfo, VisitorFactory},
     tree_shake::asset::EcmascriptModulePartAsset,
 };
@@ -483,12 +483,13 @@ impl ChunkItem for ModuleChunkItem {
     }
 
     #[turbo_tasks::function]
-    fn as_chunk(&self, availability_info: Value<AvailabilityInfo>) -> Vc<Box<dyn Chunk>> {
-        Vc::upcast(EcmascriptChunk::new(
-            Vc::upcast(self.chunking_context),
-            Vc::upcast(self.module),
-            availability_info,
-        ))
+    fn ty(&self) -> Vc<Box<dyn ChunkType>> {
+        Vc::upcast(Vc::<EcmascriptChunkType>::default())
+    }
+
+    #[turbo_tasks::function]
+    fn module(&self) -> Vc<Box<dyn Module>> {
+        Vc::upcast(self.module)
     }
 }
 

--- a/crates/turbopack-ecmascript/src/manifest/chunk_item.rs
+++ b/crates/turbopack-ecmascript/src/manifest/chunk_item.rs
@@ -1,11 +1,8 @@
 use anyhow::Result;
 use indoc::formatdoc;
-use turbo_tasks::{TryJoinIterExt, Value, Vc};
+use turbo_tasks::{TryJoinIterExt, Vc};
 use turbopack_core::{
-    chunk::{
-        availability_info::AvailabilityInfo, Chunk, ChunkData, ChunkItem, ChunkingContext,
-        ChunksData,
-    },
+    chunk::{ChunkData, ChunkItem, ChunkType, ChunkingContext, ChunksData},
     ident::AssetIdent,
     module::Module,
     reference::{ModuleReferences, SingleOutputAssetReference},
@@ -14,8 +11,8 @@ use turbopack_core::{
 use super::chunk_asset::ManifestChunkAsset;
 use crate::{
     chunk::{
-        data::EcmascriptChunkData, EcmascriptChunk, EcmascriptChunkItem,
-        EcmascriptChunkItemContent, EcmascriptChunkingContext,
+        data::EcmascriptChunkData, EcmascriptChunkItem, EcmascriptChunkItemContent,
+        EcmascriptChunkType, EcmascriptChunkingContext,
     },
     utils::StringifyJs,
 };
@@ -101,11 +98,12 @@ impl ChunkItem for ManifestChunkItem {
     }
 
     #[turbo_tasks::function]
-    fn as_chunk(&self, availability_info: Value<AvailabilityInfo>) -> Vc<Box<dyn Chunk>> {
-        Vc::upcast(EcmascriptChunk::new(
-            Vc::upcast(self.chunking_context),
-            Vc::upcast(self.manifest),
-            availability_info,
-        ))
+    fn ty(&self) -> Vc<Box<dyn ChunkType>> {
+        Vc::upcast(Vc::<EcmascriptChunkType>::default())
+    }
+
+    #[turbo_tasks::function]
+    fn module(&self) -> Vc<Box<dyn Module>> {
+        Vc::upcast(self.manifest)
     }
 }

--- a/crates/turbopack-ecmascript/src/manifest/loader_item.rs
+++ b/crates/turbopack-ecmascript/src/manifest/loader_item.rs
@@ -2,11 +2,10 @@ use std::io::Write as _;
 
 use anyhow::{anyhow, Result};
 use indoc::writedoc;
-use turbo_tasks::{TryJoinIterExt, Value, Vc};
+use turbo_tasks::{TryJoinIterExt, Vc};
 use turbopack_core::{
     chunk::{
-        availability_info::AvailabilityInfo, Chunk, ChunkData, ChunkItem, ChunkItemExt,
-        ChunkableModule, ChunkingContext, ChunksData,
+        ChunkData, ChunkItem, ChunkItemExt, ChunkType, ChunkableModule, ChunkingContext, ChunksData,
     },
     ident::AssetIdent,
     module::Module,
@@ -16,8 +15,8 @@ use turbopack_core::{
 use super::chunk_asset::ManifestChunkAsset;
 use crate::{
     chunk::{
-        data::EcmascriptChunkData, EcmascriptChunk, EcmascriptChunkItem,
-        EcmascriptChunkItemContent, EcmascriptChunkPlaceable, EcmascriptChunkingContext,
+        data::EcmascriptChunkData, EcmascriptChunkItem, EcmascriptChunkItemContent,
+        EcmascriptChunkPlaceable, EcmascriptChunkType, EcmascriptChunkingContext,
     },
     utils::StringifyJs,
 };
@@ -121,12 +120,13 @@ impl ChunkItem for ManifestLoaderItem {
     }
 
     #[turbo_tasks::function]
-    fn as_chunk(&self, availability_info: Value<AvailabilityInfo>) -> Vc<Box<dyn Chunk>> {
-        Vc::upcast(EcmascriptChunk::new(
-            self.chunking_context,
-            Vc::upcast(self.manifest),
-            availability_info,
-        ))
+    fn ty(&self) -> Vc<Box<dyn ChunkType>> {
+        Vc::upcast(Vc::<EcmascriptChunkType>::default())
+    }
+
+    #[turbo_tasks::function]
+    fn module(&self) -> Vc<Box<dyn Module>> {
+        Vc::upcast(self.manifest)
     }
 }
 

--- a/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -18,8 +18,8 @@ use turbo_tasks_fs::{DirectoryContent, DirectoryEntry, FileSystemPath};
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{
-        availability_info::AvailabilityInfo, Chunk, ChunkItem, ChunkItemExt, ChunkableModule,
-        ChunkableModuleReference, ChunkingContext,
+        ChunkItem, ChunkItemExt, ChunkType, ChunkableModule, ChunkableModuleReference,
+        ChunkingContext,
     },
     ident::AssetIdent,
     issue::{IssueSeverity, OptionIssueSource},
@@ -31,7 +31,7 @@ use turbopack_core::{
 
 use crate::{
     chunk::{
-        EcmascriptChunk, EcmascriptChunkItem, EcmascriptChunkItemContent,
+        EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkType,
         EcmascriptChunkingContext, EcmascriptExports,
     },
     code_gen::CodeGeneration,
@@ -516,11 +516,12 @@ impl ChunkItem for RequireContextChunkItem {
     }
 
     #[turbo_tasks::function]
-    fn as_chunk(&self, availability_info: Value<AvailabilityInfo>) -> Vc<Box<dyn Chunk>> {
-        Vc::upcast(EcmascriptChunk::new(
-            Vc::upcast(self.chunking_context),
-            Vc::upcast(self.inner),
-            availability_info,
-        ))
+    fn ty(&self) -> Vc<Box<dyn ChunkType>> {
+        Vc::upcast(Vc::<EcmascriptChunkType>::default())
+    }
+
+    #[turbo_tasks::function]
+    fn module(&self) -> Vc<Box<dyn Module>> {
+        Vc::upcast(self.inner)
     }
 }

--- a/crates/turbopack-ecmascript/src/tree_shake/chunk_item.rs
+++ b/crates/turbopack-ecmascript/src/tree_shake/chunk_item.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use turbo_tasks::{Value, Vc};
 use turbopack_core::{
-    chunk::{availability_info::AvailabilityInfo, Chunk, ChunkItem, ChunkingContext},
+    chunk::{availability_info::AvailabilityInfo, ChunkItem, ChunkType, ChunkingContext},
     ident::AssetIdent,
     module::Module,
     reference::ModuleReferences,
@@ -10,8 +10,8 @@ use turbopack_core::{
 use super::{asset::EcmascriptModulePartAsset, part_of_module, split_module};
 use crate::{
     chunk::{
-        placeable::EcmascriptChunkPlaceable, EcmascriptChunk, EcmascriptChunkItem,
-        EcmascriptChunkItemContent, EcmascriptChunkingContext,
+        placeable::EcmascriptChunkPlaceable, EcmascriptChunkItem, EcmascriptChunkItemContent,
+        EcmascriptChunkType, EcmascriptChunkingContext,
     },
     EcmascriptModuleContent,
 };
@@ -95,11 +95,12 @@ impl ChunkItem for EcmascriptModulePartChunkItem {
     }
 
     #[turbo_tasks::function]
-    fn as_chunk(&self, availability_info: Value<AvailabilityInfo>) -> Vc<Box<dyn Chunk>> {
-        Vc::upcast(EcmascriptChunk::new(
-            Vc::upcast(self.chunking_context),
-            Vc::upcast(self.module),
-            availability_info,
-        ))
+    fn ty(&self) -> Vc<Box<dyn ChunkType>> {
+        Vc::upcast(Vc::<EcmascriptChunkType>::default())
+    }
+
+    #[turbo_tasks::function]
+    fn module(&self) -> Vc<Box<dyn Module>> {
+        Vc::upcast(self.module)
     }
 }

--- a/crates/turbopack-json/src/lib.rs
+++ b/crates/turbopack-json/src/lib.rs
@@ -12,20 +12,18 @@
 use std::fmt::Write;
 
 use anyhow::{bail, Context, Error, Result};
-use turbo_tasks::{Value, ValueToString, Vc};
+use turbo_tasks::{ValueToString, Vc};
 use turbo_tasks_fs::{FileContent, FileJsonContent};
 use turbopack_core::{
     asset::{Asset, AssetContent},
-    chunk::{
-        availability_info::AvailabilityInfo, Chunk, ChunkItem, ChunkableModule, ChunkingContext,
-    },
+    chunk::{ChunkItem, ChunkType, ChunkableModule, ChunkingContext},
     ident::AssetIdent,
     module::Module,
     reference::ModuleReferences,
     source::Source,
 };
 use turbopack_ecmascript::chunk::{
-    EcmascriptChunk, EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkPlaceable,
+    EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkPlaceable, EcmascriptChunkType,
     EcmascriptChunkingContext, EcmascriptExports,
 };
 
@@ -115,12 +113,13 @@ impl ChunkItem for JsonChunkItem {
     }
 
     #[turbo_tasks::function]
-    fn as_chunk(&self, availability_info: Value<AvailabilityInfo>) -> Vc<Box<dyn Chunk>> {
-        Vc::upcast(EcmascriptChunk::new(
-            Vc::upcast(self.chunking_context),
-            Vc::upcast(self.module),
-            availability_info,
-        ))
+    fn ty(&self) -> Vc<Box<dyn ChunkType>> {
+        Vc::upcast(Vc::<EcmascriptChunkType>::default())
+    }
+
+    #[turbo_tasks::function]
+    fn module(&self) -> Vc<Box<dyn Module>> {
+        Vc::upcast(self.module)
     }
 }
 

--- a/crates/turbopack-mdx/src/lib.rs
+++ b/crates/turbopack-mdx/src/lib.rs
@@ -8,9 +8,7 @@ use turbo_tasks::{Value, ValueDefault, Vc};
 use turbo_tasks_fs::{rope::Rope, File, FileContent, FileSystemPath};
 use turbopack_core::{
     asset::{Asset, AssetContent},
-    chunk::{
-        availability_info::AvailabilityInfo, Chunk, ChunkItem, ChunkableModule, ChunkingContext,
-    },
+    chunk::{ChunkItem, ChunkType, ChunkableModule, ChunkingContext},
     context::AssetContext,
     ident::AssetIdent,
     module::Module,
@@ -21,8 +19,8 @@ use turbopack_core::{
 };
 use turbopack_ecmascript::{
     chunk::{
-        EcmascriptChunk, EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkPlaceable,
-        EcmascriptChunkingContext, EcmascriptExports,
+        EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkPlaceable,
+        EcmascriptChunkType, EcmascriptChunkingContext, EcmascriptExports,
     },
     AnalyzeEcmascriptModuleResult, EcmascriptInputTransforms, EcmascriptModuleAsset,
     EcmascriptModuleAssetType,
@@ -251,12 +249,13 @@ impl ChunkItem for MdxChunkItem {
     }
 
     #[turbo_tasks::function]
-    fn as_chunk(&self, availability_info: Value<AvailabilityInfo>) -> Vc<Box<dyn Chunk>> {
-        Vc::upcast(EcmascriptChunk::new(
-            Vc::upcast(self.chunking_context),
-            Vc::upcast(self.module),
-            availability_info,
-        ))
+    fn ty(&self) -> Vc<Box<dyn ChunkType>> {
+        Vc::upcast(Vc::<EcmascriptChunkType>::default())
+    }
+
+    #[turbo_tasks::function]
+    fn module(&self) -> Vc<Box<dyn Module>> {
+        Vc::upcast(self.module)
     }
 }
 

--- a/crates/turbopack-static/src/lib.rs
+++ b/crates/turbopack-static/src/lib.rs
@@ -15,13 +15,11 @@
 pub mod fixed;
 
 use anyhow::{anyhow, Context, Result};
-use turbo_tasks::{Value, ValueToString, Vc};
+use turbo_tasks::{ValueToString, Vc};
 use turbo_tasks_fs::FileContent;
 use turbopack_core::{
     asset::{Asset, AssetContent},
-    chunk::{
-        availability_info::AvailabilityInfo, Chunk, ChunkItem, ChunkableModule, ChunkingContext,
-    },
+    chunk::{ChunkItem, ChunkType, ChunkableModule, ChunkingContext},
     context::AssetContext,
     ident::AssetIdent,
     module::Module,
@@ -32,8 +30,8 @@ use turbopack_core::{
 use turbopack_css::embed::{CssEmbed, CssEmbeddable};
 use turbopack_ecmascript::{
     chunk::{
-        EcmascriptChunk, EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkPlaceable,
-        EcmascriptChunkingContext, EcmascriptExports,
+        EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkPlaceable,
+        EcmascriptChunkType, EcmascriptChunkingContext, EcmascriptExports,
     },
     utils::StringifyJs,
 };
@@ -197,12 +195,13 @@ impl ChunkItem for ModuleChunkItem {
     }
 
     #[turbo_tasks::function]
-    fn as_chunk(&self, availability_info: Value<AvailabilityInfo>) -> Vc<Box<dyn Chunk>> {
-        Vc::upcast(EcmascriptChunk::new(
-            Vc::upcast(self.chunking_context),
-            Vc::upcast(self.module),
-            availability_info,
-        ))
+    fn ty(&self) -> Vc<Box<dyn ChunkType>> {
+        Vc::upcast(Vc::<EcmascriptChunkType>::default())
+    }
+
+    #[turbo_tasks::function]
+    fn module(&self) -> Vc<Box<dyn Module>> {
+        Vc::upcast(self.module)
     }
 }
 

--- a/crates/turbopack-wasm/src/module_asset.rs
+++ b/crates/turbopack-wasm/src/module_asset.rs
@@ -5,7 +5,7 @@ use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{
-        availability_info::AvailabilityInfo, Chunk, ChunkItem, ChunkableModule, ChunkingContext,
+        availability_info::AvailabilityInfo, ChunkItem, ChunkType, ChunkableModule, ChunkingContext,
     },
     context::AssetContext,
     ident::AssetIdent,
@@ -17,8 +17,8 @@ use turbopack_core::{
 };
 use turbopack_ecmascript::{
     chunk::{
-        EcmascriptChunk, EcmascriptChunkItem, EcmascriptChunkItemContent,
-        EcmascriptChunkItemOptions, EcmascriptChunkPlaceable, EcmascriptChunkingContext,
+        EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkItemOptions,
+        EcmascriptChunkPlaceable, EcmascriptChunkType, EcmascriptChunkingContext,
         EcmascriptExports,
     },
     references::async_module::OptionAsyncModule,
@@ -196,12 +196,13 @@ impl ChunkItem for ModuleChunkItem {
     }
 
     #[turbo_tasks::function]
-    fn as_chunk(&self, availability_info: Value<AvailabilityInfo>) -> Vc<Box<dyn Chunk>> {
-        Vc::upcast(EcmascriptChunk::new(
-            Vc::upcast(self.chunking_context),
-            Vc::upcast(self.module),
-            availability_info,
-        ))
+    fn ty(&self) -> Vc<Box<dyn ChunkType>> {
+        Vc::upcast(Vc::<EcmascriptChunkType>::default())
+    }
+
+    #[turbo_tasks::function]
+    fn module(&self) -> Vc<Box<dyn Module>> {
+        Vc::upcast(self.module)
     }
 }
 

--- a/crates/turbopack-wasm/src/raw.rs
+++ b/crates/turbopack-wasm/src/raw.rs
@@ -1,10 +1,8 @@
 use anyhow::{bail, Context, Result};
-use turbo_tasks::{Value, ValueToString, Vc};
+use turbo_tasks::{ValueToString, Vc};
 use turbopack_core::{
     asset::{Asset, AssetContent},
-    chunk::{
-        availability_info::AvailabilityInfo, Chunk, ChunkItem, ChunkableModule, ChunkingContext,
-    },
+    chunk::{ChunkItem, ChunkType, ChunkableModule, ChunkingContext},
     context::AssetContext,
     ident::AssetIdent,
     module::Module,
@@ -14,8 +12,8 @@ use turbopack_core::{
 };
 use turbopack_ecmascript::{
     chunk::{
-        EcmascriptChunk, EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkPlaceable,
-        EcmascriptChunkingContext, EcmascriptExports,
+        EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkPlaceable,
+        EcmascriptChunkType, EcmascriptChunkingContext, EcmascriptExports,
     },
     utils::StringifyJs,
 };
@@ -134,12 +132,13 @@ impl ChunkItem for RawModuleChunkItem {
     }
 
     #[turbo_tasks::function]
-    fn as_chunk(&self, availability_info: Value<AvailabilityInfo>) -> Vc<Box<dyn Chunk>> {
-        Vc::upcast(EcmascriptChunk::new(
-            Vc::upcast(self.chunking_context),
-            Vc::upcast(self.module),
-            availability_info,
-        ))
+    fn ty(&self) -> Vc<Box<dyn ChunkType>> {
+        Vc::upcast(Vc::<EcmascriptChunkType>::default())
+    }
+
+    #[turbo_tasks::function]
+    fn module(&self) -> Vc<Box<dyn Module>> {
+        Vc::upcast(self.module)
     }
 }
 


### PR DESCRIPTION
### Description

Step 3 in our chunking refactors extracts `ChunkItem::as_chunk` into a new `ChunkType` trait. This new trait isn't useful yet, but will eventually allow us to collect `ChunkItems` of a similar type into a lists, and perform chunking over all similar items at once.

Re: https://github.com/vercel/turbo/pull/6120

### Testing Instructions



Closes WEB-1722