### PR TITLE
fix(examples): add types d.ts gen instead of .d.mts

### DIFF
--- a/examples/with-tailwind/packages/ui/tsup.config.ts
+++ b/examples/with-tailwind/packages/ui/tsup.config.ts
@@ -4,7 +4,7 @@ export default defineConfig((options: Options) => ({
   treeshake: true,
   splitting: true,
   entry: ["src/**/*.tsx"],
-  format: ["esm"],
+  format: ["esm", "cjs"],
   dts: true,
   minify: true,
   clean: true,

--- a/examples/with-tailwind/packages/ui/tsup.config.ts
+++ b/examples/with-tailwind/packages/ui/tsup.config.ts
@@ -4,6 +4,10 @@ export default defineConfig((options: Options) => ({
   treeshake: true,
   splitting: true,
   entry: ["src/**/*.tsx"],
+  // package.json["types"] should match the generated file ext.
+  // example: esm -> index.d.mts and cjs -> index.d.ts.
+  // problem: eslint `import/recommended` can't resolve package.json["types"] with `.d.mts` (esm only).
+  // ref: https://github.com/vercel/turbo/pull/6390
   format: ["esm", "cjs"],
   dts: true,
   minify: true,


### PR DESCRIPTION
eslint import rule can't resolve import without it

### =(

Check out this PR https://github.com/vercel/turbo/pull/6341. Perhaps this is a temporary problem and my fix is ​​not needed.



### Description

<!--
  ✍️ Write a short summary of your work.
  If necessary, include relevant screenshots.
-->
fix: https://github.com/vercel/style-guide/issues/76
### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->

With current `format: ["esm"],` required`"types": "./dist/index.d.ts",` not in dist:

```
ESM dist/card.mjs           50.00 B
ESM dist/chunk-MFXFT5EY.mjs 730.00 B
ESM dist/index.css          5.67 KB
ESM dist/index.mjs          50.00 B
ESM ⚡️ Build success in 273ms
DTS ⚡️ Build success in 582ms
DTS dist/card.d.mts  188.00 B
DTS dist/index.d.mts 51.00 B
```

With current `format: ["esm"],` and`"types": "./dist/index.d.mts",` we can face https://github.com/vercel/style-guide/issues/76 after build.


With new `format: ["esm", "cjs"],` and same`"types": "./dist/index.d.ts",` it works.