### PR TITLE
chore(docs): remove backticks from title/desc meta tags on CLI reference pages

### DIFF
--- a/docs/pages/repo/docs/reference/command-line-reference/bin.mdx
+++ b/docs/pages/repo/docs/reference/command-line-reference/bin.mdx
@@ -1,6 +1,6 @@
 ---
-title: "`turbo bin`"
-description: Turborepo CLI Reference for `bin` command
+title: "turbo bin"
+description: Turborepo CLI Reference for bin command
 ---
 
 # `turbo bin`

--- a/docs/pages/repo/docs/reference/command-line-reference/gen.mdx
+++ b/docs/pages/repo/docs/reference/command-line-reference/gen.mdx
@@ -1,6 +1,6 @@
 ---
-title: "`turbo gen`"
-description: Turborepo CLI Reference for `gen` command
+title: "turbo gen"
+description: Turborepo CLI Reference for gen command
 ---
 
 import Callout from "../../../../../components/Callout";

--- a/docs/pages/repo/docs/reference/command-line-reference/link.mdx
+++ b/docs/pages/repo/docs/reference/command-line-reference/link.mdx
@@ -1,6 +1,6 @@
 ---
-title: "`turbo link`"
-description: Turborepo CLI Reference for `link` command
+title: "turbo link"
+description: Turborepo CLI Reference for link command
 ---
 
 ## `turbo link`

--- a/docs/pages/repo/docs/reference/command-line-reference/login.mdx
+++ b/docs/pages/repo/docs/reference/command-line-reference/login.mdx
@@ -1,6 +1,6 @@
 ---
-title: "`turbo login`"
-description: Turborepo CLI Reference for `login` command
+title: "turbo login"
+description: Turborepo CLI Reference for login command
 ---
 
 # `turbo login`

--- a/docs/pages/repo/docs/reference/command-line-reference/logout.mdx
+++ b/docs/pages/repo/docs/reference/command-line-reference/logout.mdx
@@ -1,6 +1,6 @@
 ---
-title: "`turbo logout`"
-description: Turborepo CLI Reference for `logout` command
+title: "turbo logout"
+description: Turborepo CLI Reference for logout command
 ---
 
 ## `turbo logout`

--- a/docs/pages/repo/docs/reference/command-line-reference/prune.mdx
+++ b/docs/pages/repo/docs/reference/command-line-reference/prune.mdx
@@ -1,6 +1,6 @@
 ---
-title: "`turbo prune`"
-description: Turborepo CLI Reference for `prune` command
+title: "turbo prune"
+description: Turborepo CLI Reference for prune command
 ---
 
 import Callout from "../../../../../components/Callout";

--- a/docs/pages/repo/docs/reference/command-line-reference/run.mdx
+++ b/docs/pages/repo/docs/reference/command-line-reference/run.mdx
@@ -1,6 +1,6 @@
 ---
-title: "`turbo run`"
-description: Turborepo CLI Reference for `run` command
+title: "turbo run"
+description: Turborepo CLI Reference for run command
 ---
 
 import Callout from "../../../../../components/Callout";

--- a/docs/pages/repo/docs/reference/command-line-reference/unlink.mdx
+++ b/docs/pages/repo/docs/reference/command-line-reference/unlink.mdx
@@ -1,6 +1,6 @@
 ---
-title: "`turbo unlink`"
-description: Turborepo CLI Reference for `unlink` command
+title: "turbo unlink"
+description: Turborepo CLI Reference for unlink command
 ---
 
 ## `turbo unlink`


### PR DESCRIPTION
I originally added these, but I think they look kind of bad now

Closes TURBO-1746