### PR TITLE
Remove old redirects.

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -185,60 +185,6 @@ const nextConfig = withNextra({
         permanent: true,
       },
       {
-        // Accidentally created, eventually removable. See below.
-        source: "/repo/docs/core-concepts/running-tasks",
-        destination: "/repo/docs/core-concepts/monorepos/running-tasks",
-        permanent: true,
-      },
-      {
-        // Accidentally created, eventually removable. See below.
-        source: "/repo/docs/core-concepts/why-turborepo",
-        destination: "/repo/docs/core-concepts/monorepos",
-        permanent: true,
-      },
-      {
-        // Accidentally created, eventually removable. See below.
-        source: "/repo/docs/core-concepts/filtering",
-        destination: "/repo/docs/core-concepts/monorepos/filtering",
-        permanent: true,
-      },
-      {
-        // Accidentally created, eventually removable. See below.
-        source: "/repo/docs/core-concepts/pipelines",
-        destination: "/repo/docs/core-concepts/monorepos/running-tasks",
-        permanent: true,
-      },
-      {
-        // This rule accidentally created a bunch of URLs.
-        //
-        // They've _never_ resolved, so _eventually_ we should be able to remove the
-        // redirects we added above to fix them.
-        source: "/docs/features/:path*",
-        destination: "/repo/docs/core-concepts/:path*",
-        permanent: true,
-      },
-      {
-        // Accidentally created, eventually removable. See below.
-        source: "/repo/docs/getting-started",
-        destination: "/repo/docs",
-        permanent: true,
-      },
-      {
-        // Accidentally created, eventually removable. See below.
-        source: "/repo/docs/guides/workspaces",
-        destination: "/repo/docs/handbook/workspaces",
-        permanent: true,
-      },
-      {
-        // This rule accidentally created a bunch of URLs.
-        //
-        // They've _never_ resolved, so _eventually_ we should be able to remove the
-        // redirects we added above to fix them.
-        source: "/docs/:path*",
-        destination: "/repo/docs/:path*",
-        permanent: true,
-      },
-      {
         // Redirect old blog posts to new blog.
         source: "/posts/:path*",
         destination: "/blog/:path*",


### PR DESCRIPTION
### Description

As we work through some restructuring of the documentation, there will be some rewrites that need to happen.

Here, I'm cleaning things up so our redirects stay as simple and easy to read as possible. I checked Search Console and none of the source paths in the list are currently being indexed by Google.
