### PR TITLE
chore: avoid allocations during log capture and replay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -941,16 +941,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
 
 [[package]]
-name = "bytelines"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784face321c535fcd9a1456632fa720aa53ea0640b57341d961c8c09de2da59f"
-dependencies = [
- "futures",
- "tokio",
-]
-
-[[package]]
 name = "bytemuck"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10252,7 +10242,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "atty",
- "bytelines",
  "console",
  "indicatif",
  "lazy_static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10089,7 +10089,6 @@ dependencies = [
  "atty",
  "axum",
  "axum-server",
- "bytelines",
  "camino",
  "capnp 0.17.2",
  "capnpc",

--- a/crates/turborepo-lib/Cargo.toml
+++ b/crates/turborepo-lib/Cargo.toml
@@ -37,7 +37,6 @@ anyhow = { workspace = true, features = ["backtrace"] }
 atty = { workspace = true }
 axum = { workspace = true }
 axum-server = { workspace = true }
-bytelines = "2.4.0"
 chrono = { workspace = true, features = ["serde"] }
 clap = { workspace = true, features = ["derive", "env"] }
 clap_complete = { workspace = true }

--- a/crates/turborepo-lib/src/task_graph/visitor.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor.rs
@@ -283,7 +283,7 @@ impl<'a> Visitor<'a> {
                 };
 
                 let exit_status = match process
-                    .wait_with_single_piped_output(&mut stdout_writer)
+                    .wait_with_piped_outputs(&mut stdout_writer, None)
                     .await
                 {
                     Ok(Some(exit_status)) => exit_status,

--- a/crates/turborepo-ui/Cargo.toml
+++ b/crates/turborepo-ui/Cargo.toml
@@ -12,7 +12,6 @@ test-case = { workspace = true }
 
 [dependencies]
 atty = { workspace = true }
-bytelines = "2.4.0"
 console = { workspace = true }
 indicatif = { workspace = true }
 lazy_static = { workspace = true }


### PR DESCRIPTION
### Description

The use of `mpsc` to capture output from child processes really bothered me. I figured out how to use `select!` to avoid it and I kept pulling that thread and ended up with this PR.

This PR:
 - Drops usage of `mpsc` to combine both stdout/stderr to a single writer
 - Removes usage of `bytelines` which allows us to avoid temporary allocations (except for a single buffer) when capturing child process output
 - Folds in the two child process output capture into a single method

I'd suggest reviewing each commit on it's own.

### Testing Instructions

Existing unit tests and testing log replay in a test repo:
```
[0 olszewski@chriss-mbp] /tmp/testing $ turbo_dev build --experimental-rust-codepath 
docs:build: cache hit (outputs already on disk), suppressing logs 865e3d756acfe0ef
web:build: cache hit (outputs already on disk), suppressing logs a97ae6e5ab4613c0
docs:build: 
docs:build: > docs@1.0.0 build /private/tmp/testing/apps/docs
docs:build: > next build
docs:build: 
docs:build: - info Creating an optimized production build...
docs:build: - info Compiled successfully
docs:build: - info Linting and checking validity of types...
docs:build: - info Collecting page data...
docs:build: - info Generating static pages (0/4)
docs:build: - info Generating static pages (1/4)
docs:build: - info Generating static pages (2/4)
docs:build: - info Generating static pages (3/4)
docs:build: - info Generating static pages (4/4)
docs:build: - info Finalizing page optimization...
docs:build: 
docs:build: Route (app)                                Size     First Load JS
docs:build: ┌ ○ /                                      5.52 kB          84 kB
docs:build: └ ○ /favicon.ico                           0 B                0 B
docs:build: + First Load JS shared by all              78.5 kB
docs:build:   ├ chunks/934-196dcc5a61008b80.js         26.1 kB
web:build: 
web:build: > web@1.0.0 build /private/tmp/testing/apps/web
web:build: > next build
web:build: 
docs:build:   ├ chunks/c260e7fb-1dc88cd74c938f5d.js    50.5 kB
docs:build:   ├ chunks/main-app-2d713702b8a6a8c1.js    220 B
docs:build:   └ chunks/webpack-46498be4babc7638.js     1.68 kB
docs:build: 
docs:build: Route (pages)                              Size     First Load JS
docs:build: ─ ○ /404                                   182 B          76.5 kB
docs:build: + First Load JS shared by all              76.3 kB
docs:build:   ├ chunks/framework-eb124dc7acb3bb04.js   45.1 kB
web:build: - info Creating an optimized production build...
docs:build:   ├ chunks/main-15364e85b6f1124e.js        29.4 kB
docs:build:   ├ chunks/pages/_app-82ff52170628f1f6.js  191 B
docs:build:   └ chunks/webpack-46498be4babc7638.js     1.68 kB
web:build: - info Compiled successfully
web:build: - info Linting and checking validity of types...
web:build: - info Collecting page data...
web:build: - info Generating static pages (0/4)
web:build: - info Generating static pages (1/4)
web:build: - info Generating static pages (2/4)
web:build: - info Generating static pages (3/4)
docs:build: 
docs:build: ○  (Static)  automatically rendered as static HTML (uses no initial props)
docs:build: 
web:build: - info Generating static pages (4/4)
web:build: - info Finalizing page optimization...
web:build: 
web:build: Route (app)                                Size     First Load JS
web:build: ┌ ○ /                                      5.52 kB          84 kB
web:build: └ ○ /favicon.ico                           0 B                0 B
web:build: + First Load JS shared by all              78.5 kB
web:build:   ├ chunks/934-196dcc5a61008b80.js         26.1 kB
web:build:   ├ chunks/c260e7fb-1dc88cd74c938f5d.js    50.5 kB
web:build:   ├ chunks/main-app-dc37cd09df02200e.js    219 B
web:build:   └ chunks/webpack-46498be4babc7638.js     1.68 kB
web:build: 
web:build: Route (pages)                              Size     First Load JS
web:build: ─ ○ /404                                   182 B          76.5 kB
web:build: + First Load JS shared by all              76.3 kB
web:build:   ├ chunks/framework-eb124dc7acb3bb04.js   45.1 kB
web:build:   ├ chunks/main-15364e85b6f1124e.js        29.4 kB
web:build:   ├ chunks/pages/_app-82ff52170628f1f6.js  191 B
web:build:   └ chunks/webpack-46498be4babc7638.js     1.68 kB
web:build: 
web:build: ○  (Static)  automatically rendered as static HTML (uses no initial props)
web:build:
```


Closes TURBO-1476