### PR TITLE
Revert "Reuse existing login tokens"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,9 +434,9 @@ checksum = "7a40729d2133846d9ed0ea60a8b9541bccddab49cd30f0715a1da672fe9a2524"
 
 [[package]]
 name = "async-trait"
-version = "0.1.73"
+version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
+checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9988,7 +9988,6 @@ name = "turborepo-api-client"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-trait",
  "chrono",
  "lazy_static",
  "port_scanner",
@@ -10009,22 +10008,17 @@ name = "turborepo-auth"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-trait",
  "axum",
  "axum-server",
- "chrono",
  "hostname",
- "lazy_static",
  "port_scanner",
  "reqwest",
  "serde",
- "tempfile",
  "thiserror",
  "tokio",
  "tracing",
  "turborepo-api-client",
  "turborepo-ui",
- "turborepo-vercel-api",
  "turborepo-vercel-api-mock",
  "webbrowser",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,12 +105,14 @@ turbo-tasks-fs = { path = "crates/turbo-tasks-fs" }
 turbo-tasks-hash = { path = "crates/turbo-tasks-hash" }
 turbo-tasks-macros = { path = "crates/turbo-tasks-macros" }
 turbo-tasks-macros-shared = { path = "crates/turbo-tasks-macros-shared" }
+turbo-tasks-macros-tests = { path = "crates/turbo-tasks-macros-tests" }
 turbo-tasks-memory = { path = "crates/turbo-tasks-memory" }
 turbo-tasks-testing = { path = "crates/turbo-tasks-testing" }
 turbo-updater = { path = "crates/turborepo-updater" }
 turbopack = { path = "crates/turbopack" }
 turbopack-bench = { path = "crates/turbopack-bench" }
 turbopack-build = { path = "crates/turbopack-build" }
+turbopack-cli = { path = "crates/turbopack-cli" }
 turbopack-cli-utils = { path = "crates/turbopack-cli-utils" }
 turbopack-core = { path = "crates/turbopack-core" }
 turbopack-create-test-app = { path = "crates/turbopack-create-test-app" }
@@ -132,10 +134,12 @@ turbopack-test-utils = { path = "crates/turbopack-test-utils" }
 turbopack-tests = { path = "crates/turbopack-tests" }
 turbopack-wasm = { path = "crates/turbopack-wasm" }
 turbopath = { path = "crates/turborepo-paths" }
+turborepo = { path = "crates/turborepo" }
 turborepo-api-client = { path = "crates/turborepo-api-client" }
 turborepo-cache = { path = "crates/turborepo-cache" }
 turborepo-ci = { path = "crates/turborepo-ci" }
 turborepo-env = { path = "crates/turborepo-env" }
+turborepo-ffi = { path = "crates/turborepo-ffi" }
 turborepo-fs = { path = "crates/turborepo-fs" }
 turborepo-lib = { path = "crates/turborepo-lib", default-features = false }
 turborepo-lockfiles = { path = "crates/turborepo-lockfiles" }
@@ -202,6 +206,7 @@ petgraph = "0.6.3"
 pin-project-lite = "0.2.9"
 port_scanner = "0.1.5"
 postcard = "1.0.4"
+predicates = "2.1.5"
 pretty_assertions = "1.3.0"
 proc-macro2 = "1.0.51"
 qstring = "0.7.2"
@@ -232,6 +237,7 @@ tiny-gradient = "0.1.0"
 tokio = "1.25.0"
 tokio-util = { version = "0.7.7", features = ["io"] }
 tracing = "0.1.37"
+tracing-appender = "0.2.2"
 tracing-subscriber = "0.3.16"
 url = "2.2.2"
 urlencoding = "2.1.2"

--- a/crates/turborepo-api-client/Cargo.toml
+++ b/crates/turborepo-api-client/Cargo.toml
@@ -15,7 +15,6 @@ turborepo-vercel-api-mock = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
-async-trait.workspace = true
 chrono = { workspace = true, features = ["serde"] }
 lazy_static = { workspace = true }
 regex = { workspace = true }

--- a/crates/turborepo-api-client/src/lib.rs
+++ b/crates/turborepo-api-client/src/lib.rs
@@ -4,7 +4,6 @@
 
 use std::{backtrace::Backtrace, env};
 
-use async_trait::async_trait;
 use lazy_static::lazy_static;
 use regex::Regex;
 pub use reqwest::Response;
@@ -27,66 +26,6 @@ lazy_static! {
         Regex::new(r"(?i)(?:^|,) *authorization *(?:,|$)").unwrap();
 }
 
-#[async_trait]
-pub trait Client {
-    async fn get_user(&self, token: &str) -> Result<UserResponse>;
-    async fn get_teams(&self, token: &str) -> Result<TeamsResponse>;
-    async fn get_team(&self, token: &str, team_id: &str) -> Result<Option<Team>>;
-    fn add_ci_header(request_builder: RequestBuilder) -> RequestBuilder;
-    fn add_team_params(
-        request_builder: RequestBuilder,
-        team_id: &str,
-        team_slug: Option<&str>,
-    ) -> RequestBuilder;
-    async fn get_caching_status(
-        &self,
-        token: &str,
-        team_id: &str,
-        team_slug: Option<&str>,
-    ) -> Result<CachingStatusResponse>;
-    async fn get_spaces(&self, token: &str, team_id: Option<&str>) -> Result<SpacesResponse>;
-    async fn verify_sso_token(&self, token: &str, token_name: &str) -> Result<VerifiedSsoUser>;
-    async fn put_artifact(
-        &self,
-        hash: &str,
-        artifact_body: &[u8],
-        duration: u64,
-        tag: Option<&str>,
-        token: &str,
-    ) -> Result<()>;
-    async fn handle_403(response: Response) -> Error;
-    async fn fetch_artifact(
-        &self,
-        hash: &str,
-        token: &str,
-        team_id: &str,
-        team_slug: Option<&str>,
-    ) -> Result<Response>;
-    async fn artifact_exists(
-        &self,
-        hash: &str,
-        token: &str,
-        team_id: &str,
-        team_slug: Option<&str>,
-    ) -> Result<Response>;
-    async fn get_artifact(
-        &self,
-        hash: &str,
-        token: &str,
-        team_id: &str,
-        team_slug: Option<&str>,
-        method: Method,
-    ) -> Result<Response>;
-    async fn do_preflight(
-        &self,
-        token: &str,
-        request_url: &str,
-        request_method: &str,
-        request_headers: &str,
-    ) -> Result<PreflightResponse>;
-    fn make_url(&self, endpoint: &str) -> String;
-}
-
 pub struct APIClient {
     client: reqwest::Client,
     base_url: String,
@@ -100,9 +39,8 @@ pub struct APIAuth {
     pub team_slug: Option<String>,
 }
 
-#[async_trait]
-impl Client for APIClient {
-    async fn get_user(&self, token: &str) -> Result<UserResponse> {
+impl APIClient {
+    pub async fn get_user(&self, token: &str) -> Result<UserResponse> {
         let url = self.make_url("/v2/user");
         let request_builder = self
             .client
@@ -117,7 +55,7 @@ impl Client for APIClient {
         Ok(response.json().await?)
     }
 
-    async fn get_teams(&self, token: &str) -> Result<TeamsResponse> {
+    pub async fn get_teams(&self, token: &str) -> Result<TeamsResponse> {
         let request_builder = self
             .client
             .get(self.make_url("/v2/teams?limit=100"))
@@ -132,7 +70,7 @@ impl Client for APIClient {
         Ok(response.json().await?)
     }
 
-    async fn get_team(&self, token: &str, team_id: &str) -> Result<Option<Team>> {
+    pub async fn get_team(&self, token: &str, team_id: &str) -> Result<Option<Team>> {
         let response = self
             .client
             .get(self.make_url("/v2/team"))
@@ -146,6 +84,7 @@ impl Client for APIClient {
 
         Ok(response.json().await?)
     }
+
     fn add_ci_header(mut request_builder: RequestBuilder) -> RequestBuilder {
         if is_ci() {
             if let Some(vendor_constant) = Vendor::get_constant() {
@@ -171,7 +110,7 @@ impl Client for APIClient {
         request_builder
     }
 
-    async fn get_caching_status(
+    pub async fn get_caching_status(
         &self,
         token: &str,
         team_id: &str,
@@ -193,7 +132,7 @@ impl Client for APIClient {
         Ok(response.json().await?)
     }
 
-    async fn get_spaces(&self, token: &str, team_id: Option<&str>) -> Result<SpacesResponse> {
+    pub async fn get_spaces(&self, token: &str, team_id: Option<&str>) -> Result<SpacesResponse> {
         // create url with teamId if provided
         let endpoint = match team_id {
             Some(team_id) => format!("/v0/spaces?limit=100&teamId={}", team_id),
@@ -214,7 +153,7 @@ impl Client for APIClient {
         Ok(response.json().await?)
     }
 
-    async fn verify_sso_token(&self, token: &str, token_name: &str) -> Result<VerifiedSsoUser> {
+    pub async fn verify_sso_token(&self, token: &str, token_name: &str) -> Result<VerifiedSsoUser> {
         let request_builder = self
             .client
             .get(self.make_url("/registration/verify"))
@@ -233,7 +172,7 @@ impl Client for APIClient {
         })
     }
 
-    async fn put_artifact(
+    pub async fn put_artifact(
         &self,
         hash: &str,
         artifact_body: &[u8],
@@ -319,7 +258,7 @@ impl Client for APIClient {
         }
     }
 
-    async fn fetch_artifact(
+    pub async fn fetch_artifact(
         &self,
         hash: &str,
         token: &str,
@@ -330,7 +269,7 @@ impl Client for APIClient {
             .await
     }
 
-    async fn artifact_exists(
+    pub async fn artifact_exists(
         &self,
         hash: &str,
         token: &str,
@@ -381,7 +320,7 @@ impl Client for APIClient {
         }
     }
 
-    async fn do_preflight(
+    pub async fn do_preflight(
         &self,
         token: &str,
         request_url: &str,
@@ -425,18 +364,12 @@ impl Client for APIClient {
         })
     }
 
-    fn make_url(&self, endpoint: &str) -> String {
-        format!("{}{}", self.base_url, endpoint)
-    }
-}
-
-impl APIClient {
     pub fn new(
         base_url: impl AsRef<str>,
         timeout: u64,
         version: &str,
         use_preflight: bool,
-    ) -> Result<APIClient> {
+    ) -> Result<Self> {
         let client = if timeout != 0 {
             reqwest::Client::builder()
                 .timeout(std::time::Duration::from_secs(timeout))
@@ -459,6 +392,10 @@ impl APIClient {
             use_preflight,
         })
     }
+
+    fn make_url(&self, endpoint: &str) -> String {
+        format!("{}{}", self.base_url, endpoint)
+    }
 }
 
 #[cfg(test)]
@@ -466,7 +403,7 @@ mod test {
     use anyhow::Result;
     use turborepo_vercel_api_mock::start_test_server;
 
-    use crate::{APIClient, Client};
+    use crate::APIClient;
 
     #[tokio::test]
     async fn test_do_preflight() -> Result<()> {

--- a/crates/turborepo-auth/Cargo.toml
+++ b/crates/turborepo-auth/Cargo.toml
@@ -6,21 +6,16 @@ license = "MPL-2.0"
 
 [dependencies]
 anyhow = { workspace = true, features = ["backtrace"] }
-async-trait = "0.1.73"
 axum-server = { workspace = true }
 axum.workspace = true
-chrono = { workspace = true, features = ["serde"] }
 hostname = "0.3.1"
-lazy_static.workspace = true
 reqwest.workspace = true
 serde.workspace = true
-tempfile.workspace = true
 thiserror = "1.0.38"
 tokio.workspace = true
 tracing.workspace = true
 turborepo-api-client = { workspace = true }
 turborepo-ui.workspace = true
-turborepo-vercel-api = { workspace = true }
 turborepo-vercel-api-mock = { workspace = true }
 webbrowser = { workspace = true }
 

--- a/crates/turborepo-auth/src/lib.rs
+++ b/crates/turborepo-auth/src/lib.rs
@@ -2,9 +2,7 @@
 
 #[cfg(not(test))]
 use std::net::SocketAddr;
-#[cfg(test)]
-use std::sync::atomic::AtomicUsize;
-use std::{path::Path, sync::Arc};
+use std::sync::Arc;
 
 use anyhow::{anyhow, Context, Result};
 #[cfg(not(test))]
@@ -16,7 +14,7 @@ use tokio::sync::OnceCell;
 use tracing::error;
 #[cfg(not(test))]
 use tracing::warn;
-use turborepo_api_client::Client;
+use turborepo_api_client::APIClient;
 use turborepo_ui::{start_spinner, BOLD, CYAN, GREY, UI};
 
 const DEFAULT_HOST_NAME: &str = "127.0.0.1";
@@ -35,24 +33,6 @@ pub enum Error {
     LoginUrlCannotBeABase { value: String },
 }
 
-fn print_cli_authorized(user: &str, ui: &UI) {
-    println!(
-        "
-{} Turborepo CLI authorized for {}
-
-{}
-
-{}
-",
-        ui.rainbow(">>> Success!"),
-        user,
-        ui.apply(
-            CYAN.apply_to("To connect to your Remote Cache, run the following in any turborepo:")
-        ),
-        ui.apply(BOLD.apply_to("  npx turbo link"))
-    );
-}
-
 pub fn logout<F>(ui: &UI, mut set_token: F) -> Result<()>
 where
     F: FnMut() -> Result<()>,
@@ -66,27 +46,15 @@ where
     Ok(())
 }
 
-/// Login writes a token to disk at token_path. If a token is already present,
-/// we do not overwrite it and instead log that we found an existing token.
 pub async fn login<F>(
-    api_client: &impl Client,
+    api_client: APIClient,
     ui: &UI,
-    token_path: impl AsRef<Path>,
     mut set_token: F,
     login_url_configuration: &str,
 ) -> Result<()>
 where
     F: FnMut(&str) -> Result<()>,
 {
-    // Check if token exists first.
-    if let Ok(token) = std::fs::read_to_string(token_path) {
-        if let Ok(response) = api_client.get_user(&token).await {
-            println!("{}", ui.apply(BOLD.apply_to("Existing token found!")));
-            print_cli_authorized(&response.user.email, ui);
-            return Ok(());
-        }
-    }
-
     let redirect_url = format!("http://{DEFAULT_HOST_NAME}:{DEFAULT_PORT}");
     let mut login_url = Url::parse(login_url_configuration)?;
 
@@ -127,8 +95,22 @@ where
     // TODO: make this a request to /teams endpoint instead?
     let user_response = api_client.get_user(token.as_str()).await?;
 
-    print_cli_authorized(&user_response.user.email, ui);
+    println!(
+        "
+{} Turborepo CLI authorized for {}
 
+{}
+
+{}
+
+",
+        ui.rainbow(">>> Success!"),
+        user_response.user.email,
+        ui.apply(
+            CYAN.apply_to("To connect to your Remote Cache, run the following in any turborepo:")
+        ),
+        ui.apply(BOLD.apply_to("  npx turbo link"))
+    );
     Ok(())
 }
 
@@ -148,21 +130,12 @@ struct LoginPayload {
     token: String,
 }
 
-// Used to track how many times the server was hit. Used primarily for
-// duplicate request tracking in tests.
-#[cfg(test)]
-lazy_static::lazy_static! {
-    static ref LOGIN_HITS: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-    static ref SSO_HITS: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
-}
-
 #[cfg(test)]
 async fn run_login_one_shot_server(
     _: u16,
     _: String,
     login_token: Arc<OnceCell<String>>,
 ) -> Result<()> {
-    LOGIN_HITS.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
     login_token
         .set(turborepo_vercel_api_mock::EXPECTED_TOKEN.to_string())
         .unwrap();
@@ -206,13 +179,9 @@ struct SsoPayload {
     email: Option<String>,
 }
 
-/// sso_login writes a token to disk at token_path. If a token is already
-/// present, and the token has access to the provided `sso_team`, we do not
-/// overwrite it and instead log that we found an existing token.
 pub async fn sso_login<F>(
-    api_client: &impl Client,
+    api_client: APIClient,
     ui: &UI,
-    token_path: impl AsRef<Path>,
     mut set_token: F,
     login_url_configuration: &str,
     sso_team: &str,
@@ -220,25 +189,6 @@ pub async fn sso_login<F>(
 where
     F: FnMut(&str) -> Result<()>,
 {
-    // Check if token exists first. Must be there for the user and contain the
-    // sso_team passed into this function.
-    if let Ok(token) = std::fs::read_to_string(token_path) {
-        let (result_user, result_teams) =
-            tokio::join!(api_client.get_user(&token), api_client.get_teams(&token));
-
-        if let (Ok(response_user), Ok(response_teams)) = (result_user, result_teams) {
-            if response_teams
-                .teams
-                .iter()
-                .any(|team| team.slug == sso_team)
-            {
-                println!("{}", ui.apply(BOLD.apply_to("Existing token found!")));
-                print_cli_authorized(&response_user.user.email, ui);
-                return Ok(());
-            }
-        }
-    }
-
     let redirect_url = format!("http://{DEFAULT_HOST_NAME}:{DEFAULT_PORT}");
     let mut login_url = Url::parse(login_url_configuration)?;
 
@@ -274,7 +224,26 @@ where
 
     set_token(&verified_user.token)?;
 
-    print_cli_authorized(&user_response.user.email, ui);
+    println!(
+        "
+{} {}
+",
+        ui.rainbow(">>> Success!"),
+        ui.apply(BOLD.apply_to(format!(
+            "Turborepo CLI authorized for {}",
+            user_response.user.email
+        )))
+    );
+
+    println!(
+        "{}
+{}
+",
+        ui.apply(
+            CYAN.apply_to("To connect to your Remote Cache, run the following in any turborepo:")
+        ),
+        ui.apply(BOLD.apply_to("`npx turbo link`"))
+    );
 
     Ok(())
 }
@@ -322,7 +291,6 @@ fn get_token_and_redirect(payload: SsoPayload) -> Result<(Option<String>, Url)> 
 
 #[cfg(test)]
 async fn run_sso_one_shot_server(_: u16, verification_token: Arc<OnceCell<String>>) -> Result<()> {
-    SSO_HITS.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
     verification_token
         .set(EXPECTED_VERIFICATION_TOKEN.to_string())
         .unwrap();
@@ -360,171 +328,13 @@ async fn run_sso_one_shot_server(
 
 #[cfg(test)]
 mod test {
-    use std::path::Path;
-
-    use async_trait::async_trait;
-    use reqwest::{Method, RequestBuilder, Response, Url};
-    use turborepo_api_client::{Client, Error, Result};
+    use port_scanner;
+    use reqwest::Url;
+    use tokio;
     use turborepo_ui::UI;
-    use turborepo_vercel_api::{
-        CachingStatusResponse, Membership, PreflightResponse, Role, SpacesResponse, Team,
-        TeamsResponse, User, UserResponse, VerifiedSsoUser,
-    };
     use turborepo_vercel_api_mock::start_test_server;
 
-    use crate::{
-        get_token_and_redirect, login, sso_login, SsoPayload, EXPECTED_VERIFICATION_TOKEN,
-        LOGIN_HITS, SSO_HITS,
-    };
-
-    #[derive(Debug, thiserror::Error)]
-    enum MockApiError {
-        #[error("Empty token")]
-        EmptyToken,
-    }
-    impl From<MockApiError> for turborepo_api_client::Error {
-        fn from(error: MockApiError) -> Self {
-            match error {
-                MockApiError::EmptyToken => turborepo_api_client::Error::UnknownStatus {
-                    code: "empty token".to_string(),
-                    message: "token is empty".to_string(),
-                    backtrace: std::backtrace::Backtrace::capture(),
-                },
-            }
-        }
-    }
-
-    struct MockApiClient {
-        pub base_url: String,
-    }
-    impl MockApiClient {
-        fn new() -> Self {
-            Self {
-                base_url: String::new(),
-            }
-        }
-        fn set_base_url(&mut self, base_url: &str) {
-            self.base_url = base_url.to_string();
-        }
-    }
-
-    #[async_trait]
-    impl Client for MockApiClient {
-        async fn get_user(&self, token: &str) -> Result<UserResponse> {
-            if token.is_empty() {
-                return Err(MockApiError::EmptyToken.into());
-            }
-
-            Ok(UserResponse {
-                user: User {
-                    id: "id".to_string(),
-                    username: "username".to_string(),
-                    email: "email".to_string(),
-                    name: None,
-                    created_at: None,
-                },
-            })
-        }
-        async fn get_teams(&self, token: &str) -> Result<TeamsResponse> {
-            if token.is_empty() {
-                return Err(MockApiError::EmptyToken.into());
-            }
-
-            Ok(TeamsResponse {
-                teams: vec![Team {
-                    id: "id".to_string(),
-                    slug: "something".to_string(),
-                    name: "name".to_string(),
-                    created_at: 0,
-                    created: chrono::Utc::now(),
-                    membership: Membership::new(Role::Member),
-                }],
-            })
-        }
-        async fn get_team(&self, _token: &str, _team_id: &str) -> Result<Option<Team>> {
-            unimplemented!("get_team")
-        }
-        fn add_ci_header(_request_builder: RequestBuilder) -> RequestBuilder {
-            unimplemented!("add_ci_header")
-        }
-        fn add_team_params(
-            _request_builder: RequestBuilder,
-            _team_id: &str,
-            _team_slug: Option<&str>,
-        ) -> RequestBuilder {
-            unimplemented!("add_team_params")
-        }
-        async fn get_caching_status(
-            &self,
-            _token: &str,
-            _team_id: &str,
-            _team_slug: Option<&str>,
-        ) -> Result<CachingStatusResponse> {
-            unimplemented!("get_caching_status")
-        }
-        async fn get_spaces(&self, _token: &str, _team_id: Option<&str>) -> Result<SpacesResponse> {
-            unimplemented!("get_spaces")
-        }
-        async fn verify_sso_token(&self, token: &str, _: &str) -> Result<VerifiedSsoUser> {
-            Ok(VerifiedSsoUser {
-                token: token.to_string(),
-                team_id: Some("team_id".to_string()),
-            })
-        }
-        async fn put_artifact(
-            &self,
-            _hash: &str,
-            _artifact_body: &[u8],
-            _duration: u64,
-            _tag: Option<&str>,
-            _token: &str,
-        ) -> Result<()> {
-            unimplemented!("put_artifact")
-        }
-        async fn handle_403(_response: Response) -> Error {
-            unimplemented!("handle_403")
-        }
-        async fn fetch_artifact(
-            &self,
-            _hash: &str,
-            _token: &str,
-            _team_id: &str,
-            _team_slug: Option<&str>,
-        ) -> Result<Response> {
-            unimplemented!("fetch_artifact")
-        }
-        async fn artifact_exists(
-            &self,
-            _hash: &str,
-            _token: &str,
-            _team_id: &str,
-            _team_slug: Option<&str>,
-        ) -> Result<Response> {
-            unimplemented!("artifact_exists")
-        }
-        async fn get_artifact(
-            &self,
-            _hash: &str,
-            _token: &str,
-            _team_id: &str,
-            _team_slug: Option<&str>,
-            _method: Method,
-        ) -> Result<Response> {
-            unimplemented!("get_artifact")
-        }
-        async fn do_preflight(
-            &self,
-            _token: &str,
-            _request_url: &str,
-            _request_method: &str,
-            _request_headers: &str,
-        ) -> Result<PreflightResponse> {
-            unimplemented!("do_preflight")
-        }
-        fn make_url(&self, endpoint: &str) -> String {
-            format!("{}{}", self.base_url, endpoint)
-        }
-    }
+    use crate::{get_token_and_redirect, login, sso_login, SsoPayload};
 
     #[tokio::test]
     async fn test_login() {
@@ -532,66 +342,21 @@ mod test {
         let api_server = tokio::spawn(start_test_server(port));
         let ui = UI::new(false);
         let url = format!("http://localhost:{port}");
-        let token_filename: &str = "token.json";
-        let token_path = Path::new(token_filename);
 
-        // Since we are writing to a file, we need to make sure we clean up after in the
-        // event of an assertion failure.
-        std::panic::set_hook(Box::new(|_| {
-            // Remove test token file after completion. Recreate path due to ownership
-            // rules.
-            match std::fs::remove_file(Path::new(token_filename)) {
-                Ok(_) => {}
-                Err(e) => {
-                    println!("failed to remove token file: {}", e);
-                }
-            };
-            let _ = std::panic::take_hook();
-        }));
-
-        let api_client = MockApiClient::new();
+        let api_client =
+            turborepo_api_client::APIClient::new(url.clone(), 1000, "1", false).unwrap();
 
         // closure that will check that the token is sent correctly
         let mut got_token = String::new();
-        let set_token = |t: &str| -> anyhow::Result<(), anyhow::Error> {
-            got_token.clear();
-            got_token.push_str(t);
-            let _ = std::fs::write(token_path, t)
-                .map_err(|e| anyhow::anyhow!("failed to write token to file: {}", e));
+        let set_token = |t: &str| -> Result<(), anyhow::Error> {
+            got_token = t.to_string();
             Ok(())
         };
 
-        login(&api_client, &ui, Path::new(token_filename), set_token, &url)
-            .await
-            .unwrap();
-
-        // Re-assign set_token due to ownership rules. This shouldn't be called.
-        let set_token = |t: &str| -> anyhow::Result<(), anyhow::Error> {
-            got_token.clear();
-            // Force the got token to be incorrect if this is called a second time.
-            got_token.push_str("not expected token");
-            let _ = std::fs::write(token_path, t)
-                .map_err(|e| anyhow::anyhow!("failed to write token to file: {}", e));
-            Ok(())
-        };
-
-        // Call the login function twice to test that we check for existing tokens.
-        // Total server hits should be 1.
-        login(&api_client, &ui, token_path, set_token, &url)
-            .await
-            .unwrap();
+        login(api_client, &ui, set_token, &url).await.unwrap();
 
         api_server.abort();
-        assert_eq!(LOGIN_HITS.load(std::sync::atomic::Ordering::SeqCst), 1);
         assert_eq!(got_token, turborepo_vercel_api_mock::EXPECTED_TOKEN);
-
-        // Remove test token file after completion.
-        match std::fs::remove_file(token_path) {
-            Ok(_) => {}
-            Err(e) => {
-                println!("failed to remove token file: {}", e);
-            }
-        }
     }
 
     #[tokio::test]
@@ -602,46 +367,23 @@ mod test {
         let ui = UI::new(false);
         let team = "something";
 
-        let temp_file = tempfile::NamedTempFile::new().expect("failed to create temp file");
-        let token_path = temp_file.path();
-
-        let mut api_client = MockApiClient::new();
-        api_client.set_base_url(&url);
+        let api_client =
+            turborepo_api_client::APIClient::new(url.clone(), 1000, "1", false).unwrap();
 
         // closure that will check that the token is sent correctly
         let mut got_token = String::new();
-        let set_token = |t: &str| -> anyhow::Result<(), anyhow::Error> {
-            got_token.clear();
-            // Force the got token to be incorrect if this is called a second time.
-            got_token.push_str(t);
-            let _ = std::fs::write(token_path, t)
-                .map_err(|e| anyhow::anyhow!("failed to write token to file: {}", e));
+        let set_token = |t: &str| -> Result<(), anyhow::Error> {
+            got_token = t.to_string();
             Ok(())
         };
 
-        sso_login(&api_client, &ui, token_path, set_token, &url, team)
-            .await
-            .unwrap();
-
-        // Re-assign set_token due to ownership rules. This shouldn't be called.
-        let set_token = |t: &str| -> anyhow::Result<(), anyhow::Error> {
-            got_token.clear();
-            got_token.push_str("not expected token");
-            let _ = std::fs::write(token_path, t)
-                .map_err(|e| anyhow::anyhow!("failed to write token to file: {}", e));
-            Ok(())
-        };
-
-        // Call the login function twice to test that we check for existing tokens.
-        // Total server hits should be 1.
-        sso_login(&api_client, &ui, token_path, set_token, &url, team)
+        sso_login(api_client, &ui, set_token, &url, team)
             .await
             .unwrap();
 
         handle.abort();
 
-        assert_eq!(SSO_HITS.load(std::sync::atomic::Ordering::SeqCst), 1);
-        assert_eq!(got_token, EXPECTED_VERIFICATION_TOKEN);
+        assert_eq!(got_token, turborepo_vercel_api_mock::EXPECTED_TOKEN);
     }
 
     #[test]

--- a/crates/turborepo-auth/src/lib.rs
+++ b/crates/turborepo-auth/src/lib.rs
@@ -360,6 +360,8 @@ async fn run_sso_one_shot_server(
 
 #[cfg(test)]
 mod test {
+    use std::path::Path;
+
     use async_trait::async_trait;
     use reqwest::{Method, RequestBuilder, Response, Url};
     use turborepo_api_client::{Client, Error, Result};
@@ -530,10 +532,22 @@ mod test {
         let api_server = tokio::spawn(start_test_server(port));
         let ui = UI::new(false);
         let url = format!("http://localhost:{port}");
+        let token_filename: &str = "token.json";
+        let token_path = Path::new(token_filename);
 
-        let temp_file =
-            tempfile::NamedTempFile::new().expect("Failed to create temp file for test_login");
-        let token_path = temp_file.path();
+        // Since we are writing to a file, we need to make sure we clean up after in the
+        // event of an assertion failure.
+        std::panic::set_hook(Box::new(|_| {
+            // Remove test token file after completion. Recreate path due to ownership
+            // rules.
+            match std::fs::remove_file(Path::new(token_filename)) {
+                Ok(_) => {}
+                Err(e) => {
+                    println!("failed to remove token file: {}", e);
+                }
+            };
+            let _ = std::panic::take_hook();
+        }));
 
         let api_client = MockApiClient::new();
 
@@ -547,7 +561,7 @@ mod test {
             Ok(())
         };
 
-        login(&api_client, &ui, token_path, set_token, &url)
+        login(&api_client, &ui, Path::new(token_filename), set_token, &url)
             .await
             .unwrap();
 
@@ -570,6 +584,14 @@ mod test {
         api_server.abort();
         assert_eq!(LOGIN_HITS.load(std::sync::atomic::Ordering::SeqCst), 1);
         assert_eq!(got_token, turborepo_vercel_api_mock::EXPECTED_TOKEN);
+
+        // Remove test token file after completion.
+        match std::fs::remove_file(token_path) {
+            Ok(_) => {}
+            Err(e) => {
+                println!("failed to remove token file: {}", e);
+            }
+        }
     }
 
     #[tokio::test]

--- a/crates/turborepo-cache/src/http.rs
+++ b/crates/turborepo-cache/src/http.rs
@@ -1,7 +1,7 @@
 use std::{backtrace::Backtrace, io::Write};
 
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPathBuf};
-use turborepo_api_client::{APIAuth, APIClient, Client, Response};
+use turborepo_api_client::{APIAuth, APIClient, Response};
 
 use crate::{
     cache_archive::{CacheReader, CacheWriter},

--- a/crates/turborepo-lib/src/commands/link.rs
+++ b/crates/turborepo-lib/src/commands/link.rs
@@ -16,7 +16,7 @@ use dialoguer::{theme::ColorfulTheme, Confirm};
 use dirs_next::home_dir;
 #[cfg(test)]
 use rand::Rng;
-use turborepo_api_client::{APIClient, Client};
+use turborepo_api_client::APIClient;
 #[cfg(not(test))]
 use turborepo_ui::CYAN;
 use turborepo_ui::{BOLD, GREY, UNDERLINE};
@@ -503,12 +503,10 @@ mod test {
                     .unwrap(),
             ),
             user_config: OnceCell::from(
-                UserConfigLoader::new(
-                    AbsoluteSystemPathBuf::try_from(user_config_file.path()).unwrap(),
-                )
-                .with_token(Some("token".to_string()))
-                .load()
-                .unwrap(),
+                UserConfigLoader::new(user_config_file.path().to_str().unwrap())
+                    .with_token(Some("token".to_string()))
+                    .load()
+                    .unwrap(),
             ),
             repo_config: OnceCell::from(
                 RepoConfigLoader::new(repo_config_path)
@@ -563,12 +561,10 @@ mod test {
                     .unwrap(),
             ),
             user_config: OnceCell::from(
-                UserConfigLoader::new(
-                    AbsoluteSystemPathBuf::try_from(user_config_file.path()).unwrap(),
-                )
-                .with_token(Some("token".to_string()))
-                .load()
-                .unwrap(),
+                UserConfigLoader::new(user_config_file.path().to_str().unwrap())
+                    .with_token(Some("token".to_string()))
+                    .load()
+                    .unwrap(),
             ),
             repo_config: OnceCell::from(
                 RepoConfigLoader::new(repo_config_path)

--- a/crates/turborepo-lib/src/commands/login.rs
+++ b/crates/turborepo-lib/src/commands/login.rs
@@ -5,35 +5,23 @@ use turborepo_auth::{login as auth_login, sso_login as auth_sso_login};
 use crate::commands::CommandBase;
 
 pub async fn sso_login(base: &mut CommandBase, sso_team: &str) -> Result<()> {
-    let ui = base.ui;
     let api_client: APIClient = base.api_client()?;
+    let ui = base.ui;
     let login_url_config = base.repo_config()?.login_url().to_string();
-    let token_path = base.repo_config()?.path().to_owned();
 
     // We are passing a closure here, but it would be cleaner if we made a
     // turborepo-config crate and imported that into turborepo-auth.
-    // TODO: We aren't using `token_path` here but these are both using the same
-    //       token path.
     let set_token = |token: &str| -> Result<(), anyhow::Error> {
         Ok(base.user_config_mut()?.set_token(Some(token.to_string()))?)
     };
 
-    auth_sso_login(
-        &api_client,
-        &ui,
-        &token_path,
-        set_token,
-        &login_url_config,
-        sso_team,
-    )
-    .await
+    auth_sso_login(api_client, &ui, set_token, &login_url_config, sso_team).await
 }
 
 pub async fn login(base: &mut CommandBase) -> Result<()> {
     let api_client: APIClient = base.api_client()?;
     let ui = base.ui;
     let login_url_config = base.repo_config()?.login_url().to_string();
-    let token_path = base.repo_config()?.path().to_owned();
 
     // We are passing a closure here, but it would be cleaner if we made a
     // turborepo-config crate and imported that into turborepo-auth.
@@ -41,5 +29,5 @@ pub async fn login(base: &mut CommandBase) -> Result<()> {
         Ok(base.user_config_mut()?.set_token(Some(token.to_string()))?)
     };
 
-    auth_login(&api_client, &ui, &token_path, set_token, &login_url_config).await
+    auth_login(api_client, &ui, set_token, &login_url_config).await
 }

--- a/crates/turborepo-lib/src/config/mod.rs
+++ b/crates/turborepo-lib/src/config/mod.rs
@@ -6,6 +6,7 @@ mod user;
 
 use std::path::PathBuf;
 
+use camino::{Utf8Path, Utf8PathBuf};
 pub use client::{ClientConfig, ClientConfigLoader};
 use config::ConfigError;
 #[cfg(not(windows))]
@@ -23,7 +24,6 @@ use thiserror::Error;
 pub use turbo::{
     validate_extends, validate_no_package_task_syntax, RawTurboJSON, SpacesJson, TurboJson,
 };
-use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
 pub use user::{UserConfig, UserConfigLoader};
 
 #[derive(Debug, Error)]
@@ -71,8 +71,8 @@ pub enum Error {
     NoExtends,
 }
 
-pub fn default_user_config_path() -> Result<AbsoluteSystemPathBuf, Error> {
-    Ok(AbsoluteSystemPathBuf::try_from(
+pub fn default_user_config_path() -> Result<Utf8PathBuf, Error> {
+    Ok(Utf8PathBuf::try_from(
         config_dir()
             .map(|p| p.join("turborepo").join("config.json"))
             .ok_or(Error::NoDefaultConfigPath)?,
@@ -84,7 +84,7 @@ pub fn data_dir() -> Option<PathBuf> {
     dirs_next::data_dir().map(|p| p.join("turborepo"))
 }
 
-fn write_to_disk<T>(path: &AbsoluteSystemPath, config: &T) -> Result<(), Error>
+fn write_to_disk<T>(path: &Utf8Path, config: &T) -> Result<(), Error>
 where
     T: Serialize,
 {

--- a/crates/turborepo-lib/src/config/repo.rs
+++ b/crates/turborepo-lib/src/config/repo.rs
@@ -85,10 +85,6 @@ pub struct RepoConfigLoader {
 }
 
 impl RepoConfig {
-    pub fn path(&self) -> &AbsoluteSystemPath {
-        &self.path
-    }
-
     #[allow(dead_code)]
     pub fn api_url(&self) -> &str {
         self.config.api_url.as_deref().unwrap_or(DEFAULT_API_URL)
@@ -180,7 +176,7 @@ impl RepoConfig {
     }
 
     fn write_to_disk(&self) -> Result<(), Error> {
-        write_to_disk(&self.path, &self.disk_config)
+        write_to_disk(self.path.as_path(), &self.disk_config)
     }
 }
 

--- a/crates/turborepo-pidlock/src/lib.rs
+++ b/crates/turborepo-pidlock/src/lib.rs
@@ -210,7 +210,7 @@ impl Pidlock {
                         })?;
                 Ok(Some(pid))
             }
-            Ok(_pid) => {
+            Ok(pid) => {
                 warn!("stale pid file at {:?}", self.path);
                 if let Err(e) = fs::remove_file(&self.path) {
                     Err(PidFileError::FailedDelete(


### PR DESCRIPTION
Heya @Zertsov! This reverts #6034 and #6115 which built on top of it.

The attempt to read the `token_path` doesn't actually parse the contents or otherwise attempt to grab the token from the configuration file.

There is an additional issue in that it doesn't account for existing tokens in any of the other configuration sources. We already have a full, parsed configuration at the time we call into the auth crate. It should instead simply pass an `Option<&str>` of the existing configured token into the function, not the `token_path`.

This also addresses @mehulkar's concerns about `token_path`.

Closes TURBO-1438