### PR TITLE
feat(Turborepo): Send logging to stderr

### DIFF
--- a/crates/turborepo-lib/src/tracing.rs
+++ b/crates/turborepo-lib/src/tracing.rs
@@ -1,4 +1,4 @@
-use std::{marker::PhantomData, path::Path, sync::Mutex};
+use std::{io::Stderr, marker::PhantomData, path::Path, sync::Mutex};
 
 use chrono::Local;
 use owo_colors::{
@@ -14,7 +14,7 @@ use tracing_subscriber::{
     fmt::{
         self,
         format::{DefaultFields, Writer},
-        FmtContext, FormatEvent, FormatFields,
+        FmtContext, FormatEvent, FormatFields, MakeWriter,
     },
     layer,
     prelude::*,
@@ -26,28 +26,40 @@ use turborepo_ui::UI;
 
 // a lot of types to make sure we record the right relationships
 
-/// A basic logger that logs to stdout using the TurboFormatter.
+/// Note that we cannot express the type of `std::io::stderr` directly, so
+/// use zero-size wrapper to call the function.
+struct StdErrWrapper {}
+
+impl<'a> MakeWriter<'a> for StdErrWrapper {
+    type Writer = Stderr;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        std::io::stderr()
+    }
+}
+
+/// A basic logger that logs to stderr using the TurboFormatter.
 /// The first generic parameter refers to the previous layer, which
 /// is in this case the default layer (`Registry`).
-type StdOutLog = fmt::Layer<Registry, DefaultFields, TurboFormatter>;
+type StdErrLog = fmt::Layer<Registry, DefaultFields, TurboFormatter, StdErrWrapper>;
 /// We filter this using an EnvFilter.
-type StdOutLogFiltered = Filtered<StdOutLog, EnvFilter, Registry>;
-/// When the `StdOutLogFiltered` is applied to the `Registry`, we get a
-/// `StdOutLogLayered`, which forms the base for the next layer.
-type StdOutLogLayered = layer::Layered<StdOutLogFiltered, Registry>;
+type StdErrLogFiltered = Filtered<StdErrLog, EnvFilter, Registry>;
+/// When the `StdErrLogFiltered` is applied to the `Registry`, we get a
+/// `StdErrLogLayered`, which forms the base for the next layer.
+type StdErrLogLayered = layer::Layered<StdErrLogFiltered, Registry>;
 
 /// A logger that spits lines into a file, using the standard formatter.
-/// It is applied on top of the `StdOutLogLayered` layer.
-type DaemonLog = fmt::Layer<StdOutLogLayered, DefaultFields, fmt::format::Format, NonBlocking>;
+/// It is applied on top of the `StdErrLogLayered` layer.
+type DaemonLog = fmt::Layer<StdErrLogLayered, DefaultFields, fmt::format::Format, NonBlocking>;
 /// This layer can be reloaded. `None` means the layer is disabled.
-type DaemonReload = reload::Layer<Option<DaemonLog>, StdOutLogLayered>;
+type DaemonReload = reload::Layer<Option<DaemonLog>, StdErrLogLayered>;
 /// We filter this using a custom filter that only logs events
 /// - with evel `TRACE` or higher for the `turborepo` target
 /// - with level `INFO` or higher for all other targets
-type DaemonLogFiltered = Filtered<DaemonReload, Targets, StdOutLogLayered>;
-/// When the `DaemonLogFiltered` is applied to the `StdOutLogLayered`, we get a
+type DaemonLogFiltered = Filtered<DaemonReload, Targets, StdErrLogLayered>;
+/// When the `DaemonLogFiltered` is applied to the `StdErrLogLayered`, we get a
 /// `DaemonLogLayered`, which forms the base for the next layer.
-type DaemonLogLayered = layer::Layered<DaemonLogFiltered, StdOutLogLayered>;
+type DaemonLogLayered = layer::Layered<DaemonLogFiltered, StdErrLogLayered>;
 
 /// A logger that converts events to chrome tracing format and writes them
 /// to a file. It is applied on top of the `DaemonLogLayered` layer.
@@ -61,7 +73,7 @@ type ChromeLogFiltered = Filtered<ChromeReload, EnvFilter, DaemonLogLayered>;
 type ChromeLogLayered = layer::Layered<ChromeLogFiltered, DaemonLogLayered>;
 
 pub struct TurboSubscriber {
-    daemon_update: Handle<Option<DaemonLog>, StdOutLogLayered>,
+    daemon_update: Handle<Option<DaemonLog>, StdErrLogLayered>,
 
     /// The non-blocking file logger only continues to log while this guard is
     /// held. We keep it here so that it doesn't get dropped.
@@ -75,7 +87,7 @@ pub struct TurboSubscriber {
 }
 
 impl TurboSubscriber {
-    /// Sets up the tracing subscriber, with a default stdout layer using the
+    /// Sets up the tracing subscriber, with a default stderr layer using the
     /// TurboFormatter.
     ///
     /// ## Logging behaviour:
@@ -118,7 +130,8 @@ impl TurboSubscriber {
             .with_default(Level::INFO)
             .with_target("turborepo", Level::TRACE);
 
-        let stdout = fmt::layer()
+        let stderr = fmt::layer()
+            .with_writer(StdErrWrapper {})
             .event_format(TurboFormatter::new_with_ansi(!ui.should_strip_ansi))
             .with_filter(env_filter());
 
@@ -130,7 +143,7 @@ impl TurboSubscriber {
         let chrome: ChromeLogFiltered = chrome.with_filter(env_filter());
 
         let registry = Registry::default()
-            .with(stdout)
+            .with(stderr)
             .with(logrotate)
             .with(chrome);
 

--- a/turborepo-tests/integration/tests/command-bin.t
+++ b/turborepo-tests/integration/tests/command-bin.t
@@ -2,7 +2,7 @@ Setup
   $ . ${TESTDIR}/../../helpers/setup.sh
   $ . ${TESTDIR}/_helpers/setup_monorepo.sh $(pwd)
 
-  $ ${TURBO} bin -vvv > out.log
+  $ ${TURBO} bin -vvv > out.log 2>&1
   $ grep --quiet "Global turbo version: .*" out.log
   $ grep --quiet "No local turbo binary found at" out.log
   $ grep --quiet "Running command as global turbo" out.log

--- a/turborepo-tests/integration/tests/find-turbo/hard-mode.t
+++ b/turborepo-tests/integration/tests/find-turbo/hard-mode.t
@@ -8,11 +8,12 @@ When --skip-infer is used we use the current binary and output no global/local m
   $ ${TURBO} --help --skip-infer -vv | head -n 2
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
   The build system that makes ship happen
+  
 
 It finds repo root and uses correct version
   $ ${TESTDIR}/set_version.sh $TESTROOT "1.8.0"
   $ cd $TESTROOT/subdir/node_modules
-  $ ${TURBO} build --filter foo -vv > out.log
+  $ ${TURBO} build --filter foo -vv > out.log 2>&1
   $ grep --quiet -F "Local turbo version: 1.8.0" out.log
   $ grep --quiet -E "Running local turbo binary in .*/hard-mode.t/subdir/node_modules/.*/bin/turbo" out.log
   $ cat out.log | tail -n1
@@ -21,7 +22,7 @@ It finds repo root and uses correct version
 It respects cwd
   $ ${TESTDIR}/set_version.sh $TESTROOT "1.8.0"
   $ cd $TESTROOT
-  $ ${TURBO} build --filter foo -vv --cwd ${TESTROOT}/subdir > out.log
+  $ ${TURBO} build --filter foo -vv --cwd ${TESTROOT}/subdir > out.log 2>&1
   $ grep --quiet -F "Local turbo version: 1.8.0" out.log
   $ grep --quiet -E "Running local turbo binary in .*/hard-mode.t/subdir/node_modules/.*/bin/turbo" out.log
   $ cat out.log | tail -n1
@@ -30,7 +31,7 @@ It respects cwd
 It respects cwd and finds repo root
   $ ${TESTDIR}/set_version.sh $TESTROOT "1.8.0"
   $ cd $TESTROOT
-  $ ${TURBO} build --filter foo -vv --cwd ${TESTROOT}/subdir/node_modules > out.log
+  $ ${TURBO} build --filter foo -vv --cwd ${TESTROOT}/subdir/node_modules > out.log 2>&1
   $ grep --quiet -F "Local turbo version: 1.8.0" out.log
   $ grep --quiet -E "Running local turbo binary in .*/hard-mode.t/subdir/node_modules/.*/bin/turbo" out.log
   $ cat out.log | tail -n1

--- a/turborepo-tests/integration/tests/find-turbo/hoisted.t
+++ b/turborepo-tests/integration/tests/find-turbo/hoisted.t
@@ -4,14 +4,14 @@ Setup
 
 Make sure we use local and do not pass --skip-infer to old binary
   $ ${TESTDIR}/set_version.sh $(pwd) "1.0.0"
-  $ ${TURBO} build --filter foo -vv > out.log
+  $ ${TURBO} build --filter foo -vv > out.log 2>&1
   $ grep --quiet -F "Local turbo version: 1.0.0" out.log
   $ cat out.log | tail -n1
   build --filter foo -vv --
 
 Make sure we use local and pass --skip-infer to newer binary
   $ ${TESTDIR}/set_version.sh $(pwd) "1.8.0"
-  $ ${TURBO} build --filter foo -vv > out.log
+  $ ${TURBO} build --filter foo -vv > out.log 2>&1
   $ grep --quiet -F "Local turbo version: 1.8.0" out.log
   $ cat out.log | tail -n1
   --skip-infer build --filter foo -vv --single-package --

--- a/turborepo-tests/integration/tests/find-turbo/linked.t
+++ b/turborepo-tests/integration/tests/find-turbo/linked.t
@@ -4,14 +4,14 @@ Setup
 
 Make sure we use local, but do not pass --skip-infer to old binary
   $ ${TESTDIR}/set_version.sh $(pwd) "1.0.0"
-  $ ${TURBO} build --filter foo -vv > out.log
+  $ ${TURBO} build --filter foo -vv > out.log 2>&1
   $ grep --quiet -F "Local turbo version: 1.0.0" out.log
   $ cat out.log | tail -n1
   build --filter foo -vv --
 
 Make sure we use local, and DO pass --skip-infer to newer binary
   $ ${TESTDIR}/set_version.sh $(pwd) "1.8.0"
-  $ ${TURBO} build --filter foo -vv > out.log
+  $ ${TURBO} build --filter foo -vv > out.log 2>&1
   $ grep --quiet -F "Local turbo version: 1.8.0" out.log
   $ cat out.log | tail -n1
   --skip-infer build --filter foo -vv --single-package --

--- a/turborepo-tests/integration/tests/find-turbo/nested.t
+++ b/turborepo-tests/integration/tests/find-turbo/nested.t
@@ -4,14 +4,14 @@ Setup
 
 Make sure we use local and do not pass --skip-infer to old binary
   $ ${TESTDIR}/set_version.sh $(pwd) "1.0.0"
-  $ ${TURBO} build --filter foo -vv > out.log
+  $ ${TURBO} build --filter foo -vv > out.log 2>&1
   $ grep --quiet -F "Local turbo version: 1.0.0" out.log
   $ cat out.log | tail -n1
   build --filter foo -vv --
 
 Make sure we use local and pass --skip-infer to newer binary
   $ ${TESTDIR}/set_version.sh $(pwd) "1.8.0"
-  $ ${TURBO} build --filter foo -vv > out.log
+  $ ${TURBO} build --filter foo -vv > out.log 2>&1
   $ grep --quiet -F "Local turbo version: 1.8.0" out.log
   $ cat out.log | tail -n1
   --skip-infer build --filter foo -vv --single-package --

--- a/turborepo-tests/integration/tests/find-turbo/self.t
+++ b/turborepo-tests/integration/tests/find-turbo/self.t
@@ -4,5 +4,5 @@ Setup
 
 Make sure we do not reinvoke ourself.
   $ ${TESTDIR}/set_link.sh $(pwd) ${TURBO}
-  $ ${TURBO} --version -vv > out.log
+  $ ${TURBO} --version -vv > out.log 2>&1
   $ grep --quiet -F "Currently running turbo is local turbo" out.log

--- a/turborepo-tests/integration/tests/find-turbo/unplugged-env-moved.t
+++ b/turborepo-tests/integration/tests/find-turbo/unplugged-env-moved.t
@@ -5,7 +5,7 @@ Setup
 Make sure we use local and do not pass --skip-infer to old binary
   $ ${TESTDIR}/set_version.sh $(pwd) "1.0.0"
   $ set -o allexport; source .env; set +o allexport;
-  $ ${TURBO} build --filter foo -vv > out.log
+  $ ${TURBO} build --filter foo -vv > out.log 2>&1
   $ grep --quiet -F "Local turbo version: 1.0.0" out.log
   $ grep --quiet -E "Running local turbo binary in .*\/unplugged-env-moved\.t\/\.moved\/unplugged\/.*\/bin\/turbo" out.log
   $ cat out.log | tail -n1
@@ -14,7 +14,7 @@ Make sure we use local and do not pass --skip-infer to old binary
 Make sure we use local and pass --skip-infer to newer binary
   $ ${TESTDIR}/set_version.sh $(pwd) "1.8.0"
   $ set -o allexport; source .env; set +o allexport;
-  $ ${TURBO} build --filter foo -vv > out.log
+  $ ${TURBO} build --filter foo -vv > out.log 2>&1
   $ grep --quiet -F "Local turbo version: 1.8.0" out.log
   $ grep --quiet -E "Running local turbo binary in .*\/unplugged-env-moved\.t\/\.moved\/unplugged\/.*\/bin\/turbo" out.log
   $ cat out.log | tail -n1

--- a/turborepo-tests/integration/tests/find-turbo/unplugged-moved.t
+++ b/turborepo-tests/integration/tests/find-turbo/unplugged-moved.t
@@ -4,7 +4,7 @@ Setup
 
 Make sure we use local and do not pass --skip-infer to old binary
   $ ${TESTDIR}/set_version.sh $(pwd) "1.0.0"
-  $ ${TURBO} build --filter foo -vv > out.log
+  $ ${TURBO} build --filter foo -vv > out.log 2>&1
   $ grep --quiet -F "Local turbo version: 1.0.0" out.log
   $ grep --quiet -E "Running local turbo binary in .*\/unplugged-moved\.t\/\.moved\/unplugged\/.*\/bin\/turbo" out.log
   $ cat out.log | tail -n1
@@ -12,7 +12,7 @@ Make sure we use local and do not pass --skip-infer to old binary
 
 Make sure we use local and pass --skip-infer to newer binary
   $ ${TESTDIR}/set_version.sh $(pwd) "1.8.0"
-  $ ${TURBO} build --filter foo -vv > out.log
+  $ ${TURBO} build --filter foo -vv > out.log 2>&1
   $ grep --quiet -F "Local turbo version: 1.8.0" out.log
   $ grep --quiet -E "Running local turbo binary in .*\/unplugged-moved\.t\/\.moved\/unplugged\/.*\/bin\/turbo" out.log
   $ cat out.log | tail -n1

--- a/turborepo-tests/integration/tests/find-turbo/unplugged.t
+++ b/turborepo-tests/integration/tests/find-turbo/unplugged.t
@@ -4,7 +4,7 @@ Setup
 
 Make sure we use local and do not pass --skip-infer to old binary
   $ ${TESTDIR}/set_version.sh $(pwd) "1.0.0"
-  $ ${TURBO} build --filter foo -vv > out.log
+  $ ${TURBO} build --filter foo -vv > out.log 2>&1
   $ grep --quiet -F "Local turbo version: 1.0.0" out.log
   $ grep --quiet -E "Running local turbo binary in .*\/unplugged\.t\/\.yarn\/unplugged\/.*\/bin\/turbo" out.log
   $ cat out.log | tail -n1
@@ -12,7 +12,7 @@ Make sure we use local and do not pass --skip-infer to old binary
 
 Make sure we use local and pass --skip-infer to newer binary
   $ ${TESTDIR}/set_version.sh $(pwd) "1.8.0"
-  $ ${TURBO} build --filter foo -vv > out.log
+  $ ${TURBO} build --filter foo -vv > out.log 2>&1
   $ grep --quiet -F "Local turbo version: 1.8.0" out.log
   $ grep --quiet -E "Running local turbo binary in .*\/unplugged\.t\/\.yarn\/unplugged\/.*\/bin\/turbo" out.log
   $ cat out.log | tail -n1


### PR DESCRIPTION
### Description

 - Configure our terminal logger to go to `stderr`. Note some hacking around type constraints on a `Layer`, the end result is we call `std::io::stderr()` to get the writer for the log layer.

### Testing Instructions

Updated integration tests to expect output on `stderr`

Closes TURBO-1652
