### PR TITLE
Add yarn v2+ caveat for installing Internal Packages.

### DIFF
--- a/docs/pages/repo/docs/handbook/workspaces.mdx
+++ b/docs/pages/repo/docs/handbook/workspaces.mdx
@@ -122,7 +122,7 @@ For instance, if we want `apps/docs` to import `packages/shared-utils`, we'd nee
 ```json filename="apps/docs/package.json"
 {
   "dependencies": {
-    "shared-utils": "*" // If yarn v2/v3, use workspace:*
+    "shared-utils": "*" // If yarn v2+, use workspace:*
   }
 }
 ```

--- a/docs/pages/repo/docs/handbook/workspaces.mdx
+++ b/docs/pages/repo/docs/handbook/workspaces.mdx
@@ -122,7 +122,7 @@ For instance, if we want `apps/docs` to import `packages/shared-utils`, we'd nee
 ```json filename="apps/docs/package.json"
 {
   "dependencies": {
-    "shared-utils": "*"
+    "shared-utils": "*" // If yarn v2/v3, use workspace:*
   }
 }
 ```


### PR DESCRIPTION
yarn v1 uses `*`. yarn v2+ use `workspace:*`.

*audible sigh*

Closes #5261 and #6322