### PR TITLE
fix(Turborepo): Sort env vars, include framework inference in task summary

### DIFF
--- a/crates/turborepo-env/src/lib.rs
+++ b/crates/turborepo-env/src/lib.rs
@@ -56,7 +56,8 @@ impl EnvironmentVariableMap {
     // This is the value used to print out the task hash input,
     // so the values are cryptographically hashed
     pub fn to_secret_hashable(&self) -> EnvironmentVariablePairs {
-        self.iter()
+        let mut pairs: Vec<String> = self
+            .iter()
             .map(|(k, v)| {
                 if !v.is_empty() {
                     let mut hasher = Sha256::new();
@@ -68,7 +69,10 @@ impl EnvironmentVariableMap {
                     format!("{k}=")
                 }
             })
-            .collect()
+            .collect();
+        // Make it deterministic to facilitate comparisons
+        pairs.sort();
+        pairs
     }
 }
 

--- a/crates/turborepo-lib/src/framework.rs
+++ b/crates/turborepo-lib/src/framework.rs
@@ -160,7 +160,6 @@ impl Matcher {
     }
 }
 
-#[allow(dead_code)]
 pub fn infer_framework(workspace: &WorkspaceInfo, is_monorepo: bool) -> Option<&'static Framework> {
     let frameworks = get_frameworks();
 


### PR DESCRIPTION
### Description

 - Sorts environment variables that are used for comparisons
 - Add inferred framework to task summary

### Testing Instructions

`framework_inference.t` now passes with Rust

Fixes [TURBO-1572](https://linear.app/vercel/issue/TURBO-1572/fixup-framework-inference)
