### PR TITLE
add better messaging when running with api flag

### DIFF
--- a/crates/turborepo-lib/src/run/summary/spaces.rs
+++ b/crates/turborepo-lib/src/run/summary/spaces.rs
@@ -148,9 +148,16 @@ impl SpacesClient {
         let space_id = space_id?;
         let is_linked = api_auth.as_ref().map_or(false, |auth| auth.is_linked());
         if !is_linked {
+            let base = api_client.base_url();
+            let login_command = if base.contains("vercel") {
+                "turbo login".to_string()
+            } else {
+                format!("turbo login --api {}", base)
+            };
+
             eprintln!(
-                "Error: experimentalSpaceId is enabled, but repo is not linked to API. Run `turbo \
-                 link` or `turbo login` first"
+                "Error: experimentalSpaceId is enabled, but repo is not linked to {base}. Run \
+                 `turbo link` or `{login_command}` first",
             );
             return None;
         }


### PR DESCRIPTION
### Description
This is a pretty easy thing to miss. When running tasks with the `--api` flag or an api environment variable, if you're logged into a different api (like `vercel`), there's not super clear messaging on how you might fix it. This should address it when talking to the Spaces client

### Testing Instructions
1. Do a login (Vercel preferable)
2. Run a `turbo build --filter docs --api fake-server.some.stuff`
3. See the edited message
4. Profit