### PR TITLE
Use `"strict": true`  for TypeScript in examples.

### DIFF
--- a/examples/with-berry/packages/tsconfig/nextjs.json
+++ b/examples/with-berry/packages/tsconfig/nextjs.json
@@ -14,7 +14,7 @@
     "moduleResolution": "Bundler",
     "noEmit": true,
     "resolveJsonModule": true,
-    "strict": false,
+    "strict": true,
     "target": "es5"
   },
   "include": ["src", "next-env.d.ts"],

--- a/examples/with-prisma/packages/config-typescript/nextjs.json
+++ b/examples/with-prisma/packages/config-typescript/nextjs.json
@@ -8,7 +8,7 @@
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
-    "strict": false,
+    "strict": true,
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "incremental": true,

--- a/examples/with-react-native-web/packages/typescript-config/nextjs.json
+++ b/examples/with-react-native-web/packages/typescript-config/nextjs.json
@@ -12,7 +12,7 @@
     "module": "esnext",
     "noEmit": true,
     "resolveJsonModule": true,
-    "strict": false,
+    "strict": true,
     "target": "es5"
   },
   "include": ["src", "next-env.d.ts"],

--- a/examples/with-rollup/packages/config-typescript/nextjs.json
+++ b/examples/with-rollup/packages/config-typescript/nextjs.json
@@ -13,7 +13,7 @@
     "module": "esnext",
     "noEmit": true,
     "resolveJsonModule": true,
-    "strict": false,
+    "strict": true,
     "target": "es5"
   },
   "include": ["src", "next-env.d.ts"],

--- a/examples/with-tailwind/packages/config-typescript/nextjs.json
+++ b/examples/with-tailwind/packages/config-typescript/nextjs.json
@@ -12,7 +12,7 @@
     "lib": ["dom", "dom.iterable", "esnext"],
     "module": "esnext",
     "resolveJsonModule": true,
-    "strict": false,
+    "strict": true,
     "target": "es5"
   },
   "include": ["src", "next-env.d.ts"],


### PR DESCRIPTION
Using `"strict": true` is the sane default as we head into 2024. Our examples should reflect this.
