### PR TITLE
chore: enable more rust tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -451,6 +451,11 @@ jobs:
         env:
           EXPERIMENTAL_RUST_CODEPATH: true
 
+      - name: E2E Tests
+        run: turbo run test:rust-codepath --filter=turborepo-tests-e2e --remote-only --token=${{ secrets.TURBO_TOKEN }} --team=${{ vars.TURBO_TEAM }} --color --env-mode=strict
+        env:
+          EXPERIMENTAL_RUST_CODEPATH: true
+
   turborepo_examples:
     name: Turborepo Examples
     needs: [determine_jobs]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -398,9 +398,8 @@ jobs:
         os:
           - name: ubuntu
             runner: ubuntu-latest
-          # TODO: enable macos when --experimental-rust-codepath is passing all tests on ubuntu
-          # - name: macos
-          #   runner: macos-latest
+          - name: macos
+            runner: macos-latest
           # TODO: Enable windows in a later pass
           # - name: windows
           #   runner: windows-latest

--- a/turborepo-tests/e2e/turbo.json
+++ b/turborepo-tests/e2e/turbo.json
@@ -6,6 +6,12 @@
       "output": [],
       // For github actions
       "env": ["RUNNER_OS"]
+    },
+    "test:rust-codepath": {
+      "dependsOn": ["cli#build", "^build"],
+      "output": [],
+      // For github actions
+      "env": ["RUNNER_OS"]
     }
   }
 }


### PR DESCRIPTION
### Description

Enable Rust e2e tests and Rust macos integration tests

### Testing Instructions

CI


Closes TURBO-1732