### PR TITLE
fix: match dependency ordering between rust/go

### DIFF
--- a/crates/turborepo-repository/src/package_json.rs
+++ b/crates/turborepo-repository/src/package_json.rs
@@ -67,11 +67,11 @@ impl PackageJson {
     }
 
     pub fn all_dependencies(&self) -> impl Iterator<Item = (&String, &String)> + '_ {
-        self.dependencies
+        self.dev_dependencies
             .iter()
             .flatten()
-            .chain(self.dev_dependencies.iter().flatten())
             .chain(self.optional_dependencies.iter().flatten())
+            .chain(self.dependencies.iter().flatten())
     }
 }
 


### PR DESCRIPTION
### Description

In Go we create the set of external deps by merging `devDependencies`, `optionalDependencies`, and `dependencies` [in that order](https://github.com/vercel/turbo/blob/main/cli/internal/context/context.go#L238). This PR changes the Rust code to use the same order. 

One might say that this order shouldn't matter and they would be right, but this is a [2yr old bug](https://github.com/vercel/turbo/commit/6077c5e4894f4fa0a95b01d5cc8f3f103a227b8b) and fixing it would require changing the FFI layer. Fixing this should be a post-port effort.

### Testing Instructions

`turbo_dev build --filter='@turbo/codemod'` now passes


Closes TURBO-1654