### PR TITLE
fix: populate framework for every run

### DIFF
--- a/cli/internal/graph/graph.go
+++ b/cli/internal/graph/graph.go
@@ -122,6 +122,13 @@ func (g *CompleteGraph) GetPackageTaskVisitor(
 		envVars := g.TaskHashTracker.GetEnvVars(taskID)
 		expandedInputs := g.TaskHashTracker.GetExpandedInputs(packageTask)
 		framework := g.TaskHashTracker.GetFramework(taskID)
+		if framework == "" {
+			if frameworkInference {
+				framework = runsummary.NoFrameworkDetected
+			} else {
+				framework = runsummary.FrameworkDetectionSkipped
+			}
+		}
 
 		packageTask.Command = command
 

--- a/cli/internal/run/dry_run.go
+++ b/cli/internal/run/dry_run.go
@@ -44,14 +44,6 @@ func DryRun(
 			taskSummary.Command = runsummary.MissingTaskLabel
 		}
 
-		if taskSummary.Framework == "" {
-			if rs.Opts.runOpts.FrameworkInference {
-				taskSummary.Framework = runsummary.NoFrameworkDetected
-			} else {
-				taskSummary.Framework = runsummary.FrameworkDetectionSkipped
-			}
-		}
-
 		// This mutex is not _really_ required, since we are using Concurrency: 1 as an execution
 		// option, but we add it here to match the shape of RealRuns execFunc.
 		mu.Lock()

--- a/turborepo-tests/integration/tests/run-summary/error.t
+++ b/turborepo-tests/integration/tests/run-summary/error.t
@@ -65,7 +65,7 @@ Validate that we got a full task summary for the failed task with an error in .e
       "dotEnv": null
     },
     "expandedOutputs": [],
-    "framework": "",
+    "framework": "<NO FRAMEWORK DETECTED>",
     "envMode": "loose",
     "environmentVariables": {
       "specified": {


### PR DESCRIPTION
### Description

Hoist the filling in framework in the task summary to happen at the graph traversal instead of being up to the exec function. Concretely this means that the `framework` field in every task will always be populated.

This lead to different values for `framework` in the resulting JSON depending on whether or not the tasks were actually executed. I realize we abuse the schema as it's used for both `--dry=json` and `--summarize`, but this feels like something that should be consistent. It feels odd that there's a case where `--dry=json` has more information available than an actual run summary.

### Testing Instructions

Updated integration test displays the behavior change. Other integration tests should continue passing.


Closes TURBO-1684