### PR TITLE
fix: displaying stdout/stderr with errors-only

### DIFF
--- a/crates/turborepo-lib/src/run/cache.rs
+++ b/crates/turborepo-lib/src/run/cache.rs
@@ -149,9 +149,9 @@ impl TaskCache {
 
         log_writer.with_log_file(&self.log_file_path)?;
 
-        if matches!(
+        if !matches!(
             self.task_output_mode,
-            OutputLogsMode::Full | OutputLogsMode::NewOnly
+            OutputLogsMode::None | OutputLogsMode::HashOnly | OutputLogsMode::ErrorsOnly
         ) {
             log_writer.with_prefixed_writer(prefixed_writer);
         }

--- a/crates/turborepo-lib/src/run/cache.rs
+++ b/crates/turborepo-lib/src/run/cache.rs
@@ -212,10 +212,15 @@ impl TaskCache {
                 .await?;
 
             let Some((cache_hit_metadata, restored_files)) = cache_status else {
-                prefixed_ui.output(format!(
-                    "cache miss, executing {}",
-                    color!(self.ui, GREY, "{}", self.hash)
-                ));
+                if !matches!(
+                    self.task_output_mode,
+                    OutputLogsMode::None | OutputLogsMode::ErrorsOnly
+                ) {
+                    prefixed_ui.output(format!(
+                        "cache miss, executing {}",
+                        color!(self.ui, GREY, "{}", self.hash)
+                    ));
+                }
 
                 return Ok(None);
             };

--- a/crates/turborepo-lib/src/task_graph/visitor.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor.rs
@@ -785,6 +785,9 @@ impl ExecContext {
             }
             ChildExit::Finished(Some(code)) => {
                 // If there was an error, flush the buffered output
+                if let Err(e) = stdout_writer.flush() {
+                    error!("error flushing logs: {e}");
+                }
                 if let Err(e) = self.task_cache.on_error(&mut prefixed_ui) {
                     error!("error reading logs: {e}");
                 }

--- a/turborepo-tests/integration/tests/run-logging/errors-only.t
+++ b/turborepo-tests/integration/tests/run-logging/errors-only.t
@@ -48,8 +48,8 @@ Setup
   app-a:builderror: npm ERR! Error: command failed 
   app-a:builderror: npm ERR!   in workspace: app-a 
   app-a:builderror: npm ERR!   at location: .* (re)
-  app-a:builderror: ERROR: command finished with error: command .* npm run builderror exited \(1\) (re)
-  app-a#builderror: command .* npm run builderror exited \(1\) (re)
+  app-a:builderror: ERROR: command finished with error: command .*npm run builderror exited \(1\) (re)
+  app-a#builderror: command .*npm run builderror exited \(1\) (re)
   
    Tasks:    0 successful, 1 total
   Cached:    0 cached, 1 total
@@ -78,8 +78,8 @@ Setup
   app-a:builderror2: npm ERR! Error: command failed 
   app-a:builderror2: npm ERR!   in workspace: app-a 
   app-a:builderror2: npm ERR!   at location: .* (re)
-  app-a:builderror2: ERROR: command finished with error: command .* npm run builderror2 exited \(1\) (re)
-  app-a#builderror2: command .* npm run builderror2 exited \(1\) (re)
+  app-a:builderror2: ERROR: command finished with error: command .*npm run builderror2 exited \(1\) (re)
+  app-a#builderror2: command .*npm run builderror2 exited \(1\) (re)
   
    Tasks:    0 successful, 1 total
   Cached:    0 cached, 1 total

--- a/turborepo-tests/integration/tests/run/continue.t
+++ b/turborepo-tests/integration/tests/run/continue.t
@@ -15,8 +15,8 @@ Run without --continue
   some-lib:build: npm ERR! Error: command failed 
   some-lib:build: npm ERR!   in workspace: some-lib 
   some-lib:build: npm ERR!   at location: (.*)\/apps\/some-lib  (re)
-  some-lib:build: ERROR: command finished with error: command \((.*)\/apps\/some-lib\) npm run build exited \(1\) (re)
-  some-lib#build: command \(.*\/apps\/some-lib\) npm run build exited \(1\) (re)
+  some-lib:build: ERROR: command finished with error: command \((.*)\/apps\/some-lib\) .*npm run build exited \(1\) (re)
+  some-lib#build: command \(.*\/apps\/some-lib\) .*npm run build exited \(1\) (re)
   
    Tasks:    0 successful, 1 total
   Cached:    0 cached, 1 total
@@ -41,8 +41,8 @@ Run without --continue, and with only errors.
   some-lib:build: npm ERR! Error: command failed 
   some-lib:build: npm ERR!   in workspace: some-lib 
   some-lib:build: npm ERR!   at location: (.*)\/apps\/some-lib  (re)
-  some-lib:build: ERROR: command finished with error: command \((.*)\/apps\/some-lib\) npm run build exited \(1\) (re)
-  some-lib#build: command \(.*\) npm run build exited \(1\) (re)
+  some-lib:build: ERROR: command finished with error: command \((.*)\/apps\/some-lib\) .*npm run build exited \(1\) (re)
+  some-lib#build: command \(.*\) .*npm run build exited \(1\) (re)
   
    Tasks:    0 successful, 1 total
   Cached:    0 cached, 1 total
@@ -77,8 +77,8 @@ Run with --continue
   other-app:build: npm ERR!   in workspace: other-app 
   other-app:build: npm ERR!   at location: (.*)/apps/other-app  (re)
   other-app:build: command finished with error, but continuing...
-  some-lib#build: command \((.*)/apps/some-lib\) npm run build exited \(1\) (re)
-  other-app#build: command \((.*)/apps/other-app\) npm run build exited \(1\) (re)
+  some-lib#build: command \((.*)/apps/some-lib\) .*npm run build exited \(1\) (re)
+  other-app#build: command \((.*)/apps/other-app\) .*npm run build exited \(1\) (re)
   
    Tasks:    1 successful, 3 total
   Cached:    0 cached, 3 total


### PR DESCRIPTION
### Description

This PR fixes up our `errors-only` behavior by making sure we flush the file writer by the time we attempt to replay the logs.

### Testing Instructions

`run-logging/errors-only.t` and `run/continue.t` now both pass


Closes TURBO-1663