### PR TITLE
port(turborepo): Analytics Client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3596,6 +3596,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d64600be34b2fcfc267740a243fa7744441bb4947a619ac4e5bb6507f35fbfc"
+dependencies = [
+ "console",
+ "lazy_static",
+ "linked-hash-map",
+ "serde",
+ "similar",
+ "yaml-rust",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10361,6 +10375,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "turborepo-analytics"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "futures",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "turborepo-api-client",
+ "turborepo-vercel-api",
+ "uuid",
+]
+
+[[package]]
 name = "turborepo-api-client"
 version = "0.1.0"
 dependencies = [
@@ -10426,6 +10454,7 @@ dependencies = [
  "path-clean 1.0.1",
  "petgraph",
  "port_scanner",
+ "reqwest",
  "serde",
  "serde_json",
  "sha2",
@@ -10436,6 +10465,7 @@ dependencies = [
  "tokio",
  "tracing",
  "turbopath",
+ "turborepo-analytics",
  "turborepo-api-client",
  "turborepo-ui",
  "turborepo-vercel-api-mock",
@@ -10597,6 +10627,7 @@ dependencies = [
  "tracing-test",
  "turbo-updater",
  "turbopath",
+ "turborepo-analytics",
  "turborepo-api-client",
  "turborepo-auth",
  "turborepo-cache",
@@ -10716,7 +10747,10 @@ name = "turborepo-vercel-api"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "insta",
  "serde",
+ "serde_json",
+ "test-case",
  "url",
 ]
 
@@ -10940,9 +10974,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
+checksum = "88ad59a7560b41a70d191093a945f0b87bc1deeda46fb237479708a1d6b6cdfc"
 dependencies = [
  "getrandom",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,6 +136,7 @@ turbopack-tests = { path = "crates/turbopack-tests" }
 turbopack-wasm = { path = "crates/turbopack-wasm" }
 turbopath = { path = "crates/turborepo-paths" }
 turborepo = { path = "crates/turborepo" }
+turborepo-analytics = { path = "crates/turborepo-analytics" }
 turborepo-api-client = { path = "crates/turborepo-api-client" }
 turborepo-cache = { path = "crates/turborepo-cache" }
 turborepo-ci = { path = "crates/turborepo-ci" }

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -445,7 +445,7 @@ func (r *run) initAnalyticsClient(ctx gocontext.Context) analytics.Client {
 	}
 
 	// After we know if its _possible_ to enable remote cache, check the config
-	// and dsiable it if wanted.
+	// and disable it if wanted.
 	if r.base.Config.Enabled != nil {
 		r.opts.cacheOpts.SkipRemote = !*r.base.Config.Enabled
 	}

--- a/crates/turborepo-analytics/Cargo.toml
+++ b/crates/turborepo-analytics/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "turborepo-analytics"
+version = "0.1.0"
+edition = "2021"
+license = "MPL-2.0"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+async-trait = { workspace = true }
+futures.workspace = true
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["full", "time"] }
+tracing = { workspace = true }
+turborepo-api-client = { workspace = true }
+turborepo-vercel-api = { workspace = true }
+uuid = { version = "1.5.0", features = ["v4"] }

--- a/crates/turborepo-analytics/src/lib.rs
+++ b/crates/turborepo-analytics/src/lib.rs
@@ -1,0 +1,364 @@
+#![deny(clippy::all)]
+
+use std::time::Duration;
+
+use futures::stream::FuturesUnordered;
+use thiserror::Error;
+use tokio::{
+    select,
+    sync::{mpsc, oneshot},
+    task::{JoinError, JoinHandle},
+};
+use tracing::debug;
+use turborepo_api_client::{analytics::AnalyticsClient, APIAuth};
+pub use turborepo_vercel_api::AnalyticsEvent;
+use uuid::Uuid;
+
+const BUFFER_THRESHOLD: usize = 10;
+
+static EVENT_TIMEOUT: Duration = Duration::from_millis(200);
+static NO_TIMEOUT: Duration = Duration::from_secs(24 * 60 * 60);
+static REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Failed to send analytics event")]
+    SendError(#[from] mpsc::error::SendError<AnalyticsEvent>),
+    #[error("Failed to record analytics")]
+    Join(#[from] JoinError),
+}
+
+// We have two different types because the AnalyticsSender should be shared
+// across threads (i.e. Clone + Send), while the AnalyticsHandle cannot be
+// shared since it contains the structs necessary to shut down the worker.
+pub type AnalyticsSender = mpsc::UnboundedSender<AnalyticsEvent>;
+
+pub struct AnalyticsHandle {
+    exit_ch: oneshot::Receiver<()>,
+    handle: JoinHandle<()>,
+}
+
+pub fn start_analytics(
+    api_auth: APIAuth,
+    client: impl AnalyticsClient + Clone + Send + Sync + 'static,
+) -> (AnalyticsSender, AnalyticsHandle) {
+    let (tx, rx) = mpsc::unbounded_channel();
+    let (cancel_tx, cancel_rx) = oneshot::channel();
+    let session_id = Uuid::new_v4();
+    let worker = Worker {
+        rx,
+        buffer: Vec::new(),
+        session_id,
+        api_auth,
+        senders: FuturesUnordered::new(),
+        exit_ch: cancel_tx,
+        client,
+    };
+    let handle = worker.start();
+
+    let analytics_handle = AnalyticsHandle {
+        exit_ch: cancel_rx,
+        handle,
+    };
+
+    (tx, analytics_handle)
+}
+
+impl AnalyticsHandle {
+    async fn close(self) -> Result<(), Error> {
+        drop(self.exit_ch);
+        self.handle.await?;
+
+        Ok(())
+    }
+
+    pub async fn close_with_timeout(self) {
+        if let Err(err) = tokio::time::timeout(EVENT_TIMEOUT, self.close()).await {
+            debug!("failed to close analytics handle. error: {}", err)
+        }
+    }
+}
+
+struct Worker<C> {
+    rx: mpsc::UnboundedReceiver<AnalyticsEvent>,
+    buffer: Vec<AnalyticsEvent>,
+    session_id: Uuid,
+    api_auth: APIAuth,
+    senders: FuturesUnordered<JoinHandle<()>>,
+    // Used to cancel the worker
+    exit_ch: oneshot::Sender<()>,
+    client: C,
+}
+
+impl<C: AnalyticsClient + Clone + Send + Sync + 'static> Worker<C> {
+    pub fn start(mut self) -> JoinHandle<()> {
+        tokio::spawn(async move {
+            let mut timeout = tokio::time::sleep(NO_TIMEOUT);
+            loop {
+                select! {
+                    // We want the events to be prioritized over closing
+                    biased;
+                    event = self.rx.recv() => {
+                        if let Some(event) = event {
+                            self.buffer.push(event);
+                        }
+                        if self.buffer.len() == BUFFER_THRESHOLD {
+                            self.flush_events();
+                            timeout = tokio::time::sleep(NO_TIMEOUT);
+                        } else {
+                            timeout = tokio::time::sleep(REQUEST_TIMEOUT);
+                        }
+                    }
+                    _ = timeout => {
+                        self.flush_events();
+                        timeout = tokio::time::sleep(NO_TIMEOUT);
+                    }
+                    _ = self.exit_ch.closed() => {
+                                                self.flush_events();
+                        for handle in self.senders {
+                            if let Err(err) = handle.await {
+                                debug!("failed to send analytics event. error: {}", err)
+                            }
+                        }
+                        return;
+                    }
+                }
+            }
+        })
+    }
+
+    pub fn flush_events(&mut self) {
+        if !self.buffer.is_empty() {
+            let events = std::mem::take(&mut self.buffer);
+            let handle = self.send_events(events);
+            self.senders.push(handle);
+        }
+    }
+
+    fn send_events(&self, mut events: Vec<AnalyticsEvent>) -> JoinHandle<()> {
+        let session_id = self.session_id;
+        let client = self.client.clone();
+        let api_auth = self.api_auth.clone();
+        add_session_id(session_id, &mut events);
+
+        tokio::spawn(async move {
+            // We don't log an error for a timeout because
+            // that's what the Go code does.
+            if let Ok(Err(err)) =
+                tokio::time::timeout(REQUEST_TIMEOUT, client.record_analytics(&api_auth, events))
+                    .await
+            {
+                debug!("failed to record cache usage analytics. error: {}", err)
+            }
+        })
+    }
+}
+
+fn add_session_id(id: Uuid, events: &mut Vec<AnalyticsEvent>) {
+    for event in events {
+        event.set_session_id(id.to_string());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        cell::RefCell,
+        sync::{Arc, Mutex},
+    };
+
+    use async_trait::async_trait;
+    use tokio::{
+        select,
+        sync::{mpsc, mpsc::UnboundedReceiver},
+    };
+    use turborepo_api_client::{analytics::AnalyticsClient, APIAuth};
+    use turborepo_vercel_api::{AnalyticsEvent, CacheEvent, CacheSource};
+
+    use crate::start_analytics;
+
+    #[derive(Clone)]
+    struct DummyClient {
+        // A vector that stores each batch of events
+        events: Arc<Mutex<RefCell<Vec<Vec<AnalyticsEvent>>>>>,
+        tx: mpsc::UnboundedSender<()>,
+    }
+
+    impl DummyClient {
+        pub fn events(&self) -> Vec<Vec<AnalyticsEvent>> {
+            self.events.lock().unwrap().borrow().clone()
+        }
+    }
+
+    #[async_trait]
+    impl AnalyticsClient for DummyClient {
+        async fn record_analytics(
+            &self,
+            _api_auth: &APIAuth,
+            events: Vec<AnalyticsEvent>,
+        ) -> Result<(), turborepo_api_client::Error> {
+            self.events.lock().unwrap().borrow_mut().push(events);
+            self.tx.send(()).unwrap();
+
+            Ok(())
+        }
+    }
+
+    // Asserts that we get the message after the timeout
+    async fn expect_timeout_then_message(rx: &mut UnboundedReceiver<()>) {
+        let timeout = tokio::time::sleep(std::time::Duration::from_millis(150));
+
+        select! {
+            _ = rx.recv() => {
+                panic!("Expected to wait out the flush timeout")
+            }
+            _ = timeout => {
+            }
+        }
+
+        rx.recv().await;
+    }
+
+    // Asserts that we get the message immediately before the timeout
+    async fn expected_immediate_message(rx: &mut UnboundedReceiver<()>) {
+        let timeout = tokio::time::sleep(std::time::Duration::from_millis(150));
+
+        select! {
+            _ = rx.recv() => {
+            }
+            _ = timeout => {
+                panic!("expected to not wait out the flush timeout")
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_batching() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+
+        let client = DummyClient {
+            events: Default::default(),
+            tx,
+        };
+
+        let (analytics_sender, analytics_handle) = start_analytics(
+            APIAuth {
+                token: "foo".to_string(),
+                team_id: "bar".to_string(),
+                team_slug: None,
+            },
+            client.clone(),
+        );
+
+        for _ in 0..2 {
+            analytics_sender
+                .send(AnalyticsEvent {
+                    session_id: None,
+                    source: CacheSource::Local,
+                    event: CacheEvent::Hit,
+                    hash: "".to_string(),
+                    duration: 0,
+                })
+                .unwrap();
+        }
+        let found = client.events();
+        // Should have no events since we haven't flushed yet
+        assert_eq!(found.len(), 0);
+
+        expect_timeout_then_message(&mut rx).await;
+        let found = client.events();
+        assert_eq!(found.len(), 1);
+        let payloads = &found[0];
+        assert_eq!(payloads.len(), 2);
+
+        drop(analytics_handle);
+    }
+
+    #[tokio::test]
+    async fn test_batching_across_two_batches() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+
+        let client = DummyClient {
+            events: Default::default(),
+            tx,
+        };
+
+        let (analytics_sender, analytics_handle) = start_analytics(
+            APIAuth {
+                token: "foo".to_string(),
+                team_id: "bar".to_string(),
+                team_slug: None,
+            },
+            client.clone(),
+        );
+
+        for _ in 0..12 {
+            analytics_sender
+                .send(AnalyticsEvent {
+                    session_id: None,
+                    source: CacheSource::Local,
+                    event: CacheEvent::Hit,
+                    hash: "".to_string(),
+                    duration: 0,
+                })
+                .unwrap();
+        }
+
+        expected_immediate_message(&mut rx).await;
+
+        let found = client.events();
+        assert_eq!(found.len(), 1);
+
+        let payloads = &found[0];
+        assert_eq!(payloads.len(), 10);
+
+        expect_timeout_then_message(&mut rx).await;
+        let found = client.events();
+        assert_eq!(found.len(), 2);
+
+        let payloads = &found[1];
+        assert_eq!(payloads.len(), 2);
+
+        drop(analytics_handle);
+    }
+
+    #[tokio::test]
+    async fn test_closing() {
+        let (tx, _) = mpsc::unbounded_channel();
+
+        let client = DummyClient {
+            events: Default::default(),
+            tx,
+        };
+
+        let (analytics_sender, analytics_handle) = start_analytics(
+            APIAuth {
+                token: "foo".to_string(),
+                team_id: "bar".to_string(),
+                team_slug: None,
+            },
+            client.clone(),
+        );
+
+        for _ in 0..2 {
+            analytics_sender
+                .send(AnalyticsEvent {
+                    session_id: None,
+                    source: CacheSource::Local,
+                    event: CacheEvent::Hit,
+                    hash: "".to_string(),
+                    duration: 0,
+                })
+                .unwrap();
+        }
+
+        let found = client.events();
+        assert!(found.is_empty());
+
+        analytics_handle.close().await.unwrap();
+        let found = client.events();
+        assert_eq!(found.len(), 1);
+        let payloads = &found[0];
+        assert_eq!(payloads.len(), 2);
+    }
+}

--- a/crates/turborepo-api-client/src/analytics.rs
+++ b/crates/turborepo-api-client/src/analytics.rs
@@ -1,0 +1,34 @@
+use async_trait::async_trait;
+use reqwest::Method;
+pub use turborepo_vercel_api::{AnalyticsEvent, CacheEvent, CacheSource};
+
+use crate::{retry, APIAuth, APIClient, Error};
+
+#[async_trait]
+pub trait AnalyticsClient {
+    async fn record_analytics(
+        &self,
+        api_auth: &APIAuth,
+        events: Vec<AnalyticsEvent>,
+    ) -> Result<(), Error>;
+}
+
+#[async_trait]
+impl AnalyticsClient for APIClient {
+    async fn record_analytics(
+        &self,
+        api_auth: &APIAuth,
+        events: Vec<AnalyticsEvent>,
+    ) -> Result<(), Error> {
+        let request_builder = self
+            .create_request_builder("/v8/artifacts/events", api_auth, Method::POST)
+            .await?
+            .json(&events);
+
+        retry::make_retryable_request(request_builder)
+            .await?
+            .error_for_status()?;
+
+        Ok(())
+    }
+}

--- a/crates/turborepo-api-client/src/error.rs
+++ b/crates/turborepo-api-client/src/error.rs
@@ -31,6 +31,8 @@ pub enum Error {
         status: CachingStatus,
         message: String,
     },
+    #[error("cache miss")]
+    CacheMiss,
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/turborepo-api-client/src/lib.rs
+++ b/crates/turborepo-api-client/src/lib.rs
@@ -18,6 +18,7 @@ use url::Url;
 
 pub use crate::error::{Error, Result};
 
+pub mod analytics;
 mod error;
 mod retry;
 pub mod spaces;
@@ -462,6 +463,50 @@ impl APIClient {
             user_agent,
             use_preflight,
         })
+    }
+
+    /// Create a new request builder with the preflight check done,
+    /// team parameters added, CI header, and a content type of json.
+    pub(crate) async fn create_request_builder(
+        &self,
+        url: &str,
+        api_auth: &APIAuth,
+        method: Method,
+    ) -> Result<RequestBuilder> {
+        let mut url = self.make_url(url);
+        let mut allow_auth = true;
+
+        let APIAuth {
+            token,
+            team_id,
+            team_slug,
+        } = api_auth;
+
+        if self.use_preflight {
+            let preflight_response = self
+                .do_preflight(token, &url, method.as_str(), "Authorization, User-Agent")
+                .await?;
+
+            allow_auth = preflight_response.allow_authorization_header;
+            url = preflight_response.location.to_string();
+        }
+
+        let mut request_builder = self
+            .client
+            .request(method, &url)
+            .header("Content-Type", "application/json");
+
+        if allow_auth {
+            request_builder = request_builder.header("Authorization", format!("Bearer {}", token));
+        }
+
+        request_builder = Self::add_team_params(request_builder, team_id, team_slug.as_deref());
+
+        if let Some(constant) = turborepo_ci::Vendor::get_constant() {
+            request_builder = request_builder.header("x-artifact-client-ci", constant);
+        }
+
+        Ok(request_builder)
     }
 }
 

--- a/crates/turborepo-cache/Cargo.toml
+++ b/crates/turborepo-cache/Cargo.toml
@@ -32,6 +32,7 @@ lazy_static = { workspace = true }
 os_str_bytes = "6.5.0"
 path-clean = { workspace = true }
 petgraph = "0.6.3"
+reqwest = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
@@ -40,6 +41,7 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tracing = { workspace = true }
 turbopath = { workspace = true }
+turborepo-analytics = { workspace = true }
 turborepo-api-client = { workspace = true }
 turborepo-ui = { workspace = true }
 zstd = "0.12.3"

--- a/crates/turborepo-cache/src/fs.rs
+++ b/crates/turborepo-cache/src/fs.rs
@@ -3,6 +3,8 @@ use std::{backtrace::Backtrace, fs::OpenOptions};
 use camino::Utf8Path;
 use serde::{Deserialize, Serialize};
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPathBuf};
+use turborepo_analytics::AnalyticsSender;
+use turborepo_api_client::{analytics, analytics::AnalyticsEvent};
 
 use crate::{
     cache_archive::{CacheReader, CacheWriter},
@@ -11,6 +13,7 @@ use crate::{
 
 pub struct FSCache {
     cache_directory: AbsoluteSystemPathBuf,
+    analytics_recorder: Option<AnalyticsSender>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -41,11 +44,30 @@ impl FSCache {
     pub fn new(
         override_dir: Option<&Utf8Path>,
         repo_root: &AbsoluteSystemPath,
+        analytics_recorder: Option<AnalyticsSender>,
     ) -> Result<Self, CacheError> {
         let cache_directory = Self::resolve_cache_dir(repo_root, override_dir);
         cache_directory.create_dir_all()?;
 
-        Ok(FSCache { cache_directory })
+        Ok(FSCache {
+            cache_directory,
+            analytics_recorder,
+        })
+    }
+
+    fn log_fetch(&self, event: analytics::CacheEvent, hash: &str, duration: u64) {
+        // If analytics fails to record, it's not worth failing the cache
+        if let Some(analytics_recorder) = &self.analytics_recorder {
+            let analytics_event = AnalyticsEvent {
+                session_id: None,
+                source: analytics::CacheSource::Local,
+                event,
+                hash: hash.to_string(),
+                duration,
+            };
+
+            let _ = analytics_recorder.send(analytics_event);
+        }
     }
 
     pub fn fetch(
@@ -65,6 +87,7 @@ impl FSCache {
         } else if compressed_cache_path.exists() {
             compressed_cache_path
         } else {
+            self.log_fetch(analytics::CacheEvent::Miss, hash, 0);
             return Ok(None);
         };
 
@@ -77,6 +100,8 @@ impl FSCache {
                 .cache_directory
                 .join_component(&format!("{}-meta.json", hash)),
         )?;
+
+        self.log_fetch(analytics::CacheEvent::Hit, hash, meta.duration);
 
         Ok(Some((
             CacheHitMetadata {
@@ -157,23 +182,46 @@ mod test {
     use futures::future::try_join_all;
     use tempfile::tempdir;
     use turbopath::AnchoredSystemPath;
+    use turborepo_analytics::start_analytics;
+    use turborepo_api_client::{APIAuth, APIClient};
+    use turborepo_vercel_api_mock::start_test_server;
 
     use super::*;
-    use crate::test_cases::{get_test_cases, TestCase};
+    use crate::test_cases::{get_test_cases, validate_analytics, TestCase};
 
     #[tokio::test]
     async fn test_fs_cache() -> Result<()> {
-        try_join_all(get_test_cases().into_iter().map(round_trip_test)).await?;
+        let port = port_scanner::request_open_port().unwrap();
+        tokio::spawn(start_test_server(port));
 
+        let test_cases = get_test_cases();
+
+        try_join_all(
+            test_cases
+                .iter()
+                .map(|test_case| round_trip_test(test_case, port)),
+        )
+        .await?;
+
+        validate_analytics(&test_cases, analytics::CacheSource::Local, port).await?;
         Ok(())
     }
 
-    async fn round_trip_test(test_case: TestCase) -> Result<()> {
+    async fn round_trip_test(test_case: &TestCase, port: u16) -> Result<()> {
         let repo_root = tempdir()?;
         let repo_root_path = AbsoluteSystemPath::from_std_path(repo_root.path())?;
         test_case.initialize(repo_root_path)?;
 
-        let cache = FSCache::new(None, repo_root_path)?;
+        let api_client = APIClient::new(format!("http://localhost:{}", port), 200, "2.0.0", true)?;
+        let api_auth = APIAuth {
+            team_id: "my-team".to_string(),
+            token: "my-token".to_string(),
+            team_slug: None,
+        };
+        let (analytics_sender, analytics_handle) =
+            start_analytics(api_auth.clone(), api_client.clone());
+
+        let cache = FSCache::new(None, repo_root_path, Some(analytics_sender.clone()))?;
 
         let expected_miss = cache.exists(test_case.hash)?;
         assert!(expected_miss.is_none());
@@ -195,6 +243,7 @@ mod test {
         );
 
         let (status, files) = cache.fetch(repo_root_path, test_case.hash)?.unwrap();
+
         assert_eq!(
             status,
             CacheHitMetadata {
@@ -215,6 +264,7 @@ mod test {
             }
         }
 
+        analytics_handle.close_with_timeout().await;
         Ok(())
     }
 }

--- a/crates/turborepo-cache/src/fs.rs
+++ b/crates/turborepo-cache/src/fs.rs
@@ -223,7 +223,7 @@ mod test {
 
         let cache = FSCache::new(None, repo_root_path, Some(analytics_sender.clone()))?;
 
-        let expected_miss = cache.exists(test_case.hash)?;
+        let expected_miss = cache.fetch(repo_root_path, test_case.hash)?;
         assert!(expected_miss.is_none());
 
         let files: Vec<_> = test_case
@@ -232,15 +232,6 @@ mod test {
             .map(|f| f.path().to_owned())
             .collect();
         cache.put(repo_root_path, test_case.hash, &files, test_case.duration)?;
-
-        let expected_hit = cache.exists(test_case.hash)?;
-        assert_eq!(
-            expected_hit,
-            Some(CacheHitMetadata {
-                time_saved: test_case.duration,
-                source: CacheSource::Local
-            })
-        );
 
         let (status, files) = cache.fetch(repo_root_path, test_case.hash)?.unwrap();
 

--- a/crates/turborepo-cache/src/http.rs
+++ b/crates/turborepo-cache/src/http.rs
@@ -219,8 +219,6 @@ impl HTTPCache {
 
 #[cfg(test)]
 mod test {
-    use std::assert_matches::assert_matches;
-
     use anyhow::Result;
     use futures::future::try_join_all;
     use tempfile::tempdir;
@@ -232,7 +230,7 @@ mod test {
     use crate::{
         http::{APIAuth, HTTPCache},
         test_cases::{get_test_cases, validate_analytics, TestCase},
-        CacheError, CacheOpts, CacheSource,
+        CacheOpts, CacheSource,
     };
 
     #[tokio::test]
@@ -281,8 +279,8 @@ mod test {
         );
 
         // Should be a cache miss at first
-        let err = cache.fetch(hash).await.unwrap_err();
-        assert_matches!(err, CacheError::CacheMiss);
+        let miss = cache.fetch(hash).await?;
+        assert!(miss.is_none());
 
         let anchored_files: Vec<_> = files.iter().map(|f| f.path().to_owned()).collect();
         cache

--- a/crates/turborepo-cache/src/http.rs
+++ b/crates/turborepo-cache/src/http.rs
@@ -1,7 +1,10 @@
 use std::{backtrace::Backtrace, io::Write};
 
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPathBuf};
-use turborepo_api_client::{APIAuth, APIClient, Client, Response};
+use turborepo_analytics::AnalyticsSender;
+use turborepo_api_client::{
+    analytics, analytics::AnalyticsEvent, APIAuth, APIClient, Client, Response,
+};
 
 use crate::{
     cache_archive::{CacheReader, CacheWriter},
@@ -14,6 +17,7 @@ pub struct HTTPCache {
     signer_verifier: Option<ArtifactSignatureAuthenticator>,
     repo_root: AbsoluteSystemPathBuf,
     api_auth: APIAuth,
+    analytics_recorder: Option<AnalyticsSender>,
 }
 
 impl HTTPCache {
@@ -22,6 +26,7 @@ impl HTTPCache {
         opts: &CacheOpts,
         repo_root: AbsoluteSystemPathBuf,
         api_auth: APIAuth,
+        analytics_recorder: Option<AnalyticsSender>,
     ) -> HTTPCache {
         let signer_verifier = if opts
             .remote_cache_opts
@@ -41,6 +46,7 @@ impl HTTPCache {
             signer_verifier,
             repo_root,
             api_auth,
+            analytics_recorder,
         }
     }
 
@@ -123,6 +129,20 @@ impl HTTPCache {
         }
     }
 
+    fn log_fetch(&self, event: analytics::CacheEvent, hash: &str, duration: u64) {
+        // If analytics fails to record, it's not worth failing the cache
+        if let Some(analytics_recorder) = &self.analytics_recorder {
+            let analytics_event = AnalyticsEvent {
+                session_id: None,
+                source: analytics::CacheSource::Remote,
+                event,
+                hash: hash.to_string(),
+                duration,
+            };
+            let _ = analytics_recorder.send(analytics_event);
+        }
+    }
+
     pub async fn fetch(
         &self,
         hash: &str,
@@ -137,6 +157,7 @@ impl HTTPCache {
             )
             .await?
         else {
+            self.log_fetch(analytics::CacheEvent::Miss, hash, 0);
             return Ok(None);
         };
 
@@ -177,6 +198,7 @@ impl HTTPCache {
 
         let files = Self::restore_tar(&self.repo_root, &body)?;
 
+        self.log_fetch(analytics::CacheEvent::Hit, hash, duration);
         Ok(Some((
             CacheHitMetadata {
                 source: CacheSource::Remote,
@@ -197,45 +219,48 @@ impl HTTPCache {
 
 #[cfg(test)]
 mod test {
+    use std::assert_matches::assert_matches;
+
     use anyhow::Result;
     use futures::future::try_join_all;
     use tempfile::tempdir;
     use turbopath::AbsoluteSystemPathBuf;
-    use turborepo_api_client::APIClient;
+    use turborepo_analytics::start_analytics;
+    use turborepo_api_client::{analytics, APIClient};
     use turborepo_vercel_api_mock::start_test_server;
 
     use crate::{
         http::{APIAuth, HTTPCache},
-        test_cases::{get_test_cases, TestCase},
-        CacheOpts, CacheSource,
+        test_cases::{get_test_cases, validate_analytics, TestCase},
+        CacheError, CacheOpts, CacheSource,
     };
 
     #[tokio::test]
     async fn test_http_cache() -> Result<()> {
         let port = port_scanner::request_open_port().unwrap();
         let handle = tokio::spawn(start_test_server(port));
+        let test_cases = get_test_cases();
 
         try_join_all(
-            get_test_cases()
-                .into_iter()
+            test_cases
+                .iter()
                 .map(|test_case| round_trip_test(test_case, port)),
         )
         .await?;
 
+        validate_analytics(&test_cases, analytics::CacheSource::Remote, port).await?;
         handle.abort();
         Ok(())
     }
 
-    async fn round_trip_test(test_case: TestCase, port: u16) -> Result<()> {
+    async fn round_trip_test(test_case: &TestCase, port: u16) -> Result<()> {
         let repo_root = tempdir()?;
         let repo_root_path = AbsoluteSystemPathBuf::try_from(repo_root.path())?;
         test_case.initialize(&repo_root_path)?;
 
-        let TestCase {
-            hash,
-            files,
-            duration,
-        } = test_case;
+        let hash = test_case.hash;
+        let files = &test_case.files;
+        let duration = test_case.duration;
 
         let api_client = APIClient::new(format!("http://localhost:{}", port), 200, "2.0.0", true)?;
         let opts = CacheOpts::default();
@@ -244,8 +269,20 @@ mod test {
             token: "my-token".to_string(),
             team_slug: None,
         };
+        let (analytics_recorder, analytics_handle) =
+            start_analytics(api_auth.clone(), api_client.clone());
 
-        let cache = HTTPCache::new(api_client, &opts, repo_root_path.to_owned(), api_auth);
+        let cache = HTTPCache::new(
+            api_client,
+            &opts,
+            repo_root_path.to_owned(),
+            api_auth,
+            Some(analytics_recorder),
+        );
+
+        // Should be a cache miss at first
+        let err = cache.fetch(hash).await.unwrap_err();
+        assert_matches!(err, CacheError::CacheMiss);
 
         let anchored_files: Vec<_> = files.iter().map(|f| f.path().to_owned()).collect();
         cache
@@ -270,6 +307,8 @@ mod test {
                 assert!(file_path.exists());
             }
         }
+
+        analytics_handle.close_with_timeout().await;
 
         Ok(())
     }

--- a/crates/turborepo-lib/Cargo.toml
+++ b/crates/turborepo-lib/Cargo.toml
@@ -79,6 +79,7 @@ tokio-util = { version = "0.7.7", features = ["compat"] }
 tonic = { version = "0.8.3", features = ["transport"] }
 tonic-reflection = { version = "0.6.0", optional = true }
 tower = "0.4.13"
+turborepo-analytics = { path = "../turborepo-analytics" }
 turborepo-auth = { path = "../turborepo-auth" }
 turborepo-fs = { path = "../turborepo-fs" }
 turborepo-repository = { path = "../turborepo-repository" }

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -15,11 +15,13 @@ use std::{
 };
 
 pub use cache::{RunCache, TaskCache};
-use chrono::Local;
+use chrono::{DateTime, Local};
 use itertools::Itertools;
 use rayon::iter::ParallelBridge;
 use tracing::{debug, info};
 use turbopath::AbsoluteSystemPathBuf;
+use turborepo_analytics::{start_analytics, AnalyticsHandle, AnalyticsSender};
+use turborepo_api_client::{APIAuth, APIClient};
 use turborepo_cache::{AsyncCache, RemoteCacheOpts};
 use turborepo_ci::Vendor;
 use turborepo_env::EnvironmentVariableMap;
@@ -73,6 +75,16 @@ impl<'a> Run<'a> {
         Ok(self.base.args().try_into()?)
     }
 
+    fn initialize_analytics(
+        api_auth: Option<APIAuth>,
+        api_client: APIClient,
+    ) -> Option<(AnalyticsSender, AnalyticsHandle)> {
+        // If there's no API auth, we don't want to record analytics
+        let api_auth = api_auth?;
+
+        Some(start_analytics(api_auth, api_client))
+    }
+
     fn print_run_prelude(&self, opts: &Opts<'_>, filtered_pkgs: &HashSet<WorkspaceName>) {
         let targets_list = opts.run_opts.tasks.join(", ");
         if opts.run_opts.single_package {
@@ -114,12 +126,36 @@ impl<'a> Run<'a> {
         );
         let start_at = Local::now();
         self.connect_process_manager(signal_subscriber);
+
+        let api_auth = self.base.api_auth()?;
+        let api_client = self.base.api_client()?;
+        let (analytics_sender, analytics_handle) =
+            Self::initialize_analytics(api_auth.clone(), api_client.clone()).unzip();
+
+        let result = self
+            .run_with_analytics(start_at, api_auth, api_client, analytics_sender)
+            .await;
+
+        if let Some(analytics_handle) = analytics_handle {
+            analytics_handle.close_with_timeout().await;
+        }
+
+        result
+    }
+
+    // We split this into a separate function because we need
+    // to close the AnalyticsHandle regardless of whether the run succeeds or not
+    async fn run_with_analytics(
+        &mut self,
+        start_at: DateTime<Local>,
+        api_auth: Option<APIAuth>,
+        api_client: APIClient,
+        analytics_sender: Option<AnalyticsSender>,
+    ) -> Result<i32, Error> {
         let package_json_path = self.base.repo_root.join_component("package.json");
         let root_package_json = PackageJson::load(&package_json_path)?;
         let mut opts = self.opts()?;
 
-        let api_auth = self.base.api_auth()?;
-        let api_client = self.base.api_client()?;
         let config = self.base.config()?;
 
         // Pulled from initAnalyticsClient in run.go
@@ -218,6 +254,7 @@ impl<'a> Run<'a> {
             &self.base.repo_root,
             api_client.clone(),
             api_auth.clone(),
+            analytics_sender,
         )?;
 
         info!("created cache");
@@ -509,6 +546,7 @@ impl<'a> Run<'a> {
             &self.base.repo_root,
             api_client.clone(),
             api_auth.clone(),
+            None,
         )?;
 
         let color_selector = ColorSelector::default();

--- a/crates/turborepo-vercel-api-mock/src/lib.rs
+++ b/crates/turborepo-vercel-api-mock/src/lib.rs
@@ -12,8 +12,8 @@ use axum::{
 use futures_util::StreamExt;
 use tokio::sync::Mutex;
 use turborepo_vercel_api::{
-    CachingStatus, CachingStatusResponse, Membership, Role, Space, SpaceRun, SpacesResponse, Team,
-    TeamsResponse, User, UserResponse, VerificationResponse,
+    AnalyticsEvent, CachingStatus, CachingStatusResponse, Membership, Role, Space, SpaceRun,
+    SpacesResponse, Team, TeamsResponse, User, UserResponse, VerificationResponse,
 };
 
 pub const EXPECTED_TOKEN: &str = "expected_token";
@@ -41,6 +41,9 @@ pub async fn start_test_server(port: u16) -> Result<()> {
     let put_durations_ref = get_durations_ref.clone();
     let put_tempdir_ref = Arc::new(tempfile::tempdir()?);
     let get_tempdir_ref = put_tempdir_ref.clone();
+
+    let get_analytics_events_ref = Arc::new(Mutex::new(Vec::new()));
+    let post_analytics_events_ref = get_analytics_events_ref.clone();
 
     let app = Router::new()
         .route(
@@ -175,7 +178,9 @@ pub async fn start_test_server(port: u16) -> Result<()> {
             get(|Path(hash): Path<String>| async move {
                 let root_path = get_tempdir_ref.path();
                 let file_path = root_path.join(&hash);
-                let buffer = std::fs::read(file_path).unwrap();
+                let Ok(buffer) = std::fs::read(file_path) else {
+                    return (StatusCode::NOT_FOUND, HeaderMap::new(), Vec::new());
+                };
                 let duration = get_durations_ref
                     .lock()
                     .await
@@ -189,7 +194,7 @@ pub async fn start_test_server(port: u16) -> Result<()> {
                     HeaderValue::from_str(&duration.to_string()).unwrap(),
                 );
 
-                (headers, buffer)
+                (StatusCode::FOUND, headers, buffer)
             }),
         )
         .route(
@@ -208,6 +213,21 @@ pub async fn start_test_server(port: u16) -> Result<()> {
 
                 (StatusCode::OK, headers)
             }),
+        )
+        .route(
+            "/v8/artifacts/events",
+            post(
+                |Json(analytics_events): Json<Vec<AnalyticsEvent>>| async move {
+                    post_analytics_events_ref
+                        .lock()
+                        .await
+                        .extend(analytics_events);
+                },
+            ),
+        )
+        .route(
+            "/v8/artifacts/events",
+            get(|| async move { Json(get_analytics_events_ref.lock().await.clone()) }),
         )
         .route(
             "/preflight/absolute-location",

--- a/crates/turborepo-vercel-api/Cargo.toml
+++ b/crates/turborepo-vercel-api/Cargo.toml
@@ -6,6 +6,11 @@ license = "MPL-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[dev-dependencies]
+insta = { version = "1.34.0", features = ["json"] }
+serde_json = { workspace = true }
+test-case = { workspace = true }
+
 [dependencies]
 chrono = { workspace = true, features = ["serde"] }
 serde = { workspace = true }

--- a/crates/turborepo-vercel-api/src/lib.rs
+++ b/crates/turborepo-vercel-api/src/lib.rs
@@ -124,3 +124,75 @@ pub struct APIError {
     pub code: String,
     pub message: String,
 }
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum CacheSource {
+    Local,
+    Remote,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum CacheEvent {
+    Hit,
+    Miss,
+}
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct AnalyticsEvent {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    pub source: CacheSource,
+    pub event: CacheEvent,
+    pub hash: String,
+    pub duration: u64,
+}
+
+impl AnalyticsEvent {
+    pub fn set_session_id(&mut self, id: String) {
+        self.session_id = Some(id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use test_case::test_case;
+
+    use crate::{AnalyticsEvent, CacheEvent, CacheSource};
+
+    #[test_case(
+      AnalyticsEvent {
+        session_id: Some("session-id".to_string()),
+        source: CacheSource::Local,
+        event: CacheEvent::Hit,
+        hash: "this-is-my-hash".to_string(),
+        duration: 58,
+      },
+      "with-id-local-hit"
+    )]
+    #[test_case(
+      AnalyticsEvent {
+        session_id: Some("session-id".to_string()),
+        source: CacheSource::Remote,
+        event: CacheEvent::Miss,
+        hash: "this-is-my-hash-2".to_string(),
+        duration: 21,
+      },
+      "with-id-remote-miss"
+    )]
+    #[test_case(
+      AnalyticsEvent {
+        session_id: None,
+        source: CacheSource::Remote,
+        event: CacheEvent::Miss,
+        hash: "this-is-my-hash-2".to_string(),
+        duration: 21,
+      },
+      "without-id-remote-miss"
+    )]
+    fn test_serialize_analytics_event(event: AnalyticsEvent, name: &str) {
+        let json = serde_json::to_string(&event).unwrap();
+        insta::assert_json_snapshot!(name, json);
+    }
+}

--- a/crates/turborepo-vercel-api/src/snapshots/turborepo_vercel_api__tests__with-id-local-hit.snap
+++ b/crates/turborepo-vercel-api/src/snapshots/turborepo_vercel_api__tests__with-id-local-hit.snap
@@ -1,0 +1,5 @@
+---
+source: crates/turborepo-vercel-api/src/lib.rs
+expression: json
+---
+"{\"sessionId\":\"session-id\",\"source\":\"LOCAL\",\"event\":\"HIT\",\"hash\":\"this-is-my-hash\",\"duration\":58}"

--- a/crates/turborepo-vercel-api/src/snapshots/turborepo_vercel_api__tests__with-id-remote-miss.snap
+++ b/crates/turborepo-vercel-api/src/snapshots/turborepo_vercel_api__tests__with-id-remote-miss.snap
@@ -1,0 +1,5 @@
+---
+source: crates/turborepo-vercel-api/src/lib.rs
+expression: json
+---
+"{\"sessionId\":\"session-id\",\"source\":\"REMOTE\",\"event\":\"MISS\",\"hash\":\"this-is-my-hash-2\",\"duration\":21}"

--- a/crates/turborepo-vercel-api/src/snapshots/turborepo_vercel_api__tests__without-id-remote-miss.snap
+++ b/crates/turborepo-vercel-api/src/snapshots/turborepo_vercel_api__tests__without-id-remote-miss.snap
@@ -1,0 +1,5 @@
+---
+source: crates/turborepo-vercel-api/src/lib.rs
+expression: json
+---
+"{\"source\":\"REMOTE\",\"event\":\"MISS\",\"hash\":\"this-is-my-hash-2\",\"duration\":21}"

--- a/go.work.sum
+++ b/go.work.sum
@@ -135,11 +135,13 @@ golang.org/x/image v0.0.0-20190802002840-cff245a6509b h1:+qEpEAPhDZ1o0x3tHzZTQDA
 golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 h1:VLliZ0d+/avPrXXH+OakdXhpJuEoBZuwh1m2j7U6Iug=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028 h1:4+4C/Iv2U4fMZBiMCc98MG1In4gJY5YRhtpDNeDeHWs=
 golang.org/x/mod v0.7.0 h1:LapD9S96VoQRhi/GrNTqeBJFrUjs5UHCAtTlgwA5oZA=
+golang.org/x/mod v0.8.0 h1:LUYupSeNrTNCGzR/hVBk2NHZO4hXcVaW1k4Qx7rjPx8=
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/net v0.10.0/go.mod h1:0qNGK6F8kojg2nk9dLZ2mShWaEBan6FAoqfSigmmuDg=
 golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 h1:RerP+noqYHUQ8CMRcPlC2nvTa4dcBIjegkuWdcUDuqg=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0 h1:/5xXl8Y5W96D+TtHSlonuFqGHIWVuyCkGJLwGh9JJFs=
 golang.org/x/tools v0.4.0 h1:7mTAgkunk3fr4GAloyyCasadO6h9zSsQZbwvcaIciV4=
+golang.org/x/tools v0.6.0 h1:BOw41kyTf3PuCW1pVQf8+Cyg8pMlkYB1oo9iJ6D/lKM=
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 google.golang.org/api v0.62.0 h1:PhGymJMXfGBzc4lBRmrx9+1w4w2wEzURHNGF/sD/xGc=


### PR DESCRIPTION
### Description

Adds analytics client for cache hits and misses.

### Testing Instructions

Added analytics to our round trip cache tests. Validates that we're properly sending the events.
