### PR TITLE
recycle trace buffers

### DIFF
--- a/crates/turbopack-trace-utils/src/flavor.rs
+++ b/crates/turbopack-trace-utils/src/flavor.rs
@@ -1,0 +1,23 @@
+use postcard::ser_flavors::Flavor;
+
+pub struct BufFlavor {
+    pub buf: Vec<u8>,
+}
+
+impl Flavor for BufFlavor {
+    type Output = Vec<u8>;
+
+    fn try_push(&mut self, data: u8) -> postcard::Result<()> {
+        self.buf.push(data);
+        Ok(())
+    }
+
+    fn finalize(self) -> postcard::Result<Self::Output> {
+        Ok(self.buf)
+    }
+
+    fn try_extend(&mut self, data: &[u8]) -> postcard::Result<()> {
+        self.buf.extend_from_slice(data);
+        Ok(())
+    }
+}

--- a/crates/turbopack-trace-utils/src/lib.rs
+++ b/crates/turbopack-trace-utils/src/lib.rs
@@ -5,6 +5,7 @@
 #![feature(arbitrary_self_types)]
 
 pub mod exit;
+mod flavor;
 pub mod raw_trace;
 pub mod trace_writer;
 pub mod tracing;

--- a/crates/turbopack-trace-utils/src/trace_writer.rs
+++ b/crates/turbopack-trace-utils/src/trace_writer.rs
@@ -4,8 +4,8 @@ use crossbeam_channel::{bounded, unbounded, Receiver, Sender, TryRecvError};
 
 #[derive(Clone, Debug)]
 pub struct TraceWriter {
-    channel: Sender<Vec<u8>>,
-    back_channel: Receiver<Vec<u8>>,
+    data_tx: Sender<Vec<u8>>,
+    return_rx: Receiver<Vec<u8>>,
 }
 
 impl TraceWriter {
@@ -19,8 +19,8 @@ impl TraceWriter {
     /// * It issues less writes by buffering the data into chunks of ~1MB, when
     ///   possible.
     pub fn new<W: Write + Send + 'static>(mut writer: W) -> (Self, TraceWriterGuard) {
-        let (tx, rx) = unbounded::<Vec<u8>>();
-        let (back_tx, back_rx) = bounded::<Vec<u8>>(1024 * 10);
+        let (data_tx, data_rx) = unbounded::<Vec<u8>>();
+        let (return_tx, return_rx) = bounded::<Vec<u8>>(1024 * 10);
 
         let handle: std::thread::JoinHandle<()> = std::thread::spawn(move || {
             let mut buf = Vec::with_capacity(1024 * 1024 * 1024);
@@ -30,7 +30,7 @@ impl TraceWriter {
                     let _ = writer.flush();
                     buf.clear();
                 }
-                let Ok(mut data) = rx.recv() else {
+                let Ok(mut data) = data_rx.recv() else {
                     break 'outer;
                 };
                 if data.is_empty() {
@@ -42,9 +42,9 @@ impl TraceWriter {
                     buf.extend_from_slice(&data);
                 }
                 data.clear();
-                let _ = back_tx.try_send(data);
+                let _ = return_tx.try_send(data);
                 loop {
-                    match rx.try_recv() {
+                    match data_rx.try_recv() {
                         Ok(data) => {
                             if data.is_empty() {
                                 break 'outer;
@@ -79,12 +79,12 @@ impl TraceWriter {
 
         (
             Self {
-                channel: tx.clone(),
-                back_channel: back_rx.clone(),
+                data_tx: data_tx.clone(),
+                return_rx: return_rx.clone(),
             },
             TraceWriterGuard {
-                channel: Some(tx),
-                back_channel: Some(back_rx),
+                data_tx: Some(data_tx),
+                return_rx: Some(return_rx),
                 handle: Some(handle),
             },
         )
@@ -92,25 +92,25 @@ impl TraceWriter {
 
     pub fn write(&self, data: Vec<u8>) {
         debug_assert!(!data.is_empty());
-        let _ = self.channel.send(data);
+        let _ = self.data_tx.send(data);
     }
 
     pub fn try_get_buffer(&self) -> Option<Vec<u8>> {
-        self.back_channel.try_recv().ok()
+        self.return_rx.try_recv().ok()
     }
 }
 
 pub struct TraceWriterGuard {
-    channel: Option<Sender<Vec<u8>>>,
-    back_channel: Option<Receiver<Vec<u8>>>,
+    data_tx: Option<Sender<Vec<u8>>>,
+    return_rx: Option<Receiver<Vec<u8>>>,
     handle: Option<JoinHandle<()>>,
 }
 
 impl Drop for TraceWriterGuard {
     fn drop(&mut self) {
-        let _ = self.channel.take().unwrap().send(Vec::new());
-        let back_channel = self.back_channel.take().unwrap();
-        while back_channel.recv().is_ok() {}
+        let _ = self.data_tx.take().unwrap().send(Vec::new());
+        let return_rx = self.return_rx.take().unwrap();
+        while return_rx.recv().is_ok() {}
         let _ = self.handle.take().unwrap().join();
     }
 }

--- a/crates/turbopack-trace-utils/src/trace_writer.rs
+++ b/crates/turbopack-trace-utils/src/trace_writer.rs
@@ -23,7 +23,7 @@ impl TraceWriter {
         let (back_tx, back_rx) = bounded::<Vec<u8>>(1024 * 10);
 
         let handle: std::thread::JoinHandle<()> = std::thread::spawn(move || {
-            let mut buf = Vec::with_capacity(1024 * 1024);
+            let mut buf = Vec::with_capacity(1024 * 1024 * 1024);
             'outer: loop {
                 if !buf.is_empty() {
                     let _ = writer.write_all(&buf);


### PR DESCRIPTION
### Description

avoid allocations by recycling buffers used for collecting tracing

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->


Closes PACK-2208