### PR TITLE
Update `swc_core` to `v0.86.81`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -770,9 +770,9 @@ dependencies = [
 
 [[package]]
 name = "binding_macros"
-version = "0.60.70"
+version = "0.60.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3aaaacc2b9a302a18b5c1e1c889590bbc734f0a5a95a32881f50168e372bcb"
+checksum = "f26ea7eee9a439637bc4cb168661c5af4e8a0f61f375516a841cdc63ee25d9e8"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -2377,16 +2377,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4eeac5c5edb79e4e39fe8439ef35207780a11f69c52cbe424ce3dfad4cb78de6"
 dependencies = [
- "enum-iterator-derive 0.7.0",
-]
-
-[[package]]
-name = "enum-iterator"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7add3873b5dd076766ee79c8e406ad1a472c385476b9e38849f8eec24f1be689"
-dependencies = [
- "enum-iterator-derive 1.2.1",
+ "enum-iterator-derive",
 ]
 
 [[package]]
@@ -2398,17 +2389,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "enum-iterator-derive"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eecf8589574ce9b895052fa12d69af7a233f99e6107f5cb8dd1044f2a17bfdcb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.32",
 ]
 
 [[package]]
@@ -2910,18 +2890,6 @@ dependencies = [
  "libc",
  "wasi",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "getset"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e45727250e75cc04ff2846a66397da8ef2b3db8e40e0cef4df67950a07621eb9"
-dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -4500,9 +4468,9 @@ dependencies = [
 
 [[package]]
 name = "modularize_imports"
-version = "0.56.0"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b938c4ffaa1180f64186fd52f51dac5998e68c8c29f3ce4a0da952b873ebe021"
+checksum = "14c2f9271c2d71d6116dc1d6b1ef9e9bdd7eaf7e7cf8dfd1fd2fb5cd9eaf4073"
 dependencies = [
  "convert_case 0.5.0",
  "handlebars",
@@ -7148,9 +7116,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "styled_components"
-version = "0.83.0"
+version = "0.86.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97aa75a37e4afde897446c920d4569ff18fbf32d2f8f3d9d0f109da674a9cb15"
+checksum = "7b0858947aeb5e5bd7c1b4fd70a280b05902fea32d5df8823d27098d7285ab8d"
 dependencies = [
  "Inflector",
  "once_cell",
@@ -7166,9 +7134,9 @@ dependencies = [
 
 [[package]]
 name = "styled_jsx"
-version = "0.60.0"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d5d705b3f746558b25d9badb4e2af0d106688880a7a7efd7cc41b4af7d42fd4"
+checksum = "8b8220480edf3268dc3b4cd6f1dcd3f00553f7eb79c132a24da32876fbd2fb47"
 dependencies = [
  "easy-error",
  "lightningcss",
@@ -7240,9 +7208,9 @@ dependencies = [
 
 [[package]]
 name = "swc"
-version = "0.269.63"
+version = "0.269.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "923407d98c0414576c664a007bfe70e961c8fdf1f3d9444d68b21865146d7d66"
+checksum = "1671c9ab69f8e55fa4f9657f2178aa89bb0d3b9bb8f74a86d408dfeaa1e55915"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
@@ -7317,9 +7285,9 @@ dependencies = [
 
 [[package]]
 name = "swc_bundler"
-version = "0.222.57"
+version = "0.222.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5023d44d6b77d8ad682a7405d0ad63008c7474b3adaee73f07cb9b6b9e6bd1bf"
+checksum = "206ab7fd044985019ca9b8db0c84d6ebc719e4eeb01a04add040e772b8a353e7"
 dependencies = [
  "anyhow",
  "crc",
@@ -7396,9 +7364,9 @@ dependencies = [
 
 [[package]]
 name = "swc_compiler_base"
-version = "0.3.65"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628308fa20b7a03f976973002270ee852b9d589f8025fc7c2832bebae426b3ff"
+checksum = "9a5d5e3228c9e3a6e6883b75a2a2e17e5d320152c794619bb8e25442a3c77207"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
@@ -7445,9 +7413,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "0.86.70"
+version = "0.86.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54313f9a5492e104affa4e8afe7a2300188c9cbb81f66304b4872addf7ae6cc6"
+checksum = "e4b4f381de91cb684507f9254da4715fe8da903a7f690fb85b48077a0aa0ec44"
 dependencies = [
  "binding_macros",
  "swc",
@@ -7654,9 +7622,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.146.30"
+version = "0.146.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "408ebdfa02c396e0660f41f0cded12ed8cd66c6050a216ff352d4c362d8d48a2"
+checksum = "0f73ea71b6e5c636bf667a892754037ed146dbda64e8fe5d12a5d2623f8d0bdd"
 dependencies = [
  "memchr",
  "num-bigint",
@@ -7686,9 +7654,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_bugfixes"
-version = "0.1.41"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c35f51af0b757f486b95004ee0f7253cd98639d25df29d4952e487cffe9817"
+checksum = "279c763a1c2d1dc2a42fe94c751665585dd771d1344d36d069ad37e4253c4d1d"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -7703,9 +7671,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_common"
-version = "0.1.27"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94ca93ad77c2ce621137a5c358c8d50f84ec4d564818e21cc7d944a04c93487f"
+checksum = "89c1bb8d34782eeca95dd46dc971b0fcd4369ae7ed90de629c3f1f6dabf91d14"
 dependencies = [
  "swc_common",
  "swc_ecma_ast",
@@ -7716,9 +7684,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2015"
-version = "0.1.41"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "491ccd30730f8ec0dafa28ea88758983f67cb57ffde608e0ed394898325a111d"
+checksum = "c784eac062d3c9c4282e70323cde066b754cca4e247b02a244c57034d5507a52"
 dependencies = [
  "arrayvec 0.7.4",
  "indexmap 1.9.3",
@@ -7742,9 +7710,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2016"
-version = "0.1.39"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4abfb63110e084c34d2064d8ae4a9265e71a998f2ee1beff8201432af05b75f2"
+checksum = "5872a8feee2889872e78d5a6b716d9dda073c9e5d30028a9f8414d98f766975d"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -7759,9 +7727,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2017"
-version = "0.1.40"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a6e179264f0fdb6d5e66f37e2df321107a2032be8b97d7d56a2d22b169b0fbc"
+checksum = "d53cbe619c4b1d8a470a35231a75b2f3eb021a23ba5f34314381ac5c39f48720"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -7777,9 +7745,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2018"
-version = "0.1.40"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14e027a1caaf8d566e4af144428c4a08bbd2cdb059a940716eb1a4756f809ac"
+checksum = "eb17f01a89474595c8284c37a04250d397502421a7509bdecd79b7bdf9740092"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -7796,9 +7764,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2019"
-version = "0.1.40"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff7f4560da2760992c5ca1adfe364c696a9735c7a0e8c9f683248cad82af939"
+checksum = "521ad6994a8c165dc1ae827770e5374aeb7263ccc89619d26be7c7441c5892c5"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -7812,9 +7780,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2020"
-version = "0.1.38"
+version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d7cff8318929027e77c3edb983c7fb087bc46368e8a62b99f24422e2a65fab7"
+checksum = "9a06f8ec7438dac0252bc1522f7491807196fdf0892687a5c8b6218a8c47f2b8"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -7830,9 +7798,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2021"
-version = "0.1.38"
+version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9939ebec11da044a20bd2a1abb68b88e323c0c325e7aedb46838cb62c901a9"
+checksum = "f32bdb471ff8dbe19a07f39d5df9261c783a62af34711a3ee4c8d577e3a212fc"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -7846,9 +7814,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2022"
-version = "0.1.39"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e37490007352ed788d2b9ca72057dd41c707603bd1276ccb83a201d1afc01d"
+checksum = "27ef60afe5793186b18fe2494e4ead74f75dee7080392f9634fad825a3ce985f"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -7865,9 +7833,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es3"
-version = "0.1.39"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9c5a6dbb39c6bb6755bf228bbdd9d7ca735865af2dbbe36c51339632d9a451"
+checksum = "05111042e0db3a4b961c271a22f4f4af936e22e821cd3000af658ddf7ca1d9d8"
 dependencies = [
  "swc_common",
  "swc_ecma_ast",
@@ -7880,9 +7848,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ext_transforms"
-version = "0.110.31"
+version = "0.110.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca4d7853d4cece03ac9672e25cad8bf99ed6b7bccabd03395e9f905c57c7f473"
+checksum = "344396bc9218d667c2d375bbdfe1aad319697922b54cbab563d2acb124a2270f"
 dependencies = [
  "phf 0.11.2",
  "swc_atoms",
@@ -7894,9 +7862,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_lints"
-version = "0.89.39"
+version = "0.89.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f7a291b58561da08077b33fc0a18a2911f2a0cd6252ec7cf53da7b9ce24f07"
+checksum = "ebb6311b5284d43f6792bd69eb390455fb2c64ebd732d4167d350642d506e438"
 dependencies = [
  "auto_impl",
  "dashmap",
@@ -7935,9 +7903,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "0.189.59"
+version = "0.189.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09e54f0a3163a21b1d5fc3aee995e9023244feea54fe59d90b36d857b10d163f"
+checksum = "b460795b5b9439f71c5961b513764efa45021e3ebfc202b3eeb5cb3c135c0b66"
 dependencies = [
  "arrayvec 0.7.4",
  "indexmap 1.9.3",
@@ -7970,9 +7938,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.141.24"
+version = "0.141.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4113ddece99e83aa301c8ee7007bb432717d9f49da1d5b36a01b8e56880a133"
+checksum = "5c01ab163c83f4e8c0d82382478d142ceecf897e5b2822707fec662a22208287"
 dependencies = [
  "either",
  "new_debug_unreachable",
@@ -7992,9 +7960,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "0.203.49"
+version = "0.203.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9565fb31e376f17d2158695bfc4ec764764a411f5076fb168c0a3d0af3246e8"
+checksum = "1a830182b77d2b59978a025758d830c6d19f193546eb630c8a99e2a93fd74abf"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -8017,9 +7985,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_quote_macros"
-version = "0.52.24"
+version = "0.52.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1e94ca9b24f4fae40d7906724355f5154c2eeeab38b6596817620598bb6b6d9"
+checksum = "cafeb878f702c360b9553869c60739a285c3d4af88c4b45ad1c37975a8c1eb9c"
 dependencies = [
  "anyhow",
  "pmutil",
@@ -8048,9 +8016,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.226.49"
+version = "0.226.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac782d0b28ffaf2ca55b7b5e052e194dbdcde4a326048aaa5b88511e48599d45"
+checksum = "688c962b8f01186b95e65ff879fcfbd2cc2beaf1893b289204d5cfd6d8603217"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -8068,9 +8036,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.134.40"
+version = "0.134.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d7f1ef5a5885fafd5de3b62d49642859140fde5f195bdd9bdcf3e511f8ac498"
+checksum = "84a880cd951f82c4f1bf970e12e8fab616ea7feb41c97203d2d0cfa063d775bb"
 dependencies = [
  "better_scoped_tls",
  "bitflags 2.4.0",
@@ -8092,9 +8060,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "0.123.41"
+version = "0.123.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe3a4cb19135a6eed9190ef979c504427bf699e13ce1dacad6cc90958beb1c39"
+checksum = "fecd75dde48c358af419a1d496ce7b2d293fb3d740db21859be752f9decd8b63"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -8106,9 +8074,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "0.160.46"
+version = "0.160.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b8e9ece87fde1b6079a17386bfbf01b8bc3476e229e96bb14ed47f66c283c40"
+checksum = "04b4d9a1b45e29a70eeb8d6cf9ddca6b3c2a80cb0cf056c212ccc764f096d700"
 dependencies = [
  "arrayvec 0.7.4",
  "indexmap 1.9.3",
@@ -8156,9 +8124,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "0.177.48"
+version = "0.177.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f8aeadf84c7e8c009983ee81147db7aa9082b07d81b0f3e4b7f4d75c3d704d"
+checksum = "6ab1c807d62a947691a1a30110753cae83387c20772a0bc4cc9d548a1e09c8d3"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -8183,9 +8151,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.195.49"
+version = "0.195.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a01b7809d4182c44949a8025acea0cda7a56cda97cc78173937dc2f2399d39"
+checksum = "721dbf997879ad84fbee1deaf196fc55c0d0a47943b6958bc1af4ee447dba4f7"
 dependencies = [
  "dashmap",
  "indexmap 1.9.3",
@@ -8208,9 +8176,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "0.168.49"
+version = "0.168.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a063806e0a0e8394d7515b588104c1743edd915972b1d559837a844a2e1578fd"
+checksum = "ccb7b031fb6722529fe29e07db588ab4b4c4b252e38c227bdfa971b15abc70db"
 dependencies = [
  "either",
  "rustc-hash",
@@ -8228,9 +8196,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.180.49"
+version = "0.180.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9675a98a9353c0316dcc797d19ad0d2857252c2c5ced4ac544546734dbb487d"
+checksum = "46dbfcfba470b79cf77ff8f5101eb8ea779dc80e9a8c0f65dffd520517e690ce"
 dependencies = [
  "base64 0.13.1",
  "dashmap",
@@ -8253,9 +8221,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_testing"
-version = "0.137.42"
+version = "0.137.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "067a0b56fb73a5c21008f9ae873a9feb7b4e76889ce4466322fdebe61354ad49"
+checksum = "fbfb208a09b01597de4dab01a4a376ede74189af96fd6e7d8af6c7c3e724b9f7"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -8279,9 +8247,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.185.47"
+version = "0.185.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10df43839e8b8a8fb5e8efa700128d855977bcf4479812b4bda47a57f3c5737d"
+checksum = "5296ade10bce7b75661ad2e79cde1654dc037ec12cf5b6a4a08b1c96734ddf2f"
 dependencies = [
  "ryu-js",
  "serde",
@@ -8296,9 +8264,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_usage_analyzer"
-version = "0.20.31"
+version = "0.20.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f5a7d35a53f95869f495e93b9e54b9cc8c2e960c3d7800a80faff8c200ba733"
+checksum = "163c7cce74915619fba4c7967937d1b1470a3acd2d44e149842cfadf5e5cea0b"
 dependencies = [
  "indexmap 1.9.3",
  "rustc-hash",
@@ -8313,9 +8281,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.124.30"
+version = "0.124.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93de94cda9904aba8301bf2e3e146bf9a584888e68a19ebbb38dba3f560635ba"
+checksum = "cd7f189c68e7aa895a19afd5c61eeeb4f4e71d80123b3b42f32e80c1f6641928"
 dependencies = [
  "indexmap 1.9.3",
  "num_cpus",
@@ -8347,9 +8315,9 @@ dependencies = [
 
 [[package]]
 name = "swc_emotion"
-version = "0.59.0"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "708a605ff7a722d169e800dbbb0328a82db38811d3b07cbb8ca87db27d7b3e9c"
+checksum = "1ae29bde2cc05fa93f03b7432d17e43070fb7570de84b79980983194025214bf"
 dependencies = [
  "base64 0.13.1",
  "byteorder",
@@ -8493,9 +8461,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_runner"
-version = "0.104.26"
+version = "0.104.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c89f3cc466f3c20cd0febdd69ea29f411b1e07aa9d245317ae8de067224071"
+checksum = "799bd78fbbcb2a266f9c00ec42c7f7c0d3bcbb063ac62a98268604abcb2b7c22"
 dependencies = [
  "anyhow",
  "enumset",
@@ -8517,9 +8485,9 @@ dependencies = [
 
 [[package]]
 name = "swc_relay"
-version = "0.31.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a144781f2f2de3e7ccc22f7381a7f24383ac36168a4afefdbb029f78c1aa973"
+checksum = "e3270973952ee96e4cc2689829f4e4a5902e253a479457ca773ac19e1cfd7edd"
 dependencies = [
  "once_cell",
  "regex",
@@ -10788,8 +10756,8 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
- "rand 0.4.6",
+ "cfg-if 1.0.0",
+ "rand 0.8.5",
  "static_assertions",
 ]
 
@@ -11060,17 +11028,12 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "vergen"
-version = "7.5.1"
+version = "8.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f21b881cd6636ece9735721cf03c1fe1e774fe258683d084bb2812ab67435749"
+checksum = "1290fd64cc4e7d3c9b07d7f333ce0ce0007253e32870e632624835cc80b83939"
 dependencies = [
  "anyhow",
- "cfg-if 1.0.0",
- "enum-iterator 1.4.1",
- "getset",
  "rustversion",
- "thiserror",
- "time 0.3.30",
 ]
 
 [[package]]
@@ -11443,7 +11406,7 @@ checksum = "f093937725e242e5529fed27e08ff836c011a9ecc22e6819fb818c2ac6ff5f88"
 dependencies = [
  "backtrace",
  "cfg-if 1.0.0",
- "enum-iterator 0.7.0",
+ "enum-iterator",
  "enumset",
  "lazy_static",
  "leb128",
@@ -11496,7 +11459,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "918d2f0bb5eaa95a80c06be33f21dee92f40f12cd0982da34490d121a99d244b"
 dependencies = [
  "bytecheck",
- "enum-iterator 0.7.0",
+ "enum-iterator",
  "enumset",
  "indexmap 1.9.3",
  "more-asserts",
@@ -11518,7 +11481,7 @@ dependencies = [
  "corosensei",
  "dashmap",
  "derivative",
- "enum-iterator 0.7.0",
+ "enum-iterator",
  "fnv",
  "indexmap 1.9.3",
  "lazy_static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -770,9 +770,9 @@ dependencies = [
 
 [[package]]
 name = "binding_macros"
-version = "0.60.65"
+version = "0.60.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5c56be21af1be0e320dcf78a3f9e700d9a3b3ea7ac58c748a84156b6786b2f5"
+checksum = "3c3aaaacc2b9a302a18b5c1e1c889590bbc734f0a5a95a32881f50168e372bcb"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -4194,9 +4194,9 @@ dependencies = [
 
 [[package]]
 name = "markdown"
-version = "1.0.0-alpha.14"
+version = "1.0.0-alpha.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2a51befc5a2b4a052c473ffbc9ad462e358de59dcc2fde4997fd2a16403dcbd"
+checksum = "ff9c0d28952698a9accc957767f2bcad203ec10251601f89b9ddc82661c3a15a"
 dependencies = [
  "unicode-id",
 ]
@@ -4249,9 +4249,9 @@ dependencies = [
 
 [[package]]
 name = "mdxjs"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7572e57307a72a93fed80bf5aaa0a81cca3a47d7faaf65af4f0d3ac4d84a1715"
+checksum = "76dd8c39a187154daf394ac55f155f6c411ac0c9f8c0dda7a00e80879610d994"
 dependencies = [
  "markdown",
  "serde",
@@ -7240,9 +7240,9 @@ dependencies = [
 
 [[package]]
 name = "swc"
-version = "0.269.58"
+version = "0.269.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71dff087f3b2e1933940fdf34b4ade8ad1e52dc28c64837af9e9e68ca8c8796f"
+checksum = "923407d98c0414576c664a007bfe70e961c8fdf1f3d9444d68b21865146d7d66"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
@@ -7317,9 +7317,9 @@ dependencies = [
 
 [[package]]
 name = "swc_bundler"
-version = "0.222.52"
+version = "0.222.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19c85d17424aa5105bf0708330cae3335173e79bce1c5d07764067edb39f513"
+checksum = "5023d44d6b77d8ad682a7405d0ad63008c7474b3adaee73f07cb9b6b9e6bd1bf"
 dependencies = [
  "anyhow",
  "crc",
@@ -7396,9 +7396,9 @@ dependencies = [
 
 [[package]]
 name = "swc_compiler_base"
-version = "0.3.60"
+version = "0.3.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e5855611431a0bd25cb494bcacc59cc2f1b79fe244382b08857a4a808665fdc"
+checksum = "628308fa20b7a03f976973002270ee852b9d589f8025fc7c2832bebae426b3ff"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
@@ -7445,9 +7445,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "0.86.65"
+version = "0.86.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b52c6d48b61d8f9f5aed41133fba8f8f30be1b1a237a596c6bdb659e338cc03"
+checksum = "54313f9a5492e104affa4e8afe7a2300188c9cbb81f66304b4872addf7ae6cc6"
 dependencies = [
  "binding_macros",
  "swc",
@@ -7654,9 +7654,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.146.29"
+version = "0.146.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea4947cb3618b243127faf16ea3d12f59d9f31e9a53f3ce02e141e13920ec1b5"
+checksum = "408ebdfa02c396e0660f41f0cded12ed8cd66c6050a216ff352d4c362d8d48a2"
 dependencies = [
  "memchr",
  "num-bigint",
@@ -7686,9 +7686,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_bugfixes"
-version = "0.1.39"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95e76fc8509088a510a993b1891de24ad58742b50e04fc5340cb0e4f882a8612"
+checksum = "44c35f51af0b757f486b95004ee0f7253cd98639d25df29d4952e487cffe9817"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -7703,9 +7703,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_common"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61f019fadf8a0c18d0ef814e4c19ac1bd74b1ec566660cea91cba5a062fd08fb"
+checksum = "94ca93ad77c2ce621137a5c358c8d50f84ec4d564818e21cc7d944a04c93487f"
 dependencies = [
  "swc_common",
  "swc_ecma_ast",
@@ -7716,9 +7716,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2015"
-version = "0.1.39"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50178ccc55ad13062673f700f21a6b39c869e20de6784c9cd81ec8c20424dcf8"
+checksum = "491ccd30730f8ec0dafa28ea88758983f67cb57ffde608e0ed394898325a111d"
 dependencies = [
  "arrayvec 0.7.4",
  "indexmap 1.9.3",
@@ -7742,9 +7742,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2016"
-version = "0.1.37"
+version = "0.1.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f49f1f9f488f836b70d17f937e5dcf8eb68244d9a82674c215e4f61f80ca010"
+checksum = "4abfb63110e084c34d2064d8ae4a9265e71a998f2ee1beff8201432af05b75f2"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -7759,9 +7759,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2017"
-version = "0.1.38"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc3c9ddfb82bf59010e374d0bcb4077961e24541d2e54d987a6ed1a1f47979b"
+checksum = "9a6e179264f0fdb6d5e66f37e2df321107a2032be8b97d7d56a2d22b169b0fbc"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -7777,9 +7777,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2018"
-version = "0.1.38"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8ba1bf40830ccc8fe161b473104de545bb6c6876336c19bf47097c9b38c7864"
+checksum = "e14e027a1caaf8d566e4af144428c4a08bbd2cdb059a940716eb1a4756f809ac"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -7796,9 +7796,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2019"
-version = "0.1.38"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f5498fa8bb58134e6d40127fd23efa065ecdbf66dd8e8f278d94ff37fcd2513"
+checksum = "6ff7f4560da2760992c5ca1adfe364c696a9735c7a0e8c9f683248cad82af939"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -7812,9 +7812,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2020"
-version = "0.1.36"
+version = "0.1.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76b5811dfc88070b6eb2d1612686f1aa6c792e947b9835a8c0de8835e519025d"
+checksum = "9d7cff8318929027e77c3edb983c7fb087bc46368e8a62b99f24422e2a65fab7"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -7830,9 +7830,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2021"
-version = "0.1.36"
+version = "0.1.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f01aece5d815eea8783e3d0a5f676e21b8d377e8698063d6dd5d877dbadb67"
+checksum = "cf9939ebec11da044a20bd2a1abb68b88e323c0c325e7aedb46838cb62c901a9"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -7846,9 +7846,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2022"
-version = "0.1.37"
+version = "0.1.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2286c1da6460016d4557facd593c7c46f60d1ff48823c794110165d60ef1a16"
+checksum = "61e37490007352ed788d2b9ca72057dd41c707603bd1276ccb83a201d1afc01d"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -7865,9 +7865,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es3"
-version = "0.1.37"
+version = "0.1.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d5386c2b17e6f99c4b9b665290249eed20acb4d7db7c39bcb28001967d2b94a"
+checksum = "2c9c5a6dbb39c6bb6755bf228bbdd9d7ca735865af2dbbe36c51339632d9a451"
 dependencies = [
  "swc_common",
  "swc_ecma_ast",
@@ -7880,9 +7880,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ext_transforms"
-version = "0.110.30"
+version = "0.110.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2ca67aa1a00fdda716784ee2060af3be56285c799526e32fdd7896883dbacff"
+checksum = "ca4d7853d4cece03ac9672e25cad8bf99ed6b7bccabd03395e9f905c57c7f473"
 dependencies = [
  "phf 0.11.2",
  "swc_atoms",
@@ -7894,9 +7894,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_lints"
-version = "0.89.37"
+version = "0.89.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00179a5eb408ed2c40cffd9b0db091ebe6e7242234d105fabb8c5dd2ab12fe4a"
+checksum = "49f7a291b58561da08077b33fc0a18a2911f2a0cd6252ec7cf53da7b9ce24f07"
 dependencies = [
  "auto_impl",
  "dashmap",
@@ -7935,9 +7935,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "0.189.54"
+version = "0.189.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "782bec110b6764bb57d2c2ef00bb81336214f1e0014945e5942005486d2e5e98"
+checksum = "09e54f0a3163a21b1d5fc3aee995e9023244feea54fe59d90b36d857b10d163f"
 dependencies = [
  "arrayvec 0.7.4",
  "indexmap 1.9.3",
@@ -7970,9 +7970,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.141.23"
+version = "0.141.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cc89c175ed17c7f795fb18cf778a5745ecd794ad19c4662f85843d7571957a8"
+checksum = "d4113ddece99e83aa301c8ee7007bb432717d9f49da1d5b36a01b8e56880a133"
 dependencies = [
  "either",
  "new_debug_unreachable",
@@ -7992,9 +7992,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "0.203.46"
+version = "0.203.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b3e9702447397ff93bca145ffa8325a162688db142b255dd9af88d3ec63ef42"
+checksum = "a9565fb31e376f17d2158695bfc4ec764764a411f5076fb168c0a3d0af3246e8"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -8017,9 +8017,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_quote_macros"
-version = "0.52.23"
+version = "0.52.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03f3312617c9f5431001406f3655fe1b2393cbb70e5ab780aa46d15af8438b78"
+checksum = "f1e94ca9b24f4fae40d7906724355f5154c2eeeab38b6596817620598bb6b6d9"
 dependencies = [
  "anyhow",
  "pmutil",
@@ -8048,9 +8048,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.226.46"
+version = "0.226.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eb9bcb045bb8ced51b03b7a61e8ed2f76babf795aede3387d38f0c4ba8af949"
+checksum = "ac782d0b28ffaf2ca55b7b5e052e194dbdcde4a326048aaa5b88511e48599d45"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -8068,9 +8068,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.134.38"
+version = "0.134.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589b4d4598d61a0a074d66a1bfd44ce1a6974b8b4095fd7f891dd44a688c3a52"
+checksum = "5d7f1ef5a5885fafd5de3b62d49642859140fde5f195bdd9bdcf3e511f8ac498"
 dependencies = [
  "better_scoped_tls",
  "bitflags 2.4.0",
@@ -8092,9 +8092,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "0.123.39"
+version = "0.123.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce8c65ade88f16e557b009839fda8f0f98f1df221789622ce09a70442cda0856"
+checksum = "fe3a4cb19135a6eed9190ef979c504427bf699e13ce1dacad6cc90958beb1c39"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -8106,9 +8106,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "0.160.44"
+version = "0.160.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a7fbc718451ee11384dca498ba8cc72eee61479d064483032edbf9e772afdda"
+checksum = "2b8e9ece87fde1b6079a17386bfbf01b8bc3476e229e96bb14ed47f66c283c40"
 dependencies = [
  "arrayvec 0.7.4",
  "indexmap 1.9.3",
@@ -8156,9 +8156,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "0.177.46"
+version = "0.177.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "029a9cef5415feb23710aed2f479da6d41125bf257a30625fe51586aa8d5dd85"
+checksum = "94f8aeadf84c7e8c009983ee81147db7aa9082b07d81b0f3e4b7f4d75c3d704d"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -8183,9 +8183,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.195.46"
+version = "0.195.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "551e146be0840a7c428d34b621f4c62b7d8b020edabef664c918c15833aa9b15"
+checksum = "66a01b7809d4182c44949a8025acea0cda7a56cda97cc78173937dc2f2399d39"
 dependencies = [
  "dashmap",
  "indexmap 1.9.3",
@@ -8208,9 +8208,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "0.168.46"
+version = "0.168.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47e7077e572c8103492c326534ae706c20a8b32e4ce20398fb45dede11415daf"
+checksum = "a063806e0a0e8394d7515b588104c1743edd915972b1d559837a844a2e1578fd"
 dependencies = [
  "either",
  "rustc-hash",
@@ -8228,9 +8228,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.180.47"
+version = "0.180.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65369e418edf290ca18e130cfc92c0f87c6c19436241523d7261f49168587c07"
+checksum = "a9675a98a9353c0316dcc797d19ad0d2857252c2c5ced4ac544546734dbb487d"
 dependencies = [
  "base64 0.13.1",
  "dashmap",
@@ -8253,9 +8253,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_testing"
-version = "0.137.40"
+version = "0.137.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2689e4be2e5a6e5a5a7ae3f477d5184ad6f5c3f592c315cc2a9b0943731a9a9"
+checksum = "067a0b56fb73a5c21008f9ae873a9feb7b4e76889ce4466322fdebe61354ad49"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -8279,9 +8279,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.185.44"
+version = "0.185.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6255a2386978c528876f2d33eb960c2abdda83c754a7a21b2b03df3e994165a"
+checksum = "10df43839e8b8a8fb5e8efa700128d855977bcf4479812b4bda47a57f3c5737d"
 dependencies = [
  "ryu-js",
  "serde",
@@ -8296,9 +8296,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_usage_analyzer"
-version = "0.20.30"
+version = "0.20.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053b13c0bf9d0cb2b1b5f8c1f0009839914eaab2127ff635f9d26e718bc525b8"
+checksum = "2f5a7d35a53f95869f495e93b9e54b9cc8c2e960c3d7800a80faff8c200ba733"
 dependencies = [
  "indexmap 1.9.3",
  "rustc-hash",
@@ -8313,9 +8313,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.124.29"
+version = "0.124.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d9434862c93aadda0b539847a5fdb82624472deed788333b35caf281773931"
+checksum = "93de94cda9904aba8301bf2e3e146bf9a584888e68a19ebbb38dba3f560635ba"
 dependencies = [
  "indexmap 1.9.3",
  "num_cpus",
@@ -8493,9 +8493,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_runner"
-version = "0.104.25"
+version = "0.104.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef2a8366b6644c99040fb3f1f38f4e2bcbcdc64ae992b98d7eecf13cdbd0062b"
+checksum = "85c89f3cc466f3c20cd0febdd69ea29f411b1e07aa9d245317ae8de067224071"
 dependencies = [
  "anyhow",
  "enumset",
@@ -10788,8 +10788,8 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
- "rand 0.4.6",
+ "cfg-if 1.0.0",
+ "rand 0.8.5",
  "static_assertions",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10788,8 +10788,8 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
- "rand 0.8.5",
+ "cfg-if 0.1.10",
+ "rand 0.4.6",
  "static_assertions",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -770,9 +770,9 @@ dependencies = [
 
 [[package]]
 name = "binding_macros"
-version = "0.60.78"
+version = "0.60.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26ea7eee9a439637bc4cb168661c5af4e8a0f61f375516a841cdc63ee25d9e8"
+checksum = "fad347930aa10cdc234781028009ccb8ebf4ee5055463fe473c055fc6e92ca90"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -4468,9 +4468,9 @@ dependencies = [
 
 [[package]]
 name = "modularize_imports"
-version = "0.58.0"
+version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c2f9271c2d71d6116dc1d6b1ef9e9bdd7eaf7e7cf8dfd1fd2fb5cd9eaf4073"
+checksum = "75b4169048f6d77763229901de98307369bd96e901ec496eb095bf9c82943608"
 dependencies = [
  "convert_case 0.5.0",
  "handlebars",
@@ -7116,9 +7116,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "styled_components"
-version = "0.86.0"
+version = "0.89.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0858947aeb5e5bd7c1b4fd70a280b05902fea32d5df8823d27098d7285ab8d"
+checksum = "98db15f396dabd0f53988952ad682b957b5d310ebb0a0106f8d93f20303c378d"
 dependencies = [
  "Inflector",
  "once_cell",
@@ -7134,9 +7134,9 @@ dependencies = [
 
 [[package]]
 name = "styled_jsx"
-version = "0.63.0"
+version = "0.66.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b8220480edf3268dc3b4cd6f1dcd3f00553f7eb79c132a24da32876fbd2fb47"
+checksum = "b8d4222bde4e3ee9d454b8e8e7585ddd9ff8f5a7c98e960b434b9c9822e625e2"
 dependencies = [
  "easy-error",
  "lightningcss",
@@ -7208,9 +7208,9 @@ dependencies = [
 
 [[package]]
 name = "swc"
-version = "0.269.70"
+version = "0.269.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1671c9ab69f8e55fa4f9657f2178aa89bb0d3b9bb8f74a86d408dfeaa1e55915"
+checksum = "a08210450ab29ec98733f71ac457d45d4355ef166a4a21d669bf79f7d1cfe5ab"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
@@ -7285,9 +7285,9 @@ dependencies = [
 
 [[package]]
 name = "swc_bundler"
-version = "0.222.66"
+version = "0.222.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206ab7fd044985019ca9b8db0c84d6ebc719e4eeb01a04add040e772b8a353e7"
+checksum = "a26ee0a3735b686dbf5819f739d969fc51932db5dbf766dd845b114d0da0aaa6"
 dependencies = [
  "anyhow",
  "crc",
@@ -7364,9 +7364,9 @@ dependencies = [
 
 [[package]]
 name = "swc_compiler_base"
-version = "0.3.74"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a5d5e3228c9e3a6e6883b75a2a2e17e5d320152c794619bb8e25442a3c77207"
+checksum = "febebd8b41806960c8ac3e00f6702eb4cecfa4c60e8cc38ce94fa1e5d8b87269"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
@@ -7413,9 +7413,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "0.86.79"
+version = "0.86.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4b4f381de91cb684507f9254da4715fe8da903a7f690fb85b48077a0aa0ec44"
+checksum = "862dfc1749e2b0ddfba5431a9001c9727c7349606b4aaa571f784232b122ff0d"
 dependencies = [
  "binding_macros",
  "swc",
@@ -7622,9 +7622,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.146.33"
+version = "0.146.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f73ea71b6e5c636bf667a892754037ed146dbda64e8fe5d12a5d2623f8d0bdd"
+checksum = "4f6b9e2e703bab3cc0f484eaf32c8081792460beb64860c2950fb7e56ff67ed8"
 dependencies = [
  "memchr",
  "num-bigint",
@@ -7654,9 +7654,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_bugfixes"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "279c763a1c2d1dc2a42fe94c751665585dd771d1344d36d069ad37e4253c4d1d"
+checksum = "b23c256c5729096df0635bd1fc727e6e34c804882478805ab3820c824060017c"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -7671,9 +7671,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_common"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89c1bb8d34782eeca95dd46dc971b0fcd4369ae7ed90de629c3f1f6dabf91d14"
+checksum = "5abed404c9425bf0d1f44da426f9fec6fe1833b696275ed4dff85550376a32d4"
 dependencies = [
  "swc_common",
  "swc_ecma_ast",
@@ -7684,9 +7684,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2015"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c784eac062d3c9c4282e70323cde066b754cca4e247b02a244c57034d5507a52"
+checksum = "139b44e5de713a690003040c1068d52f4cc400fa623887d84e29fc7a5cf01b23"
 dependencies = [
  "arrayvec 0.7.4",
  "indexmap 1.9.3",
@@ -7710,9 +7710,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2016"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5872a8feee2889872e78d5a6b716d9dda073c9e5d30028a9f8414d98f766975d"
+checksum = "4130f981d7f216116feb9b01a878fea161b19494834e7fc9ddf4ab550839ec97"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -7727,9 +7727,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2017"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53cbe619c4b1d8a470a35231a75b2f3eb021a23ba5f34314381ac5c39f48720"
+checksum = "27b25eb792480f28c5ef7d37cf3db3a4d6241a7b64e068435586d806922eac84"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -7745,9 +7745,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2018"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb17f01a89474595c8284c37a04250d397502421a7509bdecd79b7bdf9740092"
+checksum = "24abad70f29e945544994e4977cd986f5fc6579cd8b0dc16230faff2c7b14f0e"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -7764,9 +7764,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2019"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521ad6994a8c165dc1ae827770e5374aeb7263ccc89619d26be7c7441c5892c5"
+checksum = "27d7d78648bc37adc80f24941a6b84027d78aa6916638633e2f271a611d6bf0f"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -7780,9 +7780,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2020"
-version = "0.1.42"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a06f8ec7438dac0252bc1522f7491807196fdf0892687a5c8b6218a8c47f2b8"
+checksum = "10e70a88c91a60cae3ccc9513db46e83ee05dcadbe06e41fbddf72f66537e7d0"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -7798,9 +7798,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2021"
-version = "0.1.42"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f32bdb471ff8dbe19a07f39d5df9261c783a62af34711a3ee4c8d577e3a212fc"
+checksum = "6c7e5dbd76ce0ef560086aa5a34a8c2901095724c6d3cf4e1bc193c91d40ed25"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -7814,9 +7814,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2022"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ef60afe5793186b18fe2494e4ead74f75dee7080392f9634fad825a3ce985f"
+checksum = "b2bc635b5029c48b92723e10af44e4710e5c42963bfd52b1d1fd8e78835b4601"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -7833,9 +7833,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es3"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05111042e0db3a4b961c271a22f4f4af936e22e821cd3000af658ddf7ca1d9d8"
+checksum = "a5e9dcb092ae019ee6cb54abcab7659ea8469e3f0808916895cebc465c79adb1"
 dependencies = [
  "swc_common",
  "swc_ecma_ast",
@@ -7848,9 +7848,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ext_transforms"
-version = "0.110.34"
+version = "0.110.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "344396bc9218d667c2d375bbdfe1aad319697922b54cbab563d2acb124a2270f"
+checksum = "3cc0000e38d2c67772c632f3e0fe1d8c2a63479bcb9d2746b8042af6f65f42c7"
 dependencies = [
  "phf 0.11.2",
  "swc_atoms",
@@ -7862,9 +7862,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_lints"
-version = "0.89.43"
+version = "0.89.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebb6311b5284d43f6792bd69eb390455fb2c64ebd732d4167d350642d506e438"
+checksum = "ac15ed364f2a72ba02f7ecd5add9745c7713b919c8826d147b549ffea1554196"
 dependencies = [
  "auto_impl",
  "dashmap",
@@ -7903,9 +7903,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "0.189.68"
+version = "0.189.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b460795b5b9439f71c5961b513764efa45021e3ebfc202b3eeb5cb3c135c0b66"
+checksum = "5adc7f226679e7371d794b54155bf0b4afe095486c5316ed3760897e1e56045c"
 dependencies = [
  "arrayvec 0.7.4",
  "indexmap 1.9.3",
@@ -7938,9 +7938,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.141.27"
+version = "0.141.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c01ab163c83f4e8c0d82382478d142ceecf897e5b2822707fec662a22208287"
+checksum = "0b8436a58ac9f31068e9bf871e2ce7f3a18fe1d7e3fe8d54abe4896673eae20c"
 dependencies = [
  "either",
  "new_debug_unreachable",
@@ -7960,9 +7960,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "0.203.56"
+version = "0.203.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a830182b77d2b59978a025758d830c6d19f193546eb630c8a99e2a93fd74abf"
+checksum = "fdd1f8c17f6231387150aa69d62c1ebba3e1d55dc2a858e9bdf40f9f6e2adef8"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -7985,9 +7985,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_quote_macros"
-version = "0.52.27"
+version = "0.52.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cafeb878f702c360b9553869c60739a285c3d4af88c4b45ad1c37975a8c1eb9c"
+checksum = "28b017bb7d94219d36c2647f927a3937c5d578ee90630aff74f4fbc0e345341e"
 dependencies = [
  "anyhow",
  "pmutil",
@@ -8016,9 +8016,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.226.56"
+version = "0.226.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "688c962b8f01186b95e65ff879fcfbd2cc2beaf1893b289204d5cfd6d8603217"
+checksum = "c5bfa68b9931abbf582fa08aa427e74089036ffdfb1efa5624059fb3caecd9b3"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -8036,9 +8036,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.134.44"
+version = "0.134.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a880cd951f82c4f1bf970e12e8fab616ea7feb41c97203d2d0cfa063d775bb"
+checksum = "3e3b8393c86d0ea8ccc7aab30696fae48b8ec7edd69b450318bb7930ca448817"
 dependencies = [
  "better_scoped_tls",
  "bitflags 2.4.0",
@@ -8060,9 +8060,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "0.123.45"
+version = "0.123.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fecd75dde48c358af419a1d496ce7b2d293fb3d740db21859be752f9decd8b63"
+checksum = "0b718100ae10d0790bb867197e648d505a1f849f830edf25e0f0f30cdbafae0d"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -8074,9 +8074,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "0.160.50"
+version = "0.160.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04b4d9a1b45e29a70eeb8d6cf9ddca6b3c2a80cb0cf056c212ccc764f096d700"
+checksum = "b1e9596160b85bd29a0ad12294add8436555b35a1624fb294931e61378c4059b"
 dependencies = [
  "arrayvec 0.7.4",
  "indexmap 1.9.3",
@@ -8124,9 +8124,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "0.177.53"
+version = "0.177.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ab1c807d62a947691a1a30110753cae83387c20772a0bc4cc9d548a1e09c8d3"
+checksum = "d2326820487674180acee95ed55f3386e6555fe39b0ac25df13097f57c4a6bb2"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -8151,9 +8151,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.195.56"
+version = "0.195.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721dbf997879ad84fbee1deaf196fc55c0d0a47943b6958bc1af4ee447dba4f7"
+checksum = "baaf94134146830012488f6bee2b89f0675fd742611c326c2b2c1bb49f59714e"
 dependencies = [
  "dashmap",
  "indexmap 1.9.3",
@@ -8176,9 +8176,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "0.168.54"
+version = "0.168.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccb7b031fb6722529fe29e07db588ab4b4c4b252e38c227bdfa971b15abc70db"
+checksum = "6abb14f7198481c85bd1cf69ece8ed9a72c49d77260b107d0fcfdf0a12717885"
 dependencies = [
  "either",
  "rustc-hash",
@@ -8196,9 +8196,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.180.54"
+version = "0.180.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46dbfcfba470b79cf77ff8f5101eb8ea779dc80e9a8c0f65dffd520517e690ce"
+checksum = "02424cc787df6f5a37cc0c45fc159141a78f4a713dd1f394ef787f3147c4edbf"
 dependencies = [
  "base64 0.13.1",
  "dashmap",
@@ -8221,9 +8221,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_testing"
-version = "0.137.46"
+version = "0.137.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbfb208a09b01597de4dab01a4a376ede74189af96fd6e7d8af6c7c3e724b9f7"
+checksum = "a7b282c0fe89bc6bc2ce0c76211fcaf89e2472edc2b87e8f8353278be625bec7"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -8247,9 +8247,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.185.54"
+version = "0.185.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5296ade10bce7b75661ad2e79cde1654dc037ec12cf5b6a4a08b1c96734ddf2f"
+checksum = "401d899c11ca688f62a0b28bfd5c129d58d7cb838e22072aa86a54f03d8cac73"
 dependencies = [
  "ryu-js",
  "serde",
@@ -8264,9 +8264,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_usage_analyzer"
-version = "0.20.34"
+version = "0.20.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "163c7cce74915619fba4c7967937d1b1470a3acd2d44e149842cfadf5e5cea0b"
+checksum = "dfa8d5dc775d4bf35967a0216783058b13ffe5423b807927aa5dbc92251f6839"
 dependencies = [
  "indexmap 1.9.3",
  "rustc-hash",
@@ -8281,9 +8281,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.124.33"
+version = "0.124.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd7f189c68e7aa895a19afd5c61eeeb4f4e71d80123b3b42f32e80c1f6641928"
+checksum = "ad013c92a6e05a850db088ae7a17dc667209780b2a1a313544540111f33b5233"
 dependencies = [
  "indexmap 1.9.3",
  "num_cpus",
@@ -8315,9 +8315,9 @@ dependencies = [
 
 [[package]]
 name = "swc_emotion"
-version = "0.62.0"
+version = "0.65.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae29bde2cc05fa93f03b7432d17e43070fb7570de84b79980983194025214bf"
+checksum = "e658f35b695f0dc8152088a03c7678dcf6702bf7a0bacc4b7727499f7d5db454"
 dependencies = [
  "base64 0.13.1",
  "byteorder",
@@ -8461,9 +8461,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_runner"
-version = "0.104.29"
+version = "0.104.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799bd78fbbcb2a266f9c00ec42c7f7c0d3bcbb063ac62a98268604abcb2b7c22"
+checksum = "650a138a519e67dd9b85c37bf807c311be009f68267d767da6989f428d715037"
 dependencies = [
  "anyhow",
  "enumset",
@@ -8485,9 +8485,9 @@ dependencies = [
 
 [[package]]
 name = "swc_relay"
-version = "0.34.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3270973952ee96e4cc2689829f4e4a5902e253a479457ca773ac19e1cfd7edd"
+checksum = "faede0a001c4f29cd912954334b9940b57f89bc844f46aafb8d6c304f6acc211"
 dependencies = [
  "once_cell",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,15 +82,15 @@ async-recursion = "1.0.2"
 browserslist-rs = { version = "0.13.0" }
 
 mdxjs = "0.1.20"
-modularize_imports = { version = "0.56.0" }
-styled_components = { version = "0.83.0" }
-styled_jsx = { version = "0.60.0" }
-swc_core = { version = "0.86.70", features = [
+modularize_imports = { version = "0.58.0" }
+styled_components = { version = "0.86.0" }
+styled_jsx = { version = "0.63.0" }
+swc_core = { version = "0.86.79", features = [
   "ecma_loader_lru",
   "ecma_loader_parking_lot",
 ] }
-swc_emotion = { version = "0.59.0" }
-swc_relay = { version = "0.31.0" }
+swc_emotion = { version = "0.62.0" }
+swc_relay = { version = "0.34.0" }
 testing = { version = "0.35.11" }
 
 auto-hash-map = { path = "crates/turbo-tasks-auto-hash-map" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,17 +81,17 @@ async-recursion = "1.0.2"
 # Keep consistent with preset_env_base through swc_core
 browserslist-rs = { version = "0.13.0" }
 
-mdxjs = "0.1.19"
+mdxjs = "0.1.20"
 modularize_imports = { version = "0.56.0" }
 styled_components = { version = "0.83.0" }
 styled_jsx = { version = "0.60.0" }
-swc_core = { version = "0.86.60", features = [
+swc_core = { version = "0.86.70", features = [
   "ecma_loader_lru",
   "ecma_loader_parking_lot",
 ] }
 swc_emotion = { version = "0.59.0" }
 swc_relay = { version = "0.31.0" }
-testing = { version = "0.35.10" }
+testing = { version = "0.35.11" }
 
 auto-hash-map = { path = "crates/turbo-tasks-auto-hash-map" }
 node-file-trace = { path = "crates/node-file-trace", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,15 +82,15 @@ async-recursion = "1.0.2"
 browserslist-rs = { version = "0.13.0" }
 
 mdxjs = "0.1.20"
-modularize_imports = { version = "0.58.0" }
-styled_components = { version = "0.86.0" }
-styled_jsx = { version = "0.63.0" }
-swc_core = { version = "0.86.79", features = [
+modularize_imports = { version = "0.61.0" }
+styled_components = { version = "0.89.0" }
+styled_jsx = { version = "0.66.0" }
+swc_core = { version = "0.86.81", features = [
   "ecma_loader_lru",
   "ecma_loader_parking_lot",
 ] }
-swc_emotion = { version = "0.62.0" }
-swc_relay = { version = "0.34.0" }
+swc_emotion = { version = "0.65.0" }
+swc_relay = { version = "0.37.0" }
 testing = { version = "0.35.11" }
 
 auto-hash-map = { path = "crates/turbo-tasks-auto-hash-map" }

--- a/crates/turbopack-ecmascript-plugins/src/transform/styled_components.rs
+++ b/crates/turbopack-ecmascript-plugins/src/transform/styled_components.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use anyhow::Result;
 use async_trait::async_trait;
 use swc_core::{
-    common::FileName,
+    common::{comments::NoopComments, FileName},
     ecma::{ast::Program, atoms::JsWord, visit::VisitMutWith},
 };
 use turbo_tasks::{ValueDefault, Vc};
@@ -95,6 +95,7 @@ impl CustomTransformer for StyledComponentsTransformer {
             FileName::Real(PathBuf::from(ctx.file_path_str)),
             ctx.file_name_hash,
             self.config.clone(),
+            NoopComments,
         ));
 
         Ok(())


### PR DESCRIPTION
### Description

Update swc crates.

Diff: https://github.com/swc-project/swc/compare/09b3003e589409e1fffe32cf5e3328d946bd270e...c566b73bfbcd24fc34eedc2baf62d0afb8609636

### Testing Instructions

Let's look at the CI of next.js


next.js counterpart: https://github.com/vercel/next.js/pull/58517

Closes PACK-1973