### PR TITLE
chore: update lockfile after workspace deletion

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -324,18 +324,6 @@ importers:
         specifier: workspace:*
         version: link:../../turborepo-tests/helpers
 
-  examples-tests/npm-with-yarn:
-    dependencies:
-      '@turborepo-examples-tests/helpers':
-        specifier: workspace:*
-        version: link:../helpers
-      turborepo-examples:
-        specifier: workspace:*
-        version: link:../../examples
-      turborepo-tests-helpers:
-        specifier: workspace:*
-        version: link:../../turborepo-tests/helpers
-
   examples-tests/pnpm-basic:
     dependencies:
       '@turborepo-examples-tests/helpers':
@@ -385,18 +373,6 @@ importers:
         version: link:../../turborepo-tests/helpers
 
   examples-tests/yarn-non-monorepo:
-    dependencies:
-      '@turborepo-examples-tests/helpers':
-        specifier: workspace:*
-        version: link:../helpers
-      turborepo-examples:
-        specifier: workspace:*
-        version: link:../../examples
-      turborepo-tests-helpers:
-        specifier: workspace:*
-        version: link:../../turborepo-tests/helpers
-
-  examples-tests/yarn-with-npm:
     dependencies:
       '@turborepo-examples-tests/helpers':
         specifier: workspace:*


### PR DESCRIPTION
Follow up to https://github.com/vercel/turbo/pull/6632. A couple workspaces were deleted, but we need a `pnpm install` to get them out of the lockfile

Closes TURBO-1796