### PR TITLE
fix(updater): specify latest for codemod

### DIFF
--- a/crates/turborepo-updater/src/lib.rs
+++ b/crates/turborepo-updater/src/lib.rs
@@ -146,7 +146,7 @@ pub fn check_for_updates(
     if let Ok(Some(version)) = informer.check_version() {
         let latest_version = version.to_string();
         // TODO: make this package manager aware
-        let update_cmd = style("npx @turbo/codemod update").cyan().bold();
+        let update_cmd = style("npx @turbo/codemod@latest update").cyan().bold();
 
         let msg = format!(
             "


### PR DESCRIPTION
### Description

Specify latest in the updater message to avoid NPX using an older cached version.

