### PR TITLE
chore: re-enable clippy lints and fix new lint errors

### DIFF
--- a/crates/turborepo-auth/src/auth/login.rs
+++ b/crates/turborepo-auth/src/auth/login.rs
@@ -28,7 +28,7 @@ where
 {
     // Check if token exists first.
     if let Some(token) = existing_token {
-        if let Ok(response) = api_client.get_user(&token).await {
+        if let Ok(response) = api_client.get_user(token).await {
             println!("{}", ui.apply(BOLD.apply_to("Existing token found!")));
             ui::print_cli_authorized(&response.user.email, ui);
             return Ok(());

--- a/crates/turborepo-auth/src/auth/sso.rs
+++ b/crates/turborepo-auth/src/auth/sso.rs
@@ -40,7 +40,7 @@ where
     // sso_team passed into this function.
     if let Some(token) = existing_token {
         let (result_user, result_teams) =
-            tokio::join!(api_client.get_user(&token), api_client.get_teams(&token));
+            tokio::join!(api_client.get_user(token), api_client.get_teams(token));
 
         if let (Ok(response_user), Ok(response_teams)) = (result_user, result_teams) {
             if response_teams

--- a/crates/turborepo-auth/src/lib.rs
+++ b/crates/turborepo-auth/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(clippy::all)]
+
 mod auth;
 mod error;
 mod server;

--- a/crates/turborepo-auth/src/server/login_server.rs
+++ b/crates/turborepo-auth/src/server/login_server.rs
@@ -22,7 +22,9 @@ pub trait LoginServer {
 }
 
 /// TODO: Document this.
+#[derive(Default)]
 pub struct DefaultLoginServer;
+
 impl DefaultLoginServer {
     pub fn new() -> Self {
         DefaultLoginServer {}

--- a/crates/turborepo-auth/src/server/sso_server.rs
+++ b/crates/turborepo-auth/src/server/sso_server.rs
@@ -24,7 +24,9 @@ pub trait SSOLoginServer {
 }
 
 /// TODO: Document this.
+#[derive(Default)]
 pub struct DefaultSSOLoginServer;
+
 impl DefaultSSOLoginServer {
     pub fn new() -> Self {
         DefaultSSOLoginServer {}


### PR DESCRIPTION
### Description

#6150 [accidentally made clippy warnings non-blocking](https://github.com/vercel/turbo/pull/6150/files#diff-d34053cb32303b7498893f06e5d45b86ede726954dcb06968b3c6618395dc109L1). This adds back `#![deny(clippy::all)]` and fixes the Clippy warnings that were already present.

### Testing Instructions
CI

