### PR TITLE
feat(telemetry): generic parent to child event

### DIFF
--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -15,7 +15,8 @@ use turborepo_repository::inference::{RepoMode, RepoState};
 use turborepo_telemetry::{
     events::{
         command::{CodePath, CommandEventBuilder},
-        PubEventBuilder,
+        generic::GenericEventBuilder,
+        EventBuilder,
     },
     init_telemetry, TelemetryHandle,
 };
@@ -805,16 +806,23 @@ pub async fn run(
     cli_args.command = Some(command);
     cli_args.cwd = Some(repo_root.as_path().to_owned());
 
+    let root_telemetry = GenericEventBuilder::new();
+    root_telemetry.track_start();
+
     let cli_result = match cli_args.command.as_ref().unwrap() {
         Command::Bin { .. } => {
-            CommandEventBuilder::new("bin").track_call();
+            CommandEventBuilder::new("bin")
+                .with_parent(&root_telemetry)
+                .track_call();
             bin::run()?;
 
             Ok(Payload::Rust(Ok(0)))
         }
         #[allow(unused_variables)]
         Command::Daemon { command, idle_time } => {
-            CommandEventBuilder::new("daemon").track_call();
+            CommandEventBuilder::new("daemon")
+                .with_parent(&root_telemetry)
+                .track_call();
             let base = CommandBase::new(cli_args.clone(), repo_root, version, ui);
 
             match command {
@@ -837,7 +845,7 @@ pub async fn run(
             args,
             command,
         } => {
-            let event = CommandEventBuilder::new("generate");
+            let event = CommandEventBuilder::new("generate").with_parent(&root_telemetry);
             event.track_call();
             // build GeneratorCustomArgs struct
             let args = GeneratorCustomArgs {
@@ -851,7 +859,7 @@ pub async fn run(
             Ok(Payload::Rust(Ok(0)))
         }
         Command::Telemetry { command } => {
-            let event = CommandEventBuilder::new("telemetry");
+            let event = CommandEventBuilder::new("telemetry").with_parent(&root_telemetry);
             event.track_call();
             let mut base = CommandBase::new(cli_args.clone(), repo_root, version, ui);
             let child_event = event.child();
@@ -859,7 +867,9 @@ pub async fn run(
             Ok(Payload::Rust(Ok(0)))
         }
         Command::Info { workspace, json } => {
-            CommandEventBuilder::new("info").track_call();
+            CommandEventBuilder::new("info")
+                .with_parent(&root_telemetry)
+                .track_call();
             let json = *json;
             let workspace = workspace.clone();
             let mut base = CommandBase::new(cli_args, repo_root, version, ui);
@@ -871,7 +881,9 @@ pub async fn run(
             no_gitignore,
             target,
         } => {
-            CommandEventBuilder::new("link").track_call();
+            CommandEventBuilder::new("link")
+                .with_parent(&root_telemetry)
+                .track_call();
             if cli_args.test_run {
                 println!("Link test run successful");
                 return Ok(Payload::Rust(Ok(0)));
@@ -888,14 +900,17 @@ pub async fn run(
             Ok(Payload::Rust(Ok(0)))
         }
         Command::Logout { .. } => {
-            CommandEventBuilder::new("logout").track_call();
+            let event = CommandEventBuilder::new("logout").with_parent(&root_telemetry);
+            event.track_call();
             let mut base = CommandBase::new(cli_args, repo_root, version, ui);
-            logout::logout(&mut base)?;
+            let event_child = event.child();
+            logout::logout(&mut base, event_child)?;
 
             Ok(Payload::Rust(Ok(0)))
         }
         Command::Login { sso_team } => {
-            CommandEventBuilder::new("login").track_call();
+            let event = CommandEventBuilder::new("login").with_parent(&root_telemetry);
+            event.track_call();
             if cli_args.test_run {
                 println!("Login test run successful");
                 return Ok(Payload::Rust(Ok(0)));
@@ -904,17 +919,20 @@ pub async fn run(
             let sso_team = sso_team.clone();
 
             let mut base = CommandBase::new(cli_args, repo_root, version, ui);
+            let event_child = event.child();
 
             if let Some(sso_team) = sso_team {
-                login::sso_login(&mut base, &sso_team).await?;
+                login::sso_login(&mut base, &sso_team, event_child).await?;
             } else {
-                login::login(&mut base).await?;
+                login::login(&mut base, event_child).await?;
             }
 
             Ok(Payload::Rust(Ok(0)))
         }
         Command::Unlink { target } => {
-            CommandEventBuilder::new("unlink").track_call();
+            CommandEventBuilder::new("unlink")
+                .with_parent(&root_telemetry)
+                .track_call();
             if cli_args.test_run {
                 println!("Unlink test run successful");
                 return Ok(Payload::Rust(Ok(0)));
@@ -928,7 +946,7 @@ pub async fn run(
             Ok(Payload::Rust(Ok(0)))
         }
         Command::Run(args) => {
-            let event = CommandEventBuilder::new("run");
+            let event = CommandEventBuilder::new("run").with_parent(&root_telemetry);
             event.track_call();
             // in the case of enabling the run stub, we want to be able to opt-in
             // to the rust codepath for running turbo
@@ -937,6 +955,7 @@ pub async fn run(
             }
 
             if let Some((file_path, include_args)) = args.profile_file_and_include_args() {
+                event.track_run_chrome_tracing();
                 // TODO: Do we want to handle the result / error?
                 let _ = logger.enable_chrome_tracing(file_path, include_args);
             }
@@ -966,7 +985,8 @@ pub async fn run(
             docker,
             output_dir,
         } => {
-            CommandEventBuilder::new("prune").track_call();
+            let event = CommandEventBuilder::new("prune").with_parent(&root_telemetry);
+            event.track_call();
             let scope = scope_arg
                 .as_ref()
                 .or(scope.as_ref())
@@ -975,16 +995,25 @@ pub async fn run(
             let docker = *docker;
             let output_dir = output_dir.clone();
             let base = CommandBase::new(cli_args, repo_root, version, ui);
-            prune::prune(&base, &scope, docker, &output_dir).await?;
+            let event_child = event.child();
+            prune::prune(&base, &scope, docker, &output_dir, event_child).await?;
             Ok(Payload::Rust(Ok(0)))
         }
         Command::Completion { shell } => {
-            CommandEventBuilder::new("completion").track_call();
+            CommandEventBuilder::new("completion")
+                .with_parent(&root_telemetry)
+                .track_call();
             generate(*shell, &mut Args::command(), "turbo", &mut io::stdout());
             Ok(Payload::Rust(Ok(0)))
         }
     };
 
+    if cli_result.is_err() {
+        root_telemetry.track_failure();
+    } else {
+        root_telemetry.track_success();
+    }
+    root_telemetry.track_end();
     match telemetry_handle {
         Some(handle) => handle.close_with_timeout().await,
         None => debug!("Skipping telemetry close - not initialized"),

--- a/crates/turborepo-lib/src/commands/login.rs
+++ b/crates/turborepo-lib/src/commands/login.rs
@@ -2,10 +2,16 @@ use turborepo_api_client::APIClient;
 use turborepo_auth::{
     login as auth_login, sso_login as auth_sso_login, DefaultLoginServer, DefaultSSOLoginServer,
 };
+use turborepo_telemetry::events::command::{CommandEventBuilder, LoginMethod};
 
 use crate::{cli::Error, commands::CommandBase, config, rewrite_json::set_path};
 
-pub async fn sso_login(base: &mut CommandBase, sso_team: &str) -> Result<(), Error> {
+pub async fn sso_login(
+    base: &mut CommandBase,
+    sso_team: &str,
+    telemetry: CommandEventBuilder,
+) -> Result<(), Error> {
+    telemetry.track_login_method(LoginMethod::SSO);
     let api_client: APIClient = base.api_client()?;
     let ui = base.ui;
     let login_url_config = base.config()?.login_url().to_string();
@@ -47,7 +53,8 @@ pub async fn sso_login(base: &mut CommandBase, sso_team: &str) -> Result<(), Err
     Ok(())
 }
 
-pub async fn login(base: &mut CommandBase) -> Result<(), Error> {
+pub async fn login(base: &mut CommandBase, telemetry: CommandEventBuilder) -> Result<(), Error> {
+    telemetry.track_login_method(LoginMethod::Standard);
     let api_client: APIClient = base.api_client()?;
     let ui = base.ui;
     let login_url_config = base.config()?.login_url().to_string();

--- a/crates/turborepo-lib/src/commands/logout.rs
+++ b/crates/turborepo-lib/src/commands/logout.rs
@@ -1,9 +1,10 @@
 use tracing::error;
 use turborepo_auth::logout as auth_logout;
+use turborepo_telemetry::events::command::CommandEventBuilder;
 
 use crate::{cli::Error, commands::CommandBase, config, rewrite_json::unset_path};
 
-pub fn logout(base: &mut CommandBase) -> Result<(), Error> {
+pub fn logout(base: &mut CommandBase, _telemetry: CommandEventBuilder) -> Result<(), Error> {
     if let Err(err) = remove_token(base) {
         error!("could not logout. Something went wrong: {}", err);
         return Err(err);

--- a/crates/turborepo-lib/src/commands/prune.rs
+++ b/crates/turborepo-lib/src/commands/prune.rs
@@ -11,6 +11,7 @@ use turborepo_repository::{
     package_graph::{self, PackageGraph, WorkspaceName, WorkspaceNode},
     package_json::PackageJson,
 };
+use turborepo_telemetry::events::command::CommandEventBuilder;
 use turborepo_ui::BOLD;
 
 use super::CommandBase;
@@ -84,7 +85,9 @@ pub async fn prune(
     scope: &[String],
     docker: bool,
     output_dir: &str,
+    telemetry: CommandEventBuilder,
 ) -> Result<(), Error> {
+    telemetry.track_prune_method(docker);
     let prune = Prune::new(base, scope, docker, output_dir).await?;
 
     if matches!(

--- a/crates/turborepo-lib/src/task_graph/visitor.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor.rs
@@ -22,7 +22,7 @@ use turborepo_repository::{
     package_graph::{PackageGraph, WorkspaceName, ROOT_PKG_NAME},
     package_manager::PackageManager,
 };
-use turborepo_telemetry::events::{task::PackageTaskEventBuilder, PubEventBuilder};
+use turborepo_telemetry::events::{task::PackageTaskEventBuilder, EventBuilder};
 use turborepo_ui::{ColorSelector, OutputClient, OutputSink, OutputWriter, PrefixedUI, UI};
 use which::which;
 

--- a/crates/turborepo-telemetry/src/events/mod.rs
+++ b/crates/turborepo-telemetry/src/events/mod.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 
 // all event builders and their event methods
 pub mod command;
+pub mod generic;
 pub mod repo;
 pub mod task;
 
@@ -28,17 +29,15 @@ pub struct Event {
     is_sensitive: EventType,
 }
 
-/// Private trait that can be used for building telemetry events.
-///
-/// Supports connecting events via a parent-child relationship
-/// to aid in connecting events together.
-trait EventBuilder<T> {
+pub trait Identifiable {
     fn get_id(&self) -> &String;
-    fn with_parent(self, parent_event: &T) -> Self;
 }
 
 /// Public trait that can be used for building telemetry events.
-pub trait PubEventBuilder {
+/// Supports connecting events via a parent-child relationship
+/// to aid in connecting events together.
+pub trait EventBuilder {
+    fn with_parent<U: Identifiable>(self, parent_event: &U) -> Self;
     fn track(&self, event: Event);
     fn child(&self) -> Self;
 }

--- a/crates/turborepo-telemetry/src/lib.rs
+++ b/crates/turborepo-telemetry/src/lib.rs
@@ -263,7 +263,7 @@ mod tests {
     };
     use turborepo_api_client::telemetry::TelemetryClient;
     use turborepo_ui::UI;
-    use turborepo_vercel_api::{TelemetryCommandEvent, TelemetryEvent};
+    use turborepo_vercel_api::{TelemetryEvent, TelemetryGenericEvent};
 
     use crate::init;
 
@@ -339,12 +339,11 @@ mod tests {
 
         for _ in 0..2 {
             telemetry_sender
-                .send(TelemetryEvent::Command(TelemetryCommandEvent {
+                .send(TelemetryEvent::Generic(TelemetryGenericEvent {
                     id: "id".to_string(),
-                    command: "command".to_string(),
                     key: "key".to_string(),
                     value: "value".to_string(),
-                    parent: None,
+                    parent_id: None,
                 }))
                 .unwrap();
         }
@@ -377,12 +376,11 @@ mod tests {
 
         for _ in 0..12 {
             telemetry_sender
-                .send(TelemetryEvent::Command(TelemetryCommandEvent {
+                .send(TelemetryEvent::Generic(TelemetryGenericEvent {
                     id: "id".to_string(),
-                    command: "command".to_string(),
                     key: "key".to_string(),
                     value: "value".to_string(),
-                    parent: None,
+                    parent_id: None,
                 }))
                 .unwrap();
         }
@@ -421,12 +419,11 @@ mod tests {
 
         for _ in 0..2 {
             telemetry_sender
-                .send(TelemetryEvent::Command(TelemetryCommandEvent {
+                .send(TelemetryEvent::Generic(TelemetryGenericEvent {
                     id: "id".to_string(),
-                    command: "command".to_string(),
                     key: "key".to_string(),
                     value: "value".to_string(),
-                    parent: None,
+                    parent_id: None,
                 }))
                 .unwrap();
         }

--- a/crates/turborepo-vercel-api/src/lib.rs
+++ b/crates/turborepo-vercel-api/src/lib.rs
@@ -171,6 +171,7 @@ pub enum TelemetryEvent {
     Task(TelemetryTaskEvent),
     Command(TelemetryCommandEvent),
     Repo(TelemetryRepoEvent),
+    Generic(TelemetryGenericEvent),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -179,7 +180,7 @@ pub struct TelemetryCommandEvent {
     pub command: String,
     pub key: String,
     pub value: String,
-    pub parent: Option<String>,
+    pub parent_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -188,7 +189,7 @@ pub struct TelemetryRepoEvent {
     pub repo: String,
     pub key: String,
     pub value: String,
-    pub parent: Option<String>,
+    pub parent_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -198,7 +199,15 @@ pub struct TelemetryTaskEvent {
     pub task: String,
     pub key: String,
     pub value: String,
-    pub parent: Option<String>,
+    pub parent_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TelemetryGenericEvent {
+    pub id: String,
+    pub key: String,
+    pub value: String,
+    pub parent_id: Option<String>,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
### Description

Previously, the parent<>child relationship between telemetry events required that both events be the same event type. This was overly restrictive, and this PR now allows any event type to be linked together.

This is accomplished by requiring that the event passed to `with_parent` implements the `Identifiable` trait, instead of it being the exact type of a generic. 

This also adds a few other events in and sets up piping for others. 