### PR TITLE
improve nesting of tracing for invalidations

### DIFF
--- a/crates/turbo-tasks-memory/src/memory_backend_with_pg.rs
+++ b/crates/turbo-tasks-memory/src/memory_backend_with_pg.rs
@@ -1110,7 +1110,10 @@ impl<P: PersistedGraph> Backend for MemoryBackendWithPersistedGraph<P> {
                 )
             }
         };
-        Some(TaskExecutionSpec { future })
+        Some(TaskExecutionSpec {
+            future,
+            span: tracing::Span::none(),
+        })
     }
 
     fn task_execution_result(

--- a/crates/turbo-tasks/src/manager.rs
+++ b/crates/turbo-tasks/src/manager.rs
@@ -23,7 +23,7 @@ use tokio::{runtime::Handle, select, task_local};
 use tracing::{info_span, instrument, trace_span, Instrument, Level};
 
 use crate::{
-    backend::{Backend, CellContent, PersistentTaskType, TransientTaskType},
+    backend::{Backend, CellContent, PersistentTaskType, TaskExecutionSpec, TransientTaskType},
     event::{Event, EventListener},
     id::{BackendJobId, FunctionId, TraitTypeId},
     id_factory::IdFactory,
@@ -33,7 +33,7 @@ use crate::{
         TimedFuture, {self},
     },
     trace::TraceRawVcs,
-    util::{FormatDuration, StaticOrArc},
+    util::StaticOrArc,
     Completion, ConcreteTaskInput, InvalidationReason, InvalidationReasonSet, SharedReference,
     TaskId, TaskIdSet, ValueTypeId, Vc, VcRead, VcValueTrait, VcValueType,
 };
@@ -468,40 +468,36 @@ impl<B: Backend + 'static> TurboTasks<B> {
                     }
 
                     // Setup thread locals
-                    let execution_future = CELL_COUNTERS.scope(Default::default(), async {
-                        let execution = this.backend.try_start_task_execution(task_id, &*this)?;
-                        Some(
-                            TimedFuture::new(AssertUnwindSafe(execution.future).catch_unwind())
-                                .await,
-                        )
-                    });
-                    if let Some((result, duration, instant)) = execution_future.await {
-                        if cfg!(feature = "log_function_stats") && duration.as_millis() > 1000 {
-                            println!(
-                                "{} took {}",
-                                this.backend.get_task_description(task_id),
-                                FormatDuration(duration)
-                            )
-                        }
-                        let result = result.map_err(|any| match any.downcast::<String>() {
-                            Ok(owned) => Some(Cow::Owned(*owned)),
-                            Err(any) => match any.downcast::<&'static str>() {
-                                Ok(str) => Some(Cow::Borrowed(*str)),
-                                Err(_) => None,
-                            },
-                        });
-                        this.backend.task_execution_result(task_id, result, &*this);
-                        let stateful = this.finish_current_task_state();
-                        let reexecute = this
-                            .backend
-                            .task_execution_completed(task_id, duration, instant, stateful, &*this);
-                        if !reexecute {
-                            return false;
-                        }
-                    } else {
-                        return false;
-                    }
-                    true
+                    CELL_COUNTERS
+                        .scope(Default::default(), async {
+                            let Some(TaskExecutionSpec { future, span }) =
+                                this.backend.try_start_task_execution(task_id, &*this)
+                            else {
+                                return false;
+                            };
+
+                            async {
+                                let (result, duration, instant) =
+                                    TimedFuture::new(AssertUnwindSafe(future).catch_unwind()).await;
+
+                                let result = result.map_err(|any| match any.downcast::<String>() {
+                                    Ok(owned) => Some(Cow::Owned(*owned)),
+                                    Err(any) => match any.downcast::<&'static str>() {
+                                        Ok(str) => Some(Cow::Borrowed(*str)),
+                                        Err(_) => None,
+                                    },
+                                });
+                                this.backend.task_execution_result(task_id, result, &*this);
+                                let stateful = this.finish_current_task_state();
+                                let reexecute = this.backend.task_execution_completed(
+                                    task_id, duration, instant, stateful, &*this,
+                                );
+                                reexecute
+                            }
+                            .instrument(span)
+                            .await
+                        })
+                        .await
                 })
                 .await
             {}
@@ -810,7 +806,6 @@ impl<B: Backend + 'static> TurboTasks<B> {
             } = &mut *cell.borrow_mut();
             let tasks = take(tasks_to_notify);
             if !tasks.is_empty() {
-                let _guard = trace_span!("finish_current_task_state").entered();
                 self.backend.invalidate_tasks(&tasks, self);
             }
             *stateful

--- a/crates/turbo-tasks/src/manager.rs
+++ b/crates/turbo-tasks/src/manager.rs
@@ -489,10 +489,9 @@ impl<B: Backend + 'static> TurboTasks<B> {
                                 });
                                 this.backend.task_execution_result(task_id, result, &*this);
                                 let stateful = this.finish_current_task_state();
-                                let reexecute = this.backend.task_execution_completed(
+                                this.backend.task_execution_completed(
                                     task_id, duration, instant, stateful, &*this,
-                                );
-                                reexecute
+                                )
                             }
                             .instrument(span)
                             .await

--- a/crates/turbo-tasks/src/value_type.rs
+++ b/crates/turbo-tasks/src/value_type.rs
@@ -10,6 +10,7 @@ use std::{
 
 use auto_hash_map::{AutoMap, AutoSet};
 use serde::{Deserialize, Serialize};
+use tracing::Span;
 
 use crate::{
     id::{FunctionId, TraitTypeId},
@@ -253,6 +254,13 @@ impl TraitType {
 
     pub fn register(&'static self, global_name: &'static str) {
         register_trait_type(global_name, self);
+    }
+
+    pub fn resolve_span(&'static self, name: &str) -> Span {
+        tracing::trace_span!(
+            "turbo_tasks::resolve_trait_call",
+            name = format_args!("{}::{name}", &self.name),
+        )
     }
 }
 

--- a/crates/turbopack-core/src/chunk/chunking.rs
+++ b/crates/turbopack-core/src/chunk/chunking.rs
@@ -114,7 +114,7 @@ async fn handle_split_group(
 
 /// Creates a chunk with the given `chunk_items. `key` should be unique and is
 /// used with [keyed_cell] to place the chunk items into a cell.
-#[tracing::instrument(level = Level::TRACE, skip(chunk_items, split_context))]
+#[tracing::instrument(level = Level::TRACE, skip_all, fields(key = display(key)))]
 async fn make_chunk(
     chunk_items: Vec<ChunkItemWithInfo>,
     key: &mut String,
@@ -138,7 +138,7 @@ async fn make_chunk(
 
 /// Split chunk items into app code and vendor code. Continues splitting with
 /// [package_name_split] if necessary.
-#[tracing::instrument(level = Level::TRACE, skip(chunk_items, split_context))]
+#[tracing::instrument(level = Level::TRACE, skip_all, fields(name = display(&name)))]
 async fn app_vendors_split(
     chunk_items: Vec<ChunkItemWithInfo>,
     mut name: String,
@@ -187,7 +187,7 @@ async fn app_vendors_split(
 
 /// Split chunk items by node_modules package name. Continues splitting with
 /// [folder_split] if necessary.
-#[tracing::instrument(level = Level::TRACE, skip(chunk_items, split_context))]
+#[tracing::instrument(level = Level::TRACE, skip_all, fields(name = display(&name)))]
 async fn package_name_split(
     chunk_items: Vec<ChunkItemWithInfo>,
     mut name: String,
@@ -229,7 +229,7 @@ fn folder_split_boxed<'a, 'b>(
 }
 
 /// Split chunk items by folder structure.
-#[tracing::instrument(level = Level::TRACE, skip(chunk_items, split_context))]
+#[tracing::instrument(level = Level::TRACE, skip_all, fields(name = display(&name), location))]
 async fn folder_split(
     mut chunk_items: Vec<ChunkItemWithInfo>,
     mut location: usize,


### PR DESCRIPTION
### Description

Before stuff that run after the task execution has finished wasn't accounted towards the task span. This includes cells changes which trigger a task reexecution.

Now we account these things to the task span too, which improves the trace reporting

Closes PACK-2193