### PR TITLE
feat(Turborepo): Use a wrapper around the raw strings we pass to globwalk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3125,7 +3125,9 @@ dependencies = [
 name = "globwalk"
 version = "0.1.0"
 dependencies = [
+ "camino",
  "itertools",
+ "path-clean 1.0.1",
  "path-slash",
  "regex",
  "tempdir",
@@ -11308,7 +11310,6 @@ dependencies = [
  "globwalk",
  "hex",
  "ignore",
- "itertools",
  "nom",
  "sha1 0.10.5",
  "tempfile",

--- a/crates/turborepo-globwalk/Cargo.toml
+++ b/crates/turborepo-globwalk/Cargo.toml
@@ -10,7 +10,9 @@ license = "MPL-2.0"
 workspace = true
 
 [dependencies]
+camino = { workspace = true }
 itertools.workspace = true
+path-clean = "1.0.1"
 path-slash = "0.2.1"
 regex.workspace = true
 thiserror.workspace = true

--- a/crates/turborepo-globwalk/src/lib.rs
+++ b/crates/turborepo-globwalk/src/lib.rs
@@ -227,23 +227,12 @@ fn glob_with_contextual_error<S: AsRef<str> + std::fmt::Debug>(
         .map_err(|e| WalkError::BadPattern(raw.to_string(), Box::new(e)))
 }
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
+#[error("Invalid globwalking input {raw_input}: {reason}")]
 pub struct GlobError {
     raw_input: String,
     reason: String,
 }
-
-impl Display for GlobError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "Invalid globwalking input {}: {}",
-            self.raw_input, self.reason
-        )
-    }
-}
-
-impl Error for GlobError {}
 
 /// ValidatedGlob represents an input string that we have either validated or
 /// modified to fit our constraints. It does not _yet_ validate that the glob is

--- a/crates/turborepo-globwalk/src/lib.rs
+++ b/crates/turborepo-globwalk/src/lib.rs
@@ -1401,9 +1401,13 @@ mod test {
         let files = &["foo", "bar", "baz"];
         let tmp = setup_files_with_prefix("[path]", files);
         let root = AbsoluteSystemPathBuf::try_from(tmp.path()).unwrap();
-        let include = &["ba*".to_string()];
+        let include = ["ba*"]
+            .into_iter()
+            .map(ValidatedGlob::from_str)
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
         let exclude = &[];
-        let iter = globwalk(&root, include, exclude, WalkType::Files).unwrap();
+        let iter = globwalk(&root, &include, exclude, WalkType::Files).unwrap();
         let paths = iter
             .into_iter()
             .map(|path| {

--- a/crates/turborepo-globwalk/src/lib.rs
+++ b/crates/turborepo-globwalk/src/lib.rs
@@ -274,6 +274,8 @@ impl FromStr for ValidatedGlob {
         // Lexically clean the path
         let path_buf = Utf8PathBuf::from_str(s).expect("infallible");
         let cleaned_path = path_buf.as_std_path().clean();
+        // TODO: fully deprecate allowing absolute paths (that won't work anyways),
+        // and return an error here if cleaned_path is absolute
         let cleaned = cleaned_path.to_str().expect("valid utf-8");
 
         // Check slashes + ':'
@@ -292,14 +294,6 @@ impl FromStr for ValidatedGlob {
             }
             to_slashed
         };
-
-        // Check relative path. Since we've errored on ':' and converted to slashes
-        // already, we just need to check for leading /
-        // TODO: fully deprecate allowing absolute paths (that won't work anyways)
-        // if cross_platform.chars().next() == Some('/') {
-        //     return Err(err("globs must be relative paths".to_string()));
-        // }
-        //let cross_platform = cross_platform.trim_start_matches('/').to_owned();
 
         Ok(Self {
             inner: cross_platform,

--- a/crates/turborepo-globwalk/src/lib.rs
+++ b/crates/turborepo-globwalk/src/lib.rs
@@ -4,12 +4,17 @@
 use std::{
     borrow::Cow,
     collections::HashSet,
+    error::Error,
+    fmt::Display,
     io::ErrorKind,
     path::{Path, PathBuf},
+    str::FromStr,
     sync::OnceLock,
 };
 
+use camino::Utf8PathBuf;
 use itertools::Itertools;
+use path_clean::PathClean;
 use path_slash::PathExt;
 use regex::Regex;
 use tracing::{info_span, Span};
@@ -222,8 +227,97 @@ fn glob_with_contextual_error<S: AsRef<str> + std::fmt::Debug>(
         .map_err(|e| WalkError::BadPattern(raw.to_string(), Box::new(e)))
 }
 
-#[tracing::instrument]
+#[derive(Debug)]
+pub struct GlobError {
+    raw_input: String,
+    reason: String,
+}
+
+impl Display for GlobError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Invalid globwalking input {}: {}",
+            self.raw_input, self.reason
+        )
+    }
+}
+
+impl Error for GlobError {}
+
+/// ValidatedGlob represents an input string that we have either validated or
+/// modified to fit our constraints. It does not _yet_ validate that the glob is
+/// a valid glob pattern, just that we have checked for unix format, ':'s, clean
+/// paths, etc.
+#[derive(Clone, Debug)]
+pub struct ValidatedGlob {
+    inner: String,
+}
+
+impl ValidatedGlob {
+    pub fn as_str(&self) -> &str {
+        self.inner.as_str()
+    }
+}
+
+impl FromStr for ValidatedGlob {
+    type Err = GlobError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // Valid globs:
+        // 1. are to_slash'd,
+        // 2. are relative
+        // 3. directory traversals are leading or not at all
+        // 4. single `.`s removed
+        // 5. colons escaped on unix, error on windows
+
+        // Check slashes + ':'
+        #[cfg(not(windows))]
+        let cross_platform = s.replace(':', "\\:");
+        #[cfg(windows)]
+        let cross_platform = {
+            let to_slashed = s.replace('\\', "/");
+            if let Some(index) = to_slashed.find(':') {
+                return Err(GlobError {
+                    raw_input: s.to_owned(),
+                    reason: format!(
+                        "Found invalid windows relative path character ':' at position {index}"
+                    ),
+                });
+            }
+            to_slashed
+        };
+
+        // Check relative path. Since we've errored on ':' and converted to slashes
+        // already, we just need to check for leading /
+        // TODO: fully deprecate allowing absolute paths (that won't work anyways)
+        // if cross_platform.chars().next() == Some('/') {
+        //     return Err(err("globs must be relative paths".to_string()));
+        // }
+        let cross_platform = cross_platform.trim_start_matches('/').to_owned();
+
+        // TODO: path clean goes here
+        let path_buf = Utf8PathBuf::from_str(&cross_platform).expect("infallible");
+        let cleaned = path_buf.as_std_path().clean();
+        Ok(Self {
+            inner: cleaned.to_str().expect("valid utf-8").to_string(),
+        })
+    }
+}
+
 pub fn globwalk(
+    base_path: &AbsoluteSystemPath,
+    include: &[ValidatedGlob],
+    exclude: &[ValidatedGlob],
+    walk_type: WalkType,
+) -> Result<HashSet<AbsoluteSystemPathBuf>, WalkError> {
+    let include = include.iter().map(|i| i.inner.clone()).collect::<Vec<_>>();
+    let exclude = exclude.iter().map(|e| e.inner.clone()).collect::<Vec<_>>();
+    globwalk_internal(base_path, &include, &exclude, walk_type)
+}
+
+#[tracing::instrument]
+pub fn globwalk_internal(
     base_path: &AbsoluteSystemPath,
     include: &[String],
     exclude: &[String],
@@ -310,14 +404,15 @@ pub fn globwalk(
 
 #[cfg(test)]
 mod test {
-    use std::collections::HashSet;
+    use std::{collections::HashSet, str::FromStr};
 
     use itertools::Itertools;
     use test_case::test_case;
     use turbopath::AbsoluteSystemPathBuf;
 
     use crate::{
-        collapse_path, escape_glob_literals, fix_glob_pattern, globwalk, WalkError, WalkType,
+        collapse_path, escape_glob_literals, fix_glob_pattern, globwalk, ValidatedGlob, WalkError,
+        WalkType,
     };
 
     #[cfg(unix)]
@@ -577,7 +672,8 @@ mod test {
         let dir = setup();
 
         let path = AbsoluteSystemPathBuf::try_from(dir.path()).unwrap();
-        let success = match super::globwalk(&path, &[pattern.into()], &[], crate::WalkType::All) {
+        let validated = ValidatedGlob::from_str(pattern).unwrap();
+        let success = match super::globwalk(&path, &[validated], &[], crate::WalkType::All) {
             Ok(e) => e.into_iter(),
             Err(e) => return Some(e),
         };
@@ -1141,8 +1237,14 @@ mod test {
         let dir = setup_files(files);
         let base_path = base_path.trim_start_matches('/');
         let path = AbsoluteSystemPathBuf::try_from(dir.path().join(base_path)).unwrap();
-        let include: Vec<_> = include.iter().map(|s| s.to_string()).collect();
-        let exclude: Vec<_> = exclude.iter().map(|s| s.to_string()).collect();
+        let include: Vec<_> = include
+            .iter()
+            .map(|s| ValidatedGlob::from_str(s).expect("valid inputs"))
+            .collect();
+        let exclude: Vec<_> = exclude
+            .iter()
+            .map(|s| ValidatedGlob::from_str(s).expect("valid inputs"))
+            .collect();
 
         for (walk_type, expected) in [
             (crate::WalkType::Files, expected_files),
@@ -1237,7 +1339,7 @@ mod test {
         let tmp = setup_files(files);
         let root = AbsoluteSystemPathBuf::try_from(tmp.path()).unwrap();
         let child = root.join_component("child");
-        let include = &["../*-file".to_string()];
+        let include = &[ValidatedGlob::from_str("../*-file").unwrap()];
         let exclude = &[];
         let iter = globwalk(&child, include, exclude, WalkType::Files)
             .unwrap()
@@ -1261,13 +1363,21 @@ mod test {
         ];
         let tmp = setup_files(files);
         let root = AbsoluteSystemPathBuf::try_from(tmp.path()).unwrap();
-        let include = &[
-            "apps/*/package.json".to_string(),
-            "docs/package.json".to_string(),
-            "empty/*/package.json".to_string(),
-        ];
-        let exclude = &["apps/ignored".to_string(), "**/node_modules/**".to_string()];
-        let iter = globwalk(&root, include, exclude, WalkType::Files).unwrap();
+        let include = [
+            "apps/*/package.json",
+            "docs/package.json",
+            "empty/*/package.json",
+        ]
+        .into_iter()
+        .map(ValidatedGlob::from_str)
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+        let exclude = ["apps/ignored", "**/node_modules/**"]
+            .into_iter()
+            .map(ValidatedGlob::from_str)
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        let iter = globwalk(&root, &include, &exclude, WalkType::Files).unwrap();
         let paths = iter
             .into_iter()
             .map(|path| {

--- a/crates/turborepo-lib/src/run/cache.rs
+++ b/crates/turborepo-lib/src/run/cache.rs
@@ -25,6 +25,8 @@ pub enum Error {
     Cache(#[from] turborepo_cache::CacheError),
     #[error("Error finding outputs to save: {0}")]
     Globwalk(#[from] globwalk::WalkError),
+    #[error("Invalid globwalk pattern: {0}")]
+    Glob(#[from] globwalk::GlobError),
     #[error("Error with daemon: {0}")]
     Daemon(#[from] crate::daemon::DaemonError),
     #[error("no connection to daemon")]
@@ -315,8 +317,8 @@ impl TaskCache {
 
         let files_to_be_cached = globwalk::globwalk(
             &self.run_cache.repo_root,
-            &self.repo_relative_globs.inclusions,
-            &self.repo_relative_globs.exclusions,
+            &self.repo_relative_globs.validated_inclusions()?,
+            &self.repo_relative_globs.validated_exclusions()?,
             globwalk::WalkType::All,
         )?;
 

--- a/crates/turborepo-lib/src/task_graph/mod.rs
+++ b/crates/turborepo-lib/src/task_graph/mod.rs
@@ -1,5 +1,8 @@
 mod visitor;
 
+use std::str::FromStr;
+
+use globwalk::{GlobError, ValidatedGlob};
 use serde::{Deserialize, Serialize};
 use turbopath::{AnchoredSystemPath, AnchoredSystemPathBuf, RelativeUnixPathBuf};
 pub use visitor::{Error as VisitorError, Visitor};
@@ -16,6 +19,22 @@ use crate::{
 pub struct TaskOutputs {
     pub inclusions: Vec<String>,
     pub exclusions: Vec<String>,
+}
+
+impl TaskOutputs {
+    pub fn validated_inclusions(&self) -> Result<Vec<ValidatedGlob>, GlobError> {
+        self.inclusions
+            .iter()
+            .map(|i| ValidatedGlob::from_str(i))
+            .collect()
+    }
+
+    pub fn validated_exclusions(&self) -> Result<Vec<ValidatedGlob>, GlobError> {
+        self.exclusions
+            .iter()
+            .map(|e| ValidatedGlob::from_str(e))
+            .collect()
+    }
 }
 
 // Constructed from a RawTaskDefinition

--- a/crates/turborepo-scm/Cargo.toml
+++ b/crates/turborepo-scm/Cargo.toml
@@ -15,7 +15,6 @@ git2 = { version = "0.16.1", default-features = false }
 globwalk = { path = "../turborepo-globwalk" }
 hex = { workspace = true }
 ignore = "0.4.20"
-itertools.workspace = true
 nom = "7.1.3"
 sha1 = "0.10.5"
 thiserror = { workspace = true }

--- a/crates/turborepo-scm/src/lib.rs
+++ b/crates/turborepo-scm/src/lib.rs
@@ -59,6 +59,8 @@ pub enum Error {
     Ignore(#[from] ignore::Error, #[backtrace] backtrace::Backtrace),
     #[error("invalid glob: {0}")]
     Glob(#[source] Box<wax::BuildError>, backtrace::Backtrace),
+    #[error("invalid globwalk pattern: {0}")]
+    Globwalk(#[from] globwalk::GlobError),
     #[error(transparent)]
     Walk(#[from] globwalk::WalkError),
 }


### PR DESCRIPTION
### Description

 - adds a wrapper type for strings that we intend to use as patterns, or parts of patterns, for globwalking
 - does some transformation on the raw strings (`to_slash`, `clean`, escape or error on `:`, etc.)
 - DOES NOT remove any path or pattern transformations inside the `globwalk` code. Some of that is likely duplicate work now, which we ought to tackle once we're confident we're validating properly, and perhaps do an earlier step to compile to an intermediate format.
 - DOES NOT propagate beyond existing call sites, with the exception of `WorkspaceGlobs`, but even that could probably use another pass. It is very likely that some of our data structures could hold `ValidatedGlob` instances rather than strings to both 1) validate earlier and 2) avoid duplicate validation

### Testing Instructions

 - Existing tests updated to use new type signature

Closes TURBO-1972