### PR TITLE
fix: kill process group instead of children

### DIFF
--- a/crates/turborepo-lib/src/process/child.rs
+++ b/crates/turborepo-lib/src/process/child.rs
@@ -747,4 +747,19 @@ mod test {
         assert_eq!(buffer, &[0, 159, 146, 150, b'\n']);
         assert_matches!(exit, Some(ChildExit::Finished(Some(0))));
     }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_kill_process_group() {
+        let mut cmd = Command::new("sh");
+        cmd.args(["-c", "while true; do sleep 0.2; done"]);
+        let mut child =
+            Child::spawn(cmd, ShutdownStyle::Graceful(Duration::from_millis(100))).unwrap();
+
+        tokio::time::sleep(STARTUP_DELAY).await;
+
+        let exit = child.stop().await;
+
+        assert_matches!(exit, Some(ChildExit::Finished(None)));
+    }
 }

--- a/crates/turborepo-lib/src/process/child.rs
+++ b/crates/turborepo-lib/src/process/child.rs
@@ -91,8 +91,10 @@ impl ShutdownStyle {
                     let fut = async {
                         if let Some(pid) = child.id() {
                             debug!("sending SIGINT to child {}", pid);
+                            // kill takes negative pid to indicate that you want to use gpid
+                            let pgid = -(pid as i32);
                             unsafe {
-                                libc::kill(pid as i32, libc::SIGINT);
+                                libc::kill(pgid, libc::SIGINT);
                             }
                             debug!("waiting for child {}", pid);
                             child.wait().await.map(|es| es.code())


### PR DESCRIPTION
### Description

We were setting up the process groups correctly, we just weren't sending the signal to them instead of the process. [Corresponding Go code](https://github.com/vercel/turbo/blob/main/cli/internal/process/child.go#L322)

Future work might be dropping the `command_group` crate and switch over to [`Command::process_group`](https://docs.rs/tokio/latest/tokio/process/struct.Command.html#method.process_group)

### Testing Instructions

Added failing unit test for the behavior. It now passes with the fix.

Also tested that we shut down dev servers when a sigint is sent to turbo.


Closes TURBO-1604