### PR TITLE
fix: Move package manager tests to turbo info

### DIFF
--- a/crates/turborepo-lib/src/commands/info.rs
+++ b/crates/turborepo-lib/src/commands/info.rs
@@ -16,12 +16,15 @@ use crate::{
 };
 
 #[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 struct RepositoryDetails<'a> {
     config: &'a ConfigurationOptions,
+    package_manager: &'a PackageManager,
     workspaces: Vec<(&'a WorkspaceName, RepositoryWorkspaceDetails<'a>)>,
 }
 
 #[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 struct RepositoryWorkspaceDetails<'a> {
     path: &'a AnchoredSystemPath,
 }
@@ -77,7 +80,11 @@ impl<'a> RepositoryDetails<'a> {
             .collect();
         workspaces.sort_by(|a, b| a.0.cmp(b.0));
 
-        Self { config, workspaces }
+        Self {
+            config,
+            package_manager: package_graph.package_manager(),
+            workspaces,
+        }
     }
     fn print(&self) -> Result<(), cli::Error> {
         let is_logged_in = self.config.token.is_some();

--- a/turborepo-tests/integration/tests/package_manager.t
+++ b/turborepo-tests/integration/tests/package_manager.t
@@ -3,14 +3,14 @@ Setup
   $ . ${TESTDIR}/_helpers/setup_monorepo.sh $(pwd) basic_monorepo "npm@8.19.4"
 
 Run test run
-  $ TURBO_LOG_VERBOSITY=off ${TURBO} run build --__test-run | jq .package_manager
+  $ TURBO_LOG_VERBOSITY=off ${TURBO} info --json | jq .packageManager
   "npm"
 
 Set package manager to yarn in package.json
   $ jq '.packageManager = "yarn@1.22.7"' package.json > package.json.tmp && mv package.json.tmp package.json
 
 Run test run
-  $ TURBO_LOG_VERBOSITY=off ${TURBO} run build --__test-run | jq .package_manager
+  $ TURBO_LOG_VERBOSITY=off ${TURBO} info --json | jq .packageManager
   "yarn"
 
 Set up .yarnrc.yml
@@ -20,7 +20,7 @@ Set package manager to berry in package.json
   $ jq '.packageManager = "yarn@2.0.0"' package.json > package.json.tmp && mv package.json.tmp package.json
 
 Run test run
-  $ TURBO_LOG_VERBOSITY=off ${TURBO} run build --__test-run | jq .package_manager
+  $ TURBO_LOG_VERBOSITY=off ${TURBO} info --json | jq .packageManager
   "berry"
 
 Set package manager to pnpm6 in package.json
@@ -31,14 +31,14 @@ Set up pnpm-workspace.yaml
   $ echo "  - apps/*" >> pnpm-workspace.yaml
 
 Run test run
-  $ TURBO_LOG_VERBOSITY=off ${TURBO} run build --__test-run | jq .package_manager
+  $ TURBO_LOG_VERBOSITY=off ${TURBO} info --json | jq .packageManager
   "pnpm6"
 
 Set package manager to pnpm in package.json
   $ jq '.packageManager = "pnpm@7.0.0"' package.json > package.json.tmp && mv package.json.tmp package.json
 
 Run test run
-  $ TURBO_LOG_VERBOSITY=off ${TURBO} run build --__test-run | jq .package_manager
+  $ TURBO_LOG_VERBOSITY=off ${TURBO} info --json | jq .packageManager
   "pnpm"
 
 Clear package manager field in package.json
@@ -55,7 +55,7 @@ Create yarn.lock
   $ touch yarn.lock
 
 Run test run
-  $ TURBO_LOG_VERBOSITY=off ${TURBO} run build --__test-run | jq .package_manager
+  $ TURBO_LOG_VERBOSITY=off ${TURBO} info --json | jq .packageManager
   "yarn"
 
 Use yarn 3.5.1
@@ -63,7 +63,7 @@ Use yarn 3.5.1
   Preparing yarn@3.5.1 for immediate activation...
 
 Run test run
-  $ TURBO_LOG_VERBOSITY=off ${TURBO} run build --__test-run | jq .package_manager
+  $ TURBO_LOG_VERBOSITY=off ${TURBO} info --json | jq .packageManager
   "berry"
 
 Delete yarn.lock
@@ -73,7 +73,7 @@ Create pnpm-lock.yaml
   $ touch pnpm-lock.yaml
 
 Run test run
-  $ TURBO_LOG_VERBOSITY=off ${TURBO} run build --__test-run | jq .package_manager
+  $ TURBO_LOG_VERBOSITY=off ${TURBO} info --json | jq .packageManager
   "pnpm"
 
 Delete pnpm-lock.yaml
@@ -83,5 +83,5 @@ Create package-lock.json
   $ touch package-lock.json
 
 Run test run
-  $ TURBO_LOG_VERBOSITY=off ${TURBO} run build --__test-run | jq .package_manager
+  $ TURBO_LOG_VERBOSITY=off ${TURBO} info --json | jq .packageManager
   "npm"


### PR DESCRIPTION
### Description

Moving more tests off of `--__test-run` and into `turbo info`

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->


Closes TURBO-1591