### PR TITLE
chore: replace BASH_SOURCE usage with realpath

### DIFF
--- a/examples-tests/setup.sh
+++ b/examples-tests/setup.sh
@@ -8,7 +8,7 @@ exampleName=$1
 pkgManager=$2
 
 # Copy the example dir over to the test dir that prysk puts you in
-SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
+SCRIPT_DIR=$(dirname "$(realpath "$0")")
 MONOREPO_ROOT_DIR="$SCRIPT_DIR/.."
 EXAMPLE_DIR="$MONOREPO_ROOT_DIR/examples/$exampleName"
 

--- a/turborepo-tests/helpers/setup.sh
+++ b/turborepo-tests/helpers/setup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-THIS_DIR=$(dirname "${BASH_SOURCE[0]}")
+THIS_DIR=$(dirname "$(realpath "$0")")
 ROOT_DIR="${THIS_DIR}/../.."
 
 TURBO=${ROOT_DIR}/target/debug/turbo

--- a/turborepo-tests/integration/tests/_helpers/copy_fixture.sh
+++ b/turborepo-tests/integration/tests/_helpers/copy_fixture.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+SCRIPT_DIR=$(dirname "$(realpath "$0")")
 TARGET_DIR=$1
 FIXTURE="_fixtures/${2-basic_monorepo}"
 cp -a ${SCRIPT_DIR}/../$FIXTURE/. ${TARGET_DIR}/

--- a/turborepo-tests/integration/tests/_helpers/setup_monorepo.sh
+++ b/turborepo-tests/integration/tests/_helpers/setup_monorepo.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+SCRIPT_DIR=$(dirname "$(realpath "$0")")
 FIXTURE="_fixtures/${2-basic_monorepo}"
 TURBOREPO_TESTS_DIR="$SCRIPT_DIR/../../.."
 

--- a/turborepo-tests/integration/tests/find_turbo/setup.sh
+++ b/turborepo-tests/integration/tests/find_turbo/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+SCRIPT_DIR=$(dirname "$(realpath "$0")")
 TARGET_DIR=$1
 FIXTURE_DIR=$2
 

--- a/turborepo-tests/integration/tests/inference/nested_workspaces_setup.sh
+++ b/turborepo-tests/integration/tests/inference/nested_workspaces_setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+SCRIPT_DIR=$(dirname "$(realpath "$0")")
 TARGET_DIR=$1
 TURBOREPO_TESTS_DIR="$SCRIPT_DIR/../../.."
 SETUP_GIT_SCRIPT="${TURBOREPO_TESTS_DIR}/helpers/setup_git.sh"

--- a/turborepo-tests/integration/tests/inference/no_workspaces_setup.sh
+++ b/turborepo-tests/integration/tests/inference/no_workspaces_setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+SCRIPT_DIR=$(dirname "$(realpath "$0")")
 TARGET_DIR=$1
 TURBOREPO_TESTS_DIR="$SCRIPT_DIR/../../.."
 SETUP_GIT_SCRIPT="${TURBOREPO_TESTS_DIR}/helpers/setup_git.sh"

--- a/turborepo-tests/integration/tests/lockfile_aware_caching/setup.sh
+++ b/turborepo-tests/integration/tests/lockfile_aware_caching/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+SCRIPT_DIR=$(dirname "$(realpath "$0")")
 TARGET_DIR=$1
 FIXTURE_DIR=$2
 cp -a ${SCRIPT_DIR}/../_fixtures/lockfile_aware_caching/. ${TARGET_DIR}/


### PR DESCRIPTION
realpath is not specific to bash and resolves relative links which makes debugging a lot easier

Closes TURBO-1622