### PR TITLE
chore: make go-fallback confilct with remote cache read only

### DIFF
--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -108,7 +108,7 @@ pub struct Args {
     pub cwd: Option<Utf8PathBuf>,
     /// Fallback to use Go for task execution
     #[serde(skip)]
-    #[clap(long, global = true)]
+    #[clap(long, global = true, conflicts_with = "remote_cache_read_only")]
     pub go_fallback: bool,
     /// Specify a file to save a pprof heap profile
     #[clap(long, global = true, value_parser)]
@@ -1973,5 +1973,34 @@ mod test {
                 ..Args::default()
             }
         );
+    }
+
+    #[test]
+    fn test_go_fallback_conflicts_with_remote_read_only() {
+        assert!(Args::try_parse_from([
+            "turbo",
+            "build",
+            "--remote-cache-read-only",
+            "--go-fallback"
+        ])
+        .unwrap_err()
+        .to_string()
+        .contains(
+            "the argument '--remote-cache-read-only [<BOOL>]' cannot be used with '--go-fallback"
+        ));
+        assert!(Args::try_parse_from([
+            "turbo",
+            "run",
+            "build",
+            "--remote-cache-read-only",
+            "--go-fallback"
+        ])
+        .unwrap_err()
+        .to_string()
+        .contains(
+            "the argument '--remote-cache-read-only [<BOOL>]' cannot be used with '--go-fallback"
+        ));
+        assert!(Args::try_parse_from(["turbo", "build", "--go-fallback"]).is_ok(),);
+        assert!(Args::try_parse_from(["turbo", "build", "--remote-cache-read-only",]).is_ok(),);
     }
 }

--- a/turborepo-tests/integration/tests/no-args.t
+++ b/turborepo-tests/integration/tests/no-args.t
@@ -27,7 +27,6 @@ Make sure exit code is 2 when no args are passed
         --color                           Force color usage in the terminal
         --cpuprofile <CPU_PROFILE>        Specify a file to save a cpu profile
         --cwd <CWD>                       The directory in which to run turbo
-        --go-fallback                     Fallback to use Go for task execution
         --heap <HEAP>                     Specify a file to save a pprof heap profile
         --login <LOGIN>                   Override the login endpoint
         --no-color                        Suppress color usage in the terminal
@@ -50,6 +49,8 @@ Make sure exit code is 2 when no args are passed
             Continue execution even if a task exits with an error or non-zero exit code. The default behavior is to bail
         --dry-run [<DRY_RUN>]
             [possible values: text, json]
+        --go-fallback
+            Fallback to use Go for task execution
         --single-package
             Run turbo in single-package mode
     -F, --filter <FILTER>

--- a/turborepo-tests/integration/tests/turbo-help.t
+++ b/turborepo-tests/integration/tests/turbo-help.t
@@ -27,7 +27,6 @@ Test help flag
         --color                           Force color usage in the terminal
         --cpuprofile <CPU_PROFILE>        Specify a file to save a cpu profile
         --cwd <CWD>                       The directory in which to run turbo
-        --go-fallback                     Fallback to use Go for task execution
         --heap <HEAP>                     Specify a file to save a pprof heap profile
         --login <LOGIN>                   Override the login endpoint
         --no-color                        Suppress color usage in the terminal
@@ -50,6 +49,8 @@ Test help flag
             Continue execution even if a task exits with an error or non-zero exit code. The default behavior is to bail
         --dry-run [<DRY_RUN>]
             [possible values: text, json]
+        --go-fallback
+            Fallback to use Go for task execution
         --single-package
             Run turbo in single-package mode
     -F, --filter <FILTER>
@@ -127,7 +128,6 @@ Test help flag
         --color                           Force color usage in the terminal
         --cpuprofile <CPU_PROFILE>        Specify a file to save a cpu profile
         --cwd <CWD>                       The directory in which to run turbo
-        --go-fallback                     Fallback to use Go for task execution
         --heap <HEAP>                     Specify a file to save a pprof heap profile
         --login <LOGIN>                   Override the login endpoint
         --no-color                        Suppress color usage in the terminal
@@ -150,6 +150,8 @@ Test help flag
             Continue execution even if a task exits with an error or non-zero exit code. The default behavior is to bail
         --dry-run [<DRY_RUN>]
             [possible values: text, json]
+        --go-fallback
+            Fallback to use Go for task execution
         --single-package
             Run turbo in single-package mode
     -F, --filter <FILTER>
@@ -213,7 +215,6 @@ Test help flag for link command
         --color                           Force color usage in the terminal
         --cpuprofile <CPU_PROFILE>        Specify a file to save a cpu profile
         --cwd <CWD>                       The directory in which to run turbo
-        --go-fallback                     Fallback to use Go for task execution
         --heap <HEAP>                     Specify a file to save a pprof heap profile
         --login <LOGIN>                   Override the login endpoint
         --no-color                        Suppress color usage in the terminal
@@ -240,7 +241,6 @@ Test help flag for unlink command
         --color                           Force color usage in the terminal
         --cpuprofile <CPU_PROFILE>        Specify a file to save a cpu profile
         --cwd <CWD>                       The directory in which to run turbo
-        --go-fallback                     Fallback to use Go for task execution
         --heap <HEAP>                     Specify a file to save a pprof heap profile
         --login <LOGIN>                   Override the login endpoint
         --no-color                        Suppress color usage in the terminal
@@ -267,7 +267,6 @@ Test help flag for login command
         --color                           Force color usage in the terminal
         --cpuprofile <CPU_PROFILE>        Specify a file to save a cpu profile
         --cwd <CWD>                       The directory in which to run turbo
-        --go-fallback                     Fallback to use Go for task execution
         --heap <HEAP>                     Specify a file to save a pprof heap profile
         --login <LOGIN>                   Override the login endpoint
         --no-color                        Suppress color usage in the terminal
@@ -293,7 +292,6 @@ Test help flag for logout command
         --color                           Force color usage in the terminal
         --cpuprofile <CPU_PROFILE>        Specify a file to save a cpu profile
         --cwd <CWD>                       The directory in which to run turbo
-        --go-fallback                     Fallback to use Go for task execution
         --heap <HEAP>                     Specify a file to save a pprof heap profile
         --login <LOGIN>                   Override the login endpoint
         --no-color                        Suppress color usage in the terminal


### PR DESCRIPTION
### Description

Since `--remote-cache-read-only` is only implemented in Rust it should fail when used with `--go-fallback` so users understand that the read only flag won't be respected when using the Go codepath.

### Testing Instructions
Added unit test to make sure the `conflicts_with` attribute behaves as we expect.


Closes TURBO-1848