### PR TITLE
chore: include response body if not valid JSON

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10887,6 +10887,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
+ "http",
  "lazy_static",
  "port_scanner",
  "regex",

--- a/crates/turborepo-api-client/Cargo.toml
+++ b/crates/turborepo-api-client/Cargo.toml
@@ -10,8 +10,8 @@ native-tls = ["reqwest/native-tls"]
 rustls-tls = ["reqwest/rustls-tls"]
 
 [dev-dependencies]
+http = "0.2.9"
 port_scanner = { workspace = true }
-serde_json = { workspace = true }
 test-case = { workspace = true }
 turborepo-vercel-api-mock = { workspace = true }
 
@@ -27,6 +27,7 @@ regex = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }
 rustc_version_runtime = "0.2.1"
 serde = { workspace = true }
+serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 turbopath = { workspace = true }

--- a/crates/turborepo-api-client/src/error.rs
+++ b/crates/turborepo-api-client/src/error.rs
@@ -31,6 +31,11 @@ pub enum Error {
         status: CachingStatus,
         message: String,
     },
+    #[error("unable to parse '{text}' as JSON: {err}")]
+    InvalidJson {
+        err: serde_json::Error,
+        text: String,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/turborepo-api-client/src/lib.rs
+++ b/crates/turborepo-api-client/src/lib.rs
@@ -282,9 +282,19 @@ impl Client for APIClient {
         struct WrappedAPIError {
             error: APIError,
         }
-        let WrappedAPIError { error: api_error } = match response.json().await {
-            Ok(api_error) => api_error,
+        let body = match response.text().await {
+            Ok(body) => body,
             Err(e) => return Error::ReqwestError(e),
+        };
+
+        let WrappedAPIError { error: api_error } = match serde_json::from_str(&body) {
+            Ok(api_error) => api_error,
+            Err(err) => {
+                return Error::InvalidJson {
+                    err,
+                    text: body.clone(),
+                }
+            }
         };
 
         if let Some(status_string) = api_error.code.strip_prefix("remote_caching_") {
@@ -589,5 +599,30 @@ mod test {
 
         handle.abort();
         Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_handle_403_includes_text_on_invalid_json() {
+        let response = reqwest::Response::from(
+            http::Response::builder()
+                .body("this isn't valid JSON")
+                .unwrap(),
+        );
+        let err = APIClient::handle_403(response).await;
+        assert_eq!(
+            err.to_string(),
+            "unable to parse 'this isn't valid JSON' as JSON: expected ident at line 1 column 2"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_handle_403_parses_error_if_present() {
+        let response = reqwest::Response::from(
+            http::Response::builder()
+                .body(r#"{"error": {"code": "forbidden", "message": "Not authorized"}}"#)
+                .unwrap(),
+        );
+        let err = APIClient::handle_403(response).await;
+        assert_eq!(err.to_string(), "unknown status forbidden: Not authorized");
     }
 }


### PR DESCRIPTION
### Description

I noticed in our Ubuntu CI runs there's sometimes a `artifact verification failed: Error making HTTP request: error decoding response body: expected value at line 1 column 1` [source](https://github.com/vercel/turbo/actions/runs/7210774346/job/19644690101#step:6:408)

It would be more useful if we could get an idea of what the response was instead of a JSON parse error.

### Testing Instructions

Added unit tests