### PR TITLE
fix: avoid retry panic

### DIFF
--- a/crates/turborepo-api-client/src/error.rs
+++ b/crates/turborepo-api-client/src/error.rs
@@ -15,8 +15,8 @@ pub enum Error {
     TlsError(#[source] reqwest::Error),
     #[error("Error parsing header: {0}")]
     InvalidHeader(#[from] ToStrError),
-    #[error("Error parsing URL: {0}")]
-    InvalidUrl(#[from] url::ParseError),
+    #[error("Error parsing '{url}' as URL: {err}")]
+    InvalidUrl { url: String, err: url::ParseError },
     #[error("unknown caching status: {0}")]
     UnknownCachingStatus(String, #[backtrace] Backtrace),
     #[error("unknown status {code}: {message}")]

--- a/crates/turborepo-api-client/src/lib.rs
+++ b/crates/turborepo-api-client/src/lib.rs
@@ -105,7 +105,7 @@ impl Client for APIClient {
         &self.base_url
     }
     async fn get_token_metadata(&self, token: &str) -> Result<TokenMetadata> {
-        let url = self.make_url("/v5/user/tokens/current");
+        let url = self.make_url("/v5/user/tokens/current")?;
         let request_builder = self
             .client
             .get(url)

--- a/crates/turborepo-auth/src/mocks/mock_api_client.rs
+++ b/crates/turborepo-auth/src/mocks/mock_api_client.rs
@@ -173,15 +173,6 @@ impl Client for MockApiClient {
     ) -> turborepo_api_client::Result<Option<Response>> {
         unimplemented!("get_artifact")
     }
-    async fn do_preflight(
-        &self,
-        _token: &str,
-        _request_url: &str,
-        _request_method: &str,
-        _request_headers: &str,
-    ) -> turborepo_api_client::Result<PreflightResponse> {
-        unimplemented!("do_preflight")
-    }
     fn make_url(&self, endpoint: &str) -> String {
         format!("{}{}", self.base_url, endpoint)
     }

--- a/crates/turborepo-auth/src/mocks/mock_api_client.rs
+++ b/crates/turborepo-auth/src/mocks/mock_api_client.rs
@@ -7,6 +7,7 @@ use turborepo_vercel_api::{
     CachingStatusResponse, Membership, PreflightResponse, Role, Space, SpacesResponse, Team,
     TeamsResponse, TokenMetadata, User, UserResponse, VerifiedSsoUser,
 };
+use url::Url;
 
 #[derive(Debug, thiserror::Error)]
 pub enum MockApiError {
@@ -173,7 +174,8 @@ impl Client for MockApiClient {
     ) -> turborepo_api_client::Result<Option<Response>> {
         unimplemented!("get_artifact")
     }
-    fn make_url(&self, endpoint: &str) -> String {
-        format!("{}{}", self.base_url, endpoint)
+    fn make_url(&self, endpoint: &str) -> turborepo_api_client::Result<Url> {
+        let url = format!("{}{}", self.base_url, endpoint);
+        Url::parse(&url).map_err(|err| turborepo_api_client::Error::InvalidUrl { url, err })
     }
 }

--- a/crates/turborepo-auth/src/mocks/mock_api_client.rs
+++ b/crates/turborepo-auth/src/mocks/mock_api_client.rs
@@ -4,8 +4,8 @@ use async_trait::async_trait;
 use reqwest::{Method, RequestBuilder, Response};
 use turborepo_api_client::Client;
 use turborepo_vercel_api::{
-    CachingStatusResponse, Membership, PreflightResponse, Role, Space, SpacesResponse, Team,
-    TeamsResponse, TokenMetadata, User, UserResponse, VerifiedSsoUser,
+    CachingStatusResponse, Membership, Role, Space, SpacesResponse, Team, TeamsResponse,
+    TokenMetadata, User, UserResponse, VerifiedSsoUser,
 };
 use url::Url;
 


### PR DESCRIPTION
### Description

As reported in #6921 `turbo` is panicking when making HTTP requests. This PR doesn't fix the user issue, but it does avoid the panic and provide a better warning message to the end user.

The panic can be caused in 2 ways:
 - Trying to retry a request that has a streaming body. This wasn't happening, but I changed the code so we at least don't panic if we accidentally call this function with a streaming body.
 - Constructing a `RequestBuilder` with an invalid url (see https://github.com/seanmonstar/reqwest/issues/1943) will cause the `try_clone` method to return `None` causing us to panic. This can easily be done if a user passes an invalid API url. We mitigate this by now only constructing `RequestBuilder` with `Url` which has already been verified instead of `&str` which delays the verification and obscures the failure.

Minor change is removing the `do_preflight` method from the client trait as it is an implementation detail and it reduced the amount of places that needed to get updated.

### Testing Instructions

Create a bogus entry in `auth.json` e.g. 
```
[0 olszewski@chriss-mbp] /Users/olszewski/code/vercel/turborepo $ bat ~/Library/Application\ Support/turborepo/auth.json 
───────┬─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
       │ File: /Users/olszewski/Library/Application Support/turborepo/auth.json
───────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   1   │ {
   2   │   "tokens": {
   3   │     "junk-url": "junk-token"
   4   │   }
   5   │ }
───────┴─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
```

On main verify that the current experience is far from ideal:
<img width="956" alt="Screenshot 2024-01-05 at 1 26 09 PM" src="https://github.com/vercel/turbo/assets/4131117/f63c60f1-db0f-441f-a386-11e4078cd55c">

Build using these changes and verify that there's a better UX:

<img width="1038" alt="Screenshot 2024-01-05 at 1 30 05 PM" src="https://github.com/vercel/turbo/assets/4131117/13fb3d21-bf48-44b9-9586-089d03afa8ee">



Closes TURBO-2002