### PR TITLE
feat(Turborepo): Initial run preamble

### DIFF
--- a/crates/turborepo-api-client/src/lib.rs
+++ b/crates/turborepo-api-client/src/lib.rs
@@ -100,18 +100,6 @@ pub struct APIAuth {
     pub team_slug: Option<String>,
 }
 
-impl APIAuth {
-    pub fn is_linked(&self) -> bool {
-        !self.token.is_empty()
-            && (!self.team_id.is_empty()
-                || !self
-                    .team_slug
-                    .as_ref()
-                    .map(|slug| slug.is_empty())
-                    .unwrap_or(true))
-    }
-}
-
 #[async_trait]
 impl Client for APIClient {
     async fn get_user(&self, token: &str) -> Result<UserResponse> {

--- a/crates/turborepo-api-client/src/lib.rs
+++ b/crates/turborepo-api-client/src/lib.rs
@@ -100,6 +100,18 @@ pub struct APIAuth {
     pub team_slug: Option<String>,
 }
 
+impl APIAuth {
+    pub fn is_linked(&self) -> bool {
+        !self.token.is_empty()
+            && (!self.team_id.is_empty()
+                || !self
+                    .team_slug
+                    .as_ref()
+                    .map(|slug| slug.is_empty())
+                    .unwrap_or(true))
+    }
+}
+
 #[async_trait]
 impl Client for APIClient {
     async fn get_user(&self, token: &str) -> Result<UserResponse> {

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -92,10 +92,7 @@ impl<'a> Run<'a> {
         let api_client = self.base.api_client()?;
 
         // Pulled from initAnalyticsClient in run.go
-        let is_linked = api_auth
-            .as_ref()
-            .map(|auth| auth.is_linked())
-            .unwrap_or(false);
+        let is_linked = api_auth.is_some();
         if !is_linked {
             opts.cache_opts.skip_remote = true;
         } else if let Some(enabled) = config.enabled {

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -134,10 +134,10 @@ impl<'a> Run<'a> {
         }
 
         // There's some warning handling code in Go that I'm ignoring
-        let is_ci_and_not_tty = turborepo_ci::is_ci() && !std::io::stdout().is_terminal();
+        let is_ci_or_not_tty = turborepo_ci::is_ci() || !std::io::stdout().is_terminal();
 
         let mut daemon = None;
-        if is_ci_and_not_tty && !opts.run_opts.no_daemon {
+        if is_ci_or_not_tty && !opts.run_opts.no_daemon {
             info!("skipping turbod since we appear to be in a non-interactive context");
         } else if !opts.run_opts.no_daemon {
             let connector = DaemonConnector {

--- a/crates/turborepo-ui/src/lib.rs
+++ b/crates/turborepo-ui/src/lib.rs
@@ -72,13 +72,24 @@ macro_rules! cprintln {
 }
 
 #[macro_export]
-macro_rules! cwrite {
+macro_rules! cprint {
     ($ui:expr, $color:expr, $format_string:expr $(, $arg:expr)*) => {{
         let formatted_str = format!($format_string $(, $arg)*);
 
         let colored_str = $color.apply_to(formatted_str);
 
-        write!("{}", $ui.apply(colored_str))
+        print!("{}", $ui.apply(colored_str))
+    }};
+}
+
+#[macro_export]
+macro_rules! cwrite {
+    ($dst:expr, $ui:expr, $color:expr, $format_string:expr $(, $arg:expr)*) => {{
+        let formatted_str = format!($format_string $(, $arg)*);
+
+        let colored_str = $color.apply_to(formatted_str);
+
+        write!($dst, "{}", $ui.apply(colored_str))
     }};
 }
 
@@ -172,6 +183,7 @@ lazy_static! {
     pub static ref MAGENTA: Style = Style::new().magenta();
     pub static ref UNDERLINE: Style = Style::new().underlined();
     pub static ref BOLD_CYAN: Style = Style::new().cyan().bold();
+    pub static ref BOLD_GREY: Style = Style::new().dim().bold();
 }
 
 pub const RESET: &str = "\x1b[0m";

--- a/turborepo-tests/integration/tests/single_package/graph.t
+++ b/turborepo-tests/integration/tests/single_package/graph.t
@@ -15,6 +15,8 @@ Graph
   
 Graph in Rust
   $ ${TURBO} run build --graph --experimental-rust-codepath
+  \xe2\x80\xa2 Running build (esc)
+  \xe2\x80\xa2 Remote caching disabled (esc)
   digraph {
   \tcompound = "true" (esc)
   \tnewrank = "true" (esc)


### PR DESCRIPTION
### Description

 - Adds packages and targets summary at the beginning of a run
 - Some minor tweaks to output to match Go logic
 - Minor bugfix to `cwrite!` macro
 - Add a `cprint!` macro for lines with mixed color formatting

### Testing Instructions

Existing test suite. We're still missing the post-run summary, so we don't have more integration tests passing, but the diff is smaller now.


Closes TURBO-1484