### PR TITLE
chore: clean up run

### DIFF
--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -205,7 +205,6 @@ impl<'a> Run<'a> {
             opts.run_opts.experimental_space_id = root_turbo_json.space_id.clone();
         }
 
-        // There's some warning handling code in Go that I'm ignoring
         let is_ci_or_not_tty = turborepo_ci::is_ci() || !std::io::stdout().is_terminal();
 
         let daemon = if is_ci_or_not_tty && !opts.run_opts.no_daemon {

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -361,9 +361,6 @@ impl<'a> Run<'a> {
             return Ok(0);
         }
 
-        // remove dead code warnings
-        let _proc_manager = ProcessManager::new();
-
         let pkg_dep_graph = Arc::new(pkg_dep_graph);
         let engine = Arc::new(engine);
 


### PR DESCRIPTION
### Description

Remove:
 - unused process manager created early on in run outline work and never hooked up
 - outdated comment, no error handling is left to port

### Testing Instructions

CI
