### PR TITLE
fix: ignore permission errors during globbing

### DIFF
--- a/crates/turborepo-globwalk/src/lib.rs
+++ b/crates/turborepo-globwalk/src/lib.rs
@@ -293,10 +293,11 @@ pub fn globwalk(
                             ),
                             Err(e) => {
                                 let io_err = std::io::Error::from(e);
-                                if io_err.kind() == std::io::ErrorKind::NotFound {
-                                    None
-                                } else {
-                                    Some(Err(io_err.into()))
+                                match io_err.kind() {
+                                    // Ignore DNE and permission errors
+                                    std::io::ErrorKind::NotFound
+                                    | std::io::ErrorKind::PermissionDenied => None,
+                                    _ => Some(Err(io_err.into())),
                                 }
                             }
                         }


### PR DESCRIPTION
### Description

Fixes https://github.com/vercel/turbo/issues/6863

This brings us closer to the Go behavior where we would ignore [all IO errors](https://github.com/vercel/turbo/blob/main/cli/internal/doublestar/globwalk.go#L27).

We could do a similar thing by ignoring any error that doesn't have `ErrorKind::Other`, but that feels like slight overkill to me. I think ignoring `NotFound` and `PermissionDenied` is probably the sweet spot.

### Testing Instructions

I would love a unit test, but I'm unaware of an easy way to create a file via Rust that the same process is unable to read. Using a manual test instead:
Create a directory that you can't read
```
mkdir apps/docs/protected
sudo chown root apps/docs/protected
sudo chmod go-rw apps/docs/protected
```
Verify existing canary fails when running `turbo build`:
```
[0 olszewski@chriss-mbp] /tmp/daemon-bug $ turbo build --output-logs new-only    
• Packages in scope: @repo/eslint-config, @repo/typescript-config, @repo/ui, docs, web
• Running build in 5 packages
• Remote caching disabled
 ERROR  run failed: IO Error: failed to match directory tree: failed to read file at `Some("/private/tmp/daemon-bug/apps/docs/protected")`: Permission denied (os error 13)
```
Build PR and verify that this no longer causes a failure:
```
[1 olszewski@chriss-mbp] /tmp/daemon-bug $ turbo_dev build --output-logs new-only
• Packages in scope: @repo/eslint-config, @repo/typescript-config, @repo/ui, docs, web
• Running build in 5 packages
• Remote caching disabled
web:build: cache hit, suppressing logs b7e193fc8c53023e
docs:build: cache hit, suppressing logs 67c737e5d2f3d57a

 Tasks:    2 successful, 2 total
Cached:    2 cached, 2 total
  Time:    428ms >>> FULL TURBO
```



Closes TURBO-2013