### PR TITLE
fix: Check cache on dry run

### DIFF
--- a/crates/turborepo-cache/src/async_cache.rs
+++ b/crates/turborepo-cache/src/async_cache.rs
@@ -117,7 +117,7 @@ impl AsyncCache {
         }
     }
 
-    pub async fn exists(&mut self, key: &str) -> Result<Option<CacheHitMetadata>, CacheError> {
+    pub async fn exists(&self, key: &str) -> Result<Option<CacheHitMetadata>, CacheError> {
         self.real_cache.exists(key).await
     }
 

--- a/crates/turborepo-lib/src/run/cache.rs
+++ b/crates/turborepo-lib/src/run/cache.rs
@@ -50,9 +50,15 @@ impl RunCache {
         color_selector: ColorSelector,
         daemon_client: Option<DaemonClient<DaemonConnector>>,
         ui: UI,
+        is_dry_run: bool,
     ) -> Self {
+        let task_output_mode = if is_dry_run {
+            Some(OutputLogsMode::None)
+        } else {
+            opts.task_output_mode_override
+        };
         RunCache {
-            task_output_mode: opts.task_output_mode_override,
+            task_output_mode,
             cache,
             reads_disabled: opts.skip_reads,
             writes_disabled: opts.skip_writes,

--- a/crates/turborepo-lib/src/run/cache.rs
+++ b/crates/turborepo-lib/src/run/cache.rs
@@ -3,7 +3,7 @@ use std::{io::Write, sync::Arc, time::Duration};
 use console::StyledObject;
 use tracing::{debug, log::warn};
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPathBuf};
-use turborepo_cache::{AsyncCache, CacheHitMetadata, CacheSource};
+use turborepo_cache::{AsyncCache, CacheError, CacheHitMetadata, CacheSource};
 use turborepo_repository::package_graph::WorkspaceInfo;
 use turborepo_ui::{
     color, replay_logs, ColorSelector, LogWriter, PrefixedUI, PrefixedWriter, GREY, UI,
@@ -163,6 +163,10 @@ impl TaskCache {
         }
 
         Ok(log_writer)
+    }
+
+    pub async fn exists(&mut self) -> Result<Option<CacheHitMetadata>, CacheError> {
+        self.run_cache.cache.exists(&self.hash).await
     }
 
     pub async fn restore_outputs(

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -314,6 +314,7 @@ impl<'a> Run<'a> {
             color_selector,
             daemon,
             self.base.ui,
+            opts.run_opts.dry_run.is_some(),
         ));
 
         let mut global_env_mode = opts.run_opts.env_mode;
@@ -568,6 +569,8 @@ impl<'a> Run<'a> {
             color_selector,
             None,
             self.base.ui,
+            // Always dry run when getting hashes
+            true,
         ));
 
         let run_tracker = RunTracker::new(

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -162,7 +162,9 @@ impl<'a> Run<'a> {
         let config = self.base.config()?;
 
         // Pulled from initAnalyticsClient in run.go
-        let is_linked = api_auth.is_some();
+        let is_linked = api_auth
+            .as_ref()
+            .map_or(false, |api_auth| api_auth.is_linked());
         if !is_linked {
             opts.cache_opts.skip_remote = true;
         } else if let Some(enabled) = config.enabled {

--- a/crates/turborepo-lib/src/run/summary/task.rs
+++ b/crates/turborepo-lib/src/run/summary/task.rs
@@ -130,9 +130,6 @@ impl TaskCacheSummary {
     }
 }
 
-// This is an `Option<Option<CacheHitMetadata>>` because we could fail
-// to fetch from cache (giving `None`), and we could also get a miss
-// `Some(None)`
 impl From<Option<CacheHitMetadata>> for TaskCacheSummary {
     fn from(response: Option<CacheHitMetadata>) -> Self {
         match response {

--- a/crates/turborepo-lib/src/task_graph/visitor.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor.rs
@@ -593,7 +593,13 @@ impl ExecContext {
         output_client: OutputClient<impl std::io::Write>,
         tracker: TaskTracker<()>,
     ) {
-        if let Ok(Some(status)) = self.task_cache.restore_outputs(None).await {
+        let mut prefixed_ui = Visitor::prefixed_ui(
+            self.ui,
+            self.is_github_actions,
+            &output_client,
+            self.pretty_prefix.clone(),
+        );
+        if let Ok(Some(status)) = self.task_cache.restore_outputs(&mut prefixed_ui).await {
             // we need to set expanded outputs
             self.hash_tracker.insert_expanded_outputs(
                 self.task_id.clone(),

--- a/turborepo-tests/integration/tests/run-logging/verbosity.t
+++ b/turborepo-tests/integration/tests/run-logging/verbosity.t
@@ -48,6 +48,7 @@ Verbosity level 2
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::task_hash: task hash env vars for util:build (re)
    vars: \[] (re)
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::task_graph::visitor: task util#build hash is 1ce33e04f265f95c (re)
+  [-0-9:.TWZ+]+ \[DEBUG] log: Engine visitor dropped callback sender without sending result (re)
   [-0-9:.TWZ+]+ \[DEBUG] turbo: Found go binary at "[\-\w\/\.]+" (re)
   [-0-9:.TWZ+]+ \[DEBUG] turbo: build tag: rust (re)
   [-0-9:.TWZ+]+ \[INFO]  turbo: skipping turbod since we appear to be in a non-interactive context (re)
@@ -93,6 +94,7 @@ Verbosity level 2
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::task_hash: task hash env vars for util:build (re)
    vars: []
   [-0-9:.TWZ+]+ \[DEBUG] turborepo_lib::task_graph::visitor: task util#build hash is 1ce33e04f265f95c (re)
+  [-0-9:.TWZ+]+ \[DEBUG] log: Engine visitor dropped callback sender without sending result (re)
   [-0-9:.TWZ+]+ \[DEBUG] turbo: Found go binary at "[\-\w\/\.]+" (re)
   [-0-9:.TWZ+]+ \[DEBUG] turbo: build tag: rust (re)
   [-0-9:.TWZ+]+ \[INFO]  turbo: skipping turbod since we appear to be in a non-interactive context (re)


### PR DESCRIPTION
### Description

We need to check the cache so the cache metadata is in the task hash tracker. This lets us produce the correct cache data for dry run

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->


Closes TURBO-1677