### PR TITLE
feat: add anon-profile flag

### DIFF
--- a/crates/turborepo-lib/src/tracing.rs
+++ b/crates/turborepo-lib/src/tracing.rs
@@ -189,10 +189,14 @@ impl TurboSubscriber {
 
     /// Enables chrome tracing.
     #[tracing::instrument(skip(self, to_file))]
-    pub fn enable_chrome_tracing<P: AsRef<Path>>(&self, to_file: P) -> Result<(), Error> {
+    pub fn enable_chrome_tracing<P: AsRef<Path>>(
+        &self,
+        to_file: P,
+        include_args: bool,
+    ) -> Result<(), Error> {
         let (layer, guard) = tracing_chrome::ChromeLayerBuilder::new()
             .file(to_file)
-            .include_args(true)
+            .include_args(include_args)
             .include_locations(true)
             .build();
 

--- a/turborepo-tests/integration/tests/no-args.t
+++ b/turborepo-tests/integration/tests/no-args.t
@@ -85,6 +85,8 @@ Make sure exit code is 2 when no args are passed
             Execute all tasks in parallel
         --profile <PROFILE>
             File to write turbo's performance profile output into. You can load the file up in chrome://tracing to see which parts of your build were slow
+        --anon-profile <ANON_PROFILE>
+            File to write turbo's performance profile output into. All identifying data omitted from the profile
         --remote-only [<BOOL>]
             Ignore the local filesystem cache for all tasks. Only allow reading and caching artifacts using the remote cache [env: TURBO_REMOTE_ONLY=] [default: false] [possible values: true, false]
         --remote-cache-read-only [<BOOL>]

--- a/turborepo-tests/integration/tests/turbo-help.t
+++ b/turborepo-tests/integration/tests/turbo-help.t
@@ -85,6 +85,8 @@ Test help flag
             Execute all tasks in parallel
         --profile <PROFILE>
             File to write turbo's performance profile output into. You can load the file up in chrome://tracing to see which parts of your build were slow
+        --anon-profile <ANON_PROFILE>
+            File to write turbo's performance profile output into. All identifying data omitted from the profile
         --remote-only [<BOOL>]
             Ignore the local filesystem cache for all tasks. Only allow reading and caching artifacts using the remote cache [env: TURBO_REMOTE_ONLY=] [default: false] [possible values: true, false]
         --remote-cache-read-only [<BOOL>]
@@ -186,6 +188,8 @@ Test help flag
             Execute all tasks in parallel
         --profile <PROFILE>
             File to write turbo's performance profile output into. You can load the file up in chrome://tracing to see which parts of your build were slow
+        --anon-profile <ANON_PROFILE>
+            File to write turbo's performance profile output into. All identifying data omitted from the profile
         --remote-only [<BOOL>]
             Ignore the local filesystem cache for all tasks. Only allow reading and caching artifacts using the remote cache [env: TURBO_REMOTE_ONLY=] [default: false] [possible values: true, false]
         --remote-cache-read-only [<BOOL>]


### PR DESCRIPTION
### Description

This PR adds `--anon-profile` which will generate a profile, but without any identifying data included. It will only output where in the code that time was spent.

(The PR also adds a requirement that a user passes a non-empty path for the profile file)

### Testing Instructions

Added unit tests for usage of `--profile` and `--anon-profile`. Quick spot check that `--anon-profile` removes any identifying data:
```
turbo_dev build --anon-profile="profile.json" -vv
```
Resulting [profile.json](https://github.com/vercel/turbo/files/13654482/profile.json)



Closes TURBO-1903