### PR TITLE
feat: add package discovery trait and a few discovery strategies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10970,6 +10970,7 @@ dependencies = [
  "tokio-scoped",
  "tracing",
  "turbopath",
+ "turborepo-repository",
  "walkdir",
  "wax",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9506,9 +9506,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fb52b74f05dbf495a8fba459fdc331812b96aa086d9eb78101fa0d4569c3313"
+checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -11155,6 +11155,8 @@ dependencies = [
  "tempfile",
  "test-case",
  "thiserror",
+ "tokio",
+ "tokio-stream",
  "tracing",
  "turbopath",
  "turborepo-graph-utils",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10969,6 +10969,7 @@ dependencies = [
  "tokio",
  "tokio-scoped",
  "tracing",
+ "tracing-test",
  "turbopath",
  "turborepo-repository",
  "walkdir",

--- a/cli/internal/turbodprotocol/turbod.proto
+++ b/cli/internal/turbodprotocol/turbod.proto
@@ -11,6 +11,8 @@ service Turbod {
   // Implement cache watching
   rpc NotifyOutputsWritten (NotifyOutputsWrittenRequest) returns (NotifyOutputsWrittenResponse);
   rpc GetChangedOutputs (GetChangedOutputsRequest) returns (GetChangedOutputsResponse);
+
+  rpc DiscoverPackages (DiscoverPackagesRequest) returns (DiscoverPackagesResponse);
 }
 
 message HelloRequest {
@@ -72,4 +74,28 @@ message GetChangedOutputsResponse {
 message DaemonStatus {
   string log_file = 1;
   uint64 uptime_msec = 2;
+}
+
+message DiscoverPackagesRequest {
+
+}
+
+message DiscoverPackagesResponse {
+  repeated PackageFiles package_files = 1;
+  PackageManager package_manager = 2;
+}
+
+message PackageFiles {
+  string package_json = 1;
+  optional string turbo_json = 2;
+
+}
+
+enum PackageManager {
+  Berry = 0;
+  Npm = 1;
+  Pnpm = 2;
+  Pnpm6 = 3;
+  Yarn = 4;
+  Bun = 5;
 }

--- a/cli/internal/turbodprotocol/turbod.proto
+++ b/cli/internal/turbodprotocol/turbod.proto
@@ -12,6 +12,9 @@ service Turbod {
   rpc NotifyOutputsWritten (NotifyOutputsWrittenRequest) returns (NotifyOutputsWrittenResponse);
   rpc GetChangedOutputs (GetChangedOutputsRequest) returns (GetChangedOutputsResponse);
 
+  // Request the list of packages that the daemon is aware of.
+  //
+  // Since 1.11.0
   rpc DiscoverPackages (DiscoverPackagesRequest) returns (DiscoverPackagesResponse);
 }
 

--- a/crates/turborepo-filewatch/Cargo.toml
+++ b/crates/turborepo-filewatch/Cargo.toml
@@ -18,6 +18,7 @@ notify = "6.0.1"
 thiserror = "1.0.38"
 tokio = { workspace = true, features = ["full", "time"] }
 tracing = "0.1.37"
+tracing-test = "0.2.4"
 turbopath = { workspace = true }
 turborepo-repository = { version = "0.1.0", path = "../turborepo-repository" }
 walkdir = "2.3.3"

--- a/crates/turborepo-filewatch/Cargo.toml
+++ b/crates/turborepo-filewatch/Cargo.toml
@@ -19,6 +19,7 @@ thiserror = "1.0.38"
 tokio = { workspace = true, features = ["full", "time"] }
 tracing = "0.1.37"
 turbopath = { workspace = true }
+turborepo-repository = { version = "0.1.0", path = "../turborepo-repository" }
 walkdir = "2.3.3"
 wax = { workspace = true }
 

--- a/crates/turborepo-filewatch/src/lib.rs
+++ b/crates/turborepo-filewatch/src/lib.rs
@@ -39,6 +39,7 @@ pub mod cookie_jar;
 #[cfg(target_os = "macos")]
 mod fsevent;
 pub mod globwatcher;
+pub mod package_watcher;
 
 #[cfg(not(target_os = "macos"))]
 type Backend = RecommendedWatcher;

--- a/crates/turborepo-filewatch/src/package_watcher.rs
+++ b/crates/turborepo-filewatch/src/package_watcher.rs
@@ -1,0 +1,309 @@
+//! This module hosts the `PackageWatcher` type, which is used to watch the
+//! filesystem for changes to packages.
+
+use std::{
+    collections::HashMap,
+    future::IntoFuture,
+    path::PathBuf,
+    sync::{Arc, Mutex},
+};
+
+use notify::Event;
+use tokio::{
+    join,
+    sync::{
+        broadcast::{self, error::RecvError},
+        oneshot, watch,
+    },
+};
+use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
+use turborepo_repository::{
+    discovery::{PackageDiscovery, WorkspaceData},
+    package_manager::{self, Error, PackageManager, WorkspaceGlobs},
+};
+
+use crate::NotifyError;
+
+/// Watches the filesystem for changes to packages and package managers.
+pub struct PackageWatcher {
+    // _exit_ch exists to trigger a close on the receiver when an instance
+    // of this struct is dropped. The task that is receiving events will exit,
+    // dropping the other sender for the broadcast channel, causing all receivers
+    // to be notified of a close.
+    _exit_tx: oneshot::Sender<()>,
+    _handle: tokio::task::JoinHandle<()>,
+
+    package_data: Arc<Mutex<HashMap<AbsoluteSystemPathBuf, WorkspaceData>>>,
+    manager_rx: watch::Receiver<PackageManager>,
+}
+
+impl PackageWatcher {
+    /// Creates a new package watcher whose current package data can be queried.
+    pub async fn new<T: PackageDiscovery + Send + 'static>(
+        root: AbsoluteSystemPathBuf,
+        recv: broadcast::Receiver<Result<Event, NotifyError>>,
+        backup_discovery: T,
+    ) -> Result<Self, package_manager::Error> {
+        let (exit_tx, exit_rx) = oneshot::channel();
+        let subscriber = Subscriber::new(exit_rx, root, recv, backup_discovery).await?;
+        let manager_rx = subscriber.manager_receiver();
+        let package_data = subscriber.package_data();
+        let handle = tokio::spawn(subscriber.watch());
+        Ok(Self {
+            _exit_tx: exit_tx,
+            _handle: handle,
+            package_data,
+            manager_rx,
+        })
+    }
+
+    pub async fn get_package_data(&self) -> Vec<WorkspaceData> {
+        self.package_data
+            .lock()
+            .expect("not poisoned")
+            .clone()
+            .into_values()
+            .collect()
+    }
+
+    pub async fn get_package_manager(&self) -> PackageManager {
+        *self.manager_rx.borrow()
+    }
+}
+
+/// The underlying task that listens to file system events and updates the
+/// internal package state.
+struct Subscriber<T: PackageDiscovery> {
+    exit_rx: oneshot::Receiver<()>,
+    filter: WorkspaceGlobs,
+    recv: broadcast::Receiver<Result<Event, NotifyError>>,
+    repo_root: AbsoluteSystemPathBuf,
+    backup_discovery: T,
+
+    // package manager data
+    package_data: Arc<Mutex<HashMap<AbsoluteSystemPathBuf, WorkspaceData>>>,
+    manager_rx: watch::Receiver<PackageManager>,
+    manager_tx: watch::Sender<PackageManager>,
+
+    // stored as PathBuf to avoid processing later.
+    // if package_json changes, we need to re-infer
+    // the package manager
+    package_json_path: std::path::PathBuf,
+    workspace_config_path: std::path::PathBuf,
+}
+
+impl<T: PackageDiscovery + Send + 'static> Subscriber<T> {
+    async fn new(
+        exit_rx: oneshot::Receiver<()>,
+        repo_root: AbsoluteSystemPathBuf,
+        recv: broadcast::Receiver<Result<Event, NotifyError>>,
+        mut discovery: T,
+    ) -> Result<Self, Error> {
+        let manager = discovery.discover_packages().await.unwrap().package_manager;
+
+        let (package_json_path, workspace_config_path, filter) =
+            Self::update_package_manager(&manager, &repo_root)?;
+
+        let (manager_tx, manager_rx) = watch::channel(manager);
+
+        Ok(Self {
+            exit_rx,
+            filter,
+            package_data: Default::default(),
+            recv,
+            manager_rx,
+            manager_tx,
+            repo_root,
+            backup_discovery: discovery,
+
+            package_json_path,
+            workspace_config_path,
+        })
+    }
+
+    async fn watch(mut self) {
+        // initialize the contents
+        self.rediscover_packages().await;
+
+        // respond to changes
+        loop {
+            tokio::select! {
+                _ = &mut self.exit_rx => return,
+                file_event = self.recv.recv().into_future() => match file_event {
+                    Ok(Ok(event)) => self.handle_file_event(event).await,
+                    // if we get an error, we need to re-discover the packages
+                    Ok(Err(_)) => self.rediscover_packages().await,
+                    Err(RecvError::Closed) => return,
+                    // if we end up lagging, warn and rediscover packages
+                    Err(RecvError::Lagged(count)) => {
+                        tracing::warn!("lagged behind {count} processing file watching events");
+                        self.rediscover_packages().await;
+                    },
+                }
+            }
+        }
+    }
+
+    fn update_package_manager(
+        manager: &PackageManager,
+        repo_root: &AbsoluteSystemPath,
+    ) -> Result<(PathBuf, PathBuf, WorkspaceGlobs), Error> {
+        let package_json_path = repo_root
+            .join_component("package.json")
+            .as_std_path()
+            .to_owned();
+
+        let workspace_config_path = manager
+            .workspace_configuration_path()
+            .map_or(package_json_path.clone(), |p| {
+                repo_root.join_component(p).as_std_path().to_owned()
+            });
+        let filter = manager.get_workspace_globs(repo_root)?;
+
+        Ok((package_json_path, workspace_config_path, filter))
+    }
+
+    pub fn manager_receiver(&self) -> watch::Receiver<PackageManager> {
+        self.manager_rx.clone()
+    }
+
+    pub fn package_data(&self) -> Arc<Mutex<HashMap<AbsoluteSystemPathBuf, WorkspaceData>>> {
+        self.package_data.clone()
+    }
+
+    fn manager(&self) -> PackageManager {
+        *self.manager_rx.borrow()
+    }
+
+    async fn handle_file_event(&mut self, file_event: Event) {
+        tracing::trace!("file event: {:?}", file_event);
+
+        if file_event
+            .paths
+            .iter()
+            .any(|p| self.package_json_path.eq(p))
+        {
+            tracing::debug!("package.json changed");
+            // if the package.json changed, we need to re-infer the package manager
+            // and update the glob list
+            let new_manager =
+                PackageManager::get_package_manager(&self.repo_root, None).and_then(|manager| {
+                    Self::update_package_manager(&manager, &self.repo_root)
+                        .map(|(a, b, c)| (manager, a, b, c))
+                });
+
+            match new_manager {
+                Ok((new_manager, package_json_path, workspace_config_path, filter)) => {
+                    // if this fails, we are closing anyways so ignore
+                    self.manager_tx.send(new_manager).ok();
+                    self.package_json_path = package_json_path;
+                    self.workspace_config_path = workspace_config_path;
+                    self.filter = filter;
+                }
+                Err(e) => {
+                    // a change in the package json does not necessarily mean
+                    // that the package manager has changed, so continue with
+                    // best effort
+                    tracing::error!("error getting package manager: {}", e);
+                }
+            }
+        }
+
+        // if it is the package manager, update the glob list
+        let changed = if file_event
+            .paths
+            .iter()
+            .any(|p| self.workspace_config_path.eq(p))
+        {
+            let new_filter = self
+                .manager()
+                .get_workspace_globs(&self.repo_root)
+                // under some saving strategies a file can be totally empty for a moment
+                // during a save. these strategies emit multiple events and so we can
+                // a previous or subsequent event in the 'cluster' will still trigger
+                .unwrap_or_else(|_| self.filter.clone());
+
+            let changed = self.filter != new_filter;
+            self.filter = new_filter;
+            changed
+        } else {
+            false
+        };
+
+        if changed {
+            // if the glob list has changed, do a recursive walk and replace
+            self.rediscover_packages().await;
+        } else {
+            // if a path is not a valid utf8 string, it is not a valid path, so ignore
+            for path in file_event
+                .paths
+                .iter()
+                .filter_map(|p| p.as_os_str().to_str())
+            {
+                let path_file =
+                    AbsoluteSystemPathBuf::new(path).expect("watched paths are absolute");
+
+                // the path to the workspace this file is in is the parent
+                let path_workspace = path_file
+                    .parent()
+                    .expect("watched paths will not be at the root")
+                    .to_owned();
+
+                let is_workspace = match self
+                    .filter
+                    .target_is_workspace(&self.repo_root, &path_workspace)
+                {
+                    Ok(is_workspace) => is_workspace,
+                    Err(e) => {
+                        // this will only error if `repo_root` is not an anchor of `path_workspace`.
+                        // if we hit this case, we can safely ignore it
+                        tracing::debug!("yielded path not in workspace: {:?}", e);
+                        continue;
+                    }
+                };
+
+                if is_workspace {
+                    tracing::debug!("tracing file in package: {:?}", path_file);
+                    let package_json = path_workspace.join_component("package.json");
+                    let turbo_json = path_workspace.join_component("turbo.json");
+
+                    let (package_exists, turbo_exists) = join!(
+                        tokio::fs::try_exists(&package_json),
+                        tokio::fs::try_exists(&turbo_json)
+                    );
+
+                    let mut data = self.package_data.lock().expect("not poisoned");
+                    if let Ok(true) = package_exists {
+                        data.insert(
+                            path_workspace,
+                            WorkspaceData {
+                                package_json,
+                                turbo_json: turbo_exists.unwrap_or_default().then_some(turbo_json),
+                            },
+                        );
+                    } else {
+                        data.remove(&path_workspace);
+                    }
+                }
+            }
+        }
+    }
+
+    async fn rediscover_packages(&mut self) {
+        tracing::debug!("rediscovering packages");
+        if let Ok(data) = self.backup_discovery.discover_packages().await {
+            let workspace = data
+                .workspaces
+                .into_iter()
+                .map(|p| (p.package_json.parent().expect("non-root").to_owned(), p))
+                .collect();
+            let mut data = self.package_data.lock().expect("not poisoned");
+            *data = workspace;
+        } else {
+            tracing::error!("error discovering packages");
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {}

--- a/crates/turborepo-filewatch/src/package_watcher.rs
+++ b/crates/turborepo-filewatch/src/package_watcher.rs
@@ -99,7 +99,7 @@ impl<T: PackageDiscovery + Send + 'static> Subscriber<T> {
         recv: broadcast::Receiver<Result<Event, NotifyError>>,
         mut discovery: T,
     ) -> Result<Self, Error> {
-        let manager = discovery.discover_packages().await.unwrap().package_manager;
+        let manager = discovery.discover_packages().await?.package_manager;
 
         let (package_json_path, workspace_config_path, filter) =
             Self::update_package_manager(&manager, &repo_root)?;
@@ -395,7 +395,8 @@ mod test {
             root.join_component("package.json"),
             r#"{"workspaces":["packages/*"]}"#,
         )
-        .await;
+        .await
+        .unwrap();
 
         let mock_discovery = MockDiscovery {
             manager: manager.clone(),
@@ -612,6 +613,7 @@ mod test {
                 .unwrap()
                 .values()
                 .cloned()
+                .sorted_by_key(|f| f.package_json.clone())
                 .collect::<Vec<_>>(),
             vec![
                 WorkspaceData {

--- a/crates/turborepo-filewatch/src/package_watcher.rs
+++ b/crates/turborepo-filewatch/src/package_watcher.rs
@@ -128,6 +128,7 @@ impl<T: PackageDiscovery + Send + 'static> Subscriber<T> {
         // respond to changes
         loop {
             tokio::select! {
+                biased;
                 _ = &mut self.exit_rx => {
                     tracing::info!("exiting package watcher");
                     return

--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -757,7 +757,7 @@ pub async fn run(
             let json = *json;
             let workspace = workspace.clone();
             let mut base = CommandBase::new(cli_args, repo_root, version, ui);
-            info::run(&mut base, workspace.as_deref(), json)?;
+            info::run(&mut base, workspace.as_deref(), json).await?;
 
             Ok(Payload::Rust(Ok(0)))
         }
@@ -853,7 +853,7 @@ pub async fn run(
             let docker = *docker;
             let output_dir = output_dir.clone();
             let base = CommandBase::new(cli_args, repo_root, version, ui);
-            prune::prune(&base, &scope, docker, &output_dir)?;
+            prune::prune(&base, &scope, docker, &output_dir).await?;
             Ok(Payload::Rust(Ok(0)))
         }
         Command::Completion { shell } => {

--- a/crates/turborepo-lib/src/commands/daemon.rs
+++ b/crates/turborepo-lib/src/commands/daemon.rs
@@ -174,14 +174,15 @@ pub async fn daemon_server(
         }
         CloseReason::Interrupt
     });
-    let reason = crate::daemon::serve(
-        &base.repo_root,
-        &daemon_root,
+    let server = crate::daemon::TurboGrpcService::new(
+        base.repo_root.clone(),
+        daemon_root,
         log_file,
         timeout,
         exit_signal,
-    )
-    .await;
+    );
+
+    let reason = server.serve().await;
 
     match reason {
         CloseReason::SocketOpenError(SocketOpenError::LockError(AlreadyOwned)) => {

--- a/crates/turborepo-lib/src/commands/info.rs
+++ b/crates/turborepo-lib/src/commands/info.rs
@@ -34,15 +34,16 @@ struct WorkspaceDetails<'a> {
     dependencies: Vec<&'a str>,
 }
 
-pub fn run(base: &mut CommandBase, workspace: Option<&str>, json: bool) -> Result<(), cli::Error> {
+pub async fn run(
+    base: &mut CommandBase,
+    workspace: Option<&str>,
+    json: bool,
+) -> Result<(), cli::Error> {
     let root_package_json = PackageJson::load(&base.repo_root.join_component("package.json"))?;
 
-    let package_manager =
-        PackageManager::get_package_manager(&base.repo_root, Some(&root_package_json))?;
-
     let package_graph = PackageGraph::builder(&base.repo_root, root_package_json)
-        .with_package_manger(Some(package_manager))
-        .build()?;
+        .build()
+        .await?;
 
     let config = base.config()?;
 

--- a/crates/turborepo-lib/src/commands/prune.rs
+++ b/crates/turborepo-lib/src/commands/prune.rs
@@ -79,13 +79,13 @@ fn turbo_json() -> &'static AnchoredSystemPath {
     PATH.get_or_init(|| AnchoredSystemPath::new("turbo.json").unwrap())
 }
 
-pub fn prune(
+pub async fn prune(
     base: &CommandBase,
     scope: &[String],
     docker: bool,
     output_dir: &str,
 ) -> Result<(), Error> {
-    let prune = Prune::new(base, scope, docker, output_dir)?;
+    let prune = Prune::new(base, scope, docker, output_dir).await?;
 
     if matches!(
         prune.package_graph.package_manager(),
@@ -243,7 +243,7 @@ enum CopyDestination {
 }
 
 impl<'a> Prune<'a> {
-    fn new(
+    async fn new(
         base: &CommandBase,
         scope: &'a [String],
         docker: bool,
@@ -256,7 +256,9 @@ impl<'a> Prune<'a> {
         let root_package_json_path = base.repo_root.join_component("package.json");
         let root_package_json = PackageJson::load(&root_package_json_path)?;
 
-        let package_graph = PackageGraph::builder(&base.repo_root, root_package_json).build()?;
+        let package_graph = PackageGraph::builder(&base.repo_root, root_package_json)
+            .build()
+            .await?;
 
         let out_directory = AbsoluteSystemPathBuf::from_unknown(&base.repo_root, output_dir);
 

--- a/crates/turborepo-lib/src/daemon/client.rs
+++ b/crates/turborepo-lib/src/daemon/client.rs
@@ -202,6 +202,9 @@ pub enum DaemonError {
 
     #[error("failed to setup cookie dir {1}: {0}")]
     CookieDir(io::Error, AbsoluteSystemPathBuf),
+
+    #[error("failed to determine package manager: {0}")]
+    PackageManager(#[from] turborepo_repository::package_manager::Error),
 }
 
 impl From<Status> for DaemonError {

--- a/crates/turborepo-lib/src/daemon/connector.rs
+++ b/crates/turborepo-lib/src/daemon/connector.rs
@@ -637,6 +637,13 @@ mod test {
         ) -> tonic::Result<tonic::Response<proto::GetChangedOutputsResponse>> {
             unimplemented!()
         }
+
+        async fn discover_packages(
+            &self,
+            _req: tonic::Request<proto::DiscoverPackagesRequest>,
+        ) -> Result<tonic::Response<proto::DiscoverPackagesResponse>, tonic::Status> {
+            unimplemented!()
+        }
     }
 
     #[tokio::test]

--- a/crates/turborepo-lib/src/daemon/mod.rs
+++ b/crates/turborepo-lib/src/daemon/mod.rs
@@ -26,7 +26,7 @@ pub(crate) mod proto {
     /// - Bump the minor version if adding new features, such that clients can
     ///   mandate at least some set of features on the target server.
     /// - Bump the patch version if making backwards compatible bug fixes.
-    pub const VERSION: &str = "1.10.17";
+    pub const VERSION: &str = "1.11.0";
 
     impl From<PackageManager> for turborepo_repository::package_manager::PackageManager {
         fn from(pm: PackageManager) -> Self {

--- a/crates/turborepo-lib/src/daemon/mod.rs
+++ b/crates/turborepo-lib/src/daemon/mod.rs
@@ -7,11 +7,11 @@ mod server;
 
 pub use client::{DaemonClient, DaemonError};
 pub use connector::{DaemonConnector, DaemonConnectorError};
-pub use server::{serve, CloseReason};
+pub use server::{CloseReason, FileWatching, TurboGrpcService};
 
 pub(crate) mod proto {
-    tonic::include_proto!("turbodprotocol");
 
+    tonic::include_proto!("turbodprotocol");
     /// The version of the protocol that this library implements.
     ///
     /// Protocol buffers aim to be backward and forward compatible at a protocol
@@ -27,4 +27,30 @@ pub(crate) mod proto {
     ///   mandate at least some set of features on the target server.
     /// - Bump the patch version if making backwards compatible bug fixes.
     pub const VERSION: &str = "1.10.17";
+
+    impl From<PackageManager> for turborepo_repository::package_manager::PackageManager {
+        fn from(pm: PackageManager) -> Self {
+            match pm {
+                PackageManager::Npm => Self::Npm,
+                PackageManager::Yarn => Self::Yarn,
+                PackageManager::Berry => Self::Berry,
+                PackageManager::Pnpm => Self::Pnpm,
+                PackageManager::Pnpm6 => Self::Pnpm6,
+                PackageManager::Bun => Self::Bun,
+            }
+        }
+    }
+
+    impl From<turborepo_repository::package_manager::PackageManager> for PackageManager {
+        fn from(pm: turborepo_repository::package_manager::PackageManager) -> Self {
+            match pm {
+                turborepo_repository::package_manager::PackageManager::Npm => Self::Npm,
+                turborepo_repository::package_manager::PackageManager::Yarn => Self::Yarn,
+                turborepo_repository::package_manager::PackageManager::Berry => Self::Berry,
+                turborepo_repository::package_manager::PackageManager::Pnpm => Self::Pnpm,
+                turborepo_repository::package_manager::PackageManager::Pnpm6 => Self::Pnpm6,
+                turborepo_repository::package_manager::PackageManager::Bun => Self::Bun,
+            }
+        }
+    }
 }

--- a/crates/turborepo-lib/src/daemon/server.rs
+++ b/crates/turborepo-lib/src/daemon/server.rs
@@ -701,13 +701,19 @@ mod test {
         let exit_signal = rx.map(|_result| CloseReason::Interrupt);
 
         let server = TurboGrpcService::new(
-            repo_root,
+            repo_root.clone(),
             daemon_root,
             log_file,
             Duration::from_millis(10),
             exit_signal,
         )
         .with_package_discovery_backup(MockDiscovery);
+
+        // the package watcher reads data from the package.json file
+        // so we need to create it
+        repo_root.create_dir_all().unwrap();
+        let package_json = repo_root.join_component("package.json");
+        std::fs::write(package_json, r#"{"workspaces": ["packages/*"]}"#).unwrap();
 
         let close_reason = server.serve().await;
 

--- a/crates/turborepo-lib/src/daemon/server.rs
+++ b/crates/turborepo-lib/src/daemon/server.rs
@@ -156,7 +156,8 @@ where
         let (watcher_tx, watcher_rx) = watch::channel(None);
 
         let package_discovery = WatchingPackageDiscovery::new(watcher_rx.clone());
-        let package_discovery_backup = LocalPackageDiscoveryBuilder::new(repo_root.clone(), None);
+        let package_discovery_backup =
+            LocalPackageDiscoveryBuilder::new(repo_root.clone(), None, None);
 
         // Run the actual service. It takes ownership of the struct given to it,
         // so we use a private struct with just the pieces of state needed to handle

--- a/crates/turborepo-lib/src/engine/builder.rs
+++ b/crates/turborepo-lib/src/engine/builder.rs
@@ -431,6 +431,7 @@ mod test {
 
     // Only used to prevent package graph construction from attempting to read
     // lockfile from disk
+    #[derive(Debug)]
     struct MockLockfile;
     impl Lockfile for MockLockfile {
         fn resolve_package(

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -4,6 +4,7 @@ mod cache;
 mod error;
 pub(crate) mod global_hash;
 mod graph_visualizer;
+pub(crate) mod package_discovery;
 mod scope;
 pub(crate) mod summary;
 pub mod task_id;

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -227,7 +227,12 @@ impl<'a> Run<'a> {
                 .with_single_package_mode(opts.run_opts.single_package)
                 .with_package_discovery(FallbackPackageDiscovery::new(
                     daemon.as_mut().map(DaemonPackageDiscovery::new),
-                    LocalPackageDiscoveryBuilder::new(self.base.repo_root.clone(), None).build()?,
+                    LocalPackageDiscoveryBuilder::new(
+                        self.base.repo_root.clone(),
+                        None,
+                        Some(root_package_json.clone()),
+                    )
+                    .build()?,
                     Duration::from_millis(10),
                 ))
                 .build()

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -193,7 +193,6 @@ impl<'a> Run<'a> {
 
         let is_single_package = opts.run_opts.single_package;
 
-        // There's some warning handling code in Go that I'm ignoring
         let is_ci_or_not_tty = turborepo_ci::is_ci() || !std::io::stdout().is_terminal();
 
         let mut daemon = if is_ci_or_not_tty && !opts.run_opts.no_daemon {
@@ -227,6 +226,8 @@ impl<'a> Run<'a> {
                 .with_single_package_mode(opts.run_opts.single_package)
                 .with_package_discovery(FallbackPackageDiscovery::new(
                     daemon.as_mut().map(DaemonPackageDiscovery::new),
+                    // TODO: we may never need this fallback, so we could make this a builder
+                    // instead and instantiate it lazily
                     LocalPackageDiscoveryBuilder::new(
                         self.base.repo_root.clone(),
                         None,

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -13,7 +13,7 @@ use std::{
     collections::HashSet,
     io::{IsTerminal, Write},
     sync::Arc,
-    time::SystemTime,
+    time::{Duration, SystemTime},
 };
 
 pub use cache::{RunCache, TaskCache};
@@ -27,6 +27,7 @@ use turborepo_cache::{AsyncCache, RemoteCacheOpts};
 use turborepo_ci::Vendor;
 use turborepo_env::EnvironmentVariableMap;
 use turborepo_repository::{
+    discovery::{FallbackPackageDiscovery, LocalPackageDiscoveryBuilder, PackageDiscoveryBuilder},
     package_graph::{PackageGraph, WorkspaceName},
     package_json::PackageJson,
 };
@@ -43,7 +44,10 @@ use crate::{
     engine::{Engine, EngineBuilder},
     opts::Opts,
     process::ProcessManager,
-    run::{global_hash::get_global_hash_inputs, summary::RunTracker},
+    run::{
+        global_hash::get_global_hash_inputs, package_discovery::DaemonPackageDiscovery,
+        summary::RunTracker,
+    },
     shim::TurboState,
     signal::{SignalHandler, SignalSubscriber},
     task_graph::Visitor,
@@ -189,36 +193,10 @@ impl<'a> Run<'a> {
 
         let is_single_package = opts.run_opts.single_package;
 
-        let mut pkg_dep_graph =
-            PackageGraph::builder(&self.base.repo_root, root_package_json.clone())
-                .with_single_package_mode(opts.run_opts.single_package)
-                .build()
-                .await?;
-
-        let root_turbo_json =
-            TurboJson::load(&self.base.repo_root, &root_package_json, is_single_package)?;
-
-        let team_id = root_turbo_json
-            .remote_cache
-            .as_ref()
-            .and_then(|configuration_options| configuration_options.team_id.clone())
-            .unwrap_or_default();
-
-        let signature = root_turbo_json
-            .remote_cache
-            .as_ref()
-            .and_then(|configuration_options| configuration_options.signature)
-            .unwrap_or_default();
-
-        opts.cache_opts.remote_cache_opts = Some(RemoteCacheOpts::new(team_id, signature));
-
-        if opts.run_opts.experimental_space_id.is_none() {
-            opts.run_opts.experimental_space_id = root_turbo_json.space_id.clone();
-        }
-
+        // There's some warning handling code in Go that I'm ignoring
         let is_ci_or_not_tty = turborepo_ci::is_ci() || !std::io::stdout().is_terminal();
 
-        let daemon = if is_ci_or_not_tty && !opts.run_opts.no_daemon {
+        let mut daemon = if is_ci_or_not_tty && !opts.run_opts.no_daemon {
             debug!("skipping turbod since we appear to be in a non-interactive context");
             None
         } else if !opts.run_opts.no_daemon {
@@ -243,6 +221,38 @@ impl<'a> Run<'a> {
             // We are opted out of using the daemon
             None
         };
+
+        let mut pkg_dep_graph =
+            PackageGraph::builder(&self.base.repo_root, root_package_json.clone())
+                .with_single_package_mode(opts.run_opts.single_package)
+                .with_package_discovery(FallbackPackageDiscovery::new(
+                    daemon.as_mut().map(DaemonPackageDiscovery::new),
+                    LocalPackageDiscoveryBuilder::new(self.base.repo_root.clone(), None).build()?,
+                    Duration::from_millis(10),
+                ))
+                .build()
+                .await?;
+
+        let root_turbo_json =
+            TurboJson::load(&self.base.repo_root, &root_package_json, is_single_package)?;
+
+        let team_id = root_turbo_json
+            .remote_cache
+            .as_ref()
+            .and_then(|configuration_options| configuration_options.team_id.clone())
+            .unwrap_or_default();
+
+        let signature = root_turbo_json
+            .remote_cache
+            .as_ref()
+            .and_then(|configuration_options| configuration_options.signature)
+            .unwrap_or_default();
+
+        opts.cache_opts.remote_cache_opts = Some(RemoteCacheOpts::new(team_id, signature));
+
+        if opts.run_opts.experimental_space_id.is_none() {
+            opts.run_opts.experimental_space_id = root_turbo_json.space_id.clone();
+        }
 
         pkg_dep_graph.validate()?;
 

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -191,7 +191,8 @@ impl<'a> Run<'a> {
         let mut pkg_dep_graph =
             PackageGraph::builder(&self.base.repo_root, root_package_json.clone())
                 .with_single_package_mode(opts.run_opts.single_package)
-                .build()?;
+                .build()
+                .await?;
 
         let root_turbo_json =
             TurboJson::load(&self.base.repo_root, &root_package_json, is_single_package)?;
@@ -466,7 +467,8 @@ impl<'a> Run<'a> {
         let mut pkg_dep_graph =
             PackageGraph::builder(&self.base.repo_root, root_package_json.clone())
                 .with_single_package_mode(opts.run_opts.single_package)
-                .build()?;
+                .build()
+                .await?;
 
         let root_turbo_json =
             TurboJson::load(&self.base.repo_root, &root_package_json, is_single_package)?;

--- a/crates/turborepo-lib/src/run/package_discovery/mod.rs
+++ b/crates/turborepo-lib/src/run/package_discovery/mod.rs
@@ -79,28 +79,3 @@ impl PackageDiscovery for WatchingPackageDiscovery {
         })
     }
 }
-
-#[cfg(test)]
-mod test {
-    use turbopath::AbsoluteSystemPathBuf;
-
-    use crate::daemon::DaemonConnector;
-
-    #[tokio::test]
-    async fn test_daemon_package_discovery() {
-        let connector = DaemonConnector {
-            can_start_server: true,
-            can_kill_server: true,
-            pid_file: AbsoluteSystemPathBuf::new("/tmp/turbod/6c5948bd4171b931/turbod.pid")
-                .unwrap(),
-            sock_file: AbsoluteSystemPathBuf::new("/tmp/turbod/6c5948bd4171b931/turbod.sock")
-                .unwrap(),
-        };
-
-        let mut client = connector.connect().await.unwrap();
-
-        let packages = client.discover_packages().await.unwrap();
-
-        println!("{:#?}", packages);
-    }
-}

--- a/crates/turborepo-lib/src/run/package_discovery/mod.rs
+++ b/crates/turborepo-lib/src/run/package_discovery/mod.rs
@@ -1,0 +1,106 @@
+use std::sync::Arc;
+
+use tokio::sync::watch::Receiver;
+use turbopath::AbsoluteSystemPathBuf;
+use turborepo_repository::discovery::{DiscoveryResponse, Error, PackageDiscovery, WorkspaceData};
+
+use crate::daemon::{proto::PackageManager, DaemonClient, FileWatching};
+
+pub struct DaemonPackageDiscovery<'a, C: Clone> {
+    daemon: &'a mut DaemonClient<C>,
+}
+
+impl<'a, C: Clone> DaemonPackageDiscovery<'a, C> {
+    pub fn new(daemon: &'a mut DaemonClient<C>) -> Self {
+        Self { daemon }
+    }
+}
+
+impl<'a, C: Clone + Send> PackageDiscovery for DaemonPackageDiscovery<'a, C> {
+    async fn discover_packages(&mut self) -> Result<DiscoveryResponse, Error> {
+        let response = self
+            .daemon
+            .discover_packages()
+            .await
+            .map_err(|_| Error::Failed)?;
+
+        Ok(DiscoveryResponse {
+            workspaces: response
+                .package_files
+                .into_iter()
+                .map(|p| WorkspaceData {
+                    package_json: AbsoluteSystemPathBuf::new(p.package_json).expect("absolute"),
+                    turbo_json: p
+                        .turbo_json
+                        .map(|t| AbsoluteSystemPathBuf::new(t).expect("absolute")),
+                })
+                .collect(),
+            package_manager: PackageManager::from_i32(response.package_manager)
+                .expect("valid")
+                .into(),
+        })
+    }
+}
+
+/// A package discovery strategy that watches the file system for changes. Basic
+/// idea:
+/// - Set up a watcher on file changes on the relevant workspace file for the
+///   package manager
+/// - When the workspace globs change, re-discover the workspace
+/// - When a package.json changes, re-discover the workspace
+/// - Keep an in-memory cache of the workspace
+pub struct WatchingPackageDiscovery {
+    /// file watching may not be ready yet so we store a watcher
+    /// through which we can get the file watching stack
+    watcher: Receiver<Option<Arc<crate::daemon::FileWatching>>>,
+}
+
+impl WatchingPackageDiscovery {
+    pub fn new(watcher: Receiver<Option<Arc<FileWatching>>>) -> Self {
+        Self { watcher }
+    }
+}
+
+impl PackageDiscovery for WatchingPackageDiscovery {
+    async fn discover_packages(&mut self) -> Result<DiscoveryResponse, Error> {
+        // need to clone and drop the Ref before we can await
+        let watcher = {
+            let watcher = self
+                .watcher
+                .wait_for(|opt| opt.is_some())
+                .await
+                .map_err(|_| Error::Failed)?;
+            watcher.as_ref().expect("guaranteed some above").clone()
+        };
+
+        Ok(DiscoveryResponse {
+            workspaces: watcher.package_watcher.get_package_data().await,
+            package_manager: watcher.package_watcher.get_package_manager().await,
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use turbopath::AbsoluteSystemPathBuf;
+
+    use crate::daemon::DaemonConnector;
+
+    #[tokio::test]
+    async fn test_daemon_package_discovery() {
+        let connector = DaemonConnector {
+            can_start_server: true,
+            can_kill_server: true,
+            pid_file: AbsoluteSystemPathBuf::new("/tmp/turbod/6c5948bd4171b931/turbod.pid")
+                .unwrap(),
+            sock_file: AbsoluteSystemPathBuf::new("/tmp/turbod/6c5948bd4171b931/turbod.sock")
+                .unwrap(),
+        };
+
+        let mut client = connector.connect().await.unwrap();
+
+        let packages = client.discover_packages().await.unwrap();
+
+        println!("{:#?}", packages);
+    }
+}

--- a/crates/turborepo-lib/src/run/package_discovery/mod.rs
+++ b/crates/turborepo-lib/src/run/package_discovery/mod.rs
@@ -22,7 +22,7 @@ impl<'a, C: Clone + Send> PackageDiscovery for DaemonPackageDiscovery<'a, C> {
             .daemon
             .discover_packages()
             .await
-            .map_err(|_| Error::Failed)?;
+            .map_err(|e| Error::Failed(Box::new(e)))?;
 
         Ok(DiscoveryResponse {
             workspaces: response
@@ -69,7 +69,7 @@ impl PackageDiscovery for WatchingPackageDiscovery {
                 .watcher
                 .wait_for(|opt| opt.is_some())
                 .await
-                .map_err(|_| Error::Failed)?;
+                .map_err(|e| Error::Failed(Box::new(e)))?;
             watcher.as_ref().expect("guaranteed some above").clone()
         };
 

--- a/crates/turborepo-lockfiles/src/berry/mod.rs
+++ b/crates/turborepo-lockfiles/src/berry/mod.rs
@@ -39,6 +39,7 @@ pub enum Error {
 // We depend on BTree iteration being sorted for correct serialization
 type Map<K, V> = std::collections::BTreeMap<K, V>;
 
+#[derive(Debug)]
 pub struct BerryLockfile {
     data: LockfileData,
     resolutions: Map<Descriptor<'static>, Locator<'static>>,

--- a/crates/turborepo-lockfiles/src/bun/mod.rs
+++ b/crates/turborepo-lockfiles/src/bun/mod.rs
@@ -20,6 +20,7 @@ pub enum Error {
     NotImplemented(),
 }
 
+#[derive(Debug)]
 pub struct BunLockfile {
     inner: Map<String, Entry>,
 }

--- a/crates/turborepo-lockfiles/src/lib.rs
+++ b/crates/turborepo-lockfiles/src/lib.rs
@@ -31,7 +31,7 @@ pub struct Package {
 // This trait will only be used when migrating the Go lockfile implementations
 // to Rust. Once the migration is complete we will leverage petgraph for doing
 // our graph calculations.
-pub trait Lockfile: Send + Sync + Any {
+pub trait Lockfile: Send + Sync + Any + std::fmt::Debug {
     // Given a workspace, a package it imports and version returns the key, resolved
     // version, and if it was found
     fn resolve_package(

--- a/crates/turborepo-lockfiles/src/yarn1/mod.rs
+++ b/crates/turborepo-lockfiles/src/yarn1/mod.rs
@@ -19,6 +19,7 @@ pub enum Error {
     NonUTF8(#[from] std::str::Utf8Error),
 }
 
+#[derive(Debug)]
 pub struct Yarn1Lockfile {
     inner: Map<String, Entry>,
 }

--- a/crates/turborepo-repository/Cargo.toml
+++ b/crates/turborepo-repository/Cargo.toml
@@ -19,6 +19,8 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 thiserror = "1.0.38"
+tokio-stream = "0.1.14"
+tokio.workspace = true
 tracing.workspace = true
 turbopath = { workspace = true }
 turborepo-graph-utils = { path = "../turborepo-graph-utils" }

--- a/crates/turborepo-repository/src/discovery.rs
+++ b/crates/turborepo-repository/src/discovery.rs
@@ -12,7 +12,10 @@
 use tokio_stream::{iter, StreamExt};
 use turbopath::AbsoluteSystemPathBuf;
 
-use crate::package_manager::{self, PackageManager};
+use crate::{
+    package_json::PackageJson,
+    package_manager::{self, PackageManager},
+};
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct WorkspaceData {
@@ -80,13 +83,19 @@ impl LocalPackageDiscovery {
 pub struct LocalPackageDiscoveryBuilder {
     repo_root: AbsoluteSystemPathBuf,
     package_manager: Option<PackageManager>,
+    package_json: Option<PackageJson>,
 }
 
 impl LocalPackageDiscoveryBuilder {
-    pub fn new(repo_root: AbsoluteSystemPathBuf, package_manager: Option<PackageManager>) -> Self {
+    pub fn new(
+        repo_root: AbsoluteSystemPathBuf,
+        package_manager: Option<PackageManager>,
+        package_json: Option<PackageJson>,
+    ) -> Self {
         Self {
             repo_root,
             package_manager,
+            package_json,
         }
     }
 }
@@ -98,7 +107,9 @@ impl PackageDiscoveryBuilder for LocalPackageDiscoveryBuilder {
     fn build(self) -> Result<Self::Output, Self::Error> {
         let package_manager = match self.package_manager {
             Some(pm) => pm,
-            None => PackageManager::get_package_manager(&self.repo_root, None)?,
+            None => {
+                PackageManager::get_package_manager(&self.repo_root, self.package_json.as_ref())?
+            }
         };
 
         Ok(LocalPackageDiscovery {

--- a/crates/turborepo-repository/src/discovery.rs
+++ b/crates/turborepo-repository/src/discovery.rs
@@ -1,0 +1,260 @@
+//! turborepo-discovery
+//!
+//! This package contains a number of strategies for discovering various things
+//! about a workspace. These traits come with a basic implementation and some
+//! adaptors that can be used to compose them together.
+//!
+//! This powers various intents such as 'query the daemon for this data, or
+//! fallback to local discovery if the daemon is not available'. Eventually,
+//! these strategies will implement some sort of monad-style composition so that
+//! we can track areas of run that are performing sub-optimally.
+
+use tokio_stream::{iter, StreamExt};
+use turbopath::AbsoluteSystemPathBuf;
+
+use crate::package_manager::{self, PackageManager};
+
+#[derive(Clone)]
+pub struct WorkspaceData {
+    pub package_json: AbsoluteSystemPathBuf,
+    pub turbo_json: Option<AbsoluteSystemPathBuf>,
+}
+
+#[derive(Clone)]
+pub struct DiscoveryResponse {
+    pub workspaces: Vec<WorkspaceData>,
+    pub package_manager: PackageManager,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("discovery unavailable")]
+    Unavailable,
+    #[error("discovery failed")]
+    Failed,
+}
+
+/// Defines a strategy for discovering packages on the filesystem.
+pub trait PackageDiscovery {
+    // desugar to assert that the future is Send
+    fn discover_packages(
+        &mut self,
+    ) -> impl std::future::Future<Output = Result<DiscoveryResponse, Error>> + Send;
+}
+
+/// We want to allow for lazily generating the PackageDiscovery implementation
+/// to prevent unnecessary work. This trait allows us to do that.
+///
+/// Note: there is a blanket implementation for everything that implements
+/// PackageDiscovery
+pub trait PackageDiscoveryBuilder {
+    type Output: PackageDiscovery;
+    type Error: std::error::Error;
+
+    fn build(self) -> Result<Self::Output, Self::Error>;
+}
+
+impl<T: PackageDiscovery + Send> PackageDiscovery for Option<T> {
+    async fn discover_packages(&mut self) -> Result<DiscoveryResponse, Error> {
+        match self {
+            Some(d) => d.discover_packages().await,
+            None => Err(Error::Unavailable),
+        }
+    }
+}
+
+pub struct LocalPackageDiscovery {
+    repo_root: AbsoluteSystemPathBuf,
+    package_manager: PackageManager,
+}
+
+impl LocalPackageDiscovery {
+    pub fn new(repo_root: AbsoluteSystemPathBuf, package_manager: PackageManager) -> Self {
+        Self {
+            repo_root,
+            package_manager,
+        }
+    }
+}
+
+pub struct LocalPackageDiscoveryBuilder {
+    repo_root: AbsoluteSystemPathBuf,
+    package_manager: Option<PackageManager>,
+}
+
+impl LocalPackageDiscoveryBuilder {
+    pub fn new(repo_root: AbsoluteSystemPathBuf, package_manager: Option<PackageManager>) -> Self {
+        Self {
+            repo_root,
+            package_manager,
+        }
+    }
+}
+
+impl PackageDiscoveryBuilder for LocalPackageDiscoveryBuilder {
+    type Output = LocalPackageDiscovery;
+    type Error = package_manager::Error;
+
+    fn build(self) -> Result<Self::Output, Self::Error> {
+        let package_manager = match self.package_manager {
+            Some(pm) => pm,
+            None => PackageManager::get_package_manager(&self.repo_root, None)?,
+        };
+
+        Ok(LocalPackageDiscovery {
+            repo_root: self.repo_root,
+            package_manager,
+        })
+    }
+}
+
+impl PackageDiscovery for LocalPackageDiscovery {
+    async fn discover_packages(&mut self) -> Result<DiscoveryResponse, Error> {
+        iter(
+            self.package_manager
+                .get_package_jsons(&self.repo_root)
+                .map_err(|_e| Error::Failed)?,
+        )
+        .then(|a| async move {
+            let potential_turbo = a.parent().expect("non-root").join_component("turbo.json");
+            let potential_turbo_exists = tokio::fs::try_exists(potential_turbo.as_path()).await;
+
+            Ok(WorkspaceData {
+                package_json: a,
+                turbo_json: potential_turbo_exists
+                    .ok()
+                    .and_then(|pe| pe.then_some(potential_turbo)),
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .await
+        .map(|workspaces| DiscoveryResponse {
+            workspaces,
+            package_manager: self.package_manager.clone(),
+        })
+    }
+}
+
+/// Attempts to run the `primary` strategy for an amount of time
+/// specified by `timeout` before falling back to `fallback`
+pub struct FallbackPackageDiscovery<P, F> {
+    primary: P,
+    fallback: F,
+    timeout: std::time::Duration,
+}
+
+impl<P: PackageDiscovery, F: PackageDiscovery> FallbackPackageDiscovery<P, F> {
+    pub fn new(primary: P, fallback: F, timeout: std::time::Duration) -> Self {
+        Self {
+            primary,
+            fallback,
+            timeout,
+        }
+    }
+}
+
+impl<T: PackageDiscovery> PackageDiscoveryBuilder for T {
+    type Output = T;
+    type Error = std::convert::Infallible;
+
+    fn build(self) -> Result<Self::Output, Self::Error> {
+        Ok(self)
+    }
+}
+
+impl<A: PackageDiscovery + Send, B: PackageDiscovery + Send> PackageDiscovery
+    for FallbackPackageDiscovery<A, B>
+{
+    async fn discover_packages(&mut self) -> Result<DiscoveryResponse, Error> {
+        match tokio::time::timeout(self.timeout, self.primary.discover_packages()).await {
+            Ok(Ok(packages)) => Ok(packages),
+            Ok(Err(err1)) => match self.fallback.discover_packages().await {
+                Ok(packages) => Ok(packages),
+                // if the backup is unavailable, return the original error
+                Err(Error::Unavailable) => Err(err1),
+                Err(err2) => Err(err2),
+            },
+            Err(_) => self.fallback.discover_packages().await,
+        }
+    }
+}
+
+pub struct CachingPackageDiscovery<P: PackageDiscovery> {
+    primary: P,
+    data: Option<DiscoveryResponse>,
+}
+
+impl<P: PackageDiscovery> CachingPackageDiscovery<P> {
+    pub fn new(primary: P) -> Self {
+        Self {
+            primary,
+            data: None,
+        }
+    }
+}
+
+impl<P: PackageDiscovery + Send> PackageDiscovery for CachingPackageDiscovery<P> {
+    async fn discover_packages(&mut self) -> Result<DiscoveryResponse, Error> {
+        match self.data.take() {
+            Some(data) => Ok(data),
+            None => {
+                let data = self.primary.discover_packages().await?;
+                self.data = Some(data.clone());
+                Ok(data)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod fallback_tests {
+    use std::time::Duration;
+
+    use tokio::runtime::Runtime;
+
+    use super::*;
+
+    struct MockPrimaryDiscovery {
+        should_fail: bool,
+    }
+
+    impl PackageDiscovery for MockPrimaryDiscovery {
+        async fn discover_packages(&mut self) -> Result<DiscoveryResponse, Error> {
+            if self.should_fail {
+                Err(Error::Failed)
+            } else {
+                // Simulate successful package discovery
+                Ok(DiscoveryResponse {})
+            }
+        }
+    }
+
+    struct MockFallbackDiscovery;
+
+    impl PackageDiscovery for MockFallbackDiscovery {
+        async fn discover_packages(&mut self) -> Result<DiscoveryResponse, Error> {
+            // Simulate successful package discovery
+            Ok(DiscoveryResponse {
+                // Mocked response
+            })
+        }
+    }
+
+    #[test]
+    fn test_fallback_on_primary_failure() {
+        let rt = Runtime::new().unwrap();
+        rt.block_on(async {
+            let primary = MockPrimaryDiscovery { should_fail: true };
+            let fallback = MockFallbackDiscovery;
+
+            let mut discovery =
+                FallbackPackageDiscovery::new(primary, fallback, Duration::from_secs(5));
+
+            // Invoke the method under test
+            let result = discovery.discover_packages().await;
+
+            // Assert that the fallback was used and successful
+            assert!(result.is_ok());
+        });
+    }
+}

--- a/crates/turborepo-repository/src/discovery.rs
+++ b/crates/turborepo-repository/src/discovery.rs
@@ -14,7 +14,7 @@ use turbopath::AbsoluteSystemPathBuf;
 
 use crate::package_manager::{self, PackageManager};
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct WorkspaceData {
     pub package_json: AbsoluteSystemPathBuf,
     pub turbo_json: Option<AbsoluteSystemPathBuf>,

--- a/crates/turborepo-repository/src/discovery.rs
+++ b/crates/turborepo-repository/src/discovery.rs
@@ -121,7 +121,7 @@ impl PackageDiscoveryBuilder for LocalPackageDiscoveryBuilder {
 
 impl PackageDiscovery for LocalPackageDiscovery {
     async fn discover_packages(&mut self) -> Result<DiscoveryResponse, Error> {
-        let packages = match self.package_manager.get_package_jsons(&self.repo_root) {
+        let package_paths = match self.package_manager.get_package_jsons(&self.repo_root) {
             Ok(packages) => packages,
             // if there is not a list of workspaces, it is not necessarily an error. just report no
             // workspaces
@@ -134,16 +134,19 @@ impl PackageDiscovery for LocalPackageDiscovery {
             Err(e) => return Err(Error::Failed(Box::new(e))),
         };
 
-        iter(packages)
-            .then(|a| async move {
-                let potential_turbo = a.parent().expect("non-root").join_component("turbo.json");
+        iter(package_paths)
+            .then(|path| async move {
+                let potential_turbo = path
+                    .parent()
+                    .expect("non-root")
+                    .join_component("turbo.json");
                 let potential_turbo_exists = tokio::fs::try_exists(potential_turbo.as_path()).await;
 
                 Ok(WorkspaceData {
-                    package_json: a,
+                    package_json: path,
                     turbo_json: potential_turbo_exists
-                        .ok()
-                        .and_then(|pe| pe.then_some(potential_turbo)),
+                        .unwrap_or_default()
+                        .then_some(potential_turbo),
                 })
             })
             .collect::<Result<Vec<_>, _>>()

--- a/crates/turborepo-repository/src/lib.rs
+++ b/crates/turborepo-repository/src/lib.rs
@@ -1,6 +1,7 @@
 #![feature(assert_matches)]
 #![feature(error_generic_member_access)]
 
+pub mod discovery;
 pub mod inference;
 pub mod package_graph;
 pub mod package_json;

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -65,7 +65,11 @@ pub enum Error {
 impl<'a> PackageGraphBuilder<'a, LocalPackageDiscoveryBuilder> {
     pub fn new(repo_root: &'a AbsoluteSystemPath, root_package_json: PackageJson) -> Self {
         Self {
-            package_discovery: LocalPackageDiscoveryBuilder::new(repo_root.to_owned(), None),
+            package_discovery: LocalPackageDiscoveryBuilder::new(
+                repo_root.to_owned(),
+                None,
+                Some(root_package_json.clone()),
+            ),
             repo_root,
             root_package_json,
             is_single_package: false,

--- a/crates/turborepo-repository/src/package_manager/mod.rs
+++ b/crates/turborepo-repository/src/package_manager/mod.rs
@@ -16,7 +16,7 @@ use lazy_regex::{lazy_regex, Lazy};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, RelativeUnixPath};
+use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, PathError, RelativeUnixPath};
 use turborepo_lockfiles::Lockfile;
 use wax::{Any, Glob, Pattern};
 use which::which;
@@ -88,7 +88,7 @@ impl Display for PackageManager {
 }
 
 // WorkspaceGlobs is suitable for finding package.json files via globwalk
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct WorkspaceGlobs {
     directory_inclusions: Any<'static>,
     directory_exclusions: Any<'static>,
@@ -162,11 +162,16 @@ impl WorkspaceGlobs {
         })
     }
 
+    /// Checks if the given `target` matches this `WorkspaceGlobs`.
+    ///
+    /// Errors:
+    /// This function returns an Err if `root` is not a valid anchor for
+    /// `target`
     pub fn target_is_workspace(
         &self,
         root: &AbsoluteSystemPath,
         target: &AbsoluteSystemPath,
-    ) -> Result<bool, Error> {
+    ) -> Result<bool, PathError> {
         let search_value = root.anchor(target)?;
 
         let includes = self.directory_inclusions.is_match(&search_value);
@@ -269,6 +274,12 @@ pub enum Error {
     Lockfile(#[from] turborepo_lockfiles::Error),
 }
 
+impl From<std::convert::Infallible> for Error {
+    fn from(_: std::convert::Infallible) -> Self {
+        unreachable!()
+    }
+}
+
 static PACKAGE_MANAGER_PATTERN: Lazy<Regex> =
     lazy_regex!(r"(?P<manager>bun|npm|pnpm|yarn)@(?P<version>\d+\.\d+\.\d+(-.+)?)");
 
@@ -322,9 +333,9 @@ impl PackageManager {
             PackageManager::Pnpm | PackageManager::Pnpm6 => {
                 // Make sure to convert this to a missing workspace error
                 // so we can catch it in the case of single package mode.
-                let workspace_yaml =
-                    fs::read_to_string(root_path.join_component("pnpm-workspace.yaml"))
-                        .map_err(|_| Error::Workspace(MissingWorkspaceError::from(self)))?;
+                let source = self.workspace_glob_source(root_path);
+                let workspace_yaml = fs::read_to_string(source)
+                    .map_err(|_| Error::Workspace(MissingWorkspaceError::from(self)))?;
                 let pnpm_workspace: PnpmWorkspace = serde_yaml::from_str(&workspace_yaml)?;
                 if pnpm_workspace.packages.is_empty() {
                     return Err(MissingWorkspaceError::from(self).into());
@@ -336,8 +347,7 @@ impl PackageManager {
             | PackageManager::Npm
             | PackageManager::Yarn
             | PackageManager::Bun => {
-                let package_json_text =
-                    fs::read_to_string(root_path.join_component("package.json"))?;
+                let package_json_text = fs::read_to_string(self.workspace_glob_source(root_path))?;
                 let package_json: PackageJsonWorkspaces = serde_json::from_str(&package_json_text)
                     .map_err(|_| Error::Workspace(MissingWorkspaceError::from(self)))?; // Make sure to convert this to a missing workspace error
 
@@ -358,6 +368,13 @@ impl PackageManager {
         });
 
         Ok((inclusions, exclusions))
+    }
+
+    pub fn workspace_glob_source(&self, root_path: &AbsoluteSystemPath) -> AbsoluteSystemPathBuf {
+        root_path.join_component(
+            self.workspace_configuration_path()
+                .unwrap_or("package.json"),
+        )
     }
 
     // TODO: consider if this method should not need an Option, and possibly be a

--- a/crates/turborepo-repository/src/package_manager/mod.rs
+++ b/crates/turborepo-repository/src/package_manager/mod.rs
@@ -22,6 +22,7 @@ use wax::{Any, Glob, Pattern};
 use which::which;
 
 use crate::{
+    discovery,
     package_json::PackageJson,
     package_manager::{bun::BunDetector, npm::NpmDetector, pnpm::PnpmDetector, yarn::YarnDetector},
 };
@@ -272,6 +273,9 @@ pub enum Error {
     Glob(String, #[source] Box<wax::BuildError>),
     #[error(transparent)]
     Lockfile(#[from] turborepo_lockfiles::Error),
+
+    #[error("discovering workspace: {0}")]
+    WorkspaceDiscovery(#[from] discovery::Error),
 }
 
 impl From<std::convert::Infallible> for Error {

--- a/crates/turborepo-repository/src/package_manager/mod.rs
+++ b/crates/turborepo-repository/src/package_manager/mod.rs
@@ -381,8 +381,12 @@ impl PackageManager {
         )
     }
 
-    // TODO: consider if this method should not need an Option, and possibly be a
-    // method on PackageJSON
+    /// Try to detect the package manager by inspecting the repository.
+    /// This method does not read the package.json, instead looking for
+    /// lockfiles and other files that indicate the package manager.
+    ///
+    /// TODO: consider if this method should not need an Option, and possibly be
+    /// a method on PackageJSON
     pub fn get_package_manager(
         repo_root: &AbsoluteSystemPath,
         pkg: Option<&PackageJson>,


### PR DESCRIPTION
### Description

This adds a basic trait for discovering packages (paths to package and turbo jsons) using a variety of strategies:

- **local**: runs in-process and does a recursive walk of the FS
- **watch**: runs a file watching thread maintains a list in memory
- **daemon**: makes a request to a remote service over GRPC
- **timeout**: attempts a primary strategy and falls back in the event of errors or a timeout

This PR still needs some tests for the strategies, but it is ready for a basic look.

### Testing Instructions

There is one integration test for the daemon strategy which requires a daemon to be running. It will be improved when ready to be merged.


Closes TURBO-1530