### PR TITLE
chore(ci): keep crlf usage consistent on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -208,6 +208,16 @@ jobs:
           - name: windows
             runner: windows-latest
     steps:
+      # On Windows, set autocrlf to input so that when the repo is cloned down
+      # the fixtures retain their line endings and don't get updated to CRLF.
+      # We want this because this repo also contains the fixtures for our test cases
+      # and these fixtures have files that need stable file hashes. If we let git update
+      # the line endings on checkout, the file hashes will change.
+      # https://www.git-scm.com/book/en/v2/Customizing-Git-Git-Configuration#_core_autocrlf
+      - name: set crlf
+        if: matrix.os.name == 'windows'
+        shell: bash
+        run: git config --global core.autocrlf input
       - name: Checkout
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -208,16 +208,6 @@ jobs:
           - name: windows
             runner: windows-latest
     steps:
-      # On Windows, set autocrlf to input so that when the repo is cloned down
-      # the fixtures retain their line endings and don't get updated to CRLF.
-      # We want this because this repo also contains the fixtures for our test cases
-      # and these fixtures have files that need stable file hashes. If we let git update
-      # the line endings on checkout, the file hashes will change.
-      # https://www.git-scm.com/book/en/v2/Customizing-Git-Git-Configuration#_core_autocrlf
-      - name: set crlf
-        if: matrix.os.name == 'windows'
-        shell: bash
-        run: git config --global core.autocrlf input
       - name: Checkout
         uses: actions/checkout@v3
         with:
@@ -321,16 +311,6 @@ jobs:
           - name: windows
             runner: windows-latest
     steps:
-      # On Windows, set autocrlf to input so that when the repo is cloned down
-      # the fixtures retain their line endings and don't get updated to CRLF.
-      # We want this because this repo also contains the fixtures for our test cases
-      # and these fixtures have files that need stable file hashes. If we let git update
-      # the line endings on checkout, the file hashes will change.
-      # https://www.git-scm.com/book/en/v2/Customizing-Git-Git-Configuration#_core_autocrlf
-      - name: set crlf
-        if: matrix.os.name == 'windows'
-        shell: bash
-        run: git config --global core.autocrlf input
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-turborepo-environment
         with:

--- a/turborepo-tests/.gitattributes
+++ b/turborepo-tests/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/turborepo-tests/helpers/setup_git.sh
+++ b/turborepo-tests/helpers/setup_git.sh
@@ -13,5 +13,8 @@ git ${GIT_ARGS} config user.name "Turbo Test"
 # shell rather than the full path and npm will find it on its own on each platform.
 echo "script-shell=bash" > ${TARGET_DIR}/.npmrc
 
+# Set repository to only use LF even on windows
+echo "* text eol=lf" > ${TARGET_DIR}/.gitattributes
+
 git ${GIT_ARGS} add .
 git ${GIT_ARGS} commit -m "Initial" --quiet

--- a/turborepo-tests/integration/tests/dry-json/single-package-no-config.t
+++ b/turborepo-tests/integration/tests/dry-json/single-package-no-config.t
@@ -33,8 +33,9 @@ Setup
       {
         "taskId": "build",
         "task": "build",
-        "hash": "e46d6df5143cae99",
+        "hash": "6b3b1f6928b77978",
         "inputs": {
+          ".gitattributes": "fcadb2cf97913f58a2523f535336e725c6b59d1f",
           ".gitignore": "03b541460c1b836f96f9c0a941ceb48e91a9fd83",
           "package-lock.json": "1c117cce37347befafe3a9cba1b8a609b3600021",
           "package.json": "5519edda652c463054307421a3c05ff49f080328",

--- a/turborepo-tests/integration/tests/dry-json/single-package-with-deps.t
+++ b/turborepo-tests/integration/tests/dry-json/single-package-with-deps.t
@@ -32,8 +32,9 @@ Setup
       {
         "taskId": "build",
         "task": "build",
-        "hash": "f09bf783beacf5c9",
+        "hash": "8475c6395fe03dbe",
         "inputs": {
+          ".gitattributes": "fcadb2cf97913f58a2523f535336e725c6b59d1f",
           ".gitignore": "03b541460c1b836f96f9c0a941ceb48e91a9fd83",
           "package-lock.json": "1c117cce37347befafe3a9cba1b8a609b3600021",
           "package.json": "5519edda652c463054307421a3c05ff49f080328",
@@ -88,8 +89,9 @@ Setup
       {
         "taskId": "test",
         "task": "test",
-        "hash": "8bfab5dc6b4ccb3b",
+        "hash": "f206eb144f759670",
         "inputs": {
+          ".gitattributes": "fcadb2cf97913f58a2523f535336e725c6b59d1f",
           ".gitignore": "03b541460c1b836f96f9c0a941ceb48e91a9fd83",
           "package-lock.json": "1c117cce37347befafe3a9cba1b8a609b3600021",
           "package.json": "5519edda652c463054307421a3c05ff49f080328",

--- a/turborepo-tests/integration/tests/dry-json/single-package.t
+++ b/turborepo-tests/integration/tests/dry-json/single-package.t
@@ -32,8 +32,9 @@ Setup
       {
         "taskId": "build",
         "task": "build",
-        "hash": "f09bf783beacf5c9",
+        "hash": "8475c6395fe03dbe",
         "inputs": {
+          ".gitattributes": "fcadb2cf97913f58a2523f535336e725c6b59d1f",
           ".gitignore": "03b541460c1b836f96f9c0a941ceb48e91a9fd83",
           "package-lock.json": "1c117cce37347befafe3a9cba1b8a609b3600021",
           "package.json": "5519edda652c463054307421a3c05ff49f080328",

--- a/turborepo-tests/integration/tests/run/single-package/dry-run.t
+++ b/turborepo-tests/integration/tests/run/single-package/dry-run.t
@@ -18,7 +18,7 @@ Check
   Tasks to Run
   build
     Task                           = build\s* (re)
-    Hash                           = f09bf783beacf5c9\s* (re)
+    Hash                           = 8475c6395fe03dbe
     Cached \(Local\)                 = false\s* (re)
     Cached \(Remote\)                = false\s* (re)
     Command                        = echo building > foo.txt\s* (re)
@@ -26,7 +26,7 @@ Check
     Log File                       = .turbo(\/|\\)turbo-build.log\s* (re)
     Dependencies                   =\s* (re)
     Dependents                     =\s* (re)
-    Inputs Files Considered        = 5\s* (re)
+    Inputs Files Considered        = 6\s* (re)
     .env Files Considered          = 0\s* (re)
     Env Vars                       =\s* (re)
     Env Vars Values                =\s* (re)

--- a/turborepo-tests/integration/tests/run/single-package/no-config.t
+++ b/turborepo-tests/integration/tests/run/single-package/no-config.t
@@ -20,7 +20,7 @@ Check
   Tasks to Run
   build
     Task                           = build\s* (re)
-    Hash                           = e46d6df5143cae99\s* (re)
+    Hash                           = 6b3b1f6928b77978\s* (re)
     Cached \(Local\)                 = false\s* (re)
     Cached \(Remote\)                = false\s* (re)
     Command                        = echo building > foo.txt\s* (re)
@@ -28,7 +28,7 @@ Check
     Log File                       = .turbo(\/|\\)turbo-build.log\s* (re)
     Dependencies                   =\s* (re)
     Dependents                     =\s* (re)
-    Inputs Files Considered        = 4\s* (re)
+    Inputs Files Considered        = 5\s* (re)
     .env Files Considered          = 0\s* (re)
     Env Vars                       =\s* (re)
     Env Vars Values                =\s* (re)
@@ -52,7 +52,7 @@ Run real once
   $ ${TURBO} run build
   \xe2\x80\xa2 Running build (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  build: cache bypass, force executing e46d6df5143cae99
+  build: cache bypass, force executing 6b3b1f6928b77978
   build: 
   build: > build
   build: > echo building > foo.txt
@@ -66,7 +66,7 @@ Run a second time, verify no caching because there is no config
   $ ${TURBO} run build
   \xe2\x80\xa2 Running build (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  build: cache bypass, force executing e46d6df5143cae99
+  build: cache bypass, force executing 6b3b1f6928b77978
   build: 
   build: > build
   build: > echo building > foo.txt

--- a/turborepo-tests/integration/tests/run/single-package/run-yarn.t
+++ b/turborepo-tests/integration/tests/run/single-package/run-yarn.t
@@ -5,7 +5,7 @@ Check
   $ ${TURBO} run build
   \xe2\x80\xa2 Running build (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  build: cache miss, executing c1d6153f4a6d83b5
+  build: cache miss, executing 631b7025637055ed
   build: yarn run v1.22.17
   build: warning package.json: No license field
   build: $ echo building > foo.txt
@@ -18,7 +18,7 @@ Check
   $ ${TURBO} run build
   \xe2\x80\xa2 Running build (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  build: cache hit, replaying logs c1d6153f4a6d83b5
+  build: cache hit, replaying logs 631b7025637055ed
   build: yarn run v1.22.17
   build: warning package.json: No license field
   build: $ echo building > foo.txt

--- a/turborepo-tests/integration/tests/run/single-package/run.t
+++ b/turborepo-tests/integration/tests/run/single-package/run.t
@@ -5,7 +5,7 @@ Check
   $ ${TURBO} run build
   \xe2\x80\xa2 Running build (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  build: cache miss, executing f09bf783beacf5c9
+  build: cache miss, executing 8475c6395fe03dbe
   build: 
   build: > build
   build: > echo building > foo.txt
@@ -22,7 +22,7 @@ Run a second time, verify caching works because there is a config
   $ ${TURBO} run build
   \xe2\x80\xa2 Running build (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  build: cache hit, replaying logs f09bf783beacf5c9
+  build: cache hit, replaying logs 8475c6395fe03dbe
   build: 
   build: > build
   build: > echo building > foo.txt

--- a/turborepo-tests/integration/tests/run/single-package/with-deps-dry-run.t
+++ b/turborepo-tests/integration/tests/run/single-package/with-deps-dry-run.t
@@ -18,7 +18,7 @@ Check
   Tasks to Run
   build
     Task                           = build\s* (re)
-    Hash                           = f09bf783beacf5c9\s* (re)
+    Hash                           = 8475c6395fe03dbe\s* (re)
     Cached \(Local\)                 = false\s* (re)
     Cached \(Remote\)                = false\s* (re)
     Command                        = echo building > foo.txt\s* (re)
@@ -26,7 +26,7 @@ Check
     Log File                       = .turbo(\/|\\)turbo-build.log\s* (re)
     Dependencies                   =\s* (re)
     Dependents                     = test\s* (re)
-    Inputs Files Considered        = 5\s* (re)
+    Inputs Files Considered        = 6\s* (re)
     .env Files Considered          = 0\s* (re)
     Env Vars                       =\s* (re)
     Env Vars Values                =\s* (re)
@@ -37,7 +37,7 @@ Check
     Framework                      =\s* (re)
   test
     Task                           = test\s* (re)
-    Hash                           = 8bfab5dc6b4ccb3b\s* (re)
+    Hash                           = f206eb144f759670\s* (re)
     Cached \(Local\)                 = false\s* (re)
     Cached \(Remote\)                = false\s* (re)
     Command                        = cat foo.txt\s* (re)
@@ -45,7 +45,7 @@ Check
     Log File                       = .turbo(\/|\\)turbo-test.log\s* (re)
     Dependencies                   = build\s* (re)
     Dependents                     =\s* (re)
-    Inputs Files Considered        = 5\s* (re)
+    Inputs Files Considered        = 6\s* (re)
     .env Files Considered          = 0\s* (re)
     Env Vars                       =\s* (re)
     Env Vars Values                =\s* (re)

--- a/turborepo-tests/integration/tests/run/single-package/with-deps-run.t
+++ b/turborepo-tests/integration/tests/run/single-package/with-deps-run.t
@@ -5,12 +5,12 @@ Check
   $ ${TURBO} run test
   \xe2\x80\xa2 Running test (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  build: cache miss, executing f09bf783beacf5c9
+  build: cache miss, executing 8475c6395fe03dbe
   build: 
   build: > build
   build: > echo building > foo.txt
   build: 
-  test: cache miss, executing 8bfab5dc6b4ccb3b
+  test: cache miss, executing f206eb144f759670
   test: 
   test: > test
   test: > cat foo.txt
@@ -25,12 +25,12 @@ Run a second time, verify caching works because there is a config
   $ ${TURBO} run test
   \xe2\x80\xa2 Running test (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  build: cache hit, replaying logs f09bf783beacf5c9
+  build: cache hit, replaying logs 8475c6395fe03dbe
   build: 
   build: > build
   build: > echo building > foo.txt
   build: 
-  test: cache hit, replaying logs 8bfab5dc6b4ccb3b
+  test: cache hit, replaying logs f206eb144f759670
   test: 
   test: > test
   test: > cat foo.txt
@@ -45,8 +45,8 @@ Run with --output-logs=hash-only
   $ ${TURBO} run test --output-logs=hash-only
   \xe2\x80\xa2 Running test (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  build: cache hit, suppressing logs f09bf783beacf5c9
-  test: cache hit, suppressing logs 8bfab5dc6b4ccb3b
+  build: cache hit, suppressing logs 8475c6395fe03dbe
+  test: cache hit, suppressing logs f206eb144f759670
   
    Tasks:    2 successful, 2 total
   Cached:    2 cached, 2 total

--- a/turborepo-tests/integration/tests/task-dependencies/root-worksapce.t
+++ b/turborepo-tests/integration/tests/task-dependencies/root-worksapce.t
@@ -11,7 +11,7 @@ This tests asserts that root tasks can depend on workspace#task
   lib-a:build: > echo build-lib-a
   lib-a:build: 
   lib-a:build: build-lib-a
-  //:mytask: cache miss, executing 3ae433af4902b1a0
+  //:mytask: cache miss, executing 53334aa043b26a57
   //:mytask: 
   //:mytask: > mytask
   //:mytask: > echo root-mytask


### PR DESCRIPTION
### Description

I noticed that for Windows only we're getting cache misses for `cli#build` on integration tests.

[Build turborepo](https://github.com/vercel/turbo/actions/runs/7105368951/job/19342475934?pr=6702#step:5:25): `cli#build` hash is `49dd89a5b438705a`
[Integration tests](https://github.com/vercel/turbo/actions/runs/7105368951/job/19343093111?pr=6702#step:7:29): `cli#build` hash is `95d2992a8cdf174b`

### Testing Instructions

On this PR the Windows integration tests should have a cache hit for `cli#build`


Closes TURBO-1851