### PR TITLE
fix aggregation of outdated children and collectibles

### DIFF
--- a/crates/turbo-tasks-memory/src/task.rs
+++ b/crates/turbo-tasks-memory/src/task.rs
@@ -1418,6 +1418,15 @@ impl Task {
                 thresholds_job = ensure_thresholds(&aggregation_context, &mut guard);
                 let TaskGuard { guard, .. } = guard;
                 let mut state = TaskMetaStateWriteGuard::full_from(guard.into_inner(), self);
+                if let TaskStateType::InProgress {
+                    outdated_children, ..
+                } = &mut state.state_type
+                {
+                    if outdated_children.remove(&child_id) {
+                        state.children.insert(child_id);
+                        return;
+                    }
+                }
                 if state.children.insert(child_id) {
                     add_job = Some(
                         state

--- a/crates/turbo-tasks-memory/src/task.rs
+++ b/crates/turbo-tasks-memory/src/task.rs
@@ -1418,16 +1418,15 @@ impl Task {
                 thresholds_job = ensure_thresholds(&aggregation_context, &mut guard);
                 let TaskGuard { guard, .. } = guard;
                 let mut state = TaskMetaStateWriteGuard::full_from(guard.into_inner(), self);
-                if let TaskStateType::InProgress {
-                    outdated_children, ..
-                } = &mut state.state_type
-                {
-                    if outdated_children.remove(&child_id) {
-                        state.children.insert(child_id);
-                        return;
-                    }
-                }
                 if state.children.insert(child_id) {
+                    if let TaskStateType::InProgress {
+                        outdated_children, ..
+                    } = &mut state.state_type
+                    {
+                        if outdated_children.remove(&child_id) {
+                            return;
+                        }
+                    }
                     add_job = Some(
                         state
                             .aggregation_leaf

--- a/crates/turbo-tasks-memory/src/task.rs
+++ b/crates/turbo-tasks-memory/src/task.rs
@@ -1408,14 +1408,21 @@ impl Task {
     ) {
         let mut aggregation_context = TaskAggregationContext::new(turbo_tasks, backend);
         {
-            let thresholds_job;
             let mut add_job = None;
             {
                 let mut guard = TaskGuard {
                     id: self.id,
                     guard: self.state_mut(),
                 };
-                thresholds_job = ensure_thresholds(&aggregation_context, &mut guard);
+                while let Some(thresholds_job) = ensure_thresholds(&aggregation_context, &mut guard)
+                {
+                    drop(guard);
+                    thresholds_job();
+                    guard = TaskGuard {
+                        id: self.id,
+                        guard: self.state_mut(),
+                    };
+                }
                 let TaskGuard { guard, .. } = guard;
                 let mut state = TaskMetaStateWriteGuard::full_from(guard.into_inner(), self);
                 if state.children.insert(child_id) {
@@ -1434,7 +1441,6 @@ impl Task {
                     );
                 }
             }
-            thresholds_job();
             if let Some(job) = add_job {
                 // To avoid bubbling up the dirty tasks into the new parent tree, we make a
                 // quick check for activeness of the parent when the child is dirty. This is

--- a/crates/turbo-tasks-memory/src/task/aggregation.rs
+++ b/crates/turbo-tasks-memory/src/task/aggregation.rs
@@ -415,7 +415,12 @@ impl<'l> AggregationItemLock for TaskGuard<'l> {
 
     fn number_of_children(&self) -> usize {
         match self.guard {
-            TaskMetaStateWriteGuard::Full(ref guard) => guard.children.len(),
+            TaskMetaStateWriteGuard::Full(ref guard) => match &guard.state_type {
+                TaskStateType::InProgress {
+                    outdated_children, ..
+                } => guard.children.len() + outdated_children.len(),
+                _ => guard.children.len(),
+            },
             TaskMetaStateWriteGuard::Partial(_) | TaskMetaStateWriteGuard::Unloaded(_) => 0,
         }
     }
@@ -423,9 +428,21 @@ impl<'l> AggregationItemLock for TaskGuard<'l> {
     fn children(&self) -> Self::ChildrenIter<'_> {
         match self.guard {
             TaskMetaStateWriteGuard::Full(ref guard) => {
-                Some(guard.children.iter().map(Cow::Borrowed))
-                    .into_iter()
-                    .flatten()
+                let outdated_children = match &guard.state_type {
+                    TaskStateType::InProgress {
+                        outdated_children, ..
+                    } => Some(outdated_children.iter().map(Cow::Borrowed)),
+                    _ => None,
+                };
+                Some(
+                    guard
+                        .children
+                        .iter()
+                        .map(Cow::Borrowed)
+                        .chain(outdated_children.into_iter().flatten()),
+                )
+                .into_iter()
+                .flatten()
             }
             TaskMetaStateWriteGuard::Partial(_) | TaskMetaStateWriteGuard::Unloaded(_) => {
                 None.into_iter().flatten()
@@ -455,6 +472,17 @@ impl<'l> AggregationItemLock for TaskGuard<'l> {
                 if let Some(collectibles) = guard.collectibles.as_ref() {
                     for (&(trait_type_id, collectible), _) in collectibles.iter() {
                         change.collectibles.push((trait_type_id, collectible, 1));
+                    }
+                }
+                if let TaskStateType::InProgress {
+                    outdated_collectibles,
+                    ..
+                } = &guard.state_type
+                {
+                    if let Some(collectibles) = outdated_collectibles.as_ref() {
+                        for (&(trait_type_id, collectible), _) in collectibles.iter() {
+                            change.collectibles.push((trait_type_id, collectible, 1));
+                        }
                     }
                 }
                 if change.is_empty() {
@@ -489,6 +517,17 @@ impl<'l> AggregationItemLock for TaskGuard<'l> {
                 if let Some(collectibles) = guard.collectibles.as_ref() {
                     for (&(trait_type_id, collectible), _) in collectibles.iter() {
                         change.collectibles.push((trait_type_id, collectible, -1));
+                    }
+                }
+                if let TaskStateType::InProgress {
+                    outdated_collectibles,
+                    ..
+                } = &guard.state_type
+                {
+                    if let Some(collectibles) = outdated_collectibles.as_ref() {
+                        for (&(trait_type_id, collectible), _) in collectibles.iter() {
+                            change.collectibles.push((trait_type_id, collectible, -1));
+                        }
                     }
                 }
                 if change.is_empty() {


### PR DESCRIPTION
### Description

The delayed removal of children and collectibles for "in progress" tasks of the aggregate tree causes some inconsistency in the aggregated tree when "in progress" task are connected to other node. We need to fix that by reporting outdated children and collectibles as children/collectibles of the "in progress" tasks.

This fixes an race condition when temporary errors are incorrectly shows as final result. e. g. it was visible as `can't resolve "ACTIONS_MODULE9"` in next.js.

Closes PACK-2219