### PR TITLE
Upload Are We Turbo Yet data to Vercel KV

### DIFF
--- a/.github/workflows/daily-nextjs-integration-test.yml
+++ b/.github/workflows/daily-nextjs-integration-test.yml
@@ -36,6 +36,7 @@ jobs:
     needs: [next_js_integration]
     if: ${{ github.event_name == 'schedule' }} && always()
     uses: ./.github/workflows/upload-nextjs-integration-test-results.yml
+    secrets: inherit
     with:
       is_main_branch: true
 

--- a/.github/workflows/upload-nextjs-integration-test-results.yml
+++ b/.github/workflows/upload-nextjs-integration-test-results.yml
@@ -63,3 +63,9 @@ jobs:
         with:
           file_pattern: test-results/**
           commit_message: "test(integration): Integration test results for ${{ env.NEXTJS_VERSION }} (${{ env.SHA_SHORT }})"
+
+      - name: "Upload Are We Turbo Yet data"
+        env:
+          TURBOYET_KV_REST_API_URL: ${{ secrets.TURBOYET_KV_REST_API_URL }}
+          TURBOYET_KV_REST_API_TOKEN: ${{ secrets.TURBOYET_KV_REST_API_TOKEN }}
+        uses: ./.github/actions/upload-turboyet-data


### PR DESCRIPTION
This calls a new action added to the `nextjs-test-integration-data` branch that uploads relevant data to Vercel KV


Closes WEB-1799