### PR TITLE
fix(docs): clarify output mode for Dockerfile

### DIFF
--- a/docs/pages/repo/docs/handbook/deploying-with-docker.mdx
+++ b/docs/pages/repo/docs/handbook/deploying-with-docker.mdx
@@ -113,6 +113,10 @@ Splitting up **dependencies** and **source files** in this way lets us **only ru
 
 Our detailed [`with-docker` example](https://github.com/vercel/turbo/tree/main/examples/with-docker) goes into depth on how to utilise `prune` to its full potential. Here's the Dockerfile, copied over for convenience.
 
+<Callout type="info">
+  This Dockerfile is written for a [Next.js](https://nextjs.org/) app that is using the `standalone` [output mode](https://nextjs.org/docs/pages/api-reference/next-config-js/output).
+</Callout>
+
 ```docker
 FROM node:18-alpine AS base
 


### PR DESCRIPTION
### Description

Clarify that the Dockerfile in the docs requires using the Next.js standalone output mode




Closes TURBO-1601