### PR TITLE
chore: use parent() method instead of .. directory traversal

### DIFF
--- a/crates/turborepo-lib/src/shim.rs
+++ b/crates/turborepo-lib/src/shim.rs
@@ -347,7 +347,7 @@ impl LocalTurboState {
         let canonical_path =
             fs_canonicalize(root_path.as_path().join("node_modules").join("turbo")).ok()?;
 
-        AbsoluteSystemPathBuf::try_from(canonical_path.join("..")).ok()
+        AbsoluteSystemPathBuf::try_from(canonical_path.parent()?).ok()
     }
 
     // The unplugged directory doesn't have a fixed path.


### PR DESCRIPTION
more readable, if tests pass, we'll keep this one

Closes TURBO-1794