### PR TITLE
fix(turbo-ignore): better error for invalid commit

### DIFF
--- a/packages/turbo-ignore/__tests__/ignore.test.ts
+++ b/packages/turbo-ignore/__tests__/ignore.test.ts
@@ -127,7 +127,7 @@ describe("turboIgnore()", () => {
 
     validateLogs(
       [
-        `turbo-ignore could not complete - commit does not exist or is unreachable`,
+        `turbo-ignore could not complete - a ref or SHA is invalid. It could have been removed from the branch history via a force push, or this could be a shallow clone with insufficient history`,
       ],
       mockConsole.warn,
       { prefix: "≫  " }

--- a/packages/turbo-ignore/src/errors.ts
+++ b/packages/turbo-ignore/src/errors.ts
@@ -2,25 +2,27 @@ import type { NonFatalErrorKey, NonFatalErrors } from "./types";
 
 export const NON_FATAL_ERRORS: NonFatalErrors = {
   MISSING_LOCKFILE: {
-    regex:
+    regex: [
       /reading (?:yarn.lock|package-lock.json|pnpm-lock.yaml):.*?no such file or directory/i,
+    ],
     message: `turbo-ignore could not complete - no lockfile found, please commit one to your repository`,
   },
   NO_PACKAGE_MANAGER: {
-    regex:
+    regex: [
       /run failed: We did not detect an in-use package manager for your project/i,
+    ],
     message: `turbo-ignore could not complete - no package manager detected, please commit a lockfile, or set "packageManager" in your root "package.json"`,
   },
   UNREACHABLE_PARENT: {
-    regex: /failed to resolve packages to run: commit HEAD\^ does not exist/i,
+    regex: [/failed to resolve packages to run: commit HEAD\^ does not exist/i],
     message: `turbo-ignore could not complete - parent commit does not exist or is unreachable`,
   },
-  UNREACHABLE_COMMIT: {
-    regex: /commit \S+ does not exist/i,
-    message: `turbo-ignore could not complete - commit does not exist or is unreachable`,
-  },
   INVALID_COMPARISON: {
-    regex: /invalid symmetric difference expression/i,
+    regex: [
+      /commit \S+ does not exist/i,
+      /unknown revision/i,
+      /invalid symmetric difference expression/i,
+    ],
     message: `turbo-ignore could not complete - a ref or SHA is invalid. It could have been removed from the branch history via a force push, or this could be a shallow clone with insufficient history`,
   },
 };
@@ -32,7 +34,7 @@ export function shouldWarn({ err }: { err: string }): {
 } {
   const knownError = Object.keys(NON_FATAL_ERRORS).find((key) => {
     const { regex } = NON_FATAL_ERRORS[key as NonFatalErrorKey];
-    return regex.test(err);
+    return regex.some((r) => r.test(err));
   });
 
   if (knownError) {

--- a/packages/turbo-ignore/src/types.ts
+++ b/packages/turbo-ignore/src/types.ts
@@ -2,11 +2,10 @@ export type NonFatalErrorKey =
   | "MISSING_LOCKFILE"
   | "NO_PACKAGE_MANAGER"
   | "UNREACHABLE_PARENT"
-  | "UNREACHABLE_COMMIT"
   | "INVALID_COMPARISON";
 
 export interface NonFatalError {
-  regex: RegExp;
+  regex: Array<RegExp>;
   message: string;
 }
 


### PR DESCRIPTION
### Description

Adds a better error to cover the case when the commit to compare is invalid


Closes TURBO-1560