### PR TITLE
port(Turborepo): Add summary error to match Go

### DIFF
--- a/crates/turborepo-lib/src/commands/run.rs
+++ b/crates/turborepo-lib/src/commands/run.rs
@@ -25,7 +25,12 @@ pub async fn run(base: CommandBase) -> Result<i32, run::Error> {
             // Run finished so close the signal handler
             handler.close().await;
             match result {
-                Ok(code) => Ok(code),
+                Ok(code) => {
+                    if code != 0 {
+                        error!("run failed: command  exited ({code})")
+                    }
+                    Ok(code)
+                },
                 Err(err) => {
                     error!("run failed: {}", err);
                     Err(err)

--- a/crates/turborepo-lib/src/opts.rs
+++ b/crates/turborepo-lib/src/opts.rs
@@ -142,10 +142,11 @@ pub struct RunOpts<'a> {
 
 impl<'a> RunOpts<'a> {
     pub fn args_for_task(&self, task_id: &TaskId) -> Option<Vec<String>> {
-        if self
-            .tasks
-            .iter()
-            .any(|task| task.as_str() == task_id.task())
+        if !self.pass_through_args.is_empty()
+            && self
+                .tasks
+                .iter()
+                .any(|task| task.as_str() == task_id.task())
         {
             Some(Vec::from(self.pass_through_args))
         } else {

--- a/turborepo-tests/integration/tests/run/one-script-error.t
+++ b/turborepo-tests/integration/tests/run/one-script-error.t
@@ -23,8 +23,8 @@ Note that npm reports any failed script as exit code 1, even though we "exit 2"
   my-app:error: npm ERR! Error: command failed 
   my-app:error: npm ERR!   in workspace: my-app 
   my-app:error: npm ERR!   at location: .*apps/my-app  (re)
-  my-app:error: ERROR: command finished with error: command \(.*apps/my-app\) npm run error exited \(1\) (re)
-  my-app#error: command \(.*apps/my-app\) npm run error exited \(1\) (re)
+  my-app:error: ERROR: command finished with error: command \(.*apps/my-app\) (.*)npm run error exited \(1\) (re)
+  my-app#error: command \(.*apps/my-app\) (.*)npm run error exited \(1\) (re)
   
    Tasks:    1 successful, 2 total
   Cached:    0 cached, 2 total
@@ -54,8 +54,8 @@ Make sure error isn't cached
   my-app:error: npm ERR! Error: command failed 
   my-app:error: npm ERR!   in workspace: my-app 
   my-app:error: npm ERR!   at location: .*apps/my-app  (re)
-  my-app:error: ERROR: command finished with error: command \(.*apps/my-app\) npm run error exited \(1\) (re)
-  my-app#error: command \(.*apps/my-app\) npm run error exited \(1\) (re)
+  my-app:error: ERROR: command finished with error: command \(.*apps/my-app\) (.*)npm run error exited \(1\) (re)
+  my-app#error: command \(.*apps/my-app\) (.*)npm run error exited \(1\) (re)
   
    Tasks:    1 successful, 2 total
   Cached:    1 cached, 2 total
@@ -92,7 +92,7 @@ Make sure error code isn't swallowed with continue
   my-app:okay2: > echo 'working'
   my-app:okay2: 
   my-app:okay2: working
-  my-app#error: command \((.*)/apps/my-app\) npm run error exited \(1\) (re)
+  my-app#error: command \((.*)/apps/my-app\) (.*)npm run error exited \(1\) (re)
   
    Tasks:    2 successful, 3 total
   Cached:    1 cached, 3 total


### PR DESCRIPTION
### Description

 - Mimic the command failure error line from Go. Not a long-term solution, but causes less thrash now
 - Fix passthrough args to not append `--` if there are no args
 - Allow optionally matching on the full path to the package manager that we run

### Testing Instructions

 - Updated integration test to allow matching on the full path to the relevant package manager

Closes TURBO-1647