### PR TITLE
fix: rust spaces auth requirements

### DIFF
--- a/crates/turborepo-analytics/src/lib.rs
+++ b/crates/turborepo-analytics/src/lib.rs
@@ -244,7 +244,7 @@ mod tests {
         let (analytics_sender, analytics_handle) = start_analytics(
             APIAuth {
                 token: "foo".to_string(),
-                team_id: "bar".to_string(),
+                team_id: Some("bar".to_string()),
                 team_slug: None,
             },
             client.clone(),
@@ -286,7 +286,7 @@ mod tests {
         let (analytics_sender, analytics_handle) = start_analytics(
             APIAuth {
                 token: "foo".to_string(),
-                team_id: "bar".to_string(),
+                team_id: Some("bar".to_string()),
                 team_slug: None,
             },
             client.clone(),
@@ -334,7 +334,7 @@ mod tests {
         let (analytics_sender, analytics_handle) = start_analytics(
             APIAuth {
                 token: "foo".to_string(),
-                team_id: "bar".to_string(),
+                team_id: Some("bar".to_string()),
                 team_slug: None,
             },
             client.clone(),

--- a/crates/turborepo-api-client/src/lib.rs
+++ b/crates/turborepo-api-client/src/lib.rs
@@ -93,7 +93,7 @@ pub struct APIClient {
 
 #[derive(Clone)]
 pub struct APIAuth {
-    pub team_id: String,
+    pub team_id: Option<String>,
     pub token: String,
     pub team_slug: Option<String>,
 }
@@ -481,7 +481,7 @@ impl APIClient {
         }
 
         request_builder =
-            Self::add_team_params(request_builder, Some(team_id), team_slug.as_deref());
+            Self::add_team_params(request_builder, team_id.as_deref(), team_slug.as_deref());
 
         if let Some(constant) = turborepo_ci::Vendor::get_constant() {
             request_builder = request_builder.header("x-artifact-client-ci", constant);
@@ -505,6 +505,12 @@ impl APIClient {
             request_builder = request_builder.query(&[("slug", slug)]);
         }
         request_builder
+    }
+}
+
+impl APIAuth {
+    pub fn is_linked(&self) -> bool {
+        self.team_id.is_some() || self.team_slug.is_some()
     }
 }
 

--- a/crates/turborepo-api-client/src/lib.rs
+++ b/crates/turborepo-api-client/src/lib.rs
@@ -34,11 +34,6 @@ pub trait Client {
     async fn get_teams(&self, token: &str) -> Result<TeamsResponse>;
     async fn get_team(&self, token: &str, team_id: &str) -> Result<Option<Team>>;
     fn add_ci_header(request_builder: RequestBuilder) -> RequestBuilder;
-    fn add_team_params(
-        request_builder: RequestBuilder,
-        team_id: &str,
-        team_slug: Option<&str>,
-    ) -> RequestBuilder;
     async fn get_caching_status(
         &self,
         token: &str,
@@ -154,21 +149,6 @@ impl Client for APIClient {
             if let Some(vendor_constant) = Vendor::get_constant() {
                 request_builder = request_builder.header("x-artifact-client-ci", vendor_constant);
             }
-        }
-
-        request_builder
-    }
-
-    fn add_team_params(
-        mut request_builder: RequestBuilder,
-        team_id: &str,
-        team_slug: Option<&str>,
-    ) -> RequestBuilder {
-        if let Some(slug) = team_slug {
-            request_builder = request_builder.query(&[("teamSlug", slug)]);
-        }
-        if team_id.starts_with("team_") {
-            request_builder = request_builder.query(&[("teamId", team_id)]);
         }
 
         request_builder
@@ -507,6 +487,21 @@ impl APIClient {
         }
 
         Ok(request_builder)
+    }
+
+    fn add_team_params(
+        mut request_builder: RequestBuilder,
+        team_id: &str,
+        team_slug: Option<&str>,
+    ) -> RequestBuilder {
+        if let Some(slug) = team_slug {
+            request_builder = request_builder.query(&[("teamSlug", slug)]);
+        }
+        if team_id.starts_with("team_") {
+            request_builder = request_builder.query(&[("teamId", team_id)]);
+        }
+
+        request_builder
     }
 }
 

--- a/crates/turborepo-auth/src/auth/login.rs
+++ b/crates/turborepo-auth/src/auth/login.rs
@@ -185,13 +185,6 @@ mod tests {
         fn add_ci_header(_request_builder: RequestBuilder) -> RequestBuilder {
             unimplemented!("add_ci_header")
         }
-        fn add_team_params(
-            _request_builder: RequestBuilder,
-            _team_id: &str,
-            _team_slug: Option<&str>,
-        ) -> RequestBuilder {
-            unimplemented!("add_team_params")
-        }
         async fn get_caching_status(
             &self,
             _token: &str,

--- a/crates/turborepo-auth/src/auth/login.rs
+++ b/crates/turborepo-auth/src/auth/login.rs
@@ -188,7 +188,7 @@ mod tests {
         async fn get_caching_status(
             &self,
             _token: &str,
-            _team_id: &str,
+            _team_id: Option<&str>,
             _team_slug: Option<&str>,
         ) -> turborepo_api_client::Result<CachingStatusResponse> {
             unimplemented!("get_caching_status")
@@ -227,7 +227,7 @@ mod tests {
             &self,
             _hash: &str,
             _token: &str,
-            _team_id: &str,
+            _team_id: Option<&str>,
             _team_slug: Option<&str>,
         ) -> turborepo_api_client::Result<Option<Response>> {
             unimplemented!("fetch_artifact")
@@ -236,7 +236,7 @@ mod tests {
             &self,
             _hash: &str,
             _token: &str,
-            _team_id: &str,
+            _team_id: Option<&str>,
             _team_slug: Option<&str>,
         ) -> turborepo_api_client::Result<Option<Response>> {
             unimplemented!("artifact_exists")
@@ -245,7 +245,7 @@ mod tests {
             &self,
             _hash: &str,
             _token: &str,
-            _team_id: &str,
+            _team_id: Option<&str>,
             _team_slug: Option<&str>,
             _method: Method,
         ) -> turborepo_api_client::Result<Option<Response>> {

--- a/crates/turborepo-auth/src/auth/sso.rs
+++ b/crates/turborepo-auth/src/auth/sso.rs
@@ -199,7 +199,7 @@ mod tests {
         async fn get_caching_status(
             &self,
             _token: &str,
-            _team_id: &str,
+            _team_id: Option<&str>,
             _team_slug: Option<&str>,
         ) -> turborepo_api_client::Result<CachingStatusResponse> {
             unimplemented!("get_caching_status")
@@ -238,7 +238,7 @@ mod tests {
             &self,
             _hash: &str,
             _token: &str,
-            _team_id: &str,
+            _team_id: Option<&str>,
             _team_slug: Option<&str>,
         ) -> turborepo_api_client::Result<Option<Response>> {
             unimplemented!("fetch_artifact")
@@ -247,7 +247,7 @@ mod tests {
             &self,
             _hash: &str,
             _token: &str,
-            _team_id: &str,
+            _team_id: Option<&str>,
             _team_slug: Option<&str>,
         ) -> turborepo_api_client::Result<Option<Response>> {
             unimplemented!("artifact_exists")
@@ -256,7 +256,7 @@ mod tests {
             &self,
             _hash: &str,
             _token: &str,
-            _team_id: &str,
+            _team_id: Option<&str>,
             _team_slug: Option<&str>,
             _method: Method,
         ) -> turborepo_api_client::Result<Option<Response>> {

--- a/crates/turborepo-auth/src/auth/sso.rs
+++ b/crates/turborepo-auth/src/auth/sso.rs
@@ -196,13 +196,6 @@ mod tests {
         fn add_ci_header(_request_builder: RequestBuilder) -> RequestBuilder {
             unimplemented!("add_ci_header")
         }
-        fn add_team_params(
-            _request_builder: RequestBuilder,
-            _team_id: &str,
-            _team_slug: Option<&str>,
-        ) -> RequestBuilder {
-            unimplemented!("add_team_params")
-        }
         async fn get_caching_status(
             &self,
             _token: &str,

--- a/crates/turborepo-cache/src/async_cache.rs
+++ b/crates/turborepo-cache/src/async_cache.rs
@@ -200,7 +200,7 @@ mod tests {
 
         let api_client = APIClient::new(format!("http://localhost:{}", port), 200, "2.0.0", true)?;
         let api_auth = Some(APIAuth {
-            team_id: "my-team-id".to_string(),
+            team_id: Some("my-team-id".to_string()),
             token: "my-token".to_string(),
             team_slug: None,
         });
@@ -275,7 +275,7 @@ mod tests {
         // network
         let api_client = APIClient::new("http://example.com", 200, "2.0.0", true)?;
         let api_auth = Some(APIAuth {
-            team_id: "my-team-id".to_string(),
+            team_id: Some("my-team-id".to_string()),
             token: "my-token".to_string(),
             team_slug: None,
         });
@@ -356,7 +356,7 @@ mod tests {
 
         let api_client = APIClient::new(format!("http://localhost:{}", port), 200, "2.0.0", true)?;
         let api_auth = Some(APIAuth {
-            team_id: "my-team-id".to_string(),
+            team_id: Some("my-team-id".to_string()),
             token: "my-token".to_string(),
             team_slug: None,
         });

--- a/crates/turborepo-cache/src/fs.rs
+++ b/crates/turborepo-cache/src/fs.rs
@@ -214,7 +214,7 @@ mod test {
 
         let api_client = APIClient::new(format!("http://localhost:{}", port), 200, "2.0.0", true)?;
         let api_auth = APIAuth {
-            team_id: "my-team".to_string(),
+            team_id: Some("my-team".to_string()),
             token: "my-token".to_string(),
             team_slug: None,
         };

--- a/crates/turborepo-cache/src/http.rs
+++ b/crates/turborepo-cache/src/http.rs
@@ -99,7 +99,7 @@ impl HTTPCache {
             .artifact_exists(
                 hash,
                 &self.api_auth.token,
-                &self.api_auth.team_id,
+                Some(&self.api_auth.team_id),
                 self.api_auth.team_slug.as_deref(),
             )
             .await?
@@ -152,7 +152,7 @@ impl HTTPCache {
             .fetch_artifact(
                 hash,
                 &self.api_auth.token,
-                &self.api_auth.team_id,
+                Some(&self.api_auth.team_id),
                 self.api_auth.team_slug.as_deref(),
             )
             .await?

--- a/crates/turborepo-cache/src/http.rs
+++ b/crates/turborepo-cache/src/http.rs
@@ -34,7 +34,12 @@ impl HTTPCache {
             .map_or(false, |remote_cache_opts| remote_cache_opts.signature)
         {
             Some(ArtifactSignatureAuthenticator {
-                team_id: api_auth.team_id.as_bytes().to_vec(),
+                team_id: api_auth
+                    .team_id
+                    .as_deref()
+                    .unwrap_or_default()
+                    .as_bytes()
+                    .to_vec(),
                 secret_key_override: None,
             })
         } else {
@@ -99,7 +104,7 @@ impl HTTPCache {
             .artifact_exists(
                 hash,
                 &self.api_auth.token,
-                Some(&self.api_auth.team_id),
+                self.api_auth.team_id.as_deref(),
                 self.api_auth.team_slug.as_deref(),
             )
             .await?
@@ -152,7 +157,7 @@ impl HTTPCache {
             .fetch_artifact(
                 hash,
                 &self.api_auth.token,
-                Some(&self.api_auth.team_id),
+                self.api_auth.team_id.as_deref(),
                 self.api_auth.team_slug.as_deref(),
             )
             .await?
@@ -263,7 +268,7 @@ mod test {
         let api_client = APIClient::new(format!("http://localhost:{}", port), 200, "2.0.0", true)?;
         let opts = CacheOpts::default();
         let api_auth = APIAuth {
-            team_id: "my-team".to_string(),
+            team_id: Some("my-team".to_string()),
             token: "my-token".to_string(),
             team_slug: None,
         };

--- a/crates/turborepo-lib/src/commands/link.rs
+++ b/crates/turborepo-lib/src/commands/link.rs
@@ -119,7 +119,7 @@ pub(crate) async fn verify_caching_enabled<'a>(
     });
 
     let response = api_client
-        .get_caching_status(token, team_id, team_slug)
+        .get_caching_status(token, Some(team_id), team_slug)
         .await
         .map_err(Error::CachingStatusNotFound)?;
 

--- a/crates/turborepo-lib/src/commands/mod.rs
+++ b/crates/turborepo-lib/src/commands/mod.rs
@@ -98,10 +98,12 @@ impl CommandBase {
         let team_id = config.team_id();
         let team_slug = config.team_slug();
 
-        let token = config.token();
+        let Some(token) = config.token() else {
+            return Ok(None);
+        };
 
-        Ok(team_id.zip(token).map(|(team_id, token)| APIAuth {
-            team_id: team_id.to_string(),
+        Ok(Some(APIAuth {
+            team_id: team_id.map(|s| s.to_string()),
             token: token.to_string(),
             team_slug: team_slug.map(|s| s.to_string()),
         }))

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -83,8 +83,9 @@ impl<'a> Run<'a> {
     ) -> Option<(AnalyticsSender, AnalyticsHandle)> {
         // If there's no API auth, we don't want to record analytics
         let api_auth = api_auth?;
-
-        Some(start_analytics(api_auth, api_client))
+        api_auth
+            .is_linked()
+            .then(|| start_analytics(api_auth, api_client))
     }
 
     fn print_run_prelude(&self, opts: &Opts<'_>, filtered_pkgs: &HashSet<WorkspaceName>) {

--- a/crates/turborepo-lib/src/run/summary/spaces.rs
+++ b/crates/turborepo-lib/src/run/summary/spaces.rs
@@ -140,13 +140,15 @@ impl SpacesClient {
     ) -> Option<Self> {
         // If space_id is empty, we don't build a client
         let space_id = space_id?;
-        let Some(api_auth) = api_auth else {
+        let is_linked = api_auth.as_ref().map_or(false, |auth| auth.is_linked());
+        if !is_linked {
             eprintln!(
                 "Error: experimentalSpaceId is enabled, but repo is not linked to API. Run `turbo \
                  link` or `turbo login` first"
             );
             return None;
-        };
+        }
+        let api_auth = api_auth.expect("presence of api auth was just checked");
 
         Some(Self {
             space_id,
@@ -342,7 +344,7 @@ mod tests {
 
         let api_auth = Some(APIAuth {
             token: EXPECTED_TOKEN.to_string(),
-            team_id: EXPECTED_TEAM_ID.to_string(),
+            team_id: Some(EXPECTED_TEAM_ID.to_string()),
             team_slug: Some(EXPECTED_TEAM_SLUG.to_string()),
         });
 


### PR DESCRIPTION
### Description

Fix our too strict requirement on the presence of `team_id` for making API calls. We don't have this requirement in Go and instead have the `IsLinked` method that checks that one of them is present. This is used in exactly 2 places [spaces](https://github.com/vercel/turbo/blob/main/cli/internal/runsummary/spaces.go#L71) and [analytics](https://github.com/vercel/turbo/blob/main/cli/internal/run/run.go#L440) to check if there's some way of identifying the team. In this PR we port this behavior from Go.

One thing to note is that this also gets us to parity of the Go behavior for the HTTP cache (whether it's desired is another question). There's no requirement that `team_id` is non-empty when constructing the HTTP cache artifact signer: [construction](https://github.com/vercel/turbo/blob/main/cli/internal/cache/cache_http.go#L246) [signing](https://github.com/vercel/turbo/blob/main/cli/internal/cache/cache_signature_authentication.go#L59). We copy this behavior in Rust and allow for an empty `team_id`.

Future work:
There's some type-safety gains we can make by representing team identification as an enum to avoid the case where `APIAuth` doesn't have a team identifier. This requires an audit of what API calls require what information exactly and changing of those interfaces. There's also the question of the validity of both a team slug and a team id. In the name of getting this out quick, I copied the Go behavior with whatever flaws has so we can at least match the behavior.



It will probably be slightly easier to remove each commit on it's own as it's mostly code shuffling until the final commit.

### Testing Instructions

Sending info to spaces now works if only a team slug is provided e.g.
```
EXPERIMENTAL_RUST_CODEPATH=true turbo_dev build --filter='@turbo/codemod' --team=vercel --token=**secret**
...
 Tasks:    3 successful, 3 total
Cached:    3 cached, 3 total
  Time:    390ms >>> FULL TURBO

Sending to space
Run: https://vercel.com/teams/...
```
