### PR TITLE
Fix with-svelte-example

### DIFF
--- a/examples/with-svelte/apps/docs/package.json
+++ b/examples/with-svelte/apps/docs/package.json
@@ -2,7 +2,7 @@
   "name": "docs",
 	"version": "0.0.1",
 	"private": true,
-  "type": "module",
+	"type": "module",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",
@@ -21,6 +21,7 @@
 		"@playwright/test": "^1.40.1",
 		"@sveltejs/adapter-auto": "^3.1.0",
 		"@sveltejs/kit": "^2.0.6",
+		"@sveltejs/vite-plugin-svelte": "^3.0.1",
 		"@typescript-eslint/eslint-plugin": "^6.17.0",
 		"@typescript-eslint/parser": "^6.17.0",
 		"eslint": "^8.56.0",

--- a/examples/with-svelte/apps/docs/svelte.config.js
+++ b/examples/with-svelte/apps/docs/svelte.config.js
@@ -1,11 +1,11 @@
 import adapter from '@sveltejs/adapter-auto';
-import { sveltekit } from '@sveltejs/kit/vite';
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	// Consult https://kit.svelte.dev/docs/integrations#preprocessors
 	// for more information about preprocessors
-	preprocess: sveltekit(),
+	preprocess: vitePreprocess(),
 	kit: {
 		// adapter-auto only supports some environments, see https://kit.svelte.dev/docs/adapter-auto for a list.
 		// If your environment is not supported or you settled on a specific environment, switch out the adapter.

--- a/examples/with-svelte/apps/docs/tests/test.ts
+++ b/examples/with-svelte/apps/docs/tests/test.ts
@@ -2,5 +2,5 @@ import { expect, test } from '@playwright/test';
 
 test('index page has expected h1', async ({ page }) => {
 	await page.goto('/');
-	await expect(page.getByRole('heading', { name: 'Welcome to SvelteKit' })).toBeVisible();
+	await expect(page.getByRole('heading', { name: 'Docs' })).toBeVisible();
 });

--- a/examples/with-svelte/apps/docs/vite.config.ts
+++ b/examples/with-svelte/apps/docs/vite.config.ts
@@ -6,9 +6,6 @@ export default defineConfig({
   test: {
     include: ['src/**/*.{test,spec}.{js,ts}']
   },
-  optimizeDeps: {
-    include: ['@repo/ui'],
-  },
   build: {
     commonjsOptions: {
       include: [/@repo-ui/, /node_modules/],

--- a/examples/with-svelte/apps/web/package.json
+++ b/examples/with-svelte/apps/web/package.json
@@ -2,7 +2,7 @@
   "name": "web",
 	"version": "0.0.1",
 	"private": true,
-  "type": "module",
+	"type": "module",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",
@@ -21,6 +21,7 @@
 		"@playwright/test": "^1.40.1",
 		"@sveltejs/adapter-auto": "^3.1.0",
 		"@sveltejs/kit": "^2.0.6",
+		"@sveltejs/vite-plugin-svelte": "^3.0.1",
 		"@typescript-eslint/eslint-plugin": "^6.17.0",
 		"@typescript-eslint/parser": "^6.17.0",
 		"eslint": "^8.56.0",

--- a/examples/with-svelte/apps/web/svelte.config.js
+++ b/examples/with-svelte/apps/web/svelte.config.js
@@ -1,11 +1,11 @@
 import adapter from '@sveltejs/adapter-auto';
-import { sveltekit } from '@sveltejs/kit/vite';
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	// Consult https://kit.svelte.dev/docs/integrations#preprocessors
 	// for more information about preprocessors
-	preprocess: sveltekit(),
+	preprocess: vitePreprocess(),
 	kit: {
 		// adapter-auto only supports some environments, see https://kit.svelte.dev/docs/adapter-auto for a list.
 		// If your environment is not supported or you settled on a specific environment, switch out the adapter.

--- a/examples/with-svelte/apps/web/tests/test.ts
+++ b/examples/with-svelte/apps/web/tests/test.ts
@@ -2,5 +2,5 @@ import { expect, test } from '@playwright/test';
 
 test('index page has expected h1', async ({ page }) => {
 	await page.goto('/');
-	await expect(page.getByRole('heading', { name: 'Welcome to SvelteKit' })).toBeVisible();
+	await expect(page.getByRole('heading', { name: 'Web' })).toBeVisible();
 });

--- a/examples/with-svelte/apps/web/vite.config.ts
+++ b/examples/with-svelte/apps/web/vite.config.ts
@@ -6,9 +6,6 @@ export default defineConfig({
   test: {
     include: ['src/**/*.{test,spec}.{js,ts}']
   },
-  optimizeDeps: {
-    include: ['@repo/ui'],
-  },
   build: {
     commonjsOptions: {
       include: [/@repo-ui/, /node_modules/],

--- a/examples/with-svelte/pnpm-lock.yaml
+++ b/examples/with-svelte/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       '@sveltejs/kit':
         specifier: ^2.0.6
         version: 2.0.6(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@4.2.8)(vite@5.0.10)
+      '@sveltejs/vite-plugin-svelte':
+        specifier: ^3.0.1
+        version: 3.0.1(svelte@4.2.8)(vite@5.0.10)
       '@typescript-eslint/eslint-plugin':
         specifier: ^6.17.0
         version: 6.17.0(@typescript-eslint/parser@6.17.0)(eslint@8.56.0)(typescript@5.3.3)
@@ -94,6 +97,9 @@ importers:
       '@sveltejs/kit':
         specifier: ^2.0.6
         version: 2.0.6(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@4.2.8)(vite@5.0.10)
+      '@sveltejs/vite-plugin-svelte':
+        specifier: ^3.0.1
+        version: 3.0.1(svelte@4.2.8)(vite@5.0.10)
       '@typescript-eslint/eslint-plugin':
         specifier: ^6.17.0
         version: 6.17.0(@typescript-eslint/parser@6.17.0)(eslint@8.56.0)(typescript@5.3.3)


### PR DESCRIPTION
### Description

- vite-plugin-svelte is now a peer dependency and therefore needs to appear in the user's `package.json`
- fixed preprocessor import in `svelte.config.js`
- removed `optimizeDeps.include` which makes Vite treat the package as an external dependency that it should bundle once, resulting in changes not getting picked up (this was introduced in #6576 but I'm not sure why)
- fixed e2e tests

### Testing Instructions

check manually
