### PR TITLE
fix(Turborepo): Update missing-tasks.t to pass with Rust

### DIFF
--- a/turborepo-tests/integration/tests/run/missing-tasks.t
+++ b/turborepo-tests/integration/tests/run/missing-tasks.t
@@ -4,25 +4,22 @@ Setup
 
 # Running non-existent tasks errors
   $ ${TURBO} run doesnotexist
-  Error: Could not find the following tasks in project: doesnotexist
+  (Error:| ERROR  run failed:) Could not find the following tasks in project: doesnotexist (re)
   [1]
 
 # Multiple non-existent tasks also error
   $ ${TURBO} run doesnotexist alsono
-  Error: Could not find the following tasks in project: alsono, doesnotexist
+  (Error:| ERROR  run failed:) Could not find the following tasks in project: alsono, doesnotexist (re)
   [1]
 
 # One good and one bad task does not error
   $ ${TURBO} run build doesnotexist
-  Error: Could not find the following tasks in project: doesnotexist
+  (Error:| ERROR  run failed:) Could not find the following tasks in project: doesnotexist (re)
   [1]
 
 # Bad command
-  $ ${TURBO} run something --dry
-  Error: root task //#something (turbo run build) looks like it invokes turbo and might cause a loop
-  [1]
+  $ ${TURBO} run something --dry 2>&1 | grep --quiet "root task //#something (turbo run build) looks like it invokes turbo and might cause a loop"
 
 # Bad command
-  $ ${TURBO} run something
-  Error: root task //#something (turbo run build) looks like it invokes turbo and might cause a loop
-  [1]
+  $ ${TURBO} run something 2>&1 | grep --quiet "root task //#something (turbo run build) looks like it invokes turbo and might cause a loop"
+


### PR DESCRIPTION
### Description

A combination of regex magic and `grep` to ensure we have the relevant error strings in both implementations.

### Testing Instructions

Updated `missing-tasks.t`

Closes TURBO-1646