### PR TITLE
fix(Turborepo): Fix dry-json/monorepo.t

### DIFF
--- a/turborepo-tests/integration/tests/dry-json/monorepo.t
+++ b/turborepo-tests/integration/tests/dry-json/monorepo.t
@@ -180,5 +180,5 @@ Run again with NODE_ENV set and see the value in the summary. --filter=util work
 
 Tasks that don't exist throw an error
   $ ${TURBO} run doesnotexist --dry=json
-  Error: Could not find the following tasks in project: doesnotexist
+  (Error:| ERROR  run failed:) Could not find the following tasks in project: doesnotexist (re)
   [1]


### PR DESCRIPTION
### Description

Use regex magic to allow both Go and Rust error strings

### Testing Instructions

Updated test now passes with Rust

Closes TURBO-1638
