### PR TITLE
fix: update global cache keys

### DIFF
--- a/cli/internal/run/global_hash.go
+++ b/cli/internal/run/global_hash.go
@@ -16,7 +16,7 @@ import (
 	"github.com/vercel/turbo/cli/internal/util"
 )
 
-const _globalCacheKey = "You don't understand! I coulda had class. I coulda been a contender. I could've been somebody, instead of a bum, which is what I am."
+const _globalCacheKey = "HEY STELLLLLLLAAAAAAAAAAAAA"
 
 // Variables that we always include
 var _defaultEnvVars = []string{

--- a/crates/turborepo-lib/src/run/global_hash.rs
+++ b/crates/turborepo-lib/src/run/global_hash.rs
@@ -17,9 +17,7 @@ use crate::{
 
 static DEFAULT_ENV_VARS: [&str; 1] = ["VERCEL_ANALYTICS_ID"];
 
-const GLOBAL_CACHE_KEY: &str = "You don't understand! I coulda had class. I coulda been a \
-                                contender. I could've been somebody, instead of a bum, which is \
-                                what I am.";
+const GLOBAL_CACHE_KEY: &str = "HEY STELLLLLLLAAAAAAAAAAAAA";
 
 #[derive(Debug, Error)]
 enum GlobalHashError {}


### PR DESCRIPTION
### Description

https://github.com/vercel/turbo/pull/6156 only updated integration tests and not the actual cache keys. This PR should main back to green.

### Testing Instructions

Integration tests should run and should now pass

Closes TURBO-1457