### PR TITLE
fix: Allow for long symlinks by using append_link

### DIFF
--- a/crates/turborepo-cache/src/cache_archive/create.rs
+++ b/crates/turborepo-cache/src/cache_archive/create.rs
@@ -101,6 +101,8 @@ impl<'a> CacheWriter<'a> {
             let file = source_path.open()?;
             self.append_data(&mut header, file_path.as_str(), file)?;
         } else if matches!(header.entry_type(), EntryType::Symlink) {
+            // We convert to a Unix path because all paths in tar should be
+            // Unix-style. This will get restored to a system path.
             let target = source_path.read_link()?.into_unix();
             self.append_link(&mut header, file_path.as_str(), &target)?;
         } else {

--- a/crates/turborepo-cache/src/cache_archive/create.rs
+++ b/crates/turborepo-cache/src/cache_archive/create.rs
@@ -131,6 +131,7 @@ impl<'a> CacheWriter<'a> {
             // We do *not* set the linkname here because it could be too long
             // Instead we set it when we add the file to the archive
             header.set_entry_type(EntryType::Symlink);
+            header.set_size(0);
         } else if file_info.is_dir() {
             header.set_size(0);
             header.set_entry_type(EntryType::Directory);
@@ -426,10 +427,16 @@ mod tests {
         let tar_path = tar_dir_path.join_component("test.tar");
         let mut archive = CacheWriter::create(&tar_path)?;
         let really_long_file = AnchoredSystemPath::new("this-is-a-really-really-really-long-path-like-so-very-long-that-i-can-list-all-of-my-favorite-directors-like-edward-yang-claire-denis-lucrecia-martel-wong-kar-wai-even-kurosawa").unwrap();
+        let really_long_symlink = AnchoredSystemPath::new("this-is-a-really-really-really-long-symlink-like-so-very-long-that-i-can-list-all-of-my-other-favorite-directors-like-jim-jarmusch-michelangelo-antonioni-and-terrence-malick-symlink").unwrap();
 
         let really_long_path = archive_dir_path.resolve(really_long_file);
         really_long_path.create_with_contents("The End!")?;
+
+        let really_long_symlink_path = archive_dir_path.resolve(really_long_symlink);
+        really_long_symlink_path.symlink_to_file(really_long_file.as_str())?;
+
         archive.add_file(archive_dir_path, really_long_file)?;
+        archive.add_file(archive_dir_path, really_long_symlink)?;
 
         archive.finish()?;
 
@@ -438,8 +445,9 @@ mod tests {
 
         let mut restore = CacheReader::open(&tar_path)?;
         let files = restore.restore(restore_dir_path)?;
-        assert_eq!(files.len(), 1);
+        assert_eq!(files.len(), 2);
         assert_eq!(files[0].as_str(), really_long_file.as_str());
+        assert_eq!(files[1].as_str(), really_long_symlink.as_str());
         Ok(())
     }
 


### PR DESCRIPTION
### Description

We were using `Header::set_link_name` instead of using `Builder::append_link`, which handles long link names correctly. In general we should avoid using methods on `Header` and instead use the ones on `Entry`.

### Testing Instructions

Modifies the long name test to include a symlink with a long link name.

Closes TURBO-1968