### PR TITLE
fix(examples): Typo correction on design-system package.json

### DIFF
--- a/examples/design-system/packages/eslint-config/package.json
+++ b/examples/design-system/packages/eslint-config/package.json
@@ -5,7 +5,7 @@
   "files": [
     "library.js",
     "react.js",
-    "storybook.j"
+    "storybook.js"
   ],
   "devDependencies": {
     "@vercel/style-guide": "^5.0.0",


### PR DESCRIPTION
### Description

Typo fix on package.json from design-system example.

The file `storybook.js` was referenced as `storybook.j` on files field.
