### PR TITLE
fix: treat missing and empty scripts the same

### DIFF
--- a/crates/turborepo-lib/src/task_graph/visitor.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor.rs
@@ -228,8 +228,8 @@ impl<'a> Visitor<'a> {
                     // the following block should never get hit. In the meantime, keep it after
                     // hashing so that downstream tasks can count on the hash existing
                     //
-                    // bail if the script doesn't exist
-                    if command.is_none() {
+                    // bail if the script doesn't exist or is empty
+                    if command.map_or(true, |s| s.is_empty()) {
                         continue;
                     }
 


### PR DESCRIPTION
### Description

In Go we would skip running a task if the [`packageJson[taskName] == ""`](https://github.com/vercel/turbo/blob/main/cli/internal/run/real_run.go#L412) which is true for both when there's no script definition *and* when there's an empty string as the script definition.

To match the Go behavior in Rust we skip a task if `package_json.scripts.get(task_name)` is `None` or `Some("")`

### Testing Instructions

`vercel-site#prepare-dev` should no longer be run via `turbo prepare-dev --filter=vercel-site`

Before
```
...
vercel-site:prepare-dev: ERROR: command finished with error: command (/Users/olszewski/code/vercel/front/apps/vercel-site) /Users/olszewski/.nvm/versions/node/v16.18.1/bin/pnpm run prepare-dev exited (1)
vercel-site#prepare-dev: command (/Users/olszewski/code/vercel/front/apps/vercel-site) /Users/olszewski/.nvm/versions/node/v16.18.1/bin/pnpm run prepare-dev exited (1)

 Tasks:    8 successful, 9 total
Cached:    8 cached, 9 total
  Time:    2s 
Failed:    vercel-site#prepare-dev
```

After (note we have one less task to run since `vercel-site#prepare-dev` is marked as not needing to be run)
```
...
 Tasks:    8 successful, 8 total
Cached:    8 cached, 8 total
  Time:    772ms >>> FULL TURBO
```

Closes TURBO-1740