### PR TITLE
fix(Turborepo): Make verbosity test pass with Rust

### DIFF
--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -177,7 +177,7 @@ func (r *run) run(ctx gocontext.Context, targets []string, executionState *turbo
 	}
 
 	if ui.IsCI && !r.opts.runOpts.NoDaemon {
-		r.base.Logger.Info("skipping turbod since we appear to be in a non-interactive context")
+		r.base.Logger.Debug("skipping turbod since we appear to be in a non-interactive context")
 	} else if !r.opts.runOpts.NoDaemon {
 		turbodClient, err := daemon.GetClient(ctx, r.base.RepoRoot, r.base.Logger, r.base.TurboVersion, daemon.ClientOpts{})
 		if err != nil {

--- a/crates/turborepo-lib/src/process/child.rs
+++ b/crates/turborepo-lib/src/process/child.rs
@@ -29,7 +29,7 @@ use tokio::{
     join,
     sync::{mpsc, watch, RwLock},
 };
-use tracing::{debug, info};
+use tracing::debug;
 
 #[derive(Debug)]
 pub enum ChildState {
@@ -104,14 +104,14 @@ impl ShutdownStyle {
                         }
                     };
 
-                    info!("starting shutdown");
+                    debug!("starting shutdown");
 
                     let result = tokio::time::timeout(*timeout, fut).await;
                     match result {
                         Ok(Ok(result)) => ChildState::Exited(ChildExit::Finished(result)),
                         Ok(Err(_)) => ChildState::Exited(ChildExit::Failed),
                         Err(_) => {
-                            info!("graceful shutdown timed out, killing child");
+                            debug!("graceful shutdown timed out, killing child");
                             match child.kill().await {
                                 Ok(_) => ChildState::Exited(ChildExit::Killed),
                                 Err(_) => ChildState::Exited(ChildExit::Failed),
@@ -215,7 +215,7 @@ impl Child {
         let task_state = state.clone();
 
         let _task = tokio::spawn(async move {
-            info!("waiting for task");
+            debug!("waiting for task");
             tokio::select! {
                 command = command_rx.recv() => {
                     let state = match command {

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -206,7 +206,7 @@ impl<'a> Run<'a> {
         let is_ci_or_not_tty = turborepo_ci::is_ci() || !std::io::stdout().is_terminal();
 
         let daemon = if is_ci_or_not_tty && !opts.run_opts.no_daemon {
-            info!("skipping turbod since we appear to be in a non-interactive context");
+            debug!("skipping turbod since we appear to be in a non-interactive context");
             None
         } else if !opts.run_opts.no_daemon {
             let connector = DaemonConnector {

--- a/turborepo-tests/integration/tests/run-logging/verbosity.t
+++ b/turborepo-tests/integration/tests/run-logging/verbosity.t
@@ -4,7 +4,6 @@ Setup
 
 Verbosity level 1
   $ ${TURBO} build -v --filter=util --force
-  [-0-9:.TWZ+]+ \[INFO]  turbo: skipping turbod since we appear to be in a non-interactive context (re)
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
@@ -20,7 +19,6 @@ Verbosity level 1
     Time:\s*[\.0-9]+m?s  (re)
   
   $ ${TURBO} build --verbosity=1 --filter=util --force
-  [-0-9:.TWZ+]+ \[INFO]  turbo: skipping turbod since we appear to be in a non-interactive context (re)
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
@@ -37,96 +35,11 @@ Verbosity level 1
   
 
 Verbosity level 2
-  $ ${TURBO} build -vv --filter=util --force
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running command as global turbo (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::run::global_hash: global hash env vars \[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::run::global_hash: external deps hash: 459c029558afe716 (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::task_hash: task hash env vars for util:build (re)
-   vars: \[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::task_graph::visitor: task util#build hash is 1ce33e04f265f95c (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Found go binary at "[\-\w\/\.]+" (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: build tag: rust (re)
-  [-0-9:.TWZ+]+ \[INFO]  turbo: skipping turbod since we appear to be in a non-interactive context (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: filter patterns: patterns=\["util"] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Parsed selector: selector="&{includeDependencies:false matchDependencies:false includeDependents:false exclude:false excludeSelf:false followProdDepsOnly:false parentDir: namePattern:util fromRef: toRefOverride: raw:util}" (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtering packages: allPackageSelectors=\["&{false false false false false false  util   util}"] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtered packages: selector="&{includeDependencies:false matchDependencies:false includeDependents:false exclude:false excludeSelf:false followProdDepsOnly:false parentDir: namePattern:util fromRef: toRefOverride: raw:util}" entryPackages=map\[util:util] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtered packages: cherryPickedPackages=map\[util:util] walkedDependencies=map\[] walkedDependents=map\[] walkedDependentsDependencies=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtered packages: cherryPickedPackages=map\[] walkedDependencies=map\[] walkedDependents=map\[] walkedDependentsDependencies=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: filtered packages: packages=map\[util:util] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash env vars: vars=\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash: value=2107205f32600eb9 (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash matches between Rust and Go (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: local cache folder: path="" (re)
-  \xe2\x80\xa2 Packages in scope: util (esc)
-  \xe2\x80\xa2 Running build in 1 packages (esc)
-  \xe2\x80\xa2 Remote caching disabled (esc)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: task hash env vars for util:build: vars=\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo.: start (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: task hash: value=1ce33e04f265f95c (re)
-  util:build: cache bypass, force executing 1ce33e04f265f95c
-  util:build: 
-  util:build: > build
-  util:build: > echo building
-  util:build: 
-  util:build: building
-  [-0-9:.TWZ+]+ \[DEBUG] turbo.: caching output: outputs="{\[packages/util/.turbo/turbo-build.log] \[]}" (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo.: done: status=complete duration=[\.0-9]+m?s (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: task hashes match (re)
-  
-   Tasks:    1 successful, 1 total
-  Cached:    0 cached, 1 total
-    Time:\s*[\.0-9]+m?s  (re)
-  
-  $ ${TURBO} build --verbosity=2 --filter=util --force
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Global turbo version: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Repository Root: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: No local turbo binary found at: .* (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::shim: Running command as global turbo (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::run::global_hash: global hash env vars \[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::run::global_hash: external deps hash: 459c029558afe716 (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::task_hash: task hash env vars for util:build (re)
-   vars: []
-  [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::task_graph::visitor: task util#build hash is 1ce33e04f265f95c (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Found go binary at "[\-\w\/\.]+" (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: build tag: rust (re)
-  [-0-9:.TWZ+]+ \[INFO]  turbo: skipping turbod since we appear to be in a non-interactive context (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: filter patterns: patterns=\["util"] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Parsed selector: selector="&{includeDependencies:false matchDependencies:false includeDependents:false exclude:false excludeSelf:false followProdDepsOnly:false parentDir: namePattern:util fromRef: toRefOverride: raw:util}" (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtering packages: allPackageSelectors=\["&{false false false false false false  util   util}"] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtered packages: selector="&{includeDependencies:false matchDependencies:false includeDependents:false exclude:false excludeSelf:false followProdDepsOnly:false parentDir: namePattern:util fromRef: toRefOverride: raw:util}" entryPackages=map\[util:util] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtered packages: cherryPickedPackages=map\[util:util] walkedDependencies=map\[] walkedDependents=map\[] walkedDependentsDependencies=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: Filtered packages: cherryPickedPackages=map\[] walkedDependencies=map\[] walkedDependents=map\[] walkedDependentsDependencies=map\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: filtered packages: packages=map\[util:util] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash env vars: vars=\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash: value=2107205f32600eb9 (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: global hash matches between Rust and Go (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: local cache folder: path="" (re)
-  \xe2\x80\xa2 Packages in scope: util (esc)
-  \xe2\x80\xa2 Running build in 1 packages (esc)
-  \xe2\x80\xa2 Remote caching disabled (esc)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: task hash env vars for util:build: vars=\[] (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo.: start (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: task hash: value=1ce33e04f265f95c (re)
-  util:build: cache bypass, force executing 1ce33e04f265f95c
-  util:build: 
-  util:build: > build
-  util:build: > echo building
-  util:build: 
-  util:build: building
-  [-0-9:.TWZ+]+ \[DEBUG] turbo.: caching output: outputs="{\[packages/util/.turbo/turbo-build.log] \[]}" (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo.: done: status=complete duration=[\.0-9]+m?s (re)
-  [-0-9:.TWZ+]+ \[DEBUG] turbo: task hashes match (re)
-  
-   Tasks:    1 successful, 1 total
-  Cached:    0 cached, 1 total
-    Time:\s*[\.0-9]+m?s  (re)
-  
+  $ ${TURBO} build -vv --filter=util --force 1> VERBOSEVV 2>&1
+  $ grep --quiet "[DEBUG]" VERBOSEVV
+
+  $ ${TURBO} build --verbosity=2 --filter=util --force 1> VERBOSE2 2>&1
+  $ grep --quiet "[DEBUG]" VERBOSE2
 
 Make sure users can only use one verbosity flag
   $ ${TURBO} build -v --verbosity=1


### PR DESCRIPTION
### Description

 - drop skipping daemon log message to debug
 - switch rust process manager logging to debug

### Testing Instructions

 - switch highest verbosity settings to just check that we print out `DEBUG`

Closes TURBO-1642