### PR TITLE
fix(Turborepo): Ensure process manager stays closed

### DIFF
--- a/crates/turborepo-lib/src/process/mod.rs
+++ b/crates/turborepo-lib/src/process/mod.rs
@@ -119,7 +119,6 @@ impl ProcessManager {
 
             // just allocate a new vec rather than clearing the old one
             lock.children = vec![];
-            lock.is_closing = false;
         }
     }
 }
@@ -210,12 +209,10 @@ mod test {
             "child process should exit before output is printed"
         );
 
-        // We will want to change this so you can't spawn a child after closing
+        // Verify that we can't start new child processes
         assert!(manager
             .spawn(get_command(), Duration::from_secs(2))
-            .is_some());
-
-        sleep(Duration::from_millis(100)).await;
+            .is_none());
 
         manager.stop().await;
     }


### PR DESCRIPTION
### Description

 - Adds tests for process manager remaining closed after being closed (courtesy of @chris-olszewski )
 - Ensures the process manager does not reopen after `close` has been called, or after `wait` has completed.

### Testing Instructions

Updated tests.


Closes TURBO-1526