### PR TITLE
feat(telemetry): track prune args

### DIFF
--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -415,7 +415,7 @@ pub enum Command {
         scope_arg: Option<Vec<String>>,
         #[clap(long)]
         docker: bool,
-        #[clap(long = "out-dir", default_value_t = String::from("out"), value_parser)]
+        #[clap(long = "out-dir", default_value_t = String::from(prune::DEFAULT_OUTPUT_DIR), value_parser)]
         output_dir: String,
     },
 

--- a/crates/turborepo-lib/src/commands/prune.rs
+++ b/crates/turborepo-lib/src/commands/prune.rs
@@ -17,6 +17,8 @@ use turborepo_ui::BOLD;
 use super::CommandBase;
 use crate::config::RawTurboJson;
 
+pub const DEFAULT_OUTPUT_DIR: &str = "out";
+
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("io error while pruning: {0}")]
@@ -87,7 +89,9 @@ pub async fn prune(
     output_dir: &str,
     telemetry: CommandEventBuilder,
 ) -> Result<(), Error> {
-    telemetry.track_prune_method(docker);
+    telemetry.track_prune_arg_method(docker);
+    telemetry.track_arg_usage("out-dir", output_dir != DEFAULT_OUTPUT_DIR);
+
     let prune = Prune::new(base, scope, docker, output_dir).await?;
 
     if matches!(

--- a/crates/turborepo-lib/src/commands/prune.rs
+++ b/crates/turborepo-lib/src/commands/prune.rs
@@ -89,7 +89,7 @@ pub async fn prune(
     output_dir: &str,
     telemetry: CommandEventBuilder,
 ) -> Result<(), Error> {
-    telemetry.track_prune_arg_method(docker);
+    telemetry.track_arg_usage("docker", docker);
     telemetry.track_arg_usage("out-dir", output_dir != DEFAULT_OUTPUT_DIR);
 
     let prune = Prune::new(base, scope, docker, output_dir).await?;

--- a/crates/turborepo-telemetry/src/events/command.rs
+++ b/crates/turborepo-telemetry/src/events/command.rs
@@ -136,16 +136,6 @@ impl CommandEventBuilder {
         self
     }
 
-    // prune
-    pub fn track_prune_arg_method(&self, is_docker: bool) -> &Self {
-        self.track(Event {
-            key: "arg:docker".to_string(),
-            value: if is_docker { "docker" } else { "default" }.to_string(),
-            is_sensitive: EventType::NonSensitive,
-        });
-        self
-    }
-
     // login
     pub fn track_login_method(&self, method: LoginMethod) -> &Self {
         self.track(Event {

--- a/crates/turborepo-telemetry/src/events/command.rs
+++ b/crates/turborepo-telemetry/src/events/command.rs
@@ -76,6 +76,15 @@ impl CommandEventBuilder {
         self
     }
 
+    pub fn track_arg_usage(&self, arg: &str, is_set: bool) -> &Self {
+        self.track(Event {
+            key: format!("arg:{}", arg),
+            value: if is_set { "set" } else { "default" }.to_string(),
+            is_sensitive: EventType::NonSensitive,
+        });
+        self
+    }
+
     // telemetry
     pub fn track_telemetry_config(&self, enabled: bool) -> &Self {
         self.track(Event {
@@ -128,9 +137,9 @@ impl CommandEventBuilder {
     }
 
     // prune
-    pub fn track_prune_method(&self, is_docker: bool) -> &Self {
+    pub fn track_prune_arg_method(&self, is_docker: bool) -> &Self {
         self.track(Event {
-            key: "method".to_string(),
+            key: "arg:docker".to_string(),
             value: if is_docker { "docker" } else { "default" }.to_string(),
             is_sensitive: EventType::NonSensitive,
         });


### PR DESCRIPTION
### Description

Track all prune args. This is used to determine usage to inform API changes / improvements. Actual values are not recorded in this case. 
