### PR TITLE
chore: fail if chrometracing setup fails

### DIFF
--- a/crates/turborepo-lib/src/cli.rs
+++ b/crates/turborepo-lib/src/cli.rs
@@ -809,7 +809,7 @@ pub async fn run(
                 return Err(anyhow!("at least one task must be specified"));
             }
             if let Some(file_path) = &args.profile {
-                logger.enable_chrome_tracing(file_path);
+                logger.enable_chrome_tracing(file_path)?;
             }
             let base = CommandBase::new(cli_args.clone(), repo_root, version, ui);
 

--- a/crates/turborepo-lib/src/cli.rs
+++ b/crates/turborepo-lib/src/cli.rs
@@ -827,7 +827,7 @@ pub async fn run(
                 tracing::warn!("rust codepath enabled, but not compiled with support");
             }
             if let Some(file_path) = &args.profile {
-                logger.enable_chrome_tracing(file_path);
+                logger.enable_chrome_tracing(file_path)?;
             }
             if args.tasks.is_empty() {
                 return Err(anyhow!("at least one task must be specified"));


### PR DESCRIPTION
### Description

Was getting a lint warning for us not handling the `Result`. We could ignore a failure here, but I think it makes sense if the user requests a profile via `--profile=run.trace` we should fail if we can't produce that profile.

### Testing Instructions

👀 


Closes TURBO-1461