### PR TITLE
handle dynamic imports when chunk loading is disabled

### DIFF
--- a/crates/turbopack-ecmascript/src/references/amd.rs
+++ b/crates/turbopack-ecmascript/src/references/amd.rs
@@ -20,7 +20,7 @@ use turbopack_core::{
     resolve::{origin::ResolveOrigin, parse::Request, ModuleResolveResult},
 };
 
-use super::pattern_mapping::{PatternMapping, ResolveType::Cjs};
+use super::pattern_mapping::{PatternMapping, ResolveType::ChunkItem};
 use crate::{
     chunk::EcmascriptChunkingContext,
     code_gen::{CodeGenerateable, CodeGeneration},
@@ -159,7 +159,7 @@ impl CodeGenerateable for AmdDefineWithDependenciesCodeGen {
                                     Some(self.issue_source),
                                     try_to_severity(self.in_try),
                                 ),
-                                Value::new(Cjs),
+                                Value::new(ChunkItem),
                             )
                             .await?,
                             request.await?.request(),

--- a/crates/turbopack-ecmascript/src/references/cjs.rs
+++ b/crates/turbopack-ecmascript/src/references/cjs.rs
@@ -11,7 +11,7 @@ use turbopack_core::{
     resolve::{origin::ResolveOrigin, parse::Request, ModuleResolveResult},
 };
 
-use super::pattern_mapping::{PatternMapping, ResolveType::Cjs};
+use super::pattern_mapping::{PatternMapping, ResolveType::ChunkItem};
 use crate::{
     chunk::EcmascriptChunkingContext,
     code_gen::{CodeGenerateable, CodeGeneration},
@@ -148,7 +148,7 @@ impl CodeGenerateable for CjsRequireAssetReference {
                 Some(self.issue_source),
                 try_to_severity(self.in_try),
             ),
-            Value::new(Cjs),
+            Value::new(ChunkItem),
         )
         .await?;
         let mut visitors = Vec::new();
@@ -272,7 +272,7 @@ impl CodeGenerateable for CjsRequireResolveAssetReference {
                 Some(self.issue_source),
                 try_to_severity(self.in_try),
             ),
-            Value::new(Cjs),
+            Value::new(ChunkItem),
         )
         .await?;
         let mut visitors = Vec::new();

--- a/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
+++ b/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
@@ -59,8 +59,8 @@ pub(crate) enum PatternMapping {
 #[derive(PartialOrd, Ord, Hash, Debug, Copy, Clone)]
 #[turbo_tasks::value(serialization = "auto_for_input")]
 pub(crate) enum ResolveType {
-    EsmAsync,
-    Cjs,
+    AsyncChunkLoader,
+    ChunkItem,
 }
 
 impl PatternMapping {
@@ -165,13 +165,13 @@ impl PatternMapping {
             Vc::try_resolve_downcast::<Box<dyn ChunkableModule>>(module).await?
         {
             match *resolve_type {
-                ResolveType::EsmAsync => {
+                ResolveType::AsyncChunkLoader => {
                     let loader_id = chunking_context.async_loader_chunk_item_id(chunkable);
                     return Ok(PatternMapping::cell(PatternMapping::SingleLoader(
                         loader_id.await?.clone_value(),
                     )));
                 }
-                ResolveType::Cjs => {
+                ResolveType::ChunkItem => {
                     let chunk_item = chunkable.as_chunk_item(chunking_context);
                     return Ok(PatternMapping::cell(PatternMapping::Single(
                         chunk_item.id().await?.clone_value(),

--- a/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -37,7 +37,7 @@ use crate::{
     code_gen::CodeGeneration,
     create_visitor,
     references::{
-        pattern_mapping::{PatternMapping, ResolveType::Cjs},
+        pattern_mapping::{PatternMapping, ResolveType},
         AstPath,
     },
     resolve::{cjs_resolve, try_to_severity},
@@ -439,7 +439,7 @@ impl EcmascriptChunkItem for RequireContextChunkItem {
                 self.origin,
                 Vc::upcast(self.chunking_context),
                 entry.result,
-                Value::new(Cjs),
+                Value::new(ResolveType::ChunkItem),
             )
             .await?;
 


### PR DESCRIPTION
### Description

When chunk loading is disable, dynamic imports will just bundle all referenced modules instead of created in separate chunk group

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->


Closes PACK-1984