### PR TITLE
fix: don't escape html when serializing dry runs

### DIFF
--- a/cli/internal/runsummary/format_json.go
+++ b/cli/internal/runsummary/format_json.go
@@ -1,6 +1,7 @@
 package runsummary
 
 import (
+	"bytes"
 	"encoding/json"
 	"sort"
 
@@ -13,19 +14,24 @@ import (
 func (rsm *Meta) FormatJSON() ([]byte, error) {
 	rsm.normalize() // normalize data
 
-	var bytes []byte
 	var err error
+	var buffer bytes.Buffer
+
+	encoder := json.NewEncoder(&buffer)
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent("", "  ")
 
 	if rsm.singlePackage {
-		bytes, err = json.MarshalIndent(nonMonorepoRunSummary(*rsm.RunSummary), "", "  ")
+		err = encoder.Encode(nonMonorepoRunSummary(*rsm.RunSummary))
 	} else {
-		bytes, err = json.MarshalIndent(rsm.RunSummary, "", "  ")
+		err = encoder.Encode(rsm.RunSummary)
 	}
 
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to render JSON")
 	}
-	return bytes, nil
+
+	return buffer.Bytes(), nil
 }
 
 func (rsm *Meta) normalize() {

--- a/turborepo-tests/integration/tests/dry_json/single_package.t
+++ b/turborepo-tests/integration/tests/dry_json/single_package.t
@@ -48,7 +48,7 @@ Setup
           "status": "MISS",
           "timeSaved": 0
         },
-        "command": "echo 'building' \u003e foo",
+        "command": "echo 'building' > foo",
         "cliArguments": [],
         "outputs": [
           "foo"
@@ -71,7 +71,7 @@ Setup
           "dotEnv": null
         },
         "expandedOutputs": [],
-        "framework": "\u003cNO FRAMEWORK DETECTED\u003e",
+        "framework": "<NO FRAMEWORK DETECTED>",
         "envMode": "loose",
         "environmentVariables": {
           "specified": {
@@ -92,6 +92,7 @@ Setup
       "branch": ".+" (re)
     }
   }
+  
 
   $ ${TURBO} run build --dry=json --experimental-rust-codepath
   {

--- a/turborepo-tests/integration/tests/dry_json/single_package_no_config.t
+++ b/turborepo-tests/integration/tests/dry_json/single_package_no_config.t
@@ -48,7 +48,7 @@ Setup
           "status": "MISS",
           "timeSaved": 0
         },
-        "command": "echo 'building' \u003e foo",
+        "command": "echo 'building' > foo",
         "cliArguments": [],
         "outputs": null,
         "excludedOutputs": null,
@@ -67,7 +67,7 @@ Setup
           "dotEnv": null
         },
         "expandedOutputs": [],
-        "framework": "\u003cNO FRAMEWORK DETECTED\u003e",
+        "framework": "<NO FRAMEWORK DETECTED>",
         "envMode": "loose",
         "environmentVariables": {
           "specified": {
@@ -88,6 +88,7 @@ Setup
       "branch": ".+" (re)
     }
   }
+  
 
   $ ${TURBO} run build --dry=json --experimental-rust-codepath
   {

--- a/turborepo-tests/integration/tests/dry_json/single_package_with_deps.t
+++ b/turborepo-tests/integration/tests/dry_json/single_package_with_deps.t
@@ -46,7 +46,7 @@ Setup
           "status": "MISS",
           "timeSaved": 0
         },
-        "command": "echo 'building' \u003e foo",
+        "command": "echo 'building' > foo",
         "cliArguments": [],
         "outputs": [
           "foo"
@@ -71,7 +71,7 @@ Setup
           "dotEnv": null
         },
         "expandedOutputs": [],
-        "framework": "\u003cNO FRAMEWORK DETECTED\u003e",
+        "framework": "<NO FRAMEWORK DETECTED>",
         "envMode": "loose",
         "environmentVariables": {
           "specified": {
@@ -101,7 +101,7 @@ Setup
           "status": "MISS",
           "timeSaved": 0
         },
-        "command": "[[ ( -f foo ) \u0026\u0026 $(cat foo) == 'building' ]]",
+        "command": "[[ ( -f foo ) && $(cat foo) == 'building' ]]",
         "cliArguments": [],
         "outputs": null,
         "excludedOutputs": null,
@@ -124,7 +124,7 @@ Setup
           "dotEnv": null
         },
         "expandedOutputs": [],
-        "framework": "\u003cNO FRAMEWORK DETECTED\u003e",
+        "framework": "<NO FRAMEWORK DETECTED>",
         "envMode": "loose",
         "environmentVariables": {
           "specified": {
@@ -145,6 +145,7 @@ Setup
       "branch": ".+" (re)
     }
   }
+  
 
   $ ${TURBO} run test --dry=json --experimental-rust-codepath
   {


### PR DESCRIPTION
### Description

I noticed that some of our integration tests contained escaped characters while working on https://github.com/vercel/turbo/pull/6282

We now no longer escape HTML special characters so we don't mangle some common shell operations

### Testing Instructions

Updated integration tests


Closes TURBO-1536