### PR TITLE
port: Fixing run summary json output

### DIFF
--- a/crates/turborepo-lib/src/run/summary/execution.rs
+++ b/crates/turborepo-lib/src/run/summary/execution.rs
@@ -26,6 +26,9 @@ pub struct ExecutionTracker {
 pub struct ExecutionSummary<'a> {
     // a synthesized turbo command to produce this invocation
     command: String,
+    // the (possibly empty) path from the turborepo root to where the command was run
+    #[serde(rename = "repoPath")]
+    repo_path: &'a AnchoredSystemPath,
     // number of tasks that exited successfully (does not include cache hits)
     success: usize,
     // number of tasks that exited with failure
@@ -34,9 +37,6 @@ pub struct ExecutionSummary<'a> {
     cached: usize,
     // number of tasks that started
     attempted: usize,
-    // the (possibly empty) path from the turborepo root to where the command was run
-    #[serde(rename = "repoPath")]
-    repo_path: &'a AnchoredSystemPath,
     pub(crate) start_time: i64,
     pub(crate) end_time: i64,
     #[serde(skip)]

--- a/crates/turborepo-lib/src/run/summary/mod.rs
+++ b/crates/turborepo-lib/src/run/summary/mod.rs
@@ -201,6 +201,7 @@ impl RunTracker {
         run_opts: &RunOpts<'a>,
         packages: HashSet<WorkspaceName>,
         global_hash_summary: GlobalHashSummary<'a>,
+        global_env_mode: EnvMode,
         task_factory: TaskSummaryFactory<'a>,
     ) -> Result<RunSummary<'a>, Error> {
         let single_package = run_opts.single_package;
@@ -235,7 +236,7 @@ impl RunTracker {
             turbo_version: self.version,
             packages: packages.into_iter().sorted().collect(),
             execution: Some(execution_summary),
-            env_mode: run_opts.env_mode.into(),
+            env_mode: global_env_mode,
             framework_inference: run_opts.framework_inference,
             tasks,
             global_hash_summary,
@@ -286,6 +287,7 @@ impl RunTracker {
                 run_opts,
                 packages,
                 global_hash_summary,
+                global_env_mode.into(),
                 task_factory,
             )
             .await?;

--- a/crates/turborepo-lib/src/run/summary/task.rs
+++ b/crates/turborepo-lib/src/run/summary/task.rs
@@ -80,11 +80,11 @@ pub(crate) struct SharedTaskSummary<T> {
     pub resolved_task_definition: TaskSummaryTaskDefinition,
     pub expanded_outputs: Vec<AnchoredSystemPathBuf>,
     pub framework: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub execution: Option<TaskExecutionSummary>,
     pub env_mode: EnvMode,
     pub environment_variables: TaskEnvVarSummary,
     pub dot_env: Option<Vec<RelativeUnixPathBuf>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub execution: Option<TaskExecutionSummary>,
 }
 
 #[derive(Debug, Serialize, Clone)]
@@ -112,7 +112,6 @@ pub struct TaskSummaryTaskDefinition {
 #[serde(rename_all = "camelCase")]
 pub struct TaskEnvVarSummary {
     pub specified: TaskEnvConfiguration,
-
     pub configured: Vec<String>,
     pub inferred: Vec<String>,
     #[serde(rename = "passthrough")]
@@ -182,14 +181,16 @@ impl TaskEnvVarSummary {
         // TODO: this operation differs from the actual env that gets passed in during
         // task execution it should be unified, but first we should copy Go's
         // behavior as we try to match the implementations
-        let pass_through = env_at_execution_start
-            .from_wildcards(
-                task_definition
-                    .pass_through_env
-                    .as_deref()
-                    .unwrap_or_default(),
-            )?
-            .to_secret_hashable();
+        let pass_through = task_definition
+            .pass_through_env
+            .as_deref()
+            .map(|pass_through_env| -> Result<_, turborepo_env::Error> {
+                Ok(env_at_execution_start
+                    .from_wildcards(pass_through_env)?
+                    .to_secret_hashable())
+            })
+            .transpose()?;
+
         Ok(Self {
             specified: TaskEnvConfiguration {
                 env: task_definition.env.clone(),
@@ -197,10 +198,7 @@ impl TaskEnvVarSummary {
             },
             configured: env_vars.by_source.explicit.to_secret_hashable(),
             inferred: env_vars.by_source.matching.to_secret_hashable(),
-            pass_through: match pass_through.is_empty() {
-                false => Some(pass_through),
-                true => None,
-            },
+            pass_through,
         })
     }
 }


### PR DESCRIPTION
### Description

Fixing the output for run summary json. Mostly moving some fields around and fixing the global env var to resolve away `infer`. Also fixes the passthrough env variables to be null when the Go version is null.
### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->


Closes TURBO-1649