### PR TITLE
Add transpilePackages to `with-tailwind` example.

### DIFF
--- a/examples/with-tailwind/apps/docs/next.config.js
+++ b/examples/with-tailwind/apps/docs/next.config.js
@@ -1,3 +1,5 @@
+/** @type {import('next').NextConfig} */
 module.exports = {
   reactStrictMode: true,
+  transpilePackages: ["@repo/ui"],
 };

--- a/examples/with-tailwind/apps/web/next.config.js
+++ b/examples/with-tailwind/apps/web/next.config.js
@@ -1,3 +1,5 @@
+/** @type {import('next').NextConfig} */
 module.exports = {
   reactStrictMode: true,
+  transpilePackages: ["@repo/ui"],
 };


### PR DESCRIPTION
Puts the `transpilePackages` property into the `with-tailwind` example. Missed it on the first go around!