### PR TITLE
add base url getter to APIClient

### DIFF
--- a/crates/turborepo-api-client/src/lib.rs
+++ b/crates/turborepo-api-client/src/lib.rs
@@ -462,6 +462,10 @@ impl APIClient {
         })
     }
 
+    pub fn base_url(&self) -> &str {
+        self.base_url.as_str()
+    }
+
     /// Create a new request builder with the preflight check done,
     /// team parameters added, CI header, and a content type of json.
     pub(crate) async fn create_request_builder(


### PR DESCRIPTION
### Description
I think some stuff got nuked in the big auth revert. This should get us building.

### Testing Instructions
Try building Turborepo


Closes TURBO-1992