### PR TITLE
Turbopack: Defer calculating source positions until needed

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -853,6 +853,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          # TODO: Remove this specific version constraint once pnpm ships with
+          # node-gyp that's compatible with Python 3.12+
+          python-version: 3.11
+
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
         with:

--- a/crates/turbopack-core/src/issue/analyze.rs
+++ b/crates/turbopack-core/src/issue/analyze.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use turbo_tasks::Vc;
 use turbo_tasks_fs::FileSystemPath;
 
-use super::{Issue, IssueSeverity, IssueSource, OptionIssueSource};
+use super::{Issue, IssueSeverity, LazyIssueSource, OptionIssueSource};
 use crate::ident::AssetIdent;
 
 #[turbo_tasks::value(shared)]
@@ -13,7 +13,7 @@ pub struct AnalyzeIssue {
     pub message: Vc<String>,
     pub category: Vc<String>,
     pub code: Option<String>,
-    pub source: Option<Vc<IssueSource>>,
+    pub source: Option<Vc<LazyIssueSource>>,
 }
 
 #[turbo_tasks::value_impl]
@@ -49,6 +49,6 @@ impl Issue for AnalyzeIssue {
 
     #[turbo_tasks::function]
     fn source(&self) -> Vc<OptionIssueSource> {
-        Vc::cell(self.source)
+        Vc::cell(self.source.map(|s| s.to_issue_source()))
     }
 }

--- a/crates/turbopack-core/src/issue/mod.rs
+++ b/crates/turbopack-core/src/issue/mod.rs
@@ -396,6 +396,10 @@ impl CapturedIssues {
     }
 }
 
+/// Use this to pass and store byte offsets for an AST node along with its
+/// source. When row/column is needed, this can be lazily converted into a
+/// proper `IssueSource` at that time using
+/// [LazyIssueSource::to_issue_source].
 #[turbo_tasks::value]
 #[derive(Clone, Debug)]
 pub struct LazyIssueSource {

--- a/crates/turbopack-core/src/issue/mod.rs
+++ b/crates/turbopack-core/src/issue/mod.rs
@@ -397,11 +397,37 @@ impl CapturedIssues {
 }
 
 #[turbo_tasks::value]
-#[derive(Clone)]
-pub struct IssueSource {
+#[derive(Clone, Debug)]
+pub struct LazyIssueSource {
     pub source: Vc<Box<dyn Source>>,
-    pub start: SourcePos,
-    pub end: SourcePos,
+    pub start: usize,
+    pub end: usize,
+}
+
+#[turbo_tasks::value_impl]
+impl LazyIssueSource {
+    #[turbo_tasks::function]
+    pub fn new(source: Vc<Box<dyn Source>>, start: usize, end: usize) -> Vc<Self> {
+        Self::cell(LazyIssueSource { source, start, end })
+    }
+
+    #[turbo_tasks::function]
+    pub async fn to_issue_source(self: Vc<Self>) -> Result<Vc<IssueSource>> {
+        let this = &*self.await?;
+        Ok(IssueSource::from_byte_offset(
+            this.source,
+            this.start,
+            this.end,
+        ))
+    }
+}
+
+#[turbo_tasks::value]
+#[derive(Clone, Debug)]
+pub struct IssueSource {
+    source: Vc<Box<dyn Source>>,
+    start: SourcePos,
+    end: SourcePos,
 }
 
 #[turbo_tasks::value_impl]

--- a/crates/turbopack-core/src/issue/resolve.rs
+++ b/crates/turbopack-core/src/issue/resolve.rs
@@ -7,7 +7,7 @@ use turbo_tasks_fs::FileSystemPath;
 use super::{Issue, OptionIssueSource};
 use crate::{
     error::PrettyPrintError,
-    issue::{IssueSeverity, IssueSource},
+    issue::{IssueSeverity, LazyIssueSource},
     resolve::{options::ResolveOptions, parse::Request},
 };
 
@@ -19,7 +19,7 @@ pub struct ResolvingIssue {
     pub file_path: Vc<FileSystemPath>,
     pub resolve_options: Vc<ResolveOptions>,
     pub error_message: Option<String>,
-    pub source: Option<Vc<IssueSource>>,
+    pub source: Option<Vc<LazyIssueSource>>,
 }
 
 #[turbo_tasks::value_impl]
@@ -102,7 +102,7 @@ impl Issue for ResolvingIssue {
 
     #[turbo_tasks::function]
     fn source(&self) -> Vc<OptionIssueSource> {
-        Vc::cell(self.source)
+        Vc::cell(self.source.map(|s| s.to_issue_source()))
     }
 
     // TODO add sub_issue for a description of resolve_options

--- a/crates/turbopack-core/src/resolve/mod.rs
+++ b/crates/turbopack-core/src/resolve/mod.rs
@@ -26,7 +26,7 @@ use self::{
 };
 use crate::{
     file_source::FileSource,
-    issue::{resolve::ResolvingIssue, IssueExt},
+    issue::{resolve::ResolvingIssue, IssueExt, LazyIssueSource},
     module::{Module, Modules, OptionModule},
     output::{OutputAsset, OutputAssets},
     package_json::{read_package_json, PackageJsonIssue},
@@ -54,7 +54,7 @@ pub use alias_map::{
 };
 pub use remap::{ResolveAliasMap, SubpathValue};
 
-use crate::issue::{IssueSeverity, IssueSource};
+use crate::issue::IssueSeverity;
 
 #[turbo_tasks::value(shared)]
 #[derive(Clone, Debug)]
@@ -1930,8 +1930,8 @@ pub async fn handle_resolve_error(
     origin_path: Vc<FileSystemPath>,
     request: Vc<Request>,
     resolve_options: Vc<ResolveOptions>,
-    source: Option<Vc<IssueSource>>,
     severity: Vc<IssueSeverity>,
+    source: Option<Vc<LazyIssueSource>>,
 ) -> Result<Vc<ModuleResolveResult>> {
     Ok(match result.is_unresolveable().await {
         Ok(unresolveable) => {

--- a/crates/turbopack-css/src/references/import.rs
+++ b/crates/turbopack-css/src/references/import.rs
@@ -12,7 +12,7 @@ use swc_core::{
 use turbo_tasks::{Value, ValueToString, Vc};
 use turbopack_core::{
     chunk::{ChunkableModuleReference, ChunkingContext},
-    issue::IssueSource,
+    issue::LazyIssueSource,
     reference::ModuleReference,
     reference_type::CssReferenceSubType,
     resolve::{origin::ResolveOrigin, parse::Request, ModuleResolveResult},
@@ -187,7 +187,7 @@ pub struct ImportAssetReference {
     pub request: Vc<Request>,
     pub path: Vc<AstPath>,
     pub attributes: Vc<ImportAttributes>,
-    pub issue_source: Vc<IssueSource>,
+    pub issue_source: Vc<LazyIssueSource>,
 }
 
 #[turbo_tasks::value_impl]
@@ -198,7 +198,7 @@ impl ImportAssetReference {
         request: Vc<Request>,
         path: Vc<AstPath>,
         attributes: Vc<ImportAttributes>,
-        issue_source: Vc<IssueSource>,
+        issue_source: Vc<LazyIssueSource>,
     ) -> Vc<Self> {
         Self::cell(ImportAssetReference {
             origin,

--- a/crates/turbopack-css/src/references/mod.rs
+++ b/crates/turbopack-css/src/references/mod.rs
@@ -12,7 +12,7 @@ use swc_core::{
 };
 use turbo_tasks::{Value, Vc};
 use turbopack_core::{
-    issue::{IssueSeverity, IssueSource},
+    issue::{IssueSeverity, LazyIssueSource},
     reference::{ModuleReference, ModuleReferences},
     reference_type::{CssReferenceSubType, ReferenceType},
     resolve::{
@@ -133,7 +133,7 @@ impl<'a> VisitAstPath for ModuleReferencesVisitor<'a> {
             Request::parse(Value::new(src.to_string().into())),
             Vc::cell(as_parent_path(ast_path)),
             ImportAttributes::new_from_prelude(i).into(),
-            IssueSource::from_byte_offset(
+            LazyIssueSource::new(
                 Vc::upcast(self.source),
                 issue_span.lo.to_usize(),
                 issue_span.hi.to_usize(),
@@ -160,7 +160,7 @@ impl<'a> VisitAstPath for ModuleReferencesVisitor<'a> {
                 self.origin,
                 Request::parse(Value::new(src.to_string().into())),
                 Vc::cell(as_parent_path(ast_path)),
-                IssueSource::from_byte_offset(
+                LazyIssueSource::new(
                     Vc::upcast(self.source),
                     issue_span.lo.to_usize(),
                     issue_span.hi.to_usize(),
@@ -177,7 +177,7 @@ pub async fn css_resolve(
     origin: Vc<Box<dyn ResolveOrigin>>,
     request: Vc<Request>,
     ty: Value<CssReferenceSubType>,
-    issue_source: Option<Vc<IssueSource>>,
+    issue_source: Option<Vc<LazyIssueSource>>,
 ) -> Result<Vc<ModuleResolveResult>> {
     let ty = Value::new(ReferenceType::Css(ty.into_value()));
     let options = origin.resolve_options(ty.clone());
@@ -189,8 +189,8 @@ pub async fn css_resolve(
         origin.origin_path(),
         request,
         options,
-        issue_source,
         IssueSeverity::Error.cell(),
+        issue_source,
     )
     .await
 }

--- a/crates/turbopack-css/src/references/url.rs
+++ b/crates/turbopack-css/src/references/url.rs
@@ -7,7 +7,7 @@ use turbo_tasks::{Value, ValueToString, Vc};
 use turbopack_core::{
     chunk::ChunkingContext,
     ident::AssetIdent,
-    issue::{IssueSeverity, IssueSource},
+    issue::{IssueSeverity, LazyIssueSource},
     output::OutputAsset,
     reference::ModuleReference,
     reference_type::UrlReferenceSubType,
@@ -34,7 +34,7 @@ pub struct UrlAssetReference {
     pub origin: Vc<Box<dyn ResolveOrigin>>,
     pub request: Vc<Request>,
     pub path: Vc<AstPath>,
-    pub issue_source: Vc<IssueSource>,
+    pub issue_source: Vc<LazyIssueSource>,
 }
 
 #[turbo_tasks::value_impl]
@@ -44,7 +44,7 @@ impl UrlAssetReference {
         origin: Vc<Box<dyn ResolveOrigin>>,
         request: Vc<Request>,
         path: Vc<AstPath>,
-        issue_source: Vc<IssueSource>,
+        issue_source: Vc<LazyIssueSource>,
     ) -> Vc<Self> {
         Self::cell(UrlAssetReference {
             origin,

--- a/crates/turbopack-ecmascript/src/references/amd.rs
+++ b/crates/turbopack-ecmascript/src/references/amd.rs
@@ -15,7 +15,7 @@ use turbo_tasks::{
 };
 use turbopack_core::{
     chunk::ChunkableModuleReference,
-    issue::IssueSource,
+    issue::LazyIssueSource,
     reference::ModuleReference,
     resolve::{origin::ResolveOrigin, parse::Request, ModuleResolveResult},
 };
@@ -34,7 +34,7 @@ use crate::{
 pub struct AmdDefineAssetReference {
     origin: Vc<Box<dyn ResolveOrigin>>,
     request: Vc<Request>,
-    issue_source: Vc<IssueSource>,
+    issue_source: Vc<LazyIssueSource>,
     in_try: bool,
 }
 
@@ -44,7 +44,7 @@ impl AmdDefineAssetReference {
     pub fn new(
         origin: Vc<Box<dyn ResolveOrigin>>,
         request: Vc<Request>,
-        issue_source: Vc<IssueSource>,
+        issue_source: Vc<LazyIssueSource>,
         in_try: bool,
     ) -> Vc<Self> {
         Self::cell(AmdDefineAssetReference {
@@ -109,7 +109,7 @@ pub struct AmdDefineWithDependenciesCodeGen {
     origin: Vc<Box<dyn ResolveOrigin>>,
     path: Vc<AstPath>,
     factory_type: AmdDefineFactoryType,
-    issue_source: Vc<IssueSource>,
+    issue_source: Vc<LazyIssueSource>,
     in_try: bool,
 }
 
@@ -119,7 +119,7 @@ impl AmdDefineWithDependenciesCodeGen {
         origin: Vc<Box<dyn ResolveOrigin>>,
         path: Vc<AstPath>,
         factory_type: AmdDefineFactoryType,
-        issue_source: Vc<IssueSource>,
+        issue_source: Vc<LazyIssueSource>,
         in_try: bool,
     ) -> Vc<Self> {
         Self::cell(AmdDefineWithDependenciesCodeGen {

--- a/crates/turbopack-ecmascript/src/references/cjs.rs
+++ b/crates/turbopack-ecmascript/src/references/cjs.rs
@@ -6,7 +6,7 @@ use swc_core::{
 use turbo_tasks::{Value, ValueToString, Vc};
 use turbopack_core::{
     chunk::ChunkableModuleReference,
-    issue::IssueSource,
+    issue::LazyIssueSource,
     reference::ModuleReference,
     resolve::{origin::ResolveOrigin, parse::Request, ModuleResolveResult},
 };
@@ -25,7 +25,7 @@ use crate::{
 pub struct CjsAssetReference {
     pub origin: Vc<Box<dyn ResolveOrigin>>,
     pub request: Vc<Request>,
-    pub issue_source: Vc<IssueSource>,
+    pub issue_source: Vc<LazyIssueSource>,
     pub in_try: bool,
 }
 
@@ -35,7 +35,7 @@ impl CjsAssetReference {
     pub fn new(
         origin: Vc<Box<dyn ResolveOrigin>>,
         request: Vc<Request>,
-        issue_source: Vc<IssueSource>,
+        issue_source: Vc<LazyIssueSource>,
         in_try: bool,
     ) -> Vc<Self> {
         Self::cell(CjsAssetReference {
@@ -80,7 +80,7 @@ pub struct CjsRequireAssetReference {
     pub origin: Vc<Box<dyn ResolveOrigin>>,
     pub request: Vc<Request>,
     pub path: Vc<AstPath>,
-    pub issue_source: Vc<IssueSource>,
+    pub issue_source: Vc<LazyIssueSource>,
     pub in_try: bool,
 }
 
@@ -91,7 +91,7 @@ impl CjsRequireAssetReference {
         origin: Vc<Box<dyn ResolveOrigin>>,
         request: Vc<Request>,
         path: Vc<AstPath>,
-        issue_source: Vc<IssueSource>,
+        issue_source: Vc<LazyIssueSource>,
         in_try: bool,
     ) -> Vc<Self> {
         Self::cell(CjsRequireAssetReference {
@@ -204,7 +204,7 @@ pub struct CjsRequireResolveAssetReference {
     pub origin: Vc<Box<dyn ResolveOrigin>>,
     pub request: Vc<Request>,
     pub path: Vc<AstPath>,
-    pub issue_source: Vc<IssueSource>,
+    pub issue_source: Vc<LazyIssueSource>,
     pub in_try: bool,
 }
 
@@ -215,7 +215,7 @@ impl CjsRequireResolveAssetReference {
         origin: Vc<Box<dyn ResolveOrigin>>,
         request: Vc<Request>,
         path: Vc<AstPath>,
-        issue_source: Vc<IssueSource>,
+        issue_source: Vc<LazyIssueSource>,
         in_try: bool,
     ) -> Vc<Self> {
         Self::cell(CjsRequireResolveAssetReference {

--- a/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -103,7 +103,6 @@ pub struct EsmAssetReference {
     pub origin: Vc<Box<dyn ResolveOrigin>>,
     pub request: Vc<Request>,
     pub annotations: ImportAnnotations,
-
     pub export_name: Option<Vc<ModulePart>>,
 }
 
@@ -162,8 +161,8 @@ impl ModuleReference for EsmAssetReference {
             self.get_origin().resolve().await?,
             self.request,
             ty,
-            None,
             IssueSeverity::Error.cell(),
+            None,
         ))
     }
 }

--- a/crates/turbopack-ecmascript/src/references/esm/dynamic.rs
+++ b/crates/turbopack-ecmascript/src/references/esm/dynamic.rs
@@ -6,7 +6,7 @@ use swc_core::{
 use turbo_tasks::{Value, ValueToString, Vc};
 use turbopack_core::{
     chunk::{ChunkableModuleReference, ChunkingType, ChunkingTypeOption},
-    issue::IssueSource,
+    issue::LazyIssueSource,
     reference::ModuleReference,
     reference_type::EcmaScriptModulesReferenceSubType,
     resolve::{origin::ResolveOrigin, parse::Request, ModuleResolveResult},
@@ -27,7 +27,7 @@ pub struct EsmAsyncAssetReference {
     pub origin: Vc<Box<dyn ResolveOrigin>>,
     pub request: Vc<Request>,
     pub path: Vc<AstPath>,
-    pub issue_source: Vc<IssueSource>,
+    pub issue_source: Vc<LazyIssueSource>,
     pub in_try: bool,
 }
 
@@ -38,7 +38,7 @@ impl EsmAsyncAssetReference {
         origin: Vc<Box<dyn ResolveOrigin>>,
         request: Vc<Request>,
         path: Vc<AstPath>,
-        issue_source: Vc<IssueSource>,
+        issue_source: Vc<LazyIssueSource>,
         in_try: bool,
     ) -> Vc<Self> {
         Self::cell(EsmAsyncAssetReference {
@@ -59,8 +59,8 @@ impl ModuleReference for EsmAsyncAssetReference {
             self.origin,
             self.request,
             Default::default(),
-            Some(self.issue_source),
             try_to_severity(self.in_try),
+            Some(self.issue_source),
         )
     }
 }
@@ -99,8 +99,8 @@ impl CodeGenerateable for EsmAsyncAssetReference {
                 self.origin,
                 self.request,
                 Value::new(EcmaScriptModulesReferenceSubType::Undefined),
-                Some(self.issue_source),
                 try_to_severity(self.in_try),
+                Some(self.issue_source),
             ),
             Value::new(EsmAsync),
         )

--- a/crates/turbopack-ecmascript/src/references/esm/url.rs
+++ b/crates/turbopack-ecmascript/src/references/esm/url.rs
@@ -9,7 +9,7 @@ use turbopack_core::{
         ChunkItemExt, ChunkableModule, ChunkableModuleReference, ChunkingType, ChunkingTypeOption,
     },
     environment::Rendering,
-    issue::{code_gen::CodeGenerationIssue, IssueExt, IssueSeverity, IssueSource},
+    issue::{code_gen::CodeGenerationIssue, IssueExt, IssueSeverity, LazyIssueSource},
     reference::ModuleReference,
     reference_type::UrlReferenceSubType,
     resolve::{origin::ResolveOrigin, parse::Request, ModuleResolveResult},
@@ -36,7 +36,7 @@ pub struct UrlAssetReference {
     request: Vc<Request>,
     rendering: Vc<Rendering>,
     ast_path: Vc<AstPath>,
-    issue_source: Vc<IssueSource>,
+    issue_source: Vc<LazyIssueSource>,
     in_try: bool,
 }
 
@@ -48,7 +48,7 @@ impl UrlAssetReference {
         request: Vc<Request>,
         rendering: Vc<Rendering>,
         ast_path: Vc<AstPath>,
-        issue_source: Vc<IssueSource>,
+        issue_source: Vc<LazyIssueSource>,
         in_try: bool,
     ) -> Vc<Self> {
         UrlAssetReference {

--- a/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/crates/turbopack-ecmascript/src/references/mod.rs
@@ -51,7 +51,7 @@ use turbo_tasks_fs::{FileJsonContent, FileSystemPath};
 use turbopack_core::{
     compile_time_info::{CompileTimeInfo, FreeVarReference},
     error::PrettyPrintError,
-    issue::{analyze::AnalyzeIssue, IssueExt, IssueSeverity, IssueSource},
+    issue::{analyze::AnalyzeIssue, IssueExt, IssueSeverity, LazyIssueSource},
     module::Module,
     reference::{ModuleReference, ModuleReferences, SourceMapReference},
     reference_type::{CommonJsReferenceSubType, ReferenceType},
@@ -962,7 +962,7 @@ pub(crate) async fn analyze_ecmascript_module(
                     Request::parse(Value::new(pat)),
                     compile_time_info.environment().rendering(),
                     Vc::cell(ast_path),
-                    IssueSource::from_byte_offset(source, span.lo.to_usize(), span.hi.to_usize()),
+                    LazyIssueSource::new(source, span.lo.to_usize(), span.hi.to_usize()),
                     in_try,
                 ));
             }
@@ -1778,8 +1778,8 @@ async fn handle_free_var_reference(
     Ok(true)
 }
 
-fn issue_source(source: Vc<Box<dyn Source>>, span: Span) -> Vc<IssueSource> {
-    IssueSource::from_byte_offset(source, span.lo.to_usize(), span.hi.to_usize())
+fn issue_source(source: Vc<Box<dyn Source>>, span: Span) -> Vc<LazyIssueSource> {
+    LazyIssueSource::new(source, span.lo.to_usize(), span.hi.to_usize())
 }
 
 fn analyze_amd_define(

--- a/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -22,7 +22,7 @@ use turbopack_core::{
         ChunkingContext,
     },
     ident::AssetIdent,
-    issue::{IssueSeverity, IssueSource},
+    issue::{IssueSeverity, LazyIssueSource},
     module::Module,
     reference::{ModuleReference, ModuleReferences},
     resolve::{origin::ResolveOrigin, parse::Request, ModuleResolveResult},
@@ -165,7 +165,7 @@ impl RequireContextMap {
         dir: Vc<FileSystemPath>,
         recursive: bool,
         filter: Vc<Regex>,
-        issue_source: Option<Vc<IssueSource>>,
+        issue_source: Option<Vc<LazyIssueSource>>,
         issue_severity: Vc<IssueSeverity>,
     ) -> Result<Vc<Self>> {
         let origin_path = &*origin.origin_path().parent().await?;
@@ -206,7 +206,7 @@ pub struct RequireContextAssetReference {
     pub include_subdirs: bool,
 
     pub path: Vc<AstPath>,
-    pub issue_source: Option<Vc<IssueSource>>,
+    pub issue_source: Option<Vc<LazyIssueSource>>,
     pub in_try: bool,
 }
 
@@ -220,7 +220,7 @@ impl RequireContextAssetReference {
         include_subdirs: bool,
         filter: Vc<Regex>,
         path: Vc<AstPath>,
-        issue_source: Option<Vc<IssueSource>>,
+        issue_source: Option<Vc<LazyIssueSource>>,
         in_try: bool,
     ) -> Vc<Self> {
         let map = RequireContextMap::generate(

--- a/crates/turbopack-ecmascript/src/typescript/resolve.rs
+++ b/crates/turbopack-ecmascript/src/typescript/resolve.rs
@@ -372,8 +372,8 @@ pub async fn type_resolve(
         origin.origin_path(),
         request,
         options,
-        None,
         IssueSeverity::Error.cell(),
+        None,
     )
     .await
 }

--- a/crates/turbopack-swc-utils/src/emitter.rs
+++ b/crates/turbopack-swc-utils/src/emitter.rs
@@ -7,7 +7,7 @@ use swc_core::common::{
 };
 use turbo_tasks::Vc;
 use turbopack_core::{
-    issue::{analyze::AnalyzeIssue, IssueExt, IssueSeverity, IssueSource},
+    issue::{analyze::AnalyzeIssue, IssueExt, IssueSeverity, LazyIssueSource},
     source::Source,
 };
 
@@ -40,13 +40,10 @@ impl Emitter for IssueEmitter {
             message = message_split.remainder().unwrap_or("").to_string();
         }
 
-        let source = db.span.primary_span().map(|span| {
-            IssueSource::from_byte_offset(
-                self.source,
-                self.source_map.lookup_byte_offset(span.lo()).pos.to_usize(),
-                self.source_map.lookup_byte_offset(span.lo()).pos.to_usize(),
-            )
-        });
+        let source = db
+            .span
+            .primary_span()
+            .map(|span| LazyIssueSource::new(self.source, span.lo.to_usize(), span.hi.to_usize()));
         // TODO add other primary and secondary spans with labels as sub_issues
 
         AnalyzeIssue {


### PR DESCRIPTION
Previously, many references would eagerly calculate their row/column in the source code even if they did not cause an `Issue` to occur. This requires reading the source code and calculating this information from byte offsets from the swc node's `Span`.

This introduces `LazyIssueSource`, which simply wraps the `Source` and the start/end byte offsets from the swc span. This is only converted to an `IssueSource` when the issue's source location is accessed.
