### PR TITLE
chore(ci): Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -379,7 +379,7 @@ jobs:
           ref: ${{ needs.stage.outputs.stage-branch }}
       - name: Get version
         id: getVersion
-        run: echo ::set-output name=version::$(head -n 1 version.txt)
+        run: echo "version=$(head -n 1 version.txt)" >> $GITHUB_OUTPUT
       - name: Create pull request
         uses: thomaseizinger/create-pull-request@master
         if: ${{ !inputs.dry_run }}


### PR DESCRIPTION
### Description

<!--
  ✍️ Write a short summary of your work.
  If necessary, include relevant screenshots.
-->

Update `.github/workflows/turborepo-release.yml` to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow file that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yaml
run: echo ::set-output name=version::$(head -n 1 version.txt)
```

**TO-BE**

```yaml
run: echo "version=$(head -n 1 version.txt)" >> $GITHUB_OUTPUT
```


### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->

None
