### PR TITLE
chore: add tracing to primary lockfile functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10567,6 +10567,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_qs",
+ "sourcemap",
  "swc_core",
  "tokio",
  "tracing",
@@ -11177,6 +11178,7 @@ dependencies = [
  "serde_yaml 0.9.27",
  "test-case",
  "thiserror",
+ "tracing",
  "turbopath",
 ]
 

--- a/crates/turborepo-lockfiles/Cargo.toml
+++ b/crates/turborepo-lockfiles/Cargo.toml
@@ -19,6 +19,7 @@ serde = { version = "1.0.126", features = ["derive", "rc"] }
 serde_json = "1.0.86"
 serde_yaml = "0.9.27"
 thiserror = "1.0.38"
+tracing.workspace = true
 turbopath = { path = "../turborepo-paths" }
 
 [dev-dependencies]

--- a/crates/turborepo-lockfiles/src/berry/mod.rs
+++ b/crates/turborepo-lockfiles/src/berry/mod.rs
@@ -372,6 +372,7 @@ impl BerryLockfile {
 }
 
 impl Lockfile for BerryLockfile {
+    #[tracing::instrument(skip(self))]
     fn resolve_package(
         &self,
         workspace_path: &str,
@@ -410,6 +411,7 @@ impl Lockfile for BerryLockfile {
         }))
     }
 
+    #[tracing::instrument(skip(self))]
     fn all_dependencies(
         &self,
         key: &str,

--- a/crates/turborepo-lockfiles/src/bun/mod.rs
+++ b/crates/turborepo-lockfiles/src/bun/mod.rs
@@ -56,6 +56,7 @@ impl FromStr for BunLockfile {
 }
 
 impl Lockfile for BunLockfile {
+    #[tracing::instrument(skip(self, _workspace_path))]
     fn resolve_package(
         &self,
         _workspace_path: &str,
@@ -74,6 +75,7 @@ impl Lockfile for BunLockfile {
         Ok(None)
     }
 
+    #[tracing::instrument(skip(self))]
     fn all_dependencies(
         &self,
         key: &str,

--- a/crates/turborepo-lockfiles/src/lib.rs
+++ b/crates/turborepo-lockfiles/src/lib.rs
@@ -77,6 +77,7 @@ pub fn all_transitive_closures<L: Lockfile + ?Sized>(
 }
 
 // this should get replaced by petgraph in the future :)
+#[tracing::instrument(skip_all)]
 pub fn transitive_closure<L: Lockfile + ?Sized>(
     lockfile: &L,
     workspace_path: &str,

--- a/crates/turborepo-lockfiles/src/npm.rs
+++ b/crates/turborepo-lockfiles/src/npm.rs
@@ -45,6 +45,7 @@ struct NpmPackage {
 }
 
 impl Lockfile for NpmLockfile {
+    #[tracing::instrument(skip(self, _version))]
     fn resolve_package(
         &self,
         workspace_path: &str,
@@ -78,6 +79,7 @@ impl Lockfile for NpmLockfile {
             .transpose()
     }
 
+    #[tracing::instrument(skip(self))]
     fn all_dependencies(&self, key: &str) -> Result<Option<HashMap<String, String>>, Error> {
         self.packages
             .get(key)

--- a/crates/turborepo-lockfiles/src/pnpm/data.rs
+++ b/crates/turborepo-lockfiles/src/pnpm/data.rs
@@ -275,6 +275,7 @@ struct GlobalFields<'a> {
 }
 
 impl crate::Lockfile for PnpmLockfile {
+    #[tracing::instrument(skip(self))]
     fn resolve_package(
         &self,
         workspace_path: &str,
@@ -321,6 +322,7 @@ impl crate::Lockfile for PnpmLockfile {
         }
     }
 
+    #[tracing::instrument(skip(self))]
     fn all_dependencies(
         &self,
         key: &str,

--- a/crates/turborepo-lockfiles/src/yarn1/mod.rs
+++ b/crates/turborepo-lockfiles/src/yarn1/mod.rs
@@ -55,6 +55,7 @@ impl FromStr for Yarn1Lockfile {
 }
 
 impl Lockfile for Yarn1Lockfile {
+    #[tracing::instrument(skip(self, _workspace_path))]
     fn resolve_package(
         &self,
         _workspace_path: &str,
@@ -73,6 +74,7 @@ impl Lockfile for Yarn1Lockfile {
         Ok(None)
     }
 
+    #[tracing::instrument(skip(self))]
     fn all_dependencies(
         &self,
         key: &str,

--- a/crates/turborepo-repository/src/package_manager/mod.rs
+++ b/crates/turborepo-repository/src/package_manager/mod.rs
@@ -512,7 +512,7 @@ impl PackageManager {
         self.parse_lockfile(root_package_json, &contents)
     }
 
-    #[tracing::instrument(skip(self, root_package_json))]
+    #[tracing::instrument(skip(self, root_package_json, contents))]
     pub fn parse_lockfile(
         &self,
         root_package_json: &PackageJson,


### PR DESCRIPTION
### Description

Add tracing timings to the functions used when calculating transitive closures. Didn't go deeper than the two functions that are used by `transitive_closure` as this is probably all we can do without producing a wild amount of events. This will at least let us understand from a profile if parsing is slow or if it's one of the traversal methods.

### Testing Instructions

<img width="1649" alt="Screenshot 2023-12-14 at 4 36 56 PM" src="https://github.com/vercel/turbo/assets/4131117/c62f3b7d-428a-46a1-b190-4686c112dc59">



Closes TURBO-1937