### PR TITLE
chore: remove verbosity filter from chrome profile

### DIFF
--- a/crates/turborepo-lib/src/tracing.rs
+++ b/crates/turborepo-lib/src/tracing.rs
@@ -66,11 +66,9 @@ type DaemonLogLayered = layer::Layered<DaemonLogFiltered, StdErrLogLayered>;
 type ChromeLog = ChromeLayer<DaemonLogLayered>;
 /// This layer can be reloaded. `None` means the layer is disabled.
 type ChromeReload = reload::Layer<Option<ChromeLog>, DaemonLogLayered>;
-/// We filter this using an EnvFilter.
-type ChromeLogFiltered = Filtered<ChromeReload, EnvFilter, DaemonLogLayered>;
 /// When the `ChromeLogFiltered` is applied to the `DaemonLogLayered`, we get a
 /// `ChromeLogLayered`, which forms the base for the next layer.
-type ChromeLogLayered = layer::Layered<ChromeLogFiltered, DaemonLogLayered>;
+type ChromeLogLayered = layer::Layered<ChromeReload, DaemonLogLayered>;
 
 pub struct TurboSubscriber {
     daemon_update: Handle<Option<DaemonLog>, StdErrLogLayered>,
@@ -140,7 +138,6 @@ impl TurboSubscriber {
         let logrotate: DaemonLogFiltered = logrotate.with_filter(daemon_filter);
 
         let (chrome, chrome_update) = reload::Layer::new(Option::<ChromeLog>::None);
-        let chrome: ChromeLogFiltered = chrome.with_filter(env_filter());
 
         let registry = Registry::default()
             .with(stderr)


### PR DESCRIPTION
### Description

Just remove the `EnvFilter` from the chrome tracing layer as we don't actually want to filter events if we're profiling. 

### Testing Instructions

Double checked that you no longer need `-vvv` when creating a `--profile`:
```
[0 olszewski@chriss-mbp] /tmp/profile-test $ turbo_dev build --profile=profile.json
• Packages in scope: @repo/eslint-config, @repo/typescript-config, @repo/ui, docs, web
• Running build in 5 packages
• Remote caching disabled
web:build: cache hit (outputs already on disk), replaying logs 1ca71cbe42d6964f
docs:build: cache hit (outputs already on disk), replaying logs 8716c2923c92c7c2
web:build: 
web:build: > web@1.0.0 build /private/tmp/profile-test/apps/web
web:build: > next build
web:build: 
...
web:build: 
docs:build: 
docs:build: 
web:build: 
web:build: ○  (Static)  prerendered as static content
docs:build: ○  (Static)  prerendered as static content
docs:build: 
web:build: 

 Tasks:    2 successful, 2 total
Cached:    2 cached, 2 total
  Time:    379ms >>> FULL TURBO
[0 olszewski@chriss-mbp] /tmp/profile-test $ head profile.json 
[
{"args":{"name":"main"},"name":"thread_name","ph":"M","pid":1,"tid":0},
{".file":"crates/turborepo-lib/src/tracing.rs",".line":191,"cat":"turborepo_lib::tracing","name":"enable_chrome_tracing","ph":"E","pid":1,"tid":0,"ts":35.25},
{".file":"crates/turborepo-lib/src/commands/run.rs",".line":33,"args":{"message":"using the experimental rust codepath"},"cat":"turborepo_lib::commands::run","name":"event crates/turborepo-lib/src/commands/run.rs:33","ph":"i","pid":1,"s":"t","tid":0,"ts":200.583},
{".file":"crates/turborepo-lib/src/commands/run.rs",".line":34,"args":{"message":"configured run struct: Run { base: CommandBase { repo_root: AbsoluteSystemPathBuf(\"/private/tmp/profile-test\"), ui: UI { should_strip_ansi: false }, config: OnceCell(<uninit>), args: Args { version: false, skip_infer: false, no_update_notifier: false, api: None, color: false, cpu_profile: None, cwd: Some(\"/private/tmp/profile-test\"), heap: None, login: None, no_color: false, preflight: false, remote_cache_timeout: None, team: None, token: None, trace: None, verbosity: Verbosity { verbosity: None, v: 0 }, check_for_update: false, test_run: false, run_args: None, command: Some(Run(RunArgs { cache_dir: None, cache_workers: 10, concurrency: None, continue_execution: false, dry_run: None, go_fallback: false, single_package: false, filter: [], force: None, framework_inference: true, global_deps: [], graph: None, env_mode: Infer, ignore: [], include_dependencies: false, no_cache: false, daemon: false, no_daemon: false, no_deps: false, output_logs: None, log_order: Auto, only: false, parallel: false, pkg_inference_root: None, profile: Some(\"profile.json\"), remote_only: false, remote_cache_read_only: false, scope: [], since: None, summarize: None, log_prefix: Auto, tasks: [\"build\"], pass_through_args: [], experimental_space_id: None })) }, version: \"1.11.2-canary.0\" }, processes: ProcessManager(Mutex { data: ProcessManagerInner { is_closing: false, children: [] }, poisoned: false, .. }) }"},"cat":"turborepo_lib::commands::run","name":"event crates/turborepo-lib/src/commands/run.rs:34","ph":"i","pid":1,"s":"t","tid":0,"ts":218.958},
{".file":"crates/turborepo-lib/src/run/mod.rs",".line":123,"cat":"turborepo_lib::run","name":"run","ph":"B","pid":1,"tid":0,"ts":334.083},
{".file":"crates/turborepo-lib/src/run/mod.rs",".line":125,"args":{"message":"performing run on \"darwin-arm64\"","numcpus":"10","platform":"darwin-arm64","start_time":"1702417532949052","turbo_version":"1.11.2-canary.0"},"cat":"turborepo_lib::run","name":"event crates/turborepo-lib/src/run/mod.rs:125","ph":"i","pid":1,"s":"t","tid":0,"ts":350.75},
{".file":"crates/turborepo-lib/src/daemon/connector.rs",".line":89,"cat":"turborepo_lib::daemon::connector","name":"connect","ph":"B","pid":1,"tid":0,"ts":1504.291},
{".file":"crates/turborepo-lib/src/daemon/connector.rs",".line":133,"args":{"message":"looking for pid in lockfile: AbsoluteSystemPathBuf(\"/var/folders/3m/rxkycvgs5jgfvs0k9xcgp6km0000gn/T/turbod/9797303bde4f4c9a/turbod.pid\")"},"cat":"turborepo_lib::daemon::connector","name":"event crates/turborepo-lib/src/daemon/connector.rs:133","ph":"i","pid":1,"s":"t","tid":0,"ts":1519.208},
{".file":"crates/turborepo-lib/src/daemon/connector.rs",".line":139,"args":{"message":"found pid: 90363"},"cat":"turborepo_lib::daemon::connector","name":"event crates/turborepo-lib/src/daemon/connector.rs:139","ph":"i","pid":1,"s":"t","tid":0,"ts":1701.291},
```

Also double checked that `-vv` still works as expected for stderr output:
```
[0 olszewski@chriss-mbp] /tmp/profile-test $ turbo_dev build -vv | head
2023-12-12T13:47:43.618-0800 [DEBUG] turborepo_lib::shim: Global turbo version: 1.11.2-canary.0
2023-12-12T13:47:43.634-0800 [DEBUG] turborepo_lib::shim: Repository Root: /private/tmp/profile-test
...
[0 olszewski@chriss-mbp] /tmp/profile-test $ turbo_dev build -vvv | head
2023-12-12T13:48:06.640-0800 [DEBUG] turborepo_lib::shim: Global turbo version: 1.11.2-canary.0
...
2023-12-12T13:48:06.659-0800 [TRACE] turborepo_lib::run: performing run on "darwin-arm64"
```


Closes TURBO-1901