### PR TITLE
Remove `OutputAssets::new` if condition

### DIFF
--- a/crates/turbopack-core/src/output.rs
+++ b/crates/turbopack-core/src/output.rs
@@ -25,11 +25,7 @@ pub struct OutputAssets(Vec<Vc<Box<dyn OutputAsset>>>);
 impl OutputAssets {
     #[turbo_tasks::function]
     pub fn new(assets: Vec<Vc<Box<dyn OutputAsset>>>) -> Vc<Self> {
-        if assets.is_empty() {
-            OutputAssets::empty()
-        } else {
-            Vc::cell(assets)
-        }
+        Vc::cell(assets)
     }
 
     #[turbo_tasks::function]

--- a/crates/turbopack-core/src/output.rs
+++ b/crates/turbopack-core/src/output.rs
@@ -27,7 +27,9 @@ impl OutputAssets {
     pub fn new(assets: Vec<Vc<Box<dyn OutputAsset>>>) -> Vc<Self> {
         Vc::cell(assets)
     }
+}
 
+impl OutputAssets {
     pub fn empty() -> Vc<Self> {
         Self::new(vec![])
     }

--- a/crates/turbopack-core/src/output.rs
+++ b/crates/turbopack-core/src/output.rs
@@ -28,9 +28,8 @@ impl OutputAssets {
         Vc::cell(assets)
     }
 
-    #[turbo_tasks::function]
     pub fn empty() -> Vc<Self> {
-        Vc::cell(vec![])
+        Self::new(vec![])
     }
 }
 


### PR DESCRIPTION
### Description

It's unneeded, the input param caching will correctly handle this case already.

https://github.com/vercel/turbo/pull/6194#discussion_r1362484606

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->


Closes WEB-1794