### PR TITLE
fix(docs): change default collapse level of sidebar

### DIFF
--- a/docs/theme.config.tsx
+++ b/docs/theme.config.tsx
@@ -11,7 +11,7 @@ const SITE_ROOT = "https://turbo.build";
 
 const config: DocsThemeConfig = {
   sidebar: {
-    defaultMenuCollapseLevel: 10000,
+    defaultMenuCollapseLevel: 1,
     toggleButton: true,
   },
   docsRepositoryBase: "https://github.com/vercel/turbo/blob/main/docs",


### PR DESCRIPTION
| before | after |
|--------|--------|
|![CleanShot 2023-11-16 at 01 42 16@2x](https://github.com/vercel/turbo/assets/490968/4e215dc4-54bb-4906-b85e-ecef1273a676)| ![CleanShot 2023-11-16 at 01 42 02@2x](https://github.com/vercel/turbo/assets/490968/b741ce96-7b19-4eaf-b0bd-2fe1c2458457)

Closes TURBO-1687