### PR TITLE
feat: port task execution env restriction

### DIFF
--- a/crates/turborepo-env/src/lib.rs
+++ b/crates/turborepo-env/src/lib.rs
@@ -15,7 +15,7 @@ use thiserror::Error;
 const DEFAULT_ENV_VARS: [&str; 1] = ["VERCEL_ANALYTICS_ID"];
 
 /// Environment mode after we've resolved the `Infer` variant
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub enum ResolvedEnvMode {
     Loose,
     Strict,

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -291,6 +291,15 @@ impl<'a> Run<'a> {
         let pkg_dep_graph = Arc::new(pkg_dep_graph);
         let engine = Arc::new(engine);
 
+        let global_env = {
+            let mut env = env_at_execution_start
+                .from_wildcards(global_hash_inputs.pass_through_env.unwrap_or_default())?;
+            if let Some(resolved_global) = &global_hash_inputs.resolved_env_vars {
+                env.union(&resolved_global.all);
+            }
+            env
+        };
+
         let visitor = Visitor::new(
             pkg_dep_graph.clone(),
             runcache,
@@ -303,6 +312,7 @@ impl<'a> Run<'a> {
             false,
             self.processes.clone(),
             &self.base.repo_root,
+            global_env,
         );
 
         // we look for this log line to mark the start of the run
@@ -514,6 +524,9 @@ impl<'a> Run<'a> {
             true,
             self.processes.clone(),
             &self.base.repo_root,
+            // TODO: this is only needed for full execution, figure out better way to model this
+            // not affecting a dry run
+            EnvironmentVariableMap::default(),
         )
         .dry_run();
 

--- a/crates/turborepo-lib/src/task_graph/visitor.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor.rs
@@ -194,7 +194,7 @@ impl<'a> Visitor<'a> {
             }
 
             // We do this calculation earlier than we do in Go due to the `task_hasher`
-            // being !Send In the future we can look at doing this right before
+            // being !Send. In the future we can look at doing this right before
             // task execution instead.
             let execution_env =
                 self.task_hasher
@@ -259,7 +259,7 @@ impl<'a> Visitor<'a> {
                 // We clear the env before populating it with variables we expect
                 cmd.env_clear();
                 cmd.envs(execution_env.iter());
-                // Always last to make sure it clobbers.
+                // Always last to make sure it overwrites any user configured env var.
                 cmd.env("TURBO_HASH", &task_hash);
 
                 let mut stdout_writer =


### PR DESCRIPTION
### Description

Ports the environment variable restriction behavior from Go and plumbs it through to the actual child process.

Fairly straight forward port from Go with two callouts:
 - I combine [`env` and `passThroughEnv`](https://github.com/vercel/turbo/blob/main/cli/internal/run/real_run.go#L502-L503) into a single map in `run/mod.rs`. These two maps are only read once in Go and they immediately get union/d.
 - We calculate the environment variable map eagerly now on the main thread as opposed to right before task execution starts in a separate `goroutine`. We have to do that since the `TaskHasher` contains a lifetime making it `!Send + !Sync`. In the future we should see if we can restructure things to avoid blocking the main thread.

### Testing Instructions

Existing integration tests that test env var restrictions:
```
[0 olszewski@chriss-mbp] /Users/olszewski/code/vercel/turborepo/turborepo-tests/integration $ EXPERIMENTAL_RUST_CODEPATH=true .cram_env/bin/prysk --shell=bash tests/strict_env_vars/*.t          
!
--- tests/strict_env_vars/dry_json.t
+++ tests/strict_env_vars/dry_json.t.err
@@ -4,15 +4,17 @@
 
 Empty passthroughs are null
   $ ${TURBO} build --dry=json | jq -r '.tasks[0].environmentVariables | { passthrough, globalPassthrough }'
-  {
-    "passthrough": null,
-    "globalPassthrough": null
-  }
+  parse error: Invalid numeric literal at line 1, column 7
+  thread 'main' panicked at library/std/src/io/stdio.rs:1019:9:
+  failed printing to stdout: Broken pipe (os error 32)
+  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+  [4]
 
 Make sure that we populate the JSON output
   $ cp "$TESTDIR/../_fixtures/strict_env_vars_configs/all.json" "$(pwd)/turbo.json" && git commit -am "no comment" --quiet
   $ ${TURBO} build --dry=json | jq -r '.tasks[0].environmentVariables | { passthrough, globalPassthrough }'
-  {
-    "passthrough": [],
-    "globalPassthrough": null
-  }
+  parse error: Invalid numeric literal at line 1, column 7
+  thread 'main' panicked at library/std/src/io/stdio.rs:1019:9:
+  failed printing to stdout: Broken pipe (os error 32)
+  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+  [4]
.......
# Ran 8 tests, 0 skipped, 1 failed.
```

The test that fails is expected due to `--dry=JSON` not being hooked up yet.


Closes TURBO-1473