### PR TITLE
chore: simplify inference test grep commands

### DIFF
--- a/turborepo-tests/integration/tests/inference/has-workspaces.t
+++ b/turborepo-tests/integration/tests/inference/has-workspaces.t
@@ -3,31 +3,22 @@ Setup
   $ . ${TESTDIR}/../_helpers/setup_monorepo.sh $(pwd) inference/has_workspaces
 
   $ cd $TARGET_DIR && ${TURBO} run build --filter=nothing -vv 1> ROOT 2>&1
-  $ cat ROOT | grep --only-match 'pkg_inference_root set'
+  $ grep --quiet 'pkg_inference_root set' ROOT
   [1]
-  $ cat ROOT | grep --only-match "No tasks were executed as part of this run."
-  No tasks were executed as part of this run.
+  $ grep --quiet "No tasks were executed as part of this run." ROOT
 
   $ cd $TARGET_DIR/apps/web && ${TURBO} run build --filter=nothing -vv 1> WEB 2>&1
-  $ cat WEB | grep --only-match 'pkg_inference_root set to "apps/web"'
-  pkg_inference_root set to "apps/web"
-  $ cat WEB | grep --only-match "No tasks were executed as part of this run."
-  No tasks were executed as part of this run.
+  $ grep --quiet 'pkg_inference_root set to "apps/web"' WEB
+  $ grep --quiet "No tasks were executed as part of this run." WEB
 
   $ cd $TARGET_DIR/crates && ${TURBO} run build --filter=nothing -vv 1> CRATES 2>&1
-  $ cat CRATES | grep --only-match 'pkg_inference_root set to "crates"'
-  pkg_inference_root set to "crates"
-  $ cat CRATES | grep --only-match "No tasks were executed as part of this run."
-  No tasks were executed as part of this run.
+  $ grep --quiet 'pkg_inference_root set to "crates"' CRATES
+  $ grep --quiet "No tasks were executed as part of this run." CRATES
 
   $ cd $TARGET_DIR/crates/super-crate/tests/test-package && ${TURBO} run build --filter=nothing -vv 1> TEST_PACKAGE 2>&1
-  $ cat TEST_PACKAGE | grep --only-match 'pkg_inference_root set to "crates/super-crate/tests/test-package"'
-  pkg_inference_root set to "crates/super-crate/tests/test-package"
-  $ cat TEST_PACKAGE | grep --only-match "No tasks were executed as part of this run."
-  No tasks were executed as part of this run.
+  $ grep --quiet 'pkg_inference_root set to "crates/super-crate/tests/test-package"' TEST_PACKAGE
+  $ grep --quiet "No tasks were executed as part of this run." TEST_PACKAGE
 
   $ cd $TARGET_DIR/packages/ui-library/src && ${TURBO} run build --filter=nothing -vv 1> UI_LIBRARY 2>&1
-  $ cat UI_LIBRARY | grep --only-match 'pkg_inference_root set to "packages/ui-library/src"'
-  pkg_inference_root set to "packages/ui-library/src"
-  $ cat UI_LIBRARY | grep --only-match "No tasks were executed as part of this run."
-  No tasks were executed as part of this run.
+  $ grep --quiet 'pkg_inference_root set to "packages/ui-library/src"' UI_LIBRARY
+  $ grep --quiet "No tasks were executed as part of this run." UI_LIBRARY

--- a/turborepo-tests/integration/tests/inference/nested-workspaces.t
+++ b/turborepo-tests/integration/tests/inference/nested-workspaces.t
@@ -3,82 +3,58 @@ Setup
   $ . ${TESTDIR}/nested_workspaces_setup.sh $(pwd)/nested_workspaces
 
   $ cd $TARGET_DIR/outer && ${TURBO} run build --filter=nothing -vv 1> OUTER 2>&1
-  $ cat OUTER | grep --only-match -E "Repository Root: .*/nested_workspaces/outer"
-  Repository Root: .*/nested_workspaces/outer (re)
-  $ cat OUTER | grep --only-match "No tasks were executed as part of this run."
-  No tasks were executed as part of this run.
+  $ grep --quiet -E "Repository Root: .*/nested_workspaces/outer" OUTER
+  $ cat OUTER | grep --quiet "No tasks were executed as part of this run."
 
   $ cd $TARGET_DIR/outer/apps && ${TURBO} run build --filter=nothing -vv 1> OUTER_APPS 2>&1
-  $ cat OUTER_APPS | grep --only-match -E "Repository Root: .*/nested_workspaces/outer"
-  Repository Root: .*/nested_workspaces/outer (re)
-  $ cat OUTER_APPS | grep --only-match "No tasks were executed as part of this run."
-  No tasks were executed as part of this run.
+  $ grep --quiet -E "Repository Root: .*/nested_workspaces/outer" OUTER_APPS
+  $ grep --quiet "No tasks were executed as part of this run." OUTER_APPS
 
   $ cd $TARGET_DIR/outer/inner && ${TURBO} run build --filter=nothing -vv 1> OUTER_INNER 2>&1
-  $ cat OUTER_INNER | grep --only-match -E "Repository Root: .*/nested_workspaces/outer/inner"
-  Repository Root: .*/nested_workspaces/outer/inner (re)
-  $ cat OUTER_INNER | grep --only-match "No tasks were executed as part of this run."
-  No tasks were executed as part of this run.
+  $ grep --quiet -E "Repository Root: .*/nested_workspaces/outer/inner" OUTER_INNER
+  $ grep --quiet "No tasks were executed as part of this run." OUTER_INNER
 
   $ cd $TARGET_DIR/outer/inner/apps && ${TURBO} run build --filter=nothing -vv 1> OUTER_INNER_APPS 2>&1
-  $ cat OUTER_INNER_APPS | grep --only-match -E "Repository Root: .*/nested_workspaces/outer/inner"
-  Repository Root: .*/nested_workspaces/outer/inner (re)
-  $ cat OUTER_INNER_APPS | grep --only-match "No tasks were executed as part of this run."
-  No tasks were executed as part of this run.
+  $ grep --quiet -E "Repository Root: .*/nested_workspaces/outer/inner" OUTER_INNER_APPS
+  $ grep --quiet "No tasks were executed as part of this run." OUTER_INNER_APPS
 
 Locate a repository with no turbo.json. We'll get the right root, but there's nothing to run
   $ cd $TARGET_DIR/outer/inner-no-turbo && ${TURBO} run build --filter=nothing -vv 1> INNER_NO_TURBO 2>&1
   [1]
-  $ cat INNER_NO_TURBO | grep --only-match -E "Repository Root: .*/nested_workspaces/outer/inner-no-turbo"
-  Repository Root: .*/nested_workspaces/outer/inner-no-turbo (re)
-  $ cat INNER_NO_TURBO | grep --only-match "Could not find turbo.json. Follow directions at https://turbo.build/repo/docs to create one"
-  Could not find turbo.json. Follow directions at https://turbo.build/repo/docs to create one
+  $ grep --quiet -E "Repository Root: .*/nested_workspaces/outer/inner-no-turbo" INNER_NO_TURBO
+  $ grep --quiet "Could not find turbo.json. Follow directions at https://turbo.build/repo/docs to create one" INNER_NO_TURBO
 
 Locate a repository with no turbo.json. We'll get the right root and inference directory, but there's nothing to run
   $ cd $TARGET_DIR/outer/inner-no-turbo/apps && ${TURBO} run build --filter=nothing -vv 1> INNER_NO_TURBO_APPS 2>&1
   [1]
-  $ cat INNER_NO_TURBO_APPS | grep --only-match -E "Repository Root: .*/nested_workspaces/outer/inner-no-turbo"
-  Repository Root: .*/nested_workspaces/outer/inner-no-turbo (re)
-  $ cat INNER_NO_TURBO_APPS | grep --only-match "Could not find turbo.json. Follow directions at https://turbo.build/repo/docs to create one"
-  Could not find turbo.json. Follow directions at https://turbo.build/repo/docs to create one
+  $ grep --quiet -E "Repository Root: .*/nested_workspaces/outer/inner-no-turbo" INNER_NO_TURBO_APPS
+  $ grep --quiet "Could not find turbo.json. Follow directions at https://turbo.build/repo/docs to create one" INNER_NO_TURBO_APPS
 
   $ cd $TARGET_DIR/outer-no-turbo && ${TURBO} run build --filter=nothing -vv 1> OUTER_NO_TURBO 2>&1
   [1]
-  $ cat OUTER_NO_TURBO | grep --only-match -E "Repository Root: .*/nested_workspaces/outer-no-turbo"
-  Repository Root: .*/nested_workspaces/outer-no-turbo (re)
-  $ cat OUTER_NO_TURBO | grep --only-match "Could not find turbo.json. Follow directions at https://turbo.build/repo/docs to create one"
-  Could not find turbo.json. Follow directions at https://turbo.build/repo/docs to create one
+  $ grep --quiet -E "Repository Root: .*/nested_workspaces/outer-no-turbo" OUTER_NO_TURBO
+  $ grep --quiet "Could not find turbo.json. Follow directions at https://turbo.build/repo/docs to create one" OUTER_NO_TURBO
 
   $ cd $TARGET_DIR/outer-no-turbo/apps && ${TURBO} run build --filter=nothing -vv 1> OUTER_NO_TURBO_APPS 2>&1
   [1]
-  $ cat OUTER_NO_TURBO_APPS | grep --only-match -E "Repository Root: .*/nested_workspaces/outer-no-turbo"
-  Repository Root: .*/nested_workspaces/outer-no-turbo (re)
-  $ cat OUTER_NO_TURBO_APPS | grep --only-match "Could not find turbo.json. Follow directions at https://turbo.build/repo/docs to create one"
-  Could not find turbo.json. Follow directions at https://turbo.build/repo/docs to create one
+  $ grep --quiet -E "Repository Root: .*/nested_workspaces/outer-no-turbo" OUTER_NO_TURBO_APPS
+  $ grep --quiet "Could not find turbo.json. Follow directions at https://turbo.build/repo/docs to create one" OUTER_NO_TURBO_APPS
 
   $ cd $TARGET_DIR/outer-no-turbo/inner && ${TURBO} run build --filter=nothing -vv 1> OUTER_NO_TURBO_INNER 2>&1
-  $ cat OUTER_NO_TURBO_INNER | grep --only-match -E "Repository Root: .*/nested_workspaces/outer-no-turbo/inner"
-  Repository Root: .*/nested_workspaces/outer-no-turbo/inner (re)
-  $ cat OUTER_NO_TURBO_INNER | grep --only-match "No tasks were executed as part of this run."
-  No tasks were executed as part of this run.
+  $ grep --quiet -E "Repository Root: .*/nested_workspaces/outer-no-turbo/inner" OUTER_NO_TURBO_INNER
+  $ grep --quiet "No tasks were executed as part of this run." OUTER_NO_TURBO_INNER
 
   $ cd $TARGET_DIR/outer-no-turbo/inner/apps && ${TURBO} run build --filter=nothing -vv 1> OUTER_NO_TURBO_INNER_APPS 2>&1
-  $ cat OUTER_NO_TURBO_INNER_APPS | grep --only-match -E "Repository Root: .*/nested_workspaces/outer-no-turbo/inner"
-  Repository Root: .*/nested_workspaces/outer-no-turbo/inner (re)
-  $ cat OUTER_NO_TURBO_INNER_APPS | grep --only-match "No tasks were executed as part of this run."
-  No tasks were executed as part of this run.
+  $ grep --quiet -E "Repository Root: .*/nested_workspaces/outer-no-turbo/inner" OUTER_NO_TURBO_INNER_APPS
+  $ grep --quiet "No tasks were executed as part of this run." OUTER_NO_TURBO_INNER_APPS
 
   $ cd $TARGET_DIR/outer-no-turbo/inner-no-turbo && ${TURBO} run build --filter=nothing -vv 1> INNER_NO_TURBO 2>&1
   [1]
-  $ cat INNER_NO_TURBO | grep --only-match -E "Repository Root: .*/nested_workspaces/outer-no-turbo/inner-no-turbo"
-  Repository Root: .*/nested_workspaces/outer-no-turbo/inner-no-turbo (re)
-  $ cat INNER_NO_TURBO | grep --only-match "Could not find turbo.json. Follow directions at https://turbo.build/repo/docs to create one"
-  Could not find turbo.json. Follow directions at https://turbo.build/repo/docs to create one
+  $ grep --quiet -E "Repository Root: .*/nested_workspaces/outer-no-turbo/inner-no-turbo" INNER_NO_TURBO
+  $ grep --quiet "Could not find turbo.json. Follow directions at https://turbo.build/repo/docs to create one" INNER_NO_TURBO
 
   $ cd $TARGET_DIR/outer-no-turbo/inner-no-turbo/apps && ${TURBO} run build --filter=nothing -vv 1> INNER_NO_TURBO_APPS 2>&1
   [1]
-  $ cat INNER_NO_TURBO_APPS | grep --only-match -E "Repository Root: .*/nested_workspaces/outer-no-turbo/inner-no-turbo"
-  Repository Root: .*/nested_workspaces/outer-no-turbo/inner-no-turbo (re)
-  $ cat INNER_NO_TURBO_APPS | grep --only-match "Could not find turbo.json. Follow directions at https://turbo.build/repo/docs to create one"
-  Could not find turbo.json. Follow directions at https://turbo.build/repo/docs to create one
+  $ grep --quiet -E "Repository Root: .*/nested_workspaces/outer-no-turbo/inner-no-turbo" INNER_NO_TURBO_APPS
+  $ grep --quiet "Could not find turbo.json. Follow directions at https://turbo.build/repo/docs to create one" INNER_NO_TURBO_APPS
 

--- a/turborepo-tests/integration/tests/inference/nested-workspaces.t
+++ b/turborepo-tests/integration/tests/inference/nested-workspaces.t
@@ -4,7 +4,7 @@ Setup
 
   $ cd $TARGET_DIR/outer && ${TURBO} run build --filter=nothing -vv 1> OUTER 2>&1
   $ grep --quiet -E "Repository Root: .*/nested_workspaces/outer" OUTER
-  $ cat OUTER | grep --quiet "No tasks were executed as part of this run."
+  $ grep --quiet "No tasks were executed as part of this run." OUTER
 
   $ cd $TARGET_DIR/outer/apps && ${TURBO} run build --filter=nothing -vv 1> OUTER_APPS 2>&1
   $ grep --quiet -E "Repository Root: .*/nested_workspaces/outer" OUTER_APPS


### PR DESCRIPTION
This is a follow up from #6437.

Using --quiet means we can avoid duplicating the same string twice and rely on the exit code to indicate a match, also making the path matching simpler for Windows (https://github.com/vercel/turbo/pull/6279). The change to not use `cat` is to just follow the pattern from #6400.