### PR TITLE
fix: add newline to graph output

### DIFF
--- a/crates/turborepo-lib/src/engine/dot.rs
+++ b/crates/turborepo-lib/src/engine/dot.rs
@@ -17,7 +17,7 @@ impl Engine<Built> {
     }
 }
 
-const GRAPH_PRELUDE: &str = "digraph {\n\tcompound = \"true\"
+const GRAPH_PRELUDE: &str = "\ndigraph {\n\tcompound = \"true\"
 \tnewrank = \"true\"
 \tsubgraph \"root\" {
 ";

--- a/crates/turborepo-lib/src/engine/dot.rs
+++ b/crates/turborepo-lib/src/engine/dot.rs
@@ -70,7 +70,7 @@ mod test {
         render_graph(&graph, |n| n.to_string(), &mut bytes).unwrap();
         assert_eq!(
             String::from_utf8(bytes).unwrap(),
-            "digraph {
+            "\ndigraph {
 \tcompound = \"true\"
 \tnewrank = \"true\"
 \tsubgraph \"root\" {

--- a/turborepo-tests/integration/tests/run/single-package/graph.t
+++ b/turborepo-tests/integration/tests/run/single-package/graph.t
@@ -13,13 +13,4 @@ Graph
   \t} (esc)
   }
   
-Graph in Rust
-  $ EXPERIMENTAL_RUST_CODEPATH=true ${TURBO} run build --graph
-  digraph {
-  \tcompound = "true" (esc)
-  \tnewrank = "true" (esc)
-  \tsubgraph "root" { (esc)
-  \t\t"[root] build" -> "[root] ___ROOT___" (esc)
-  \t} (esc)
-  }
-  
+


### PR DESCRIPTION
### Description

Add a leading newline to the graph preamble. This is the same behavior as [Go](https://github.com/vercel/turbo/blob/main/cli/internal/graphvisualizer/graphvisualizer.go#L67)

### Testing Instructions

`single-package/graph.t` now passes (and other tests which use `--graph` are closer to passing)

Got rid of the Rust codepath test as we now have a matching Rust/Go codepath output


Closes TURBO-1607