### PR TITLE
Updating pnpm flags in example tests.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -455,7 +455,7 @@ jobs:
         # Note: using CLI flags instead of env vars because
         # envs var would apply to the actual tests that exercise turbo also,
         # making test output non-deterministic.
-        run: turbo run test -F "@turborepo-examples-tests/*" --color --remote-only --token=${{ secrets.TURBO_TOKEN }} --team=${{ vars.TURBO_TEAM }} --env-mode=strict
+        run: turbo run test -F "@turborepo-examples-tests/*" --continue --color --remote-only --token=${{ secrets.TURBO_TOKEN }} --team=${{ vars.TURBO_TEAM }} --env-mode=strict
         env:
           EXPERIMENTAL_RUST_CODEPATH: true
 

--- a/turborepo-tests/example-pnpm-basic/test.t
+++ b/turborepo-tests/example-pnpm-basic/test.t
@@ -1,7 +1,7 @@
   $ . ${TESTDIR}/../helpers/examples_setup.sh basic pnpm
 
 # run twice and make sure it works
-  $ pnpm run build lint -- --output-logs=errors-only
+  $ pnpm run build lint --output-logs=errors-only
   
   \> my-turborepo@ build (.*)/test.t (re)
   \> turbo build "lint" "--output-logs=errors-only" (re)
@@ -14,7 +14,7 @@
   Cached:    0 cached, 5 total
     Time:\s*[\.0-9ms]+  (re)
   
-  $ pnpm run build lint -- --output-logs=errors-only
+  $ pnpm run build lint --output-logs=errors-only
   
   \> my-turborepo@ build (.*)/test.t (re)
   \> turbo build "lint" "--output-logs=errors-only" (re)

--- a/turborepo-tests/example-pnpm-gatsby/test.t
+++ b/turborepo-tests/example-pnpm-gatsby/test.t
@@ -1,7 +1,7 @@
   $ . ${TESTDIR}/../helpers/examples_setup.sh with-gatsby pnpm
 
 # run twice and make sure it works
-  $ pnpm run build lint -- --output-logs=errors-only
+  $ pnpm run build lint --output-logs=errors-only
   
   \> with-gatsby@0.0.0 build (.*)/test.t (re)
   \> turbo build "lint" "--output-logs=errors-only" (re)
@@ -15,7 +15,7 @@
     Time:\s*[\.0-9ms]+  (re)
   
 
-  $ pnpm run build lint -- --output-logs=errors-only
+  $ pnpm run build lint --output-logs=errors-only
   
   \> with-gatsby@0.0.0 build (.*)/test.t (re)
   \> turbo build "lint" "--output-logs=errors-only" (re)

--- a/turborepo-tests/example-pnpm-kitchen-sink/test.t
+++ b/turborepo-tests/example-pnpm-kitchen-sink/test.t
@@ -1,7 +1,7 @@
   $ . ${TESTDIR}/../helpers/examples_setup.sh kitchen-sink pnpm
 
 # run twice and make sure it works
-  $ pnpm run build lint -- --output-logs=errors-only
+  $ pnpm run build lint --output-logs=errors-only
   
   \> @ build (.*)/test.t (re)
   \> turbo build "lint" "--output-logs=errors-only" (re)
@@ -14,7 +14,7 @@
   Cached:    0 cached, 12 total
     Time:\s*[\.0-9ms]+  (re)
   
-  $ pnpm run build lint -- --output-logs=errors-only
+  $ pnpm run build lint --output-logs=errors-only
   
   \> @ build (.*)/test.t (re)
   \> turbo build "lint" "--output-logs=errors-only" (re)

--- a/turborepo-tests/example-pnpm-with-svelte/test.t
+++ b/turborepo-tests/example-pnpm-with-svelte/test.t
@@ -1,7 +1,7 @@
   $ . ${TESTDIR}/../helpers/examples_setup.sh with-svelte pnpm
 
 # run twice and make sure it works
-  $ pnpm run build lint -- --output-logs=errors-only
+  $ pnpm run build lint --output-logs=errors-only
   
   \> @ build (.*)/test.t (re)
   \> turbo run build "lint" "--output-logs=errors-only" (re)
@@ -14,7 +14,7 @@
   Cached:    0 cached, 5 total
     Time:\s*[\.0-9ms]+  (re)
   
-  $ pnpm run build lint -- --output-logs=errors-only
+  $ pnpm run build lint --output-logs=errors-only
   
   \> @ build (.*)/test.t (re)
   \> turbo run build "lint" "--output-logs=errors-only" (re)


### PR DESCRIPTION
We're no longer locking to pnpm@6 in our example tests. Instead they are using, the version in the example itself.

Our examples are on pnpm@8. It looks like the pass-through flagging for `pnpm run` has changed.