### PR TITLE
feat(turbopack-ecmascript): support named client references

### DIFF
--- a/crates/turbopack-ecmascript-plugins/src/transform/directives/server_to_client_proxy.rs
+++ b/crates/turbopack-ecmascript-plugins/src/transform/directives/server_to_client_proxy.rs
@@ -2,7 +2,7 @@ use swc_core::{
     common::DUMMY_SP,
     ecma::{
         ast::{
-            Expr, ExprStmt, Ident, ImportDecl, ImportDefaultSpecifier, ImportSpecifier,
+            Expr, ExprStmt, Ident, ImportDecl, ImportSpecifier, ImportStarAsSpecifier,
             KeyValueProp, Lit, Module, ModuleDecl, ModuleItem, ObjectLit, Program, Prop, PropName,
             PropOrSpread, Stmt, Str,
         },
@@ -13,7 +13,7 @@ use swc_core::{
 use turbopack_ecmascript::TURBOPACK_HELPER;
 
 pub fn create_proxy_module(transition_name: &str, target_import: &str) -> Program {
-    let ident = private_ident!("createProxy");
+    let ident = private_ident!("clientProxy");
     Program::Module(Module {
         body: vec![
             ModuleItem::Stmt(Stmt::Expr(ExprStmt {
@@ -25,7 +25,7 @@ pub fn create_proxy_module(transition_name: &str, target_import: &str) -> Progra
                 span: DUMMY_SP,
             })),
             ModuleItem::ModuleDecl(ModuleDecl::Import(ImportDecl {
-                specifiers: vec![ImportSpecifier::Default(ImportDefaultSpecifier {
+                specifiers: vec![ImportSpecifier::Namespace(ImportStarAsSpecifier {
                     local: ident.clone(),
                     span: DUMMY_SP,
                 })],


### PR DESCRIPTION
### Description

Makes expanding star exports public to be used from `next-core` for generating exports in the proxy module.

Needs to be merged with the next.js PR: https://github.com/vercel/next.js/pull/59578