### PR TITLE
Escape colons in globs before sending to the daemon

### DIFF
--- a/cli/internal/daemonclient/daemonclient_test.go
+++ b/cli/internal/daemonclient/daemonclient_test.go
@@ -1,0 +1,17 @@
+package daemonclient
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestFormatRepoRelativeGlob(t *testing.T) {
+	rawGlob := filepath.Join("some", "path:in", "repo", "**", "*.ts")
+	// Note that we expect unix slashes whether or not we are on Windows
+	expected := "some/path\\:in/repo/**/*.ts"
+
+	result := formatRepoRelativeGlob(rawGlob)
+	if result != expected {
+		t.Errorf("formatRepoRelativeGlob(%v) got %v, want %v", rawGlob, result, expected)
+	}
+}

--- a/cli/internal/daemonclient/daemonclient_test.go
+++ b/cli/internal/daemonclient/daemonclient_test.go
@@ -2,13 +2,19 @@ package daemonclient
 
 import (
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
 func TestFormatRepoRelativeGlob(t *testing.T) {
-	rawGlob := filepath.Join("some", "path:in", "repo", "**", "*.ts")
+	rawGlob := filepath.Join("some", ".turbo", "turbo-foo:bar.log")
 	// Note that we expect unix slashes whether or not we are on Windows
-	expected := "some/path\\:in/repo/**/*.ts"
+	var expected string
+	if runtime.GOOS == "windows" {
+		expected = "some/.turbo/turbo-foo"
+	} else {
+		expected = "some/.turbo/turbo-foo\\:bar.log"
+	}
 
 	result := formatRepoRelativeGlob(rawGlob)
 	if result != expected {

--- a/cli/internal/runcache/runcache.go
+++ b/cli/internal/runcache/runcache.go
@@ -123,7 +123,6 @@ func (tc *TaskCache) RestoreOutputs(ctx context.Context, prefixedUI *cli.Prefixe
 
 	if err != nil {
 		progressLogger.Warn(fmt.Sprintf("Failed to check if we can skip restoring outputs for %v: %v. Proceeding to check cache", tc.pt.TaskID, err))
-		prefixedUI.Warn(ui.Dim(fmt.Sprintf("Failed to check if we can skip restoring outputs for %v: %v. Proceeding to check cache", tc.pt.TaskID, err)))
 		changedOutputGlobs = tc.repoRelativeGlobs.Inclusions
 	}
 

--- a/crates/turborepo-filewatch/src/globwatcher.rs
+++ b/crates/turborepo-filewatch/src/globwatcher.rs
@@ -593,7 +593,7 @@ mod test {
 
         let glob_watcher = GlobWatcher::new(&repo_root, cookie_jar, watcher.subscribe());
 
-        let raw_includes = &["my-pkg/.next/next-file"];
+        let raw_includes = &["my-pkg/.next/next-file\\:build"];
         let raw_excludes: [&str; 0] = [];
         let globs = GlobSet {
             include: make_includes(raw_includes),
@@ -619,7 +619,7 @@ mod test {
 
         // Change the watched file
         repo_root
-            .join_components(&["my-pkg", ".next", "next-file"])
+            .join_components(&["my-pkg", ".next", "next-file:build"])
             .create_with_contents("hello")
             .unwrap();
         let results = glob_watcher

--- a/crates/turborepo-filewatch/src/globwatcher.rs
+++ b/crates/turborepo-filewatch/src/globwatcher.rs
@@ -593,6 +593,11 @@ mod test {
 
         let glob_watcher = GlobWatcher::new(&repo_root, cookie_jar, watcher.subscribe());
 
+        // On windows, we expect different sanitization before the
+        // globs are passed in, due to alternative data streams in files.
+        #[cfg(windows)]
+        let raw_includes = &["my-pkg/.next/next-file"];
+        #[cfg(not(windows))]
         let raw_includes = &["my-pkg/.next/next-file\\:build"];
         let raw_excludes: [&str; 0] = [];
         let globs = GlobSet {
@@ -618,10 +623,8 @@ mod test {
         assert!(results.is_empty());
 
         // Change the watched file
-        repo_root
-            .join_components(&["my-pkg", ".next", "next-file:build"])
-            .create_with_contents("hello")
-            .unwrap();
+        let watched_file = repo_root.join_components(&["my-pkg", ".next", "next-file:build"]);
+        watched_file.create_with_contents("hello").unwrap();
         let results = glob_watcher
             .get_changed_globs(hash.clone(), candidates.clone())
             .await


### PR DESCRIPTION
### Description

Fixes #6136 
 - Escaped `:` in globs sent to the daemon from the Go client from unix clients, and truncate filenames with `:` on windows due to [Alternate Data Stream](https://learn.microsoft.com/en-us/sysinternals/downloads/streams)
 - Dropped printed warning when we fail to use the daemon for something. It is entirely possible that filewatching will initially time out while getting set up. We don't need to warn on that, there's nothing the user can do, it may just take a while on a large repository.

Note for the future: this may not be the ideal location for converting the format of the globs. It should most likely happen earlier in the process and be tagged with glob source information.

### Testing Instructions

 - Adds a test of the formatting rules applied to globs


Closes TURBO-1441