### PR TITLE
feat(turbopack): support "loading" WebAssembly injected as global varables in edge runtime

### DIFF
--- a/crates/turbopack-ecmascript-runtime/js/src/dev/runtime/none/tsconfig.json
+++ b/crates/turbopack-ecmascript-runtime/js/src/dev/runtime/none/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    // environment
-    "lib": ["ESNext"]
+    // environment, we need WebWorker for WebAssembly types
+    "lib": ["ESNext", "WebWorker"]
   },
   "include": ["*.ts"]
 }


### PR DESCRIPTION
### Description

Next.js supports injecting WASM files into the edge runtime via the middleware manifest, so we want to be able to support that usecase as well

Closes PACK-2027