### PR TITLE
fix: Make execution state use auth crate

### DIFF
--- a/crates/turborepo-auth/src/auth_file.rs
+++ b/crates/turborepo-auth/src/auth_file.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, ops::Deref};
 
 use serde::{Deserialize, Serialize};
 use turbopath::AbsoluteSystemPath;
@@ -83,6 +83,12 @@ impl AuthToken {
         } else {
             &self.api
         }
+    }
+    pub fn api(&self) -> &str {
+        &self.api
+    }
+    pub fn token(&self) -> &str {
+        &self.token
     }
 }
 

--- a/crates/turborepo-auth/src/auth_file.rs
+++ b/crates/turborepo-auth/src/auth_file.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, ops::Deref};
+use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 use turbopath::AbsoluteSystemPath;

--- a/crates/turborepo-auth/src/lib.rs
+++ b/crates/turborepo-auth/src/lib.rs
@@ -16,7 +16,6 @@ mod sso_server;
 mod ui;
 
 use turbopath::AbsoluteSystemPath;
-use turborepo_api_client::Client;
 
 pub use self::{
     auth_file::*, config_token::ConfigToken, error::Error, login::*, login_server::*, logout::*,
@@ -47,7 +46,7 @@ pub const DEFAULT_API_URL: &str = "https://vercel.com/api";
 pub fn read_or_create_auth_file(
     auth_file_path: &AbsoluteSystemPath,
     config_file_path: &AbsoluteSystemPath,
-    client: &impl Client,
+    api: &str,
 ) -> Result<AuthFile, Error> {
     if auth_file_path.try_exists()? {
         let content = auth_file_path
@@ -74,10 +73,10 @@ pub fn read_or_create_auth_file(
         let config_token: ConfigToken = serde_json::from_str(&content)
             .map_err(|e| Error::FailedToDeserializeConfigToken { source: e })?;
 
-        let auth_token = convert_to_auth_token(&config_token.token, client.base_url());
+        let auth_token = convert_to_auth_token(&config_token.token, api);
 
         let mut auth_file = AuthFile::new();
-        auth_file.insert(client.base_url().to_owned(), auth_token.token);
+        auth_file.insert(api.to_owned(), auth_token.token);
         auth_file.write_to_disk(auth_file_path)?;
         return Ok(auth_file);
     }
@@ -92,6 +91,8 @@ pub fn read_or_create_auth_file(
 #[cfg(test)]
 mod tests {
     use std::{fs::File, io::Write};
+
+    use turborepo_api_client::Client;
 
     use super::*;
     use crate::mocks::MockApiClient;
@@ -112,7 +113,7 @@ mod tests {
 
         let client = MockApiClient::new();
 
-        let result = read_or_create_auth_file(auth_file_path, config_file_path, &client);
+        let result = read_or_create_auth_file(auth_file_path, config_file_path, client.base_url());
 
         assert!(result.is_ok());
         let auth_file = result.unwrap();
@@ -129,7 +130,7 @@ mod tests {
             .expect("Failed to create config file path");
 
         let client = MockApiClient::new();
-        let result = read_or_create_auth_file(auth_file_path, config_file_path, &client);
+        let result = read_or_create_auth_file(auth_file_path, config_file_path, client.base_url());
 
         assert!(result.is_ok());
         assert!(std::fs::try_exists(auth_file_path).unwrap_or(false));
@@ -160,7 +161,11 @@ mod tests {
         let client = MockApiClient::new();
 
         // Test: Get the result of reading the auth file
-        let result = read_or_create_auth_file(full_auth_file_path, full_config_file_path, &client);
+        let result = read_or_create_auth_file(
+            full_auth_file_path,
+            full_config_file_path,
+            client.base_url(),
+        );
 
         // Make sure no errors come back
         assert!(result.is_ok());

--- a/crates/turborepo-lib/src/commands/link.rs
+++ b/crates/turborepo-lib/src/commands/link.rs
@@ -174,11 +174,10 @@ pub async fn link(
     let api_client = base.api_client()?;
     let auth_file_path = base.global_auth_path()?;
     let config_file_path = base.global_config_path()?;
-    let auth = read_or_create_auth_file(&auth_file_path, &config_file_path, &api_client).map_err(
-        |_| Error::TokenNotFound {
+    let auth = read_or_create_auth_file(&auth_file_path, &config_file_path, api_client.base_url())
+        .map_err(|_| Error::TokenNotFound {
             command: base.ui.apply(BOLD.apply_to("npx turbo login")),
-        },
-    )?;
+        })?;
     let token = &auth
         .get_token(api_client.base_url())
         .ok_or_else(|| Error::TokenNotFound {

--- a/crates/turborepo-lib/src/commands/login.rs
+++ b/crates/turborepo-lib/src/commands/login.rs
@@ -28,8 +28,11 @@ impl<T: LoginServer> Login<T> {
         let global_auth_path = base.global_auth_path()?;
         let global_config_path = base.global_config_path()?;
 
-        let mut auth_file =
-            read_or_create_auth_file(&global_auth_path, &global_config_path, &api_client)?;
+        let mut auth_file = read_or_create_auth_file(
+            &global_auth_path,
+            &global_config_path,
+            api_client.base_url(),
+        )?;
 
         if self
             .has_existing_token(&api_client, &mut auth_file, &ui)
@@ -81,8 +84,11 @@ impl<T: SSOLoginServer> Login<T> {
         let global_auth_path = base.global_auth_path()?;
         let global_config_path = base.global_config_path()?;
 
-        let mut auth_file =
-            read_or_create_auth_file(&global_auth_path, &global_config_path, &api_client)?;
+        let mut auth_file = read_or_create_auth_file(
+            &global_auth_path,
+            &global_config_path,
+            api_client.base_url(),
+        )?;
 
         if self
             .has_existing_sso_token(&api_client, &mut auth_file, &base.ui, sso_team)
@@ -239,7 +245,8 @@ mod tests {
         // Pass in the auth file path for both possible paths becuase we
         // should never read the config from here.
         let found_auth_file =
-            read_or_create_auth_file(&auth_file_path, &auth_file_path, &mock_api_client).unwrap();
+            read_or_create_auth_file(&auth_file_path, &auth_file_path, mock_api_client.base_url())
+                .unwrap();
 
         api_server.abort();
         assert_eq!(
@@ -273,7 +280,8 @@ mod tests {
         assert!(result.is_ok());
 
         let found_auth_file =
-            read_or_create_auth_file(&auth_file_path, &auth_file_path, &mock_api_client).unwrap();
+            read_or_create_auth_file(&auth_file_path, &auth_file_path, mock_api_client.base_url())
+                .unwrap();
 
         api_server.abort();
 

--- a/crates/turborepo-lib/src/commands/logout.rs
+++ b/crates/turborepo-lib/src/commands/logout.rs
@@ -1,4 +1,5 @@
 use tracing::error;
+use turborepo_api_client::Client;
 use turborepo_auth::{logout as auth_logout, read_or_create_auth_file, AuthToken};
 use turborepo_telemetry::events::command::CommandEventBuilder;
 
@@ -8,7 +9,7 @@ pub async fn logout(base: &mut CommandBase, _telemetry: CommandEventBuilder) -> 
     let client = base.api_client()?;
     let auth_path = base.global_auth_path()?;
     let config_path = base.global_config_path()?;
-    let mut auth_file = read_or_create_auth_file(&auth_path, &config_path, &client)?;
+    let mut auth_file = read_or_create_auth_file(&auth_path, &config_path, client.base_url())?;
 
     match auth_file.tokens().len() {
         0 => {

--- a/crates/turborepo-lib/src/commands/mod.rs
+++ b/crates/turborepo-lib/src/commands/mod.rs
@@ -30,9 +30,7 @@ pub(crate) mod unlink;
 pub struct CommandBase {
     pub repo_root: AbsoluteSystemPathBuf,
     pub ui: UI,
-    #[cfg(test)]
     pub global_config_path: Option<AbsoluteSystemPathBuf>,
-    #[cfg(test)]
     pub global_auth_path: Option<AbsoluteSystemPathBuf>,
     config: OnceCell<ConfigurationOptions>,
     args: Args,
@@ -50,9 +48,7 @@ impl CommandBase {
             repo_root,
             ui,
             args,
-            #[cfg(test)]
             global_config_path: None,
-            #[cfg(test)]
             global_auth_path: None,
             config: OnceCell::new(),
             version,
@@ -137,8 +133,11 @@ impl CommandBase {
         let auth_file_path = self.global_auth_path()?;
         let config_file_path = self.global_config_path()?;
         let client = self.api_client()?;
-        let auth =
-            turborepo_auth::read_or_create_auth_file(&auth_file_path, &config_file_path, &client)?;
+        let auth = turborepo_auth::read_or_create_auth_file(
+            &auth_file_path,
+            &config_file_path,
+            client.base_url(),
+        )?;
 
         let auth_token = auth.get_token(client.base_url());
         if let Some(auth_token) = auth_token {

--- a/crates/turborepo-lib/src/commands/mod.rs
+++ b/crates/turborepo-lib/src/commands/mod.rs
@@ -30,7 +30,9 @@ pub(crate) mod unlink;
 pub struct CommandBase {
     pub repo_root: AbsoluteSystemPathBuf,
     pub ui: UI,
+    #[cfg(test)]
     pub global_config_path: Option<AbsoluteSystemPathBuf>,
+    #[cfg(test)]
     pub global_auth_path: Option<AbsoluteSystemPathBuf>,
     config: OnceCell<ConfigurationOptions>,
     args: Args,
@@ -48,7 +50,9 @@ impl CommandBase {
             repo_root,
             ui,
             args,
+            #[cfg(test)]
             global_config_path: None,
+            #[cfg(test)]
             global_auth_path: None,
             config: OnceCell::new(),
             version,

--- a/crates/turborepo-lib/src/commands/mod.rs
+++ b/crates/turborepo-lib/src/commands/mod.rs
@@ -81,7 +81,7 @@ impl CommandBase {
     }
 
     // Getting all of the paths.
-    fn global_config_path(&self) -> Result<AbsoluteSystemPathBuf, ConfigError> {
+    pub fn global_config_path(&self) -> Result<AbsoluteSystemPathBuf, ConfigError> {
         #[cfg(test)]
         if let Some(global_config_path) = self.global_config_path.clone() {
             return Ok(global_config_path);
@@ -94,7 +94,7 @@ impl CommandBase {
         AbsoluteSystemPathBuf::try_from(global_config_path).map_err(ConfigError::PathError)
     }
     /// Returns the path to the global auth file (auth.json).
-    fn global_auth_path(&self) -> Result<AbsoluteSystemPathBuf, ConfigError> {
+    pub fn global_auth_path(&self) -> Result<AbsoluteSystemPathBuf, ConfigError> {
         #[cfg(test)]
         if let Some(global_auth_path) = &self.global_auth_path {
             return Ok(global_auth_path.clone());

--- a/crates/turborepo-lib/src/execution_state.rs
+++ b/crates/turborepo-lib/src/execution_state.rs
@@ -49,8 +49,6 @@ impl<'a> TryFrom<&'a CommandBase> for ExecutionState<'a> {
 
         let config = base.config()?;
 
-        // TODO(voz): Don't unwrap here. Should be fine since this can rarely ever be
-        // None.
         let auth_file_path = base.global_auth_path()?;
         let config_file_path = base.global_config_path()?;
         let auth = turborepo_auth::read_or_create_auth_file(

--- a/crates/turborepo-lib/src/execution_state.rs
+++ b/crates/turborepo-lib/src/execution_state.rs
@@ -51,8 +51,8 @@ impl<'a> TryFrom<&'a CommandBase> for ExecutionState<'a> {
 
         // TODO(voz): Don't unwrap here. Should be fine since this can rarely ever be
         // None.
-        let auth_file_path = base.global_auth_path.clone().unwrap();
-        let config_file_path = base.global_config_path.clone().unwrap();
+        let auth_file_path = base.global_auth_path()?;
+        let config_file_path = base.global_config_path()?;
         let auth = turborepo_auth::read_or_create_auth_file(
             &auth_file_path,
             &config_file_path,

--- a/crates/turborepo-lib/src/run/error.rs
+++ b/crates/turborepo-lib/src/run/error.rs
@@ -11,6 +11,8 @@ use crate::{
 
 #[derive(Debug, Error, Diagnostic)]
 pub enum Error {
+    #[error(transparent)]
+    Auth(#[from] turborepo_auth::Error),
     #[error("error preparing engine: Invalid persistent task configuration:\n{0}")]
     EngineValidation(String),
     #[error(transparent)]


### PR DESCRIPTION
### Description
How about I do a PR this time?
This updates the execution state to use the `turborepo_auth` crate, beginning the end of the `CommandBase` as the token holder.

### Testing Instructions
Run a command with the `--go-fallback`. This should pass.


Closes TURBO-1987