### PR TITLE
chore(ci): launch prysk tests with JS instead of bash

### DIFF
--- a/turborepo-tests/integration/package.json
+++ b/turborepo-tests/integration/package.json
@@ -1,10 +1,9 @@
 {
   "name": "turborepo-tests-integration",
   "scripts": {
-    "test:setup": "./setup.sh",
-    "test": "./test.sh",
-    "test:rust-codepath": "EXPERIMENTAL_RUST_CODEPATH=true ./test.sh",
-    "test:interactive": "./test-interactive.sh",
+    "test": "node ./test.mjs",
+    "test:rust-codepath": "EXPERIMENTAL_RUST_CODEPATH=true node ./test.mjs",
+    "test:interactive": "PRYSK_INTERACTIVE=true node ./test.mjs",
     "test:parallel": ".cram_env/bin/pytest -n auto tests --prysk-shell=`which bash`",
     "pretest:parallel": ".cram_env/bin/pip3 install --quiet pytest \"prysk[pytest-plugin]\" pytest-xdist"
   },

--- a/turborepo-tests/integration/setup.sh
+++ b/turborepo-tests/integration/setup.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-python3 -m venv .cram_env
-.cram_env/bin/python3 -m pip install --quiet --upgrade pip
-.cram_env/bin/pip install "prysk==0.15.0"

--- a/turborepo-tests/integration/test-interactive.sh
+++ b/turborepo-tests/integration/test-interactive.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-# disable package manager update notifiers
-export NO_UPDATE_NOTIFIER=1
-if [ "$1" = "" ]; then
-  .cram_env/bin/prysk --shell="$(which bash)" -i tests
-else
-  .cram_env/bin/prysk --shell="$(which bash)" -i "tests/$1"
-fi

--- a/turborepo-tests/integration/test.mjs
+++ b/turborepo-tests/integration/test.mjs
@@ -4,6 +4,7 @@ import { fileURLToPath } from "url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = __filename.replace(/[^/\\]*$/, "");
+
 const VENV_NAME = ".cram_env";
 
 // disable package manager update notifiers

--- a/turborepo-tests/integration/test.mjs
+++ b/turborepo-tests/integration/test.mjs
@@ -1,0 +1,52 @@
+import { execSync } from "child_process";
+import path from "node:path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = __filename.replace(/[^/\\]*$/, "");
+const VENV_NAME = ".cram_env";
+
+// disable package manager update notifiers
+process.env.NO_UPDATE_NOTIFIER = 1;
+
+// Make virtualenv
+execSync(`python3 -m venv ${VENV_NAME}`);
+
+// Upgrade pip
+execSync(`${getVenvBin("python3")} -m pip install --quiet --upgrade pip`);
+
+// Install prysk
+execSync(`${getVenvBin("pip")} install "prysk==0.15.0"`);
+
+// Which tests do we want to run?
+const testArg = process.argv[2] ? process.argv[2] : "";
+const tests = path.join("tests", testArg);
+
+const flags = [
+  "--shell=$(which bash)",
+  process.env.PRYSK_INTERACTIVE ? "--interactive" : "",
+].join(" ");
+
+const cmd = [getVenvBin("prysk"), flags, tests].join(" ");
+console.log(`Running ${cmd}`);
+
+try {
+  execSync(cmd, { stdio: "inherit", env: process.env });
+} catch (e) {
+  // Swallow the node error stack trace. stdio: inherit should
+  // already have the test failures printed. We don't need the Node.js
+  // execution to also print its stack trace from execSync.
+  process.exit(1);
+}
+
+function getVenvBin(tool) {
+  const allowedVenvTools = ["python3", "pip", "prysk"];
+  if (!allowedVenvTools.includes(tool)) {
+    throw new Error(`Tool not allowed: ${tool}`);
+  }
+
+  const venvPath = path.join(__dirname, VENV_NAME);
+  const venvBin = path.join(venvPath, "bin");
+
+  return path.join(venvBin, tool);
+}

--- a/turborepo-tests/integration/test.sh
+++ b/turborepo-tests/integration/test.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-# disable package manager update notifiers
-export NO_UPDATE_NOTIFIER=1
-if [ "$1" = "" ]; then
-  .cram_env/bin/prysk --shell="$(which bash)" tests
-else
-  .cram_env/bin/prysk --shell="$(which bash)" "tests/$1"
-fi

--- a/turborepo-tests/integration/turbo.json
+++ b/turborepo-tests/integration/turbo.json
@@ -7,15 +7,12 @@
       "dependsOn": ["^topo"]
     },
     "test": {
-      "dependsOn": ["cli#build", "topo", "test:setup"],
+      "dependsOn": ["cli#build", "topo"],
       "passThroughEnv": ["CI"]
     },
     "test:rust-codepath": {
-      "dependsOn": ["cli#build", "topo", "test:setup"],
+      "dependsOn": ["cli#build", "topo"],
       "passThroughEnv": ["CI"]
-    },
-    "test:setup": {
-      "cache": false
     }
   }
 }


### PR DESCRIPTION
We need to encode some Windows-specific logic when launching these tests
and it's easier to do it in JS than bash (although technically feasible to do it in Bash). 

JS launcher also lets us apply tooling like linting/formatting that we don't have setup for bash.

The main drawback is that that this will launching prysk in yet another subprocess rather than
sourcing a bash script in the same process.

Closes TURBO-1675