### PR TITLE
Add support for FreeVarReference::Error

### DIFF
--- a/crates/turbopack-core/src/compile_time_info.rs
+++ b/crates/turbopack-core/src/compile_time_info.rs
@@ -136,6 +136,7 @@ pub enum FreeVarReference {
         export: Option<String>,
     },
     Value(CompileTimeDefineValue),
+    Error(String),
 }
 
 impl From<bool> for FreeVarReference {

--- a/crates/turbopack-ecmascript/src/errors.rs
+++ b/crates/turbopack-ecmascript/src/errors.rs
@@ -15,5 +15,6 @@ pub mod failed_to_analyse {
         pub const NODE_PROTOBUF_LOADER: &str = "TP1105";
         pub const AMD_DEFINE: &str = "TP1200";
         pub const NEW_URL_IMPORT_META: &str = "TP1201";
+        pub const FREE_VAR_REFERENCE: &str = "TP1202";
     }
 }


### PR DESCRIPTION
### Description

Next.js needs a way to error when certain globals are used in the edge runtime. For example `setImmediate`, to cause an error at compile time. This implements support for `FreeVarReference::Error` which can be used to provide an error message.
Since the internals already track the span the message is applied with the right code location automatically.

<!--
  ✍️ Write a short summary of your work.
  If necessary, include relevant screenshots.
-->

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
