### PR TITLE
Only warn for ESLint issues in editor.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,7 @@
     "typescriptreact"
   ],
   "eslint.workingDirectories": [{ "mode": "auto" }],
+  "eslint.rules.customizations": [{ "rule": "*", "severity": "warn" }],
   "debug.javascript.unmapMissingSources": true,
   "go.lintTool": "golangci-lint",
   "go.buildTags": "rust",
@@ -21,5 +22,5 @@
   },
   "search.exclude": {
     "crates/turbopack-tests/tests/snapshot/**": true
-  },
+  }
 }


### PR DESCRIPTION
### Description

I find better DX with TypeScript errors being red squigglies and ESLint errors/warnings being yellow squigglies.

This comes with the tradeoff that what you see in your editor might differ from what CI sees. However, any ESLint issue should block CI anyway so I find it doesn't tend to matter what color they are in your editor anyway.