### PR TITLE
fix(docs): improve landing page titles

### DIFF
--- a/docs/theme.config.tsx
+++ b/docs/theme.config.tsx
@@ -27,12 +27,24 @@ const config: DocsThemeConfig = {
       section = "Turborepo";
     }
 
+    // only show section if we're not on a landing page (these show as "Index")
+    let titleTemplate = `%s – ${section}`;
+    if (router?.pathname === "/repo") {
+      titleTemplate = `Turborepo`;
+    }
+    if (router?.pathname === "/pack") {
+      titleTemplate = `Turbopack`;
+    }
+    if (router?.pathname === "/") {
+      titleTemplate = `Turbo`;
+    }
+
     const defaultTitle = frontMatter.overrideTitle || section;
 
     return {
       description: frontMatter.description,
       defaultTitle,
-      titleTemplate: `%s – ${section}`,
+      titleTemplate,
     };
   },
   gitTimestamp({ timestamp }) {


### PR DESCRIPTION
### Description

1. `/` goes from `Index - Turbo` to `Turbo`
1. `/repo` goes from `Index - Turborepo` to `Turborepo` 
1. `/pack` goes from `Index - Turbopack` to `Turbopack`

All others remain the same





Closes TURBO-1815