### PR TITLE
Only run examples tests on ubuntu.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -417,15 +417,7 @@ jobs:
     if: needs.determine_jobs.outputs.examples == 'true'
     timeout-minutes: 40
 
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - runner: ubuntu-latest
-          - runner: macos-latest
-          # TODO: enable this
-          # - runner: windows-latest
-    runs-on: ${{ matrix.os.runner }}
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
### Description

We're opting to drop the macOS runners. We were getting negative value out of them on the examples/documentation side and we don't believe they are contributing to core development stability.
