### PR TITLE
Remove button type.

### DIFF
--- a/docs/components/pages/home-shared/CTAButton.tsx
+++ b/docs/components/pages/home-shared/CTAButton.tsx
@@ -20,6 +20,7 @@ export function CTAButton({
 
   return (
     <div className="relative w-full group">
+      {/* eslint-disable-next-line react/button-has-type -- Nextra wrecks the styles if we add a type. */}
       <button
         className={`w-full min-w-[120px] text-base font-medium no-underline ${
           outline ? outlineClasses : filledClasses
@@ -27,7 +28,6 @@ export function CTAButton({
           monospace ? "font-mono" : ""
         }`}
         onClick={onClick}
-        type="button"
       >
         {children}
       </button>


### PR DESCRIPTION
### Description

Adding a type to the button messed up the styling on the CTA button. The stylesheet that is overwriting this property is deeply nested into Nextra.

Because this breakage is prominent, strictly visual, I did it, and I don't wont to bother my teammates for a review during our holiday break, I'm going to push this through without review.

Fixes #6856 
