### PR TITLE
fix: Hard error on spaces

### DIFF
--- a/turborepo-tests/integration/package.json
+++ b/turborepo-tests/integration/package.json
@@ -3,6 +3,7 @@
   "scripts": {
     "test": "cross-env EXPERIMENTAL_RUST_CODEPATH=false node ./test.mjs",
     "test:rust-codepath": "cross-env EXPERIMENTAL_RUST_CODEPATH=true node ./test.mjs",
+    "test:rust-codepath:interactive": "cross-env EXPERIMENTAL_RUST_CODEPATH=true PRYSK_INTERACTIVE=true node ./test.mjs",
     "test:interactive": "EXPERIMENTAL_RUST_CODEPATH=false PRYSK_INTERACTIVE=true node ./test.mjs",
     "test:parallel": ".cram_env/bin/pytest -n auto tests --prysk-shell=`which bash`",
     "pretest:parallel": ".cram_env/bin/pip3 install --quiet pytest \"prysk[pytest-plugin]\" pytest-xdist"

--- a/turborepo-tests/integration/tests/_fixtures/spaces_failure/.gitignore
+++ b/turborepo-tests/integration/tests/_fixtures/spaces_failure/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.turbo
+.npmrc

--- a/turborepo-tests/integration/tests/_fixtures/spaces_failure/apps/my-app/package.json
+++ b/turborepo-tests/integration/tests/_fixtures/spaces_failure/apps/my-app/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "my-app",
+  "scripts": {
+    "build": "echo building",
+    "maybefails": "exit 4"
+  },
+  "dependencies": {
+    "util": "*"
+  }
+}

--- a/turborepo-tests/integration/tests/_fixtures/spaces_failure/bar.txt
+++ b/turborepo-tests/integration/tests/_fixtures/spaces_failure/bar.txt
@@ -1,0 +1,1 @@
+other file, not a global dependency

--- a/turborepo-tests/integration/tests/_fixtures/spaces_failure/foo.txt
+++ b/turborepo-tests/integration/tests/_fixtures/spaces_failure/foo.txt
@@ -1,0 +1,1 @@
+global dep! all tasks depend on this content!

--- a/turborepo-tests/integration/tests/_fixtures/spaces_failure/package.json
+++ b/turborepo-tests/integration/tests/_fixtures/spaces_failure/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "monorepo",
+  "scripts": {
+    "something": "turbo run build"
+  },
+  "workspaces": [
+    "apps/**",
+    "packages/**"
+  ]
+}

--- a/turborepo-tests/integration/tests/_fixtures/spaces_failure/packages/another/package.json
+++ b/turborepo-tests/integration/tests/_fixtures/spaces_failure/packages/another/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "another",
+  "scripts": {}
+}

--- a/turborepo-tests/integration/tests/_fixtures/spaces_failure/packages/util/package.json
+++ b/turborepo-tests/integration/tests/_fixtures/spaces_failure/packages/util/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "util",
+  "scripts": {
+    "build": "echo building",
+    "maybefails": "echo didnotfail"
+  }
+}

--- a/turborepo-tests/integration/tests/_fixtures/spaces_failure/turbo.json
+++ b/turborepo-tests/integration/tests/_fixtures/spaces_failure/turbo.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "globalDependencies": ["foo.txt"],
+  "globalEnv": ["SOME_ENV_VAR"],
+  "pipeline": {
+    "build": {
+      "env": ["NODE_ENV"],
+      "outputs": []
+    },
+    // this comment verifies that turbo can read .json files with comments
+    "my-app#build": {
+      "outputs": ["banana.txt", "apple.json"],
+      "dotEnv": [".env.local"]
+    },
+
+    "something": {},
+    "//#something": {},
+
+    "maybefails": {}
+  },
+  "experimentalSpaces": {
+    "id": "my-space"
+  }
+}

--- a/turborepo-tests/integration/tests/spaces-failure.t
+++ b/turborepo-tests/integration/tests/spaces-failure.t
@@ -3,4 +3,4 @@ Setup
   $ . ${TESTDIR}/_helpers/setup_monorepo.sh $(pwd) spaces_failure
 
 Ensures that even when spaces fails, the build still succeeds.
-  $ ${TURBO} run build --token foobarbaz --team bat --output-logs none > /dev/null 2>&1
+  $ ${TURBO} run build --token foobarbaz --team bat --api https://example.com > /dev/null 2>&1

--- a/turborepo-tests/integration/tests/spaces-failure.t
+++ b/turborepo-tests/integration/tests/spaces-failure.t
@@ -1,0 +1,6 @@
+Setup
+  $ . ${TESTDIR}/../../helpers/setup.sh
+  $ . ${TESTDIR}/_helpers/setup_monorepo.sh $(pwd) spaces_failure
+
+Ensures that even when spaces fails, the build still succeeds.
+  $ ${TURBO} run build --token foobarbaz --team bat --output-logs none > /dev/null 2>&1


### PR DESCRIPTION
### Description

When we fail to start the `SpacesClient`, this can lead to an error when we try to close it at the end of a run. Instead of erroring, we simply log out the error and continue, since spaces is not critical to execution.

### Testing Instructions

Added a test for spaces failure that ensures we exit with 0

Closes TURBO-1764