### PR TITLE
fix tsconfig alias cycle

### DIFF
--- a/crates/turbopack-ecmascript/src/typescript/resolve.rs
+++ b/crates/turbopack-ecmascript/src/typescript/resolve.rs
@@ -268,7 +268,16 @@ pub async fn tsconfig_resolve_options(
                     if let JsonValue::Array(vec) = value {
                         let entries = vec
                             .iter()
-                            .filter_map(|entry| entry.as_str().map(|s| format!("./{s}")))
+                            .filter_map(|entry| {
+                                entry.as_str().map(|s| {
+                                    // tsconfig paths are always relative requests
+                                    if s.starts_with("./") || s.starts_with("../") {
+                                        s.to_string()
+                                    } else {
+                                        format!("./{s}")
+                                    }
+                                })
+                            })
                             .collect();
                         all_paths.insert(
                             key.to_string(),

--- a/crates/turbopack-ecmascript/src/typescript/resolve.rs
+++ b/crates/turbopack-ecmascript/src/typescript/resolve.rs
@@ -268,7 +268,7 @@ pub async fn tsconfig_resolve_options(
                     if let JsonValue::Array(vec) = value {
                         let entries = vec
                             .iter()
-                            .filter_map(|entry| entry.as_str().map(|s| s.to_string()))
+                            .filter_map(|entry| entry.as_str().map(|s| format!("./{s}")))
                             .collect();
                         all_paths.insert(
                             key.to_string(),


### PR DESCRIPTION
### Description

* add info level logging for resolveing
* tsconfig paths are always relative
* make sure that global wildcard doesn't match relative requests

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
