### PR TITLE
feat: add support for --parallel

### DIFF
--- a/crates/turborepo-lib/src/opts.rs
+++ b/crates/turborepo-lib/src/opts.rs
@@ -57,7 +57,7 @@ impl<'a> From<&'a RunArgs> for RunCacheOpts {
 pub struct RunOpts<'a> {
     pub(crate) tasks: &'a [String],
     pub(crate) concurrency: u32,
-    parallel: bool,
+    pub(crate) parallel: bool,
     pub(crate) env_mode: EnvMode,
     // Whether or not to infer the framework for each workspace.
     pub(crate) framework_inference: bool,

--- a/crates/turborepo-lib/src/package_graph/mod.rs
+++ b/crates/turborepo-lib/src/package_graph/mod.rs
@@ -120,30 +120,17 @@ impl PackageGraph {
         Ok(graph::validate_graph(&self.workspace_graph)?)
     }
 
-    pub fn no_workspace_dependencies(self) -> Self {
-        let Self {
-            mut workspace_graph,
-            node_lookup,
-            workspaces,
-            package_manager,
-            lockfile,
-        } = self;
-        let root_index = node_lookup
+    pub fn remove_workspace_dependencies(&mut self) {
+        let root_index = self
+            .node_lookup
             .get(&WorkspaceNode::Root)
             .expect("graph should have root workspace node");
-        workspace_graph.retain_edges(|graph, index| {
+        self.workspace_graph.retain_edges(|graph, index| {
             let Some((_src, dst)) = graph.edge_endpoints(index) else {
                 return false;
             };
             dst == *root_index
         });
-        Self {
-            workspace_graph,
-            node_lookup,
-            workspaces,
-            package_manager,
-            lockfile,
-        }
     }
 
     /// Returns the number of workspaces in the repo

--- a/crates/turborepo-lib/src/package_graph/mod.rs
+++ b/crates/turborepo-lib/src/package_graph/mod.rs
@@ -120,6 +120,32 @@ impl PackageGraph {
         Ok(graph::validate_graph(&self.workspace_graph)?)
     }
 
+    pub fn no_workspace_dependencies(self) -> Self {
+        let Self {
+            mut workspace_graph,
+            node_lookup,
+            workspaces,
+            package_manager,
+            lockfile,
+        } = self;
+        let root_index = node_lookup
+            .get(&WorkspaceNode::Root)
+            .expect("graph should have root workspace node");
+        workspace_graph.retain_edges(|graph, index| {
+            let Some((_src, dst)) = graph.edge_endpoints(index) else {
+                return false;
+            };
+            dst == *root_index
+        });
+        Self {
+            workspace_graph,
+            node_lookup,
+            workspaces,
+            package_manager,
+            lockfile,
+        }
+    }
+
     /// Returns the number of workspaces in the repo
     /// *including* the root workspace.
     pub fn len(&self) -> usize {

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -227,22 +227,6 @@ impl<'a> Run<'a> {
                 )
             })?;
 
-        if let Some(graph_opts) = opts.run_opts.graph {
-            match graph_opts {
-                GraphOpts::File(graph_file) => {
-                    let graph_file =
-                        AbsoluteSystemPathBuf::from_unknown(self.base.cwd(), graph_file);
-                    let file = graph_file.open()?;
-                    let _writer = BufWriter::new(file);
-                    todo!("Need to implement different format support");
-                }
-                GraphOpts::Stdout => {
-                    engine.dot_graph(std::io::stdout(), opts.run_opts.single_package)?
-                }
-            }
-            return Ok(0);
-        }
-
         if !opts.run_opts.dry_run {
             self.print_run_prelude(&opts, &filtered_pkgs);
         }
@@ -302,6 +286,22 @@ impl<'a> Run<'a> {
             engine.task_definitions(),
             &self.base.repo_root,
         )?;
+
+        if let Some(graph_opts) = opts.run_opts.graph {
+            match graph_opts {
+                GraphOpts::File(graph_file) => {
+                    let graph_file =
+                        AbsoluteSystemPathBuf::from_unknown(self.base.cwd(), graph_file);
+                    let file = graph_file.open()?;
+                    let _writer = BufWriter::new(file);
+                    todo!("Need to implement different format support");
+                }
+                GraphOpts::Stdout => {
+                    engine.dot_graph(std::io::stdout(), opts.run_opts.single_package)?
+                }
+            }
+            return Ok(0);
+        }
 
         // remove dead code warnings
         let _proc_manager = ProcessManager::new();

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -229,7 +229,7 @@ impl<'a> Run<'a> {
                 )
             })?;
 
-        if !opts.run_opts.dry_run {
+        if !opts.run_opts.dry_run && opts.run_opts.graph.is_none() {
             self.print_run_prelude(&opts, &filtered_pkgs);
         }
 

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -290,7 +290,7 @@ impl<'a> Run<'a> {
         )?;
 
         if opts.run_opts.parallel {
-            pkg_dep_graph = pkg_dep_graph.no_workspace_dependencies();
+            pkg_dep_graph.remove_workspace_dependencies();
             engine = self.build_engine(&pkg_dep_graph, &opts, &root_turbo_json, &filtered_pkgs)?;
         }
 
@@ -496,7 +496,7 @@ impl<'a> Run<'a> {
         )?;
 
         if opts.run_opts.parallel {
-            pkg_dep_graph = pkg_dep_graph.no_workspace_dependencies();
+            pkg_dep_graph.remove_workspace_dependencies();
             engine = self.build_engine(&pkg_dep_graph, &opts, &root_turbo_json, &filtered_pkgs)?;
         }
 


### PR DESCRIPTION
### Description

This PR hooks up the correct behavior of `--parallel`

Some code shuffling happens in the first few commits to get the Rust `run` function in a closer shape the Go code.

### Testing Instructions

- Create a new repo with `npx create-turbo`
- Remove installed version of turbo `npm rm turbo`
- Add a `build` script to `packages/ui/package.json`: `"build": "echo 'building'; sleep 5; echo 'done'",`
- `turbo_dev build --parallel --experimental-rust-codepath` should show that `docs#build` and `web#build` start before`ui#build` is finished even though they depend on the `ui` workspace


Closes TURBO-1566