### PR TITLE
perf: Use `&'static str` instead of `String` if possible

### DIFF
--- a/crates/turbo-tasks/src/native_function.rs
+++ b/crates/turbo-tasks/src/native_function.rs
@@ -70,7 +70,7 @@ impl NativeFunction {
         }
     }
 
-    pub fn register(&'static self, global_name: &str) {
+    pub fn register(&'static self, global_name: &'static str) {
         register_function(global_name, self);
     }
 }

--- a/crates/turbo-tasks/src/registry.rs
+++ b/crates/turbo-tasks/src/registry.rs
@@ -90,7 +90,7 @@ pub fn get_function(id: FunctionId) -> &'static NativeFunction {
 }
 
 pub fn get_function_global_name(id: FunctionId) -> &'static str {
-    &FUNCTIONS.get(*id).unwrap().1
+    FUNCTIONS.get(*id).unwrap().1
 }
 
 pub fn register_value_type(global_name: &'static str, ty: &'static ValueType) {
@@ -117,7 +117,7 @@ pub fn get_value_type(id: ValueTypeId) -> &'static ValueType {
 }
 
 pub fn get_value_type_global_name(id: ValueTypeId) -> &'static str {
-    &VALUE_TYPES.get(*id).unwrap().1
+    VALUE_TYPES.get(*id).unwrap().1
 }
 
 pub fn register_trait_type(global_name: &'static str, ty: &'static TraitType) {
@@ -144,5 +144,5 @@ pub fn get_trait(id: TraitTypeId) -> &'static TraitType {
 }
 
 pub fn get_trait_type_global_name(id: TraitTypeId) -> &'static str {
-    &TRAIT_TYPES.get(*id).unwrap().1
+    TRAIT_TYPES.get(*id).unwrap().1
 }

--- a/crates/turbo-tasks/src/registry.rs
+++ b/crates/turbo-tasks/src/registry.rs
@@ -11,42 +11,43 @@ use crate::{
 };
 
 static FUNCTION_ID_FACTORY: IdFactory<FunctionId> = IdFactory::new();
-static FUNCTIONS_BY_NAME: Lazy<DashMap<String, FunctionId>> = Lazy::new(DashMap::new);
+static FUNCTIONS_BY_NAME: Lazy<DashMap<&'static str, FunctionId>> = Lazy::new(DashMap::new);
 static FUNCTIONS_BY_VALUE: Lazy<DashMap<&'static NativeFunction, FunctionId>> =
     Lazy::new(DashMap::new);
-static FUNCTIONS: Lazy<NoMoveVec<(&'static NativeFunction, String)>> = Lazy::new(NoMoveVec::new);
+static FUNCTIONS: Lazy<NoMoveVec<(&'static NativeFunction, &'static str)>> =
+    Lazy::new(NoMoveVec::new);
 
 static VALUE_TYPE_ID_FACTORY: IdFactory<ValueTypeId> = IdFactory::new();
-static VALUE_TYPES_BY_NAME: Lazy<DashMap<String, ValueTypeId>> = Lazy::new(DashMap::new);
+static VALUE_TYPES_BY_NAME: Lazy<DashMap<&'static str, ValueTypeId>> = Lazy::new(DashMap::new);
 static VALUE_TYPES_BY_VALUE: Lazy<DashMap<&'static ValueType, ValueTypeId>> =
     Lazy::new(DashMap::new);
-static VALUE_TYPES: Lazy<NoMoveVec<(&'static ValueType, String)>> = Lazy::new(NoMoveVec::new);
+static VALUE_TYPES: Lazy<NoMoveVec<(&'static ValueType, &'static str)>> = Lazy::new(NoMoveVec::new);
 
 static TRAIT_TYPE_ID_FACTORY: IdFactory<TraitTypeId> = IdFactory::new();
-static TRAIT_TYPES_BY_NAME: Lazy<DashMap<String, TraitTypeId>> = Lazy::new(DashMap::new);
+static TRAIT_TYPES_BY_NAME: Lazy<DashMap<&'static str, TraitTypeId>> = Lazy::new(DashMap::new);
 static TRAIT_TYPES_BY_VALUE: Lazy<DashMap<&'static TraitType, TraitTypeId>> =
     Lazy::new(DashMap::new);
-static TRAIT_TYPES: Lazy<NoMoveVec<(&'static TraitType, String)>> = Lazy::new(NoMoveVec::new);
+static TRAIT_TYPES: Lazy<NoMoveVec<(&'static TraitType, &'static str)>> = Lazy::new(NoMoveVec::new);
 
 fn register_thing<
     K: From<usize> + Deref<Target = usize> + Sync + Send + Copy,
     V: Clone + Hash + Ord + Eq + Sync + Send + Copy,
     const INITIAL_CAPACITY_BITS: u32,
 >(
-    global_name: &str,
+    global_name: &'static str,
     value: V,
     id_factory: &IdFactory<K>,
-    store: &NoMoveVec<(V, String), INITIAL_CAPACITY_BITS>,
-    map_by_name: &DashMap<String, K>,
+    store: &NoMoveVec<(V, &'static str), INITIAL_CAPACITY_BITS>,
+    map_by_name: &DashMap<&'static str, K>,
     map_by_value: &DashMap<V, K>,
 ) {
     if let Entry::Vacant(e) = map_by_value.entry(value) {
         let new_id = id_factory.get();
         // SAFETY: this is a fresh id
         unsafe {
-            store.insert(*new_id, (value, global_name.to_string()));
+            store.insert(*new_id, (value, global_name));
         }
-        map_by_name.insert(global_name.to_string(), new_id);
+        map_by_name.insert(global_name, new_id);
         e.insert(new_id);
     }
 }
@@ -65,7 +66,7 @@ fn get_thing_id<
     }
 }
 
-pub fn register_function(global_name: &str, func: &'static NativeFunction) {
+pub fn register_function(global_name: &'static str, func: &'static NativeFunction) {
     register_thing(
         global_name,
         func,
@@ -92,7 +93,7 @@ pub fn get_function_global_name(id: FunctionId) -> &'static str {
     &FUNCTIONS.get(*id).unwrap().1
 }
 
-pub fn register_value_type(global_name: &str, ty: &'static ValueType) {
+pub fn register_value_type(global_name: &'static str, ty: &'static ValueType) {
     register_thing(
         global_name,
         ty,
@@ -119,7 +120,7 @@ pub fn get_value_type_global_name(id: ValueTypeId) -> &'static str {
     &VALUE_TYPES.get(*id).unwrap().1
 }
 
-pub fn register_trait_type(global_name: &str, ty: &'static TraitType) {
+pub fn register_trait_type(global_name: &'static str, ty: &'static TraitType) {
     register_thing(
         global_name,
         ty,

--- a/crates/turbo-tasks/src/value_type.rs
+++ b/crates/turbo-tasks/src/value_type.rs
@@ -192,7 +192,7 @@ impl ValueType {
         self.traits.iter().copied()
     }
 
-    pub fn register(&'static self, global_name: &str) {
+    pub fn register(&'static self, global_name: &'static str) {
         register_value_type(global_name, self)
     }
 }
@@ -251,7 +251,7 @@ impl TraitType {
         self.default_trait_methods.insert(name, native_fn);
     }
 
-    pub fn register(&'static self, global_name: &str) {
+    pub fn register(&'static self, global_name: &'static str) {
         register_trait_type(global_name, self);
     }
 }


### PR DESCRIPTION
### Description

All calls are generated by the proc-macro, so we don't need to allocate.

### Testing Instructions



Closes PACK-2177