### PR TITLE
fix(gen): correct arg parsing

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -132,6 +132,15 @@
       "cwd": "${workspaceRoot}/examples/basic"
     },
     {
+      "name": "Generators",
+      "type": "lldb",
+      "request": "launch",
+      "preLaunchTask": "prepare turbo",
+      "program": "${workspaceRoot}/target/debug/turbo",
+      "args": ["gen", "blog - release post", "--args", "1.11.0", "1.10.0", "_", "tagline about my really cool release"],
+      "cwd": "${workspaceRoot}"
+    },
+    {
       "name": "Daemon",
       "type": "lldb",
       "request": "launch",

--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -336,7 +336,7 @@ pub enum Command {
         #[clap(short = 'r', long)]
         root: Option<String>,
         /// Answers passed directly to generator
-        #[clap(short = 'a', long, value_delimiter = ' ', num_args = 1..)]
+        #[clap(short = 'a', long, num_args = 1..)]
         args: Vec<String>,
 
         #[clap(subcommand)]


### PR DESCRIPTION
### Description

We don't need to split the args by space, the default behavior works fine. 

Fixes TURBO-6430