### PR TITLE
fix(Turborepo): Drop root package removal

### DIFF
--- a/crates/turborepo-lib/src/run/scope/filter.rs
+++ b/crates/turborepo-lib/src/run/scope/filter.rs
@@ -144,7 +144,7 @@ impl<'a, T: PackageChangeDetector> FilterResolver<'a, T> {
         // inference is None only if we are in the root
         let is_all_packages = patterns.is_empty() && self.inference.is_none();
 
-        let mut filter_patterns = if is_all_packages {
+        let filter_patterns = if is_all_packages {
             // return all packages in the workspace
             self.pkg_graph
                 .workspaces()
@@ -153,9 +153,6 @@ impl<'a, T: PackageChangeDetector> FilterResolver<'a, T> {
         } else {
             self.get_packages_from_patterns(patterns)?
         };
-
-        // if the root package is in the filtered packages, remove it
-        filter_patterns.remove(&WorkspaceName::Root);
 
         Ok(filter_patterns)
     }


### PR DESCRIPTION
### Description

 Removes a line that came from some Go-based confusion. The [original line](https://github.com/vercel/turbo/blob/9ae772ac8e4437d36a34a998eea0057a4eb546d9/cli/internal/scope/scope.go#L169) removes the [synthetic graph root token](https://github.com/vercel/turbo/blob/9ae772ac8e4437d36a34a998eea0057a4eb546d9/cli/internal/core/engine.go#L19), _not_ the root package (`//`). With our Rust implementation, we don't need the synthetic root node, and so don't have to remove anything. 

### Testing Instructions

Fixes some diffs in the integration tests when run with the rust implementation


Closes TURBO-1487