### PR TITLE
fix(Turborepo): escape colons in log filenames

### DIFF
--- a/cli/internal/graph/graph.go
+++ b/cli/internal/graph/graph.go
@@ -123,15 +123,6 @@ func (g *CompleteGraph) GetPackageTaskVisitor(
 		expandedInputs := g.TaskHashTracker.GetExpandedInputs(packageTask)
 		framework := g.TaskHashTracker.GetFramework(taskID)
 
-		logFileAbsolutePath := taskLogFile(g.RepoRoot, pkgDir, taskName)
-
-		var logFileRelativePath string
-		if logRelative, err := logFileAbsolutePath.RelativeTo(g.RepoRoot); err == nil {
-			logFileRelativePath = logRelative.ToString()
-		}
-
-		// Give packageTask a string version of the logFile relative to root.
-		packageTask.LogFile = logFileRelativePath
 		packageTask.Command = command
 
 		envVarPassThroughMap, err := g.TaskHashTracker.EnvAtExecutionStart.FromWildcards(taskDefinition.PassThroughEnv)
@@ -152,7 +143,7 @@ func (g *CompleteGraph) GetPackageTaskVisitor(
 			Dir:                    pkgDir.ToString(),
 			Outputs:                taskDefinition.Outputs.Inclusions,
 			ExcludedOutputs:        taskDefinition.Outputs.Exclusions,
-			LogFileRelativePath:    logFileRelativePath,
+			LogFileRelativePath:    packageTask.RepoRelativeSystemLogFile(),
 			ResolvedTaskDefinition: taskDefinition,
 			ExpandedInputs:         expandedInputs,
 			ExpandedOutputs:        []turbopath.AnchoredSystemPath{},
@@ -233,12 +224,6 @@ func (g *CompleteGraph) GetPackageJSONFromWorkspace(workspaceName string) (*fs.P
 	}
 
 	return nil, fmt.Errorf("No package.json for %s", workspaceName)
-}
-
-// taskLogFile returns the path to the log file for this task execution as an absolute path
-func taskLogFile(root turbopath.AbsoluteSystemPath, dir turbopath.AnchoredSystemPath, taskName string) turbopath.AbsoluteSystemPath {
-	pkgDir := dir.RestoreAnchor(root)
-	return pkgDir.UntypedJoin(".turbo", fmt.Sprintf("turbo-%v.log", taskName))
 }
 
 // getTaskGraphAncestors gets all the ancestors for a given task in the graph.

--- a/cli/internal/nodes/packagetask.go
+++ b/cli/internal/nodes/packagetask.go
@@ -3,6 +3,8 @@ package nodes
 
 import (
 	"fmt"
+	"path/filepath"
+	"strings"
 
 	"github.com/vercel/turbo/cli/internal/fs"
 	"github.com/vercel/turbo/cli/internal/fs/hash"
@@ -21,8 +23,24 @@ type PackageTask struct {
 	Command         string
 	Outputs         []string
 	ExcludedOutputs []string
-	LogFile         string
 	Hash            string
+}
+
+const logDir = ".turbo"
+
+// RepoRelativeSystemLogFile returns the path from the repo root
+// to the log file in system format
+func (pt *PackageTask) RepoRelativeSystemLogFile() string {
+	return filepath.Join(pt.Dir, logDir, logFilename(pt.Task))
+}
+
+func (pt *PackageTask) packageRelativeSharableLogFile() string {
+	return strings.Join([]string{logDir, logFilename(pt.Task)}, "/")
+}
+
+func logFilename(taskName string) string {
+	escapedTaskName := strings.ReplaceAll(taskName, ":", "$colon$")
+	return fmt.Sprintf("turbo-%v.log", escapedTaskName)
 }
 
 // OutputPrefix returns the prefix to be used for logging and ui for this task
@@ -36,7 +54,7 @@ func (pt *PackageTask) OutputPrefix(isSinglePackage bool) string {
 // HashableOutputs returns the package-relative globs for files to be considered outputs
 // of this task
 func (pt *PackageTask) HashableOutputs() hash.TaskOutputs {
-	inclusionOutputs := []string{fmt.Sprintf(".turbo/turbo-%v.log", pt.Task)}
+	inclusionOutputs := []string{pt.packageRelativeSharableLogFile()}
 	inclusionOutputs = append(inclusionOutputs, pt.TaskDefinition.Outputs.Inclusions...)
 
 	hashable := hash.TaskOutputs{

--- a/cli/internal/nodes/packagetask_test.go
+++ b/cli/internal/nodes/packagetask_test.go
@@ -1,0 +1,29 @@
+package nodes
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestLogFilename(t *testing.T) {
+	testCases := []struct{ input, want string }{
+		{
+			"build",
+			"turbo-build.log",
+		},
+		{
+			"build:prod",
+			"turbo-build$colon$prod.log",
+		},
+		{
+			"build:prod:extra",
+			"turbo-build$colon$prod$colon$extra.log",
+		},
+	}
+
+	for _, testCase := range testCases {
+		got := logFilename(testCase.input)
+		assert.Equal(t, got, testCase.want)
+	}
+}

--- a/cli/internal/runcache/runcache.go
+++ b/cli/internal/runcache/runcache.go
@@ -302,7 +302,7 @@ func (tc *TaskCache) SaveOutputs(ctx context.Context, logger hclog.Logger, termi
 // TaskCache returns a TaskCache instance, providing an interface to the underlying cache specific
 // to this run and the given PackageTask
 func (rc *RunCache) TaskCache(pt *nodes.PackageTask, packageTaskHash string) TaskCache {
-	logFileName := rc.repoRoot.UntypedJoin(pt.LogFile)
+	logFileName := rc.repoRoot.UntypedJoin(pt.RepoRelativeSystemLogFile())
 	hashableOutputs := pt.HashableOutputs()
 	repoRelativeGlobs := hash.TaskOutputs{
 		Inclusions: make([]string, len(hashableOutputs.Inclusions)),

--- a/cli/internal/runsummary/task_summary.go
+++ b/cli/internal/runsummary/task_summary.go
@@ -54,28 +54,30 @@ func NewTaskCacheSummary(itemStatus cache.ItemStatus) TaskCacheSummary {
 // as the information is also available in ResolvedTaskDefinition. We could remove them
 // and favor a version of Outputs that is the fully expanded list of files.
 type TaskSummary struct {
-	TaskID                 string                                `json:"taskId,omitempty"`
-	Task                   string                                `json:"task"`
-	Package                string                                `json:"package,omitempty"`
-	Hash                   string                                `json:"hash"`
-	ExpandedInputs         map[turbopath.AnchoredUnixPath]string `json:"inputs"`
-	ExternalDepsHash       string                                `json:"hashOfExternalDependencies"`
-	CacheSummary           TaskCacheSummary                      `json:"cache"`
-	Command                string                                `json:"command"`
-	CommandArguments       []string                              `json:"cliArguments"`
-	Outputs                []string                              `json:"outputs"`
-	ExcludedOutputs        []string                              `json:"excludedOutputs"`
-	LogFileRelativePath    string                                `json:"logFile"`
-	Dir                    string                                `json:"directory,omitempty"`
-	Dependencies           []string                              `json:"dependencies"`
-	Dependents             []string                              `json:"dependents"`
-	ResolvedTaskDefinition *fs.TaskDefinition                    `json:"resolvedTaskDefinition"`
-	ExpandedOutputs        []turbopath.AnchoredSystemPath        `json:"expandedOutputs"`
-	Framework              string                                `json:"framework"`
-	EnvMode                util.EnvMode                          `json:"envMode"`
-	EnvVars                TaskEnvVarSummary                     `json:"environmentVariables"`
-	DotEnv                 turbopath.AnchoredUnixPathArray       `json:"dotEnv"`
-	Execution              *TaskExecutionSummary                 `json:"execution,omitempty"` // omit when it's not set
+	TaskID           string                                `json:"taskId,omitempty"`
+	Task             string                                `json:"task"`
+	Package          string                                `json:"package,omitempty"`
+	Hash             string                                `json:"hash"`
+	ExpandedInputs   map[turbopath.AnchoredUnixPath]string `json:"inputs"`
+	ExternalDepsHash string                                `json:"hashOfExternalDependencies"`
+	CacheSummary     TaskCacheSummary                      `json:"cache"`
+	Command          string                                `json:"command"`
+	CommandArguments []string                              `json:"cliArguments"`
+	Outputs          []string                              `json:"outputs"`
+	ExcludedOutputs  []string                              `json:"excludedOutputs"`
+	// Repo-relative, relative system path
+	LogFileRelativePath string `json:"logFile"`
+	// Repo-relative, relative system path
+	Dir                    string                          `json:"directory,omitempty"`
+	Dependencies           []string                        `json:"dependencies"`
+	Dependents             []string                        `json:"dependents"`
+	ResolvedTaskDefinition *fs.TaskDefinition              `json:"resolvedTaskDefinition"`
+	ExpandedOutputs        []turbopath.AnchoredSystemPath  `json:"expandedOutputs"`
+	Framework              string                          `json:"framework"`
+	EnvMode                util.EnvMode                    `json:"envMode"`
+	EnvVars                TaskEnvVarSummary               `json:"environmentVariables"`
+	DotEnv                 turbopath.AnchoredUnixPathArray `json:"dotEnv"`
+	Execution              *TaskExecutionSummary           `json:"execution,omitempty"` // omit when it's not set
 }
 
 // TaskEnvConfiguration contains the environment variable inputs for a task

--- a/crates/turborepo-lib/src/package_graph/mod.rs
+++ b/crates/turborepo-lib/src/package_graph/mod.rs
@@ -53,7 +53,6 @@ impl WorkspaceInfo {
             .expect("at least one segment")
     }
 
-
     pub fn get_external_deps_hash(&self) -> String {
         let mut transitive_deps = Vec::with_capacity(
             self.transitive_dependencies

--- a/crates/turborepo-lib/src/package_graph/mod.rs
+++ b/crates/turborepo-lib/src/package_graph/mod.rs
@@ -53,12 +53,6 @@ impl WorkspaceInfo {
             .expect("at least one segment")
     }
 
-    // pub fn task_log_path(&self, task_id: &TaskId) -> AnchoredSystemPathBuf {
-    //     let mut log_path = self.package_path().to_owned();
-    //     log_path.push(".turbo");
-    //     log_path.push(&format!("turbo-{}.log", task_id.task()));
-    //     log_path
-    // }
 
     pub fn get_external_deps_hash(&self) -> String {
         let mut transitive_deps = Vec::with_capacity(

--- a/crates/turborepo-lib/src/package_graph/mod.rs
+++ b/crates/turborepo-lib/src/package_graph/mod.rs
@@ -10,7 +10,7 @@ use turbopath::{AbsoluteSystemPath, AnchoredSystemPath, AnchoredSystemPathBuf};
 use turborepo_lockfiles::Lockfile;
 use turborepo_repository::{package_json::PackageJson, package_manager::PackageManager};
 
-use crate::{graph, run::task_id::TaskId};
+use crate::graph;
 
 mod builder;
 
@@ -53,12 +53,12 @@ impl WorkspaceInfo {
             .expect("at least one segment")
     }
 
-    pub fn task_log_path(&self, task_id: &TaskId) -> AnchoredSystemPathBuf {
-        let mut log_path = self.package_path().to_owned();
-        log_path.push(".turbo");
-        log_path.push(&format!("turbo-{}.log", task_id.task()));
-        log_path
-    }
+    // pub fn task_log_path(&self, task_id: &TaskId) -> AnchoredSystemPathBuf {
+    //     let mut log_path = self.package_path().to_owned();
+    //     log_path.push(".turbo");
+    //     log_path.push(&format!("turbo-{}.log", task_id.task()));
+    //     log_path
+    // }
 
     pub fn get_external_deps_hash(&self) -> String {
         let mut transitive_deps = Vec::with_capacity(

--- a/crates/turborepo-lib/src/run/cache.rs
+++ b/crates/turborepo-lib/src/run/cache.rs
@@ -79,7 +79,8 @@ impl RunCache {
     ) -> TaskCache {
         let log_file_path = self
             .repo_root
-            .resolve(&workspace_info.task_log_path(&task_id));
+            .resolve(workspace_info.package_path())
+            .resolve(&task_definition.workspace_relative_log_file(task_id.task()));
         let repo_relative_globs =
             task_definition.repo_relative_hashable_outputs(&task_id, workspace_info.package_path());
 

--- a/crates/turborepo-lib/src/run/cache.rs
+++ b/crates/turborepo-lib/src/run/cache.rs
@@ -80,7 +80,7 @@ impl RunCache {
         let log_file_path = self
             .repo_root
             .resolve(workspace_info.package_path())
-            .resolve(&task_definition.workspace_relative_log_file(task_id.task()));
+            .resolve(&TaskDefinition::workspace_relative_log_file(task_id.task()));
         let repo_relative_globs =
             task_definition.repo_relative_hashable_outputs(&task_id, workspace_info.package_path());
 

--- a/crates/turborepo-lib/src/task_graph/mod.rs
+++ b/crates/turborepo-lib/src/task_graph/mod.rs
@@ -173,7 +173,7 @@ const LOG_DIR: &str = ".turbo";
 
 impl TaskDefinition {
     pub fn workspace_relative_log_file(task_name: &str) -> AnchoredSystemPathBuf {
-        let log_dir = AnchoredSystemPath::from_raw(LOG_DIR)
+        let log_dir = AnchoredSystemPath::new(LOG_DIR)
             .expect("LOG_DIR should be a valid AnchoredSystemPathBuf");
         log_dir.join_component(&task_log_filename(task_name))
     }
@@ -185,9 +185,8 @@ impl TaskDefinition {
     }
 
     pub fn hashable_outputs(&self, task_name: &TaskId) -> TaskOutputs {
-        let mut inclusion_outputs = vec![self
-            .sharable_workspace_relative_log_file(task_name.task())
-            .to_string()];
+        let mut inclusion_outputs =
+            vec![Self::sharable_workspace_relative_log_file(task_name.task()).to_string()];
         inclusion_outputs.extend_from_slice(&self.outputs.inclusions[..]);
 
         let mut hashable = TaskOutputs {
@@ -325,22 +324,21 @@ mod test {
 
     #[test]
     fn test_escape_log_file() {
-        let task_defn = TaskDefinition::default();
-        let build_log = task_defn.workspace_relative_log_file("build");
+        let build_log = TaskDefinition::workspace_relative_log_file("build");
         let build_expected = AnchoredSystemPathBuf::from_raw(
             &[".turbo", "turbo-build.log"].join(MAIN_SEPARATOR_STR),
         )
         .unwrap();
         assert_eq!(build_log, build_expected);
 
-        let build_log = task_defn.workspace_relative_log_file("build:prod");
+        let build_log = TaskDefinition::workspace_relative_log_file("build:prod");
         let build_expected = AnchoredSystemPathBuf::from_raw(
             &[".turbo", "turbo-build$colon$prod.log"].join(MAIN_SEPARATOR_STR),
         )
         .unwrap();
         assert_eq!(build_log, build_expected);
 
-        let build_log = task_defn.workspace_relative_log_file("build:prod:extra");
+        let build_log = TaskDefinition::workspace_relative_log_file("build:prod:extra");
         let build_expected = AnchoredSystemPathBuf::from_raw(
             &[".turbo", "turbo-build$colon$prod$colon$extra.log"].join(MAIN_SEPARATOR_STR),
         )

--- a/crates/turborepo-lib/src/task_graph/mod.rs
+++ b/crates/turborepo-lib/src/task_graph/mod.rs
@@ -316,7 +316,7 @@ mod test {
             TaskOutputs {
                 inclusions: vec![
                     format!("{relative_prefix}.next/**/*"),
-                    format!("{relative_prefix}.turbo{MAIN_SEPARATOR_STR}turbo-build.log"),
+                    format!("{relative_prefix}.turbo/turbo-build.log"),
                 ],
                 exclusions: vec![format!("{relative_prefix}.next/bad-file")],
             }

--- a/crates/turborepo-lib/src/task_graph/mod.rs
+++ b/crates/turborepo-lib/src/task_graph/mod.rs
@@ -173,7 +173,7 @@ const LOG_DIR: &str = ".turbo";
 
 impl TaskDefinition {
     pub fn workspace_relative_log_file(task_name: &str) -> AnchoredSystemPathBuf {
-        let log_dir = AnchoredSystemPathBuf::from_raw(LOG_DIR)
+        let log_dir = AnchoredSystemPath::from_raw(LOG_DIR)
             .expect("LOG_DIR should be a valid AnchoredSystemPathBuf");
         log_dir.join_component(&task_log_filename(task_name))
     }

--- a/crates/turborepo-lib/src/task_graph/mod.rs
+++ b/crates/turborepo-lib/src/task_graph/mod.rs
@@ -172,13 +172,13 @@ macro_rules! set_field {
 const LOG_DIR: &str = ".turbo";
 
 impl TaskDefinition {
-    pub fn workspace_relative_log_file(&self, task_name: &str) -> AnchoredSystemPathBuf {
+    pub fn workspace_relative_log_file(task_name: &str) -> AnchoredSystemPathBuf {
         let log_dir = AnchoredSystemPathBuf::from_raw(LOG_DIR)
             .expect("LOG_DIR should be a valid AnchoredSystemPathBuf");
         log_dir.join_component(&task_log_filename(task_name))
     }
 
-    fn sharable_workspace_relative_log_file(&self, task_name: &str) -> RelativeUnixPathBuf {
+    fn sharable_workspace_relative_log_file(task_name: &str) -> RelativeUnixPathBuf {
         let log_dir = RelativeUnixPathBuf::new(LOG_DIR)
             .expect("LOG_DIR should be a valid relative unix path");
         log_dir.join_component(&task_log_filename(task_name))

--- a/crates/turborepo-paths/src/anchored_system_path.rs
+++ b/crates/turborepo-paths/src/anchored_system_path.rs
@@ -88,4 +88,9 @@ impl AnchoredSystemPath {
 
         buf.unwrap_or_else(|_| panic!("anchored system path is relative: {}", self.0.as_str()))
     }
+
+    pub fn join_component(&self, segment: &str) -> AnchoredSystemPathBuf {
+        debug_assert!(!segment.contains(std::path::MAIN_SEPARATOR));
+        AnchoredSystemPathBuf(self.0.join(segment))
+    }
 }

--- a/crates/turborepo-paths/src/relative_unix_path.rs
+++ b/crates/turborepo-paths/src/relative_unix_path.rs
@@ -80,6 +80,11 @@ impl RelativeUnixPath {
     pub fn extension(&self) -> Option<&str> {
         Utf8Path::new(&self.0).extension()
     }
+
+    pub fn join_component(&self, segment: &str) -> RelativeUnixPathBuf {
+        debug_assert!(!segment.contains('/'));
+        RelativeUnixPathBuf(format!("{}/{}", &self.0, segment))
+    }
 }
 
 impl AsRef<RelativeUnixPath> for RelativeUnixPath {


### PR DESCRIPTION
### Description

Rename the log file used by `turbo` to incorporate the hash, rather than the script name. Script names are not always valid filenames

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->


Closes TURBO-1528