### PR TITLE
fix(Turborepo): Fix error stutter, update tests to match on relevent error text

### DIFF
--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -84,7 +84,6 @@ func RunWithExecutionState(executionState *turbostate.ExecutionState, turboVersi
 		if errors.As(execErr, &exitErr) {
 			return exitErr.ExitCode
 		} else if execErr != nil {
-			fmt.Printf("Turbo error: %v\n", execErr)
 			return 1
 		}
 		return 0

--- a/crates/turborepo-lib/src/lib.rs
+++ b/crates/turborepo-lib/src/lib.rs
@@ -54,6 +54,8 @@ pub fn get_version() -> &'static str {
 pub fn main() -> Payload {
     match shim::run() {
         Ok(payload) => payload,
+        // We don't need to print "Turbo error" for Run errors
+        Err(err @ shim::Error::Cli(cli::Error::Run(_))) => Payload::Rust(Err(err)),
         Err(err) => {
             // This raw print matches the Go behavior, once we no longer care
             // about matching formatting we should remove this.

--- a/turborepo-tests/integration/tests/persistent-dependencies/1-topological.t
+++ b/turborepo-tests/integration/tests/persistent-dependencies/1-topological.t
@@ -16,6 +16,4 @@
   $ ${TURBO} run dev
    ERROR  run failed: error preparing engine: Invalid persistent task configuration:
   "pkg-a#dev" is a persistent task, "app-a#dev" cannot depend on it
-  Turbo error: error preparing engine: Invalid persistent task configuration:
-  "pkg-a#dev" is a persistent task, "app-a#dev" cannot depend on it
   [1]

--- a/turborepo-tests/integration/tests/persistent-dependencies/10-too-many.t
+++ b/turborepo-tests/integration/tests/persistent-dependencies/10-too-many.t
@@ -5,13 +5,9 @@
   $ ${TURBO} run build --concurrency=1
    ERROR  run failed: error preparing engine: Invalid persistent task configuration:
   You have 2 persistent tasks but `turbo` is configured for concurrency of 1. Set --concurrency to at least 3
-  Turbo error: error preparing engine: Invalid persistent task configuration:
-  You have 2 persistent tasks but `turbo` is configured for concurrency of 1. Set --concurrency to at least 3
   [1]
 
   $ ${TURBO} run build --concurrency=2
    ERROR  run failed: error preparing engine: Invalid persistent task configuration:
-  You have 2 persistent tasks but `turbo` is configured for concurrency of 2. Set --concurrency to at least 3
-  Turbo error: error preparing engine: Invalid persistent task configuration:
   You have 2 persistent tasks but `turbo` is configured for concurrency of 2. Set --concurrency to at least 3
   [1]

--- a/turborepo-tests/integration/tests/persistent-dependencies/2-same-workspace.t
+++ b/turborepo-tests/integration/tests/persistent-dependencies/2-same-workspace.t
@@ -16,6 +16,4 @@
   $ ${TURBO} run build
    ERROR  run failed: error preparing engine: Invalid persistent task configuration:
   "app-a#dev" is a persistent task, "app-a#build" cannot depend on it
-  Turbo error: error preparing engine: Invalid persistent task configuration:
-  "app-a#dev" is a persistent task, "app-a#build" cannot depend on it
   [1]

--- a/turborepo-tests/integration/tests/persistent-dependencies/3-workspace-specific.t
+++ b/turborepo-tests/integration/tests/persistent-dependencies/3-workspace-specific.t
@@ -21,7 +21,4 @@
    ERROR  run failed: error preparing engine: Invalid persistent task configuration:
   "pkg-a#dev" is a persistent task, "app-a#build" cannot depend on it
   "pkg-a#dev" is a persistent task, "pkg-a#build" cannot depend on it
-  Turbo error: error preparing engine: Invalid persistent task configuration:
-  "pkg-a#dev" is a persistent task, "app-a#build" cannot depend on it
-  "pkg-a#dev" is a persistent task, "pkg-a#build" cannot depend on it
   [1]

--- a/turborepo-tests/integration/tests/persistent-dependencies/4-cross-workspace.t
+++ b/turborepo-tests/integration/tests/persistent-dependencies/4-cross-workspace.t
@@ -10,6 +10,4 @@
   $ ${TURBO} run dev
    ERROR  run failed: error preparing engine: Invalid persistent task configuration:
   "pkg-a#dev" is a persistent task, "app-a#dev" cannot depend on it
-  Turbo error: error preparing engine: Invalid persistent task configuration:
-  "pkg-a#dev" is a persistent task, "app-a#dev" cannot depend on it
   [1]

--- a/turborepo-tests/integration/tests/persistent-dependencies/5-root-workspace.t
+++ b/turborepo-tests/integration/tests/persistent-dependencies/5-root-workspace.t
@@ -16,6 +16,4 @@
   $ ${TURBO} run build
    ERROR  run failed: error preparing engine: Invalid persistent task configuration:
   "//#dev" is a persistent task, "app-a#build" cannot depend on it
-  Turbo error: error preparing engine: Invalid persistent task configuration:
-  "//#dev" is a persistent task, "app-a#build" cannot depend on it
   [1]

--- a/turborepo-tests/integration/tests/persistent-dependencies/7-topological-nested.t
+++ b/turborepo-tests/integration/tests/persistent-dependencies/7-topological-nested.t
@@ -23,6 +23,4 @@
   $ ${TURBO} run dev
    ERROR  run failed: error preparing engine: Invalid persistent task configuration:
   "pkg-b#dev" is a persistent task, "pkg-a#dev" cannot depend on it
-  Turbo error: error preparing engine: Invalid persistent task configuration:
-  "pkg-b#dev" is a persistent task, "pkg-a#dev" cannot depend on it
   [1]

--- a/turborepo-tests/integration/tests/persistent-dependencies/8-topological-with-extra.t
+++ b/turborepo-tests/integration/tests/persistent-dependencies/8-topological-with-extra.t
@@ -22,6 +22,4 @@
   $ ${TURBO} run build
    ERROR  run failed: error preparing engine: Invalid persistent task configuration:
   "pkg-z#dev" is a persistent task, "pkg-b#build" cannot depend on it
-  Turbo error: error preparing engine: Invalid persistent task configuration:
-  "pkg-z#dev" is a persistent task, "pkg-b#build" cannot depend on it
   [1]

--- a/turborepo-tests/integration/tests/persistent-dependencies/9-cross-workspace-nested.t
+++ b/turborepo-tests/integration/tests/persistent-dependencies/9-cross-workspace-nested.t
@@ -15,6 +15,4 @@
   $ ${TURBO} run build
    ERROR  run failed: error preparing engine: Invalid persistent task configuration:
   "app-z#dev" is a persistent task, "app-c#build" cannot depend on it
-  Turbo error: error preparing engine: Invalid persistent task configuration:
-  "app-z#dev" is a persistent task, "app-c#build" cannot depend on it
   [1]

--- a/turborepo-tests/integration/tests/workspace-configs/bad-json.t
+++ b/turborepo-tests/integration/tests/workspace-configs/bad-json.t
@@ -9,5 +9,5 @@ Setup
 # Errors are shown if we run across a malformed turbo.json
   $ ${TURBO} run trailing-comma --filter=bad-json > tmp.log 2>&1
   [1]
-  $ cat tmp.log
-  Error: trailing comma at line 1 column 36
+  $ cat tmp.log | grep --only-matching "trailing comma at line 1 column 36"
+  trailing comma at line 1 column 36

--- a/turborepo-tests/integration/tests/workspace-configs/invalid-config.t
+++ b/turborepo-tests/integration/tests/workspace-configs/invalid-config.t
@@ -7,8 +7,8 @@ Setup
 Errors are shown if we run a task that is misconfigured (invalid-config#build)
   $ ${TURBO} run build --filter=invalid-config > tmp.log 2>&1
   [1]
-  $ cat tmp.log | grep "Invalid turbo.json"
-  Error: Invalid turbo.json:
+  $ cat tmp.log | grep --only-matching "Invalid turbo.json"
+  Invalid turbo.json
   $ cat tmp.log | grep "invalid-config#build"
    - "invalid-config#build". Use "build" instead
   $ cat tmp.log | grep "//#some-root-task"
@@ -19,8 +19,8 @@ Errors are shown if we run a task that is misconfigured (invalid-config#build)
 Same error even if you're running a valid task in the package.
   $ ${TURBO} run valid-task --filter=invalid-config > tmp.log 2>&1
   [1]
-  $ cat tmp.log | grep "Invalid turbo.json"
-  Error: Invalid turbo.json:
+  $ cat tmp.log | grep --only-matching "Invalid turbo.json"
+  Invalid turbo.json
   $ cat tmp.log | grep "invalid-config#build"
    - "invalid-config#build". Use "build" instead
   $ cat tmp.log | grep "//#some-root-task"

--- a/turborepo-tests/integration/tests/workspace-configs/persistent.t
+++ b/turborepo-tests/integration/tests/workspace-configs/persistent.t
@@ -13,8 +13,6 @@ This test covers:
   $ ${TURBO} run persistent-task-1-parent --filter=persistent
    ERROR  run failed: error preparing engine: Invalid persistent task configuration:
   "persistent#persistent-task-1" is a persistent task, "persistent#persistent-task-1-parent" cannot depend on it
-  Turbo error: error preparing engine: Invalid persistent task configuration:
-  "persistent#persistent-task-1" is a persistent task, "persistent#persistent-task-1-parent" cannot depend on it
   [1]
 
 # persistent-task-2-parent dependsOn persistent-task-2
@@ -46,15 +44,11 @@ This test covers:
   $ ${TURBO} run persistent-task-3-parent --filter=persistent
    ERROR  run failed: error preparing engine: Invalid persistent task configuration:
   "persistent#persistent-task-3" is a persistent task, "persistent#persistent-task-3-parent" cannot depend on it
-  Turbo error: error preparing engine: Invalid persistent task configuration:
-  "persistent#persistent-task-3" is a persistent task, "persistent#persistent-task-3-parent" cannot depend on it
   [1]
 
 # persistent-task-4-parent dependsOn persistent-task-4
 # persistent-task-4 has no config in the root workspace, and is set to true in the workspace
   $ ${TURBO} run persistent-task-4-parent --filter=persistent
    ERROR  run failed: error preparing engine: Invalid persistent task configuration:
-  "persistent#persistent-task-4" is a persistent task, "persistent#persistent-task-4-parent" cannot depend on it
-  Turbo error: error preparing engine: Invalid persistent task configuration:
   "persistent#persistent-task-4" is a persistent task, "persistent#persistent-task-4-parent" cannot depend on it
   [1]


### PR DESCRIPTION
### Description

 - Drop error stutter from Go
 - Update tests to no longer expect duplicate errors
 - top-level rust main no longer prints `turbo error` for errors from `run`
 - Update a few tests to match on specific error text to handle errors always coming from Rust, even when we're executing Go

### Testing Instructions

Updated integration tests

Closes TURBO-1626