### PR TITLE
Clean up inputs doc.

### DIFF
--- a/docs/pages/repo/docs/reference/configuration.mdx
+++ b/docs/pages/repo/docs/reference/configuration.mdx
@@ -359,14 +359,14 @@ Defaults to `true`. Whether or not to cache the task [`outputs`](#outputs). Sett
 
 `type: string[]`
 
-Defaults to `[]`. Tells `turbo` the set of files to consider when determining if a workspace has changed for a particular task.
-Setting this to a list of globs will cause the task to only be rerun when files matching those globs have
+Tells `turbo` the set of files to consider when determining if a package has changed for a particular task.
+Setting this to a list of globs will cause the task to only be run when files matching those globs have
 changed. This can be helpful if you want to, for example, skip running tests unless a source file changed.
 
-Specifying `[]` will cause the task to be rerun when any file in the workspace changes.
+The default is `[]` to run the task when any file in the package changes.
 
 <Callout type="info">
-  `inputs` globs must be specified as relative paths rooted at the workspace directory.
+  `inputs` globs must be specified as relative paths rooted at the package's directory.
 </Callout>
 
 **Example**
@@ -375,14 +375,8 @@ Specifying `[]` will cause the task to be rerun when any file in the workspace c
 {
   "$schema": "https://turbo.build/schema.json",
   "pipeline": {
-    // ... omitted for brevity
-
     "test": {
-      // A workspace's `test` task depends on that workspace's
-      // own `build` task being completed first.
-      "dependsOn": ["build"],
-      "outputs": [".next/**", "!.next/cache/**"],
-      // A workspace's `test` task should only be rerun when
+      // A package's `test` task should only be ran when
       // either a `.tsx` or `.ts` file has changed.
       "inputs": ["src/**/*.tsx", "src/**/*.ts", "test/**/*.ts"]
     }


### PR DESCRIPTION
### Description

Cleaning up the inputs doc so that it more closely aligns with https://vercel.com/docs/vercel-platform/glossary

`workspace` => `package`, mainly.

CLOSES TURBO-2007
