### PR TITLE
chore(ci): separate global turborepo install from turbo env setup

### DIFF
--- a/.github/actions/setup-global-turbo/action.yml
+++ b/.github/actions/setup-global-turbo/action.yml
@@ -1,0 +1,26 @@
+name: "Setup Global Turborepo"
+description: "Install turbo globally with npm"
+inputs:
+  setup-node:
+    description: "If Node.js should get setup first. Set false to avoid double setup."
+    required: false
+    default: "true"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Node
+      if: ${{ inputs.setup-node == 'true' }}
+      uses: ./.github/actions/setup-node
+      # Skip package installation and corepack. For this action, we only need
+      # node/npm available so we can install turbo globally.
+      with:
+        package-install: "false"
+        enable-corepack: "false"
+
+    - name: Install
+      shell: bash
+      run: |
+        VERSION=$(npm view turbo --json | jq -r '.versions | last')
+        echo "Latest published version: $VERSION"
+        npm i -g turbo@$VERSION

--- a/.github/actions/setup-turborepo-environment/action.yml
+++ b/.github/actions/setup-turborepo-environment/action.yml
@@ -30,10 +30,3 @@ runs:
 
     - name: "Setup capnproto"
       uses: ./.github/actions/setup-capnproto
-
-    - name: Install Turbo globally
-      shell: bash
-      run: |
-        VERSION=$(npm view turbo --json | jq -r '.versions | last')
-        echo "Latest published version: $VERSION"
-        npm i -g turbo@$VERSION

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -232,6 +232,11 @@ jobs:
           windows: ${{ matrix.os.name == 'windows' }}
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
+      - name: Install Turbo globally
+        uses: ./.github/actions/setup-global-turbo
+        with:
+          setup-node: "false" # Already setup with setup-turborepo-environment above
+
       - run: turbo run build --filter=cli --color --env-mode=strict --token=${{ secrets.TURBO_TOKEN }} --team=${{ vars.TURBO_TEAM }}
         env:
           SCCACHE_BUCKET: turborepo-sccache
@@ -296,10 +301,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+
       - uses: ./.github/actions/setup-turborepo-environment
         with:
           windows: ${{ matrix.os.name == 'windows' }}
           github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Install Turbo globally
+        uses: ./.github/actions/setup-global-turbo
+        with:
+          setup-node: "false" # Already setup with setup-turborepo-environment above
 
       - run: turbo run test --filter=cli --color
 
@@ -317,6 +328,7 @@ jobs:
             runner: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
       - uses: ./.github/actions/setup-turborepo-environment
         with:
           windows: ${{ matrix.os.name == 'windows' }}
@@ -328,6 +340,11 @@ jobs:
         with:
           path: cli/.cram_env
           key: prysk-venv-${{ matrix.os.name }}
+
+      - name: Install Turbo globally
+        uses: ./.github/actions/setup-global-turbo
+        with:
+          setup-node: "false" # Already setup with setup-turborepo-environment above
 
       - name: Integration Tests
         run: turbo run test --filter=turborepo-tests-integration --color --env-mode=strict --token=${{ secrets.TURBO_TOKEN }} --team=${{ vars.TURBO_TEAM }}
@@ -358,6 +375,11 @@ jobs:
           path: cli/.cram_env
           key: prysk-venv-${{ matrix.os.name }}
 
+      - name: Install Turbo globally
+        uses: ./.github/actions/setup-global-turbo
+        with:
+          setup-node: "false" # Already setup with setup-turborepo-environment above
+
       - name: Integration Tests
         run: turbo run test:rust-codepath --filter=turborepo-tests-integration --color --env-mode=strict --token=${{ secrets.TURBO_TOKEN }} --team=${{ vars.TURBO_TEAM }}
 
@@ -384,6 +406,10 @@ jobs:
           windows: ${{ matrix.os.name == 'windows' }}
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
+      - name: Install Turbo globally
+        uses: ./.github/actions/setup-global-turbo
+        with:
+          setup-node: "false" # Already setup with setup-turborepo-environment above
       - name: E2E Tests
         run: turbo run test --filter=turborepo-tests-e2e --remote-only --token=${{ secrets.TURBO_TOKEN }} --team=${{ vars.TURBO_TEAM }} --color --env-mode=strict
 
@@ -437,6 +463,11 @@ jobs:
           cache: ${{ matrix.manager }}
           cache-dependency-path: package.json
 
+      - name: Install Turbo globally
+        uses: ./.github/actions/setup-global-turbo
+        with:
+          setup-node: "false" # Already setup with setup-turborepo-environment above
+
       - name: Check examples
         shell: bash
         # Note: using CLI flags instead of env vars because
@@ -484,12 +515,15 @@ jobs:
           ref: ${{ github.ref }}
           fetch-depth: ${{ steps.fetch-depth.outputs.depth  }}
 
-      - name: Build turborepo CLI from source
-        uses: ./.github/actions/setup-turborepo-environment
+      - uses: ./.github/actions/setup-turborepo-environment
         with:
           windows: ${{ matrix.os.name == 'windows' }}
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
+      - name: Install Turbo globally
+        uses: ./.github/actions/setup-global-turbo
+        with:
+          setup-node: "false" # Already setup with setup-turborepo-environment above
       - name: Run tests
         run: |
           turbo run check-types test --filter={./packages/*}...[${{ github.event.pull_request.base.sha || 'HEAD^1' }}] --color
@@ -919,6 +953,12 @@ jobs:
       - uses: ./.github/actions/setup-turborepo-environment
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Install Turbo globally
+        uses: ./.github/actions/setup-global-turbo
+        with:
+          setup-node: "false" # Already setup with setup-turborepo-environment above
+
       - name: Lint
         # Filters some workspaces out:
         # - `cli` because it runs golangci-lint and this Job doesn't have all the dependencies for that.


### PR DESCRIPTION
`setup-turborepo-environment` exists to install things that are needed to be able to build turbo. the global `turbo` install isn't required for that so I'm separating that step into its own action.

Closes TURBO-1534