### PR TITLE
chore: fix clippy lints in tests

### DIFF
--- a/crates/turborepo-lib/src/engine/builder.rs
+++ b/crates/turborepo-lib/src/engine/builder.rs
@@ -1030,6 +1030,6 @@ mod test {
                 }
             })
             .err();
-        assert_eq!(result.as_deref(), reason.as_deref());
+        assert_eq!(result.as_deref(), reason);
     }
 }

--- a/crates/turborepo-lib/src/task_graph/mod.rs
+++ b/crates/turborepo-lib/src/task_graph/mod.rs
@@ -325,22 +325,21 @@ mod test {
     #[test]
     fn test_escape_log_file() {
         let build_log = TaskDefinition::workspace_relative_log_file("build");
-        let build_expected = AnchoredSystemPathBuf::from_raw(
-            &[".turbo", "turbo-build.log"].join(MAIN_SEPARATOR_STR),
-        )
-        .unwrap();
+        let build_expected =
+            AnchoredSystemPathBuf::from_raw([".turbo", "turbo-build.log"].join(MAIN_SEPARATOR_STR))
+                .unwrap();
         assert_eq!(build_log, build_expected);
 
         let build_log = TaskDefinition::workspace_relative_log_file("build:prod");
         let build_expected = AnchoredSystemPathBuf::from_raw(
-            &[".turbo", "turbo-build$colon$prod.log"].join(MAIN_SEPARATOR_STR),
+            [".turbo", "turbo-build$colon$prod.log"].join(MAIN_SEPARATOR_STR),
         )
         .unwrap();
         assert_eq!(build_log, build_expected);
 
         let build_log = TaskDefinition::workspace_relative_log_file("build:prod:extra");
         let build_expected = AnchoredSystemPathBuf::from_raw(
-            &[".turbo", "turbo-build$colon$prod$colon$extra.log"].join(MAIN_SEPARATOR_STR),
+            [".turbo", "turbo-build$colon$prod$colon$extra.log"].join(MAIN_SEPARATOR_STR),
         )
         .unwrap();
         assert_eq!(build_log, build_expected);


### PR DESCRIPTION
### Description

Fix some clippy lints in our tests that have been bothering me for a bit.

These aren't caught by CI since we're not enabling the `test` feature and I would much rather have clippy check production codepath as opposed to the test codepath. There does exists a `--tests` option for `clippy`, but we'd need to teach `cargo-groups` how to properly forward it.

### Testing Instructions

👀 


Closes TURBO-1600