### PR TITLE
Fix code block spacing in tabs.

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -53,3 +53,7 @@ article.nextra-body-typesetting-article h3,
 article.nextra-body-typesetting-article h4 {
   line-height: 1.25 !important;
 }
+
+[id^="headlessui-tabs-panel"] > #custom-code-block:first-child {
+  margin-top: 0 !important;
+}

--- a/docs/theme.config.tsx
+++ b/docs/theme.config.tsx
@@ -226,7 +226,7 @@ const config: DocsThemeConfig = {
       // Taken from original Nextra docs theme.
       // Only functional change is adding `data-pagefind-weight`.
       return (
-        <div className="relative">
+        <div className="relative mt-6" id="custom-code-block">
           <pre
             className="nx-bg-primary-700/5 nx-mb-4 nx-overflow-x-auto nx-rounded-xl nx-subpixel-antialiased dark:nx-bg-primary-300/10 nx-text-[.9em] contrast-more:nx-border contrast-more:nx-border-primary-900/20 contrast-more:nx-contrast-150 contrast-more:dark:nx-border-primary-100/40 nx-py-4"
             {...props}


### PR DESCRIPTION
### Description

Code blocks within tabs needed more room to breathe.
