### PR TITLE
chore: tracing overhaul

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10965,6 +10965,7 @@ dependencies = [
  "test-case",
  "thiserror",
  "tokio",
+ "tracing",
  "turbopath",
  "turborepo-ci",
  "turborepo-vercel-api",

--- a/crates/turborepo-analytics/src/lib.rs
+++ b/crates/turborepo-analytics/src/lib.rs
@@ -84,6 +84,7 @@ impl AnalyticsHandle {
 
     /// Closes the handle with an explicit timeout. If the handle fails to close
     /// within that timeout, it will log an error and drop the handle.
+    #[tracing::instrument(skip_all)]
     pub async fn close_with_timeout(self) {
         if let Err(err) = tokio::time::timeout(EVENT_TIMEOUT, self.close()).await {
             debug!("failed to close analytics handle. error: {}", err)

--- a/crates/turborepo-api-client/Cargo.toml
+++ b/crates/turborepo-api-client/Cargo.toml
@@ -30,6 +30,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
+tracing = { workspace = true }
 turbopath = { workspace = true }
 turborepo-ci = { workspace = true }
 turborepo-vercel-api = { workspace = true }

--- a/crates/turborepo-api-client/src/analytics.rs
+++ b/crates/turborepo-api-client/src/analytics.rs
@@ -15,6 +15,7 @@ pub trait AnalyticsClient {
 
 #[async_trait]
 impl AnalyticsClient for APIClient {
+    #[tracing::instrument(skip_all)]
     async fn record_analytics(
         &self,
         api_auth: &APIAuth,

--- a/crates/turborepo-api-client/src/lib.rs
+++ b/crates/turborepo-api-client/src/lib.rs
@@ -242,6 +242,7 @@ impl Client for APIClient {
         })
     }
 
+    #[tracing::instrument(skip_all)]
     async fn put_artifact(
         &self,
         hash: &str,
@@ -346,6 +347,7 @@ impl Client for APIClient {
         }
     }
 
+    #[tracing::instrument(skip_all)]
     async fn fetch_artifact(
         &self,
         hash: &str,
@@ -357,6 +359,7 @@ impl Client for APIClient {
             .await
     }
 
+    #[tracing::instrument(skip_all)]
     async fn artifact_exists(
         &self,
         hash: &str,

--- a/crates/turborepo-api-client/src/spaces.rs
+++ b/crates/turborepo-api-client/src/spaces.rs
@@ -139,6 +139,7 @@ impl FinishSpaceRunPayload {
 }
 
 impl APIClient {
+    #[tracing::instrument(skip_all)]
     pub async fn create_space_run(
         &self,
         space_id: &str,
@@ -158,6 +159,7 @@ impl APIClient {
         Ok(response.json().await?)
     }
 
+    #[tracing::instrument(skip_all)]
     pub async fn create_task_summary(
         &self,
         space_id: &str,
@@ -181,6 +183,7 @@ impl APIClient {
         Ok(())
     }
 
+    #[tracing::instrument(skip_all)]
     pub async fn finish_space_run(
         &self,
         space_id: &str,

--- a/crates/turborepo-cache/src/fs.rs
+++ b/crates/turborepo-cache/src/fs.rs
@@ -41,6 +41,7 @@ impl FSCache {
         }
     }
 
+    #[tracing::instrument(skip_all)]
     pub fn new(
         override_dir: Option<&Utf8Path>,
         repo_root: &AbsoluteSystemPath,
@@ -70,6 +71,7 @@ impl FSCache {
         }
     }
 
+    #[tracing::instrument(skip_all)]
     pub fn fetch(
         &self,
         anchor: &AbsoluteSystemPath,
@@ -112,6 +114,7 @@ impl FSCache {
         )))
     }
 
+    #[tracing::instrument(skip_all)]
     pub(crate) fn exists(&self, hash: &str) -> Result<Option<CacheHitMetadata>, CacheError> {
         let uncompressed_cache_path = self
             .cache_directory
@@ -138,6 +141,7 @@ impl FSCache {
         }))
     }
 
+    #[tracing::instrument(skip_all)]
     pub fn put(
         &self,
         anchor: &AbsoluteSystemPath,

--- a/crates/turborepo-cache/src/http.rs
+++ b/crates/turborepo-cache/src/http.rs
@@ -22,6 +22,7 @@ pub struct HTTPCache {
 }
 
 impl HTTPCache {
+    #[tracing::instrument(skip_all)]
     pub fn new(
         client: APIClient,
         opts: &CacheOpts,
@@ -56,6 +57,7 @@ impl HTTPCache {
         }
     }
 
+    #[tracing::instrument(skip_all)]
     pub async fn put(
         &self,
         anchor: &AbsoluteSystemPath,
@@ -87,6 +89,7 @@ impl HTTPCache {
         Ok(())
     }
 
+    #[tracing::instrument(skip_all)]
     async fn write(
         &self,
         writer: impl Write,
@@ -101,6 +104,7 @@ impl HTTPCache {
         Ok(())
     }
 
+    #[tracing::instrument(skip_all)]
     pub async fn exists(&self, hash: &str) -> Result<Option<CacheHitMetadata>, CacheError> {
         let Some(response) = self
             .client
@@ -152,6 +156,7 @@ impl HTTPCache {
         }
     }
 
+    #[tracing::instrument(skip_all)]
     pub async fn fetch(
         &self,
         hash: &str,

--- a/crates/turborepo-cache/src/http.rs
+++ b/crates/turborepo-cache/src/http.rs
@@ -222,6 +222,7 @@ impl HTTPCache {
         )))
     }
 
+    #[tracing::instrument(skip_all)]
     pub(crate) fn restore_tar(
         root: &AbsoluteSystemPath,
         body: &[u8],

--- a/crates/turborepo-cache/src/multiplexer.rs
+++ b/crates/turborepo-cache/src/multiplexer.rs
@@ -22,6 +22,7 @@ pub struct CacheMultiplexer {
 }
 
 impl CacheMultiplexer {
+    #[tracing::instrument(skip_all)]
     pub fn new(
         opts: &CacheOpts,
         repo_root: &AbsoluteSystemPath,
@@ -75,6 +76,7 @@ impl CacheMultiplexer {
         }
     }
 
+    #[tracing::instrument(skip_all)]
     pub async fn put(
         &self,
         anchor: &AbsoluteSystemPath,
@@ -125,6 +127,7 @@ impl CacheMultiplexer {
         }
     }
 
+    #[tracing::instrument(skip_all)]
     pub async fn fetch(
         &self,
         anchor: &AbsoluteSystemPath,
@@ -155,6 +158,7 @@ impl CacheMultiplexer {
         Ok(None)
     }
 
+    #[tracing::instrument(skip_all)]
     pub async fn exists(&self, key: &str) -> Result<Option<CacheHitMetadata>, CacheError> {
         if let Some(fs) = &self.fs {
             match fs.exists(key) {

--- a/crates/turborepo-cache/src/signature_authentication.rs
+++ b/crates/turborepo-cache/src/signature_authentication.rs
@@ -94,6 +94,7 @@ impl ArtifactSignatureAuthenticator {
         Ok(BASE64_STANDARD.encode(hmac_output.into_bytes()))
     }
 
+    #[tracing::instrument(skip_all)]
     pub fn validate(
         &self,
         hash: &[u8],

--- a/crates/turborepo-cache/src/signature_authentication.rs
+++ b/crates/turborepo-cache/src/signature_authentication.rs
@@ -68,6 +68,7 @@ impl ArtifactSignatureAuthenticator {
         Ok(mac)
     }
 
+    #[tracing::instrument(skip_all)]
     pub fn generate_tag_bytes(
         &self,
         hash: &[u8],
@@ -80,6 +81,7 @@ impl ArtifactSignatureAuthenticator {
         Ok(hmac_output.into_bytes().to_vec())
     }
 
+    #[tracing::instrument(skip_all)]
     pub fn generate_tag(
         &self,
         hash: &[u8],

--- a/crates/turborepo-lib/src/run/summary/mod.rs
+++ b/crates/turborepo-lib/src/run/summary/mod.rs
@@ -403,6 +403,7 @@ impl<'a> RunSummary<'a> {
         Ok(())
     }
 
+    #[tracing::instrument(skip_all)]
     async fn send_to_space(
         &self,
         spaces_client_handle: SpacesClientHandle,

--- a/crates/turborepo-lib/src/run/summary/spaces.rs
+++ b/crates/turborepo-lib/src/run/summary/spaces.rs
@@ -84,6 +84,7 @@ impl SpacesClientHandle {
         }
     }
 
+    #[tracing::instrument(skip_all)]
     pub async fn finish_run(&self, exit_code: i32, end_time: DateTime<Local>) -> Result<(), Error> {
         Ok(self
             .tx

--- a/crates/turborepo-lib/src/task_graph/visitor.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor.rs
@@ -127,7 +127,7 @@ impl<'a> Visitor<'a> {
         }
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip_all)]
     pub async fn visit(&self, engine: Arc<Engine>) -> Result<Vec<TaskError>, Error> {
         let concurrency = self.opts.run_opts.concurrency as usize;
         let (node_sender, mut node_stream) = mpsc::channel(concurrency);

--- a/crates/turborepo-lib/src/tracing.rs
+++ b/crates/turborepo-lib/src/tracing.rs
@@ -13,7 +13,7 @@ use tracing_subscriber::{
     filter::{Filtered, Targets},
     fmt::{
         self,
-        format::{DefaultFields, Writer},
+        format::{DefaultFields, FmtSpan, Writer},
         FmtContext, FormatEvent, FormatFields, MakeWriter,
     },
     layer,
@@ -172,6 +172,7 @@ impl TurboSubscriber {
         trace!("created non-blocking file writer");
 
         let layer: DaemonLog = tracing_subscriber::fmt::layer()
+            .with_span_events(FmtSpan::FULL)
             .with_writer(file_writer)
             .with_ansi(false);
 
@@ -195,6 +196,7 @@ impl TurboSubscriber {
             .file(to_file)
             .include_args(include_args)
             .include_locations(true)
+            .trace_style(tracing_chrome::TraceStyle::Async)
             .build();
 
         self.chrome_update.reload(Some(layer))?;


### PR DESCRIPTION
### Description

This PR does a few things:
 - Adds tracing to far more functions
 - Corrects our use of spans in async code (TL;DR you shouldn't hold a span guard across an await [see docs for more info](https://docs.rs/tracing/latest/tracing/span/struct.Span.html#in-asynchronous-code))
 - Switch our chrome trace to show tasks vs threads. This makes the profile easier to read as a task which might get worked on by multiple threads will now show as one contiguous block instead of multiple slices across different threads.

Future work:
The keep alive HTTP/2 connection used by `h2` means that the span for our first request lasts until the connection is closed. One can still decipher what happens, but it does mean that the profile can look like one request took the entire run.
![Screenshot 2024-01-02 at 11 43 45 AM](https://github.com/vercel/turbo/assets/4131117/a1b8aede-69c8-415a-9090-a7d3e8e7d6cc)

### Testing Instructions

Example profile 
[profile.json](https://github.com/vercel/turbo/files/13813362/profile.json) open in a chrome trace viewer like Perfetto


Closes TURBO-1975