### PR TITLE
Ensure daemon connection errors are non-fatal

### DIFF
--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -18,7 +18,7 @@ pub use cache::{RunCache, TaskCache};
 use chrono::{DateTime, Local};
 use itertools::Itertools;
 use rayon::iter::ParallelBridge;
-use tracing::{debug, info, warn};
+use tracing::{debug, info};
 use turbopath::AbsoluteSystemPathBuf;
 use turborepo_analytics::{start_analytics, AnalyticsHandle, AnalyticsSender};
 use turborepo_api_client::{APIAuth, APIClient};
@@ -221,7 +221,7 @@ impl<'a> Run<'a> {
                     Some(client)
                 }
                 Err(e) => {
-                    warn!("failed to connect to daemon {e}");
+                    debug!("failed to connect to daemon {e}");
                     None
                 }
             }

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -18,7 +18,7 @@ pub use cache::{RunCache, TaskCache};
 use chrono::{DateTime, Local};
 use itertools::Itertools;
 use rayon::iter::ParallelBridge;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 use turbopath::AbsoluteSystemPathBuf;
 use turborepo_analytics::{start_analytics, AnalyticsHandle, AnalyticsSender};
 use turborepo_api_client::{APIAuth, APIClient};
@@ -204,9 +204,9 @@ impl<'a> Run<'a> {
         // There's some warning handling code in Go that I'm ignoring
         let is_ci_or_not_tty = turborepo_ci::is_ci() || !std::io::stdout().is_terminal();
 
-        let mut daemon = None;
-        if is_ci_or_not_tty && !opts.run_opts.no_daemon {
+        let daemon = if is_ci_or_not_tty && !opts.run_opts.no_daemon {
             info!("skipping turbod since we appear to be in a non-interactive context");
+            None
         } else if !opts.run_opts.no_daemon {
             let connector = DaemonConnector {
                 can_start_server: true,
@@ -215,10 +215,20 @@ impl<'a> Run<'a> {
                 sock_file: self.base.daemon_file_root().join_component("turbod.sock"),
             };
 
-            let client = connector.connect().await?;
-            debug!("running in daemon mode");
-            daemon = Some(client);
-        }
+            match connector.connect().await {
+                Ok(client) => {
+                    debug!("running in daemon mode");
+                    Some(client)
+                }
+                Err(e) => {
+                    warn!("failed to connect to daemon {e}");
+                    None
+                }
+            }
+        } else {
+            // We are opted out of using the daemon
+            None
+        };
 
         pkg_dep_graph.validate()?;
 


### PR DESCRIPTION
### Description

Makes failure to start or connect to the daemon non-fatal. It's purely a performance optimization and we can still execute without it.

### Testing Instructions

Verified manually with a 1ms timeout

Closes TURBO-1655