### PR TITLE
fix: properly catch sigterm sent from global

### DIFF
--- a/crates/turborepo-lib/src/commands/run.rs
+++ b/crates/turborepo-lib/src/commands/run.rs
@@ -5,7 +5,7 @@ use crate::{commands::CommandBase, run, run::Run, signal::SignalHandler};
 pub async fn run(base: CommandBase) -> Result<i32, run::Error> {
     #[cfg(windows)]
     let signal = {
-        let ctrl_c = tokio::signal::windows::ctrl_c().map_err(run::Error::SignalHandler)?;
+        let mut ctrl_c = tokio::signal::windows::ctrl_c().map_err(run::Error::SignalHandler)?;
         async move { ctrl_c.recv().await }
     };
     #[cfg(not(windows))]

--- a/crates/turborepo-lib/src/commands/run.rs
+++ b/crates/turborepo-lib/src/commands/run.rs
@@ -4,7 +4,9 @@ use crate::{commands::CommandBase, run, run::Run, signal::SignalHandler};
 
 pub async fn run(base: CommandBase) -> Result<i32, run::Error> {
     #[cfg(windows)]
-    let signal = tokio::signal::windows::ctrl_c().map_err(run::Error::SignalHandler)?;
+    let signal = tokio::signal::windows::ctrl_c()
+        .map_err(run::Error::SignalHandler)?
+        .recv();
     #[cfg(not(windows))]
     let signal = {
         use tokio::signal::unix;

--- a/crates/turborepo-lib/src/commands/run.rs
+++ b/crates/turborepo-lib/src/commands/run.rs
@@ -4,9 +4,10 @@ use crate::{commands::CommandBase, run, run::Run, signal::SignalHandler};
 
 pub async fn run(base: CommandBase) -> Result<i32, run::Error> {
     #[cfg(windows)]
-    let signal = tokio::signal::windows::ctrl_c()
-        .map_err(run::Error::SignalHandler)?
-        .recv();
+    let signal = {
+        let ctrl_c = tokio::signal::windows::ctrl_c().map_err(run::Error::SignalHandler)?;
+        async move { ctrl_c.recv().await }
+    };
     #[cfg(not(windows))]
     let signal = {
         use tokio::signal::unix;

--- a/crates/turborepo-lib/src/commands/run.rs
+++ b/crates/turborepo-lib/src/commands/run.rs
@@ -3,7 +3,28 @@ use tracing::{debug, error};
 use crate::{commands::CommandBase, run, run::Run, signal::SignalHandler};
 
 pub async fn run(base: CommandBase) -> Result<i32, run::Error> {
-    let handler = SignalHandler::new(tokio::signal::ctrl_c());
+    #[cfg(windows)]
+    let signal = tokio::signal::windows::ctrl_c().map_err(run::Error::SignalHandler)?;
+    #[cfg(not(windows))]
+    let signal = {
+        use tokio::signal::unix;
+        let mut sigint =
+            unix::signal(unix::SignalKind::interrupt()).map_err(run::Error::SignalHandler)?;
+        let mut sigterm =
+            unix::signal(unix::SignalKind::terminate()).map_err(run::Error::SignalHandler)?;
+        async move {
+            tokio::select! {
+                res = sigint.recv() => {
+                    res
+                }
+                res = sigterm.recv() => {
+                    res
+                }
+            }
+        }
+    };
+
+    let handler = SignalHandler::new(signal);
 
     let mut run = Run::new(&base);
     debug!("using the experimental rust codepath");

--- a/crates/turborepo-lib/src/run/error.rs
+++ b/crates/turborepo-lib/src/run/error.rs
@@ -42,4 +42,6 @@ pub enum Error {
     TaskHash(#[from] task_hash::Error),
     #[error(transparent)]
     Visitor(#[from] task_graph::VisitorError),
+    #[error("error registering signal handler: {0}")]
+    SignalHandler(std::io::Error),
 }


### PR DESCRIPTION
### Description

Global `turbo` sends a `SIGTERM` to local `turbo` when it receives any of `SIGINT`/`SIGTERM`/`SIGHUP` and local `turbo` only had signal handlers setup for `SIGINT`. This PR adds a signal handler for the `SIGTERM` that gets sent.

Immediate future work is plumbing the differing signals down to the process manager. The process manager currently only allows for sending `SIGINT` to child process. I just wanted to get this out the door ASAP to get us into a better state.

Future work will be reworking the global `turbo` signal handling so that we forward the correct signals to local `turbo`.

### Testing Instructions

Send a `SIGTERM` to `turbo` and make sure that the signal handler gets triggered:
```
# with binary built off of main
[0 olszewski@chriss-mbp] /Users/olszewski/code/vercel/turborepo $ pstree 46675
-+= 46675 olszewski /Users/olszewski/code/vercel/turborepo/target/debug/turbo dev
 |-+= 46712 olszewski node /Users/olszewski/.nvm/versions/node/v16.18.1/bin/pnpm run dev
 | \-+- 46726 olszewski node /private/tmp/ctrl-c-test/apps/docs/node_modules/.bin/../next/dist/bin/next dev --port 3001
 |   \--- 46757 olszewski next-server 
 \-+= 46713 olszewski node /Users/olszewski/.nvm/versions/node/v16.18.1/bin/pnpm run dev
   \-+- 46739 olszewski node /private/tmp/ctrl-c-test/apps/web/node_modules/.bin/../next/dist/bin/next dev
     \--- 46758 olszewski next-server 
[0 olszewski@chriss-mbp] /Users/olszewski/code/vercel/turborepo $ kill 46675
[0 olszewski@chriss-mbp] /Users/olszewski/code/vercel/turborepo $ lsof -i :3000
COMMAND   PID      USER   FD   TYPE             DEVICE SIZE/OFF NODE NAME
node    46758 olszewski   16u  IPv6 0xed7930af6ecc15d3      0t0  TCP *:hbci (LISTEN)
[0 olszewski@chriss-mbp] /Users/olszewski/code/vercel/turborepo $
# with changes in this PR
[0 olszewski@chriss-mbp] /Users/olszewski/code/vercel/turborepo $ pstree 38435
-+= 38435 olszewski /Users/olszewski/code/vercel/turborepo/target/debug/turbo dev
 |-+= 38472 olszewski node /Users/olszewski/.nvm/versions/node/v16.18.1/bin/pnpm run dev
 | \-+- 38501 olszewski node /private/tmp/ctrl-c-test/apps/docs/node_modules/.bin/../next/dist/bin/next dev --port 3001
 |   \--- 38512 olszewski next-server 
 \-+= 38473 olszewski node /Users/olszewski/.nvm/versions/node/v16.18.1/bin/pnpm run dev
   \-+- 38488 olszewski node /private/tmp/ctrl-c-test/apps/web/node_modules/.bin/../next/dist/bin/next dev
     \--- 38513 olszewski next-server 
[0 olszewski@chriss-mbp] /Users/olszewski/code/vercel/turborepo $ kill 38435
[0 olszewski@chriss-mbp] /Users/olszewski/code/vercel/turborepo $ lsof -i :3000
[1 olszewski@chriss-mbp] /Users/olszewski/code/vercel/turborepo $
```


Closes TURBO-1858