### PR TITLE
feat(Turborepo): Check env var indexing by literals

### DIFF
--- a/packages/eslint-plugin-turbo/__tests__/lib/no-undeclared-env-vars.test.ts
+++ b/packages/eslint-plugin-turbo/__tests__/lib/no-undeclared-env-vars.test.ts
@@ -11,6 +11,30 @@ ruleTester.run(RULES.noUndeclaredEnvVars, rule, {
   valid: [
     {
       code: `
+        const env2 = process.env['ENV_2'];
+      `,
+      options: [
+        { cwd: path.join(__dirname, "../../__fixtures__/workspace-configs") },
+      ],
+      filename: path.join(
+        __dirname,
+        "../../__fixtures__/workspace-configs/apps/web/index.js"
+      ),
+    },
+    {
+      code: `
+        const env2 = process.env["ENV_2"];
+      `,
+      options: [
+        { cwd: path.join(__dirname, "../../__fixtures__/workspace-configs") },
+      ],
+      filename: path.join(
+        __dirname,
+        "../../__fixtures__/workspace-configs/apps/web/index.js"
+      ),
+    },
+    {
+      code: `
         const { ENV_2 } = process.env;
       `,
       options: [
@@ -254,6 +278,42 @@ ruleTester.run(RULES.noUndeclaredEnvVars, rule, {
   ],
 
   invalid: [
+    {
+      code: `
+        const env2 = process.env['ENV_3'];
+      `,
+      options: [
+        { cwd: path.join(__dirname, "../../__fixtures__/workspace-configs") },
+      ],
+      filename: path.join(
+        __dirname,
+        "../../__fixtures__/workspace-configs/apps/web/index.js"
+      ),
+      errors: [
+        {
+          message:
+            "ENV_3 is not listed as a dependency in the root turbo.json or workspace (apps/web) turbo.json",
+        },
+      ],
+    },
+    {
+      code: `
+        const env2 = process.env["ENV_3"];
+      `,
+      options: [
+        { cwd: path.join(__dirname, "../../__fixtures__/workspace-configs") },
+      ],
+      filename: path.join(
+        __dirname,
+        "../../__fixtures__/workspace-configs/apps/web/index.js"
+      ),
+      errors: [
+        {
+          message:
+            "ENV_3 is not listed as a dependency in the root turbo.json or workspace (apps/web) turbo.json",
+        },
+      ],
+    },
     {
       code: `
         const { ENV_2 } = process.env;

--- a/packages/eslint-plugin-turbo/lib/rules/no-undeclared-env-vars.ts
+++ b/packages/eslint-plugin-turbo/lib/rules/no-undeclared-env-vars.ts
@@ -153,13 +153,11 @@ function create(context: RuleContextWithOptions): Rule.RuleListener {
       if (
         "name" in node.object &&
         "name" in node.property &&
-        !isComputed(node)
+        node.object.name === "process" &&
+        node.property.name === "env"
       ) {
-        const objectName = node.object.name;
-        const propertyName = node.property.name;
-
         // we're doing something with process.env
-        if (objectName === "process" && propertyName === "env") {
+        if (!isComputed(node)) {
           // destructuring from process.env
           if ("id" in node.parent && node.parent.id?.type === "ObjectPattern") {
             const values = node.parent.id.properties.values();
@@ -177,6 +175,13 @@ function create(context: RuleContextWithOptions): Rule.RuleListener {
           ) {
             checkKey(node.parent, node.parent.property.name);
           }
+        } else if (
+          "property" in node.parent &&
+          node.parent.property.type === "Literal" &&
+          typeof node.parent.property.value === "string"
+        ) {
+          // If we're indexing by a literal, we can check it
+          checkKey(node.parent, node.parent.property.value);
         }
       }
     },


### PR DESCRIPTION
### Description

Previously, we ignored indexing `process.env` by string literals (`process.env["foo"]`), with this PR we now explicitly check those env vars when they are literals. Computed indices are still ignored.

### Testing Instructions

New tests added. The valid cases pass with and without this change, since we previously ignored them. The invalid cases are newly-passing with this change.

Closes TURBO-1523