### PR TITLE
fix: Empty command returns help text and not error

### DIFF
--- a/benchmark/src/ttft.ts
+++ b/benchmark/src/ttft.ts
@@ -30,7 +30,7 @@ if (!fs.existsSync(TURBO_BIN)) {
   throw new Error("No turbo binary found");
 }
 
-const turboFlags = `-vvv --experimental-rust-codepath --dry --skip-infer --profile=${fullProfilePath}`;
+const turboFlags = `-vvv --dry --skip-infer --profile=${fullProfilePath}`;
 
 console.log("Executing turbo build in child process", {
   cwd: process.cwd(),
@@ -42,7 +42,10 @@ console.log("Executing turbo build in child process", {
 // When this script runs, cwd is benchmark/large-monorepo (i.e. REPO_PATH)
 const cmd = `${TURBO_BIN} run build ${turboFlags}`;
 try {
-  cp.execSync(cmd, DEFAULT_EXEC_OPTS);
+  cp.execSync(cmd, {
+    ...DEFAULT_EXEC_OPTS,
+    env: { ...process.env, EXPERIMENTAL_RUST_CODEPATH: "true" },
+  });
 } catch (e) {
   // catch errors and exit. the build command seems to be erroring out due to very large output?
   // need to chase it down, but the benchmark seems to still be working, and when the same turbo run build

--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -147,6 +147,11 @@ pub struct Args {
     pub run_args: Option<RunArgs>,
     #[clap(subcommand)]
     pub command: Option<Command>,
+
+    /// Opt-in to the rust codepath for running turbo
+    /// rather than using the go shim
+    #[clap(long, env, hide = true, default_value_t = false)]
+    pub experimental_rust_codepath: bool,
 }
 
 #[derive(Debug, Parser, Serialize, Clone, Copy, PartialEq, Eq, Default)]
@@ -587,11 +592,6 @@ pub struct RunArgs {
     // Pass a string to enable posting Run Summaries to Vercel
     #[clap(long, hide = true)]
     pub experimental_space_id: Option<String>,
-
-    /// Opt-in to the rust codepath for running turbo
-    /// rather than using the go shim
-    #[clap(long, env, hide = true, default_value_t = false)]
-    pub experimental_rust_codepath: bool,
 }
 
 #[derive(ValueEnum, Clone, Copy, Debug, PartialEq, Serialize)]
@@ -816,7 +816,7 @@ pub async fn run(
             }
             let base = CommandBase::new(cli_args.clone(), repo_root, version, ui);
 
-            if args.experimental_rust_codepath {
+            if cli_args.experimental_rust_codepath {
                 use crate::commands::run;
                 let exit_code = run::run(base).await?;
                 Ok(Payload::Rust(Ok(exit_code)))

--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -150,7 +150,10 @@ pub struct Args {
 
     /// Opt-in to the rust codepath for running turbo
     /// rather than using the go shim
-    #[clap(long, env, hide = true, default_value_t = false, global = true)]
+    /// NOTE: This is only the flag. The env variable also needs to
+    /// be checked, but we can't do it in clap because then setting the
+    /// var will stop clap from showing the help text.
+    #[clap(long, hide = true, default_value_t = false, global = true)]
     #[serde(skip)]
     pub experimental_rust_codepath: bool,
 }
@@ -817,7 +820,9 @@ pub async fn run(
             }
             let base = CommandBase::new(cli_args.clone(), repo_root, version, ui);
 
-            if cli_args.experimental_rust_codepath {
+            if cli_args.experimental_rust_codepath
+                || env::var("EXPERIMENTAL_RUST_CODEPATH").as_deref() == Ok("true")
+            {
                 use crate::commands::run;
                 let exit_code = run::run(base).await?;
                 Ok(Payload::Rust(Ok(exit_code)))

--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -147,15 +147,6 @@ pub struct Args {
     pub run_args: Option<RunArgs>,
     #[clap(subcommand)]
     pub command: Option<Command>,
-
-    /// Opt-in to the rust codepath for running turbo
-    /// rather than using the go shim
-    /// NOTE: This is only the flag. The env variable also needs to
-    /// be checked, but we can't do it in clap because then setting the
-    /// var will stop clap from showing the help text.
-    #[clap(long, hide = true, default_value_t = false, global = true)]
-    #[serde(skip)]
-    pub experimental_rust_codepath: bool,
 }
 
 #[derive(Debug, Parser, Serialize, Clone, Copy, PartialEq, Eq, Default)]
@@ -820,9 +811,7 @@ pub async fn run(
             }
             let base = CommandBase::new(cli_args.clone(), repo_root, version, ui);
 
-            if cli_args.experimental_rust_codepath
-                || env::var("EXPERIMENTAL_RUST_CODEPATH").as_deref() == Ok("true")
-            {
+            if env::var("EXPERIMENTAL_RUST_CODEPATH").as_deref() == Ok("true") {
                 use crate::commands::run;
                 let exit_code = run::run(base).await?;
                 Ok(Payload::Rust(Ok(exit_code)))

--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -150,7 +150,8 @@ pub struct Args {
 
     /// Opt-in to the rust codepath for running turbo
     /// rather than using the go shim
-    #[clap(long, env, hide = true, default_value_t = false)]
+    #[clap(long, env, hide = true, default_value_t = false, global = true)]
+    #[serde(skip)]
     pub experimental_rust_codepath: bool,
 }
 

--- a/turborepo-tests/integration/tests/bad_flag.t
+++ b/turborepo-tests/integration/tests/bad_flag.t
@@ -19,7 +19,7 @@ Bad flag with an implied run command should display run flags
   
     tip: to pass '--bad-flag' as a value, use '-- --bad-flag'
   
-  Usage: turbo <--cache-dir <CACHE_DIR>|--cache-workers <CACHE_WORKERS>|--concurrency <CONCURRENCY>|--continue|--dry-run [<DRY_RUN>]|--single-package|--filter <FILTER>|--force [<FORCE>]|--framework-inference [<BOOL>]|--global-deps <GLOBAL_DEPS>|--graph [<GRAPH>]|--env-mode [<ENV_MODE>]|--ignore <IGNORE>|--include-dependencies|--no-cache|--no-daemon|--no-deps|--output-logs <OUTPUT_LOGS>|--log-order <LOG_ORDER>|--only|--parallel|--pkg-inference-root <PKG_INFERENCE_ROOT>|--profile <PROFILE>|--remote-only [<BOOL>]|--scope <SCOPE>|--since <SINCE>|--summarize [<SUMMARIZE>]|--log-prefix <LOG_PREFIX>|TASKS|PASS_THROUGH_ARGS|--experimental-space-id <EXPERIMENTAL_SPACE_ID>|--experimental-rust-codepath>
+  Usage: turbo <--cache-dir <CACHE_DIR>|--cache-workers <CACHE_WORKERS>|--concurrency <CONCURRENCY>|--continue|--dry-run [<DRY_RUN>]|--single-package|--filter <FILTER>|--force [<FORCE>]|--framework-inference [<BOOL>]|--global-deps <GLOBAL_DEPS>|--graph [<GRAPH>]|--env-mode [<ENV_MODE>]|--ignore <IGNORE>|--include-dependencies|--no-cache|--no-daemon|--no-deps|--output-logs <OUTPUT_LOGS>|--log-order <LOG_ORDER>|--only|--parallel|--pkg-inference-root <PKG_INFERENCE_ROOT>|--profile <PROFILE>|--remote-only [<BOOL>]|--scope <SCOPE>|--since <SINCE>|--summarize [<SUMMARIZE>]|--log-prefix <LOG_PREFIX>|TASKS|PASS_THROUGH_ARGS|--experimental-space-id <EXPERIMENTAL_SPACE_ID>>
   
   For more information, try '--help'.
   

--- a/turborepo-tests/integration/tests/dry_json/monorepo-no-changes.t
+++ b/turborepo-tests/integration/tests/dry_json/monorepo-no-changes.t
@@ -9,7 +9,7 @@ Setup
   []
 
 # Save JSON to tmp file so we don't need to keep re-running the build
-  $ ${TURBO} run build --experimental-rust-codepath --dry=json --filter=main > tmpjson.log
+  $ EXPERIMENTAL_RUST_CODEPATH=true ${TURBO} run build --dry=json --filter=main > tmpjson.log
 
   $ cat tmpjson.log | jq .packages
   []

--- a/turborepo-tests/integration/tests/run-summary/monorepo.t
+++ b/turborepo-tests/integration/tests/run-summary/monorepo.t
@@ -126,7 +126,7 @@ Setup
 # Delete all run summaries
   $ rm -rf .turbo/runs
 
-  $ ${TURBO} run build --summarize --experimental-rust-codepath --no-daemon -- someargs > /dev/null # first run (should be cache miss)
+  $ EXPERIMENTAL_RUST_CODEPATH=true ${TURBO} run build --summarize --no-daemon -- someargs > /dev/null # first run (should be cache miss)
 
 # HACK: Generated run summaries are named with a ksuid, which is a time-sorted ID. This _generally_ works
 # but we're seeing in this test that sometimes a summary file is not sorted (with /bin/ls) in the order we expect
@@ -138,7 +138,7 @@ Setup
 # If you find this sleep statement, try running this test 10 times in a row. If there are no
 # failures, it *should* be safe to remove.
   $ sleep 1
-  $ ${TURBO} run build --summarize --experimental-rust-codepath --no-daemon -- someargs > /dev/null # run again (expecting full turbo here)
+  $ EXPERIMENTAL_RUST_CODEPATH=true ${TURBO} run build --summarize --no-daemon -- someargs > /dev/null # run again (expecting full turbo here)
 
 # no output, just check for 0 status code, which means the directory was created
   $ test -d .turbo/runs

--- a/turborepo-tests/integration/tests/run-summary/single-package.t
+++ b/turborepo-tests/integration/tests/run-summary/single-package.t
@@ -113,7 +113,7 @@ Check
 
   $ rm -r .turbo/runs
 Check Rust implementation
-  $ ${TURBO} run build --summarize --experimental-rust-codepath --no-daemon > /dev/null
+  $ EXPERIMENTAL_RUST_CODEPATH=true ${TURBO} run build --summarize --no-daemon > /dev/null
   $ test -d .turbo/runs
   $ ls .turbo/runs/*.json | wc -l
   \s*1 (re)

--- a/turborepo-tests/integration/tests/single_package/graph.t
+++ b/turborepo-tests/integration/tests/single_package/graph.t
@@ -14,7 +14,7 @@ Graph
   }
   
 Graph in Rust
-  $ ${TURBO} run build --graph --experimental-rust-codepath
+  $ EXPERIMENTAL_RUST_CODEPATH=true ${TURBO} run build --graph
   digraph {
   \tcompound = "true" (esc)
   \tnewrank = "true" (esc)


### PR DESCRIPTION
### Description
Our command version test that runs `turbo -v` returns the help text on the rust codepath. This is because if `EXPERIMENTAL_RUST_CODEPATH` is set, it implicitly creates the `RunArgs` struct in `Args`, which then makes our code think that the user passed a command when they didn't.

We solve this by moving the `experimental_rust_codepath` field to the global `Args` struct (it doesn't really matter where the flag is because it's a purely internal). 

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->


Closes TURBO-1567