### PR TITLE
chore(test): validate that pruning carries remoteCache fields correctly

### DIFF
--- a/turborepo-tests/integration/README.md
+++ b/turborepo-tests/integration/README.md
@@ -1,6 +1,6 @@
 ## Integration Tests
 
-The `cli/integration_tests` directory contains tests for Turborepo, exercising builds of
+The `turborepo-tests/integration` directory contains tests for Turborepo, exercising builds of
 Turborepo against custom monorepos and turbo.json setups. Tests are written using [`prysk`][1],
 which executes the CLI and can execute arbitrary other commands to assert the result. Some tests
 assert the log output, some assert the created artifacts, some assert configuration, etc etc.

--- a/turborepo-tests/integration/tests/prune/produces_valid_turbo_json.t
+++ b/turborepo-tests/integration/tests/prune/produces_valid_turbo_json.t
@@ -28,3 +28,43 @@ Verify turbo can read the produced turbo.json
     "shared",
     "util"
   ]
+
+Modify turbo.json to add a remoteCache.enabled field set to true
+  $ rm -rf out
+  $ cat turbo.json | jq '.remoteCache.enabled = true' > turbo.json.tmp
+  $ mv turbo.json.tmp turbo.json
+  $ ${TURBO} prune docs > /dev/null
+  $ cat out/turbo.json | jq '.remoteCache | keys'
+  [
+    "apiUrl",
+    "enabled",
+    "loginUrl",
+    "preflight",
+    "signature",
+    "teamId",
+    "teamSlug",
+    "timeout",
+    "token"
+  ]
+  $ cat out/turbo.json | jq '.remoteCache.enabled'
+  true
+
+Modify turbo.json to add a remoteCache.enabled field set to false
+  $ rm -rf out
+  $ cat turbo.json | jq '.remoteCache.enabled = false' > turbo.json.tmp
+  $ mv turbo.json.tmp turbo.json
+  $ ${TURBO} prune docs > /dev/null
+  $ cat out/turbo.json | jq '.remoteCache | keys'
+  [
+    "apiUrl",
+    "enabled",
+    "loginUrl",
+    "preflight",
+    "signature",
+    "teamId",
+    "teamSlug",
+    "timeout",
+    "token"
+  ]
+  $ cat out/turbo.json | jq '.remoteCache.enabled'
+  false


### PR DESCRIPTION
Ref: #5414

Closes TURBO-1500