### PR TITLE
refactor: switch daemon version to be independent of turbo version

### DIFF
--- a/cli/internal/turbodprotocol/turbod.proto
+++ b/cli/internal/turbodprotocol/turbod.proto
@@ -16,6 +16,26 @@ service Turbod {
 message HelloRequest {
   string version = 1;
   string session_id = 2;
+
+  // The version compatibility range that the client requests.
+  // For example, if the client requests Patch level compatibility,
+  // then the server should trigger a failed precondition if the
+  // server's version is not identical down to the patch level.
+  VersionRange supported_version_range = 3;
+}
+
+enum VersionRange {
+  // Default to match old behaviour. Requires exact string match,
+  // performing no compatibility checks.
+  Exact = 0;
+  // The Major and Minor version must match, and the Patch version
+  // must be greater than or equal to the client's Patch version.
+  Patch = 1;
+  // The Major version must match, and the Minor version must be
+  // greater than or equal to the client's Minor version.
+  Minor = 2;
+  // The Major version must match. This is the most lenient check.
+  Major = 3;
 }
 
 message HelloResponse {}

--- a/crates/turborepo-lib/src/daemon/connector.rs
+++ b/crates/turborepo-lib/src/daemon/connector.rs
@@ -14,7 +14,7 @@ use tokio::{sync::mpsc, time::timeout};
 use tonic::transport::Endpoint;
 use tracing::debug;
 
-use super::{client::proto::turbod_client::TurbodClient, DaemonClient};
+use super::{proto::turbod_client::TurbodClient, DaemonClient};
 use crate::daemon::DaemonError;
 
 #[derive(Error, Debug)]
@@ -408,7 +408,7 @@ mod test {
     use turbopath::AbsoluteSystemPathBuf;
 
     use super::*;
-    use crate::daemon::client::proto;
+    use crate::daemon::proto;
 
     #[cfg(not(target_os = "windows"))]
     const NODE_EXE: &str = "node";

--- a/crates/turborepo-lib/src/daemon/mod.rs
+++ b/crates/turborepo-lib/src/daemon/mod.rs
@@ -11,4 +11,20 @@ pub use server::{serve, CloseReason};
 
 pub(crate) mod proto {
     tonic::include_proto!("turbodprotocol");
+
+    /// The version of the protocol that this library implements.
+    ///
+    /// Protocol buffers aim to be backward and forward compatible at a protocol
+    /// level, however that doesn't mean that our daemon will have the same
+    /// logical API. We may decide to change the API in the future, and this
+    /// version number will be used to indicate that.
+    ///
+    /// Changes are driven by the server changing its implementation.
+    ///
+    /// Guideline for bumping the daemon protocol version:
+    /// - Bump the major version if making backwards incompatible changes.
+    /// - Bump the minor version if adding new features, such that clients can
+    ///   mandate at least some set of features on the target server.
+    /// - Bump the patch version if making backwards compatible bug fixes.
+    pub const VERSION: &str = "1.10.17";
 }


### PR DESCRIPTION
This change is backwards compatible, since we set the starting version of the daemon protocol to be equal to the current turbo version meaning we will not get any clashes with old clients reporting a bad version. Even though the version is currently equal to the turbo version, it is not expected to always be the case.

### Description

If we want to allow other tools to interact with the turbo daemon, we should not be as strict with our versioning. As it stands, a 3rd party tool such as an LSP would need to perfectly match the version of turbo used in the repo which is an unreasonable constraint.

This also relaxes the version requirement for all _new_ versions to least the same minor version (ie. that all the features available to the client are implemented by the server). Old clients will still demand identical versions (and have that demand respected correctly).

### Testing Instructions

Unit tests for the semver check included.