### PR TITLE
feat(Turborepo): Add publish step for @turbo/repository

### DIFF
--- a/.github/workflows/turborepo-library-release.yml
+++ b/.github/workflows/turborepo-library-release.yml
@@ -94,7 +94,6 @@ jobs:
 
       - name: Package Artifacts
         run: |
-          pwd
           mkdir tarballs
           npm pack packages/turbo-repository/npm/darwin-arm64
           npm pack packages/turbo-repository/npm/darwin-x64
@@ -104,6 +103,20 @@ jobs:
           npm pack packages/turbo-repository/npm/win32-x64-msvc
           npm pack packages/turbo-repository/js
           mv *.tgz tarballs/
+
+      - name: Publish Artifacts
+        run: |
+          npm config set --location=project "//registry.npmjs.org/:_authToken" $(NPM_TOKEN)
+          VERSION=$(jq -r .version packages/turbo-repository/js/package.json)
+          TARBALLS="packages/turbo-repository/tarballs"
+          TAG="canary"
+          npm publish -ddd --tag ${TAG} ${TARBALLS}/turbo-repository-darwin-arm64-${VERSION}.tgz
+          npm publish -ddd --tag ${TAG} ${TARBALLS}/turbo-repository-darwin-x64-${VERSION}.tgz
+          npm publish -ddd --tag ${TAG} ${TARBALLS}/turbo-repository-linux-arm64-gnu-${VERSION}.tgz
+          npm publish -ddd --tag ${TAG} ${TARBALLS}/turbo-repository-linux-x64-gnu-${VERSION}.tgz
+          npm publish -ddd --tag ${TAG} ${TARBALLS}/turbo-repository-win32-arm64-msvc-${VERSION}.tgz
+          npm publish -ddd --tag ${TAG} ${TARBALLS}/turbo-repository-win32-x64-msvc-${VERSION}.tgz
+          npm publish -ddd --tag ${TAG} ${TARBALLS}/turbo-repository-${VERSION}.tgz
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v3

--- a/packages/turbo-repository/js/package.json
+++ b/packages/turbo-repository/js/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "bugs": "https://github.com/vercel/turbo/issues",
   "homepage": "https://turbo.build/repo",
+  "license": "MPL-2.0",
   "main": "dist/index.js",
   "scripts": {
     "build": "mkdir -p dist && cp index.js dist/index.js && cp index.d.ts dist/index.d.ts"

--- a/packages/turbo-repository/package.json
+++ b/packages/turbo-repository/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://turbo.build/repo",
   "scripts": {
     "build": "napi build --platform -p turborepo-napi --cargo-cwd ../../ --cargo-name turborepo_napi native --js false --dts ../js/index-generated.d.ts",
-    "build:release": "napi build --release --platform -p turborepo-napi --cargo-cwd ../../ --cargo-name turborepo_napi native --js ../js/dist/index.js --dts ../js/dist/index.d.ts",
+    "build:release": "napi build --release --platform -p turborepo-napi --cargo-cwd ../../ --cargo-name turborepo_napi native --js false --dts false",
     "package": "node scripts/publish.mjs"
   },
   "keywords": [],


### PR DESCRIPTION
### Description

 - drop generating `index.js` and `index.d.ts` in the `build:release` task. We don't need them,  we build them separately
 - Add publish step to the end of the github action

### Testing Instructions

Not yet tested, since this will publish the artifacts live. It's possible that it will require some iteration.

Closes TURBO-1488