### PR TITLE
fix(docs): redirect old blog to new

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -239,6 +239,12 @@ const nextConfig = withNextra({
         destination: "/repo/docs/:path*",
         permanent: true,
       },
+      {
+        // Redirect old blog posts to new blog.
+        source: "/posts/:path*",
+        destination: "/blog/:path*",
+        permanent: true,
+      },
     ];
   },
 });


### PR DESCRIPTION
### Description

Redirect old blog posts to new


Closes TURBO-1952