### PR TITLE
chore: remove unnecessary vercel.json from docs

### DIFF
--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -1,5 +1,0 @@
-{
-  "$schema": "https://openapi.vercel.sh/vercel.json",
-  "installCommand": null,
-  "buildCommand": null
-}


### PR DESCRIPTION
Since project settings have been updated to remove the overrides, we can now remove this `vercel.json` config.

I tested with different cache settings and both [`cache hit`](https://vercel.com/vercel/turbo-site/FbmmE3JfV3XmKdg9TVcndbwzgR5A) and [`cache bypass`](https://vercel.com/vercel/turbo-site/TPumbZ8fSCKS2mSmMzytByf7gDka) work.