### PR TITLE
feat(turbopack): support url rewrite behavior options

### DIFF
--- a/crates/turbopack-ecmascript/src/lib.rs
+++ b/crates/turbopack-ecmascript/src/lib.rs
@@ -34,6 +34,7 @@ use code_gen::CodeGenerateable;
 pub use parse::ParseResultSourceMap;
 use parse::{parse, ParseResult};
 use path_visitor::ApplyVisitors;
+use references::esm::UrlRewriteBehavior;
 pub use references::{AnalyzeEcmascriptModuleResult, TURBOPACK_HELPER};
 pub use static_code::StaticEcmascriptCode;
 use swc_core::{
@@ -94,6 +95,10 @@ pub struct EcmascriptOptions {
     pub import_parts: bool,
     /// module is forced to a specific type (happens e. g. for .cjs and .mjs)
     pub specified_module_type: SpecifiedModuleType,
+    /// Determines how to treat `new URL(...)` rewrites.
+    /// This allows to construct url depends on the different building context,
+    /// e.g. SSR, CSR, or Node.js.
+    pub url_rewrite_behavior: Option<UrlRewriteBehavior>,
 }
 
 #[turbo_tasks::value(serialization = "auto_for_input")]

--- a/crates/turbopack-ecmascript/src/references/esm/mod.rs
+++ b/crates/turbopack-ecmascript/src/references/esm/mod.rs
@@ -14,5 +14,5 @@ pub use self::{
     export::{EsmExport, EsmExports},
     meta::{ImportMetaBinding, ImportMetaRef},
     module_item::EsmModuleItem,
-    url::UrlAssetReference,
+    url::{UrlAssetReference, UrlRewriteBehavior},
 };

--- a/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/crates/turbopack-ecmascript/src/references/mod.rs
@@ -117,7 +117,7 @@ use crate::{
     references::{
         async_module::{AsyncModule, OptionAsyncModule},
         cjs::{CjsRequireAssetReference, CjsRequireCacheAccess, CjsRequireResolveAssetReference},
-        esm::{module_id::EsmModuleIdAssetReference, EsmBinding},
+        esm::{module_id::EsmModuleIdAssetReference, EsmBinding, UrlRewriteBehavior},
         require_context::{RequireContextAssetReference, RequireContextMap},
         type_issue::SpecifiedModuleTypeIssue,
     },
@@ -964,6 +964,10 @@ pub(crate) async fn analyze_ecmascript_module(
                     Vc::cell(ast_path),
                     LazyIssueSource::new(source, span.lo.to_usize(), span.hi.to_usize()),
                     in_try,
+                    options
+                        .url_rewrite_behavior
+                        .unwrap_or(UrlRewriteBehavior::Full)
+                        .cell(),
                 ));
             }
         }

--- a/crates/turbopack/src/module_options/mod.rs
+++ b/crates/turbopack/src/module_options/mod.rs
@@ -76,6 +76,7 @@ impl ModuleOptions {
             ref custom_rules,
             execution_context,
             ref rules,
+            esm_url_rewrite_behavior,
             ..
         } = *module_options_context.await?;
         if !rules.is_empty() {
@@ -129,6 +130,7 @@ impl ModuleOptions {
         let ecmascript_options = EcmascriptOptions {
             split_into_parts: enable_tree_shaking,
             import_parts: enable_tree_shaking,
+            url_rewrite_behavior: esm_url_rewrite_behavior,
             ..Default::default()
         };
 

--- a/crates/turbopack/src/module_options/module_options_context.rs
+++ b/crates/turbopack/src/module_options/module_options_context.rs
@@ -2,7 +2,7 @@ use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use turbo_tasks::{trace::TraceRawVcs, ValueDefault, Vc};
 use turbopack_core::{environment::Environment, resolve::options::ImportMapping};
-use turbopack_ecmascript::TransformPlugin;
+use turbopack_ecmascript::{references::esm::UrlRewriteBehavior, TransformPlugin};
 use turbopack_node::{
     execution_context::ExecutionContext, transforms::webpack::WebpackLoaderItems,
 };
@@ -164,6 +164,7 @@ pub struct ModuleOptionsContext {
     pub rules: Vec<(ContextCondition, Vc<ModuleOptionsContext>)>,
     pub placeholder_for_future_extensions: (),
     pub enable_tree_shaking: bool,
+    pub esm_url_rewrite_behavior: Option<UrlRewriteBehavior>,
 }
 
 #[turbo_tasks::value_impl]


### PR DESCRIPTION
### Description

This PR attempts to address supporting different approach to handle `new URL(...)` depends on the caller's context. Mostly, it aims to mimic options like https://webpack.js.org/configuration/module/#moduleparserjavascripturl.

In next.js, depends on the compilation context it specifies how `new URL` is being treated (https://github.com/vercel/next.js/blob/canary/packages/next/src/build/webpack-config.ts#L1384 / https://github.com/vercel/next.js/blob/canary/packages/next/src/build/webpack-config.ts#L1861) so generated output can resolve to the given url seamleassly regardless of running context. Turbopack currently rewrites url every time, only cares of rendering context so it is not possible - there is a rendering context differs to the actual environment that codes running (i.e `pages/api`).

To drill down hole to pass those options, PR adds a new option for the `ModuleOptionContext`, then pass it down to urlassetreference via `EcmaScriptOptions`. The actual implementation for the new rewrite behavior is not included as to verify the approach for the option itself as first step.