### PR TITLE
fix(turborepo): Only use sccache in Vercel repo

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -236,15 +236,6 @@ jobs:
         env:
           SCCACHE_BUCKET: turborepo-sccache
           SCCACHE_REGION: us-east-2
-          RUSTC_WRAPPER: "sccache"
-          CARGO_INCREMENTAL: 0
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
-      - run: turbo run build --filter=cli --color --env-mode=strict --token=${{ secrets.TURBO_TOKEN }} --team=${{ vars.TURBO_TEAM }}
-        env:
-          SCCACHE_BUCKET: turborepo-sccache
-          SCCACHE_REGION: us-east-2
           # Only use sccache if we're in the Vercel repo.
           RUSTC_WRAPPER: ${{ !github.event.pull_request.head.repo.fork && "sccache" || "" }}
           CARGO_INCREMENTAL: 0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -237,7 +237,7 @@ jobs:
           SCCACHE_BUCKET: turborepo-sccache
           SCCACHE_REGION: us-east-2
           # Only use sccache if we're in the Vercel repo.
-          RUSTC_WRAPPER: ${{ !github.event.pull_request.head.repo.fork && "sccache" || "" }}
+          RUSTC_WRAPPER: ${{ !github.event.pull_request.head.repo.fork && 'sccache' || '' }}
           CARGO_INCREMENTAL: 0
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -241,9 +241,20 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
+      - run: turbo run build --filter=cli --color --env-mode=strict --token=${{ secrets.TURBO_TOKEN }} --team=${{ vars.TURBO_TEAM }}
+        env:
+          SCCACHE_BUCKET: turborepo-sccache
+          SCCACHE_REGION: us-east-2
+          # Only use sccache if we're in the Vercel repo.
+          RUSTC_WRAPPER: ${{ !github.event.pull_request.head.repo.fork && "sccache" || "" }}
+          CARGO_INCREMENTAL: 0
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
       - name: Run sccache stat for check
         shell: bash
         run: ${SCCACHE_PATH} --show-stats
+        if: ${{ !github.event.pull_request.head.repo.fork }}
 
   go_lint:
     name: Go linting

--- a/examples-tests/pnpm-basic/test.t
+++ b/examples-tests/pnpm-basic/test.t
@@ -1,7 +1,7 @@
   $ . ${TESTDIR}/../setup.sh basic pnpm
   6.26.1
 # run twice and make sure it works
-  $ pnpm run build lint -- --output-logs=errors-only
+  $ pnpm run build lint -- -vvv
   
   \> @ build (.*)/test.t (re)
   \> turbo run build "lint" "--output-logs=errors-only" (re)


### PR DESCRIPTION
### Description

We now use sccache with s3 in our builds, but that doesn't work on forks because they don't get access to our s3 credentials. This disables sccache on forks.

### Testing Instructions
This PR is from a fork so it should test the logic


Closes TURBO-1459