### PR TITLE
fix: forward powershell style env casing

### DIFF
--- a/crates/turborepo-lib/src/task_hash.rs
+++ b/crates/turborepo-lib/src/task_hash.rs
@@ -392,9 +392,16 @@ impl<'a> TaskHasher<'a> {
         match task_env_mode {
             ResolvedEnvMode::Strict => {
                 let mut pass_through_env = EnvironmentVariableMap::default();
-                let default_env_var_pass_through_map = self
-                    .env_at_execution_start
-                    .from_wildcards(&["PATH", "SHELL", "SYSTEMROOT"])?;
+                let default_env_var_pass_through_map =
+                    self.env_at_execution_start.from_wildcards(&[
+                        "SHELL",
+                        // Command Prompt casing of env variables
+                        "PATH",
+                        "SYSTEMROOT",
+                        // Powershell casing of env variables
+                        "Path",
+                        "SystemRoot",
+                    ])?;
                 let tracker_env = self
                     .task_hash_tracker
                     .env_vars(task_id)


### PR DESCRIPTION
### Description

Powershell populates `PATH` and `SYSTEMROOT` as `Path` and `SystemRoot` causing our wildcarding to miss. These are valid populations as Windows has case-insensitive environment variables. In both Go and Rust we were explicit and forwarded `SYSTEMROOT`, but this failed on Powershell as our wildcard matching is case sensitive. The Go standard library papered over this failure since it [passes `SYSTEMROOT` for us if we don't set it](https://pkg.go.dev/os/exec#Cmd):

> As a special case on Windows, SYSTEMROOT is always added if missing and not explicitly set to the empty string.

Future work will be to investigate if we should make our environment variable matching case insensitive on Windows to better match how Windows thinks about environment variables.

### Testing Instructions

Make a repository with the following `build` script: `echo %SYSTEMROOT%`. Verify that after this PR when running this script using `turbo build --filter=foo --env-mode=strict` from Powershell now displays `C:\Windows`:

Closes TURBO-1689