### PR TITLE
[Docs] create-new.mdx - npm double slash typo fix

### DIFF
--- a/docs/pages/repo/docs/getting-started/create-new.mdx
+++ b/docs/pages/repo/docs/getting-started/create-new.mdx
@@ -81,7 +81,7 @@ Choose anywhere you like. The default is `./my-turborepo`.
 Turborepo doesn't handle installing packages, so you'll need to choose one of:
 
 - [bun](https://bun.sh/)
-- [npm](https://www.npmjs.com//)
+- [npm](https://www.npmjs.com/)
 - [pnpm](https://pnpm.io/)
 - [yarn](https://yarnpkg.com/)
 


### PR DESCRIPTION
`https://www.npmjs.com//` => `https://www.npmjs.com/`

### Description

A minor typo fix in docs. There is npm link with extra slash. `https://www.npmjs.com//`