### PR TITLE
Improve performance by reworking calculate_file_hashes

### DIFF
--- a/.github/workflows/bench-turborepo.yml
+++ b/.github/workflows/bench-turborepo.yml
@@ -9,7 +9,7 @@ on:
       - completed
   push:
     branches:
-      - main
+      - "*"
     paths:
       - "cli/**"
       - crates/turborepo*/**
@@ -104,6 +104,8 @@ jobs:
   # We'll wait for all profiles to complete before sending.
   send-to-tinybird:
     name: Send to Tinybird
+    # only dump data on main branch
+    if: github.ref == 'refs/heads/main'
     needs: [time-to-first-task]
     runs-on: ubuntu-latest
     env:
@@ -149,6 +151,8 @@ jobs:
 
   send-to-slack:
     name: Send to Slack
+    # only dump data on main branch
+    if: github.ref == 'refs/heads/main'
     needs: [time-to-first-task]
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5811,6 +5811,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "qp-trie"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec628a7d1fc2c5f5a551eb34e01e08df62d55203640959a79a9a2859c797a97"
+dependencies = [
+ "new_debug_unreachable",
+ "unreachable",
+]
+
+[[package]]
 name = "qstring"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10742,6 +10752,7 @@ dependencies = [
  "ignore",
  "itertools",
  "nom",
+ "qp-trie",
  "sha1 0.10.5",
  "tempfile",
  "test-case",
@@ -10946,6 +10957,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
+name = "unreachable"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
+dependencies = [
+ "void",
+]
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11142,6 +11162,12 @@ name = "vlq"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65dd7eed29412da847b0f78bcec0ac98588165988a8cfe41d4ea1d429f8ccfff"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "vte"

--- a/crates/turborepo-lib/src/run/global_hash.rs
+++ b/crates/turborepo-lib/src/run/global_hash.rs
@@ -59,6 +59,7 @@ pub fn get_global_hash_inputs<'a, L: ?Sized + Lockfile>(
     env_mode: EnvMode,
     framework_inference: bool,
     dot_env: Option<&'a [RelativeUnixPathBuf]>,
+    hasher: &SCM,
 ) -> Result<GlobalHashableInputs<'a>, Error> {
     let global_hashable_env_vars =
         get_global_hashable_env_vars(env_at_execution_start, global_env)?;
@@ -101,8 +102,6 @@ pub fn get_global_hash_inputs<'a, L: ?Sized + Lockfile>(
             global_deps.insert(lockfile_path);
         }
     }
-
-    let hasher = SCM::new(root_path);
 
     let global_deps_paths = global_deps
         .iter()

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -290,6 +290,7 @@ impl<'a> Run<'a> {
             opts.run_opts.env_mode,
             opts.run_opts.framework_inference,
             root_turbo_json.global_dot_env.as_deref(),
+            &scm,
         )?;
 
         let global_hash = global_hash_inputs.calculate_global_hash_from_inputs();
@@ -458,6 +459,8 @@ impl<'a> Run<'a> {
         let root_external_dependencies_hash =
             is_monorepo.then(|| get_external_deps_hash(&root_workspace.transitive_dependencies));
 
+        let scm = SCM::new(&self.base.repo_root);
+
         let mut global_hash_inputs = get_global_hash_inputs(
             root_external_dependencies_hash.as_deref(),
             &self.base.repo_root,
@@ -470,9 +473,8 @@ impl<'a> Run<'a> {
             opts.run_opts.env_mode,
             opts.run_opts.framework_inference,
             root_turbo_json.global_dot_env.as_deref(),
+            &scm,
         )?;
-
-        let scm = SCM::new(&self.base.repo_root);
 
         let filtered_pkgs = {
             let mut filtered_pkgs = scope::resolve_packages(

--- a/crates/turborepo-paths/src/anchored_system_path.rs
+++ b/crates/turborepo-paths/src/anchored_system_path.rs
@@ -5,7 +5,7 @@ use serde::Serialize;
 
 use crate::{AnchoredSystemPathBuf, PathError, RelativeUnixPathBuf};
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Hash)]
 #[serde(transparent)]
 pub struct AnchoredSystemPath(Utf8Path);
 

--- a/crates/turborepo-scm/Cargo.toml
+++ b/crates/turborepo-scm/Cargo.toml
@@ -14,6 +14,7 @@ hex = { workspace = true }
 ignore = "0.4.20"
 itertools.workspace = true
 nom = "7.1.3"
+qp-trie = "0.8.2"
 sha1 = "0.10.5"
 thiserror = { workspace = true }
 tracing = { workspace = true }

--- a/crates/turborepo-scm/src/lib.rs
+++ b/crates/turborepo-scm/src/lib.rs
@@ -126,7 +126,7 @@ pub(crate) fn wait_for_success<R: Read, T>(
     Err(Error::Git(err_text, Backtrace::capture()))
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Git {
     root: AbsoluteSystemPathBuf,
     bin: AbsoluteSystemPathBuf,

--- a/crates/turborepo-scm/src/ls_tree.rs
+++ b/crates/turborepo-scm/src/ls_tree.rs
@@ -4,13 +4,13 @@ use std::{
 };
 
 use nom::Finish;
-use turbopath::{AbsoluteSystemPathBuf, RelativeUnixPathBuf};
+use turbopath::{AbsoluteSystemPath, RelativeUnixPathBuf};
 
 use crate::{package_deps::GitHashes, wait_for_success, Error, Git};
 
 impl Git {
     #[tracing::instrument(skip(self))]
-    pub fn git_ls_tree(&self, root_path: &AbsoluteSystemPathBuf) -> Result<GitHashes, Error> {
+    pub fn git_ls_tree(&self, root_path: &AbsoluteSystemPath) -> Result<GitHashes, Error> {
         let mut hashes = GitHashes::new();
         let mut git = Command::new(self.bin.as_std_path())
             .args(["ls-tree", "-r", "-z", "HEAD"])

--- a/crates/turborepo-scm/src/package_deps.rs
+++ b/crates/turborepo-scm/src/package_deps.rs
@@ -54,6 +54,9 @@ impl<'a> CachedPackageFileHasher<'a> {
                     (path_hashes, to_hash)
                 };
 
+                let span = tracing::debug_span!("constructing trie");
+                let enter = span.enter();
+
                 let mut hash_trie = qp_trie::Trie::new();
                 for (path, hash) in path_hashes {
                     hash_trie.insert_str(path.as_str(), hash);
@@ -63,6 +66,11 @@ impl<'a> CachedPackageFileHasher<'a> {
                 for path in &to_hash {
                     file_trie.insert_str(path.as_str(), ());
                 }
+
+                drop(enter);
+
+                let span = tracing::debug_span!("constructing map");
+                let enter = span.enter();
 
                 // a subpackage will always have a longer length than its parent,
                 // so we sort by length to ensure that we always and drain subpackages
@@ -97,6 +105,8 @@ impl<'a> CachedPackageFileHasher<'a> {
                         },
                     ));
                 }
+
+                drop(enter);
 
                 Self::Git(GitCachedPackageFileHasher { git, map })
             }

--- a/crates/turborepo-scm/src/status.rs
+++ b/crates/turborepo-scm/src/status.rs
@@ -128,7 +128,10 @@ mod tests {
         for (input, prefix, (expected_filename, expect_delete)) in tests {
             let prefix = RelativeUnixPathBuf::new(*prefix).unwrap();
             let mut hashes = to_hash_map(&[(expected_filename, "some-hash")]);
-            let to_hash = read_status(input.as_bytes(), &root_path, &prefix, &mut hashes).unwrap();
+            let (to_hash, to_remove) = read_status(input.as_bytes(), &root_path, &prefix).unwrap();
+            for path in to_remove {
+                hashes.remove(&path);
+            }
             if *expect_delete {
                 assert_eq!(hashes.len(), 0, "input: {}", input);
             } else {


### PR DESCRIPTION
### Description

A large amount of time prepping turbo for execution is spent in `calculate_file_hashes`. This is particularly bad on windows taking around 300ms a pop for each package. The cost of running this once at the root is much lower in comparison, so we pre-cache this instead, storing it in a hashmap.

Pre-optimisation: https://github.com/vercel/turbo/actions/runs/6725968656
Post-optimisation: https://github.com/vercel/turbo/actions/runs/6727286792

Please inspect the profiles to see the improvement. To do so, download the artifact at the bottom of the page and load them into ui.perfetto.dev. In the benches above we trade 110 calls to `git status` at 150ms a piece for one at 900ms. This gives us a heuristic for when this optimisation makes sense. Generally, calculating this per-core will be faster if your task count is less than `5 * NUM_CPU` (on this repository). If you exceed this then the cache approach works out faster.

Closes TURBO-1446