### PR TITLE
chore(lockfiles) avoid hand written reflection 

### DIFF
--- a/crates/turborepo-lib/src/engine/builder.rs
+++ b/crates/turborepo-lib/src/engine/builder.rs
@@ -436,7 +436,7 @@ mod test {
             unreachable!()
         }
 
-        fn global_change_key(&self) -> Vec<u8> {
+        fn global_change(&self, _other: &dyn Lockfile) -> bool {
             unreachable!()
         }
     }

--- a/crates/turborepo-lib/src/package_graph/mod.rs
+++ b/crates/turborepo-lib/src/package_graph/mod.rs
@@ -545,8 +545,8 @@ mod test {
             unreachable!("lockfile encoding not necessary for package graph construction")
         }
 
-        fn global_change_key(&self) -> Vec<u8> {
-            unreachable!()
+        fn global_change(&self, _other: &dyn Lockfile) -> bool {
+            unreachable!("global change detection not necessary for package graph construction")
         }
     }
 

--- a/crates/turborepo-lib/src/package_graph/mod.rs
+++ b/crates/turborepo-lib/src/package_graph/mod.rs
@@ -326,10 +326,7 @@ impl PackageGraph {
 
         let closures = turborepo_lockfiles::all_transitive_closures(previous, external_deps)?;
 
-        let current_key = current.global_change_key();
-        let previous_key = previous.global_change_key();
-
-        let global_change = current_key != previous_key;
+        let global_change = current.global_change(previous);
 
         let changed = if global_change {
             None

--- a/crates/turborepo-lockfiles/src/bun/mod.rs
+++ b/crates/turborepo-lockfiles/src/bun/mod.rs
@@ -1,4 +1,4 @@
-use std::str::FromStr;
+use std::{any::Any, str::FromStr};
 
 use serde::Deserialize;
 
@@ -109,8 +109,11 @@ impl Lockfile for BunLockfile {
         Err(crate::Error::Bun(Error::NotImplemented()))
     }
 
-    fn global_change_key(&self) -> Vec<u8> {
-        vec![b'b', b'u', b'n', 0]
+    fn global_change(&self, other: &dyn Lockfile) -> bool {
+        let any_other = other as &dyn Any;
+        // Downcast returns none if the concrete type doesn't match
+        // if the types don't match then we changed package managers
+        any_other.downcast_ref::<Self>().is_none()
     }
 }
 

--- a/crates/turborepo-lockfiles/src/lib.rs
+++ b/crates/turborepo-lockfiles/src/lib.rs
@@ -7,7 +7,10 @@ mod npm;
 mod pnpm;
 mod yarn1;
 
-use std::collections::{HashMap, HashSet};
+use std::{
+    any::Any,
+    collections::{HashMap, HashSet},
+};
 
 pub use berry::{Error as BerryError, *};
 pub use bun::BunLockfile;
@@ -27,7 +30,7 @@ pub struct Package {
 // This trait will only be used when migrating the Go lockfile implementations
 // to Rust. Once the migration is complete we will leverage petgraph for doing
 // our graph calculations.
-pub trait Lockfile: Send + Sync {
+pub trait Lockfile: Send + Sync + Any {
     // Given a workspace, a package it imports and version returns the key, resolved
     // version, and if it was found
     fn resolve_package(
@@ -60,6 +63,11 @@ pub trait Lockfile: Send + Sync {
     /// compatibility so these keys don't need to be stable. They are
     /// ephemeral.
     fn global_change_key(&self) -> Vec<u8>;
+
+    /// Determine if there's a global change between two lockfiles
+    fn global_change(&self, other: &dyn Lockfile) -> bool {
+        self.global_change_key() == other.global_change_key()
+    }
 }
 
 /// Takes a lockfile, and a map of workspace directory paths -> (package name,

--- a/crates/turborepo-lockfiles/src/lib.rs
+++ b/crates/turborepo-lockfiles/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(trait_upcasting)]
 #![deny(clippy::all)]
 
 mod berry;
@@ -56,18 +57,8 @@ pub trait Lockfile: Send + Sync + Any {
         Ok(Vec::new())
     }
 
-    /// Present a global change key which is compared against two lockfiles
-    ///
-    /// Impl notes: please prefix this key with some magic identifier
-    /// to prevent clashes. we are not worried about inter-version
-    /// compatibility so these keys don't need to be stable. They are
-    /// ephemeral.
-    fn global_change_key(&self) -> Vec<u8>;
-
     /// Determine if there's a global change between two lockfiles
-    fn global_change(&self, other: &dyn Lockfile) -> bool {
-        self.global_change_key() == other.global_change_key()
-    }
+    fn global_change(&self, other: &dyn Lockfile) -> bool;
 }
 
 /// Takes a lockfile, and a map of workspace directory paths -> (package name,

--- a/crates/turborepo-lockfiles/src/yarn1/mod.rs
+++ b/crates/turborepo-lockfiles/src/yarn1/mod.rs
@@ -1,4 +1,4 @@
-use std::str::FromStr;
+use std::{any::Any, str::FromStr};
 
 use serde::Deserialize;
 
@@ -108,8 +108,11 @@ impl Lockfile for Yarn1Lockfile {
         Ok(self.to_string().into_bytes())
     }
 
-    fn global_change_key(&self) -> Vec<u8> {
-        vec![b'y', b'a', b'r', b'n', 0]
+    fn global_change(&self, other: &dyn Lockfile) -> bool {
+        let any_other = other as &dyn Any;
+        // Downcast returns none if the concrete type doesn't match
+        // if the types don't match then we changed package managers
+        any_other.downcast_ref::<Self>().is_none()
     }
 }
 


### PR DESCRIPTION
### Description

As part of DYF I wanted to see if I could get rid of the `global_changes_key` part of the `Lockfile` trait by leveraging `Any`. Using `Any` has two benefits:
 - It doesn't depend on uniqueness of the magic string chosen to be part of the buffer that forms the key. (We've [already almost had an issue](https://github.com/vercel/turbo/pull/5934#discussion_r1323509458))
 - It doesn't require any allocations in order to perform this comparison

This gets us back to how the Go code used to work where we would take a pointer to a `Lockfile` interface and attempt to downcast it to the same concrete type before comparing fields.

### Testing Instructions

Verifying that `--filter=[HEAD^1]` works as expected:
 - `npx create-turbo@latest test pnpm`
 - `cd test && pnpm rm turbo && git add . && git commit -m 'rm turbo'` (Remove local version of turbo so we can use global dev version easily)
 - `cd apps/web && pnpm add is-number && cd ../../ && git add . && git commit -m 'add is-number'`
 - `turbo_dev build --filter='[HEAD^1]' --experimental-rust-codepath` should only run `build` for `web`

Closes TURBO-1443