### PR TITLE
fix(docs): Add full stop punctuation and add inifinitive marker to verb

### DIFF
--- a/docs/pages/repo/docs/getting-started/existing-monorepo.mdx
+++ b/docs/pages/repo/docs/getting-started/existing-monorepo.mdx
@@ -44,7 +44,7 @@ packages:
 ```
 
 <Callout>
-`pnpm` supports the ability declare workspaces in deeply nested subdirectories with a `**` Turborepo does not currently support this behavior.
+`pnpm` supports the ability to declare workspaces in deeply nested subdirectories with a `**`. Turborepo does not currently support this behavior.
 </Callout>
   </Tab>
 </Tabs>


### PR DESCRIPTION
### Description

Add missing full stop, also added infinitive marker (to) to the verb (declare)