### PR TITLE
Conditionalize comments button.

### DIFF
--- a/docs/lib/comments.ts
+++ b/docs/lib/comments.ts
@@ -19,3 +19,8 @@ export const setCommentsState = (router: NextRouter) => {
   }
   router.reload();
 };
+
+const toolbarEnabledPaths = ["/repo/docs", "/pack/docs"];
+
+export const pathHasToolbar = (router: NextRouter) =>
+  toolbarEnabledPaths.some((path) => router.asPath.startsWith(path));

--- a/docs/pages/_app.tsx
+++ b/docs/pages/_app.tsx
@@ -6,7 +6,7 @@ import { type ReactNode } from "react";
 import { Analytics } from "@vercel/analytics/react";
 import { VercelToolbar } from "@vercel/toolbar/next";
 import { useRouter } from "next/router";
-import { getCommentsState } from "../lib/comments";
+import { getCommentsState, pathHasToolbar } from "../lib/comments";
 
 type NextraAppProps = AppProps & {
   Component: AppProps["Component"] & {
@@ -26,14 +26,8 @@ if (typeof window !== "undefined" && !("requestIdleCallback" in window)) {
   };
 }
 
-const toolbarEnabledPaths = ["/repo/docs", "/pack/docs"];
-
 export default function Nextra({ Component, pageProps }: NextraAppProps) {
   const router = useRouter();
-
-  const pathHasToolbar = toolbarEnabledPaths.some((path) =>
-    router.asPath.startsWith(path)
-  );
 
   return (
     <>
@@ -56,7 +50,7 @@ export default function Nextra({ Component, pageProps }: NextraAppProps) {
       </svg>
       <Component {...pageProps} />
       <Analytics />
-      {getCommentsState() && pathHasToolbar ? <VercelToolbar /> : null}
+      {getCommentsState() && pathHasToolbar(router) ? <VercelToolbar /> : null}
     </>
   );
 }

--- a/docs/theme.config.tsx
+++ b/docs/theme.config.tsx
@@ -10,6 +10,7 @@ import { ExtraContent } from "./components/ExtraContent";
 import { Discord, Github } from "./components/Social";
 import { Main } from "./components/Main";
 import { Search } from "./components/Search";
+import { pathHasToolbar } from "./lib/comments";
 
 const NoSSRCommentsButton = dynamic(
   () => import("./components/CommentsButton").then((mod) => mod.CommentsButton),
@@ -191,15 +192,22 @@ const config: DocsThemeConfig = {
   },
   navbar: {
     component: Navigation,
-    extraContent: (
-      <>
-        <div className="w-6 h-6 ml-2 rounded-tl-none rounded-full border-2 border-white">
-          <NoSSRCommentsButton />
-        </div>
-        <Github />
-        <Discord />
-      </>
-    ),
+    extraContent: (): JSX.Element => {
+      // eslint-disable-next-line react-hooks/rules-of-hooks -- Nextra does not infer the type of extraContent correctly.
+      const router = useRouter();
+
+      return (
+        <>
+          {pathHasToolbar(router) ? (
+            <div className="w-6 h-6 ml-2 rounded-tl-none rounded-full border-2 border-white">
+              <NoSSRCommentsButton />
+            </div>
+          ) : null}
+          <Github />
+          <Discord />
+        </>
+      );
+    },
   },
   components: {
     pre: (props: ReactElement) => {


### PR DESCRIPTION
### Description

The button to active the toolbar would also show, even on  pages that don't allow the toolbar to render.

This PR keeps the two states in sync, only showing the activation/de-activation button on routes that the toolbar renders on.
