### PR TITLE
chore: avoid panic on invalid directory filters

### DIFF
--- a/crates/turborepo-lib/src/run/scope/filter.rs
+++ b/crates/turborepo-lib/src/run/scope/filter.rs
@@ -411,7 +411,11 @@ impl<'a, T: PackageChangeDetector> FilterResolver<'a, T> {
         let mut selector_valid = false;
 
         let path = selector.parent_dir.to_unix();
-        let parent_dir_globber = wax::Glob::new(path.as_str()).unwrap();
+        let parent_dir_globber =
+            wax::Glob::new(path.as_str()).map_err(|err| ResolutionError::InvalidDirectoryGlob {
+                glob: path.as_str().to_string(),
+                err: Box::new(err),
+            })?;
 
         if !selector.from_ref.is_empty() {
             selector_valid = true;
@@ -568,6 +572,11 @@ pub enum ResolutionError {
     Scm(#[from] turborepo_scm::Error),
     #[error("Unable to calculate changes: {0}")]
     ChangeDetectError(#[from] ChangeDetectError),
+    #[error("'Invalid directory filter '{glob}': {err}")]
+    InvalidDirectoryGlob {
+        glob: String,
+        err: Box<wax::BuildError>,
+    },
 }
 
 #[cfg(test)]


### PR DESCRIPTION
### Description

We had an unwrap on trying to parse user input as a glob. This PR just changes that to a better error message.

Current behavior results in a panic:

```
[0 olszewski@chriss-mbp] /Users/olszewski/code/vercel/turborepo $ turbo run dev --filter={cli,docs}
Oops! Turbo has crashed.
         
A report has been written to /tmp/report-9c083809-41f9-43bb-86eb-6e7657e0b174.toml

Please open an issue at https://github.com/vercel/turbo/issues/new/choose and include this file
...
explanation = """
file 'crates/turborepo-lib/src/run/scope/filter.rs' at line 414
"""
cause = "called `Result::unwrap()` on an `Err` value: BuildError { kind: Parse(ParseError { expression: \"cli,docs\", locations: [ErrorEntry { fragment: \",web\", location: 5, kind: Nom(Eof) }] }) }"
method = "Panic"
backtrace = """

   0:   0xf4ce22 - <turborepo_lib[adfb7611b6a9cc2e]::run::scope::filter::FilterResolver<turborepo_lib[adfb7611b6a9cc2e]::run::scope::change_detector::SCMChangeDetector>>::filter_graph_with_selectors
```

### Testing Instructions

Verify that we no longer panic on a bad directory:
```
[0 olszewski@chriss-mbp] /Users/olszewski/code/vercel/turborepo $ turbo_dev build --filter='{cli,docs}'
 ERROR  run failed: 'Invalid directory filter 'cli,docs': failed to parse glob expression
```


Closes TURBO-2010