### PR TITLE
chore: Fix typo in log message

### DIFF
--- a/.github/actions/next-integration-stat/src/index.ts
+++ b/.github/actions/next-integration-stat/src/index.ts
@@ -259,7 +259,7 @@ async function createSlackPostSummary(payload: {
     2
   );
   console.log(
-    "Storing slack payload to ./slack-paylod.json to report into Slack channel.",
+    "Storing slack payload to ./slack-payload.json to report into Slack channel.",
     slackPayloadJson
   );
   fs.writeFileSync("./slack-payload.json", slackPayloadJson);


### PR DESCRIPTION
I was searching through how slack posting is happening for turbopack things
and looking for references of "slack-payload" and noticed this one was not showing
up

Closes TURBO-1490