### PR TITLE
refactor: Remove bookkeeping abstraction from turbo config

### DIFF
--- a/crates/turborepo-lib/src/commands/link.rs
+++ b/crates/turborepo-lib/src/commands/link.rs
@@ -593,7 +593,7 @@ mod test {
     use crate::{
         cli::LinkTarget,
         commands::{link, CommandBase},
-        config::{RawTurboJSON, TurborepoConfigBuilder},
+        config::{RawTurboJson, TurborepoConfigBuilder},
         Args,
     };
 
@@ -728,7 +728,7 @@ mod test {
 
         // verify space id is added to turbo.json
         let turbo_json_contents = fs::read_to_string(&turbo_json_file).unwrap();
-        let turbo_json: RawTurboJSON = serde_json::from_str(&turbo_json_contents).unwrap();
+        let turbo_json: RawTurboJson = serde_json::from_str(&turbo_json_contents).unwrap();
         assert_eq!(
             turbo_json.experimental_spaces.unwrap().id.unwrap(),
             turborepo_vercel_api_mock::EXPECTED_SPACE_ID

--- a/crates/turborepo-lib/src/commands/prune.rs
+++ b/crates/turborepo-lib/src/commands/prune.rs
@@ -14,7 +14,7 @@ use turborepo_repository::{
 use turborepo_ui::BOLD;
 
 use super::CommandBase;
-use crate::config::RawTurboJSON;
+use crate::config::RawTurboJson;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -426,7 +426,7 @@ impl<'a> Prune<'a> {
             }
             Err(e) => return Err(e.into()),
         };
-        let turbo_json: RawTurboJSON = serde_json::from_reader(json_comments::StripComments::new(
+        let turbo_json: RawTurboJson = serde_json::from_reader(json_comments::StripComments::new(
             turbo_json_contents.as_slice(),
         ))?;
 

--- a/crates/turborepo-lib/src/config/mod.rs
+++ b/crates/turborepo-lib/src/config/mod.rs
@@ -4,7 +4,10 @@ mod turbo_config;
 use std::io;
 
 use thiserror::Error;
-pub use turbo::{validate_extends, validate_no_package_task_syntax, RawTurboJSON, TurboJson};
+pub use turbo::{
+    validate_extends, validate_no_package_task_syntax, RawTaskDefinition, RawTurboJson,
+    SynthesizedTurboJson,
+};
 pub use turbo_config::{ConfigurationOptions, TurborepoConfigBuilder};
 use turbopath::AbsoluteSystemPathBuf;
 

--- a/crates/turborepo-lib/src/config/mod.rs
+++ b/crates/turborepo-lib/src/config/mod.rs
@@ -5,8 +5,7 @@ use std::io;
 
 use thiserror::Error;
 pub use turbo::{
-    validate_extends, validate_no_package_task_syntax, RawTaskDefinition, RawTurboJson,
-    SynthesizedTurboJson,
+    validate_extends, validate_no_package_task_syntax, RawTaskDefinition, RawTurboJson, TurboJson,
 };
 pub use turbo_config::{ConfigurationOptions, TurborepoConfigBuilder};
 use turbopath::AbsoluteSystemPathBuf;

--- a/crates/turborepo-lib/src/config/turbo.rs
+++ b/crates/turborepo-lib/src/config/turbo.rs
@@ -470,6 +470,9 @@ impl TurboJson {
             let task_name = TaskName::from(script_name.as_str());
             if !turbo_json.has_task(&task_name) {
                 let task_name = task_name.into_root_task();
+                // Explicitly set cache to Some(false) in this definition
+                // so we can pretend it was set on purpose. That way it
+                // won't get clobbered by the merge function.
                 turbo_json.pipeline.insert(
                     task_name,
                     RawTaskDefinition {

--- a/crates/turborepo-lib/src/config/turbo.rs
+++ b/crates/turborepo-lib/src/config/turbo.rs
@@ -28,7 +28,9 @@ pub struct SpacesJson {
 // A turbo.json config that is synthesized but not yet resolved.
 // This means that we've done the work to synthesize the config from
 // package.json, but we haven't yet resolved the workspace
-// turbo.json files into a single definition.
+// turbo.json files into a single definition. Therefore we keep the
+// `RawTaskDefinition` type so we can determine which fields are actually
+// set when we resolve the configuration.
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct SynthesizedTurboJson {
     pub(crate) extends: Vec<String>,

--- a/crates/turborepo-lib/src/config/turbo_config.rs
+++ b/crates/turborepo-lib/src/config/turbo_config.rs
@@ -7,7 +7,7 @@ use turborepo_repository::package_json::{Error as PackageJsonError, PackageJson}
 
 use crate::{
     commands::CommandBase,
-    config::{Error as ConfigError, RawTurboJSON},
+    config::{Error as ConfigError, RawTurboJson},
 };
 
 const DEFAULT_API_URL: &str = "https://vercel.com/api";
@@ -107,7 +107,7 @@ impl ResolvedConfigurationOptions for PackageJson {
     fn get_configuration_options(self) -> Result<ConfigurationOptions, ConfigError> {
         match &self.legacy_turbo_config {
             Some(legacy_turbo_config) => {
-                let synthetic_raw_turbo_json: RawTurboJSON =
+                let synthetic_raw_turbo_json: RawTurboJson =
                     serde_json::from_value(legacy_turbo_config.clone())?;
                 synthetic_raw_turbo_json.get_configuration_options()
             }
@@ -116,7 +116,7 @@ impl ResolvedConfigurationOptions for PackageJson {
     }
 }
 
-impl ResolvedConfigurationOptions for RawTurboJSON {
+impl ResolvedConfigurationOptions for RawTurboJson {
     fn get_configuration_options(self) -> Result<ConfigurationOptions, ConfigError> {
         match &self.remote_cache {
             Some(configuration_options) => {
@@ -394,7 +394,7 @@ impl TurborepoConfigBuilder {
             Err(e)
         })?;
         let turbo_json =
-            RawTurboJSON::read(&self.repo_root.join_component("turbo.json")).or_else(|e| {
+            RawTurboJson::read(&self.repo_root.join_component("turbo.json")).or_else(|e| {
                 if let ConfigError::Io(e) = &e {
                     if matches!(e.kind(), std::io::ErrorKind::NotFound) {
                         return Ok(Default::default());
@@ -574,7 +574,7 @@ mod test {
 
     #[test]
     fn test_shared_no_token() {
-        let mut test_shared_config: RawTurboJSON = Default::default();
+        let mut test_shared_config: RawTurboJson = Default::default();
         let configuration_options = ConfigurationOptions {
             token: Some("IF YOU CAN SEE THIS WE HAVE PROBLEMS".to_string()),
             ..Default::default()

--- a/crates/turborepo-lib/src/engine/builder.rs
+++ b/crates/turborepo-lib/src/engine/builder.rs
@@ -227,7 +227,7 @@ impl<'a> EngineBuilder<'a> {
                     // We don't need to add an edge from the root node if we're in this branch
                     if let WorkspaceNode::Workspace(dependency_workspace) = dependency_workspace {
                         has_topo_deps = true;
-                        let from_task_id = TaskId::from_graph(&dependency_workspace, from);
+                        let from_task_id = TaskId::from_graph(dependency_workspace, from);
                         let from_task_index = engine.get_index(&from_task_id);
                         engine
                             .task_graph

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -39,7 +39,7 @@ pub use crate::run::error::Error;
 use crate::{
     cli::{DryRunMode, EnvMode},
     commands::CommandBase,
-    config::SynthesizedTurboJson,
+    config::TurboJson,
     daemon::DaemonConnector,
     engine::{Engine, EngineBuilder},
     opts::Opts,
@@ -236,11 +236,8 @@ impl<'a> Run<'a> {
                 .build()
                 .await?;
 
-        let root_turbo_json = SynthesizedTurboJson::load(
-            &self.base.repo_root,
-            &root_package_json,
-            is_single_package,
-        )?;
+        let root_turbo_json =
+            TurboJson::load(&self.base.repo_root, &root_package_json, is_single_package)?;
 
         let team_id = root_turbo_json
             .remote_cache
@@ -472,7 +469,7 @@ impl<'a> Run<'a> {
         &self,
         pkg_dep_graph: &PackageGraph,
         opts: &Opts,
-        root_turbo_json: &SynthesizedTurboJson,
+        root_turbo_json: &TurboJson,
         filtered_pkgs: &HashSet<WorkspaceName>,
     ) -> Result<Engine, Error> {
         let engine = EngineBuilder::new(

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -39,7 +39,7 @@ pub use crate::run::error::Error;
 use crate::{
     cli::{DryRunMode, EnvMode},
     commands::CommandBase,
-    config::TurboJson,
+    config::SynthesizedTurboJson,
     daemon::DaemonConnector,
     engine::{Engine, EngineBuilder},
     opts::Opts,
@@ -236,8 +236,11 @@ impl<'a> Run<'a> {
                 .build()
                 .await?;
 
-        let root_turbo_json =
-            TurboJson::load(&self.base.repo_root, &root_package_json, is_single_package)?;
+        let root_turbo_json = SynthesizedTurboJson::load(
+            &self.base.repo_root,
+            &root_package_json,
+            is_single_package,
+        )?;
 
         let team_id = root_turbo_json
             .remote_cache
@@ -469,7 +472,7 @@ impl<'a> Run<'a> {
         &self,
         pkg_dep_graph: &PackageGraph,
         opts: &Opts,
-        root_turbo_json: &TurboJson,
+        root_turbo_json: &SynthesizedTurboJson,
         filtered_pkgs: &HashSet<WorkspaceName>,
     ) -> Result<Engine, Error> {
         let engine = EngineBuilder::new(

--- a/crates/turborepo-lib/src/task_graph/mod.rs
+++ b/crates/turborepo-lib/src/task_graph/mod.rs
@@ -1,6 +1,6 @@
 mod visitor;
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 use turbopath::{AnchoredSystemPath, AnchoredSystemPathBuf, RelativeUnixPathBuf};
@@ -8,24 +8,11 @@ pub use visitor::{Error as VisitorError, Visitor};
 
 use crate::{
     cli::OutputLogsMode,
+    config::RawTaskDefinition,
     run::task_id::{TaskId, TaskName},
 };
 
-pub type Pipeline = HashMap<TaskName<'static>, BookkeepingTaskDefinition>;
-
-#[derive(Clone, Debug, Default, Serialize, PartialEq, Eq)]
-pub struct BookkeepingTaskDefinition {
-    pub defined_fields: HashSet<String>,
-    pub experimental_fields: HashSet<String>,
-    pub experimental: TaskDefinitionExperiments,
-    pub task_definition: TaskDefinitionStable,
-}
-
-// A list of config fields in a task definition that are considered
-// experimental. We keep these separated so we can compute a global hash without
-// these.
-#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
-pub struct TaskDefinitionExperiments {}
+pub type Pipeline = HashMap<TaskName<'static>, TaskDefinition>;
 
 // TaskOutputs represents the patterns for including and excluding files from
 // outputs
@@ -35,42 +22,8 @@ pub struct TaskOutputs {
     pub exclusions: Vec<String>,
 }
 
-// These are the stable fields of a TaskDefinition, versus the experimental ones
-// TODO: Consolidate this and experiments, because the split is an artifact of
-// the Go implementation
-#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
-pub struct TaskDefinitionStable {
-    pub(crate) outputs: TaskOutputs,
-    pub(crate) cache: bool,
-    pub(crate) topological_dependencies: Vec<TaskName<'static>>,
-    pub(crate) task_dependencies: Vec<TaskName<'static>>,
-    pub(crate) inputs: Vec<String>,
-    pub(crate) output_mode: OutputLogsMode,
-    pub(crate) persistent: bool,
-    pub(crate) env: Vec<String>,
-    pub(crate) pass_through_env: Option<Vec<String>>,
-    pub(crate) dot_env: Option<Vec<RelativeUnixPathBuf>>,
-}
-
-impl Default for TaskDefinitionStable {
-    fn default() -> Self {
-        Self {
-            outputs: TaskOutputs::default(),
-            cache: true,
-            topological_dependencies: Vec::new(),
-            task_dependencies: Vec::new(),
-            inputs: Vec::new(),
-            output_mode: OutputLogsMode::default(),
-            persistent: false,
-            env: Vec::new(),
-            pass_through_env: None,
-            dot_env: None,
-        }
-    }
-}
-
 // Constructed from a RawTaskDefinition
-#[derive(Debug, Deserialize, PartialEq, Clone)]
+#[derive(Debug, Deserialize, PartialEq, Clone, Eq)]
 pub struct TaskDefinition {
     pub outputs: TaskOutputs,
     pub(crate) cache: bool,
@@ -106,38 +59,6 @@ pub struct TaskDefinition {
     pub persistent: bool,
 }
 
-impl BookkeepingTaskDefinition {
-    // Useful for splitting out the metadata vs fields which allows for easier
-    // definition merging
-    fn split(self) -> (Bookkeeping, TaskDefinitionStable, TaskDefinitionExperiments) {
-        let Self {
-            defined_fields,
-            experimental_fields,
-            experimental,
-            task_definition,
-        } = self;
-        (
-            Bookkeeping {
-                defined_fields,
-                experimental_fields,
-            },
-            task_definition,
-            experimental,
-        )
-    }
-}
-
-struct Bookkeeping {
-    defined_fields: HashSet<String>,
-    experimental_fields: HashSet<String>,
-}
-
-impl Bookkeeping {
-    fn has_field(&self, field_name: &str) -> bool {
-        self.defined_fields.contains(field_name) || self.experimental_fields.contains(field_name)
-    }
-}
-
 impl Default for TaskDefinition {
     fn default() -> Self {
         Self {
@@ -155,18 +76,14 @@ impl Default for TaskDefinition {
     }
 }
 
-macro_rules! set_field {
-    ($this:ident, $book:ident, $field:ident) => {{
-        if $book.has_field(stringify!($field)) {
-            $this.$field = $field;
-        }
-    }};
-
-    ($this:ident, $book:ident, $field:ident, $field_name:literal) => {{
-        if $book.has_field($field_name) {
-            $this.$field = $field;
-        }
-    }};
+impl FromIterator<RawTaskDefinition> for RawTaskDefinition {
+    fn from_iter<T: IntoIterator<Item = RawTaskDefinition>>(iter: T) -> Self {
+        iter.into_iter()
+            .fold(RawTaskDefinition::default(), |mut def, other| {
+                def.merge(other);
+                def
+            })
+    }
 }
 
 const LOG_DIR: &str = ".turbo";
@@ -229,55 +146,10 @@ impl TaskDefinition {
 
         repo_relative_globs
     }
-
-    // merge accepts a BookkeepingTaskDefinitions and
-    // merges it into TaskDefinition. It uses the bookkeeping
-    // defined_fields to determine which fields should be overwritten and when
-    // 0-values should be respected.
-    pub fn merge(&mut self, other: BookkeepingTaskDefinition) {
-        // TODO(olszewski) simplify this construction and throw off the shackles of Go
-        let (
-            meta,
-            TaskDefinitionStable {
-                outputs,
-                cache,
-                topological_dependencies,
-                task_dependencies,
-                inputs,
-                output_mode,
-                persistent,
-                env,
-                pass_through_env,
-                dot_env,
-            },
-            _experimental,
-        ) = other.split();
-
-        set_field!(self, meta, outputs, "Outputs");
-        set_field!(self, meta, cache, "Cache");
-        set_field!(self, meta, topological_dependencies, "DependsOn");
-        set_field!(self, meta, task_dependencies, "DependsOn");
-        set_field!(self, meta, inputs, "Inputs");
-        set_field!(self, meta, output_mode, "OutputMode");
-        set_field!(self, meta, persistent, "Persistent");
-        set_field!(self, meta, env, "Env");
-        set_field!(self, meta, pass_through_env, "PassThroughEnv");
-        set_field!(self, meta, dot_env, "DotEnv");
-    }
 }
 
 fn task_log_filename(task_name: &str) -> String {
     format!("turbo-{}.log", task_name.replace(':', "$colon$"))
-}
-
-impl FromIterator<BookkeepingTaskDefinition> for TaskDefinition {
-    fn from_iter<T: IntoIterator<Item = BookkeepingTaskDefinition>>(iter: T) -> Self {
-        iter.into_iter()
-            .fold(TaskDefinition::default(), |mut def, other| {
-                def.merge(other);
-                def
-            })
-    }
 }
 
 #[cfg(test)]

--- a/crates/turborepo-lib/src/task_graph/mod.rs
+++ b/crates/turborepo-lib/src/task_graph/mod.rs
@@ -1,7 +1,5 @@
 mod visitor;
 
-use std::collections::HashMap;
-
 use serde::{Deserialize, Serialize};
 use turbopath::{AnchoredSystemPath, AnchoredSystemPathBuf, RelativeUnixPathBuf};
 pub use visitor::{Error as VisitorError, Visitor};
@@ -11,8 +9,6 @@ use crate::{
     config::RawTaskDefinition,
     run::task_id::{TaskId, TaskName},
 };
-
-pub type Pipeline = HashMap<TaskName<'static>, TaskDefinition>;
 
 // TaskOutputs represents the patterns for including and excluding files from
 // outputs

--- a/crates/turborepo-lib/src/task_hash.rs
+++ b/crates/turborepo-lib/src/task_hash.rs
@@ -114,7 +114,6 @@ impl PackageInputsHashes {
                     Ok(hash_object) => hash_object,
                     Err(err) => return Some(Err(err.into())),
                 };
-
                 if let Some(dot_env) = &task_definition.dot_env {
                     if !dot_env.is_empty() {
                         let absolute_package_path = repo_root.resolve(package_path);
@@ -411,12 +410,13 @@ impl<'a> TaskHasher<'a> {
                 pass_through_env.union(global_env);
                 pass_through_env.union(&tracker_env.all);
 
-                if let Some(definition_pass_through) = &task_definition.pass_through_env {
-                    let env_var_pass_through_map = self
-                        .env_at_execution_start
-                        .from_wildcards(definition_pass_through)?;
-                    pass_through_env.union(&env_var_pass_through_map);
-                }
+                let env_var_pass_through_map = self.env_at_execution_start.from_wildcards(
+                    task_definition
+                        .pass_through_env
+                        .as_deref()
+                        .unwrap_or_default(),
+                )?;
+                pass_through_env.union(&env_var_pass_through_map);
 
                 Ok(pass_through_env)
             }


### PR DESCRIPTION
### Description

I removed the bookkeeping abstraction that we ported from Go. It wasn't necessary since we can use `Option` to detect if a field is explicitly set versus not. Also renamed `RawTurboJSON` to be `RawTurboJson` to fit with the other names.

### Testing Instructions

The existing tests should suffice.


Closes TURBO-1945