### PR TITLE
fix: use cprintln instead of warn when no tasks are run

### DIFF
--- a/crates/turborepo-lib/src/run/summary/execution.rs
+++ b/crates/turborepo-lib/src/run/summary/execution.rs
@@ -3,9 +3,8 @@ use std::{fmt, fmt::Formatter};
 use chrono::{DateTime, Duration, Local, SubsecRound};
 use serde::Serialize;
 use tokio::sync::mpsc;
-use tracing::log::warn;
 use turbopath::{AbsoluteSystemPathBuf, AnchoredSystemPath};
-use turborepo_ui::{color, BOLD, BOLD_GREEN, BOLD_RED, MAGENTA, UI};
+use turborepo_ui::{color, cprintln, BOLD, BOLD_GREEN, BOLD_RED, MAGENTA, UI, YELLOW};
 
 use crate::run::{summary::task::TaskSummary, task_id::TaskId};
 
@@ -163,7 +162,7 @@ impl ExecutionSummary<'_> {
 
         if self.attempted == 0 {
             println!();
-            warn!("No tasks were executed as a part of this run.");
+            cprintln!(ui, YELLOW, "No tasks were executed as part of this run.");
         }
 
         println!();

--- a/crates/turborepo-ui/src/lib.rs
+++ b/crates/turborepo-ui/src/lib.rs
@@ -181,6 +181,7 @@ lazy_static! {
     pub static ref CYAN: Style = Style::new().cyan();
     pub static ref BOLD: Style = Style::new().bold();
     pub static ref MAGENTA: Style = Style::new().magenta();
+    pub static ref YELLOW: Style = Style::new().yellow();
     pub static ref UNDERLINE: Style = Style::new().underlined();
     pub static ref BOLD_CYAN: Style = Style::new().cyan().bold();
     pub static ref BOLD_GREY: Style = Style::new().dim().bold();


### PR DESCRIPTION
### Description

The `warn!` macro is meant for logging purposes and prefixes a `WARNING` to the log message. In order to get identical output as Go we directly invoke `cprintln` to avoid the prefix.

### Testing Instructions

`EXPERIMENTAL_RUST_CODEPATH=true .cram_env/bin/prysk --shell=bash tests/filter-run.t` now succeeds


Closes TURBO-1537