### PR TITLE
fix: log replay message should say replay

### DIFF
--- a/crates/turborepo-lib/src/run/cache.rs
+++ b/crates/turborepo-lib/src/run/cache.rs
@@ -276,7 +276,7 @@ impl TaskCache {
             OutputLogsMode::Full => {
                 debug!("log file path: {}", self.log_file_path);
                 prefixed_ui.output(format!(
-                    "cache hit{}, suppressing logs {}",
+                    "cache hit{}, replaying logs {}",
                     more_context,
                     GREY.apply_to(&self.hash)
                 ));


### PR DESCRIPTION
### Description

Just noticed that we claim that we're suppressing logs when in fact we're replaying them.

### Testing Instructions
👀 


Closes TURBO-1481