### PR TITLE
fix: use correct command for package managers

### DIFF
--- a/crates/turborepo-lib/src/task_graph/visitor.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor.rs
@@ -261,7 +261,7 @@ impl<'a> Visitor<'a> {
                     }
                 }
 
-                let Ok(package_manager_binary) = which(package_manager.to_string()) else {
+                let Ok(package_manager_binary) = which(package_manager.command()) else {
                     manager.stop().await;
                     tracker.cancel();
                     callback.send(Err(StopExecution)).ok();

--- a/crates/turborepo-repository/src/package_manager/mod.rs
+++ b/crates/turborepo-repository/src/package_manager/mod.rs
@@ -273,6 +273,15 @@ static PACKAGE_MANAGER_PATTERN: Lazy<Regex> =
     lazy_regex!(r"(?P<manager>bun|npm|pnpm|yarn)@(?P<version>\d+\.\d+\.\d+(-.+)?)");
 
 impl PackageManager {
+    pub fn command(&self) -> &'static str {
+        match self {
+            PackageManager::Npm => "npm",
+            PackageManager::Pnpm | PackageManager::Pnpm6 => "pnpm",
+            PackageManager::Yarn | PackageManager::Berry => "yarn",
+            PackageManager::Bun => "bun",
+        }
+    }
+
     /// Returns the set of globs for the workspace.
     pub fn get_workspace_globs(
         &self,


### PR DESCRIPTION
### Description

Use actual package manager command instead of the name. This fixes the Rust codepath for Yarn3+ and pnpm <7 (we would try to invoke `berry` and `pnpm6` instead of `yarn` and `pnpm`)

### Testing Instructions

Attempt using Rust codepath with Yarn3 we now execute the correct binary.

Closes TURBO-1590