### PR TITLE
fix: add missing dependency to cargo lockfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10567,6 +10567,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_qs",
+ "sourcemap",
  "swc_core",
  "tokio",
  "tracing",


### PR DESCRIPTION
VSCode (rust-analyzer maybe?) keeps updating my lockfile with this diff. I _think_ it's because this dep was added in #6494 but the lockfile wasn't updated