### PR TITLE
fix(docs): update inconsistent CLI headings

### DIFF
--- a/docs/pages/repo/docs/reference/command-line-reference/gen.mdx
+++ b/docs/pages/repo/docs/reference/command-line-reference/gen.mdx
@@ -4,7 +4,6 @@ description: Turborepo CLI Reference for `gen` command
 ---
 
 import Callout from "../../../../../components/Callout";
-import OuputModeTable from "../../../../../components/output-mode-table.mdx";
 
 # `turbo gen`
 

--- a/docs/pages/repo/docs/reference/command-line-reference/link.mdx
+++ b/docs/pages/repo/docs/reference/command-line-reference/link.mdx
@@ -3,7 +3,7 @@ title: "`turbo link`"
 description: Turborepo CLI Reference for `link` command
 ---
 
-## `turbo link`
+# `turbo link`
 
 Link the current directory to Remote Cache scope. The selected owner (either a user or and organization) will be able to share [cache artifacts](/repo/docs/core-concepts/caching) through [Remote Caching](/repo/docs/core-concepts/remote-caching).
 You should run this command from the root of your monorepo.

--- a/docs/pages/repo/docs/reference/command-line-reference/logout.mdx
+++ b/docs/pages/repo/docs/reference/command-line-reference/logout.mdx
@@ -3,6 +3,6 @@ title: "`turbo logout`"
 description: Turborepo CLI Reference for `logout` command
 ---
 
-## `turbo logout`
+# `turbo logout`
 
 Logs you out of your Vercel account.

--- a/docs/pages/repo/docs/reference/command-line-reference/prune.mdx
+++ b/docs/pages/repo/docs/reference/command-line-reference/prune.mdx
@@ -3,9 +3,6 @@ title: "`turbo prune`"
 description: Turborepo CLI Reference for `prune` command
 ---
 
-import Callout from "../../../../../components/Callout";
-import OuputModeTable from "../../../../../components/output-mode-table.mdx";
-
 # `turbo prune <scope>...`
 
 Generate a sparse/partial monorepo with a pruned lockfile for a target workspace.

--- a/docs/pages/repo/docs/reference/command-line-reference/unlink.mdx
+++ b/docs/pages/repo/docs/reference/command-line-reference/unlink.mdx
@@ -3,6 +3,6 @@ title: "`turbo unlink`"
 description: Turborepo CLI Reference for `unlink` command
 ---
 
-## `turbo unlink`
+# `turbo unlink`
 
 Unlink the current directory from the Remote Cache.


### PR DESCRIPTION
### Description

Quick fix for inconsistent docs headings.

These should all be top level `#`, but a few of them are still `##` from when these used to be on page. As a result the top heading jumps around a bit if you click between them all quickly (font sizing and padding changes). This fixes that by making them all `h1`



Closes TURBO-1755