### PR TITLE
fix(urlassetref): get the static src property from asset

### DIFF
--- a/crates/turbopack-ecmascript/src/references/esm/url.rs
+++ b/crates/turbopack-ecmascript/src/references/esm/url.rs
@@ -162,8 +162,11 @@ impl CodeGenerateable for UrlAssetReference {
                     create_visitor!(ast_path, visit_mut_expr(new_expr: &mut Expr) {
                         if let Expr::New(NewExpr { args: Some(args), .. }) = new_expr {
                             if let Some(ExprOrSpread { box expr, spread: None }) = args.get_mut(0) {
+                                // For the static asset, the imported module is a wrapper to the phsyical asset having an
+                                // exported object contains necessary values for us. Trying to grab properties, or either fall back to
+                                // the default export itself.
                                 *expr = quote!(
-                                    "__turbopack_require__($id)" as Expr,
+                                    "__turbopack_require__($id).default?.src ?? __turbopack_require__($id).default ?? __turbopack_require__($id)" as Expr,
                                     id: Expr = module_id_to_lit(&id),
                                 );
                             }

--- a/crates/turbopack-tests/tests/snapshot/import-meta/url/output/crates_turbopack-tests_tests_snapshot_import-meta_url_input_9b6f5c._.js
+++ b/crates/turbopack-tests/tests/snapshot/import-meta/url/output/crates_turbopack-tests_tests_snapshot_import-meta_url_input_9b6f5c._.js
@@ -12,7 +12,7 @@ const __TURBOPACK__import$2e$meta__ = {
     }
 };
 "__TURBOPACK__ecmascript__hoisting__location__";
-const assetUrl = new URL(__turbopack_require__("[project]/crates/turbopack-tests/tests/snapshot/import-meta/url/input/asset.txt [test] (static)"), location.origin);
+const assetUrl = new URL(__turbopack_require__("[project]/crates/turbopack-tests/tests/snapshot/import-meta/url/input/asset.txt [test] (static)").default?.src ?? __turbopack_require__("[project]/crates/turbopack-tests/tests/snapshot/import-meta/url/input/asset.txt [test] (static)").default ?? __turbopack_require__("[project]/crates/turbopack-tests/tests/snapshot/import-meta/url/input/asset.txt [test] (static)"), location.origin);
 console.log(assetUrl);
 fetch(assetUrl).then((res)=>res.text()).then(console.log);
 


### PR DESCRIPTION
### Description

If the path to the url is a static value, turbopack returns its asset output ident to the wrapper module - unlike other plain assets, its default export is an object contains metadata values of the original asset. In result, call to `new URL` returns stringified module symbol instead of actual path.

PR adjusts lookup starts from the export's property, then falls back to the export itself if it's not available.