### PR TITLE
docs: Fix rustdoc build

### DIFF
--- a/crates/turborepo/build.rs
+++ b/crates/turborepo/build.rs
@@ -12,10 +12,10 @@ fn main() {
     }
 }
 
-#[cfg(not(feature = "go-binary"))]
+#[cfg(any(not(feature = "go-binary"), doc))]
 fn build_local_go_binary(_: String) {}
 
-#[cfg(feature = "go-binary")]
+#[cfg(all(feature = "go-binary", not(doc)))]
 fn build_local_go_binary(profile: String) {
     let cli_path = cli_path();
     let target = build_target::target().unwrap();

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "docs": "pnpm -- turbo run dev --filter=docs --no-cache",
     "prepare": "husky install",
     "test": "turbo run test",
-    "rustdoc": "RUSTDOCFLAGS=\"-Z unstable-options --enable-index-page\" cargo doc --workspace --no-deps --keep-going"
+    "rustdoc": "RUSTDOCFLAGS=\"-Z unstable-options --enable-index-page\" cargo doc --workspace --no-deps --keep-going || true"
   },
   "devDependencies": {
     "@taplo/cli": "^0.5.2",


### PR DESCRIPTION
### Description

Ignores the error code on the rustdoc build because we have the `--keep-going` flag set. Also skips the Go binary build for docs

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->


Closes TURBO-1767