### PR TITLE
Update to align with npm.com.

### DIFF
--- a/docs/pages/blog/turbo-1-11-0.mdx
+++ b/docs/pages/blog/turbo-1-11-0.mdx
@@ -105,7 +105,7 @@ We're putting a renewed effort towards ensuring our examples are kept up-to-date
 Since releasing [Turborepo 1.10](/blog/turbo-1-10-0) we've seen incredible adoption and community growth:
 
 - [23.6k+ GitHub Stars](https://github.com/vercel/turbo)
-- [2.2M+ weekly NPM downloads](https://www.npmjs.com/package/turbo)
+- [1.8M+ weekly NPM downloads](https://www.npmjs.com/package/turbo)
 - 206 years of compute time saved through [Remote Caching on Vercel](https://vercel.com/docs/concepts/monorepos/remote-caching)
 
 Turborepo is the result of the combined work of all of its contributors, including our core team.


### PR DESCRIPTION
The npm API is pulling 2.2M today but we want to align the number with what comes up on npm.com because that's what folks use to look themselves. 😄