### PR TITLE
fix support bracket filepaths

### DIFF
--- a/crates/turborepo-globwalk/src/lib.rs
+++ b/crates/turborepo-globwalk/src/lib.rs
@@ -57,8 +57,14 @@ fn preprocess_paths_and_globs(
     let base_path_slash = base_path
         .as_std_path()
         .to_slash()
-        // Windows drive paths need to be escaped, and ':' is a valid token in unix paths
-        .map(|s| s.replace(':', "\\:"))
+        .map(|s| {
+            // Windows drive paths need to be escaped, and ':' is a valid token in unix
+            // paths
+            s.replace(':', "\\:")
+                // [] are valid tokens in paths and need to be escaped
+                .replace('[', "\\[")
+                .replace(']', "\\]")
+        })
         .ok_or(WalkError::InvalidPath)?;
 
     let (include_paths, lowest_segment) = include


### PR DESCRIPTION
### Description

Fixes #6855

Since we currently construct a glob *after* joining the base path with the inclusion glob if there are special characters they can have unintended meaning and produce incorrect results. We already did a similar thing with `:` as they appear in Windows paths in the drive names.

The list of special characters comes from wax's [token/parse.rs](https://github.com/vercel/turbo/blob/main/crates/turborepo-wax/src/token/parse.rs#L245)

Future work might be using [`Glob::partition`](https://docs.rs/wax/latest/wax/struct.Glob.html#method.partition) or adding the path as part of the glob and instead relying on the `base_path` argument for `Glob::walk`.

### Testing Instructions

Added unit tests for all special character globs.

`turbo build` now works with the reproduction provided in the linked issue.


Closes TURBO-1983