### PR TITLE
fix symlink handling

### DIFF
--- a/crates/turbopack-core/src/resolve/pattern.rs
+++ b/crates/turbopack-core/src/resolve/pattern.rs
@@ -933,23 +933,6 @@ pub async fn read_matches(
                                     }
                                 }
                             }
-                            if let Some(pos) = pat.match_position(&prefix) {
-                                if let LinkContent::Link { link_type, .. } =
-                                    &*fs_path.read_link().await?
-                                {
-                                    if link_type.contains(LinkType::DIRECTORY) {
-                                        results.push((
-                                            pos,
-                                            PatternMatch::Directory(prefix.clone(), *fs_path),
-                                        ));
-                                    } else {
-                                        results.push((
-                                            pos,
-                                            PatternMatch::File(prefix.clone(), *fs_path),
-                                        ));
-                                    }
-                                }
-                            }
                             if let Some(pos) = pat.could_match_position(&prefix) {
                                 if let LinkContent::Link { link_type, .. } =
                                     &*fs_path.read_link().await?

--- a/crates/turbopack-core/src/resolve/pattern.rs
+++ b/crates/turbopack-core/src/resolve/pattern.rs
@@ -898,6 +898,7 @@ pub async fn read_matches(
                             prefix.truncate(len)
                         }
                         DirectoryEntry::Symlink(fs_path) => {
+                            let len = prefix.len();
                             prefix.push_str(key);
                             // {prefix}{key}
                             if prefix.ends_with('/') {
@@ -945,6 +946,7 @@ pub async fn read_matches(
                                     }
                                 }
                             }
+                            prefix.truncate(len)
                         }
                         DirectoryEntry::Other(_) => {}
                         DirectoryEntry::Error => {}


### PR DESCRIPTION
### Description

Incorrect handling of symlinks caused a race condition in resolving which causes weird resolving problems when a symlink is present in the same directory.

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->


Closes WEB-1823