### PR TITLE
fix: fixup unit tests that use the basic example

### DIFF
--- a/cli/internal/packagemanager/packagemanager_test.go
+++ b/cli/internal/packagemanager/packagemanager_test.go
@@ -66,15 +66,15 @@ func Test_GetWorkspaces(t *testing.T) {
 		"nodejs-pnpm": {
 			filepath.ToSlash(filepath.Join(cwd, "../../../examples/basic/apps/docs/package.json")),
 			filepath.ToSlash(filepath.Join(cwd, "../../../examples/basic/apps/web/package.json")),
-			filepath.ToSlash(filepath.Join(cwd, "../../../examples/basic/packages/eslint-config-custom/package.json")),
-			filepath.ToSlash(filepath.Join(cwd, "../../../examples/basic/packages/tsconfig/package.json")),
+			filepath.ToSlash(filepath.Join(cwd, "../../../examples/basic/packages/eslint-config/package.json")),
+			filepath.ToSlash(filepath.Join(cwd, "../../../examples/basic/packages/typescript-config/package.json")),
 			filepath.ToSlash(filepath.Join(cwd, "../../../examples/basic/packages/ui/package.json")),
 		},
 		"nodejs-pnpm6": {
 			filepath.ToSlash(filepath.Join(cwd, "../../../examples/basic/apps/docs/package.json")),
 			filepath.ToSlash(filepath.Join(cwd, "../../../examples/basic/apps/web/package.json")),
-			filepath.ToSlash(filepath.Join(cwd, "../../../examples/basic/packages/eslint-config-custom/package.json")),
-			filepath.ToSlash(filepath.Join(cwd, "../../../examples/basic/packages/tsconfig/package.json")),
+			filepath.ToSlash(filepath.Join(cwd, "../../../examples/basic/packages/eslint-config/package.json")),
+			filepath.ToSlash(filepath.Join(cwd, "../../../examples/basic/packages/typescript-config/package.json")),
 			filepath.ToSlash(filepath.Join(cwd, "../../../examples/basic/packages/ui/package.json")),
 		},
 	}

--- a/crates/turborepo-repository/src/package_manager/mod.rs
+++ b/crates/turborepo-repository/src/package_manager/mod.rs
@@ -556,6 +556,7 @@ impl PackageManager {
 mod tests {
     use std::{collections::HashSet, fs::File};
 
+    use pretty_assertions::assert_eq;
     use tempfile::tempdir;
     use turbopath::AbsoluteSystemPathBuf;
 
@@ -604,16 +605,18 @@ mod tests {
         }
 
         let basic = examples.join_component("basic");
-        let basic_expected: HashSet<AbsoluteSystemPathBuf> = HashSet::from_iter([
+        let mut basic_expected = Vec::from_iter([
             basic.join_components(&["apps", "docs", "package.json"]),
             basic.join_components(&["apps", "web", "package.json"]),
-            basic.join_components(&["packages", "eslint-config-custom", "package.json"]),
-            basic.join_components(&["packages", "tsconfig", "package.json"]),
+            basic.join_components(&["packages", "eslint-config", "package.json"]),
+            basic.join_components(&["packages", "typescript-config", "package.json"]),
             basic.join_components(&["packages", "ui", "package.json"]),
         ]);
+        basic_expected.sort();
         for mgr in &[PackageManager::Pnpm, PackageManager::Pnpm6] {
             let found = mgr.get_package_jsons(&basic).unwrap();
-            let found: HashSet<AbsoluteSystemPathBuf> = HashSet::from_iter(found);
+            let mut found = Vec::from_iter(found);
+            found.sort();
             assert_eq!(found, basic_expected, "{}", mgr);
         }
     }


### PR DESCRIPTION
### Description

We use the basic example as a test fixture for some of our unit tests.

Rust unit test has some changes that makes any diffs between expected and actual display better.

Future work is to use a non-example fixture so we can avoid breakages like these and we don't need to run all unit tests whenever we change an example.

### Testing Instructions

Rust and Go unit tests should pass on this PR

Closes TURBO-1724