### PR TITLE
fix(tests): update rust unit tests that rely on with-yarn fixture

### DIFF
--- a/crates/turborepo-repository/src/package_manager/mod.rs
+++ b/crates/turborepo-repository/src/package_manager/mod.rs
@@ -614,8 +614,8 @@ mod tests {
         let with_yarn_expected: HashSet<AbsoluteSystemPathBuf> = HashSet::from_iter([
             with_yarn.join_components(&["apps", "docs", "package.json"]),
             with_yarn.join_components(&["apps", "web", "package.json"]),
-            with_yarn.join_components(&["packages", "eslint-config-custom", "package.json"]),
-            with_yarn.join_components(&["packages", "tsconfig", "package.json"]),
+            with_yarn.join_components(&["packages", "eslint-config", "package.json"]),
+            with_yarn.join_components(&["packages", "typescript-config", "package.json"]),
             with_yarn.join_components(&["packages", "ui", "package.json"]),
         ]);
         for mgr in &[


### PR DESCRIPTION
### Description

Same as #6679

### Testing Instructions

Unit tests should pass now


Closes TURBO-1839