### PR TITLE
fix: remove duplicate rediscovering of the package graph

### DIFF
--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -345,18 +345,6 @@ impl<'a> Run<'a> {
             resolved_pass_through_env_vars,
         );
 
-        let workspaces = pkg_dep_graph.workspaces().collect();
-
-        let package_file_hashes = PackageInputsHashes::calculate_file_hashes(
-            &scm,
-            engine.tasks().par_bridge(),
-            workspaces,
-            engine.task_definitions(),
-            &self.base.repo_root,
-        )?;
-
-        trace!("package file hashes: {:?}", package_file_hashes);
-
         let mut run_summary = RunSummary::new(
             start_at,
             &self.base.repo_root,


### PR DESCRIPTION
### Description

At some point we started doing discovery twice with the same inputs. This PR just removes the second one as this call will produce the same output given the same inputs.

This also cuts down turbo's pre-run time by about 40%

Closes TURBO-1527