### PR TITLE
fix(telemetry): don’t track hash

### DIFF
--- a/crates/turborepo-lib/src/task_graph/visitor.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor.rs
@@ -203,7 +203,6 @@ impl<'a> Visitor<'a> {
                 package_task_event_child,
             )?;
 
-            package_task_event.track_hash(&task_hash.to_string());
             debug!("task {} hash is {}", info, task_hash);
             // We do this calculation earlier than we do in Go due to the `task_hasher`
             // being !Send. In the future we can look at doing this right before

--- a/crates/turborepo-telemetry/src/events/task.rs
+++ b/crates/turborepo-telemetry/src/events/task.rs
@@ -92,15 +92,6 @@ impl PackageTaskEventBuilder {
         self
     }
 
-    pub fn track_hash(&self, hash: &str) -> &Self {
-        self.track(Event {
-            key: "hash".to_string(),
-            value: hash.to_string(),
-            is_sensitive: EventType::NonSensitive,
-        });
-        self
-    }
-
     pub fn track_framework(&self, framework: &str) -> &Self {
         self.track(Event {
             key: "framework".to_string(),


### PR DESCRIPTION
### Description

Don't track the hash event
