### PR TITLE
fix(turbopack-bench): remove outdated `experimental.appDir` from next.config.js

### DIFF
--- a/crates/turbopack-bench/src/bundlers/nextjs/next.config.js
+++ b/crates/turbopack-bench/src/bundlers/nextjs/next.config.js
@@ -1,5 +1,1 @@
-module.exports = {
-  experimental: {
-    appDir: true,
-  },
-};
+module.exports = {};


### PR DESCRIPTION
### Description

This should make the benchmarks run again

Closes PACK-2041