### PR TITLE
feat: add read only remote cache

### DIFF
--- a/crates/turborepo-cache/src/async_cache.rs
+++ b/crates/turborepo-cache/src/async_cache.rs
@@ -202,6 +202,7 @@ mod tests {
 
         let opts = CacheOpts {
             override_dir: None,
+            remote_cache_read_only: false,
             skip_remote: false,
             skip_filesystem: true,
             workers: 10,
@@ -275,6 +276,7 @@ mod tests {
 
         let opts = CacheOpts {
             override_dir: None,
+            remote_cache_read_only: false,
             skip_remote: true,
             skip_filesystem: false,
             workers: 10,
@@ -358,6 +360,7 @@ mod tests {
 
         let opts = CacheOpts {
             override_dir: None,
+            remote_cache_read_only: false,
             skip_remote: false,
             skip_filesystem: false,
             workers: 10,

--- a/crates/turborepo-cache/src/lib.rs
+++ b/crates/turborepo-cache/src/lib.rs
@@ -89,6 +89,7 @@ pub struct CacheHitMetadata {
 #[derive(Debug, Default)]
 pub struct CacheOpts<'a> {
     pub override_dir: Option<&'a Utf8Path>,
+    pub read_only_remote_cache: bool,
     pub skip_remote: bool,
     pub skip_filesystem: bool,
     pub workers: u32,

--- a/crates/turborepo-cache/src/lib.rs
+++ b/crates/turborepo-cache/src/lib.rs
@@ -89,7 +89,7 @@ pub struct CacheHitMetadata {
 #[derive(Debug, Default)]
 pub struct CacheOpts<'a> {
     pub override_dir: Option<&'a Utf8Path>,
-    pub read_only_remote_cache: bool,
+    pub remote_cache_read_only: bool,
     pub skip_remote: bool,
     pub skip_filesystem: bool,
     pub workers: u32,

--- a/crates/turborepo-cache/src/multiplexer.rs
+++ b/crates/turborepo-cache/src/multiplexer.rs
@@ -86,11 +86,13 @@ impl CacheMultiplexer {
         let http_result = match self.get_http_cache() {
             Some(http) => {
                 if self.remote_cache_read_only {
+                    // Cache is functional but running in read-only mode, so we don't want to try to
+                    // write to it
+                    None
+                } else {
                     let http_result = http.put(anchor, key, files, duration).await;
 
                     Some(http_result)
-                } else {
-                    None
                 }
             }
             _ => None,

--- a/crates/turborepo-cache/src/multiplexer.rs
+++ b/crates/turborepo-cache/src/multiplexer.rs
@@ -13,6 +13,7 @@ pub struct CacheMultiplexer {
     // This does create a mild race condition where we might use the cache
     // even though another thread might be removing it, but that's fine.
     should_use_http_cache: AtomicBool,
+    read_only_remote_cache: bool,
     fs: Option<FSCache>,
     http: Option<HTTPCache>,
 }
@@ -54,6 +55,7 @@ impl CacheMultiplexer {
 
         Ok(CacheMultiplexer {
             should_use_http_cache: AtomicBool::new(http_cache.is_some()),
+            read_only_remote_cache: opts.read_only_remote_cache,
             fs: fs_cache,
             http: http_cache,
         })
@@ -83,9 +85,14 @@ impl CacheMultiplexer {
 
         let http_result = match self.get_http_cache() {
             Some(http) => {
-                let http_result = http.put(anchor, key, files, duration).await;
+                if self.read_only_remote_cache {
+                    let http_result = http.put(anchor, key, files, duration).await;
 
-                Some(http_result)
+                    Some(http_result)
+                }
+                else {
+                    None
+                }
             }
             _ => None,
         };

--- a/crates/turborepo-cache/src/multiplexer.rs
+++ b/crates/turborepo-cache/src/multiplexer.rs
@@ -57,7 +57,7 @@ impl CacheMultiplexer {
             });
 
         Ok(CacheMultiplexer {
-            should_print_skipping_remote_put: AtomicBool::new(false),
+            should_print_skipping_remote_put: AtomicBool::new(true),
             should_use_http_cache: AtomicBool::new(http_cache.is_some()),
             remote_cache_read_only: opts.remote_cache_read_only,
             fs: fs_cache,
@@ -90,14 +90,14 @@ impl CacheMultiplexer {
         let http_result = match self.get_http_cache() {
             Some(http) => {
                 if self.remote_cache_read_only {
-                    if !self
+                    if self
                         .should_print_skipping_remote_put
                         .load(Ordering::Relaxed)
                     {
                         // Warn once per build, not per task
                         warn!("Remote cache is read-only, skipping upload");
                         self.should_print_skipping_remote_put
-                            .store(true, Ordering::Relaxed);
+                            .store(false, Ordering::Relaxed);
                     }
                     // Cache is functional but running in read-only mode, so we don't want to try to
                     // write to it

--- a/crates/turborepo-cache/src/multiplexer.rs
+++ b/crates/turborepo-cache/src/multiplexer.rs
@@ -89,8 +89,7 @@ impl CacheMultiplexer {
                     let http_result = http.put(anchor, key, files, duration).await;
 
                     Some(http_result)
-                }
-                else {
+                } else {
                     None
                 }
             }

--- a/crates/turborepo-cache/src/multiplexer.rs
+++ b/crates/turborepo-cache/src/multiplexer.rs
@@ -13,7 +13,7 @@ pub struct CacheMultiplexer {
     // This does create a mild race condition where we might use the cache
     // even though another thread might be removing it, but that's fine.
     should_use_http_cache: AtomicBool,
-    read_only_remote_cache: bool,
+    remote_cache_read_only: bool,
     fs: Option<FSCache>,
     http: Option<HTTPCache>,
 }
@@ -55,7 +55,7 @@ impl CacheMultiplexer {
 
         Ok(CacheMultiplexer {
             should_use_http_cache: AtomicBool::new(http_cache.is_some()),
-            read_only_remote_cache: opts.read_only_remote_cache,
+            remote_cache_read_only: opts.remote_cache_read_only,
             fs: fs_cache,
             http: http_cache,
         })
@@ -85,7 +85,7 @@ impl CacheMultiplexer {
 
         let http_result = match self.get_http_cache() {
             Some(http) => {
-                if self.read_only_remote_cache {
+                if self.remote_cache_read_only {
                     let http_result = http.put(anchor, key, files, duration).await;
 
                     Some(http_result)

--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -564,8 +564,8 @@ pub struct RunArgs {
     #[clap(long, env = "TURBO_REMOTE_ONLY", value_name = "BOOL", action = ArgAction::Set, default_value = "false", default_missing_value = "true", num_args = 0..=1)]
     pub remote_only: bool,
     /// Treat remote cache as read only
-    #[clap(long, env = "TURBO_READ_ONLY_REMOTE_CACHE", value_name = "BOOL", action = ArgAction::Set, default_value = "false", default_missing_value = "true", num_args = 0..=1)]
-    pub read_only_remote_cache: bool,
+    #[clap(long, env = "TURBO_REMOTE_CACHE_READ_ONLY", value_name = "BOOL", action = ArgAction::Set, default_value = "false", default_missing_value = "true", num_args = 0..=1)]
+    pub remote_cache_read_only: bool,
     /// Specify package(s) to act as entry points for task execution.
     /// Supports globs.
     #[clap(long)]

--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -565,6 +565,7 @@ pub struct RunArgs {
     pub remote_only: bool,
     /// Treat remote cache as read only
     #[clap(long, env = "TURBO_REMOTE_CACHE_READ_ONLY", value_name = "BOOL", action = ArgAction::Set, default_value = "false", default_missing_value = "true", num_args = 0..=1)]
+    #[serde(skip)]
     pub remote_cache_read_only: bool,
     /// Specify package(s) to act as entry points for task execution.
     /// Supports globs.

--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -563,6 +563,9 @@ pub struct RunArgs {
     /// allow reading and caching artifacts using the remote cache.
     #[clap(long, env = "TURBO_REMOTE_ONLY", value_name = "BOOL", action = ArgAction::Set, default_value = "false", default_missing_value = "true", num_args = 0..=1)]
     pub remote_only: bool,
+    /// Treat remote cache as read only
+    #[clap(long, env = "TURBO_READ_ONLY_REMOTE_CACHE", value_name = "BOOL", action = ArgAction::Set, default_value = "false", default_missing_value = "true", num_args = 0..=1)]
+    pub read_only_remote_cache: bool,
     /// Specify package(s) to act as entry points for task execution.
     /// Supports globs.
     #[clap(long)]

--- a/crates/turborepo-lib/src/opts.rs
+++ b/crates/turborepo-lib/src/opts.rs
@@ -346,7 +346,7 @@ impl<'a> From<&'a RunArgs> for CacheOpts<'a> {
         CacheOpts {
             override_dir: run_args.cache_dir.as_deref(),
             skip_filesystem: run_args.remote_only,
-            read_only_remote_cache: run_args.read_only_remote_cache,
+            remote_cache_read_only: run_args.remote_cache_read_only,
             workers: run_args.cache_workers,
             ..CacheOpts::default()
         }

--- a/crates/turborepo-lib/src/opts.rs
+++ b/crates/turborepo-lib/src/opts.rs
@@ -346,6 +346,7 @@ impl<'a> From<&'a RunArgs> for CacheOpts<'a> {
         CacheOpts {
             override_dir: run_args.cache_dir.as_deref(),
             skip_filesystem: run_args.remote_only,
+            read_only_remote_cache: run_args.read_only_remote_cache,
             workers: run_args.cache_workers,
             ..CacheOpts::default()
         }

--- a/turborepo-tests/integration/tests/no-args.t
+++ b/turborepo-tests/integration/tests/no-args.t
@@ -40,33 +40,62 @@ Make sure exit code is 2 when no args are passed
     -h, --help                            Print help
   
   Run Arguments:
-        --cache-dir <CACHE_DIR>          Override the filesystem cache directory
-        --cache-workers <CACHE_WORKERS>  Set the number of concurrent cache operations (default 10) [default: 10]
-        --concurrency <CONCURRENCY>      Limit the concurrency of task execution. Use 1 for serial (i.e. one-at-a-time) execution
-        --continue                       Continue execution even if a task exits with an error or non-zero exit code. The default behavior is to bail
-        --dry-run [<DRY_RUN>]            [possible values: text, json]
-        --single-package                 Run turbo in single-package mode
-    -F, --filter <FILTER>                Use the given selector to specify package(s) to act as entry points. The syntax mirrors pnpm's syntax, and additional documentation and examples can be found in turbo's documentation https://turbo.build/repo/docs/reference/command-line-reference/run#--filter
-        --force [<FORCE>]                Ignore the existing cache (to force execution) [env: TURBO_FORCE=] [possible values: true, false]
-        --framework-inference [<BOOL>]   Specify whether or not to do framework inference for tasks [default: true] [possible values: true, false]
-        --global-deps <GLOBAL_DEPS>      Specify glob of global filesystem dependencies to be hashed. Useful for .env and files
-        --graph [<GRAPH>]                Generate a graph of the task execution and output to a file when a filename is specified (.svg, .png, .jpg, .pdf, .json, .html). Outputs dot graph to stdout when if no filename is provided
-        --env-mode [<ENV_MODE>]          Environment variable mode. Use "loose" to pass the entire existing environment. Use "strict" to use an allowlist specified in turbo.json. Use "infer" to defer to existence of "passThroughEnv" or "globalPassThroughEnv" in turbo.json. (default infer) [default: infer] [possible values: infer, loose, strict]
-        --ignore <IGNORE>                Files to ignore when calculating changed files (i.e. --since). Supports globs
-        --include-dependencies           Include the dependencies of tasks in execution
-        --no-cache                       Avoid saving task results to the cache. Useful for development/watch tasks
-        --no-daemon                      Run without using turbo's daemon process
-        --no-deps                        Exclude dependent task consumers from execution
-        --output-logs <OUTPUT_LOGS>      Set type of process output logging. Use "full" to show all output. Use "hash-only" to show only turbo-computed task hashes. Use "new-only" to show only new output with only hashes for cached tasks. Use "none" to hide process output. (default full) [possible values: full, none, hash-only, new-only, errors-only]
-        --log-order <LOG_ORDER>          Set type of task output order. Use "stream" to show output as soon as it is available. Use "grouped" to show output when a command has finished execution. Use "auto" to let turbo decide based on its own heuristics. (default auto) [env: TURBO_LOG_ORDER=] [default: auto] [possible values: auto, stream, grouped]
-        --only                           Only executes the tasks specified, does not execute parent tasks
-        --parallel                       Execute all tasks in parallel
-        --profile <PROFILE>              File to write turbo's performance profile output into. You can load the file up in chrome://tracing to see which parts of your build were slow
-        --remote-only [<BOOL>]           Ignore the local filesystem cache for all tasks. Only allow reading and caching artifacts using the remote cache [env: TURBO_REMOTE_ONLY=] [default: false] [possible values: true, false]
-        --scope <SCOPE>                  Specify package(s) to act as entry points for task execution. Supports globs
-        --since <SINCE>                  Limit/Set scope to changed packages since a mergebase. This uses the git diff ${target_branch}... mechanism to identify which packages have changed
-        --summarize [<SUMMARIZE>]        Generate a summary of the turbo run [env: TURBO_RUN_SUMMARY=] [possible values: true, false]
-        --log-prefix <LOG_PREFIX>        Use "none" to remove prefixes from task logs. Use "task" to get task id prefixing. Use "auto" to let turbo decide how to prefix the logs based on the execution environment. In most cases this will be the same as "task". Note that tasks running in parallel interleave their logs, so removing prefixes can make it difficult to associate logs with tasks. Use --log-order=grouped to prevent interleaving. (default auto) [default: auto] [possible values: auto, none, task]
+        --cache-dir <CACHE_DIR>
+            Override the filesystem cache directory
+        --cache-workers <CACHE_WORKERS>
+            Set the number of concurrent cache operations (default 10) [default: 10]
+        --concurrency <CONCURRENCY>
+            Limit the concurrency of task execution. Use 1 for serial (i.e. one-at-a-time) execution
+        --continue
+            Continue execution even if a task exits with an error or non-zero exit code. The default behavior is to bail
+        --dry-run [<DRY_RUN>]
+            [possible values: text, json]
+        --single-package
+            Run turbo in single-package mode
+    -F, --filter <FILTER>
+            Use the given selector to specify package(s) to act as entry points. The syntax mirrors pnpm's syntax, and additional documentation and examples can be found in turbo's documentation https://turbo.build/repo/docs/reference/command-line-reference/run#--filter
+        --force [<FORCE>]
+            Ignore the existing cache (to force execution) [env: TURBO_FORCE=] [possible values: true, false]
+        --framework-inference [<BOOL>]
+            Specify whether or not to do framework inference for tasks [default: true] [possible values: true, false]
+        --global-deps <GLOBAL_DEPS>
+            Specify glob of global filesystem dependencies to be hashed. Useful for .env and files
+        --graph [<GRAPH>]
+            Generate a graph of the task execution and output to a file when a filename is specified (.svg, .png, .jpg, .pdf, .json, .html). Outputs dot graph to stdout when if no filename is provided
+        --env-mode [<ENV_MODE>]
+            Environment variable mode. Use "loose" to pass the entire existing environment. Use "strict" to use an allowlist specified in turbo.json. Use "infer" to defer to existence of "passThroughEnv" or "globalPassThroughEnv" in turbo.json. (default infer) [default: infer] [possible values: infer, loose, strict]
+        --ignore <IGNORE>
+            Files to ignore when calculating changed files (i.e. --since). Supports globs
+        --include-dependencies
+            Include the dependencies of tasks in execution
+        --no-cache
+            Avoid saving task results to the cache. Useful for development/watch tasks
+        --no-daemon
+            Run without using turbo's daemon process
+        --no-deps
+            Exclude dependent task consumers from execution
+        --output-logs <OUTPUT_LOGS>
+            Set type of process output logging. Use "full" to show all output. Use "hash-only" to show only turbo-computed task hashes. Use "new-only" to show only new output with only hashes for cached tasks. Use "none" to hide process output. (default full) [possible values: full, none, hash-only, new-only, errors-only]
+        --log-order <LOG_ORDER>
+            Set type of task output order. Use "stream" to show output as soon as it is available. Use "grouped" to show output when a command has finished execution. Use "auto" to let turbo decide based on its own heuristics. (default auto) [env: TURBO_LOG_ORDER=] [default: auto] [possible values: auto, stream, grouped]
+        --only
+            Only executes the tasks specified, does not execute parent tasks
+        --parallel
+            Execute all tasks in parallel
+        --profile <PROFILE>
+            File to write turbo's performance profile output into. You can load the file up in chrome://tracing to see which parts of your build were slow
+        --remote-only [<BOOL>]
+            Ignore the local filesystem cache for all tasks. Only allow reading and caching artifacts using the remote cache [env: TURBO_REMOTE_ONLY=] [default: false] [possible values: true, false]
+        --remote-cache-read-only [<BOOL>]
+            Treat remote cache as read only [env: TURBO_REMOTE_CACHE_READ_ONLY=] [default: false] [possible values: true, false]
+        --scope <SCOPE>
+            Specify package(s) to act as entry points for task execution. Supports globs
+        --since <SINCE>
+            Limit/Set scope to changed packages since a mergebase. This uses the git diff ${target_branch}... mechanism to identify which packages have changed
+        --summarize [<SUMMARIZE>]
+            Generate a summary of the turbo run [env: TURBO_RUN_SUMMARY=] [possible values: true, false]
+        --log-prefix <LOG_PREFIX>
+            Use "none" to remove prefixes from task logs. Use "task" to get task id prefixing. Use "auto" to let turbo decide how to prefix the logs based on the execution environment. In most cases this will be the same as "task". Note that tasks running in parallel interleave their logs, so removing prefixes can make it difficult to associate logs with tasks. Use --log-order=grouped to prevent interleaving. (default auto) [default: auto] [possible values: auto, none, task]
   [1]
 
   $ ${TURBO} run

--- a/turborepo-tests/integration/tests/turbo-help.t
+++ b/turborepo-tests/integration/tests/turbo-help.t
@@ -40,33 +40,62 @@ Test help flag
     -h, --help                            Print help
   
   Run Arguments:
-        --cache-dir <CACHE_DIR>          Override the filesystem cache directory
-        --cache-workers <CACHE_WORKERS>  Set the number of concurrent cache operations (default 10) [default: 10]
-        --concurrency <CONCURRENCY>      Limit the concurrency of task execution. Use 1 for serial (i.e. one-at-a-time) execution
-        --continue                       Continue execution even if a task exits with an error or non-zero exit code. The default behavior is to bail
-        --dry-run [<DRY_RUN>]            [possible values: text, json]
-        --single-package                 Run turbo in single-package mode
-    -F, --filter <FILTER>                Use the given selector to specify package(s) to act as entry points. The syntax mirrors pnpm's syntax, and additional documentation and examples can be found in turbo's documentation https://turbo.build/repo/docs/reference/command-line-reference/run#--filter
-        --force [<FORCE>]                Ignore the existing cache (to force execution) [env: TURBO_FORCE=] [possible values: true, false]
-        --framework-inference [<BOOL>]   Specify whether or not to do framework inference for tasks [default: true] [possible values: true, false]
-        --global-deps <GLOBAL_DEPS>      Specify glob of global filesystem dependencies to be hashed. Useful for .env and files
-        --graph [<GRAPH>]                Generate a graph of the task execution and output to a file when a filename is specified (.svg, .png, .jpg, .pdf, .json, .html). Outputs dot graph to stdout when if no filename is provided
-        --env-mode [<ENV_MODE>]          Environment variable mode. Use "loose" to pass the entire existing environment. Use "strict" to use an allowlist specified in turbo.json. Use "infer" to defer to existence of "passThroughEnv" or "globalPassThroughEnv" in turbo.json. (default infer) [default: infer] [possible values: infer, loose, strict]
-        --ignore <IGNORE>                Files to ignore when calculating changed files (i.e. --since). Supports globs
-        --include-dependencies           Include the dependencies of tasks in execution
-        --no-cache                       Avoid saving task results to the cache. Useful for development/watch tasks
-        --no-daemon                      Run without using turbo's daemon process
-        --no-deps                        Exclude dependent task consumers from execution
-        --output-logs <OUTPUT_LOGS>      Set type of process output logging. Use "full" to show all output. Use "hash-only" to show only turbo-computed task hashes. Use "new-only" to show only new output with only hashes for cached tasks. Use "none" to hide process output. (default full) [possible values: full, none, hash-only, new-only, errors-only]
-        --log-order <LOG_ORDER>          Set type of task output order. Use "stream" to show output as soon as it is available. Use "grouped" to show output when a command has finished execution. Use "auto" to let turbo decide based on its own heuristics. (default auto) [env: TURBO_LOG_ORDER=] [default: auto] [possible values: auto, stream, grouped]
-        --only                           Only executes the tasks specified, does not execute parent tasks
-        --parallel                       Execute all tasks in parallel
-        --profile <PROFILE>              File to write turbo's performance profile output into. You can load the file up in chrome://tracing to see which parts of your build were slow
-        --remote-only [<BOOL>]           Ignore the local filesystem cache for all tasks. Only allow reading and caching artifacts using the remote cache [env: TURBO_REMOTE_ONLY=] [default: false] [possible values: true, false]
-        --scope <SCOPE>                  Specify package(s) to act as entry points for task execution. Supports globs
-        --since <SINCE>                  Limit/Set scope to changed packages since a mergebase. This uses the git diff ${target_branch}... mechanism to identify which packages have changed
-        --summarize [<SUMMARIZE>]        Generate a summary of the turbo run [env: TURBO_RUN_SUMMARY=] [possible values: true, false]
-        --log-prefix <LOG_PREFIX>        Use "none" to remove prefixes from task logs. Use "task" to get task id prefixing. Use "auto" to let turbo decide how to prefix the logs based on the execution environment. In most cases this will be the same as "task". Note that tasks running in parallel interleave their logs, so removing prefixes can make it difficult to associate logs with tasks. Use --log-order=grouped to prevent interleaving. (default auto) [default: auto] [possible values: auto, none, task]
+        --cache-dir <CACHE_DIR>
+            Override the filesystem cache directory
+        --cache-workers <CACHE_WORKERS>
+            Set the number of concurrent cache operations (default 10) [default: 10]
+        --concurrency <CONCURRENCY>
+            Limit the concurrency of task execution. Use 1 for serial (i.e. one-at-a-time) execution
+        --continue
+            Continue execution even if a task exits with an error or non-zero exit code. The default behavior is to bail
+        --dry-run [<DRY_RUN>]
+            [possible values: text, json]
+        --single-package
+            Run turbo in single-package mode
+    -F, --filter <FILTER>
+            Use the given selector to specify package(s) to act as entry points. The syntax mirrors pnpm's syntax, and additional documentation and examples can be found in turbo's documentation https://turbo.build/repo/docs/reference/command-line-reference/run#--filter
+        --force [<FORCE>]
+            Ignore the existing cache (to force execution) [env: TURBO_FORCE=] [possible values: true, false]
+        --framework-inference [<BOOL>]
+            Specify whether or not to do framework inference for tasks [default: true] [possible values: true, false]
+        --global-deps <GLOBAL_DEPS>
+            Specify glob of global filesystem dependencies to be hashed. Useful for .env and files
+        --graph [<GRAPH>]
+            Generate a graph of the task execution and output to a file when a filename is specified (.svg, .png, .jpg, .pdf, .json, .html). Outputs dot graph to stdout when if no filename is provided
+        --env-mode [<ENV_MODE>]
+            Environment variable mode. Use "loose" to pass the entire existing environment. Use "strict" to use an allowlist specified in turbo.json. Use "infer" to defer to existence of "passThroughEnv" or "globalPassThroughEnv" in turbo.json. (default infer) [default: infer] [possible values: infer, loose, strict]
+        --ignore <IGNORE>
+            Files to ignore when calculating changed files (i.e. --since). Supports globs
+        --include-dependencies
+            Include the dependencies of tasks in execution
+        --no-cache
+            Avoid saving task results to the cache. Useful for development/watch tasks
+        --no-daemon
+            Run without using turbo's daemon process
+        --no-deps
+            Exclude dependent task consumers from execution
+        --output-logs <OUTPUT_LOGS>
+            Set type of process output logging. Use "full" to show all output. Use "hash-only" to show only turbo-computed task hashes. Use "new-only" to show only new output with only hashes for cached tasks. Use "none" to hide process output. (default full) [possible values: full, none, hash-only, new-only, errors-only]
+        --log-order <LOG_ORDER>
+            Set type of task output order. Use "stream" to show output as soon as it is available. Use "grouped" to show output when a command has finished execution. Use "auto" to let turbo decide based on its own heuristics. (default auto) [env: TURBO_LOG_ORDER=] [default: auto] [possible values: auto, stream, grouped]
+        --only
+            Only executes the tasks specified, does not execute parent tasks
+        --parallel
+            Execute all tasks in parallel
+        --profile <PROFILE>
+            File to write turbo's performance profile output into. You can load the file up in chrome://tracing to see which parts of your build were slow
+        --remote-only [<BOOL>]
+            Ignore the local filesystem cache for all tasks. Only allow reading and caching artifacts using the remote cache [env: TURBO_REMOTE_ONLY=] [default: false] [possible values: true, false]
+        --remote-cache-read-only [<BOOL>]
+            Treat remote cache as read only [env: TURBO_REMOTE_CACHE_READ_ONLY=] [default: false] [possible values: true, false]
+        --scope <SCOPE>
+            Specify package(s) to act as entry points for task execution. Supports globs
+        --since <SINCE>
+            Limit/Set scope to changed packages since a mergebase. This uses the git diff ${target_branch}... mechanism to identify which packages have changed
+        --summarize [<SUMMARIZE>]
+            Generate a summary of the turbo run [env: TURBO_RUN_SUMMARY=] [possible values: true, false]
+        --log-prefix <LOG_PREFIX>
+            Use "none" to remove prefixes from task logs. Use "task" to get task id prefixing. Use "auto" to let turbo decide how to prefix the logs based on the execution environment. In most cases this will be the same as "task". Note that tasks running in parallel interleave their logs, so removing prefixes can make it difficult to associate logs with tasks. Use --log-order=grouped to prevent interleaving. (default auto) [default: auto] [possible values: auto, none, task]
 
 
 
@@ -111,33 +140,62 @@ Test help flag
     -h, --help                            Print help
   
   Run Arguments:
-        --cache-dir <CACHE_DIR>          Override the filesystem cache directory
-        --cache-workers <CACHE_WORKERS>  Set the number of concurrent cache operations (default 10) [default: 10]
-        --concurrency <CONCURRENCY>      Limit the concurrency of task execution. Use 1 for serial (i.e. one-at-a-time) execution
-        --continue                       Continue execution even if a task exits with an error or non-zero exit code. The default behavior is to bail
-        --dry-run [<DRY_RUN>]            [possible values: text, json]
-        --single-package                 Run turbo in single-package mode
-    -F, --filter <FILTER>                Use the given selector to specify package(s) to act as entry points. The syntax mirrors pnpm's syntax, and additional documentation and examples can be found in turbo's documentation https://turbo.build/repo/docs/reference/command-line-reference/run#--filter
-        --force [<FORCE>]                Ignore the existing cache (to force execution) [env: TURBO_FORCE=] [possible values: true, false]
-        --framework-inference [<BOOL>]   Specify whether or not to do framework inference for tasks [default: true] [possible values: true, false]
-        --global-deps <GLOBAL_DEPS>      Specify glob of global filesystem dependencies to be hashed. Useful for .env and files
-        --graph [<GRAPH>]                Generate a graph of the task execution and output to a file when a filename is specified (.svg, .png, .jpg, .pdf, .json, .html). Outputs dot graph to stdout when if no filename is provided
-        --env-mode [<ENV_MODE>]          Environment variable mode. Use "loose" to pass the entire existing environment. Use "strict" to use an allowlist specified in turbo.json. Use "infer" to defer to existence of "passThroughEnv" or "globalPassThroughEnv" in turbo.json. (default infer) [default: infer] [possible values: infer, loose, strict]
-        --ignore <IGNORE>                Files to ignore when calculating changed files (i.e. --since). Supports globs
-        --include-dependencies           Include the dependencies of tasks in execution
-        --no-cache                       Avoid saving task results to the cache. Useful for development/watch tasks
-        --no-daemon                      Run without using turbo's daemon process
-        --no-deps                        Exclude dependent task consumers from execution
-        --output-logs <OUTPUT_LOGS>      Set type of process output logging. Use "full" to show all output. Use "hash-only" to show only turbo-computed task hashes. Use "new-only" to show only new output with only hashes for cached tasks. Use "none" to hide process output. (default full) [possible values: full, none, hash-only, new-only, errors-only]
-        --log-order <LOG_ORDER>          Set type of task output order. Use "stream" to show output as soon as it is available. Use "grouped" to show output when a command has finished execution. Use "auto" to let turbo decide based on its own heuristics. (default auto) [env: TURBO_LOG_ORDER=] [default: auto] [possible values: auto, stream, grouped]
-        --only                           Only executes the tasks specified, does not execute parent tasks
-        --parallel                       Execute all tasks in parallel
-        --profile <PROFILE>              File to write turbo's performance profile output into. You can load the file up in chrome://tracing to see which parts of your build were slow
-        --remote-only [<BOOL>]           Ignore the local filesystem cache for all tasks. Only allow reading and caching artifacts using the remote cache [env: TURBO_REMOTE_ONLY=] [default: false] [possible values: true, false]
-        --scope <SCOPE>                  Specify package(s) to act as entry points for task execution. Supports globs
-        --since <SINCE>                  Limit/Set scope to changed packages since a mergebase. This uses the git diff ${target_branch}... mechanism to identify which packages have changed
-        --summarize [<SUMMARIZE>]        Generate a summary of the turbo run [env: TURBO_RUN_SUMMARY=] [possible values: true, false]
-        --log-prefix <LOG_PREFIX>        Use "none" to remove prefixes from task logs. Use "task" to get task id prefixing. Use "auto" to let turbo decide how to prefix the logs based on the execution environment. In most cases this will be the same as "task". Note that tasks running in parallel interleave their logs, so removing prefixes can make it difficult to associate logs with tasks. Use --log-order=grouped to prevent interleaving. (default auto) [default: auto] [possible values: auto, none, task]
+        --cache-dir <CACHE_DIR>
+            Override the filesystem cache directory
+        --cache-workers <CACHE_WORKERS>
+            Set the number of concurrent cache operations (default 10) [default: 10]
+        --concurrency <CONCURRENCY>
+            Limit the concurrency of task execution. Use 1 for serial (i.e. one-at-a-time) execution
+        --continue
+            Continue execution even if a task exits with an error or non-zero exit code. The default behavior is to bail
+        --dry-run [<DRY_RUN>]
+            [possible values: text, json]
+        --single-package
+            Run turbo in single-package mode
+    -F, --filter <FILTER>
+            Use the given selector to specify package(s) to act as entry points. The syntax mirrors pnpm's syntax, and additional documentation and examples can be found in turbo's documentation https://turbo.build/repo/docs/reference/command-line-reference/run#--filter
+        --force [<FORCE>]
+            Ignore the existing cache (to force execution) [env: TURBO_FORCE=] [possible values: true, false]
+        --framework-inference [<BOOL>]
+            Specify whether or not to do framework inference for tasks [default: true] [possible values: true, false]
+        --global-deps <GLOBAL_DEPS>
+            Specify glob of global filesystem dependencies to be hashed. Useful for .env and files
+        --graph [<GRAPH>]
+            Generate a graph of the task execution and output to a file when a filename is specified (.svg, .png, .jpg, .pdf, .json, .html). Outputs dot graph to stdout when if no filename is provided
+        --env-mode [<ENV_MODE>]
+            Environment variable mode. Use "loose" to pass the entire existing environment. Use "strict" to use an allowlist specified in turbo.json. Use "infer" to defer to existence of "passThroughEnv" or "globalPassThroughEnv" in turbo.json. (default infer) [default: infer] [possible values: infer, loose, strict]
+        --ignore <IGNORE>
+            Files to ignore when calculating changed files (i.e. --since). Supports globs
+        --include-dependencies
+            Include the dependencies of tasks in execution
+        --no-cache
+            Avoid saving task results to the cache. Useful for development/watch tasks
+        --no-daemon
+            Run without using turbo's daemon process
+        --no-deps
+            Exclude dependent task consumers from execution
+        --output-logs <OUTPUT_LOGS>
+            Set type of process output logging. Use "full" to show all output. Use "hash-only" to show only turbo-computed task hashes. Use "new-only" to show only new output with only hashes for cached tasks. Use "none" to hide process output. (default full) [possible values: full, none, hash-only, new-only, errors-only]
+        --log-order <LOG_ORDER>
+            Set type of task output order. Use "stream" to show output as soon as it is available. Use "grouped" to show output when a command has finished execution. Use "auto" to let turbo decide based on its own heuristics. (default auto) [env: TURBO_LOG_ORDER=] [default: auto] [possible values: auto, stream, grouped]
+        --only
+            Only executes the tasks specified, does not execute parent tasks
+        --parallel
+            Execute all tasks in parallel
+        --profile <PROFILE>
+            File to write turbo's performance profile output into. You can load the file up in chrome://tracing to see which parts of your build were slow
+        --remote-only [<BOOL>]
+            Ignore the local filesystem cache for all tasks. Only allow reading and caching artifacts using the remote cache [env: TURBO_REMOTE_ONLY=] [default: false] [possible values: true, false]
+        --remote-cache-read-only [<BOOL>]
+            Treat remote cache as read only [env: TURBO_REMOTE_CACHE_READ_ONLY=] [default: false] [possible values: true, false]
+        --scope <SCOPE>
+            Specify package(s) to act as entry points for task execution. Supports globs
+        --since <SINCE>
+            Limit/Set scope to changed packages since a mergebase. This uses the git diff ${target_branch}... mechanism to identify which packages have changed
+        --summarize [<SUMMARIZE>]
+            Generate a summary of the turbo run [env: TURBO_RUN_SUMMARY=] [possible values: true, false]
+        --log-prefix <LOG_PREFIX>
+            Use "none" to remove prefixes from task logs. Use "task" to get task id prefixing. Use "auto" to let turbo decide how to prefix the logs based on the execution environment. In most cases this will be the same as "task". Note that tasks running in parallel interleave their logs, so removing prefixes can make it difficult to associate logs with tasks. Use --log-order=grouped to prevent interleaving. (default auto) [default: auto] [possible values: auto, none, task]
 
 Test help flag for link command
   $ ${TURBO} link -h


### PR DESCRIPTION
### Description

Forking the existing PR of #6326 to see if this helps CI along. See that PR for more detail.

### Testing Instructions

Manual testing:
```
[0 olszewski@chriss-mbp] /Users/olszewski/code/vercel/turborepo $ turbo_dev build --filter=docs --remote-cache-read-only --force
• Packages in scope: docs
• Running build in 1 packages
• Remote caching enabled
docs:rss: cache bypass, force executing 73afc3e91d179e7d
docs:schema: cache bypass, force executing 1783946761b14ceb
@turbo/workspaces:build: cache bypass, force executing a31c222598c45c9a
docs:schema:  WARN  Unsupported engine: wanted: {"node":"20.x"} (current: {"node":"v16.18.1","pnpm":"8.9.0"})
@turbo/workspaces:build:
@turbo/workspaces:build: > @turbo/workspaces@1.10.17-canary.6 build /Users/olszewski/code/vercel/turborepo/packages/turbo-workspaces
@turbo/workspaces:build: > tsup
@turbo/workspaces:build:
docs:rss:  WARN  Unsupported engine: wanted: {"node":"20.x"} (current: {"node":"v16.18.1","pnpm":"8.9.0"})
docs:schema:
docs:schema: > docs@1.0.0 schema /Users/olszewski/code/vercel/turborepo/docs
docs:schema: > turbo-types-generate ./public/schema.json
docs:schema:
docs:rss:
docs:rss: > docs@1.0.0 rss /Users/olszewski/code/vercel/turborepo/docs
docs:rss: > node scripts/generate-rss.js
docs:rss:
 WARNING  Remote cache is read-only, skipping upload
...
```
The warning is only printed once. Without the `--remote-cache-read-only` flag the cache is written to as expected.