### PR TITLE
fix(Turborepo): Build x86_64-unknown-linux-gnu so that it works on AWS lambda

### DIFF
--- a/.github/workflows/turborepo-library-release.yml
+++ b/.github/workflows/turborepo-library-release.yml
@@ -27,13 +27,26 @@ jobs:
               echo "CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++" >> $GITHUB_ENV
           - host: ubuntu-latest
             target: "x86_64-unknown-linux-gnu"
+            container: amazon/aws-lambda-nodejs:18
+            install: |
+              yum install -y gcc gcc-c++ git
+              curl https://sh.rustup.rs -sSf | bash -s -- -y
+              npm i -g pnpm@8.9.0
+            setup: |
+              pnpm install
           - host: windows-latest
             target: "aarch64-pc-windows-msvc"
           - host: windows-latest
             target: "x86_64-pc-windows-msvc"
 
     runs-on: ${{ matrix.settings.host }}
+    container:
+      image: ${{ matrix.settings.container }}
     steps:
+      - name: Install Packages
+        run: ${{ matrix.settings.install }}
+        if: ${{ matrix.settings.install }}
+
       - name: Checkout
         uses: actions/checkout@v3
         with:
@@ -43,11 +56,13 @@ jobs:
         uses: ./.github/actions/setup-rust
         with:
           targets: ${{ matrix.settings.target }}
+        if: ${{ !matrix.settings.install }}
 
       - name: Setup Node
         uses: ./.github/actions/setup-node
         with:
           enable-corepack: false
+        if: ${{ !matrix.settings.install }}
 
       - name: Setup toolchain
         run: ${{ matrix.settings.setup }}

--- a/packages/turbo-repository/js/index.js
+++ b/packages/turbo-repository/js/index.js
@@ -27,6 +27,21 @@ function isMusl() {
     }
   } else {
     const { glibcVersionRuntime } = process.report.getReport().header;
+    if (typeof glibcVersionRuntime === "string") {
+      try {
+        // We support glibc v2.26+
+        let [major, minor] = glibcVersionRuntime.split(".", 2);
+        if (parseInt(major, 10) !== 2) {
+          return true;
+        }
+        if (parseInt(minor, 10) < 26) {
+          return true;
+        }
+        return false;
+      } catch (e) {
+        return true;
+      }
+    }
     return !glibcVersionRuntime;
   }
 }

--- a/packages/turbo-repository/js/package.json
+++ b/packages/turbo-repository/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/repository",
-  "version": "0.0.1-canary.0",
+  "version": "0.0.1-canary.1",
   "description": "",
   "bugs": "https://github.com/vercel/turbo/issues",
   "homepage": "https://turbo.build/repo",
@@ -14,11 +14,11 @@
     "dist/index.d.ts"
   ],
   "optionalDependencies": {
-    "@turbo/repository-darwin-x64": "0.0.1-canary.0",
-    "@turbo/repository-darwin-arm64": "0.0.1-canary.0",
-    "@turbo/repository-linux-x64-gnu": "0.0.1-canary.0",
-    "@turbo/repository-linux-arm64-gnu": "0.0.1-canary.0",
-    "@turbo/repository-win32-x64-msvc": "0.0.1-canary.0",
-    "@turbo/repository-win32-arm64-msvc": "0.0.1-canary.0"
+    "@turbo/repository-darwin-x64": "0.0.1-canary.1",
+    "@turbo/repository-darwin-arm64": "0.0.1-canary.1",
+    "@turbo/repository-linux-x64-gnu": "0.0.1-canary.1",
+    "@turbo/repository-linux-arm64-gnu": "0.0.1-canary.1",
+    "@turbo/repository-win32-x64-msvc": "0.0.1-canary.1",
+    "@turbo/repository-win32-arm64-msvc": "0.0.1-canary.1"
   }
 }

--- a/packages/turbo-repository/npm/darwin-arm64/package.json
+++ b/packages/turbo-repository/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/repository-darwin-arm64",
-  "version": "0.0.1-canary.0",
+  "version": "0.0.1-canary.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/vercel/turbo",

--- a/packages/turbo-repository/npm/darwin-x64/package.json
+++ b/packages/turbo-repository/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/repository-darwin-x64",
-  "version": "0.0.1-canary.0",
+  "version": "0.0.1-canary.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/vercel/turbo",

--- a/packages/turbo-repository/npm/linux-arm64-gnu/package.json
+++ b/packages/turbo-repository/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/repository-linux-arm64-gnu",
-  "version": "0.0.1-canary.0",
+  "version": "0.0.1-canary.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/vercel/turbo",

--- a/packages/turbo-repository/npm/linux-x64-gnu/package.json
+++ b/packages/turbo-repository/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/repository-linux-x64-gnu",
-  "version": "0.0.1-canary.0",
+  "version": "0.0.1-canary.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/vercel/turbo",

--- a/packages/turbo-repository/npm/win32-arm64-msvc/package.json
+++ b/packages/turbo-repository/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/repository-win32-arm64-msvc",
-  "version": "0.0.1-canary.0",
+  "version": "0.0.1-canary.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/vercel/turbo",

--- a/packages/turbo-repository/npm/win32-x64-msvc/package.json
+++ b/packages/turbo-repository/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/repository-win32-x64-msvc",
-  "version": "0.0.1-canary.0",
+  "version": "0.0.1-canary.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/vercel/turbo",


### PR DESCRIPTION
### Description

 - Use `amazon/aws-lambda-nodejs:18` as a basis for building the `x86_64-unknown-linux-gnu` version of `@turbo/repository` so that it will be compatible with AWS lambda environments
 - Bump version to `0.0.1-canary.1`
 - Update `index.js` to prefer `musl` (which is not yet supported) for targets that don't have at least `glibc>=2.26`

### Testing Instructions

Manually verified that `x86_64-unknown-linux-gnu` artifact works on `amazon/aws-lambda-nodejs:18`, which has `glibc@2.26`

Closes TURBO-1558