### PR TITLE
fix(docs): mobile screen, prevent gradient and hero overflow

### DIFF
--- a/docs/components/pages/home-shared/Gradient.tsx
+++ b/docs/components/pages/home-shared/Gradient.tsx
@@ -25,7 +25,7 @@ export function Gradient({
   return (
     <span
       className={cn(
-        "absolute",
+        "absolute max-w-full rounded-full",
         gradients.glow,
         {
           [gradients.glowPink]: pink,
@@ -40,7 +40,6 @@ export function Gradient({
         width,
         height,
         opacity,
-        borderRadius: "100%",
       }}
     />
   );

--- a/docs/components/pages/pack-home/PackHero.tsx
+++ b/docs/components/pages/pack-home/PackHero.tsx
@@ -13,22 +13,20 @@ export function PackHero() {
       noVertical
     >
       <FadeIn className="z-50 flex items-center justify-center w-full">
-        <div className="absolute min-w-[614px] min-h-[614px]">
-          <Image
-            alt="Turbopack"
-            className="hidden dark:block"
-            height={614}
-            src="/images/docs/pack/turbopack-hero-hexagons-dark.svg"
-            width={614}
-          />
-          <Image
-            alt="Turbopack"
-            className="block dark:hidden"
-            height={614}
-            src="/images/docs/pack/turbopack-hero-hexagons-light.svg"
-            width={614}
-          />
-        </div>
+        <Image
+          alt="Turbopack"
+          className="absolute hidden dark:block"
+          height={614}
+          src="/images/docs/pack/turbopack-hero-hexagons-dark.svg"
+          width={614}
+        />
+        <Image
+          alt="Turbopack"
+          className="absolute block dark:hidden"
+          height={614}
+          src="/images/docs/pack/turbopack-hero-hexagons-light.svg"
+          width={614}
+        />
         <div className="absolute z-50 flex items-center justify-center w-64 h-64">
           <Gradient
             className="dark:opacity-100 opacity-40"

--- a/docs/components/pages/repo-home/RepoHero.tsx
+++ b/docs/components/pages/repo-home/RepoHero.tsx
@@ -12,24 +12,22 @@ export function RepoHero() {
       className="font-sans w-auto min-h-[calc(100svh-var(--nextra-navbar-height))] pb-16 pt-[48px] md:pb-24 lg:pb-32 md:pt-16 lg:pt-20 flex justify-between gap-8 items-center flex-col relative z-0"
       noVertical
     >
-      <FadeIn className="z-50 flex items-center justify-center w-full ">
-        <div className="absolute min-w-[614px] min-h-[614px]">
-          {/* TODO: On dark mode, there should be a "breathing" gradient inside the inner circle */}
-          <Image
-            alt="Turborepo"
-            className="hidden dark:block"
-            height={614}
-            src="/images/docs/repo/repo-hero-circles-dark.svg"
-            width={614}
-          />
-          <Image
-            alt="Turborepo"
-            className="block dark:hidden"
-            height={614}
-            src="/images/docs/repo/repo-hero-circles-light.svg"
-            width={614}
-          />
-        </div>
+      <FadeIn className="z-50 flex items-center justify-center w-full">
+        {/* TODO: On dark mode, there should be a "breathing" gradient inside the inner circle */}
+        <Image
+          alt="Turborepo"
+          className="absolute hidden dark:block"
+          height={614}
+          src="/images/docs/repo/repo-hero-circles-dark.svg"
+          width={614}
+        />
+        <Image
+          alt="Turborepo"
+          className="absolute block dark:hidden"
+          height={614}
+          src="/images/docs/repo/repo-hero-circles-light.svg"
+          width={614}
+        />
         <div className="absolute z-50 flex items-center justify-center w-64 h-64">
           <Gradient
             className="dark:opacity-100 opacity-40"


### PR DESCRIPTION
### Description

https://turbo.build/pack and https://turbo.build/repo are overflowing to the right on mobile screens.

<img src="https://github.com/vercel/turbo/assets/762112/a96dbf51-411e-4297-ab09-9c4342b51a1d" width="250">
<img src="https://github.com/vercel/turbo/assets/762112/ab46d123-3167-486d-9a48-34e10f95d195" width="250">

- The `Gradient` component was causing screens with a width less than the `Gradient`'s `width` to overflow, here I let the `Gradient` component handle the case with a max width that will resize if the device's screen width is less than the requested one, behaving similarly to how images already resize by default with Tailwind. Another alternative is to let it overflow and wrap it to hide the overflow and center it, I think this is more a design choice than a technical one.
- The hexagon and circle images had a similar problem. Removing the explicit width and height of the container and letting the images use their `width` and `height`, and Tailwind's max width kick in fixes the overflow.

### Testing Instructions

- Run the docs.
- Using a mobile screen navigate to `/pack` and `/repo`
- Confirm it does not overflow to the right, it should look something like,
<img src="https://github.com/vercel/turbo/assets/762112/784269c5-88b4-4454-adaf-c54b4c805fcd" width="250">
<img src="https://github.com/vercel/turbo/assets/762112/0af1bca4-3242-4377-ab9b-e71121cfcefd" width="250">

