### PR TITLE
fix(docs): correct support typo

### DIFF
--- a/docs/pages/repo/docs/support.mdx
+++ b/docs/pages/repo/docs/support.mdx
@@ -59,7 +59,7 @@ Some exceptions to this may be:
 - Configuration changes in `turbo.json`.
 
   These should usually be accompanied by a codemod that you can run with
-  `npx @turbo/codemd update` and with at least one minor release that includes a
+  `npx @turbo/codemod update` and with at least one minor release that includes a
   deprecation message.
 
 - Intentional behavioral changes to `turbo`'s CLI commands.


### PR DESCRIPTION
### Description

Fixes minor typo, also curious if a rebuild will surface the page. 



Closes TURBO-1552