### PR TITLE
Error out if dependent flags are provided without their parent

### DIFF
--- a/turborepo-tests/integration/tests/conflicting-flags.t
+++ b/turborepo-tests/integration/tests/conflicting-flags.t
@@ -1,0 +1,46 @@
+Setup
+  $ . ${TESTDIR}/../../helpers/setup_integration_test.sh
+  $ ${TURBO} run build --daemon --no-daemon
+   ERROR  the argument '--[no-]daemon' cannot be used with '--no-daemon'
+  
+  Usage: turbo(\.exe)? run --\[no-\]daemon (re)
+  
+  For more information, try '--help'.
+  
+  [1]
+  $ ${TURBO} run build --since main
+   ERROR  the following required arguments were not provided:
+    --scope <SCOPE>
+  
+  Usage: turbo(\.exe)? run --scope <SCOPE> --since <SINCE> (re)
+  
+  For more information, try '--help'.
+  
+  [1]
+  $ ${TURBO} run build --ignore 'app/**'
+   ERROR  the following required arguments were not provided:
+    <--filter <FILTER>|--scope <SCOPE>>
+  
+  Usage: turbo(\.exe)? run --ignore <IGNORE> <--filter <FILTER>|--scope <SCOPE>> (re)
+  
+  For more information, try '--help'.
+  
+  [1]
+  $ ${TURBO} run build --no-deps
+   ERROR  the following required arguments were not provided:
+    --scope <SCOPE>
+  
+  Usage: turbo(\.exe)? run --scope <SCOPE> --no-deps (re)
+  
+  For more information, try '--help'.
+  
+  [1]
+  $ ${TURBO} run build --include-dependencies
+   ERROR  the following required arguments were not provided:
+    --scope <SCOPE>
+  
+  Usage: turbo(\.exe)? run --scope <SCOPE> --include-dependencies (re)
+  
+  For more information, try '--help'.
+  
+  [1]

--- a/turborepo-tests/integration/tests/no-args.t
+++ b/turborepo-tests/integration/tests/no-args.t
@@ -53,8 +53,6 @@ Make sure exit code is 2 when no args are passed
             Fallback to use Go for task execution
         --single-package
             Run turbo in single-package mode
-    -F, --filter <FILTER>
-            Use the given selector to specify package(s) to act as entry points. The syntax mirrors pnpm's syntax, and additional documentation and examples can be found in turbo's documentation https://turbo.build/repo/docs/reference/command-line-reference/run#--filter
         --force [<FORCE>]
             Ignore the existing cache (to force execution) [env: TURBO_FORCE=] [possible values: true, false]
         --framework-inference [<BOOL>]
@@ -65,16 +63,22 @@ Make sure exit code is 2 when no args are passed
             Generate a graph of the task execution and output to a file when a filename is specified (.svg, .png, .jpg, .pdf, .json, .html). Outputs dot graph to stdout when if no filename is provided
         --env-mode [<ENV_MODE>]
             Environment variable mode. Use "loose" to pass the entire existing environment. Use "strict" to use an allowlist specified in turbo.json. Use "infer" to defer to existence of "passThroughEnv" or "globalPassThroughEnv" in turbo.json. (default infer) [default: infer] [possible values: infer, loose, strict]
+    -F, --filter <FILTER>
+            Use the given selector to specify package(s) to act as entry points. The syntax mirrors pnpm's syntax, and additional documentation and examples can be found in turbo's documentation https://turbo.build/repo/docs/reference/command-line-reference/run#--filter
+        --scope <SCOPE>
+            DEPRECATED: Specify package(s) to act as entry points for task execution. Supports globs
         --ignore <IGNORE>
-            Files to ignore when calculating changed files (i.e. --since). Supports globs
+            Files to ignore when calculating changed files from '--filter'. Supports globs
+        --since <SINCE>
+            DEPRECATED: Limit/Set scope to changed packages since a mergebase. This uses the git diff ${target_branch}... mechanism to identify which packages have changed
         --include-dependencies
-            Include the dependencies of tasks in execution
+            DEPRECATED: Include the dependencies of tasks in execution
+        --no-deps
+            DEPRECATED: Exclude dependent task consumers from execution
         --no-cache
             Avoid saving task results to the cache. Useful for development/watch tasks
         --[no-]daemon
             Force turbo to either use or not use the local daemon. If unset turbo will use the default detection logic
-        --no-deps
-            Exclude dependent task consumers from execution
         --output-logs <OUTPUT_LOGS>
             Set type of process output logging. Use "full" to show all output. Use "hash-only" to show only turbo-computed task hashes. Use "new-only" to show only new output with only hashes for cached tasks. Use "none" to hide process output. (default full) [possible values: full, none, hash-only, new-only, errors-only]
         --log-order <LOG_ORDER>
@@ -91,10 +95,6 @@ Make sure exit code is 2 when no args are passed
             Ignore the local filesystem cache for all tasks. Only allow reading and caching artifacts using the remote cache [env: TURBO_REMOTE_ONLY=] [default: false] [possible values: true, false]
         --remote-cache-read-only [<BOOL>]
             Treat remote cache as read only [env: TURBO_REMOTE_CACHE_READ_ONLY=] [default: false] [possible values: true, false]
-        --scope <SCOPE>
-            Specify package(s) to act as entry points for task execution. Supports globs
-        --since <SINCE>
-            Limit/Set scope to changed packages since a mergebase. This uses the git diff ${target_branch}... mechanism to identify which packages have changed
         --summarize [<SUMMARIZE>]
             Generate a summary of the turbo run [env: TURBO_RUN_SUMMARY=] [possible values: true, false]
         --log-prefix <LOG_PREFIX>

--- a/turborepo-tests/integration/tests/turbo-help.t
+++ b/turborepo-tests/integration/tests/turbo-help.t
@@ -53,8 +53,6 @@ Test help flag
             Fallback to use Go for task execution
         --single-package
             Run turbo in single-package mode
-    -F, --filter <FILTER>
-            Use the given selector to specify package(s) to act as entry points. The syntax mirrors pnpm's syntax, and additional documentation and examples can be found in turbo's documentation https://turbo.build/repo/docs/reference/command-line-reference/run#--filter
         --force [<FORCE>]
             Ignore the existing cache (to force execution) [env: TURBO_FORCE=] [possible values: true, false]
         --framework-inference [<BOOL>]
@@ -65,16 +63,22 @@ Test help flag
             Generate a graph of the task execution and output to a file when a filename is specified (.svg, .png, .jpg, .pdf, .json, .html). Outputs dot graph to stdout when if no filename is provided
         --env-mode [<ENV_MODE>]
             Environment variable mode. Use "loose" to pass the entire existing environment. Use "strict" to use an allowlist specified in turbo.json. Use "infer" to defer to existence of "passThroughEnv" or "globalPassThroughEnv" in turbo.json. (default infer) [default: infer] [possible values: infer, loose, strict]
+    -F, --filter <FILTER>
+            Use the given selector to specify package(s) to act as entry points. The syntax mirrors pnpm's syntax, and additional documentation and examples can be found in turbo's documentation https://turbo.build/repo/docs/reference/command-line-reference/run#--filter
+        --scope <SCOPE>
+            DEPRECATED: Specify package(s) to act as entry points for task execution. Supports globs
         --ignore <IGNORE>
-            Files to ignore when calculating changed files (i.e. --since). Supports globs
+            Files to ignore when calculating changed files from '--filter'. Supports globs
+        --since <SINCE>
+            DEPRECATED: Limit/Set scope to changed packages since a mergebase. This uses the git diff ${target_branch}... mechanism to identify which packages have changed
         --include-dependencies
-            Include the dependencies of tasks in execution
+            DEPRECATED: Include the dependencies of tasks in execution
+        --no-deps
+            DEPRECATED: Exclude dependent task consumers from execution
         --no-cache
             Avoid saving task results to the cache. Useful for development/watch tasks
         --[no-]daemon
             Force turbo to either use or not use the local daemon. If unset turbo will use the default detection logic
-        --no-deps
-            Exclude dependent task consumers from execution
         --output-logs <OUTPUT_LOGS>
             Set type of process output logging. Use "full" to show all output. Use "hash-only" to show only turbo-computed task hashes. Use "new-only" to show only new output with only hashes for cached tasks. Use "none" to hide process output. (default full) [possible values: full, none, hash-only, new-only, errors-only]
         --log-order <LOG_ORDER>
@@ -91,10 +95,6 @@ Test help flag
             Ignore the local filesystem cache for all tasks. Only allow reading and caching artifacts using the remote cache [env: TURBO_REMOTE_ONLY=] [default: false] [possible values: true, false]
         --remote-cache-read-only [<BOOL>]
             Treat remote cache as read only [env: TURBO_REMOTE_CACHE_READ_ONLY=] [default: false] [possible values: true, false]
-        --scope <SCOPE>
-            Specify package(s) to act as entry points for task execution. Supports globs
-        --since <SINCE>
-            Limit/Set scope to changed packages since a mergebase. This uses the git diff ${target_branch}... mechanism to identify which packages have changed
         --summarize [<SUMMARIZE>]
             Generate a summary of the turbo run [env: TURBO_RUN_SUMMARY=] [possible values: true, false]
         --log-prefix <LOG_PREFIX>
@@ -156,8 +156,6 @@ Test help flag
             Fallback to use Go for task execution
         --single-package
             Run turbo in single-package mode
-    -F, --filter <FILTER>
-            Use the given selector to specify package(s) to act as entry points. The syntax mirrors pnpm's syntax, and additional documentation and examples can be found in turbo's documentation https://turbo.build/repo/docs/reference/command-line-reference/run#--filter
         --force [<FORCE>]
             Ignore the existing cache (to force execution) [env: TURBO_FORCE=] [possible values: true, false]
         --framework-inference [<BOOL>]
@@ -168,16 +166,22 @@ Test help flag
             Generate a graph of the task execution and output to a file when a filename is specified (.svg, .png, .jpg, .pdf, .json, .html). Outputs dot graph to stdout when if no filename is provided
         --env-mode [<ENV_MODE>]
             Environment variable mode. Use "loose" to pass the entire existing environment. Use "strict" to use an allowlist specified in turbo.json. Use "infer" to defer to existence of "passThroughEnv" or "globalPassThroughEnv" in turbo.json. (default infer) [default: infer] [possible values: infer, loose, strict]
+    -F, --filter <FILTER>
+            Use the given selector to specify package(s) to act as entry points. The syntax mirrors pnpm's syntax, and additional documentation and examples can be found in turbo's documentation https://turbo.build/repo/docs/reference/command-line-reference/run#--filter
+        --scope <SCOPE>
+            DEPRECATED: Specify package(s) to act as entry points for task execution. Supports globs
         --ignore <IGNORE>
-            Files to ignore when calculating changed files (i.e. --since). Supports globs
+            Files to ignore when calculating changed files from '--filter'. Supports globs
+        --since <SINCE>
+            DEPRECATED: Limit/Set scope to changed packages since a mergebase. This uses the git diff ${target_branch}... mechanism to identify which packages have changed
         --include-dependencies
-            Include the dependencies of tasks in execution
+            DEPRECATED: Include the dependencies of tasks in execution
+        --no-deps
+            DEPRECATED: Exclude dependent task consumers from execution
         --no-cache
             Avoid saving task results to the cache. Useful for development/watch tasks
         --[no-]daemon
             Force turbo to either use or not use the local daemon. If unset turbo will use the default detection logic
-        --no-deps
-            Exclude dependent task consumers from execution
         --output-logs <OUTPUT_LOGS>
             Set type of process output logging. Use "full" to show all output. Use "hash-only" to show only turbo-computed task hashes. Use "new-only" to show only new output with only hashes for cached tasks. Use "none" to hide process output. (default full) [possible values: full, none, hash-only, new-only, errors-only]
         --log-order <LOG_ORDER>
@@ -194,10 +198,6 @@ Test help flag
             Ignore the local filesystem cache for all tasks. Only allow reading and caching artifacts using the remote cache [env: TURBO_REMOTE_ONLY=] [default: false] [possible values: true, false]
         --remote-cache-read-only [<BOOL>]
             Treat remote cache as read only [env: TURBO_REMOTE_CACHE_READ_ONLY=] [default: false] [possible values: true, false]
-        --scope <SCOPE>
-            Specify package(s) to act as entry points for task execution. Supports globs
-        --since <SINCE>
-            Limit/Set scope to changed packages since a mergebase. This uses the git diff ${target_branch}... mechanism to identify which packages have changed
         --summarize [<SUMMARIZE>]
             Generate a summary of the turbo run [env: TURBO_RUN_SUMMARY=] [possible values: true, false]
         --log-prefix <LOG_PREFIX>


### PR DESCRIPTION
### Description

Closes #1227

We have a few flags that only make sense in the context of others. People are mistakenly using these flags on their own and correctly observing that nothing happens. This change records those deps such that people using invalid combinations of flags are warned.

This also deprecates some old flags, and reorganises the args such that they are closer to one-another in the help doc.

#### Dependencies

- since -> scope
- no-deps -> scope
- include-dependenciese -> scope
- ignore -> scope ^ filter

### Testing Instructions

New unit tests and integration tests


Closes TURBO-1902