### PR TITLE
fix: move e2e to use bash to match other jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -402,6 +402,7 @@ jobs:
         run: turbo run test --filter=turborepo-tests-e2e --remote-only --token=${{ secrets.TURBO_TOKEN }} --team=${{ vars.TURBO_TEAM }} --color --env-mode=strict
         env:
           EXPERIMENTAL_RUST_CODEPATH: true
+        shell: bash
 
   turborepo_examples:
     name: Turborepo Examples


### PR DESCRIPTION
### Description

I realized I forgot to move e2e to use bash instead of powershell as I did with the other windows jobs in #6449

This is causing the network failures on PRs e.g. https://github.com/vercel/turbo/actions/runs/6885178823/job/18729263113?pr=6473#step:4:24

### Testing Instructions

e2e windows tests should pass on this PR


Closes TURBO-1683