### PR TITLE
Fix/unrevert daemon discovery

### DIFF
--- a/crates/turborepo-lib/src/commands/daemon.rs
+++ b/crates/turborepo-lib/src/commands/daemon.rs
@@ -182,7 +182,7 @@ pub async fn daemon_server(
         exit_signal,
     );
 
-    let reason = server.serve().await;
+    let reason = server.serve().await?;
 
     match reason {
         CloseReason::SocketOpenError(SocketOpenError::LockError(AlreadyOwned)) => {

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -13,7 +13,7 @@ use std::{
     collections::HashSet,
     io::{IsTerminal, Write},
     sync::Arc,
-    time::SystemTime,
+    time::{Duration, SystemTime},
 };
 
 pub use cache::{RunCache, TaskCache};
@@ -27,7 +27,7 @@ use turborepo_cache::{AsyncCache, RemoteCacheOpts};
 use turborepo_ci::Vendor;
 use turborepo_env::EnvironmentVariableMap;
 use turborepo_repository::{
-    discovery::{LocalPackageDiscoveryBuilder, PackageDiscoveryBuilder},
+    discovery::{FallbackPackageDiscovery, LocalPackageDiscoveryBuilder, PackageDiscoveryBuilder},
     package_graph::{PackageGraph, WorkspaceName},
     package_json::PackageJson,
 };
@@ -48,7 +48,10 @@ use crate::{
     engine::{Engine, EngineBuilder},
     opts::Opts,
     process::ProcessManager,
-    run::{global_hash::get_global_hash_inputs, summary::RunTracker},
+    run::{
+        global_hash::get_global_hash_inputs, package_discovery::DaemonPackageDiscovery,
+        summary::RunTracker,
+    },
     shim::TurboState,
     signal::{SignalHandler, SignalSubscriber},
     task_graph::Visitor,
@@ -209,7 +212,7 @@ impl<'a> Run<'a> {
         let is_ci_or_not_tty = turborepo_ci::is_ci() || !std::io::stdout().is_terminal();
         run_telemetry.track_ci(turborepo_ci::Vendor::get_name());
 
-        let daemon = match (is_ci_or_not_tty, opts.run_opts.daemon) {
+        let mut daemon = match (is_ci_or_not_tty, opts.run_opts.daemon) {
             (true, None) => {
                 run_telemetry.track_daemon_init(DaemonInitStatus::Skipped);
                 debug!("skipping turbod since we appear to be in a non-interactive context");
@@ -249,17 +252,31 @@ impl<'a> Run<'a> {
             }
         };
 
-        let mut pkg_dep_graph =
-            PackageGraph::builder(&self.base.repo_root, root_package_json.clone())
-                .with_single_package_mode(opts.run_opts.single_package)
-                .with_package_discovery(
+        // if we are forcing the daemon, we don't want to fallback to local discovery
+        let (fallback, duration) = if let Some(true) = opts.run_opts.daemon {
+            (None, Duration::MAX)
+        } else {
+            (
+                Some(
                     LocalPackageDiscoveryBuilder::new(
                         self.base.repo_root.clone(),
                         None,
                         Some(root_package_json.clone()),
                     )
                     .build()?,
-                )
+                ),
+                Duration::from_millis(10),
+            )
+        };
+
+        let mut pkg_dep_graph =
+            PackageGraph::builder(&self.base.repo_root, root_package_json.clone())
+                .with_single_package_mode(opts.run_opts.single_package)
+                .with_package_discovery(FallbackPackageDiscovery::new(
+                    daemon.as_mut().map(DaemonPackageDiscovery::new),
+                    fallback,
+                    duration,
+                ))
                 .build()
                 .await?;
 

--- a/crates/turborepo-lib/src/run/package_discovery/mod.rs
+++ b/crates/turborepo-lib/src/run/package_discovery/mod.rs
@@ -18,6 +18,8 @@ impl<'a, C: Clone> DaemonPackageDiscovery<'a, C> {
 
 impl<'a, C: Clone + Send> PackageDiscovery for DaemonPackageDiscovery<'a, C> {
     async fn discover_packages(&mut self) -> Result<DiscoveryResponse, Error> {
+        tracing::debug!("discovering packages using daemon");
+
         let response = self
             .daemon
             .discover_packages()
@@ -63,6 +65,8 @@ impl WatchingPackageDiscovery {
 
 impl PackageDiscovery for WatchingPackageDiscovery {
     async fn discover_packages(&mut self) -> Result<DiscoveryResponse, Error> {
+        tracing::debug!("discovering packages using watcher implementation");
+
         // need to clone and drop the Ref before we can await
         let watcher = {
             let watcher = self

--- a/crates/turborepo-repository/src/discovery.rs
+++ b/crates/turborepo-repository/src/discovery.rs
@@ -10,7 +10,6 @@
 //! we can track areas of run that are performing sub-optimally.
 
 use tokio_stream::{iter, StreamExt};
-use tracing::debug;
 use turbopath::AbsoluteSystemPathBuf;
 
 use crate::{
@@ -191,23 +190,14 @@ impl<A: PackageDiscovery + Send, B: PackageDiscovery + Send> PackageDiscovery
 {
     async fn discover_packages(&mut self) -> Result<DiscoveryResponse, Error> {
         match tokio::time::timeout(self.timeout, self.primary.discover_packages()).await {
-            Ok(Ok(packages)) => {
-                debug!("used primary strategy");
-                Ok(packages)
-            }
-            Ok(Err(err1)) => {
-                debug!("primary strategy failed. using fallback strategy");
-                match self.fallback.discover_packages().await {
-                    Ok(packages) => Ok(packages),
-                    // if the backup is unavailable, return the original error
-                    Err(Error::Unavailable) => Err(err1),
-                    Err(err2) => Err(err2),
-                }
-            }
-            Err(_) => {
-                debug!("primary strategy timed out. using fallback strategy");
-                self.fallback.discover_packages().await
-            }
+            Ok(Ok(packages)) => Ok(packages),
+            Ok(Err(err1)) => match self.fallback.discover_packages().await {
+                Ok(packages) => Ok(packages),
+                // if the backup is unavailable, return the original error
+                Err(Error::Unavailable) => Err(err1),
+                Err(err2) => Err(err2),
+            },
+            Err(_) => self.fallback.discover_packages().await,
         }
     }
 }

--- a/turborepo-tests/integration-rust/tests/daemon/daemon-build.t
+++ b/turborepo-tests/integration-rust/tests/daemon/daemon-build.t
@@ -2,11 +2,27 @@ Setup
   $ . ${TESTDIR}/../../../helpers/setup_integration_test.sh
 
 Running a build with the daemon forced should run in daemon mode
+Also checks that the daemon workspace discovery handles cold boot
   $ TURBO_LOG_VERBOSITY=debug ${TURBO} run build --daemon > tmp.log 2>&1
   $ grep --quiet -E "turborepo_lib::run: running in daemon mode" tmp.log
+Also check we only make one request to the daemon
+  $ grep -E "turborepo_lib::run::package_discovery: discovering packages using daemon" tmp.log
+  (.+) turborepo_lib::run::package_discovery: discovering packages using daemon (re)
+Two tasks are run
   $ grep -E "turborepo_lib::process::child: child process exited normally" tmp.log
   (.+) turborepo_lib::process::child: child process exited normally (re)
   (.+) turborepo_lib::process::child: child process exited normally (re)
-
+Create a new package
+  $ cp -r apps/my-app apps/my-app2
+  $ sed -i'.bak' -e 's/my-app/my-app2/g' apps/my-app2/package.json
+Running daemon-based package discovery discovers the new package and run only that
+  $ TURBO_LOG_VERBOSITY=debug ${TURBO} run build --daemon > tmp.log 2>&1
+  $ grep --quiet -E "turborepo_lib::run: running in daemon mode" tmp.log
+Check we only make one request to the daemon
+  $ grep -E "turborepo_lib::run::package_discovery: discovering packages using daemon" tmp.log
+  (.+) turborepo_lib::run::package_discovery: discovering packages using daemon (re)
+Run that one task
+  $ grep -E "turborepo_lib::process::child: child process exited normally" tmp.log
+  (.+) turborepo_lib::process::child: child process exited normally (re)
 On some platforms we can't perform cleanup if the daemon is running, so stop it
   $ ${TURBO} daemon stop


### PR DESCRIPTION
### Description

This PR unreverts #6695 and ensures that the daemon's data is populated immediately rather than waiting for filesystem updates.

### Testing Instructions

Querying a newly started daemon could cause invalid answers while it populated its in memory cache. This change forces it to do that up front, preventing the issue. To test, kill the daemon, and start a build a handful of times. The old race condition will not occur.

Closes TURBO-1853