### PR TITLE
port(Turborepo): Fix task dependencies integration tests

### DIFF
--- a/turborepo-tests/integration/tests/task-dependencies/complex.t
+++ b/turborepo-tests/integration/tests/task-dependencies/complex.t
@@ -33,15 +33,16 @@ We can scope the run to specific packages
 
 
 Can't depend on unknown tasks
-  $ ${TURBO} run build2
-  Error: Could not find "app-a#custom" in root turbo.json or "custom" in workspace
+  $ ${TURBO} run build2 > BUILD2 2>&1
   [1]
+  $ cat BUILD2 | grep --only-match 'Could not find "app-a#custom" in root turbo.json or "custom" in workspace'
+  Could not find "app-a#custom" in root turbo.json or "custom" in workspace
 
 Can't depend on tasks from unknown packages
-  $ ${TURBO} run build3
-  Error: Could not find workspace "unknown" from task "unknown#custom" in project
+  $ ${TURBO} run build3 > BUILD3 2>&1
   [1]
-
+  $ cat BUILD3 | grep --only-match 'Could not find workspace "unknown" from task "unknown#custom" in project'
+  Could not find workspace "unknown" from task "unknown#custom" in project
 
 Complex dependency chain
   $ ${TURBO} run test --graph
@@ -98,6 +99,7 @@ Check that --only only runs leaf tasks
 
 
 Can't depend on itself
-  $ ${TURBO} run build4
-  Error: (lib-a|lib-b|lib-c|lib-d|app-a|app-b)#build4 depends on itself (re)
+  $ ${TURBO} run build4 > BUILD4 2>&1
   [1]
+  $ cat BUILD4 | grep --only-match -E '(lib-a|lib-b|lib-c|lib-d|app-a|app-b)#build4 depends on itself'
+  (lib-a|lib-b|lib-c|lib-d|app-a|app-b)#build4 depends on itself (re)

--- a/turborepo-tests/integration/tests/task-dependencies/workspace-tasks.t
+++ b/turborepo-tests/integration/tests/task-dependencies/workspace-tasks.t
@@ -36,9 +36,10 @@ Can depend on root tasks
 
 
 Can't depend on a missing root task
-  $ ${TURBO} run build3 --graph
-  Error: //#not-exists needs an entry in turbo.json before it can be depended on because it is a task run from the root package
+  $ ${TURBO} run build3 --graph > BUILD3 2>&1
   [1]
+  $ cat BUILD3 | grep --only-match '//#not-exists needs an entry in turbo.json before it can be depended on because it is a task run from the root package'
+  //#not-exists needs an entry in turbo.json before it can be depended on because it is a task run from the root package
 
 Package tasks can depend on things
   $ ${TURBO} run special --graph


### PR DESCRIPTION
### Description

 - switch to grep for error matching in task dependencies integration tests

### Testing Instructions

 - Updated integration tests to use error matching via `grep`

Closes TURBO-1648