### PR TITLE
port(Turborepo): Migrate inference tests to grep

### DIFF
--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -260,8 +260,6 @@ impl<'a> Run<'a> {
             analytics_sender,
         )?;
 
-        info!("created cache");
-
         let mut engine =
             self.build_engine(&pkg_dep_graph, &opts, &root_turbo_json, &filtered_pkgs)?;
 
@@ -306,8 +304,6 @@ impl<'a> Run<'a> {
             daemon,
             self.base.ui,
         ));
-
-        info!("created cache");
 
         let mut global_env_mode = opts.run_opts.env_mode;
         if matches!(global_env_mode, EnvMode::Infer)

--- a/turborepo-tests/integration/tests/inference/has-workspaces.t
+++ b/turborepo-tests/integration/tests/inference/has-workspaces.t
@@ -2,181 +2,32 @@ Setup
   $ . ${TESTDIR}/../../../helpers/setup.sh
   $ . ${TESTDIR}/../_helpers/setup_monorepo.sh $(pwd) inference/has_workspaces
 
-  $ cd $TARGET_DIR && ${TURBO} run build --filter=nothing -vv
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/has-workspaces\.t (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running command as global turbo (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::run::global_hash: global hash env vars \[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::run::global_hash: external deps hash: 459c029558afe716 (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Found go binary at "[\-\w\/]+" (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: build tag: rust (re)
-  [-0-9:.TWZ+]+ \[INFO]  turbo: skipping turbod since we appear to be in a non-interactive context (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: filter patterns: patterns=\["nothing"] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Parsed selector: selector="&{includeDependencies:false matchDependencies:false includeDependents:false exclude:false excludeSelf:false followProdDepsOnly:false parentDir: namePattern:nothing fromRef: toRefOverride: raw:nothing}" (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtering packages: allPackageSelectors=\["&{false false false false false false  nothing   nothing}"] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtered packages: selector="&{includeDependencies:false matchDependencies:false includeDependents:false exclude:false excludeSelf:false followProdDepsOnly:false parentDir: namePattern:nothing fromRef: toRefOverride: raw:nothing}" entryPackages=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtered packages: cherryPickedPackages=map\[] walkedDependencies=map\[] walkedDependents=map\[] walkedDependentsDependencies=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtered packages: cherryPickedPackages=map\[] walkedDependencies=map\[] walkedDependents=map\[] walkedDependentsDependencies=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: filtered packages: packages=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash env vars: vars=\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash: value=00437efdb7e230f5 (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash matches between Rust and Go (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: local cache folder: path="" (re)
-  \xe2\x80\xa2 Packages in scope:  (esc)
-  \xe2\x80\xa2 Running build in 0 packages (esc)
-  \xe2\x80\xa2 Remote caching disabled (esc)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: task hashes match (re)
-  
+  $ cd $TARGET_DIR && ${TURBO} run build --filter=nothing -vv 1> ROOT 2>&1
+  $ cat ROOT | grep --only-match 'pkg_inference_root set'
+  [1]
+  $ cat ROOT | grep --only-match "No tasks were executed as part of this run."
   No tasks were executed as part of this run.
-  
-   Tasks:    0 successful, 0 total
-  Cached:    0 cached, 0 total
-    Time:\s*[\.0-9]+m?s  (re)
-  
 
-  $ cd $TARGET_DIR/apps/web && ${TURBO} run build --filter=nothing -vv
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/has-workspaces\.t (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running command as global turbo (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::cli: pkg_inference_root set to "apps/web" (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::run::global_hash: global hash env vars \[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::run::global_hash: external deps hash: 459c029558afe716 (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::run::scope::filter: Using apps/web as a basis for selecting packages (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Found go binary at "[\-\w\/]+" (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: build tag: rust (re)
-  [-0-9:.TWZ+]+ \[INFO]  turbo: skipping turbod since we appear to be in a non-interactive context (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Using apps/web as a basis for selecting packages (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: filter patterns: patterns=\["nothing"] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Parsed selector: selector="&{includeDependencies:false matchDependencies:false includeDependents:false exclude:false excludeSelf:false followProdDepsOnly:false parentDir: namePattern:nothing fromRef: toRefOverride: raw:nothing}" (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtering packages: allPackageSelectors=\["&{false false false false false false  nothing   nothing}"] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtered packages: selector="&{includeDependencies:false matchDependencies:false includeDependents:false exclude:false excludeSelf:false followProdDepsOnly:false parentDir: namePattern:nothing fromRef: toRefOverride: raw:nothing}" entryPackages=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtered packages: cherryPickedPackages=map\[] walkedDependencies=map\[] walkedDependents=map\[] walkedDependentsDependencies=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtered packages: cherryPickedPackages=map\[] walkedDependencies=map\[] walkedDependents=map\[] walkedDependentsDependencies=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: filtered packages: packages=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash env vars: vars=\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash: value=00437efdb7e230f5 (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash matches between Rust and Go (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: local cache folder: path="" (re)
-  \xe2\x80\xa2 Packages in scope:  (esc)
-  \xe2\x80\xa2 Running build in 0 packages (esc)
-  \xe2\x80\xa2 Remote caching disabled (esc)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: task hashes match (re)
-  
+  $ cd $TARGET_DIR/apps/web && ${TURBO} run build --filter=nothing -vv 1> WEB 2>&1
+  $ cat WEB | grep --only-match 'pkg_inference_root set to "apps/web"'
+  pkg_inference_root set to "apps/web"
+  $ cat WEB | grep --only-match "No tasks were executed as part of this run."
   No tasks were executed as part of this run.
-  
-   Tasks:    0 successful, 0 total
-  Cached:    0 cached, 0 total
-    Time:\s*[\.0-9]+m?s  (re)
-  
-  $ cd $TARGET_DIR/crates && ${TURBO} run build --filter=nothing -vv
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/has-workspaces\.t (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running command as global turbo (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::cli: pkg_inference_root set to "crates" (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::run::global_hash: global hash env vars \[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::run::global_hash: external deps hash: 459c029558afe716 (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::run::scope::filter: Using crates as a basis for selecting packages (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Found go binary at "[\-\w\/]+" (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: build tag: rust (re)
-  [-0-9:.TWZ+]+ \[INFO]  turbo: skipping turbod since we appear to be in a non-interactive context (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Using crates as a basis for selecting packages (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: filter patterns: patterns=\["nothing"] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Parsed selector: selector="&{includeDependencies:false matchDependencies:false includeDependents:false exclude:false excludeSelf:false followProdDepsOnly:false parentDir: namePattern:nothing fromRef: toRefOverride: raw:nothing}" (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtering packages: allPackageSelectors=\["&{false false false false false false  nothing   nothing}"] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtered packages: selector="&{includeDependencies:false matchDependencies:false includeDependents:false exclude:false excludeSelf:false followProdDepsOnly:false parentDir: namePattern:nothing fromRef: toRefOverride: raw:nothing}" entryPackages=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtered packages: cherryPickedPackages=map\[] walkedDependencies=map\[] walkedDependents=map\[] walkedDependentsDependencies=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtered packages: cherryPickedPackages=map\[] walkedDependencies=map\[] walkedDependents=map\[] walkedDependentsDependencies=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: filtered packages: packages=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash env vars: vars=\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash: value=00437efdb7e230f5 (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash matches between Rust and Go (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: local cache folder: path="" (re)
-  \xe2\x80\xa2 Packages in scope:  (esc)
-  \xe2\x80\xa2 Running build in 0 packages (esc)
-  \xe2\x80\xa2 Remote caching disabled (esc)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: task hashes match (re)
-  
+
+  $ cd $TARGET_DIR/crates && ${TURBO} run build --filter=nothing -vv 1> CRATES 2>&1
+  $ cat CRATES | grep --only-match 'pkg_inference_root set to "crates"'
+  pkg_inference_root set to "crates"
+  $ cat CRATES | grep --only-match "No tasks were executed as part of this run."
   No tasks were executed as part of this run.
-  
-   Tasks:    0 successful, 0 total
-  Cached:    0 cached, 0 total
-    Time:\s*[\.0-9]+m?s  (re)
-  
-  $ cd $TARGET_DIR/crates/super-crate/tests/test-package && ${TURBO} run build --filter=nothing -vv
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/has-workspaces\.t (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running command as global turbo (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::cli: pkg_inference_root set to "crates/super-crate/tests/test-package" (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::run::global_hash: global hash env vars \[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::run::global_hash: external deps hash: 459c029558afe716 (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::run::scope::filter: Using crates/super-crate/tests/test-package as a basis for selecting packages (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Found go binary at "[\-\w\/]+" (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: build tag: rust (re)
-  [-0-9:.TWZ+]+ \[INFO]  turbo: skipping turbod since we appear to be in a non-interactive context (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Using crates/super-crate/tests/test-package as a basis for selecting packages (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: filter patterns: patterns=\["nothing"] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Parsed selector: selector="&{includeDependencies:false matchDependencies:false includeDependents:false exclude:false excludeSelf:false followProdDepsOnly:false parentDir: namePattern:nothing fromRef: toRefOverride: raw:nothing}" (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtering packages: allPackageSelectors=\["&{false false false false false false  nothing   nothing}"] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtered packages: selector="&{includeDependencies:false matchDependencies:false includeDependents:false exclude:false excludeSelf:false followProdDepsOnly:false parentDir: namePattern:nothing fromRef: toRefOverride: raw:nothing}" entryPackages=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtered packages: cherryPickedPackages=map\[] walkedDependencies=map\[] walkedDependents=map\[] walkedDependentsDependencies=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtered packages: cherryPickedPackages=map\[] walkedDependencies=map\[] walkedDependents=map\[] walkedDependentsDependencies=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: filtered packages: packages=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash env vars: vars=\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash: value=00437efdb7e230f5 (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash matches between Rust and Go (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: local cache folder: path="" (re)
-  \xe2\x80\xa2 Packages in scope:  (esc)
-  \xe2\x80\xa2 Running build in 0 packages (esc)
-  \xe2\x80\xa2 Remote caching disabled (esc)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: task hashes match (re)
-  
+
+  $ cd $TARGET_DIR/crates/super-crate/tests/test-package && ${TURBO} run build --filter=nothing -vv 1> TEST_PACKAGE 2>&1
+  $ cat TEST_PACKAGE | grep --only-match 'pkg_inference_root set to "crates/super-crate/tests/test-package"'
+  pkg_inference_root set to "crates/super-crate/tests/test-package"
+  $ cat TEST_PACKAGE | grep --only-match "No tasks were executed as part of this run."
   No tasks were executed as part of this run.
-  
-   Tasks:    0 successful, 0 total
-  Cached:    0 cached, 0 total
-    Time:\s*[\.0-9]+m?s  (re)
-  
-  $ cd $TARGET_DIR/packages/ui-library/src && ${TURBO} run build --filter=nothing -vv
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/has-workspaces\.t (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running command as global turbo (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::cli: pkg_inference_root set to "packages/ui-library/src" (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::run::global_hash: global hash env vars \[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::run::global_hash: external deps hash: 459c029558afe716 (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::run::scope::filter: Using packages/ui-library/src as a basis for selecting packages (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Found go binary at "[\-\w\/]+" (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: build tag: rust (re)
-  [-0-9:.TWZ+]+ \[INFO]  turbo: skipping turbod since we appear to be in a non-interactive context (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Using packages/ui-library/src as a basis for selecting packages (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: filter patterns: patterns=\["nothing"] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Parsed selector: selector="&{includeDependencies:false matchDependencies:false includeDependents:false exclude:false excludeSelf:false followProdDepsOnly:false parentDir: namePattern:nothing fromRef: toRefOverride: raw:nothing}" (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtering packages: allPackageSelectors=\["&{false false false false false false  nothing   nothing}"] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtered packages: selector="&{includeDependencies:false matchDependencies:false includeDependents:false exclude:false excludeSelf:false followProdDepsOnly:false parentDir: namePattern:nothing fromRef: toRefOverride: raw:nothing}" entryPackages=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtered packages: cherryPickedPackages=map\[] walkedDependencies=map\[] walkedDependents=map\[] walkedDependentsDependencies=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtered packages: cherryPickedPackages=map\[] walkedDependencies=map\[] walkedDependents=map\[] walkedDependentsDependencies=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: filtered packages: packages=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash env vars: vars=\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash: value=00437efdb7e230f5 (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash matches between Rust and Go (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: local cache folder: path="" (re)
-  \xe2\x80\xa2 Packages in scope:  (esc)
-  \xe2\x80\xa2 Running build in 0 packages (esc)
-  \xe2\x80\xa2 Remote caching disabled (esc)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: task hashes match (re)
-  
+
+  $ cd $TARGET_DIR/packages/ui-library/src && ${TURBO} run build --filter=nothing -vv 1> UI_LIBRARY 2>&1
+  $ cat UI_LIBRARY | grep --only-match 'pkg_inference_root set to "packages/ui-library/src"'
+  pkg_inference_root set to "packages/ui-library/src"
+  $ cat UI_LIBRARY | grep --only-match "No tasks were executed as part of this run."
   No tasks were executed as part of this run.
-  
-   Tasks:    0 successful, 0 total
-  Cached:    0 cached, 0 total
-    Time:\s*[\.0-9]+m?s  (re)
-  

--- a/turborepo-tests/integration/tests/inference/nested-workspaces.t
+++ b/turborepo-tests/integration/tests/inference/nested-workspaces.t
@@ -2,268 +2,83 @@ Setup
   $ . ${TESTDIR}/../../../helpers/setup.sh
   $ . ${TESTDIR}/nested_workspaces_setup.sh $(pwd)/nested_workspaces
 
-  $ cd $TARGET_DIR/outer && ${TURBO} run build --filter=nothing -vv
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/nested_workspaces/outer (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running command as global turbo (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::run::global_hash: global hash env vars \[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::run::global_hash: external deps hash: 459c029558afe716 (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Found go binary at "[\-\w\/\.]+" (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: build tag: rust (re)
-  [-0-9:.TWZ+]+ \[INFO]  turbo: skipping turbod since we appear to be in a non-interactive context (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: filter patterns: patterns=\["nothing"] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Parsed selector: selector="&{includeDependencies:false matchDependencies:false includeDependents:false exclude:false excludeSelf:false followProdDepsOnly:false parentDir: namePattern:nothing fromRef: toRefOverride: raw:nothing}" (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtering packages: allPackageSelectors=\["&{false false false false false false  nothing   nothing}"] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtered packages: selector="&{includeDependencies:false matchDependencies:false includeDependents:false exclude:false excludeSelf:false followProdDepsOnly:false parentDir: namePattern:nothing fromRef: toRefOverride: raw:nothing}" entryPackages=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtered packages: cherryPickedPackages=map\[] walkedDependencies=map\[] walkedDependents=map\[] walkedDependentsDependencies=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtered packages: cherryPickedPackages=map\[] walkedDependencies=map\[] walkedDependents=map\[] walkedDependentsDependencies=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: filtered packages: packages=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash env vars: vars=\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash: value=00437efdb7e230f5 (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash matches between Rust and Go (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: local cache folder: path="" (re)
-  \xe2\x80\xa2 Packages in scope:  (esc)
-  \xe2\x80\xa2 Running build in 0 packages (esc)
-  \xe2\x80\xa2 Remote caching disabled (esc)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: task hashes match (re)
-  
+  $ cd $TARGET_DIR/outer && ${TURBO} run build --filter=nothing -vv 1> OUTER 2>&1
+  $ cat OUTER | grep --only-match -E "Repository Root: .*/nested_workspaces/outer"
+  Repository Root: .*/nested_workspaces/outer (re)
+  $ cat OUTER | grep --only-match "No tasks were executed as part of this run."
   No tasks were executed as part of this run.
-  
-   Tasks:    0 successful, 0 total
-  Cached:    0 cached, 0 total
-    Time:\s*[\.0-9]+m?s  (re)
-  
-  $ cd $TARGET_DIR/outer/apps && ${TURBO} run build --filter=nothing -vv
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/nested_workspaces/outer (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running command as global turbo (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::cli: pkg_inference_root set to "apps" (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::run::global_hash: global hash env vars \[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::run::global_hash: external deps hash: 459c029558afe716 (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::run::scope::filter: Using apps as a basis for selecting packages (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Found go binary at "[\-\w\/\.]+" (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: build tag: rust (re)
-  [-0-9:.TWZ+]+ \[INFO]  turbo: skipping turbod since we appear to be in a non-interactive context (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Using apps as a basis for selecting packages (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: filter patterns: patterns=\["nothing"] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Parsed selector: selector="&{includeDependencies:false matchDependencies:false includeDependents:false exclude:false excludeSelf:false followProdDepsOnly:false parentDir: namePattern:nothing fromRef: toRefOverride: raw:nothing}" (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtering packages: allPackageSelectors=\["&{false false false false false false  nothing   nothing}"] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtered packages: selector="&{includeDependencies:false matchDependencies:false includeDependents:false exclude:false excludeSelf:false followProdDepsOnly:false parentDir: namePattern:nothing fromRef: toRefOverride: raw:nothing}" entryPackages=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtered packages: cherryPickedPackages=map\[] walkedDependencies=map\[] walkedDependents=map\[] walkedDependentsDependencies=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtered packages: cherryPickedPackages=map\[] walkedDependencies=map\[] walkedDependents=map\[] walkedDependentsDependencies=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: filtered packages: packages=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash env vars: vars=\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash: value=00437efdb7e230f5 (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash matches between Rust and Go (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: local cache folder: path="" (re)
-  \xe2\x80\xa2 Packages in scope:  (esc)
-  \xe2\x80\xa2 Running build in 0 packages (esc)
-  \xe2\x80\xa2 Remote caching disabled (esc)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: task hashes match (re)
-  
+
+  $ cd $TARGET_DIR/outer/apps && ${TURBO} run build --filter=nothing -vv 1> OUTER_APPS 2>&1
+  $ cat OUTER_APPS | grep --only-match -E "Repository Root: .*/nested_workspaces/outer"
+  Repository Root: .*/nested_workspaces/outer (re)
+  $ cat OUTER_APPS | grep --only-match "No tasks were executed as part of this run."
   No tasks were executed as part of this run.
-  
-   Tasks:    0 successful, 0 total
-  Cached:    0 cached, 0 total
-    Time:\s*[\.0-9]+m?s  (re)
-  
-  $ cd $TARGET_DIR/outer/inner && ${TURBO} run build --filter=nothing -vv
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/nested_workspaces/outer/inner (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running command as global turbo (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::run::global_hash: global hash env vars \[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::run::global_hash: external deps hash: 459c029558afe716 (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Found go binary at "[\-\w\/\.]+" (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: build tag: rust (re)
-  [-0-9:.TWZ+]+ \[INFO]  turbo: skipping turbod since we appear to be in a non-interactive context (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: filter patterns: patterns=\["nothing"] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Parsed selector: selector="&{includeDependencies:false matchDependencies:false includeDependents:false exclude:false excludeSelf:false followProdDepsOnly:false parentDir: namePattern:nothing fromRef: toRefOverride: raw:nothing}" (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtering packages: allPackageSelectors=\["&{false false false false false false  nothing   nothing}"] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtered packages: selector="&{includeDependencies:false matchDependencies:false includeDependents:false exclude:false excludeSelf:false followProdDepsOnly:false parentDir: namePattern:nothing fromRef: toRefOverride: raw:nothing}" entryPackages=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtered packages: cherryPickedPackages=map\[] walkedDependencies=map\[] walkedDependents=map\[] walkedDependentsDependencies=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtered packages: cherryPickedPackages=map\[] walkedDependencies=map\[] walkedDependents=map\[] walkedDependentsDependencies=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: filtered packages: packages=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash env vars: vars=\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash: value=00437efdb7e230f5 (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash matches between Rust and Go (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: local cache folder: path="" (re)
-  \xe2\x80\xa2 Packages in scope:  (esc)
-  \xe2\x80\xa2 Running build in 0 packages (esc)
-  \xe2\x80\xa2 Remote caching disabled (esc)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: task hashes match (re)
-  
+
+  $ cd $TARGET_DIR/outer/inner && ${TURBO} run build --filter=nothing -vv 1> OUTER_INNER 2>&1
+  $ cat OUTER_INNER | grep --only-match -E "Repository Root: .*/nested_workspaces/outer/inner"
+  Repository Root: .*/nested_workspaces/outer/inner (re)
+  $ cat OUTER_INNER | grep --only-match "No tasks were executed as part of this run."
   No tasks were executed as part of this run.
-  
-   Tasks:    0 successful, 0 total
-  Cached:    0 cached, 0 total
-    Time:\s*[\.0-9]+m?s  (re)
-  
-  $ cd $TARGET_DIR/outer/inner/apps && ${TURBO} run build --filter=nothing -vv
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/nested_workspaces/outer/inner (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running command as global turbo (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::cli: pkg_inference_root set to "apps" (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::run::global_hash: global hash env vars \[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::run::global_hash: external deps hash: 459c029558afe716 (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::run::scope::filter: Using apps as a basis for selecting packages (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Found go binary at "[\-\w\/\.]+" (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: build tag: rust (re)
-  [-0-9:.TWZ+]+ \[INFO]  turbo: skipping turbod since we appear to be in a non-interactive context (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Using apps as a basis for selecting packages (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: filter patterns: patterns=\["nothing"] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Parsed selector: selector="&{includeDependencies:false matchDependencies:false includeDependents:false exclude:false excludeSelf:false followProdDepsOnly:false parentDir: namePattern:nothing fromRef: toRefOverride: raw:nothing}" (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtering packages: allPackageSelectors=\["&{false false false false false false  nothing   nothing}"] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtered packages: selector="&{includeDependencies:false matchDependencies:false includeDependents:false exclude:false excludeSelf:false followProdDepsOnly:false parentDir: namePattern:nothing fromRef: toRefOverride: raw:nothing}" entryPackages=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtered packages: cherryPickedPackages=map\[] walkedDependencies=map\[] walkedDependents=map\[] walkedDependentsDependencies=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtered packages: cherryPickedPackages=map\[] walkedDependencies=map\[] walkedDependents=map\[] walkedDependentsDependencies=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: filtered packages: packages=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash env vars: vars=\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash: value=00437efdb7e230f5 (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash matches between Rust and Go (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: local cache folder: path="" (re)
-  \xe2\x80\xa2 Packages in scope:  (esc)
-  \xe2\x80\xa2 Running build in 0 packages (esc)
-  \xe2\x80\xa2 Remote caching disabled (esc)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: task hashes match (re)
-  
+
+  $ cd $TARGET_DIR/outer/inner/apps && ${TURBO} run build --filter=nothing -vv 1> OUTER_INNER_APPS 2>&1
+  $ cat OUTER_INNER_APPS | grep --only-match -E "Repository Root: .*/nested_workspaces/outer/inner"
+  Repository Root: .*/nested_workspaces/outer/inner (re)
+  $ cat OUTER_INNER_APPS | grep --only-match "No tasks were executed as part of this run."
   No tasks were executed as part of this run.
-  
-   Tasks:    0 successful, 0 total
-  Cached:    0 cached, 0 total
-    Time:\s*[\.0-9]+m?s  (re)
-  
+
 Locate a repository with no turbo.json. We'll get the right root, but there's nothing to run
-  $ cd $TARGET_DIR/outer/inner-no-turbo && ${TURBO} run build --filter=nothing -vv
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/nested_workspaces/outer/inner-no-turbo (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running command as global turbo (re)
-  Error: Could not find turbo.json. Follow directions at https://turbo.build/repo/docs to create one
+  $ cd $TARGET_DIR/outer/inner-no-turbo && ${TURBO} run build --filter=nothing -vv 1> INNER_NO_TURBO 2>&1
   [1]
+  $ cat INNER_NO_TURBO | grep --only-match -E "Repository Root: .*/nested_workspaces/outer/inner-no-turbo"
+  Repository Root: .*/nested_workspaces/outer/inner-no-turbo (re)
+  $ cat INNER_NO_TURBO | grep --only-match "Could not find turbo.json. Follow directions at https://turbo.build/repo/docs to create one"
+  Could not find turbo.json. Follow directions at https://turbo.build/repo/docs to create one
 
 Locate a repository with no turbo.json. We'll get the right root and inference directory, but there's nothing to run
-  $ cd $TARGET_DIR/outer/inner-no-turbo/apps && ${TURBO} run build --filter=nothing -vv
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/nested_workspaces/outer/inner-no-turbo (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running command as global turbo (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::cli: pkg_inference_root set to "apps" (re)
-  Error: Could not find turbo.json. Follow directions at https://turbo.build/repo/docs to create one
+  $ cd $TARGET_DIR/outer/inner-no-turbo/apps && ${TURBO} run build --filter=nothing -vv 1> INNER_NO_TURBO_APPS 2>&1
   [1]
+  $ cat INNER_NO_TURBO_APPS | grep --only-match -E "Repository Root: .*/nested_workspaces/outer/inner-no-turbo"
+  Repository Root: .*/nested_workspaces/outer/inner-no-turbo (re)
+  $ cat INNER_NO_TURBO_APPS | grep --only-match "Could not find turbo.json. Follow directions at https://turbo.build/repo/docs to create one"
+  Could not find turbo.json. Follow directions at https://turbo.build/repo/docs to create one
 
-  $ cd $TARGET_DIR/outer-no-turbo && ${TURBO} run build --filter=nothing -vv
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/nested_workspaces/outer-no-turbo (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running command as global turbo (re)
-  Error: Could not find turbo.json. Follow directions at https://turbo.build/repo/docs to create one
+  $ cd $TARGET_DIR/outer-no-turbo && ${TURBO} run build --filter=nothing -vv 1> OUTER_NO_TURBO 2>&1
   [1]
+  $ cat OUTER_NO_TURBO | grep --only-match -E "Repository Root: .*/nested_workspaces/outer-no-turbo"
+  Repository Root: .*/nested_workspaces/outer-no-turbo (re)
+  $ cat OUTER_NO_TURBO | grep --only-match "Could not find turbo.json. Follow directions at https://turbo.build/repo/docs to create one"
+  Could not find turbo.json. Follow directions at https://turbo.build/repo/docs to create one
 
-  $ cd $TARGET_DIR/outer-no-turbo/apps && ${TURBO} run build --filter=nothing -vv
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: [\-\w\/\.]+ (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: [\-\w\/\.]+ (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: [\-\w\/\.]+ (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running command as global turbo (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::cli: pkg_inference_root set to "apps" (re)
-  Error: Could not find turbo.json. Follow directions at https://turbo.build/repo/docs to create one
+  $ cd $TARGET_DIR/outer-no-turbo/apps && ${TURBO} run build --filter=nothing -vv 1> OUTER_NO_TURBO_APPS 2>&1
   [1]
+  $ cat OUTER_NO_TURBO_APPS | grep --only-match -E "Repository Root: .*/nested_workspaces/outer-no-turbo"
+  Repository Root: .*/nested_workspaces/outer-no-turbo (re)
+  $ cat OUTER_NO_TURBO_APPS | grep --only-match "Could not find turbo.json. Follow directions at https://turbo.build/repo/docs to create one"
+  Could not find turbo.json. Follow directions at https://turbo.build/repo/docs to create one
 
-  $ cd $TARGET_DIR/outer-no-turbo/inner && ${TURBO} run build --filter=nothing -vv
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/nested_workspaces/outer-no-turbo/inner (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running command as global turbo (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::run::global_hash: global hash env vars \[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::run::global_hash: external deps hash: 459c029558afe716 (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Found go binary at "[\-\w\/\.]+" (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: build tag: (go|rust) (re)
-  [-0-9:.TWZ+]+ \[INFO]  turbo: skipping turbod since we appear to be in a non-interactive context (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: filter patterns: patterns=\["nothing"] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Parsed selector: selector="&{includeDependencies:false matchDependencies:false includeDependents:false exclude:false excludeSelf:false followProdDepsOnly:false parentDir: namePattern:nothing fromRef: toRefOverride: raw:nothing}" (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtering packages: allPackageSelectors=\["&{false false false false false false  nothing   nothing}"] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtered packages: selector="&{includeDependencies:false matchDependencies:false includeDependents:false exclude:false excludeSelf:false followProdDepsOnly:false parentDir: namePattern:nothing fromRef: toRefOverride: raw:nothing}" entryPackages=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtered packages: cherryPickedPackages=map\[] walkedDependencies=map\[] walkedDependents=map\[] walkedDependentsDependencies=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtered packages: cherryPickedPackages=map\[] walkedDependencies=map\[] walkedDependents=map\[] walkedDependentsDependencies=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: filtered packages: packages=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash env vars: vars=\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash: value=00437efdb7e230f5 (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash matches between Rust and Go (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: local cache folder: path="" (re)
-  \xe2\x80\xa2 Packages in scope:  (esc)
-  \xe2\x80\xa2 Running build in 0 packages (esc)
-  \xe2\x80\xa2 Remote caching disabled (esc)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: task hashes match (re)
-  
+  $ cd $TARGET_DIR/outer-no-turbo/inner && ${TURBO} run build --filter=nothing -vv 1> OUTER_NO_TURBO_INNER 2>&1
+  $ cat OUTER_NO_TURBO_INNER | grep --only-match -E "Repository Root: .*/nested_workspaces/outer-no-turbo/inner"
+  Repository Root: .*/nested_workspaces/outer-no-turbo/inner (re)
+  $ cat OUTER_NO_TURBO_INNER | grep --only-match "No tasks were executed as part of this run."
   No tasks were executed as part of this run.
-  
-   Tasks:    0 successful, 0 total
-  Cached:    0 cached, 0 total
-    Time:\s*[\.0-9]+m?s  (re)
-  
-  $ cd $TARGET_DIR/outer-no-turbo/inner/apps && ${TURBO} run build --filter=nothing -vv
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/nested_workspaces/outer-no-turbo/inner (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running command as global turbo (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::cli: pkg_inference_root set to "apps" (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::run::global_hash: global hash env vars \[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::run::global_hash: external deps hash: 459c029558afe716 (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::run::scope::filter: Using apps as a basis for selecting packages (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Found go binary at "[\-\w\/\.]+" (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: build tag: rust (re)
-  [-0-9:.TWZ+]+ \[INFO]  turbo: skipping turbod since we appear to be in a non-interactive context (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Using apps as a basis for selecting packages (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: filter patterns: patterns=\["nothing"] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Parsed selector: selector="&{includeDependencies:false matchDependencies:false includeDependents:false exclude:false excludeSelf:false followProdDepsOnly:false parentDir: namePattern:nothing fromRef: toRefOverride: raw:nothing}" (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtering packages: allPackageSelectors=\["&{false false false false false false  nothing   nothing}"] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtered packages: selector="&{includeDependencies:false matchDependencies:false includeDependents:false exclude:false excludeSelf:false followProdDepsOnly:false parentDir: namePattern:nothing fromRef: toRefOverride: raw:nothing}" entryPackages=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtered packages: cherryPickedPackages=map\[] walkedDependencies=map\[] walkedDependents=map\[] walkedDependentsDependencies=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtered packages: cherryPickedPackages=map\[] walkedDependencies=map\[] walkedDependents=map\[] walkedDependentsDependencies=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: filtered packages: packages=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash env vars: vars=\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash: value=00437efdb7e230f5 (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash matches between Rust and Go (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: local cache folder: path="" (re)
-  \xe2\x80\xa2 Packages in scope:  (esc)
-  \xe2\x80\xa2 Running build in 0 packages (esc)
-  \xe2\x80\xa2 Remote caching disabled (esc)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: task hashes match (re)
-  
-  No tasks were executed as part of this run.
-  
-   Tasks:    0 successful, 0 total
-  Cached:    0 cached, 0 total
-    Time:\s*[\.0-9]+m?s  (re)
-  
-  $ cd $TARGET_DIR/outer-no-turbo/inner-no-turbo && ${TURBO} run build --filter=nothing -vv
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/nested_workspaces/outer-no-turbo/inner-no-turbo (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running command as global turbo (re)
-  Error: Could not find turbo.json. Follow directions at https://turbo.build/repo/docs to create one
-  [1]
 
-  $ cd $TARGET_DIR/outer-no-turbo/inner-no-turbo/apps && ${TURBO} run build --filter=nothing -vv
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/nested_workspaces/outer-no-turbo/inner-no-turbo (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running command as global turbo (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::cli: pkg_inference_root set to "apps" (re)
-  Error: Could not find turbo.json. Follow directions at https://turbo.build/repo/docs to create one
+  $ cd $TARGET_DIR/outer-no-turbo/inner/apps && ${TURBO} run build --filter=nothing -vv 1> OUTER_NO_TURBO_INNER_APPS 2>&1
+  $ cat OUTER_NO_TURBO_INNER_APPS | grep --only-match -E "Repository Root: .*/nested_workspaces/outer-no-turbo/inner"
+  Repository Root: .*/nested_workspaces/outer-no-turbo/inner (re)
+  $ cat OUTER_NO_TURBO_INNER_APPS | grep --only-match "No tasks were executed as part of this run."
+  No tasks were executed as part of this run.
+
+  $ cd $TARGET_DIR/outer-no-turbo/inner-no-turbo && ${TURBO} run build --filter=nothing -vv 1> INNER_NO_TURBO 2>&1
   [1]
+  $ cat INNER_NO_TURBO | grep --only-match -E "Repository Root: .*/nested_workspaces/outer-no-turbo/inner-no-turbo"
+  Repository Root: .*/nested_workspaces/outer-no-turbo/inner-no-turbo (re)
+  $ cat INNER_NO_TURBO | grep --only-match "Could not find turbo.json. Follow directions at https://turbo.build/repo/docs to create one"
+  Could not find turbo.json. Follow directions at https://turbo.build/repo/docs to create one
+
+  $ cd $TARGET_DIR/outer-no-turbo/inner-no-turbo/apps && ${TURBO} run build --filter=nothing -vv 1> INNER_NO_TURBO_APPS 2>&1
+  [1]
+  $ cat INNER_NO_TURBO_APPS | grep --only-match -E "Repository Root: .*/nested_workspaces/outer-no-turbo/inner-no-turbo"
+  Repository Root: .*/nested_workspaces/outer-no-turbo/inner-no-turbo (re)
+  $ cat INNER_NO_TURBO_APPS | grep --only-match "Could not find turbo.json. Follow directions at https://turbo.build/repo/docs to create one"
+  Could not find turbo.json. Follow directions at https://turbo.build/repo/docs to create one
+

--- a/turborepo-tests/integration/tests/inference/no-workspaces.t
+++ b/turborepo-tests/integration/tests/inference/no-workspaces.t
@@ -2,31 +2,9 @@ Setup
   $ . ${TESTDIR}/../../../helpers/setup.sh
   $ . ${TESTDIR}/no_workspaces_setup.sh $(pwd)/no_workspaces
 
-  $ cd $TARGET_DIR && ${TURBO} run build --filter=nothing -vv
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/no_workspaces (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running command as global turbo (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::run::global_hash: global hash env vars \[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::run::global_hash: external deps hash: no hash \(single package\) (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Found go binary at "[\-\w\/]+" (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: build tag: rust (re)
-  [-0-9:.TWZ+]+ \[INFO]  turbo: skipping turbod since we appear to be in a non-interactive context (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: filter patterns: patterns=\["nothing"] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Parsed selector: selector="&{includeDependencies:false matchDependencies:false includeDependents:false exclude:false excludeSelf:false followProdDepsOnly:false parentDir: namePattern:nothing fromRef: toRefOverride: raw:nothing}" (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtering packages: allPackageSelectors=\["&{false false false false false false  nothing   nothing}"] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtered packages: selector="&{includeDependencies:false matchDependencies:false includeDependents:false exclude:false excludeSelf:false followProdDepsOnly:false parentDir: namePattern:nothing fromRef: toRefOverride: raw:nothing}" entryPackages=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtered packages: cherryPickedPackages=map\[] walkedDependencies=map\[] walkedDependents=map\[] walkedDependentsDependencies=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtered packages: cherryPickedPackages=map\[] walkedDependencies=map\[] walkedDependents=map\[] walkedDependentsDependencies=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: filtered packages: packages=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash env vars: vars=\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash: value=070330d74e4b29de (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash matches between Rust and Go (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: local cache folder: path="" (re)
+  $ cd $TARGET_DIR && ${TURBO} run build --filter=nothing
   \xe2\x80\xa2 Running build (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: task hashes match (re)
   
   No tasks were executed as part of this run.
   
@@ -34,31 +12,9 @@ Setup
   Cached:    0 cached, 0 total
     Time:\s*[\.0-9]+m?s  (re)
   
-  $ cd $TARGET_DIR/parent && ${TURBO} run build --filter=nothing -vv
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/no_workspaces/parent (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running command as global turbo (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::run::global_hash: global hash env vars \[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::run::global_hash: external deps hash: no hash \(single package\) (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Found go binary at "[\-\w\/]+" (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: build tag: (go|rust) (re)
-  [-0-9:.TWZ+]+ \[INFO]  turbo: skipping turbod since we appear to be in a non-interactive context (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: filter patterns: patterns=\["nothing"] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Parsed selector: selector="&{includeDependencies:false matchDependencies:false includeDependents:false exclude:false excludeSelf:false followProdDepsOnly:false parentDir: namePattern:nothing fromRef: toRefOverride: raw:nothing}" (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtering packages: allPackageSelectors=\["&{false false false false false false  nothing   nothing}"] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtered packages: selector="&{includeDependencies:false matchDependencies:false includeDependents:false exclude:false excludeSelf:false followProdDepsOnly:false parentDir: namePattern:nothing fromRef: toRefOverride: raw:nothing}" entryPackages=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtered packages: cherryPickedPackages=map\[] walkedDependencies=map\[] walkedDependents=map\[] walkedDependentsDependencies=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtered packages: cherryPickedPackages=map\[] walkedDependencies=map\[] walkedDependents=map\[] walkedDependentsDependencies=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: filtered packages: packages=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash env vars: vars=\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash: value=908de86919a5f21a (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash matches between Rust and Go (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: local cache folder: path="" (re)
+  $ cd $TARGET_DIR/parent && ${TURBO} run build --filter=nothing
   \xe2\x80\xa2 Running build (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: task hashes match (re)
   
   No tasks were executed as part of this run.
   
@@ -66,31 +22,9 @@ Setup
   Cached:    0 cached, 0 total
     Time:\s*[\.0-9]+m?s  (re)
   
-  $ cd $TARGET_DIR/parent/child && ${TURBO} run build --filter=nothing -vv
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .*/no_workspaces/parent/child (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running command as global turbo (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::run::global_hash: global hash env vars \[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::run::global_hash: external deps hash: no hash \(single package\) (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Found go binary at "[\-\w\/]+" (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: build tag: (go|rust) (re)
-  [-0-9:.TWZ+]+ \[INFO]  turbo: skipping turbod since we appear to be in a non-interactive context (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: filter patterns: patterns=\["nothing"] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Parsed selector: selector="&{includeDependencies:false matchDependencies:false includeDependents:false exclude:false excludeSelf:false followProdDepsOnly:false parentDir: namePattern:nothing fromRef: toRefOverride: raw:nothing}" (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtering packages: allPackageSelectors=\["&{false false false false false false  nothing   nothing}"] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtered packages: selector="&{includeDependencies:false matchDependencies:false includeDependents:false exclude:false excludeSelf:false followProdDepsOnly:false parentDir: namePattern:nothing fromRef: toRefOverride: raw:nothing}" entryPackages=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtered packages: cherryPickedPackages=map\[] walkedDependencies=map\[] walkedDependents=map\[] walkedDependentsDependencies=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtered packages: cherryPickedPackages=map\[] walkedDependencies=map\[] walkedDependents=map\[] walkedDependentsDependencies=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: filtered packages: packages=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash env vars: vars=\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash: value=a482b5cbf06694fd (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash matches between Rust and Go (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: local cache folder: path="" (re)
+  $ cd $TARGET_DIR/parent/child && ${TURBO} run build --filter=nothing
   \xe2\x80\xa2 Running build (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: task hashes match (re)
   
   No tasks were executed as part of this run.
   


### PR DESCRIPTION
### Description

 - Drop two instances of "cache created" info-level log lines
 - Migrate the inference integration tests to use `grep` and match on relevant lines

### Testing Instructions

Updated tests

Closes TURBO-1639