### PR TITLE
fix: analytics closing when all senders drop

### DIFF
--- a/crates/turborepo-analytics/src/lib.rs
+++ b/crates/turborepo-analytics/src/lib.rs
@@ -109,7 +109,7 @@ impl<C: AnalyticsClient + Clone + Send + Sync + 'static> Worker<C> {
                             self.flush_events();
                             timeout = tokio::time::sleep(NO_TIMEOUT);
                         } else {
-                            timeout = tokio::time::sleep(REQUEST_TIMEOUT);
+                            timeout = tokio::time::sleep(EVENT_TIMEOUT);
                         }
                     }
                     _ = timeout => {


### PR DESCRIPTION
### Description

This PR primarily fixes an issue where the worker would spin if all senders were closed. Since the `select` was biased, if `self.rx.recv()` was ready then it would always be chosen. In the case that all senders are dropped, this future will always be ready with a `None` message. Solution is to just shutdown if there aren't going to be any other messages.

Other fixes:
 - Joining the senders as they finish instead of an arbitrary order and then waiting for whichever one we got to finish
 - Using the 20ms timeout before we send events if there's still room in the batch as opposed to 10s

### Testing Instructions

The unit test for closing now exercises realistic usage of the analytics client. If you checkout the first commit, the test will fail without the fix now.

Closes TURBO-1736