### PR TITLE
feat(docs): add node version compatibility for examples

### DIFF
--- a/docs/pages/repo/docs/support.mdx
+++ b/docs/pages/repo/docs/support.mdx
@@ -28,6 +28,9 @@ active Node.js version on your system, but some features of Turborepo and its ec
 such as `create-turbo`, `turbo-ignore`, and `eslint-plugin-turbo` do. For these features,
 we intend to support the [Active and Maintenance LTS versions of Node.js][1].
 
+All of our [examples](/repo/docs/getting-started/from-example) are also expected to
+work with these versions.
+
 ## Package Managers
 
 Core `turbo` functionality depends on the package managers in the JS ecosystem


### PR DESCRIPTION
Now that all our examples are being updated by the Great @anthonyshew and we're adding `engines`, I wanted to document this explicitly. We can cover the actual testing/validation gap as we iterate on our test suites
Closes TURBO-1747