### PR TITLE
fix: explicitly set turbo command name

### DIFF
--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -80,6 +80,7 @@ pub enum EnvMode {
 #[clap(disable_help_subcommand = true)]
 #[clap(disable_version_flag = true)]
 #[clap(arg_required_else_help = true)]
+#[command(name = "turbo")]
 pub struct Args {
     #[clap(long, global = true)]
     #[serde(skip)]


### PR DESCRIPTION
### Description

Explicitly set the [command name](https://docs.rs/clap/latest/clap/_derive/index.html#command-attributes) which defaults to the crate name if one isn't provided.

### Testing Instructions

`.cram/bin/prysk --shell=bash tests/no_args.t` now passes locally on my machine

Can also be verified by expanding the `Parser` macro and verifying that the impl for `clap::CommandFactory` now uses `"turbo"` instead of `"turborepo-lib"`


Closes TURBO-1561