### PR TITLE
only test for in progress state for new children

### DIFF
--- a/crates/turbo-tasks-memory/src/task.rs
+++ b/crates/turbo-tasks-memory/src/task.rs
@@ -1418,16 +1418,15 @@ impl Task {
                 thresholds_job = ensure_thresholds(&aggregation_context, &mut guard);
                 let TaskGuard { guard, .. } = guard;
                 let mut state = TaskMetaStateWriteGuard::full_from(guard.into_inner(), self);
-                if let TaskStateType::InProgress {
-                    outdated_children, ..
-                } = &mut state.state_type
-                {
-                    if outdated_children.remove(&child_id) {
-                        state.children.insert(child_id);
-                        return;
-                    }
-                }
                 if state.children.insert(child_id) {
+                    if let TaskStateType::InProgress {
+                        outdated_children, ..
+                    } = &mut state.state_type
+                    {
+                        if outdated_children.remove(&child_id) {
+                            return;
+                        }
+                    }
                     add_job = Some(
                         state
                             .aggregation_leaf


### PR DESCRIPTION
### Description

Move in progress check to avoid unnecessary check when task is already a child

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->


Closes PACK-2209