### PR TITLE
chore: move back to powershell on windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -242,7 +242,6 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           EXPERIMENTAL_RUST_CODEPATH: true
-        shell: bash
 
       - name: Run sccache stat for check
         shell: bash
@@ -306,7 +305,6 @@ jobs:
       - run: turbo run test --filter=cli --color
         env:
           EXPERIMENTAL_RUST_CODEPATH: true
-        shell: bash
 
   turborepo_integration:
     name: Turborepo Integration Tests
@@ -402,7 +400,6 @@ jobs:
         run: turbo run test --filter=turborepo-tests-e2e --remote-only --token=${{ secrets.TURBO_TOKEN }} --team=${{ vars.TURBO_TEAM }} --color --env-mode=strict
         env:
           EXPERIMENTAL_RUST_CODEPATH: true
-        shell: bash
 
   turborepo_examples:
     name: Turborepo Examples


### PR DESCRIPTION
### Description

With #6485 merged we should now be able to use the default shell on the Windows Runner

### Testing Instructions

CI on Windows should pass now

Closes TURBO-1699