### PR TITLE
fix(mdx): support ecma transforms for the mdx assets

### DIFF
--- a/crates/turbopack-mdx/src/lib.rs
+++ b/crates/turbopack-mdx/src/lib.rs
@@ -82,6 +82,10 @@ pub struct MdxModuleAsset {
 /// only difference is it is not a valid ecmascript AST we
 /// can't pass it forward directly. Internally creates an jsx from mdx
 /// via mdxrs, then pass it through existing ecmascript analyzer.
+///
+/// To make mdx as a variant of ecmascript and use its `source_transforms`
+/// instead, there should be a way to get a valid SWC ast from mdx source input
+/// - which we don't have yet.
 async fn into_ecmascript_module_asset(
     current_context: &Vc<MdxModuleAsset>,
 ) -> Result<Vc<EcmascriptModuleAsset>> {

--- a/crates/turbopack/src/lib.rs
+++ b/crates/turbopack/src/lib.rs
@@ -370,6 +370,13 @@ async fn process_default(
                                 transforms: transforms.extend(*additional_transforms),
                                 options,
                             }),
+                            Some(ModuleType::Mdx {
+                                transforms,
+                                options,
+                            }) => Some(ModuleType::Mdx {
+                                transforms: transforms.extend(*additional_transforms),
+                                options,
+                            }),
                             Some(module_type) => {
                                 ModuleIssue {
                                     ident,

--- a/crates/turbopack/src/module_options/module_rule.rs
+++ b/crates/turbopack/src/module_options/module_rule.rs
@@ -114,6 +114,9 @@ pub enum ModuleType {
     },
     Json,
     Raw,
+    // [TODO] We want to consolidate mdx as a type of ecma|typescript module types with
+    // its source transform. Refer `turbopack-mdx::into_ecmascript_module_asset` for the reason
+    // why we keep this separately.
     Mdx {
         transforms: Vc<EcmascriptInputTransforms>,
         options: Vc<MdxTransformOptions>,


### PR DESCRIPTION
### Description

Context: https://github.com/vercel/next.js/pull/58968

MDX is a special variant of an ecma|typescript asset in turbopack, once transform is completed (which makes mdx into jsx component) it is a plain ecma script asset can apply the other transforms.

PR enables those transform check condition to the mdx. 

In the end it is better to make mdx as just an ecmascript asset with source transforms, but as noted in comments its ast is incompatible with source transform in ecmascript so we have separate asset for now.