### PR TITLE
fix: avoid deleting cached package discovery data

### DIFF
--- a/crates/turborepo-repository/src/discovery.rs
+++ b/crates/turborepo-repository/src/discovery.rs
@@ -228,7 +228,7 @@ impl<P: PackageDiscovery> CachingPackageDiscovery<P> {
 
 impl<P: PackageDiscovery + Send> PackageDiscovery for CachingPackageDiscovery<P> {
     async fn discover_packages(&mut self) -> Result<DiscoveryResponse, Error> {
-        match self.data.take() {
+        match self.data.clone() {
             Some(data) => Ok(data),
             None => {
                 let data = self.primary.discover_packages().await?;


### PR DESCRIPTION
### Description

Currently we're performing package discovery multiple times as we remove the cached data instead of copying it.

This change is part of #6712, but is critical enough that it can't wait for that to go through review.

### Testing Instructions

👀 


Closes TURBO-1978