### PR TITLE
refactor(turborepo): Changed cache misses to be a non-error

### DIFF
--- a/crates/turborepo-auth/src/auth/login.rs
+++ b/crates/turborepo-auth/src/auth/login.rs
@@ -236,7 +236,7 @@ mod tests {
             _token: &str,
             _team_id: &str,
             _team_slug: Option<&str>,
-        ) -> turborepo_api_client::Result<Response> {
+        ) -> turborepo_api_client::Result<Option<Response>> {
             unimplemented!("fetch_artifact")
         }
         async fn artifact_exists(
@@ -245,7 +245,7 @@ mod tests {
             _token: &str,
             _team_id: &str,
             _team_slug: Option<&str>,
-        ) -> turborepo_api_client::Result<Response> {
+        ) -> turborepo_api_client::Result<Option<Response>> {
             unimplemented!("artifact_exists")
         }
         async fn get_artifact(
@@ -255,7 +255,7 @@ mod tests {
             _team_id: &str,
             _team_slug: Option<&str>,
             _method: Method,
-        ) -> turborepo_api_client::Result<Response> {
+        ) -> turborepo_api_client::Result<Option<Response>> {
             unimplemented!("get_artifact")
         }
         async fn do_preflight(

--- a/crates/turborepo-auth/src/auth/sso.rs
+++ b/crates/turborepo-auth/src/auth/sso.rs
@@ -247,7 +247,7 @@ mod tests {
             _token: &str,
             _team_id: &str,
             _team_slug: Option<&str>,
-        ) -> turborepo_api_client::Result<Response> {
+        ) -> turborepo_api_client::Result<Option<Response>> {
             unimplemented!("fetch_artifact")
         }
         async fn artifact_exists(
@@ -256,7 +256,7 @@ mod tests {
             _token: &str,
             _team_id: &str,
             _team_slug: Option<&str>,
-        ) -> turborepo_api_client::Result<Response> {
+        ) -> turborepo_api_client::Result<Option<Response>> {
             unimplemented!("artifact_exists")
         }
         async fn get_artifact(
@@ -266,7 +266,7 @@ mod tests {
             _team_id: &str,
             _team_slug: Option<&str>,
             _method: Method,
-        ) -> turborepo_api_client::Result<Response> {
+        ) -> turborepo_api_client::Result<Option<Response>> {
             unimplemented!("get_artifact")
         }
         async fn do_preflight(

--- a/crates/turborepo-cache/src/fs.rs
+++ b/crates/turborepo-cache/src/fs.rs
@@ -6,7 +6,7 @@ use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPathBuf
 
 use crate::{
     cache_archive::{CacheReader, CacheWriter},
-    CacheError, CacheResponse, CacheSource,
+    CacheError, CacheHitMetadata, CacheResult, CacheSource,
 };
 
 pub struct FSCache {
@@ -52,7 +52,7 @@ impl FSCache {
         &self,
         anchor: &AbsoluteSystemPath,
         hash: &str,
-    ) -> Result<(CacheResponse, Vec<AnchoredSystemPathBuf>), CacheError> {
+    ) -> Result<CacheResult<(CacheHitMetadata, Vec<AnchoredSystemPathBuf>)>, CacheError> {
         let uncompressed_cache_path = self
             .cache_directory
             .join_component(&format!("{}.tar", hash));
@@ -65,7 +65,7 @@ impl FSCache {
         } else if compressed_cache_path.exists() {
             compressed_cache_path
         } else {
-            return Err(CacheError::CacheMiss);
+            return Ok(CacheResult::Miss);
         };
 
         let mut cache_reader = CacheReader::open(&cache_path)?;
@@ -78,16 +78,16 @@ impl FSCache {
                 .join_component(&format!("{}-meta.json", hash)),
         )?;
 
-        Ok((
-            CacheResponse {
+        Ok(CacheResult::Hit((
+            CacheHitMetadata {
                 time_saved: meta.duration,
                 source: CacheSource::Local,
             },
             restored_files,
-        ))
+        )))
     }
 
-    pub(crate) fn exists(&self, hash: &str) -> Result<CacheResponse, CacheError> {
+    pub(crate) fn exists(&self, hash: &str) -> Result<CacheResult<CacheHitMetadata>, CacheError> {
         let uncompressed_cache_path = self
             .cache_directory
             .join_component(&format!("{}.tar", hash));
@@ -96,7 +96,7 @@ impl FSCache {
             .join_component(&format!("{}.tar.zst", hash));
 
         if !uncompressed_cache_path.exists() && !compressed_cache_path.exists() {
-            return Err(CacheError::CacheMiss);
+            return Ok(CacheResult::Miss);
         }
 
         let duration = CacheMetadata::read(
@@ -107,10 +107,10 @@ impl FSCache {
         .map(|meta| meta.duration)
         .unwrap_or(0);
 
-        Ok(CacheResponse {
+        Ok(CacheResult::Hit(CacheHitMetadata {
             time_saved: duration,
             source: CacheSource::Local,
-        })
+        }))
     }
 
     pub fn put(
@@ -192,19 +192,19 @@ mod test {
         let expected_hit = cache.exists(test_case.hash)?;
         assert_eq!(
             expected_hit,
-            CacheResponse {
+            CacheResult::Hit(CacheHitMetadata {
                 time_saved: test_case.duration,
                 source: CacheSource::Local
-            }
+            })
         );
 
         let (status, files) = cache.fetch(repo_root_path, test_case.hash)?;
         assert_eq!(
             status,
-            CacheResponse {
+            CacheResult::Hit(CacheHitMetadata {
                 time_saved: test_case.duration,
                 source: CacheSource::Local
-            }
+            })
         );
 
         assert_eq!(files.len(), test_case.files.len());

--- a/crates/turborepo-cache/src/http.rs
+++ b/crates/turborepo-cache/src/http.rs
@@ -207,7 +207,7 @@ mod test {
     use crate::{
         http::{APIAuth, HTTPCache},
         test_cases::{get_test_cases, TestCase},
-        CacheOpts, CacheResult, CacheSource,
+        CacheOpts, CacheSource,
     };
 
     #[tokio::test]
@@ -257,9 +257,7 @@ mod test {
         assert_eq!(cache_response.time_saved, duration);
         assert_eq!(cache_response.source, CacheSource::Remote);
 
-        let CacheResult::Hit((cache_response, received_files)) = cache.fetch(hash).await? else {
-            panic!("should be cache hit");
-        };
+        let (cache_response, received_files) = cache.fetch(hash).await?.expect_hit();
 
         assert_eq!(cache_response.time_saved, duration);
 

--- a/crates/turborepo-cache/src/lib.rs
+++ b/crates/turborepo-cache/src/lib.rs
@@ -80,45 +80,7 @@ pub enum CacheSource {
     Remote,
 }
 
-// This is generic because exists returns just the metadata
-// while fetch returns the metadata and the files
-#[derive(Clone, Debug, PartialEq)]
-pub enum CacheResult<T> {
-    Miss,
-    Hit(T),
-}
-
-impl<T> CacheResult<T> {
-    pub fn expect_hit(self) -> T {
-        match self {
-            CacheResult::Hit(value) => value,
-            CacheResult::Miss => panic!("expected cache hit"),
-        }
-    }
-
-    pub fn is_hit(&self) -> bool {
-        match self {
-            CacheResult::Hit(_) => true,
-            CacheResult::Miss => false,
-        }
-    }
-
-    pub fn is_miss(&self) -> bool {
-        match self {
-            CacheResult::Hit(_) => false,
-            CacheResult::Miss => true,
-        }
-    }
-
-    pub fn expect_miss(self) {
-        match self {
-            CacheResult::Hit(_) => panic!("expected cache miss"),
-            CacheResult::Miss => (),
-        }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Copy)]
 pub struct CacheHitMetadata {
     pub source: CacheSource,
     pub time_saved: u64,

--- a/crates/turborepo-lib/src/run/cache.rs
+++ b/crates/turborepo-lib/src/run/cache.rs
@@ -3,7 +3,7 @@ use std::{io::Write, sync::Arc, time::Duration};
 use console::StyledObject;
 use tracing::{debug, log::warn};
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPathBuf};
-use turborepo_cache::{AsyncCache, CacheError, CacheResponse, CacheSource};
+use turborepo_cache::{AsyncCache, CacheHitMetadata, CacheResult, CacheSource};
 use turborepo_ui::{
     color, replay_logs, ColorSelector, LogWriter, PrefixedUI, PrefixedWriter, GREY, UI,
 };
@@ -29,12 +29,6 @@ pub enum Error {
     Daemon(#[from] crate::daemon::DaemonError),
     #[error("no connection to daemon")]
     NoDaemon,
-}
-
-impl Error {
-    pub fn is_cache_miss(&self) -> bool {
-        matches!(&self, Self::Cache(CacheError::CacheMiss))
-    }
 }
 
 pub struct RunCache {
@@ -168,7 +162,7 @@ impl TaskCache {
     pub async fn restore_outputs(
         &mut self,
         prefixed_ui: &mut PrefixedUI<impl Write>,
-    ) -> Result<CacheResponse, Error> {
+    ) -> Result<CacheResult<CacheHitMetadata>, Error> {
         if self.caching_disabled || self.run_cache.reads_disabled {
             if !matches!(
                 self.task_output_mode,
@@ -180,7 +174,7 @@ impl TaskCache {
                 ));
             }
 
-            return Err(CacheError::CacheMiss.into());
+            return Ok(CacheResult::Miss);
         }
 
         let changed_output_count = if let Some(daemon_client) = &mut self.daemon_client {
@@ -211,21 +205,20 @@ impl TaskCache {
             // Note that we currently don't use the output globs when restoring, but we
             // could in the future to avoid doing unnecessary file I/O. We also
             // need to pass along the exclusion globs as well.
-            let (cache_status, restored_files) = self
+            let cache_status = self
                 .run_cache
                 .cache
                 .fetch(&self.run_cache.repo_root, &self.hash)
-                .await
-                .map_err(|err| {
-                    if matches!(err, CacheError::CacheMiss) {
-                        prefixed_ui.output(format!(
-                            "cache miss, executing {}",
-                            color!(self.ui, GREY, "{}", self.hash)
-                        ));
-                    }
+                .await?;
 
-                    err
-                })?;
+            let CacheResult::Hit((cache_hit_metadata, restored_files)) = cache_status else {
+                prefixed_ui.output(format!(
+                    "cache miss, executing {}",
+                    color!(self.ui, GREY, "{}", self.hash)
+                ));
+
+                return Ok(CacheResult::Miss);
+            };
 
             self.expanded_outputs = restored_files;
 
@@ -235,7 +228,7 @@ impl TaskCache {
                         self.hash.clone(),
                         self.repo_relative_globs.inclusions.clone(),
                         self.repo_relative_globs.exclusions.clone(),
-                        cache_status.time_saved,
+                        cache_hit_metadata.time_saved,
                     )
                     .await
                 {
@@ -251,12 +244,12 @@ impl TaskCache {
                 }
             }
 
-            cache_status
+            CacheResult::Hit(cache_hit_metadata)
         } else {
-            CacheResponse {
+            CacheResult::Hit(CacheHitMetadata {
                 source: CacheSource::Local,
                 time_saved: 0,
-            }
+            })
         };
 
         let more_context = if has_changed_outputs {

--- a/crates/turborepo-lib/src/run/summary/task.rs
+++ b/crates/turborepo-lib/src/run/summary/task.rs
@@ -131,10 +131,13 @@ impl TaskCacheSummary {
     }
 }
 
-impl From<CacheResult<CacheHitMetadata>> for TaskCacheSummary {
-    fn from(response: CacheResult<CacheHitMetadata>) -> Self {
+// This is an `Option<CacheResult<CacheHitMetadata>>` because we could fail
+// to fetch from cache (giving `None`), and we could also get a miss
+// `Some(CacheResult::Miss)`
+impl From<Option<CacheResult<CacheHitMetadata>>> for TaskCacheSummary {
+    fn from(response: Option<CacheResult<CacheHitMetadata>>) -> Self {
         match response {
-            CacheResult::Hit(CacheHitMetadata { source, time_saved }) => {
+            Some(CacheResult::Hit(CacheHitMetadata { source, time_saved })) => {
                 let source = CacheSource::from(source);
                 // Assign these deprecated fields Local and Remote based on the information
                 // available in the itemStatus. Note that these fields are
@@ -156,7 +159,7 @@ impl From<CacheResult<CacheHitMetadata>> for TaskCacheSummary {
                     time_saved,
                 }
             }
-            CacheResult::Miss => Self::cache_miss(),
+            Some(CacheResult::Miss) | None => Self::cache_miss(),
         }
     }
 }

--- a/crates/turborepo-lib/src/run/summary/task.rs
+++ b/crates/turborepo-lib/src/run/summary/task.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use itertools::Itertools;
 use serde::Serialize;
 use turbopath::{AnchoredSystemPathBuf, RelativeUnixPathBuf};
-use turborepo_cache::CacheResponse;
+use turborepo_cache::{CacheHitMetadata, CacheResult};
 use turborepo_env::{DetailedMap, EnvironmentVariableMap};
 
 use super::{execution::TaskExecutionSummary, EnvMode};
@@ -131,30 +131,33 @@ impl TaskCacheSummary {
     }
 }
 
-impl From<Option<CacheResponse>> for TaskCacheSummary {
-    fn from(value: Option<CacheResponse>) -> Self {
-        value.map_or_else(Self::cache_miss, |CacheResponse { source, time_saved }| {
-            let source = CacheSource::from(source);
-            // Assign these deprecated fields Local and Remote based on the information
-            // available in the itemStatus. Note that these fields are
-            // problematic, because an ItemStatus isn't always the composite
-            // of both local and remote caches. That means that an ItemStatus might say it
-            // was a local cache hit, and we return remote: false here. That's misleading
-            // because it does not mean that there is no remote cache hit,
-            // it _could_ mean that we never checked the remote cache. These
-            // fields are being deprecated for this reason.
-            let (local, remote) = match source {
-                CacheSource::Local => (true, false),
-                CacheSource::Remote => (false, true),
-            };
-            Self {
-                local,
-                remote,
-                status: CacheStatus::Hit,
-                source: Some(source),
-                time_saved,
+impl From<CacheResult<CacheHitMetadata>> for TaskCacheSummary {
+    fn from(response: CacheResult<CacheHitMetadata>) -> Self {
+        match response {
+            CacheResult::Hit(CacheHitMetadata { source, time_saved }) => {
+                let source = CacheSource::from(source);
+                // Assign these deprecated fields Local and Remote based on the information
+                // available in the itemStatus. Note that these fields are
+                // problematic, because an ItemStatus isn't always the composite
+                // of both local and remote caches. That means that an ItemStatus might say it
+                // was a local cache hit, and we return remote: false here. That's misleading
+                // because it does not mean that there is no remote cache hit,
+                // it _could_ mean that we never checked the remote cache. These
+                // fields are being deprecated for this reason.
+                let (local, remote) = match source {
+                    CacheSource::Local => (true, false),
+                    CacheSource::Remote => (false, true),
+                };
+                Self {
+                    local,
+                    remote,
+                    status: CacheStatus::Hit,
+                    source: Some(source),
+                    time_saved,
+                }
             }
-        })
+            CacheResult::Miss => Self::cache_miss(),
+        }
     }
 }
 

--- a/crates/turborepo-lib/src/run/summary/task.rs
+++ b/crates/turborepo-lib/src/run/summary/task.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use itertools::Itertools;
 use serde::Serialize;
 use turbopath::{AnchoredSystemPathBuf, RelativeUnixPathBuf};
-use turborepo_cache::{CacheHitMetadata, CacheResult};
+use turborepo_cache::CacheHitMetadata;
 use turborepo_env::{DetailedMap, EnvironmentVariableMap};
 
 use super::{execution::TaskExecutionSummary, EnvMode};
@@ -131,13 +131,13 @@ impl TaskCacheSummary {
     }
 }
 
-// This is an `Option<CacheResult<CacheHitMetadata>>` because we could fail
+// This is an `Option<Option<CacheHitMetadata>>` because we could fail
 // to fetch from cache (giving `None`), and we could also get a miss
-// `Some(CacheResult::Miss)`
-impl From<Option<CacheResult<CacheHitMetadata>>> for TaskCacheSummary {
-    fn from(response: Option<CacheResult<CacheHitMetadata>>) -> Self {
+// `Some(None)`
+impl From<Option<CacheHitMetadata>> for TaskCacheSummary {
+    fn from(response: Option<CacheHitMetadata>) -> Self {
         match response {
-            Some(CacheResult::Hit(CacheHitMetadata { source, time_saved })) => {
+            Some(CacheHitMetadata { source, time_saved }) => {
                 let source = CacheSource::from(source);
                 // Assign these deprecated fields Local and Remote based on the information
                 // available in the itemStatus. Note that these fields are
@@ -159,7 +159,7 @@ impl From<Option<CacheResult<CacheHitMetadata>>> for TaskCacheSummary {
                     time_saved,
                 }
             }
-            Some(CacheResult::Miss) | None => Self::cache_miss(),
+            None => Self::cache_miss(),
         }
     }
 }

--- a/crates/turborepo-lib/src/run/summary/task_factory.rs
+++ b/crates/turborepo-lib/src/run/summary/task_factory.rs
@@ -151,7 +151,11 @@ impl<'a> TaskSummaryFactory<'a> {
             .env_vars(task_id)
             .expect("env var map is inserted at the same time as hash");
 
-        let cache_summary = self.hash_tracker.cache_status(task_id).into();
+        let cache_summary = self
+            .hash_tracker
+            .cache_status(task_id)
+            .expect("cache status should be inserted")
+            .into();
 
         let (dependencies, dependents) = self.dependencies_and_dependents(task_id, display_task);
 

--- a/crates/turborepo-lib/src/run/summary/task_factory.rs
+++ b/crates/turborepo-lib/src/run/summary/task_factory.rs
@@ -151,11 +151,7 @@ impl<'a> TaskSummaryFactory<'a> {
             .env_vars(task_id)
             .expect("env var map is inserted at the same time as hash");
 
-        let cache_summary = self
-            .hash_tracker
-            .cache_status(task_id)
-            .expect("cache status should be inserted")
-            .into();
+        let cache_summary = self.hash_tracker.cache_status(task_id).into();
 
         let (dependencies, dependents) = self.dependencies_and_dependents(task_id, display_task);
 

--- a/crates/turborepo-lib/src/task_graph/visitor.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor.rs
@@ -13,7 +13,6 @@ use regex::Regex;
 use tokio::{process::Command, sync::mpsc};
 use tracing::{debug, error, Span};
 use turbopath::AbsoluteSystemPath;
-use turborepo_cache::CacheResult;
 use turborepo_env::{EnvironmentVariableMap, ResolvedEnvMode};
 use turborepo_ui::{ColorSelector, OutputClient, OutputSink, OutputWriter, PrefixedUI, UI};
 
@@ -244,7 +243,7 @@ impl<'a> Visitor<'a> {
                     Self::prefixed_ui(ui, is_github_actions, &output_client, pretty_prefix.clone());
 
                 match task_cache.restore_outputs(&mut prefixed_ui).await {
-                    Ok(status @ CacheResult::Hit(_)) => {
+                    Ok(Some(status)) => {
                         // we need to set expanded outputs
                         hash_tracker.insert_expanded_outputs(
                             task_id.clone(),
@@ -255,7 +254,7 @@ impl<'a> Visitor<'a> {
                         callback.send(Ok(())).ok();
                         return;
                     }
-                    Ok(CacheResult::Miss) => (),
+                    Ok(None) => (),
                     Err(e) => {
                         prefixed_ui.error(format!("error fetching from cache: {e}"));
                     }

--- a/crates/turborepo-lib/src/task_hash.rs
+++ b/crates/turborepo-lib/src/task_hash.rs
@@ -8,7 +8,7 @@ use serde::Serialize;
 use thiserror::Error;
 use tracing::{debug, Span};
 use turbopath::{AbsoluteSystemPath, AnchoredSystemPath, AnchoredSystemPathBuf};
-use turborepo_cache::{CacheHitMetadata, CacheResult};
+use turborepo_cache::CacheHitMetadata;
 use turborepo_env::{BySource, DetailedMap, EnvironmentVariableMap, ResolvedEnvMode};
 use turborepo_scm::SCM;
 
@@ -457,16 +457,12 @@ impl TaskHashTracker {
         state.package_task_outputs.insert(task_id, outputs);
     }
 
-    pub fn cache_status(&self, task_id: &TaskId) -> Option<CacheResult<CacheHitMetadata>> {
+    pub fn cache_status(&self, task_id: &TaskId) -> Option<CacheHitMetadata> {
         let state = self.state.lock().expect("hash tracker mutex poisoned");
-        state.package_task_cache.get(task_id).cloned()
+        state.package_task_cache.get(task_id).copied()
     }
 
-    pub fn insert_cache_status(
-        &self,
-        task_id: TaskId<'static>,
-        cache_status: CacheResult<CacheHitMetadata>,
-    ) {
+    pub fn insert_cache_status(&self, task_id: TaskId<'static>, cache_status: CacheHitMetadata) {
         let mut state = self.state.lock().expect("hash tracker mutex poisoned");
         state.package_task_cache.insert(task_id, cache_status);
     }

--- a/crates/turborepo-lib/src/task_hash.rs
+++ b/crates/turborepo-lib/src/task_hash.rs
@@ -8,7 +8,7 @@ use serde::Serialize;
 use thiserror::Error;
 use tracing::{debug, Span};
 use turbopath::{AbsoluteSystemPath, AnchoredSystemPath, AnchoredSystemPathBuf};
-use turborepo_cache::CacheResponse;
+use turborepo_cache::{CacheHitMetadata, CacheResult};
 use turborepo_env::{BySource, DetailedMap, EnvironmentVariableMap, ResolvedEnvMode};
 use turborepo_scm::SCM;
 
@@ -164,7 +164,7 @@ pub struct TaskHashTrackerState {
     #[serde(skip)]
     package_task_outputs: HashMap<TaskId<'static>, Vec<AnchoredSystemPathBuf>>,
     #[serde(skip)]
-    package_task_cache: HashMap<TaskId<'static>, CacheResponse>,
+    package_task_cache: HashMap<TaskId<'static>, CacheResult<CacheHitMetadata>>,
     #[serde(skip)]
     package_task_inputs_expanded_hashes: HashMap<TaskId<'static>, FileHashes>,
 }
@@ -457,12 +457,16 @@ impl TaskHashTracker {
         state.package_task_outputs.insert(task_id, outputs);
     }
 
-    pub fn cache_status(&self, task_id: &TaskId) -> Option<CacheResponse> {
+    pub fn cache_status(&self, task_id: &TaskId) -> Option<CacheResult<CacheHitMetadata>> {
         let state = self.state.lock().expect("hash tracker mutex poisoned");
-        state.package_task_cache.get(task_id).copied()
+        state.package_task_cache.get(task_id).cloned()
     }
 
-    pub fn insert_cache_status(&self, task_id: TaskId<'static>, cache_status: CacheResponse) {
+    pub fn insert_cache_status(
+        &self,
+        task_id: TaskId<'static>,
+        cache_status: CacheResult<CacheHitMetadata>,
+    ) {
         let mut state = self.state.lock().expect("hash tracker mutex poisoned");
         state.package_task_cache.insert(task_id, cache_status);
     }

--- a/crates/turborepo-lib/src/task_hash.rs
+++ b/crates/turborepo-lib/src/task_hash.rs
@@ -164,7 +164,7 @@ pub struct TaskHashTrackerState {
     #[serde(skip)]
     package_task_outputs: HashMap<TaskId<'static>, Vec<AnchoredSystemPathBuf>>,
     #[serde(skip)]
-    package_task_cache: HashMap<TaskId<'static>, CacheResult<CacheHitMetadata>>,
+    package_task_cache: HashMap<TaskId<'static>, CacheHitMetadata>,
     #[serde(skip)]
     package_task_inputs_expanded_hashes: HashMap<TaskId<'static>, FileHashes>,
 }


### PR DESCRIPTION
### Description

Originally we had cache misses be an error. That was a mistake because it was too easy to propagate a cache miss up the stack and not handle it properly. It was also too easy to not convert the error into a cache miss. Now we have a `CacheResult` type that indicates either a miss or a hit.

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->


Closes TURBO-1585