### PR TITLE
Revert "chore: reduce sleep length in test cases (#6640)"

### DIFF
--- a/turborepo-tests/integration/tests/_fixtures/ordered/apps/my-app/package.json
+++ b/turborepo-tests/integration/tests/_fixtures/ordered/apps/my-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "my-app",
   "scripts": {
-    "build": "echo building && sleep 0.5 && echo done"
+    "build": "echo building && sleep 1 && echo done"
   },
   "dependencies": {
     "util": "*"

--- a/turborepo-tests/integration/tests/_fixtures/ordered/packages/util/package.json
+++ b/turborepo-tests/integration/tests/_fixtures/ordered/packages/util/package.json
@@ -1,7 +1,7 @@
 {
   "name": "util",
   "scripts": {
-    "build": "sleep 0.1 && echo building && sleep 0.5 && echo completed",
+    "build": "sleep 0.5 && echo building && sleep 1 && echo completed",
     "fail": "echo failing; exit 1"
   }
 }

--- a/turborepo-tests/integration/tests/run-logging/log-order-github.t
+++ b/turborepo-tests/integration/tests/run-logging/log-order-github.t
@@ -10,19 +10,19 @@ because otherwise prysk interprets them as multiline commands
   \xe2\x80\xa2 Running build in 2 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
   ::group::my-app:build
-  cache bypass, force executing a47fc4626be5a730
+  cache bypass, force executing c1d33a8183d8cf0b
   
-  \>\sbuild (re)
-  \>\secho building && sleep 0.5 && echo done (re)
+  >\sbuild (re)
+  \>\secho building && sleep 1 && echo done (re)
   
   building
   done
   ::endgroup::
   ::group::util:build
-  cache bypass, force executing 3f2fdfad6dfa4b39
+  cache bypass, force executing ff1050c513839636
   
   >\sbuild (re)
-  \>\ssleep 0.1 && echo building && sleep 0.5 && echo completed (re)
+  \>\ssleep 0.5 && echo building && sleep 1 && echo completed (re)
   
   building
   completed
@@ -38,10 +38,10 @@ because otherwise prysk interprets them as multiline commands
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
   ::group::util:build
-  util:build: cache bypass, force executing 3f2fdfad6dfa4b39
+  util:build: cache bypass, force executing ff1050c513839636
   util:build: 
   util:build: > build
-  util:build: > sleep 0.1 && echo building && sleep 0.5 && echo completed
+  util:build: > sleep 0.5 && echo building && sleep 1 && echo completed
   util:build: 
   util:build: building
   util:build: completed
@@ -58,7 +58,7 @@ Verify that errors are grouped properly
   \xe2\x80\xa2 Running fail in 2 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
   ::group::util:fail
-  cache miss, executing fbc22a50b10b6729
+  cache miss, executing 122cca10fdcda4f0
   
   \> fail (re)
   \> echo failing; exit 1 (re)

--- a/turborepo-tests/integration/tests/run-logging/log-order-grouped.t
+++ b/turborepo-tests/integration/tests/run-logging/log-order-grouped.t
@@ -7,17 +7,17 @@
   \xe2\x80\xa2 Packages in scope: my-app, util (esc)
   \xe2\x80\xa2 Running build in 2 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache bypass, force executing a47fc4626be5a730
+  my-app:build: cache bypass, force executing [0-9a-f]+ (re)
   my-app:build: 
   my-app:build: > build
-  my-app:build: > echo building && sleep 0.5 && echo done
+  my-app:build: > echo building && sleep 1 && echo done
   my-app:build: 
   my-app:build: building
   my-app:build: done
-  util:build: cache bypass, force executing 3f2fdfad6dfa4b39
+  util:build: cache bypass, force executing [0-9a-f]+ (re)
   util:build: 
   util:build: > build
-  util:build: > sleep 0.1 && echo building && sleep 0.5 && echo completed
+  util:build: > sleep 0.5 && echo building && sleep 1 && echo completed
   util:build: 
   util:build: building
   util:build: completed
@@ -32,17 +32,17 @@
   \xe2\x80\xa2 Packages in scope: my-app, util (esc)
   \xe2\x80\xa2 Running build in 2 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache bypass, force executing a47fc4626be5a730
+  my-app:build: cache bypass, force executing [0-9a-f]+ (re)
   my-app:build: 
   my-app:build: > build
-  my-app:build: > echo building && sleep 0.5 && echo done
+  my-app:build: > echo building && sleep 1 && echo done
   my-app:build: 
   my-app:build: building
   my-app:build: done
-  util:build: cache bypass, force executing 3f2fdfad6dfa4b39
+  util:build: cache bypass, force executing [0-9a-f]+ (re)
   util:build: 
   util:build: > build
-  util:build: > sleep 0.1 && echo building && sleep 0.5 && echo completed
+  util:build: > sleep 0.5 && echo building && sleep 1 && echo completed
   util:build: 
   util:build: building
   util:build: completed
@@ -56,17 +56,17 @@
   \xe2\x80\xa2 Packages in scope: my-app, util (esc)
   \xe2\x80\xa2 Running build in 2 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache bypass, force executing a47fc4626be5a730
+  my-app:build: cache bypass, force executing [0-9a-f]+ (re)
   my-app:build: 
   my-app:build: > build
-  my-app:build: > echo building && sleep 0.5 && echo done
+  my-app:build: > echo building && sleep 1 && echo done
   my-app:build: 
   my-app:build: building
   my-app:build: done
-  util:build: cache bypass, force executing 3f2fdfad6dfa4b39
+  util:build: cache bypass, force executing [0-9a-f]+ (re)
   util:build: 
   util:build: > build
-  util:build: > sleep 0.1 && echo building && sleep 0.5 && echo completed
+  util:build: > sleep 0.5 && echo building && sleep 1 && echo completed
   util:build: 
   util:build: building
   util:build: completed


### PR DESCRIPTION
This reverts commit 4b07f76c19ff607bed0e85aa0c7cbc2a36d67620.

### Description

I think we're flying a little too close to the sun with this one: https://github.com/vercel/turbo/actions/runs/7052873305/job/19199324958?pr=6649#step:7:721

I think the extra <1s when running this test is worth reducing the flakiness.

### Testing Instructions

👀 


Closes TURBO-1821