### PR TITLE
Mix of server and client components in basic example.

### DIFF
--- a/examples/basic/apps/docs/app/page.module.css
+++ b/examples/basic/apps/docs/app/page.module.css
@@ -312,10 +312,7 @@
   color: #000000;
   cursor: pointer;
   display: inline-block;
-  font-family: "Haas Grot Text R Web", "Helvetica Neue", Helvetica, Arial,
-    sans-serif;
-  font-size: 14px;
-  font-weight: 500;
+  font-size: 16px;
   height: 40px;
   line-height: 20px;
   list-style: none;

--- a/examples/basic/apps/docs/app/page.module.css
+++ b/examples/basic/apps/docs/app/page.module.css
@@ -214,6 +214,7 @@
   position: absolute;
   min-width: 614px;
   min-height: 614px;
+  pointer-events: none;
 }
 
 .logo {
@@ -275,6 +276,7 @@
   position: absolute;
   mix-blend-mode: normal;
   will-change: filter;
+  pointer-events: none;
 }
 
 .gradientSmall {
@@ -300,4 +302,37 @@
   width: 1000px;
   height: 1000px;
   opacity: 0.15;
+}
+
+.button {
+  background-color: #ffffff;
+  border-radius: 8px;
+  border-style: none;
+  box-sizing: border-box;
+  color: #000000;
+  cursor: pointer;
+  display: inline-block;
+  font-family: "Haas Grot Text R Web", "Helvetica Neue", Helvetica, Arial,
+    sans-serif;
+  font-size: 14px;
+  font-weight: 500;
+  height: 40px;
+  line-height: 20px;
+  list-style: none;
+  margin: 0;
+  outline: none;
+  padding: 10px 16px;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  transition: color 100ms;
+  vertical-align: baseline;
+  user-select: none;
+  -webkit-user-select: none;
+  touch-action: manipulation;
+}
+
+.button:hover,
+.button:focus {
+  background-color: #e5e4e2;
 }

--- a/examples/basic/apps/docs/app/page.tsx
+++ b/examples/basic/apps/docs/app/page.tsx
@@ -2,6 +2,7 @@ import Image from "next/image";
 import { Card } from "@repo/ui/card";
 import { Code } from "@repo/ui/code";
 import styles from "./page.module.css";
+import { Button } from "@repo/ui/button";
 
 function Gradient({
   conic,
@@ -77,6 +78,10 @@ export default function Page(): JSX.Element {
         </div>
       </div>
 
+      <Button appName="web" className={styles.button}>
+        Click me!
+      </Button>
+
       <div className={styles.hero}>
         <div className={styles.heroContent}>
           <div className={styles.logos}>
@@ -86,6 +91,7 @@ export default function Page(): JSX.Element {
                 height={614}
                 src="circles.svg"
                 width={614}
+                style={{ pointerEvents: "none" }}
               />
             </div>
             <div className={styles.logoGradientContainer}>
@@ -99,6 +105,7 @@ export default function Page(): JSX.Element {
                 priority
                 src="turborepo.svg"
                 width={120}
+                style={{ pointerEvents: "none" }}
               />
             </div>
           </div>

--- a/examples/basic/apps/web/app/page.module.css
+++ b/examples/basic/apps/web/app/page.module.css
@@ -312,10 +312,7 @@
   color: #000000;
   cursor: pointer;
   display: inline-block;
-  font-family: "Haas Grot Text R Web", "Helvetica Neue", Helvetica, Arial,
-    sans-serif;
-  font-size: 14px;
-  font-weight: 500;
+  font-size: 16px;
   height: 40px;
   line-height: 20px;
   list-style: none;

--- a/examples/basic/apps/web/app/page.module.css
+++ b/examples/basic/apps/web/app/page.module.css
@@ -214,6 +214,7 @@
   position: absolute;
   min-width: 614px;
   min-height: 614px;
+  pointer-events: none;
 }
 
 .logo {
@@ -275,6 +276,7 @@
   position: absolute;
   mix-blend-mode: normal;
   will-change: filter;
+  pointer-events: none;
 }
 
 .gradientSmall {
@@ -300,4 +302,37 @@
   width: 1000px;
   height: 1000px;
   opacity: 0.15;
+}
+
+.button {
+  background-color: #ffffff;
+  border-radius: 8px;
+  border-style: none;
+  box-sizing: border-box;
+  color: #000000;
+  cursor: pointer;
+  display: inline-block;
+  font-family: "Haas Grot Text R Web", "Helvetica Neue", Helvetica, Arial,
+    sans-serif;
+  font-size: 14px;
+  font-weight: 500;
+  height: 40px;
+  line-height: 20px;
+  list-style: none;
+  margin: 0;
+  outline: none;
+  padding: 10px 16px;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  transition: color 100ms;
+  vertical-align: baseline;
+  user-select: none;
+  -webkit-user-select: none;
+  touch-action: manipulation;
+}
+
+.button:hover,
+.button:focus {
+  background-color: #e5e4e2;
 }

--- a/examples/basic/apps/web/app/page.tsx
+++ b/examples/basic/apps/web/app/page.tsx
@@ -2,6 +2,7 @@ import Image from "next/image";
 import { Card } from "@repo/ui/card";
 import { Code } from "@repo/ui/code";
 import styles from "./page.module.css";
+import { Button } from "@repo/ui/button";
 
 function Gradient({
   conic,
@@ -77,15 +78,20 @@ export default function Page(): JSX.Element {
         </div>
       </div>
 
+      <Button appName="web" className={styles.button}>
+        Click me!
+      </Button>
+
       <div className={styles.hero}>
         <div className={styles.heroContent}>
           <div className={styles.logos}>
             <div className={styles.circles}>
               <Image
-                alt="Turborepo"
+                alt=""
                 height={614}
                 src="circles.svg"
                 width={614}
+                style={{ pointerEvents: "none" }}
               />
             </div>
             <div className={styles.logoGradientContainer}>
@@ -94,11 +100,12 @@ export default function Page(): JSX.Element {
 
             <div className={styles.logo}>
               <Image
-                alt=""
+                alt="Turborepo"
                 height={120}
                 priority
                 src="turborepo.svg"
                 width={120}
+                style={{ pointerEvents: "none" }}
               />
             </div>
           </div>

--- a/examples/basic/packages/eslint-config/next.js
+++ b/examples/basic/packages/eslint-config/next.js
@@ -16,6 +16,7 @@ module.exports = {
   },
   env: {
     node: true,
+    browser: true,
   },
   plugins: ["only-warn"],
   settings: {

--- a/examples/basic/packages/ui/package.json
+++ b/examples/basic/packages/ui/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "exports": {
+    "./button": "./src/button.tsx",
     "./card": "./src/card.tsx",
     "./code": "./src/code.tsx"
   },

--- a/examples/basic/packages/ui/src/button.tsx
+++ b/examples/basic/packages/ui/src/button.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { ReactNode } from "react";
+
+interface ButtonProps {
+  children: ReactNode;
+  className?: string;
+  appName: string;
+}
+
+export const Button = ({ children, className, appName }: ButtonProps) => {
+  return (
+    <button
+      className={className}
+      onClick={() => alert(`Hello from your ${appName} app!`)}
+    >
+      {children}
+    </button>
+  );
+};


### PR DESCRIPTION
Previously, the `basic` example (AKA create-turbo) was entirely Server Components. In this PR, we're continuing to leverage the Internal Package pattern such that we have a mix of React Server Components **and** Client components.

The Client Component is the new `Button` component in the `@repo/ui` package.

Notably, this PR closes #6019, fulfilling these requirements:
- A mix of Server Components and Client Components
- Editor go-to-definition across packages (already done in previous work)
- Using an `src` folder in the package but not having to use it when importing into another package
- Tree-shaking (already done in previous work, check out `exports` in `./packages/ui.package.json`

Non-goals of this PR:
- Including the entirety of `shadcn-ui` (We're showing you the fundamentals of how to support `shadcn-ui` here but not bringing in the components)
- Using `tsup` to create an RSC package (Please open a new issue/add reactions to an existing issue if you'd like to see this)