### PR TITLE
fix: avoid double slash if glob ends with slash

### DIFF
--- a/crates/turborepo-repository/src/package_manager/mod.rs
+++ b/crates/turborepo-repository/src/package_manager/mod.rs
@@ -136,7 +136,11 @@ impl WorkspaceGlobs {
             .iter()
             .map(|s| {
                 let mut s: String = s.clone();
-                s.push_str("/package.json");
+                if s.ends_with('/') {
+                    s.push_str("package.json");
+                } else {
+                    s.push_str("/package.json");
+                }
                 s
             })
             .collect::<Vec<_>>();
@@ -869,5 +873,15 @@ mod tests {
             serde_json::from_str("{ \"workspaces\": {\"packages\": [\"packages/**\"]}}")?;
         assert_eq!(nested.workspaces.as_ref(), vec!["packages/**"]);
         Ok(())
+    }
+
+    #[test]
+    fn test_workspace_globs_trailing_slash() {
+        let globs =
+            WorkspaceGlobs::new(vec!["scripts/", "packages/**"], vec!["package/template"]).unwrap();
+        assert_eq!(
+            &globs.package_json_inclusions,
+            &["scripts/package.json", "packages/**/package.json"]
+        );
     }
 }


### PR DESCRIPTION
### Description

Fixes #6748

### Testing Instructions

Added unit test making sure we don't have multiple forward slashes in the `package.json` globs.

Also tested that we no longer error if a workspace glob has a trailing slash:
```
[0 olszewski@chriss-mbp] /tmp/trailing-slash $ cat pnpm-workspace.yaml 
packages:
  - "apps/*"
  - "packages/*"
  - ci/
# before changes in PR
[0 olszewski@chriss-mbp] /tmp/trailing-slash $ turbo_dev info                                                                               
Turbo error: discovery failed: bad pattern /private/tmp/trailing-slash/ci//package.json: malformed glob expression: adjacent component bounda
ries `/` or `**`

# after PR changes
[0 olszewski@chriss-mbp] /tmp/trailing-slash $ turbo_dev info
You are logged in but not linked
6 packages found in workspace

- @repo/eslint-config packages/eslint-config
- @repo/typescript-config packages/typescript-config
- @repo/ui packages/ui
- ci ci
- docs apps/docs
- web apps/web
```

Closes TURBO-1896