### PR TITLE
chore(test): fix gitignore in fixture

### DIFF
--- a/turborepo-tests/integration/tests/_fixtures/framework_inference/.gitignore
+++ b/turborepo-tests/integration/tests/_fixtures/framework_inference/.gitignore
@@ -1,1 +1,2 @@
 .turbo/
+node_modules/


### PR DESCRIPTION
when npm install is run for this fixture, it generates a node_modules directory that is included in the git repo.

This issue shows up in #6279 because git complains for every single file in node_modules that line endings are `LF` and they will be changed to `CRLF` 

Closes TURBO-1541