### PR TITLE
feat(gen): pass the command cwd through

### DIFF
--- a/packages/turbo-gen/src/utils/plop.ts
+++ b/packages/turbo-gen/src/utils/plop.ts
@@ -199,6 +199,7 @@ function injectTurborepoData({
   generator: PlopGenerator & { basePath?: string };
 }) {
   const paths = {
+    cwd: process.cwd(),
     root: project.paths.root,
     workspace: generator.basePath
       ? searchUp({ cwd: generator.basePath, target: "package.json" })


### PR DESCRIPTION
### Description

We base all of our generators around workspace roots, anchoring execution there no matter where the command is run. However, there are still times when you may want to access the cwd where the generator command was executed. This passes that through for use in answers.

Feature request from @arlyon 

Closes TURBO-1918