### PR TITLE
Remove source key from with-docker example.

### DIFF
--- a/docs/pages/repo/docs/support.mdx
+++ b/docs/pages/repo/docs/support.mdx
@@ -38,7 +38,7 @@ and their implementations of workspace configuration (in monorepos) and
 lockfiles formats. We intend to support:
 
 - `npm` (v6+)
-- `yarn` (v1+)
+- `yarn` (v1+) (v4 partially supported)
 - `pnpm` (v6+)
 - `bun` (v1+) (beta, doesn't support all features)
 

--- a/examples/with-docker/packages/logger/package.json
+++ b/examples/with-docker/packages/logger/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.0",
   "private": true,
   "main": "./dist/index.js",
-  "source": "./src/index.ts",
   "types": "./dist/index.d.ts",
   "files": [
     "dist/**"


### PR DESCRIPTION
Removing the out-of-spec `source` key here. Have seen it confuse folks more than a handful of times.