### PR TITLE
chore: fix new clippy lints in auth crate

### DIFF
--- a/crates/turborepo-auth/src/auth/login.rs
+++ b/crates/turborepo-auth/src/auth/login.rs
@@ -53,11 +53,9 @@ where
     let spinner = start_spinner("Waiting for your authorization...");
 
     // Try to open browser for auth confirmation.
-    if !cfg!(test) {
-        let url = login_url.as_str();
-        if webbrowser::open(url).is_err() {
-            warn!("Failed to open browser. Please visit {url} in your browser.");
-        }
+    let url = login_url.as_str();
+    if !cfg!(test) && webbrowser::open(url).is_err() {
+        warn!("Failed to open browser. Please visit {url} in your browser.");
     }
 
     let token_cell = Arc::new(OnceCell::new());

--- a/crates/turborepo-auth/src/auth/sso.rs
+++ b/crates/turborepo-auth/src/auth/sso.rs
@@ -76,10 +76,8 @@ where
     let url = login_url.as_str();
 
     // Don't open the browser in tests.
-    if !cfg!(test) {
-        if webbrowser::open(url).is_err() {
-            warn!("Failed to open browser. Please visit {url} in your browser.");
-        }
+    if !cfg!(test) && webbrowser::open(url).is_err() {
+        warn!("Failed to open browser. Please visit {url} in your browser.");
     }
 
     let token_cell = Arc::new(OnceCell::new());


### PR DESCRIPTION
### Description

#6186 and #6187 raced and landed in an order that let in a new clippy warning *and* errors on said warning

### Testing Instructions

No clippy warnings
