### PR TITLE
fix: avoid upgrading outdated packages on GH actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -331,6 +331,10 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Setup Graphviz
         uses: ts-graphviz/setup-graphviz@v1
+        with:
+          macos-skip-brew-update: "true"
+        env:
+          HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: true
       - name: Cache Prysk
         id: cache-prysk
         uses: actions/cache@v3
@@ -412,6 +416,10 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Setup Graphviz
         uses: ts-graphviz/setup-graphviz@v1
+        with:
+          macos-skip-brew-update: "true"
+        env:
+          HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: true
       - name: Cache Prysk
         id: cache-prysk
         uses: actions/cache@v3


### PR DESCRIPTION
### Description

Setting up `graphviz` for macos on CI has been flakey. It seems it fails when it tries to upgrade some existing packages on the runner.
[Successful run](https://github.com/vercel/turbo/actions/runs/6947834378/job/18904625583#step:4:84): Note that only `brew install graphviz` gets executed as part of the action
[Failed run](https://github.com/vercel/turbo/actions/runs/6949330954/job/18907649525#step:4:266): Note that homebrew tries to update python for us which we do not want.

We can opt out of this twofold:
 - Skip the initial `brew update` performed by the [`setup-graphviz` action](https://github.com/marketplace/actions/setup-graphviz)
 - Skip upgrading unrelated packages on the `brew install graphviz` by using the `https://docs.brew.sh/Manpage#install-options-formulacask-` environment variable.

### Testing Instructions

CI for macos integration tests should not run `brew update` or `brew upgrade` when installing `graphviz`: [logs](https://github.com/vercel/turbo/actions/runs/6949949249/job/18909583646?pr=6538#step:4:73)