### PR TITLE
ci(action): pin nextest

### DIFF
--- a/.github/workflows/bench-turbotrace-against-node-nft.yml
+++ b/.github/workflows/bench-turbotrace-against-node-nft.yml
@@ -43,7 +43,9 @@ jobs:
           pnpm install -r --side-effects-cache false
 
       - name: Install nextest
-        uses: taiki-e/install-action@nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest@0.9.61
 
       - name: Build benchmark
         timeout-minutes: 60

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -829,7 +829,9 @@ jobs:
         run: npm install
 
       - name: Install nextest
-        uses: taiki-e/install-action@nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest@0.9.61
 
       - name: Build nextest
         timeout-minutes: 120
@@ -906,7 +908,9 @@ jobs:
         run: npm install
 
       - name: Install nextest
-        uses: taiki-e/install-action@nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest@0.9.61
 
       - name: Build nextest
         timeout-minutes: 120


### PR DESCRIPTION
Closes PACK-1969

CI was failing to run turbopack tests with obscure error message

```
binding) ignoring invalid dependency `turbopack-tests` which is missing a lib target
error: error parsing Cargo metadata

Caused by:
  failed to construct package graph: for package 'preset_env_base 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)': no dependencies found matching 'browserslist'
```

Tried a bunch of bisect, and finally able to figure out the dependency chain

- `cargo-nextest` releases a new version, which was a culprit of above bug
- `install-action` silently installs new version 
- CI started to fail all of sudden without any repo / user level code changes

Cargo's executable won't update unless explicitly specified, so this was not reproducible locally with currently installed version.

Mainly this is a side effect of cargo doesn't support dev deps executable (ref: https://github.com/rust-lang/cargo/issues/2267). I tried to workaround via 3rd party pkg cargo-run-bin (https://github.com/dustinblackman/cargo-run-bin) but unfortunately it doesn't support Windows so it's not an easy option to adapt.