### PR TITLE
fix: ignore exit codes when child killed by manager

### DIFF
--- a/crates/turborepo-lib/src/process/child.rs
+++ b/crates/turborepo-lib/src/process/child.rs
@@ -108,7 +108,10 @@ impl ShutdownStyle {
 
                     let result = tokio::time::timeout(*timeout, fut).await;
                     match result {
-                        Ok(Ok(result)) => ChildState::Exited(ChildExit::Finished(result)),
+                        // We ignore the exit code and mark it as killed since we sent a SIGINT
+                        // This avoids reliance on an underlying process exiting with
+                        // no exit code or a non-zero in order for turbo to operate correctly.
+                        Ok(Ok(_exit_code)) => ChildState::Exited(ChildExit::Killed),
                         Ok(Err(_)) => ChildState::Exited(ChildExit::Failed),
                         Err(_) => {
                             debug!("graceful shutdown timed out, killing child");
@@ -612,11 +615,7 @@ mod test {
 
         let state = child.state.read().await;
 
-        // process exits with no code when interrupted
-        #[cfg(unix)]
-        assert_matches!(&*state, &ChildState::Exited(ChildExit::Finished(None)));
-
-        #[cfg(not(unix))]
+        // We should ignore the exit code of the process and always treat it as killed
         assert_matches!(&*state, &ChildState::Exited(ChildExit::Killed));
     }
 
@@ -766,7 +765,7 @@ mod test {
 
         let exit = child.stop().await;
 
-        assert_matches!(exit, Some(ChildExit::Finished(None)));
+        assert_matches!(exit, Some(ChildExit::Killed));
     }
 
     #[tokio::test]

--- a/crates/turborepo-lib/src/process/mod.rs
+++ b/crates/turborepo-lib/src/process/mod.rs
@@ -146,12 +146,7 @@ mod test {
         cmd
     }
 
-    // windows doesn't support graceful stop
-    const STOPPED_EXIT: Option<ChildExit> = Some(if cfg!(windows) {
-        ChildExit::Killed
-    } else {
-        ChildExit::Finished(None)
-    });
+    const STOPPED_EXIT: Option<ChildExit> = Some(ChildExit::Killed);
 
     #[tokio::test]
     async fn test_basic() {


### PR DESCRIPTION
### Description

Fixes https://github.com/vercel/turbo/issues/6754

As of `pnpm@8.10.0` `pnpm run script` will respond to a `SIGINT` with an exit code of `0` (See https://github.com/pnpm/npm-lifecycle/pull/41). `turbo` would see this exit code and assume the task successfully completed which results in unwanted behavior on our part.

In Go we don't run into this issue as we [lock the stop channel during shutdown](https://github.com/vercel/turbo/blob/main/cli/internal/process/child.go#L205) and then [will fail this check once the lock is released](https://github.com/vercel/turbo/blob/main/cli/internal/process/child.go#L251) meaning that we would never send the underlying exit code to the exit channel.

Huge thanks to @laat for reporting the bug with a paired down reproduction repo and for finding the underlying PR that changed `pnpm`'s behavior.

### Testing Instructions

Updating existing unit tests to check that we get a `ChildExit::Killed` instead of the underlying process exit code.


Closes TURBO-1893