### PR TITLE
build(cargo): skip external build script with rust-analyzer

### DIFF
--- a/crates/turborepo-lib/build.rs
+++ b/crates/turborepo-lib/build.rs
@@ -8,17 +8,31 @@ fn check_tls_config() {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     check_tls_config();
 
-    tonic_build::configure()
+    let tonic_build_result = tonic_build::configure()
         .build_server(true)
         .file_descriptor_set_path("src/daemon/file_descriptor_set.bin")
-        .compile(&["turbod.proto"], &["../../cli/internal/turbodprotocol"])?;
-
-    capnpc::CompilerCommand::new()
+        .compile(&["turbod.proto"], &["../../cli/internal/turbodprotocol"]);
+    let capnpc_result = capnpc::CompilerCommand::new()
         .file("./src/hash/proto.capnp")
         .import_path("./src/hash/std") // we need to include the 'stdlib' for capnp-go
         .default_parent_module(vec!["hash".to_string()])
-        .run()
-        .expect("schema compiler command");
+        .run();
+
+    let invocation = std::env::var("RUSTC_WRAPPER").unwrap_or_default();
+    if invocation.ends_with("rust-analyzer") {
+        if tonic_build_result.is_err() {
+            println!("cargo:warning=tonic_build failed, but continuing with rust-analyzer");
+        }
+
+        if capnpc_result.is_err() {
+            println!("cargo:warning=capnpc failed, but continuing with rust-analyzer");
+        }
+
+        return Ok(());
+    } else {
+        tonic_build_result.expect("tonic_build command");
+        capnpc_result.expect("schema compiler command");
+    }
 
     Ok(())
 }

--- a/crates/turborepo/build.rs
+++ b/crates/turborepo/build.rs
@@ -6,7 +6,8 @@ fn main() {
     let is_ci_release =
         &profile == "release" && matches!(env::var("RELEASE_TURBO_CLI"), Ok(v) if v == "true");
 
-    if !is_ci_release {
+    let invocation = std::env::var("RUSTC_WRAPPER").unwrap_or_default();
+    if !is_ci_release && !invocation.ends_with("rust-analyzer") {
         build_local_go_binary(profile);
     }
 }


### PR DESCRIPTION
### Description

Currently turborepo-* have some build script relies on external dependencies, which fails editor analysis if those are not ready. This makes some inconviniences if someone want to work on the turbopack specifics.

PR changes behavior for 2 build script, one for turborepo-lib to _allow_ failures with invocation of those dependencies, and _skipping_ turborepo's build script requires go toolchain.