### PR TITLE
chore: Removed run stub feature

### DIFF
--- a/crates/turborepo-lib/Cargo.toml
+++ b/crates/turborepo-lib/Cargo.toml
@@ -10,7 +10,6 @@ license = "MPL-2.0"
 default = ["rustls-tls"]
 native-tls = ["turborepo-api-client/native-tls", "turbo-updater/native-tls"]
 rustls-tls = ["turborepo-api-client/rustls-tls", "turbo-updater/rustls-tls"]
-run-stub = []
 
 # serve the daemon over a port (useful for testing)
 http = ["tonic-reflection"]

--- a/crates/turborepo-lib/src/cli.rs
+++ b/crates/turborepo-lib/src/cli.rs
@@ -804,8 +804,7 @@ pub async fn run(
 
             Ok(Payload::Rust(Ok(0)))
         }
-        #[cfg(feature = "run-stub")]
-        Command::Run(args) => {
+        Command::Run(args) if args.experimental_rust_codepath => {
             // in the case of enabling the run stub, we want to be able to opt-in
             // to the rust codepath for running turbo
             if args.tasks.is_empty() {
@@ -824,20 +823,6 @@ pub async fn run(
             } else {
                 Ok(Payload::Go(Box::new(base)))
             }
-        }
-        #[cfg(not(feature = "run-stub"))]
-        Command::Run(args) => {
-            if args.experimental_rust_codepath {
-                tracing::warn!("rust codepath enabled, but not compiled with support");
-            }
-            if let Some(file_path) = &args.profile {
-                logger.enable_chrome_tracing(file_path)?;
-            }
-            if args.tasks.is_empty() {
-                return Err(anyhow!("at least one task must be specified"));
-            }
-            let base = CommandBase::new(cli_args, repo_root, version, ui);
-            Ok(Payload::Go(Box::new(base)))
         }
         Command::Prune {
             scope,

--- a/crates/turborepo-lib/src/cli.rs
+++ b/crates/turborepo-lib/src/cli.rs
@@ -804,7 +804,7 @@ pub async fn run(
 
             Ok(Payload::Rust(Ok(0)))
         }
-        Command::Run(args) if args.experimental_rust_codepath => {
+        Command::Run(args) => {
             // in the case of enabling the run stub, we want to be able to opt-in
             // to the rust codepath for running turbo
             if args.tasks.is_empty() {

--- a/crates/turborepo/Cargo.toml
+++ b/crates/turborepo/Cargo.toml
@@ -9,12 +9,11 @@ license = "MPL-2.0"
 # This is for the convenience of running daily dev workflows, i.e running
 # `cargo xxx` without explicitly specifying features, not that we want to
 # promote this as default backend.
-default = ["rustls-tls", "run-stub", "go-binary"]
+default = ["rustls-tls", "go-binary"]
 native-tls = ["turborepo-lib/native-tls"]
 rustls-tls = ["turborepo-lib/rustls-tls"]
 http = ["turborepo-lib/http"]
 go-daemon = ["turborepo-lib/go-daemon"]
-run-stub = ["turborepo-lib/run-stub"]
 go-binary = []
 pprof = ["turborepo-lib/pprof"]
 


### PR DESCRIPTION
### Description

We enable the run stub feature by default, so there's no reason to even have it. Now the only part gating the rust code is the `--experimental-rust-codepath` flag.

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->


Closes TURBO-1506