### PR TITLE
chore(tests): setup graphviz before running tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -378,6 +378,13 @@ jobs:
           windows: ${{ matrix.os.name == 'windows' }}
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
+      - name: Setup Graphviz
+        uses: ts-graphviz/setup-graphviz@v1
+        with:
+          macos-skip-brew-update: "true"
+        env:
+          HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: true
+
       - name: Cache Prysk
         id: cache-prysk
         uses: actions/cache@v3


### PR DESCRIPTION
This setup step was added in #6490, and since Windows is a different job we need to copy it over
Closes TURBO-1754