### PR TITLE
fix(release): correct excludes label

### DIFF
--- a/.github/turborepo-release.yml
+++ b/.github/turborepo-release.yml
@@ -3,7 +3,7 @@
 changelog:
   exclude:
     labels:
-      - "team: turbopack"
+      - "owned-by: turbopack"
       - "area: ci"
   categories:
     - title: Docs


### PR DESCRIPTION
### Description

We use a different label for teams now. Correct the excludes
