### PR TITLE
chore: add a few diagnostic log lines for measuring time-to-execute

### DIFF
--- a/crates/turborepo-lib/src/shim.rs
+++ b/crates/turborepo-lib/src/shim.rs
@@ -221,7 +221,7 @@ impl Default for TurboState {
 }
 
 impl TurboState {
-    pub fn platform_package_name() -> &'static str {
+    pub const fn platform_name() -> &'static str {
         const ARCH: &str = {
             #[cfg(target_arch = "x86_64")]
             {
@@ -256,10 +256,14 @@ impl TurboState {
             }
         };
 
-        formatcp!("turbo-{}-{}", OS, ARCH)
+        formatcp!("{}-{}", OS, ARCH)
     }
 
-    pub fn binary_name() -> &'static str {
+    pub const fn platform_package_name() -> &'static str {
+        formatcp!("turbo-{}", TurboState::platform_name())
+    }
+
+    pub const fn binary_name() -> &'static str {
         {
             #[cfg(windows)]
             {

--- a/crates/turborepo-lib/src/task_hash.rs
+++ b/crates/turborepo-lib/src/task_hash.rs
@@ -67,6 +67,8 @@ impl PackageInputsHashes {
         task_definitions: &HashMap<TaskId<'static>, TaskDefinition>,
         repo_root: &AbsoluteSystemPath,
     ) -> Result<PackageInputsHashes, Error> {
+        tracing::trace!(scm_manual=%scm.is_manual(), "scm running in {} mode", if scm.is_manual() { "manual" } else { "git" });
+
         let (hashes, expanded_hashes): (HashMap<_, _>, HashMap<_, _>) = all_tasks
             .filter_map(|task| {
                 let TaskNode::Task(task_id) = task else {

--- a/crates/turborepo-scm/src/lib.rs
+++ b/crates/turborepo-scm/src/lib.rs
@@ -193,6 +193,10 @@ impl SCM {
             SCM::Manual
         })
     }
+
+    pub fn is_manual(&self) -> bool {
+        matches!(self, SCM::Manual)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
### Description

For collecting benches we are extracting data from chrome traces. We can use the following `jq` script to very easily pull out a summary of the data, but for that we need to log specific things out so that chrome tracing can pick them up.

```jq
map({
    platform: .args.platform, 
    name: "time-to-first-task", 
    startTimeUnixMs: (if .args.start_time then .args.start_time | tonumber else null end), 
    durationMs: (if .args.message == "running visitor" then .ts else null end), 
    turboVersion: .args.turbo_version,
    scm: (if .args.scm_manual == "true" then "manual" elif .args.scm_manual == "false" then "git" else null end),
}) 
| reduce .[] as $item ({}; . *= ($item | del(.. | nulls)))
```

### Testing Instructions

N/A (diagnostic changes only)


Closes TURBO-1464