### PR TITLE
Reduce resolve and resolving tasks

### DIFF
--- a/crates/turbopack-core/src/resolve/mod.rs
+++ b/crates/turbopack-core/src/resolve/mod.rs
@@ -1355,7 +1355,9 @@ async fn resolve_into_folder(
                         let request =
                             Request::parse(Value::new(normalize_request(field_value).into()));
 
-                        let result = &*resolve_internal(package_path, request, options).await?;
+                        let result = &*resolve_internal_inline(package_path, request, options)
+                            .await?
+                            .await?;
                         // we are not that strict when a main field fails to resolve
                         // we continue to try other alternatives
                         if !result.is_unresolveable_ref() {
@@ -1551,11 +1553,8 @@ async fn resolve_into_package(
         new_pat.push_front(".".to_string().into());
 
         let relative = Request::relative(Value::new(new_pat), query, true);
-        results.push(resolve_internal(
-            package_path,
-            relative.resolve().await?,
-            options,
-        ));
+        results
+            .push(resolve_internal_inline(package_path, relative.resolve().await?, options).await?);
     }
     Ok(merge_results(results))
 }

--- a/crates/turbopack-core/src/resolve/mod.rs
+++ b/crates/turbopack-core/src/resolve/mod.rs
@@ -1339,11 +1339,12 @@ async fn resolve_into_folder(
                         )
                     })?;
                 let request = Request::parse(Value::new(str.into()));
-                return Ok(resolve_internal(
+                return Ok(resolve_internal_inline(
                     package_path,
                     request.resolve().await?,
                     options,
-                ));
+                )
+                .await?);
             }
             ResolveIntoPackage::MainField(name) => {
                 if let Some(package_json) = &*read_package_json(package_json_path).await? {

--- a/crates/turbopack-core/src/resolve/mod.rs
+++ b/crates/turbopack-core/src/resolve/mod.rs
@@ -1233,11 +1233,12 @@ async fn resolve_internal_inline(
             .cell()
             .emit();
 
-            resolve_internal(
+            resolve_internal_boxed(
                 lookup_path.root().resolve().await?,
                 relative.resolve().await?,
                 options,
             )
+            .await?
         }
         Request::Windows { path: _, query: _ } => {
             ResolvingIssue {

--- a/crates/turbopack-core/src/resolve/mod.rs
+++ b/crates/turbopack-core/src/resolve/mod.rs
@@ -726,7 +726,7 @@ async fn type_exists(
     for path in result.symlinks.iter() {
         refs.push(Vc::upcast(FileSource::new(*path)));
     }
-    let path = result.path;
+    let path = result.path.resolve().await?;
     Ok(if *path.get_type().await? == ty {
         Some(path)
     } else {
@@ -1453,7 +1453,7 @@ async fn resolve_module_request(
         };
 
         let FindContextFileResult::Found(package_json_path, refs) =
-            &*find_context_file(lookup_path, package_json()).await?
+            &*find_context_file(lookup_path, package_json().resolve().await?).await?
         else {
             continue;
         };
@@ -1515,7 +1515,7 @@ async fn resolve_module_request(
     for &package_path in &result.packages {
         results.push(resolve_into_package(
             Value::new(path.clone()),
-            package_path,
+            package_path.resolve().await?,
             query,
             options,
         ));

--- a/crates/turbopack-core/src/resolve/mod.rs
+++ b/crates/turbopack-core/src/resolve/mod.rs
@@ -1009,7 +1009,10 @@ pub async fn resolve(
     request: Vc<Request>,
     options: Vc<ResolveOptions>,
 ) -> Result<Vc<ResolveResult>> {
-    let raw_result = resolve_internal(lookup_path, request, options);
+    let raw_result = resolve_internal_inline(lookup_path, request, options)
+        .await?
+        .resolve()
+        .await?;
     let result = handle_resolve_plugins(lookup_path, request, options, raw_result);
     Ok(result)
 }

--- a/crates/turbopack-core/src/resolve/mod.rs
+++ b/crates/turbopack-core/src/resolve/mod.rs
@@ -1793,7 +1793,7 @@ async fn handle_exports_imports_field(
     for path in results {
         if let Some(path) = normalize_path(path) {
             let request = Request::parse(Value::new(format!("./{}", path).into()));
-            resolved_results.push(resolve_internal(package_path, request, options));
+            resolved_results.push(resolve_internal_boxed(package_path, request, options).await?);
         }
     }
 

--- a/crates/turbopack-core/src/resolve/mod.rs
+++ b/crates/turbopack-core/src/resolve/mod.rs
@@ -1330,12 +1330,8 @@ async fn resolve_into_folder(
                         )
                     })?;
                 let request = Request::parse(Value::new(str.into()));
-                return Ok(resolve_internal_inline(
-                    package_path,
-                    request.resolve().await?,
-                    options,
-                )
-                .await?);
+                return resolve_internal_inline(package_path, request.resolve().await?, options)
+                    .await;
             }
             ResolveIntoPackage::MainField(name) => {
                 if let Some(package_json) = &*read_package_json(package_json_path).await? {

--- a/crates/turbopack-core/src/resolve/mod.rs
+++ b/crates/turbopack-core/src/resolve/mod.rs
@@ -1164,7 +1164,7 @@ async fn resolve_internal_inline(
                         );
                     }
                     PatternMatch::Directory(_, path) => {
-                        results.push(resolve_into_folder(*path, options, *query).await?);
+                        results.push(resolve_into_folder(*path, options, *query));
                     }
                 }
             }
@@ -1320,6 +1320,7 @@ async fn resolve_internal_inline(
     Ok(result)
 }
 
+#[turbo_tasks::function]
 async fn resolve_into_folder(
     package_path: Vc<FileSystemPath>,
     options: Vc<ResolveOptions>,
@@ -1470,7 +1471,7 @@ async fn resolve_module_request(
     // try both.
     for package_path in &result.packages {
         if is_match {
-            results.push(resolve_into_folder(*package_path, options, query).await?);
+            results.push(resolve_into_folder(*package_path, options, query));
         }
         if !could_match_others {
             continue;
@@ -1481,7 +1482,7 @@ async fn resolve_module_request(
                 ResolveIntoPackage::Default(_) | ResolveIntoPackage::MainField(_) => {
                     // doesn't affect packages with subpath
                     if path.is_match("/") {
-                        results.push(resolve_into_folder(*package_path, options, query).await?);
+                        results.push(resolve_into_folder(*package_path, options, query));
                     }
                 }
                 ResolveIntoPackage::ExportsField {

--- a/crates/turbopack-core/src/resolve/mod.rs
+++ b/crates/turbopack-core/src/resolve/mod.rs
@@ -1139,8 +1139,9 @@ async fn resolve_internal_inline(
         Request::Alternatives { requests } => {
             let results = requests
                 .iter()
-                .map(|req| resolve_internal(lookup_path, *req, options))
-                .collect();
+                .map(|req| resolve_internal_boxed(lookup_path, *req, options))
+                .try_join()
+                .await?;
 
             merge_results(results)
         }

--- a/crates/turbopack-core/src/resolve/pattern.rs
+++ b/crates/turbopack-core/src/resolve/pattern.rs
@@ -898,6 +898,41 @@ pub async fn read_matches(
                             prefix.truncate(len)
                         }
                         DirectoryEntry::Symlink(fs_path) => {
+                            prefix.push_str(key);
+                            // {prefix}{key}
+                            if prefix.ends_with('/') {
+                                prefix.pop();
+                            }
+                            if let Some(pos) = pat.match_position(&prefix) {
+                                if let LinkContent::Link { link_type, .. } =
+                                    &*fs_path.read_link().await?
+                                {
+                                    if link_type.contains(LinkType::DIRECTORY) {
+                                        results.push((
+                                            pos,
+                                            PatternMatch::Directory(prefix.clone(), *fs_path),
+                                        ));
+                                    } else {
+                                        results.push((
+                                            pos,
+                                            PatternMatch::File(prefix.clone(), *fs_path),
+                                        ));
+                                    }
+                                }
+                            }
+                            prefix.push('/');
+                            if let Some(pos) = pat.match_position(&prefix) {
+                                if let LinkContent::Link { link_type, .. } =
+                                    &*fs_path.read_link().await?
+                                {
+                                    if link_type.contains(LinkType::DIRECTORY) {
+                                        results.push((
+                                            pos,
+                                            PatternMatch::Directory(prefix.clone(), *fs_path),
+                                        ));
+                                    }
+                                }
+                            }
                             if let Some(pos) = pat.match_position(&prefix) {
                                 if let LinkContent::Link { link_type, .. } =
                                     &*fs_path.read_link().await?

--- a/crates/turbopack-ecmascript/src/lib.rs
+++ b/crates/turbopack-ecmascript/src/lib.rs
@@ -338,7 +338,9 @@ impl EcmascriptModuleAsset {
     ) -> Result<Vc<EcmascriptModuleContent>> {
         let this = self.await?;
 
-        let parsed = parse(this.source, Value::new(this.ty), this.transforms);
+        let parsed = parse(this.source, Value::new(this.ty), this.transforms)
+            .resolve()
+            .await?;
 
         Ok(EcmascriptModuleContent::new(
             parsed,

--- a/crates/turbopack-ecmascript/src/resolve/mod.rs
+++ b/crates/turbopack-ecmascript/src/resolve/mod.rs
@@ -68,7 +68,9 @@ pub async fn esm_resolve(
     issue_severity: Vc<IssueSeverity>,
 ) -> Result<Vc<ModuleResolveResult>> {
     let ty = Value::new(ReferenceType::EcmaScriptModules(ty.into_value()));
-    let options = apply_esm_specific_options(origin.resolve_options(ty.clone()));
+    let options = apply_esm_specific_options(origin.resolve_options(ty.clone()))
+        .resolve()
+        .await?;
     specific_resolve(origin, request, options, ty, issue_source, issue_severity).await
 }
 
@@ -81,7 +83,9 @@ pub async fn cjs_resolve(
 ) -> Result<Vc<ModuleResolveResult>> {
     // TODO pass CommonJsReferenceSubType
     let ty = Value::new(ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined));
-    let options = apply_cjs_specific_options(origin.resolve_options(ty.clone()));
+    let options = apply_cjs_specific_options(origin.resolve_options(ty.clone()))
+        .resolve()
+        .await?;
     specific_resolve(origin, request, options, ty, issue_source, issue_severity).await
 }
 


### PR DESCRIPTION
### Description

* Reduce turbo-tasks resolve tasks
* Reduce tasks needed for resolving
* Avoid running resolving for every extension, instead use Pattern::Alternatives and change `read_matches` to keep order of alternates

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->


Closes WEB-1806