### PR TITLE
chore(tests): remove hardcoded packageManager when running examples tests

### DIFF
--- a/examples-tests/npm-non-monorepo/test.t
+++ b/examples-tests/npm-non-monorepo/test.t
@@ -1,5 +1,5 @@
   $ . ${TESTDIR}/../setup.sh non-monorepo npm
-  \d+\.\d+\.\d+ (re)
+
 # run twice and make sure it works
   $ npx turbo build lint --output-logs=errors-only
   \xe2\x80\xa2 Running build, lint (esc)

--- a/examples-tests/npm-with-npm/test.t
+++ b/examples-tests/npm-with-npm/test.t
@@ -1,5 +1,5 @@
   $ . ${TESTDIR}/../setup.sh with-npm npm
-  \d+\.\d+\.\d+ (re)
+
 # run twice and make sure it works
   $ npm run build lint -- --output-logs=errors-only
   

--- a/examples-tests/npm-with-yarn/test.t
+++ b/examples-tests/npm-with-yarn/test.t
@@ -1,5 +1,5 @@
   $ . ${TESTDIR}/../setup.sh with-yarn npm
-  \d+\.\d+\.\d+ (re)
+
 # run twice and make sure it works
   $ npm run build lint -- --output-logs=errors-only
   

--- a/examples-tests/pnpm-basic/test.t
+++ b/examples-tests/pnpm-basic/test.t
@@ -1,5 +1,5 @@
   $ . ${TESTDIR}/../setup.sh basic pnpm
-  6.26.1
+
 # run twice and make sure it works
   $ pnpm run build lint -- --output-logs=errors-only
   

--- a/examples-tests/pnpm-gatsby/test.t
+++ b/examples-tests/pnpm-gatsby/test.t
@@ -1,5 +1,5 @@
   $ . ${TESTDIR}/../setup.sh with-gatsby pnpm
-  6.26.1
+
 # run twice and make sure it works
   $ pnpm run build lint -- --output-logs=errors-only
   

--- a/examples-tests/pnpm-kitchen-sink/test.t
+++ b/examples-tests/pnpm-kitchen-sink/test.t
@@ -1,5 +1,5 @@
   $ . ${TESTDIR}/../setup.sh kitchen-sink pnpm
-  6.26.1
+
 # run twice and make sure it works
   $ pnpm run build lint -- --output-logs=errors-only
   

--- a/examples-tests/pnpm-with-svelte/test.t
+++ b/examples-tests/pnpm-with-svelte/test.t
@@ -1,5 +1,5 @@
   $ . ${TESTDIR}/../setup.sh with-svelte pnpm
-  6.26.1
+
 # run twice and make sure it works
   $ pnpm run build lint -- --output-logs=errors-only
   

--- a/examples-tests/setup.sh
+++ b/examples-tests/setup.sh
@@ -30,11 +30,6 @@ if [ "$TURBO_TAG" == "canary" ]; then
   mv package.json.new package.json
 fi
 
-function set_package_manager() {
-  jq --arg pm "$1" '.packageManager = $pm' package.json > package.json.new
-  mv package.json.new package.json
-}
-
 # Enable corepack so that when we set the packageManager in package.json it actually makes a diference.
 if [ "$PRYSK_TEMP" == "" ]; then
   COREPACK_INSTALL_DIR_CMD=
@@ -46,27 +41,11 @@ else
 fi
 corepack enable "${COREPACK_INSTALL_DIR_CMD}"
 
-# Set the packageManger version
-NPM_PACKAGE_MANAGER_VALUE="npm@8.1.2"
-PNPM_PACKAGE_MANAGER_VALUE="pnpm@6.26.1"
-YARN_PACKAGE_MANAGER_VALUE="yarn@1.22.17"
-
 if [ "$pkgManager" == "npm" ]; then
-  # Note! We will packageManager for npm, but it doesn't actually change the version
-  # We are effectively just removing any packageManager that's already set.
-  # https://nodejs.org/api/corepack.html#how-does-corepack-interact-with-npm
-  # > "While npm is a valid option in the "packageManager" property, the lack of shim will cause the global npm to be used."
-  set_package_manager "$NPM_PACKAGE_MANAGER_VALUE"
-
-  npm --version
   npm install > /dev/null 2>&1
 elif [ "$pkgManager" == "pnpm" ]; then
-  set_package_manager "$PNPM_PACKAGE_MANAGER_VALUE"
-  pnpm --version
   pnpm install > /dev/null 2>&1
 elif [ "$pkgManager" == "yarn" ]; then
-  set_package_manager "$YARN_PACKAGE_MANAGER_VALUE"
-  yarn --version
   # Pass a --cache-folder here because yarn seems to have trouble
   # running multiple yarn installs at the same time and we are running
   # examples tests in parallel. https://github.com/yarnpkg/yarn/issues/1275

--- a/examples-tests/yarn-non-monorepo/test.t
+++ b/examples-tests/yarn-non-monorepo/test.t
@@ -1,5 +1,4 @@
   $ . ${TESTDIR}/../setup.sh non-monorepo yarn
-  \d+\.\d+\.\d+ (re)
 
 # run twice and make sure it works
   $ yarn turbo build lint --output-logs=errors-only

--- a/examples-tests/yarn-with-npm/test.t
+++ b/examples-tests/yarn-with-npm/test.t
@@ -1,5 +1,4 @@
   $ . ${TESTDIR}/../setup.sh with-npm yarn
-  \d+\.\d+\.\d+ (re)
 
 # run twice and make sure it works
   $ yarn turbo build lint --output-logs=errors-only

--- a/examples-tests/yarn-with-yarn/test.t
+++ b/examples-tests/yarn-with-yarn/test.t
@@ -1,5 +1,4 @@
   $ . ${TESTDIR}/../setup.sh with-yarn yarn
-  \d+\.\d+\.\d+ (re)
 
 # run twice and make sure it works
   $ yarn turbo build lint --output-logs=errors-only


### PR DESCRIPTION
examples now have this field already set, so tests can just validate this

Closes TURBO-1780