### PR TITLE
Update yarn support policy.

### DIFF
--- a/docs/pages/repo/docs/support.mdx
+++ b/docs/pages/repo/docs/support.mdx
@@ -38,7 +38,7 @@ and their implementations of workspace configuration (in monorepos) and
 lockfiles formats. We intend to support:
 
 - `npm` (v6+)
-- `yarn` (v1+)
+- `yarn` (v1+) (v4 partially supported)
 - `pnpm` (v6+)
 - `bun` (v1+) (beta, doesn't support all features)
 


### PR DESCRIPTION
Yarn v4 came out with a slightly different lockfile that can break our parsing at times. We're looking to get it fixed but it is not a priority at this time.