### PR TITLE
Upgrade Turborepo bug issue template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/0-turborepo-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/0-turborepo-bug-report.yml
@@ -1,25 +1,39 @@
 name: Turborepo Bug Report
-description: Create a bug report for the Turborepo team
-title: "[turborepo] "
+description: Create a bug report for the Turborepo core team
 labels: ["kind: bug", "owned-by: turborepo", "needs: triage"]
 body:
   - type: markdown
     attributes:
-      value: Thanks for taking the time to file a bug report! Please fill out this form as completely as possible.
-  - type: markdown
+      value: |
+        This template is to report Turborepo bugs. Before opening a new issue, please do a [search](https://github.com/vercel/turbo/issues) of existing issues and :+1: upvote the existing issue instead. This will result in a quicker resolution.
+
+        If you need help with your own project, you can:
+        - Start a discussion in the ["Help" section](https://github.com/vercel/turbo/discussions/categories/help).
+        - Ask a question in [the Turbo Discord server](https://turbo.build/discord).
+
+  - type: checkboxes
     attributes:
-      value: If you leave out sections there is a high likelihood it will be moved to the GitHub Discussions "Help" section.
+      label: Verify canary release
+      description: "Please install the canary version of `turbo` (e.g. `npm install turbo@canary`) to try the canary version of Turborepo. It includes all features and fixes that have not been released to the stable version yet. Some issues may already be fixed in the canary version, so please verify that your issue reproduces before opening a new issue."
+      options:
+        - label: I verified that the issue exists in the latest Turborepo canary release.
+          required: true
+
   - type: input
     attributes:
-      label: What version of Turborepo are you using?
-      description: "For example: 1.0.0"
+      label: Link to code that reproduces this issue
+      description: |
+        A link to a **public** GitHub repository with a minimal reproduction. Ideally, minimal reproductions should be created using [`npx create-turbo@canary -e with-shell-commands`](https://github.com/vercel/turbo/tree/main/examples/with-shell-commands) and should include only changes that contribute to the issue. You may also use [`npx create-turbo@canary -e <example-name>`](https://github.com/vercel/turbo/tree/main/examples) to create a reproduction that includes frameworks if you believe your bug requires a framework to reproduce.
     validations:
       required: true
+
   - type: dropdown
     id: packageManager
     attributes:
       multiple: true
       label: What package manager are you using / does the bug impact?
+      description: |
+        You can quickly check different package managers in your reproduction using `npx turbo/workspaces convert`.
       options:
         - npm
         - pnpm
@@ -27,6 +41,7 @@ body:
         - Yarn v2/v3 (node_modules linker only)
     validations:
       required: true
+
   - type: dropdown
     id: os
     attributes:
@@ -38,36 +53,43 @@ body:
         - Other
     validations:
       required: true
+
   - type: textarea
     attributes:
       label: Describe the Bug
-      description: A clear and concise description of the bug.
+      description: |
+        A clear and concise description of the bug.
     validations:
       required: true
+
   - type: textarea
     attributes:
       label: Expected Behavior
-      description: A clear and concise description of what you expected to happen.
+      description: |
+        A clear and concise description of what you expected to happen.
     validations:
       required: true
+
   - type: textarea
     attributes:
       label: To Reproduce
-      description: Steps to reproduce the behavior, please provide a clear code snippets that always reproduces the issue or a GitHub repository. Screenshots can be provided in the issue body below.
+      description: |
+        Steps to reproduce the unexpected behavior. Please provide a clear code snippets that always reproduces the issue or a GitHub repository. Screenshots can be provided in the issue body below.
     validations:
       required: true
-  - type: input
-    attributes:
-      label: Reproduction Repo
-      description: Include a URL to a repository that reproduces this issue. This is optional, but increases the likelihood that we can help you!
-    validations:
-      required: false
+
   - type: markdown
     attributes:
-      value: Before posting the issue go through the steps you've written down to make sure the steps provided are detailed and clear.
-  - type: markdown
+      value: |
+        Another way you can help the maintainers is to pinpoint the `canary` version of `turbo` that introduced the issue. Check out our [releases](https://github.com/vercel/turbo/releases), and try to find the first `canary` release that introduced the issue. This will help us narrow down the scope of the issue, and possibly point to the PR/code change that introduced it. You can install a specific version of `turbo` by running `npm install turbo@<version>`.
+  - type: textarea
     attributes:
-      value: Contributors should be able to follow the steps provided in order to reproduce the bug.
-  - type: markdown
-    attributes:
-      value: Thanks in advance!
+      label: Additional context
+      description: |
+        Any extra information that might help us investigate. For example, where are you deploying your application (Vercel, Docker, other platform)? Is it only reproducible on that platform, or locally too? Is the issue only happening in a specific browser? etc.
+      placeholder: |
+        I tested my reproduction against different canary releases, and the first one that introduced the bug was "1.10.4-canary.2", since reverting to "1.10.4-canary.1" works.
+
+        or
+
+        I am using GitHub Actions but running my tasks locally does not have the same issue.


### PR DESCRIPTION
Title!  If I messed up the `yml`, I can fix-ship it. A little hard to debug given it has to be on `main` for GitHub to render it. 😄 

Much inspiration was taken from the Next.js bug issue template.