### PR TITLE
refactor(auth): Removed closure in login functions

### DIFF
--- a/crates/turborepo-auth/src/lib.rs
+++ b/crates/turborepo-auth/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(cow_is_borrowed)]
 #![deny(clippy::all)]
 
 mod auth;

--- a/crates/turborepo-lib/src/commands/login.rs
+++ b/crates/turborepo-lib/src/commands/login.rs
@@ -11,35 +11,31 @@ pub async fn sso_login(base: &mut CommandBase, sso_team: &str) -> Result<()> {
     let ui = base.ui;
     let login_url_config = base.config()?.login_url().to_string();
 
-    // We are passing a closure here, but it would be cleaner if we made a
-    // turborepo-config crate and imported that into turborepo-auth.
-    let set_token = |token: &str| -> Result<(), anyhow::Error> {
-        let global_config_path = base.global_config_path()?;
-        let before = global_config_path
-            .read_existing_to_string_or(Ok("{}"))
-            .map_err(|e| {
-                anyhow!(
-                    "Encountered an IO error while attempting to read {}: {}",
-                    global_config_path,
-                    e
-                )
-            })?;
-        let after = set_path(&before, &["token"], &format!("\"{}\"", token))?;
-        global_config_path.ensure_dir()?;
-        global_config_path.create_with_contents(after)?;
-        Ok(())
-    };
-
-    auth_sso_login(
+    let token = auth_sso_login(
         &api_client,
         &ui,
         base.config()?.token(),
-        set_token,
         &login_url_config,
         sso_team,
         &DefaultSSOLoginServer::new(),
     )
-    .await
+    .await?;
+
+    let global_config_path = base.global_config_path()?;
+    let before = global_config_path
+        .read_existing_to_string_or(Ok("{}"))
+        .map_err(|e| {
+            anyhow!(
+                "Encountered an IO error while attempting to read {}: {}",
+                global_config_path,
+                e
+            )
+        })?;
+    let after = set_path(&before, &["token"], &format!("\"{}\"", token))?;
+    global_config_path.ensure_dir()?;
+    global_config_path.create_with_contents(after)?;
+
+    Ok(())
 }
 
 pub async fn login(base: &mut CommandBase) -> Result<()> {
@@ -47,32 +43,28 @@ pub async fn login(base: &mut CommandBase) -> Result<()> {
     let ui = base.ui;
     let login_url_config = base.config()?.login_url().to_string();
 
-    // We are passing a closure here, but it would be cleaner if we made a
-    // turborepo-config crate and imported that into turborepo-auth.
-    let set_token = |token: &str| -> Result<(), anyhow::Error> {
-        let global_config_path = base.global_config_path()?;
-        let before = global_config_path
-            .read_existing_to_string_or(Ok("{}"))
-            .map_err(|e| {
-                anyhow!(
-                    "Encountered an IO error while attempting to read {}: {}",
-                    global_config_path,
-                    e
-                )
-            })?;
-        let after = set_path(&before, &["token"], &format!("\"{}\"", token))?;
-        global_config_path.ensure_dir()?;
-        global_config_path.create_with_contents(after)?;
-        Ok(())
-    };
-
-    auth_login(
+    let token = auth_login(
         &api_client,
         &ui,
         base.config()?.token(),
-        set_token,
         &login_url_config,
         &DefaultLoginServer::new(),
     )
-    .await
+    .await?;
+
+    let global_config_path = base.global_config_path()?;
+    let before = global_config_path
+        .read_existing_to_string_or(Ok("{}"))
+        .map_err(|e| {
+            anyhow!(
+                "Encountered an IO error while attempting to read {}: {}",
+                global_config_path,
+                e
+            )
+        })?;
+    let after = set_path(&before, &["token"], &format!("\"{}\"", token))?;
+    global_config_path.ensure_dir()?;
+    global_config_path.create_with_contents(after)?;
+
+    Ok(())
 }


### PR DESCRIPTION
### Description

Removed the closure in login functions in favor of returning the token and letting the caller determine exactly how to save it.

This should also help us with moving to `thiserror` since the error typing story inside the closure was a little messy (should it take the `turborepo_auth::Error` type or the `cli::Error` type?)

### Testing Instructions

Updated existing tests

Closes TURBO-1504