### PR TITLE
fix: make assertion assert something

### DIFF
--- a/crates/turborepo-lib/src/process/child.rs
+++ b/crates/turborepo-lib/src/process/child.rs
@@ -660,13 +660,14 @@ mod test {
 
         let state = child.state.read().await;
 
-        let _expected = if cfg!(unix) {
-            ChildExit::KilledExternal
-        } else {
-            ChildExit::Finished(Some(1))
+        let ChildState::Exited(state) = &*state else {
+            panic!("expected child to have exited after wait call");
         };
 
-        assert_matches!(&*state, ChildState::Exited(_expected));
+        #[cfg(unix)]
+        assert_matches!(state, ChildExit::KilledExternal);
+        #[cfg(not(unix))]
+        assert_matches!(state, ChildExit::Finished(Some(1)));
     }
 
     #[tokio::test]

--- a/crates/turborepo-lib/src/process/child.rs
+++ b/crates/turborepo-lib/src/process/child.rs
@@ -666,7 +666,7 @@ mod test {
         #[cfg(unix)]
         assert_matches!(state, ChildExit::KilledExternal);
         #[cfg(not(unix))]
-        assert_matches!(state, ChildExit::Finished(Some(1)));
+        assert_matches!(state, ChildExit::Finished(Some(3)));
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Description

`assert_matches!` is a very explicit macro that expands `assert_matches!(x, y)` to `match x { y => (), ref other => panic!("got {other:?"})`. The `y` branch will be taken every time in this example since`y` refers to a named variable and *not* a bound `y` that might exist. See [matching named variables](https://doc.rust-lang.org/book/ch18-03-pattern-syntax.html#matching-named-variables) from the Rust book.

We had `_expected` instead of `expected` because clippy would warn us that the variable was never used and it was right! The the `_expected` in the `assert_matches!` was referring to a different variable than the `_expected` defined above it.

This PR changes the `assert_matches` to use an variant so the assertion is checking what we want.
Now `assert_matches!` expands to
```
match state {
    ChildExit::KilledExternal => {}

    ref left_val => {
        $crate::panicking::assert_matches_failed(
            left_val,
            "ChildExit :: KilledExternal",
            $crate::option::Option::None,
        );
    }
}
```

### Testing Instructions

No unused code warnings anymore.
👀 


Closes TURBO-1894