### PR TITLE
Fix filewatching setup cookie path

### DIFF
--- a/crates/turborepo-filewatch/src/globwatcher.rs
+++ b/crates/turborepo-filewatch/src/globwatcher.rs
@@ -422,7 +422,9 @@ mod test {
         setup(&repo_root);
         let cookie_dir = repo_root.join_component(".git");
 
-        let watcher = FileSystemWatcher::new(&repo_root).await.unwrap();
+        let watcher = FileSystemWatcher::new_with_default_cookie_dir(&repo_root)
+            .await
+            .unwrap();
         let cookie_jar = CookieJar::new(&cookie_dir, Duration::from_secs(2), watcher.subscribe());
 
         let glob_watcher = GlobWatcher::new(&repo_root, cookie_jar, watcher.subscribe());
@@ -500,7 +502,9 @@ mod test {
         setup(&repo_root);
         let cookie_dir = repo_root.join_component(".git");
 
-        let watcher = FileSystemWatcher::new(&repo_root).await.unwrap();
+        let watcher = FileSystemWatcher::new_with_default_cookie_dir(&repo_root)
+            .await
+            .unwrap();
         let cookie_jar = CookieJar::new(&cookie_dir, Duration::from_secs(2), watcher.subscribe());
 
         let glob_watcher = GlobWatcher::new(&repo_root, cookie_jar, watcher.subscribe());
@@ -588,7 +592,9 @@ mod test {
         setup(&repo_root);
         let cookie_dir = repo_root.join_component(".git");
 
-        let watcher = FileSystemWatcher::new(&repo_root).await.unwrap();
+        let watcher = FileSystemWatcher::new_with_default_cookie_dir(&repo_root)
+            .await
+            .unwrap();
         let cookie_jar = CookieJar::new(&cookie_dir, Duration::from_secs(2), watcher.subscribe());
 
         let glob_watcher = GlobWatcher::new(&repo_root, cookie_jar, watcher.subscribe());

--- a/crates/turborepo-filewatch/src/lib.rs
+++ b/crates/turborepo-filewatch/src/lib.rs
@@ -84,7 +84,7 @@ pub struct FileSystemWatcher {
     // dropping the other sender for the broadcast channel, causing all receivers
     // to be notified of a close.
     _exit_ch: tokio::sync::oneshot::Sender<()>,
-    pub cookie_dir: AbsoluteSystemPathBuf,
+    cookie_dir: AbsoluteSystemPathBuf,
 }
 
 impl FileSystemWatcher {
@@ -135,6 +135,10 @@ impl FileSystemWatcher {
 
     pub fn subscribe(&self) -> broadcast::Receiver<Result<Event, NotifyError>> {
         self.sender.subscribe()
+    }
+
+    pub fn cookie_dir(&self) -> &AbsoluteSystemPath {
+        &self.cookie_dir
     }
 }
 

--- a/crates/turborepo-filewatch/src/lib.rs
+++ b/crates/turborepo-filewatch/src/lib.rs
@@ -336,7 +336,16 @@ async fn wait_for_cookie(
     root: &AbsoluteSystemPath,
     recv: &mut mpsc::Receiver<EventResult>,
 ) -> Result<(), WatchError> {
-    let cookie_path = root.join_component(".turbo-cookie");
+    // TODO: should this be passed in? Currently the caller guarantees that the
+    // directory is empty, but it could be the responsibility of the
+    // filewatcher...
+    let cookie_path = root.join_components(&[".turbo", "cookies", ".turbo-cookie"]);
+    cookie_path.ensure_dir().map_err(|e| {
+        WatchError::Setup(format!(
+            "failed to create filesystem cookie dir for {}: {}",
+            cookie_path, e
+        ))
+    })?;
     cookie_path.create_with_contents("cookie").map_err(|e| {
         WatchError::Setup(format!("failed to write cookie to {}: {}", cookie_path, e))
     })?;

--- a/crates/turborepo-filewatch/src/lib.rs
+++ b/crates/turborepo-filewatch/src/lib.rs
@@ -10,6 +10,8 @@ use std::{
     time::Duration,
 };
 
+// windows -> no recursive watch, watch ancestors
+// linux -> recursive watch, watch ancestors
 // macos -> custom watcher impl in fsevents, no recursive watch, no watching ancestors
 #[cfg(target_os = "macos")]
 use fsevent::FsEventWatcher;
@@ -21,10 +23,6 @@ use notify::{Event, EventHandler, RecursiveMode, Watcher};
 use thiserror::Error;
 use tokio::sync::{broadcast, mpsc};
 use tracing::{debug, warn};
-// windows -> no recursive watch, watch ancestors
-// linux -> recursive watch, watch ancestors
-#[cfg(feature = "watch_ancestors")]
-use turbopath::PathRelation;
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, PathRelation};
 #[cfg(feature = "manual_recursive_watch")]
 use {

--- a/crates/turborepo-lib/src/commands/daemon.rs
+++ b/crates/turborepo-lib/src/commands/daemon.rs
@@ -174,23 +174,8 @@ pub async fn daemon_server(
         }
         CloseReason::Interrupt
     });
-    // We already store logs in .turbo and recommend it be gitignore'd.
-    // Watchman uses .git, but we can't guarantee that git is present _or_
-    // that the turbo root is the same as the git root.
-    let cookie_dir = base.repo_root.join_components(&[".turbo", "cookies"]);
-    // We need to ensure that the cookie directory is cleared out first so
-    // that we can start over with cookies.
-    if cookie_dir.exists() {
-        cookie_dir
-            .remove_dir_all()
-            .map_err(|e| DaemonError::CookieDir(e, cookie_dir.clone()))?;
-    }
-    cookie_dir
-        .create_dir_all()
-        .map_err(|e| DaemonError::CookieDir(e, cookie_dir.clone()))?;
     let reason = crate::daemon::serve(
         &base.repo_root,
-        cookie_dir,
         &daemon_root,
         log_file,
         timeout,

--- a/crates/turborepo-lib/src/daemon/server.rs
+++ b/crates/turborepo-lib/src/daemon/server.rs
@@ -93,8 +93,12 @@ async fn start_filewatching(
     cookie_dir: AbsoluteSystemPathBuf,
     watcher_tx: watch::Sender<Option<Arc<FileWatching>>>,
 ) -> Result<(), WatchError> {
-    let watcher = FileSystemWatcher::new(&repo_root).await?;
-    let cookie_jar = CookieJar::new(&cookie_dir, Duration::from_millis(100), watcher.subscribe());
+    let watcher = FileSystemWatcher::new_with_default_cookie_dir(&repo_root).await?;
+    let cookie_jar = CookieJar::new(
+        &watcher.cookie_dir,
+        Duration::from_millis(100),
+        watcher.subscribe(),
+    );
     let glob_watcher = GlobWatcher::new(&repo_root, cookie_jar, watcher.subscribe());
     // We can ignore failures here, it means the server is shutting down and
     // receivers have gone out of scope.

--- a/crates/turborepo-lib/src/daemon/server.rs
+++ b/crates/turborepo-lib/src/daemon/server.rs
@@ -94,7 +94,7 @@ async fn start_filewatching(
 ) -> Result<(), WatchError> {
     let watcher = FileSystemWatcher::new_with_default_cookie_dir(&repo_root).await?;
     let cookie_jar = CookieJar::new(
-        &watcher.cookie_dir,
+        watcher.cookie_dir(),
         Duration::from_millis(100),
         watcher.subscribe(),
     );

--- a/crates/turborepo-paths/src/absolute_system_path.rs
+++ b/crates/turborepo-paths/src/absolute_system_path.rs
@@ -122,6 +122,10 @@ impl AbsoluteSystemPath {
         self.0.as_str().as_bytes()
     }
 
+    pub fn exists(&self) -> bool {
+        self.0.exists()
+    }
+
     pub fn ancestors(&self) -> impl Iterator<Item = &AbsoluteSystemPath> {
         self.0.ancestors().map(Self::new_unchecked)
     }

--- a/crates/turborepo-paths/src/absolute_system_path_buf.rs
+++ b/crates/turborepo-paths/src/absolute_system_path_buf.rs
@@ -192,10 +192,6 @@ impl AbsoluteSystemPathBuf {
         self.0.file_name()
     }
 
-    pub fn exists(&self) -> bool {
-        self.0.exists()
-    }
-
     pub fn try_exists(&self) -> Result<bool, PathError> {
         // try_exists is an experimental API and not yet in fs_err
         Ok(std::fs::try_exists(&self.0)?)


### PR DESCRIPTION
### Description

Fixes [Turbo-1469](https://linear.app/vercel/issue/TURBO-1469/turbo-keeps-creating-turbo-cookie-in-root-of-repo)

 - Moves the filewatching setup cookie into `.turbo/cookies` alongside the rest of the filesystem cookies. 
 - Updated the API so that the filewatcher handles ensuring that the cookie directory is setup and empty.
 - Updates calling path into filewatching to drop a specific cookie directory.

### Testing Instructions

Existing test suite

Closes TURBO-1471