### PR TITLE
fix(Turborepo): Add suppressing logs line for new-only output mode

### DIFF
--- a/crates/turborepo-lib/src/run/cache.rs
+++ b/crates/turborepo-lib/src/run/cache.rs
@@ -259,7 +259,7 @@ impl TaskCache {
         };
 
         match self.task_output_mode {
-            OutputLogsMode::HashOnly => {
+            OutputLogsMode::HashOnly | OutputLogsMode::NewOnly => {
                 prefixed_ui.output(format!(
                     "cache hit{}, suppressing logs {}",
                     more_context,
@@ -275,7 +275,9 @@ impl TaskCache {
                 ));
                 self.replay_log_file(prefixed_ui)?;
             }
-            _ => {}
+            // Note that if we're restoring from cache, the task succeeded
+            // so we know we don't need to print anything for errors
+            OutputLogsMode::ErrorsOnly | OutputLogsMode::None => {}
         }
 
         Ok(cache_status)


### PR DESCRIPTION
### Description

 - Properly match the `fallthrough` from the Go code to have `new-only` output mode print a suppressing logs line
 - Add a note about errors-only log mode

### Testing Instructions

`omit-keys.t` now passes

Closes TURBO-1546