### PR TITLE
chore(js): output packages to ESM only

### DIFF
--- a/packages/create-turbo/src/transforms/official-starter.ts
+++ b/packages/create-turbo/src/transforms/official-starter.ts
@@ -1,9 +1,9 @@
 import path from "node:path";
-import { readJsonSync, writeJsonSync, rmSync, existsSync } from "fs-extra";
+import { readJsonSync, writeJsonSync, rmSync, existsSync } from "fs-extra/esm";
 import type { PackageJson } from "@turbo/utils";
-import semverPrerelease from "semver/functions/prerelease";
+import semverPrerelease from "semver/functions/prerelease.js";
 import cliPkgJson from "../../package.json";
-import { isDefaultExample } from "../utils/isDefaultExample";
+import { isDefaultExample } from "../utils/isDefaultExample.js";
 import type { TransformInput, TransformResult } from "./types";
 import { TransformError } from "./errors";
 

--- a/packages/create-turbo/tsup.config.ts
+++ b/packages/create-turbo/tsup.config.ts
@@ -4,7 +4,7 @@ export default defineConfig((options: Options) => ({
   entry: ["src/cli.ts"],
   format: ["esm"],
   shim: true, // Add shims for things like __filename and __dirname usage
-  clean: true,
-  minify: true,
+  // clean: true,
+  // minify: true,
   ...options,
 }));

--- a/packages/create-turbo/tsup.config.ts
+++ b/packages/create-turbo/tsup.config.ts
@@ -3,6 +3,7 @@ import { defineConfig, Options } from "tsup";
 export default defineConfig((options: Options) => ({
   entry: ["src/cli.ts"],
   format: ["esm"],
+  shim: true,
   clean: true,
   minify: true,
   ...options,

--- a/packages/create-turbo/tsup.config.ts
+++ b/packages/create-turbo/tsup.config.ts
@@ -3,7 +3,7 @@ import { defineConfig, Options } from "tsup";
 export default defineConfig((options: Options) => ({
   entry: ["src/cli.ts"],
   format: ["esm"],
-  shim: true,
+  shim: true, // Add shims for things like __filename and __dirname usage
   clean: true,
   minify: true,
   ...options,

--- a/packages/create-turbo/tsup.config.ts
+++ b/packages/create-turbo/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig, Options } from "tsup";
 
 export default defineConfig((options: Options) => ({
   entry: ["src/cli.ts"],
-  format: ["cjs"],
+  format: ["esm"],
   clean: true,
   minify: true,
   ...options,

--- a/packages/turbo-codemod/tsup.config.ts
+++ b/packages/turbo-codemod/tsup.config.ts
@@ -3,7 +3,8 @@ import { defineConfig, Options } from "tsup";
 export default defineConfig((options: Options) => ({
   entry: ["src/cli.ts", "src/transforms/*.ts"],
   format: ["esm"],
+  shim: true,
   clean: true,
-  minify: true,
+  // minify: true,
   ...options,
 }));

--- a/packages/turbo-codemod/tsup.config.ts
+++ b/packages/turbo-codemod/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig, Options } from "tsup";
 
 export default defineConfig((options: Options) => ({
   entry: ["src/cli.ts", "src/transforms/*.ts"],
-  format: ["cjs"],
+  format: ["esm"],
   clean: true,
   minify: true,
   ...options,

--- a/packages/turbo-gen/tsup.config.ts
+++ b/packages/turbo-gen/tsup.config.ts
@@ -5,7 +5,7 @@ import chalk from "chalk";
 export default defineConfig((options: Options) => ({
   entry: ["src/cli.ts", "src/types.ts"],
   format: ["esm"],
-  shim: true,
+  shim: true, // Add shims for things like __filename and __dirname usage
   dts: true,
   clean: true,
   minify: true,

--- a/packages/turbo-gen/tsup.config.ts
+++ b/packages/turbo-gen/tsup.config.ts
@@ -5,6 +5,7 @@ import chalk from "chalk";
 export default defineConfig((options: Options) => ({
   entry: ["src/cli.ts", "src/types.ts"],
   format: ["esm"],
+  shim: true,
   dts: true,
   clean: true,
   minify: true,

--- a/packages/turbo-gen/tsup.config.ts
+++ b/packages/turbo-gen/tsup.config.ts
@@ -4,7 +4,7 @@ import chalk from "chalk";
 
 export default defineConfig((options: Options) => ({
   entry: ["src/cli.ts", "src/types.ts"],
-  format: ["cjs"],
+  format: ["esm"],
   dts: true,
   clean: true,
   minify: true,

--- a/packages/turbo-ignore/tsup.config.ts
+++ b/packages/turbo-ignore/tsup.config.ts
@@ -4,6 +4,7 @@ import { defineConfig, type Options } from "tsup";
 export default defineConfig((options: Options) => ({
   entry: ["src/cli.ts"],
   format: ["esm"],
+  shim: true,
   minify: true,
   clean: true,
   ...options,

--- a/packages/turbo-ignore/tsup.config.ts
+++ b/packages/turbo-ignore/tsup.config.ts
@@ -3,7 +3,7 @@ import { defineConfig, type Options } from "tsup";
 // eslint-disable-next-line import/no-default-export -- required for tsup
 export default defineConfig((options: Options) => ({
   entry: ["src/cli.ts"],
-  format: ["cjs"],
+  format: ["esm"],
   minify: true,
   clean: true,
   ...options,

--- a/packages/turbo-ignore/tsup.config.ts
+++ b/packages/turbo-ignore/tsup.config.ts
@@ -4,7 +4,7 @@ import { defineConfig, type Options } from "tsup";
 export default defineConfig((options: Options) => ({
   entry: ["src/cli.ts"],
   format: ["esm"],
-  shim: true,
+  shim: true, // Add shims for things like __filename and __dirname usage
   minify: true,
   clean: true,
   ...options,

--- a/packages/turbo-workspaces/tsup.config.ts
+++ b/packages/turbo-workspaces/tsup.config.ts
@@ -2,7 +2,8 @@ import { defineConfig, Options } from "tsup";
 
 export default defineConfig((options: Options) => ({
   entry: ["src/index.ts", "src/cli.ts"],
-  format: ["cjs", "esm"],
+  format: ["esm"],
+  shim: true,
   dts: true,
   clean: true,
   minify: true,

--- a/packages/turbo-workspaces/tsup.config.ts
+++ b/packages/turbo-workspaces/tsup.config.ts
@@ -3,7 +3,7 @@ import { defineConfig, Options } from "tsup";
 export default defineConfig((options: Options) => ({
   entry: ["src/index.ts", "src/cli.ts"],
   format: ["esm"],
-  shim: true,
+  shim: true, // Add shims for things like __filename and __dirname usage
   dts: true,
   clean: true,
   minify: true,


### PR DESCRIPTION
These packages are only used as binaries, they are not meant to be imported. We also [require Node 18+](https://turbo.build/repo/docs/support#nodejs-compatibility), so ESM by default should work for everyone.

Closes TURBO-1568