### PR TITLE
fix: global hash divergence for empty version strings

### DIFF
--- a/cli/internal/fs/hash/capnp.go
+++ b/cli/internal/fs/hash/capnp.go
@@ -320,7 +320,10 @@ func HashLockfilePackages(packages []lockfile.Package) (string, error) {
 			return "", err
 		}
 
-		err = entry.SetVersion(pkg.Version)
+		// We explicitly write Version to match Rust behavior when writing empty strings
+		// The Go library will emit a null pointer if the string is empty instead
+		// of a zero length list.
+		err = capnp.Struct(entry).SetNewText(1, pkg.Version)
 		if err != nil {
 			return "", err
 		}

--- a/cli/internal/fs/hash/capnp_test.go
+++ b/cli/internal/fs/hash/capnp_test.go
@@ -92,6 +92,23 @@ func Test_LockfilePackagesNonEmpty(t *testing.T) {
 	assert.Equal(t, "9e60782f386d8ff1", hash)
 }
 
+func Test_LockfilePackagesEmptyVersion(t *testing.T) {
+	packages := []lockfile.Package{
+		{
+			Key:     "key",
+			Version: "",
+			Found:   true,
+		},
+	}
+
+	hash, err := HashLockfilePackages(packages)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, "bde280722f61644a", hash)
+}
+
 func Test_CapnpLockfilePackages_InOrder(t *testing.T) {
 	packages := []lockfile.Package{
 		{

--- a/crates/turborepo-lib/src/hash/mod.rs
+++ b/crates/turborepo-lib/src/hash/mod.rs
@@ -445,6 +445,10 @@ mod test {
     }], "1b266409f3ae154e" ; "non-empty")]
     #[test_case(vec![Package {
         key: "key".to_string(),
+        version: "".to_string(),
+    }], "bde280722f61644a" ; "empty version")]
+    #[test_case(vec![Package {
+        key: "key".to_string(),
         version: "version".to_string(),
     }, Package {
         key: "zey".to_string(),


### PR DESCRIPTION
### Description

@mehulkar uncovered a case where we had hash divergence between Rust/Go on Windows. It was initially caused by something in the prysk setup where `package.json` got a dependency of the form: `"monorepo": "file:"`. This caused an external dependency to be listed with an empty version string. This proved to be problematic as the Go capnp library [encodes empty strings as null pointers](https://github.com/capnproto/go-capnp/blob/main/struct.go#L139) instead of a zero length byte array as Rust does.

As the Go library exposes slightly more internals, I chose to change the Go code to circumvent the empty string behavior.

Future work might be disallowing empty version strings, but that's a larger change and something that requires more investigation. `npm` is happy to produce/parse/use a dependency with version `file:` so we should probably support it.

### Testing Instructions

Added unit tests for serializing lockfile packages with an empty version string from Rust and Go. The first commit of the PR adds these tests where it fails on Go to match the Rust hash.

Also can check against the case that @mehulkar uncovered:
 - `mkdir /tmp/test && cd /tmp/test`
 - `~/code/turbo/turborepo-tests/integration/tests/_helpers/setup_monorepo.sh $(pwd)`
 - Edit `package.json` to contain `"dependencies": { "monorepo": "file:" }`
 - Regenerate `package-lock.json` by `npm install`
 - `turbo build --dry=json` should now pass with a binary built using this PR


Closes TURBO-1557