### PR TITLE
chore(lint): fix @typescript-eslint/naming-convention lint violations

### DIFF
--- a/docs/.eslintrc.js
+++ b/docs/.eslintrc.js
@@ -3,7 +3,6 @@ module.exports = {
   rules: {
     // Most of these rules should probably be on. Turning them off because they fail in many places
     // and we need to set aside time to make them work.
-    "@typescript-eslint/naming-convention": "warn",
     "@typescript-eslint/no-explicit-any": "warn",
     "@typescript-eslint/no-floating-promises": "warn",
     "@typescript-eslint/no-implied-eval": "warn",

--- a/docs/components/Container.tsx
+++ b/docs/components/Container.tsx
@@ -1,9 +1,9 @@
 import type { ReactNode } from "react";
 
-interface Props {
+interface ContainerProps {
   children?: ReactNode;
 }
 
-export function Container({ children }: Props) {
+export function Container({ children }: ContainerProps) {
   return <div className="mx-auto max-w-7xl sm:px-6 lg:px-8">{children}</div>;
 }

--- a/docs/components/ThemeAwareImage.tsx
+++ b/docs/components/ThemeAwareImage.tsx
@@ -10,7 +10,7 @@ interface ImageAttrs {
   props?: ImageProps;
 }
 
-interface Props {
+interface ThemeAwareImageProps {
   className?: string;
   light: ImageAttrs;
   dark: ImageAttrs;
@@ -21,7 +21,7 @@ export default function ThemeAwareImage({
   light,
   dark,
   ...other
-}: Props) {
+}: ThemeAwareImageProps) {
   const Images = (
     <>
       <Image


### PR DESCRIPTION
Just making my way down the list when I have time. This rule feels a bit silly, but I don't want to debate the rule itself, just get our accepted ruleset passing.

Closes TURBO-1773