### PR TITLE
fix(ci): Don't cache exe stub

### DIFF
--- a/packages/turbo-exe-stub/turbo.json
+++ b/packages/turbo-exe-stub/turbo.json
@@ -1,0 +1,8 @@
+{
+  "extends": ["//"],
+  "pipeline": {
+    "build": {
+      "cache": false
+    }
+  }
+}


### PR DESCRIPTION
Since the outputs aren't configured and this is not an expensive build anyway, we don't need to cache it. This is currently getting cache hits and the build script isn't putting the exe stub in the right place.