### PR TITLE
chore: remove debug logging for file hashes

### DIFF
--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -283,8 +283,6 @@ impl<'a> Run<'a> {
             &self.base.repo_root,
         )?;
 
-        debug!("package inputs hashes: {:?}", package_inputs_hashes);
-
         // remove dead code warnings
         let _proc_manager = ProcessManager::new();
 


### PR DESCRIPTION
This log is extremely large for large codebases


Closes TURBO-1478