### PR TITLE
fix(docs): update storybook build command

### DIFF
--- a/docs/pages/repo/docs/handbook/tools/storybook.mdx
+++ b/docs/pages/repo/docs/handbook/tools/storybook.mdx
@@ -182,7 +182,7 @@ The last thing that we need to do is make sure that Storybook is lined up with t
   // ...
   "scripts": {
     "dev": "storybook dev -p 6006",
-    "build": "build-storybook"
+    "build": "storybook build"
   }
 }
 ```


### PR DESCRIPTION
### Description

<!--
  ✍️ Write a short summary of your work.
  If necessary, include relevant screenshots.
-->

https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#start-storybook--build-storybook-binaries-removed

in the markdown above, `build-storybook` command is replaced with `storybook build` in `v7`. so this command in this file should be fixed.

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->

running `pnpm build` with `"build": "build-storybook"`, it causes `sh: build-storybook: command not found`.
with the updated value `"build": "storybook build"`, it works fine.