### PR TITLE
Deduplicate referenced_output_assets

### DIFF
--- a/crates/turbo-tasks/src/vc/mod.rs
+++ b/crates/turbo-tasks/src/vc/mod.rs
@@ -309,9 +309,9 @@ where
     pub async fn debug_identifier(vc: Self) -> Result<String> {
         let resolved = vc.resolve().await?;
         let raw_vc: RawVc = resolved.node;
-        if let RawVc::TaskCell(_, CellId { type_id, index }) = raw_vc {
+        if let RawVc::TaskCell(task_id, CellId { type_id, index }) = raw_vc {
             let value_ty = registry::get_value_type(type_id);
-            Ok(format!("{}#{}", value_ty.name, index))
+            Ok(format!("{}#{}: {}", value_ty.name, index, task_id))
         } else {
             unreachable!()
         }

--- a/crates/turbopack-core/src/chunk/chunk_group.rs
+++ b/crates/turbopack-core/src/chunk/chunk_group.rs
@@ -185,6 +185,6 @@ async fn references_to_output_assets(
     Ok(if output_assets.is_empty() {
         OutputAssets::empty()
     } else {
-        Vc::cell(output_assets)
+        OutputAssets::new(output_assets)
     })
 }

--- a/crates/turbopack-core/src/chunk/chunk_group.rs
+++ b/crates/turbopack-core/src/chunk/chunk_group.rs
@@ -11,7 +11,7 @@ use super::{
     chunk_content, chunking::make_chunks, AsyncModuleInfo, Chunk, ChunkContentResult, ChunkItem,
     ChunkingContext,
 };
-use crate::{module::Module, output::OutputAsset, reference::ModuleReference};
+use crate::{module::Module, output::OutputAssets, reference::ModuleReference};
 
 pub struct MakeChunkGroupResult {
     pub chunks: Vec<Vc<Box<dyn Chunk>>>,
@@ -169,7 +169,7 @@ pub async fn make_chunk_group(
 
 async fn references_to_output_assets(
     references: IndexSet<Vc<Box<dyn ModuleReference>>>,
-) -> Result<Vec<Vc<Box<dyn OutputAsset>>>> {
+) -> Result<Vc<OutputAssets>> {
     let output_assets = references
         .into_iter()
         .map(|reference| reference.resolve_reference().primary_output_assets())
@@ -182,5 +182,9 @@ async fn references_to_output_assets(
         .copied()
         .filter(|&asset| set.insert(asset))
         .collect::<Vec<_>>();
-    Ok(output_assets)
+    Ok(if output_assets.is_empty() {
+        OutputAssets::empty()
+    } else {
+        Vc::cell(output_assets)
+    })
 }

--- a/crates/turbopack-core/src/chunk/chunking.rs
+++ b/crates/turbopack-core/src/chunk/chunking.rs
@@ -13,7 +13,7 @@ use tracing::Level;
 use turbo_tasks::{ReadRef, TryJoinIterExt, ValueToString, Vc};
 
 use super::{AsyncModuleInfo, Chunk, ChunkItem, ChunkType, ChunkingContext};
-use crate::output::{OutputAsset, OutputAssets};
+use crate::output::OutputAssets;
 
 /// Creates chunks based on heuristics for the passed `chunk_items`. Also
 /// attaches `referenced_output_assets` to the first chunk.
@@ -22,7 +22,7 @@ pub async fn make_chunks(
     chunking_context: Vc<Box<dyn ChunkingContext>>,
     chunk_items: impl IntoIterator<Item = (Vc<Box<dyn ChunkItem>>, Option<Vc<AsyncModuleInfo>>)>,
     key_prefix: &str,
-    referenced_output_assets: Vec<Vc<Box<dyn OutputAsset>>>,
+    mut referenced_output_assets: Vc<OutputAssets>,
 ) -> Result<Vec<Vc<Box<dyn Chunk>>>> {
     let chunk_items = chunk_items
         .into_iter()
@@ -36,8 +36,6 @@ pub async fn make_chunks(
     for (ty, chunk_item, async_info) in chunk_items {
         map.entry(ty).or_default().push((chunk_item, async_info));
     }
-
-    let mut referenced_output_assets = Vc::cell(referenced_output_assets);
 
     let mut chunks = Vec::new();
     for (ty, chunk_items) in map {

--- a/crates/turbopack-core/src/output.rs
+++ b/crates/turbopack-core/src/output.rs
@@ -24,6 +24,11 @@ pub struct OutputAssets(Vec<Vc<Box<dyn OutputAsset>>>);
 #[turbo_tasks::value_impl]
 impl OutputAssets {
     #[turbo_tasks::function]
+    pub fn new(assets: Vec<Vc<Box<dyn OutputAsset>>>) -> Vc<Self> {
+        Vc::cell(assets)
+    }
+
+    #[turbo_tasks::function]
     pub fn empty() -> Vc<Self> {
         Vc::cell(vec![])
     }


### PR DESCRIPTION
### Description

We're chunking and outputting a multiple times for some entry points, because `references_to_output_assets` doesn't return a stable reference for empty values. It might also matter for non-empty values, but I can easily reproduce the empty ones.

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->


Closes WEB-1790