### PR TITLE
feat(telemetry): add README disabled note

### DIFF
--- a/crates/turborepo-telemetry/README.md
+++ b/crates/turborepo-telemetry/README.md
@@ -1,5 +1,9 @@
 # turborepo-telemetry
 
+<!-- TODO: [telemetry] remove this disclaimer once live -->
+
+> ## :warning: **This feature is NOT enabled, It can only be activated by manually setting `TURBO_TELEMETRY_ENABLED=1`**
+
 ## Overview
 
 This crate provides a way to optionally record anonymous usage data.


### PR DESCRIPTION
### Description

Add a note in the telemetry crate README to make extra clear that this code path is NOT enabled, and it will not be enabled until it is communicated in a blog post (1.12)

