### PR TITLE
allow to pass available chunk items when creating a chunk group

### DIFF
--- a/crates/turbopack-build/src/chunking_context.rs
+++ b/crates/turbopack-build/src/chunking_context.rs
@@ -343,6 +343,7 @@ impl ChunkingContext for BuildChunkingContext {
         self: Vc<Self>,
         _ident: Vc<AssetIdent>,
         _evaluatable_assets: Vc<EvaluatableAssets>,
+        _availability_info: Value<AvailabilityInfo>,
     ) -> Result<Vc<OutputAssets>> {
         // TODO(alexkirsz) This method should be part of a separate trait that is
         // only implemented for client/edge runtimes.

--- a/crates/turbopack-build/src/chunking_context.rs
+++ b/crates/turbopack-build/src/chunking_context.rs
@@ -10,12 +10,13 @@ use turbopack_core::{
     chunk::{
         availability_info::AvailabilityInfo,
         chunk_group::{make_chunk_group, MakeChunkGroupResult},
-        Chunk, ChunkItem, ChunkableModule, ChunkingContext, EvaluatableAssets, ModuleId,
+        Chunk, ChunkGroupResult, ChunkItem, ChunkableModule, ChunkingContext, EvaluatableAssets,
+        ModuleId,
     },
     environment::Environment,
     ident::AssetIdent,
     module::Module,
-    output::{OutputAsset, OutputAssets},
+    output::OutputAsset,
 };
 use turbopack_ecmascript::{
     chunk::{EcmascriptChunk, EcmascriptChunkPlaceable, EcmascriptChunkingContext},
@@ -141,6 +142,12 @@ impl BuildChunkingContext {
     }
 }
 
+#[turbo_tasks::value]
+pub struct EntryChunkGroupResult {
+    pub asset: Vc<Box<dyn OutputAsset>>,
+    pub availability_info: AvailabilityInfo,
+}
+
 #[turbo_tasks::value_impl]
 impl BuildChunkingContext {
     #[turbo_tasks::function]
@@ -164,10 +171,13 @@ impl BuildChunkingContext {
         module: Vc<Box<dyn EcmascriptChunkPlaceable>>,
         evaluatable_assets: Vc<EvaluatableAssets>,
         availability_info: Value<AvailabilityInfo>,
-    ) -> Result<Vc<Box<dyn OutputAsset>>> {
+    ) -> Result<Vc<EntryChunkGroupResult>> {
         let availability_info = availability_info.into_value();
 
-        let MakeChunkGroupResult { chunks } = make_chunk_group(
+        let MakeChunkGroupResult {
+            chunks,
+            availability_info,
+        } = make_chunk_group(
             Vc::upcast(self),
             once(Vc::upcast(module)).chain(
                 evaluatable_assets
@@ -192,7 +202,11 @@ impl BuildChunkingContext {
             module,
         ));
 
-        Ok(asset)
+        Ok(EntryChunkGroupResult {
+            asset,
+            availability_info,
+        }
+        .cell())
     }
 
     #[turbo_tasks::function]
@@ -313,10 +327,13 @@ impl ChunkingContext for BuildChunkingContext {
         self: Vc<Self>,
         module: Vc<Box<dyn ChunkableModule>>,
         availability_info: Value<AvailabilityInfo>,
-    ) -> Result<Vc<OutputAssets>> {
+    ) -> Result<Vc<ChunkGroupResult>> {
         let span = tracing::info_span!("chunking", module = *module.ident().to_string().await?);
         async move {
-            let MakeChunkGroupResult { chunks } = make_chunk_group(
+            let MakeChunkGroupResult {
+                chunks,
+                availability_info,
+            } = make_chunk_group(
                 Vc::upcast(self),
                 [Vc::upcast(module)],
                 availability_info.into_value(),
@@ -333,19 +350,23 @@ impl ChunkingContext for BuildChunkingContext {
                 *asset = asset.resolve().await?;
             }
 
-            Ok(Vc::cell(assets))
+            Ok(ChunkGroupResult {
+                assets: Vc::cell(assets),
+                availability_info,
+            }
+            .cell())
         }
         .instrument(span)
         .await
     }
 
     #[turbo_tasks::function]
-    async fn evaluated_chunk_group(
+    fn evaluated_chunk_group(
         self: Vc<Self>,
         _ident: Vc<AssetIdent>,
         _evaluatable_assets: Vc<EvaluatableAssets>,
         _availability_info: Value<AvailabilityInfo>,
-    ) -> Result<Vc<OutputAssets>> {
+    ) -> Result<Vc<ChunkGroupResult>> {
         // TODO(alexkirsz) This method should be part of a separate trait that is
         // only implemented for client/edge runtimes.
         bail!("the build chunking context does not support evaluated chunk groups")

--- a/crates/turbopack-build/src/chunking_context.rs
+++ b/crates/turbopack-build/src/chunking_context.rs
@@ -163,8 +163,9 @@ impl BuildChunkingContext {
         path: Vc<FileSystemPath>,
         module: Vc<Box<dyn EcmascriptChunkPlaceable>>,
         evaluatable_assets: Vc<EvaluatableAssets>,
+        availability_info: Value<AvailabilityInfo>,
     ) -> Result<Vc<Box<dyn OutputAsset>>> {
-        let availability_info = AvailabilityInfo::Root;
+        let availability_info = availability_info.into_value();
 
         let MakeChunkGroupResult { chunks } = make_chunk_group(
             Vc::upcast(self),

--- a/crates/turbopack-build/src/lib.rs
+++ b/crates/turbopack-build/src/lib.rs
@@ -5,7 +5,9 @@
 pub(crate) mod chunking_context;
 pub(crate) mod ecmascript;
 
-pub use chunking_context::{BuildChunkingContext, BuildChunkingContextBuilder, MinifyType};
+pub use chunking_context::{
+    BuildChunkingContext, BuildChunkingContextBuilder, EntryChunkGroupResult, MinifyType,
+};
 
 pub fn register() {
     turbo_tasks::register();

--- a/crates/turbopack-cli/src/build/mod.rs
+++ b/crates/turbopack-cli/src/build/mod.rs
@@ -14,7 +14,9 @@ use turbopack_build::{BuildChunkingContext, MinifyType};
 use turbopack_cli_utils::issue::{ConsoleUi, LogOptions};
 use turbopack_core::{
     asset::Asset,
-    chunk::{ChunkableModule, ChunkingContextExt, EvaluatableAssets},
+    chunk::{
+        availability_info::AvailabilityInfo, ChunkableModule, ChunkingContextExt, EvaluatableAssets,
+    },
     environment::{BrowserEnvironment, Environment, ExecutionEnvironment},
     issue::{handle_issues, IssueReporter, IssueSeverity},
     module::Module,
@@ -265,6 +267,7 @@ async fn build_internal(
                             .with_extension("entry.js".to_string()),
                         Vc::upcast(ecmascript),
                         EvaluatableAssets::one(Vc::upcast(ecmascript)),
+                        Value::new(AvailabilityInfo::Root),
                     )])
                 } else if let Some(chunkable) =
                     Vc::try_resolve_sidecast::<Box<dyn ChunkableModule>>(entry_module).await?

--- a/crates/turbopack-cli/src/build/mod.rs
+++ b/crates/turbopack-cli/src/build/mod.rs
@@ -247,32 +247,34 @@ async fn build_internal(
                 if let Some(ecmascript) =
                     Vc::try_resolve_downcast_type::<EcmascriptModuleAsset>(entry_module).await?
                 {
-                    Vc::cell(vec![Vc::try_resolve_downcast_type::<BuildChunkingContext>(
-                        chunking_context,
-                    )
-                    .await?
-                    .unwrap()
-                    .entry_chunk_group(
-                        build_output_root
-                            .join(
-                                ecmascript
-                                    .ident()
-                                    .path()
-                                    .file_stem()
-                                    .await?
-                                    .as_deref()
-                                    .unwrap()
-                                    .to_string(),
+                    Vc::cell(vec![
+                        Vc::try_resolve_downcast_type::<BuildChunkingContext>(chunking_context)
+                            .await?
+                            .unwrap()
+                            .entry_chunk_group(
+                                build_output_root
+                                    .join(
+                                        ecmascript
+                                            .ident()
+                                            .path()
+                                            .file_stem()
+                                            .await?
+                                            .as_deref()
+                                            .unwrap()
+                                            .to_string(),
+                                    )
+                                    .with_extension("entry.js".to_string()),
+                                Vc::upcast(ecmascript),
+                                EvaluatableAssets::one(Vc::upcast(ecmascript)),
+                                Value::new(AvailabilityInfo::Root),
                             )
-                            .with_extension("entry.js".to_string()),
-                        Vc::upcast(ecmascript),
-                        EvaluatableAssets::one(Vc::upcast(ecmascript)),
-                        Value::new(AvailabilityInfo::Root),
-                    )])
+                            .await?
+                            .asset,
+                    ])
                 } else if let Some(chunkable) =
                     Vc::try_resolve_sidecast::<Box<dyn ChunkableModule>>(entry_module).await?
                 {
-                    chunking_context.root_chunk_group(chunkable)
+                    chunking_context.root_chunk_group_assets(chunkable)
                 } else {
                     // TODO convert into a serve-able asset
                     bail!(

--- a/crates/turbopack-core/src/chunk/chunk_group.rs
+++ b/crates/turbopack-core/src/chunk/chunk_group.rs
@@ -14,6 +14,7 @@ use crate::{module::Module, output::OutputAssets, reference::ModuleReference};
 
 pub struct MakeChunkGroupResult {
     pub chunks: Vec<Vc<Box<dyn Chunk>>>,
+    pub availability_info: AvailabilityInfo,
 }
 
 /// Creates a chunk group from a set of entries.
@@ -100,35 +101,30 @@ pub async fn make_chunk_group(
         );
     }
 
-    // Insert async chunk loaders for every referenced async module
-    let async_loaders = if async_modules.is_empty() {
-        vec![]
-    } else {
-        // Compute new [AvailabilityInfo]
-        let inner_availability_info = {
-            let map = chunk_items
-                .iter()
-                .map(|(&chunk_item, async_info)| {
-                    (
-                        chunk_item,
-                        AvailableChunkItemInfo {
-                            is_async: async_info.is_some(),
-                        },
-                    )
-                })
-                .collect();
-            let map = Vc::cell(map);
-            availability_info.with_chunk_items(map).await?
-        };
-
-        async_modules
-            .into_iter()
-            .map(|module| {
-                chunking_context
-                    .async_loader_chunk_item(module, Value::new(inner_availability_info))
+    // Compute new [AvailabilityInfo]
+    let availability_info = {
+        let map = chunk_items
+            .iter()
+            .map(|(&chunk_item, async_info)| {
+                (
+                    chunk_item,
+                    AvailableChunkItemInfo {
+                        is_async: async_info.is_some(),
+                    },
+                )
             })
-            .collect::<Vec<_>>()
+            .collect();
+        let map = Vc::cell(map);
+        availability_info.with_chunk_items(map).await?
     };
+
+    // Insert async chunk loaders for every referenced async module
+    let async_loaders = async_modules
+        .into_iter()
+        .map(|module| {
+            chunking_context.async_loader_chunk_item(module, Value::new(availability_info))
+        })
+        .collect::<Vec<_>>();
     let async_loader_chunk_items = async_loaders.iter().map(|&chunk_item| (chunk_item, None));
 
     // And also add output assets referenced by async chunk loaders
@@ -165,7 +161,10 @@ pub async fn make_chunk_group(
     // concatenate chunks
     chunks.extend(async_loader_chunks);
 
-    Ok(MakeChunkGroupResult { chunks })
+    Ok(MakeChunkGroupResult {
+        chunks,
+        availability_info,
+    })
 }
 
 async fn references_to_output_assets(

--- a/crates/turbopack-core/src/chunk/chunking_context.rs
+++ b/crates/turbopack-core/src/chunk/chunking_context.rs
@@ -68,6 +68,7 @@ pub trait ChunkingContext {
         self: Vc<Self>,
         ident: Vc<AssetIdent>,
         evaluatable_assets: Vc<EvaluatableAssets>,
+        availability_info: Value<AvailabilityInfo>,
     ) -> Vc<OutputAssets>;
 
     async fn chunk_item_id_from_ident(

--- a/crates/turbopack-core/src/chunk/chunking_context.rs
+++ b/crates/turbopack-core/src/chunk/chunking_context.rs
@@ -11,6 +11,12 @@ use crate::{
     output::{OutputAsset, OutputAssets},
 };
 
+#[turbo_tasks::value(shared)]
+pub struct ChunkGroupResult {
+    pub assets: Vc<OutputAssets>,
+    pub availability_info: AvailabilityInfo,
+}
+
 /// A context for the chunking that influences the way chunks are created
 #[turbo_tasks::value_trait]
 pub trait ChunkingContext {
@@ -62,14 +68,14 @@ pub trait ChunkingContext {
         self: Vc<Self>,
         module: Vc<Box<dyn ChunkableModule>>,
         availability_info: Value<AvailabilityInfo>,
-    ) -> Vc<OutputAssets>;
+    ) -> Vc<ChunkGroupResult>;
 
     fn evaluated_chunk_group(
         self: Vc<Self>,
         ident: Vc<AssetIdent>,
         evaluatable_assets: Vc<EvaluatableAssets>,
         availability_info: Value<AvailabilityInfo>,
-    ) -> Vc<OutputAssets>;
+    ) -> Vc<ChunkGroupResult>;
 
     async fn chunk_item_id_from_ident(
         self: Vc<Self>,
@@ -84,13 +90,105 @@ pub trait ChunkingContext {
 }
 
 pub trait ChunkingContextExt {
-    fn root_chunk_group(self: Vc<Self>, module: Vc<Box<dyn ChunkableModule>>) -> Vc<OutputAssets>
+    fn root_chunk_group(
+        self: Vc<Self>,
+        module: Vc<Box<dyn ChunkableModule>>,
+    ) -> Vc<ChunkGroupResult>
+    where
+        Self: Send;
+
+    fn root_chunk_group_assets(
+        self: Vc<Self>,
+        module: Vc<Box<dyn ChunkableModule>>,
+    ) -> Vc<OutputAssets>
+    where
+        Self: Send;
+
+    fn evaluated_chunk_group_assets(
+        self: Vc<Self>,
+        ident: Vc<AssetIdent>,
+        evaluatable_assets: Vc<EvaluatableAssets>,
+        availability_info: Value<AvailabilityInfo>,
+    ) -> Vc<OutputAssets>
+    where
+        Self: Send;
+
+    fn chunk_group_assets(
+        self: Vc<Self>,
+        module: Vc<Box<dyn ChunkableModule>>,
+        availability_info: Value<AvailabilityInfo>,
+    ) -> Vc<OutputAssets>
     where
         Self: Send;
 }
 
 impl<T: ChunkingContext + Send + Upcast<Box<dyn ChunkingContext>>> ChunkingContextExt for T {
-    fn root_chunk_group(self: Vc<Self>, module: Vc<Box<dyn ChunkableModule>>) -> Vc<OutputAssets> {
+    fn root_chunk_group(
+        self: Vc<Self>,
+        module: Vc<Box<dyn ChunkableModule>>,
+    ) -> Vc<ChunkGroupResult> {
         self.chunk_group(module, Value::new(AvailabilityInfo::Root))
     }
+
+    fn root_chunk_group_assets(
+        self: Vc<Self>,
+        module: Vc<Box<dyn ChunkableModule>>,
+    ) -> Vc<OutputAssets> {
+        root_chunk_group_assets(Vc::upcast(self), module)
+    }
+
+    fn evaluated_chunk_group_assets(
+        self: Vc<Self>,
+        ident: Vc<AssetIdent>,
+        evaluatable_assets: Vc<EvaluatableAssets>,
+        availability_info: Value<AvailabilityInfo>,
+    ) -> Vc<OutputAssets> {
+        evaluated_chunk_group_assets(
+            Vc::upcast(self),
+            ident,
+            evaluatable_assets,
+            availability_info,
+        )
+    }
+
+    fn chunk_group_assets(
+        self: Vc<Self>,
+        module: Vc<Box<dyn ChunkableModule>>,
+        availability_info: Value<AvailabilityInfo>,
+    ) -> Vc<OutputAssets> {
+        chunk_group_assets(Vc::upcast(self), module, availability_info)
+    }
+}
+
+#[turbo_tasks::function]
+async fn root_chunk_group_assets(
+    chunking_context: Vc<Box<dyn ChunkingContext>>,
+    module: Vc<Box<dyn ChunkableModule>>,
+) -> Result<Vc<OutputAssets>> {
+    Ok(chunking_context.root_chunk_group(module).await?.assets)
+}
+
+#[turbo_tasks::function]
+async fn evaluated_chunk_group_assets(
+    chunking_context: Vc<Box<dyn ChunkingContext>>,
+    ident: Vc<AssetIdent>,
+    evaluatable_assets: Vc<EvaluatableAssets>,
+    availability_info: Value<AvailabilityInfo>,
+) -> Result<Vc<OutputAssets>> {
+    Ok(chunking_context
+        .evaluated_chunk_group(ident, evaluatable_assets, availability_info)
+        .await?
+        .assets)
+}
+
+#[turbo_tasks::function]
+async fn chunk_group_assets(
+    chunking_context: Vc<Box<dyn ChunkingContext>>,
+    module: Vc<Box<dyn ChunkableModule>>,
+    availability_info: Value<AvailabilityInfo>,
+) -> Result<Vc<OutputAssets>> {
+    Ok(chunking_context
+        .chunk_group(module, availability_info)
+        .await?
+        .assets)
 }

--- a/crates/turbopack-core/src/chunk/mod.rs
+++ b/crates/turbopack-core/src/chunk/mod.rs
@@ -32,7 +32,7 @@ use turbo_tasks_hash::DeterministicHash;
 
 use self::availability_info::AvailabilityInfo;
 pub use self::{
-    chunking_context::{ChunkingContext, ChunkingContextExt},
+    chunking_context::{ChunkGroupResult, ChunkingContext, ChunkingContextExt},
     data::{ChunkData, ChunkDataOption, ChunksData},
     evaluate::{EvaluatableAsset, EvaluatableAssetExt, EvaluatableAssets},
     passthrough_asset::PassthroughModule,

--- a/crates/turbopack-core/src/output.rs
+++ b/crates/turbopack-core/src/output.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use indexmap::IndexSet;
 use turbo_tasks::Vc;
 
@@ -26,6 +27,13 @@ impl OutputAssets {
     #[turbo_tasks::function]
     pub fn new(assets: Vec<Vc<Box<dyn OutputAsset>>>) -> Vc<Self> {
         Vc::cell(assets)
+    }
+
+    #[turbo_tasks::function]
+    pub async fn concatenate(self: Vc<Self>, other: Vc<Self>) -> Result<Vc<Self>> {
+        let mut assets: IndexSet<_> = self.await?.iter().copied().collect();
+        assets.extend(other.await?.iter().copied());
+        Ok(Vc::cell(assets.into_iter().collect()))
     }
 }
 

--- a/crates/turbopack-dev-server/src/html.rs
+++ b/crates/turbopack-dev-server/src/html.rs
@@ -1,11 +1,14 @@
 use anyhow::{anyhow, Result};
 use mime_guess::mime::TEXT_HTML_UTF_8;
-use turbo_tasks::{ReadRef, TryJoinIterExt, Vc};
+use turbo_tasks::{ReadRef, TryJoinIterExt, Value, Vc};
 use turbo_tasks_fs::{File, FileSystemPath};
 use turbo_tasks_hash::{encode_hex, Xxh3Hash64Hasher};
 use turbopack_core::{
     asset::{Asset, AssetContent},
-    chunk::{ChunkableModule, ChunkingContext, ChunkingContextExt, EvaluatableAssets},
+    chunk::{
+        availability_info::AvailabilityInfo, ChunkableModule, ChunkingContext, ChunkingContextExt,
+        EvaluatableAssets,
+    },
     ident::AssetIdent,
     module::Module,
     output::{OutputAsset, OutputAssets},
@@ -140,8 +143,11 @@ impl DevHtmlAsset {
                     } else {
                         runtime_entries
                     };
-                    chunking_context
-                        .evaluated_chunk_group(chunkable_module.ident(), runtime_entries)
+                    chunking_context.evaluated_chunk_group(
+                        chunkable_module.ident(),
+                        runtime_entries,
+                        Value::new(AvailabilityInfo::Root),
+                    )
                 } else {
                     chunking_context.root_chunk_group(Vc::upcast(chunkable_module))
                 };

--- a/crates/turbopack-dev-server/src/html.rs
+++ b/crates/turbopack-dev-server/src/html.rs
@@ -143,13 +143,13 @@ impl DevHtmlAsset {
                     } else {
                         runtime_entries
                     };
-                    chunking_context.evaluated_chunk_group(
+                    chunking_context.evaluated_chunk_group_assets(
                         chunkable_module.ident(),
                         runtime_entries,
                         Value::new(AvailabilityInfo::Root),
                     )
                 } else {
-                    chunking_context.root_chunk_group(Vc::upcast(chunkable_module))
+                    chunking_context.root_chunk_group_assets(Vc::upcast(chunkable_module))
                 };
 
                 assets.await

--- a/crates/turbopack-dev/src/chunking_context.rs
+++ b/crates/turbopack-dev/src/chunking_context.rs
@@ -6,7 +6,8 @@ use turbopack_core::{
     chunk::{
         availability_info::AvailabilityInfo,
         chunk_group::{make_chunk_group, MakeChunkGroupResult},
-        Chunk, ChunkItem, ChunkableModule, ChunkingContext, EvaluatableAssets, ModuleId,
+        Chunk, ChunkGroupResult, ChunkItem, ChunkableModule, ChunkingContext, EvaluatableAssets,
+        ModuleId,
     },
     environment::Environment,
     ident::AssetIdent,
@@ -316,10 +317,13 @@ impl ChunkingContext for DevChunkingContext {
         self: Vc<Self>,
         module: Vc<Box<dyn ChunkableModule>>,
         availability_info: Value<AvailabilityInfo>,
-    ) -> Result<Vc<OutputAssets>> {
+    ) -> Result<Vc<ChunkGroupResult>> {
         let span = tracing::info_span!("chunking", module = *module.ident().to_string().await?);
         async move {
-            let MakeChunkGroupResult { chunks } = make_chunk_group(
+            let MakeChunkGroupResult {
+                chunks,
+                availability_info,
+            } = make_chunk_group(
                 Vc::upcast(self),
                 [Vc::upcast(module)],
                 availability_info.into_value(),
@@ -343,7 +347,11 @@ impl ChunkingContext for DevChunkingContext {
                 *asset = asset.resolve().await?;
             }
 
-            Ok(Vc::cell(assets))
+            Ok(ChunkGroupResult {
+                assets: Vc::cell(assets),
+                availability_info,
+            }
+            .cell())
         }
         .instrument(span)
         .await
@@ -355,7 +363,7 @@ impl ChunkingContext for DevChunkingContext {
         ident: Vc<AssetIdent>,
         evaluatable_assets: Vc<EvaluatableAssets>,
         availability_info: Value<AvailabilityInfo>,
-    ) -> Result<Vc<OutputAssets>> {
+    ) -> Result<Vc<ChunkGroupResult>> {
         let span = {
             let ident = ident.to_string().await?;
             tracing::info_span!("chunking", chunking_type = "evaluated", ident = *ident)
@@ -372,8 +380,10 @@ impl ChunkingContext for DevChunkingContext {
                 .map(|&evaluatable| Vc::upcast(evaluatable))
                 .collect::<Vec<_>>();
 
-            let MakeChunkGroupResult { chunks } =
-                make_chunk_group(Vc::upcast(self), entries, availability_info).await?;
+            let MakeChunkGroupResult {
+                chunks,
+                availability_info,
+            } = make_chunk_group(Vc::upcast(self), entries, availability_info).await?;
 
             let mut assets: Vec<Vc<Box<dyn OutputAsset>>> = chunks
                 .iter()
@@ -396,7 +406,11 @@ impl ChunkingContext for DevChunkingContext {
                 *asset = asset.resolve().await?;
             }
 
-            Ok(Vc::cell(assets))
+            Ok(ChunkGroupResult {
+                assets: Vc::cell(assets),
+                availability_info,
+            }
+            .cell())
         }
         .instrument(span)
         .await

--- a/crates/turbopack-dev/src/chunking_context.rs
+++ b/crates/turbopack-dev/src/chunking_context.rs
@@ -354,13 +354,14 @@ impl ChunkingContext for DevChunkingContext {
         self: Vc<Self>,
         ident: Vc<AssetIdent>,
         evaluatable_assets: Vc<EvaluatableAssets>,
+        availability_info: Value<AvailabilityInfo>,
     ) -> Result<Vc<OutputAssets>> {
         let span = {
             let ident = ident.to_string().await?;
             tracing::info_span!("chunking", chunking_type = "evaluated", ident = *ident)
         };
         async move {
-            let availability_info = AvailabilityInfo::Root;
+            let availability_info = availability_info.into_value();
 
             let evaluatable_assets_ref = evaluatable_assets.await?;
 

--- a/crates/turbopack-ecmascript/src/chunk_group_files_asset.rs
+++ b/crates/turbopack-ecmascript/src/chunk_group_files_asset.rs
@@ -138,7 +138,7 @@ impl ChunkGroupFilesChunkItem {
         let chunks = if let Some(ecma) =
             Vc::try_resolve_downcast_type::<EcmascriptModuleAsset>(inner.module).await?
         {
-            inner.chunking_context.evaluated_chunk_group(
+            inner.chunking_context.evaluated_chunk_group_assets(
                 inner.module.ident(),
                 inner
                     .runtime_entries
@@ -149,7 +149,7 @@ impl ChunkGroupFilesChunkItem {
         } else {
             inner
                 .chunking_context
-                .root_chunk_group(Vc::upcast(inner.module))
+                .root_chunk_group_assets(Vc::upcast(inner.module))
         };
         Ok(chunks)
     }

--- a/crates/turbopack-ecmascript/src/chunk_group_files_asset.rs
+++ b/crates/turbopack-ecmascript/src/chunk_group_files_asset.rs
@@ -1,12 +1,12 @@
 use anyhow::{Context, Result};
 use indexmap::IndexSet;
-use turbo_tasks::{TryJoinIterExt, ValueToString, Vc};
+use turbo_tasks::{TryJoinIterExt, Value, ValueToString, Vc};
 use turbo_tasks_fs::{File, FileSystemPath};
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{
-        ChunkItem, ChunkType, ChunkableModule, ChunkingContext, ChunkingContextExt,
-        EvaluatableAssets,
+        availability_info::AvailabilityInfo, ChunkItem, ChunkType, ChunkableModule,
+        ChunkingContext, ChunkingContextExt, EvaluatableAssets,
     },
     ident::AssetIdent,
     introspect::{
@@ -144,6 +144,7 @@ impl ChunkGroupFilesChunkItem {
                     .runtime_entries
                     .unwrap_or_else(EvaluatableAssets::empty)
                     .with_entry(Vc::upcast(ecma)),
+                Value::new(AvailabilityInfo::Root),
             )
         } else {
             inner

--- a/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
+++ b/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
@@ -2,7 +2,9 @@ use anyhow::{Context, Result};
 use turbo_tasks::{Value, Vc};
 use turbopack_core::{
     asset::{Asset, AssetContent},
-    chunk::{availability_info::AvailabilityInfo, ChunkableModule, ChunkingContext},
+    chunk::{
+        availability_info::AvailabilityInfo, ChunkableModule, ChunkingContext, ChunkingContextExt,
+    },
     ident::AssetIdent,
     module::Module,
     output::OutputAssets,
@@ -54,7 +56,7 @@ impl ManifestAsyncModule {
         let this = self.await?;
         Ok(this
             .chunking_context
-            .chunk_group(Vc::upcast(this.inner), Value::new(this.availability_info)))
+            .chunk_group_assets(Vc::upcast(this.inner), Value::new(this.availability_info)))
     }
 
     #[turbo_tasks::function]
@@ -62,7 +64,7 @@ impl ManifestAsyncModule {
         let this = self.await?;
         Ok(this
             .chunking_context
-            .chunk_group(Vc::upcast(self), Value::new(this.availability_info)))
+            .chunk_group_assets(Vc::upcast(self), Value::new(this.availability_info)))
     }
 
     #[turbo_tasks::function]

--- a/crates/turbopack-node/src/bootstrap.rs
+++ b/crates/turbopack-node/src/bootstrap.rs
@@ -1,11 +1,11 @@
 use std::fmt::Write;
 
 use anyhow::Result;
-use turbo_tasks::Vc;
+use turbo_tasks::{Value, Vc};
 use turbo_tasks_fs::{File, FileSystemPath};
 use turbopack_core::{
     asset::{Asset, AssetContent},
-    chunk::{ChunkingContext, EvaluatableAssets},
+    chunk::{availability_info::AvailabilityInfo, ChunkingContext, EvaluatableAssets},
     ident::AssetIdent,
     output::{OutputAsset, OutputAssets},
 };
@@ -25,8 +25,11 @@ fn node_js_bootstrap_chunk_reference_description() -> Vc<String> {
 
 impl NodeJsBootstrapAsset {
     fn chunks(&self) -> Vc<OutputAssets> {
-        self.chunking_context
-            .evaluated_chunk_group(AssetIdent::from_path(self.path), self.evaluatable_assets)
+        self.chunking_context.evaluated_chunk_group(
+            AssetIdent::from_path(self.path),
+            self.evaluatable_assets,
+            Value::new(AvailabilityInfo::Root),
+        )
     }
 }
 

--- a/crates/turbopack-node/src/bootstrap.rs
+++ b/crates/turbopack-node/src/bootstrap.rs
@@ -5,7 +5,9 @@ use turbo_tasks::{Value, Vc};
 use turbo_tasks_fs::{File, FileSystemPath};
 use turbopack_core::{
     asset::{Asset, AssetContent},
-    chunk::{availability_info::AvailabilityInfo, ChunkingContext, EvaluatableAssets},
+    chunk::{
+        availability_info::AvailabilityInfo, ChunkingContext, ChunkingContextExt, EvaluatableAssets,
+    },
     ident::AssetIdent,
     output::{OutputAsset, OutputAssets},
 };
@@ -25,7 +27,7 @@ fn node_js_bootstrap_chunk_reference_description() -> Vc<String> {
 
 impl NodeJsBootstrapAsset {
     fn chunks(&self) -> Vc<OutputAssets> {
-        self.chunking_context.evaluated_chunk_group(
+        self.chunking_context.evaluated_chunk_group_assets(
             AssetIdent::from_path(self.path),
             self.evaluatable_assets,
             Value::new(AvailabilityInfo::Root),

--- a/crates/turbopack-tests/tests/snapshot.rs
+++ b/crates/turbopack-tests/tests/snapshot.rs
@@ -329,7 +329,7 @@ async fn run_test(resource: String) -> Result<Vc<FileSystemPath>> {
     {
         // TODO: Load runtime entries from snapshots
         match options.runtime {
-            Runtime::Dev => chunking_context.evaluated_chunk_group(
+            Runtime::Dev => chunking_context.evaluated_chunk_group_assets(
                 ecmascript.ident(),
                 runtime_entries
                     .unwrap_or_else(EvaluatableAssets::empty)
@@ -337,37 +337,39 @@ async fn run_test(resource: String) -> Result<Vc<FileSystemPath>> {
                 Value::new(AvailabilityInfo::Root),
             ),
             Runtime::Build => {
-                Vc::cell(vec![Vc::try_resolve_downcast_type::<BuildChunkingContext>(
-                    chunking_context,
-                )
-                .await?
-                .unwrap()
-                .entry_chunk_group(
-                    // `expected` expects a completely flat output directory.
-                    chunk_root_path
-                        .join(
-                            entry_module
-                                .ident()
-                                .path()
-                                .file_stem()
-                                .await?
-                                .as_deref()
-                                .unwrap()
-                                .to_string(),
+                Vc::cell(vec![
+                    Vc::try_resolve_downcast_type::<BuildChunkingContext>(chunking_context)
+                        .await?
+                        .unwrap()
+                        .entry_chunk_group(
+                            // `expected` expects a completely flat output directory.
+                            chunk_root_path
+                                .join(
+                                    entry_module
+                                        .ident()
+                                        .path()
+                                        .file_stem()
+                                        .await?
+                                        .as_deref()
+                                        .unwrap()
+                                        .to_string(),
+                                )
+                                .with_extension("entry.js".to_string()),
+                            Vc::upcast(ecmascript),
+                            runtime_entries
+                                .unwrap_or_else(EvaluatableAssets::empty)
+                                .with_entry(Vc::upcast(ecmascript)),
+                            Value::new(AvailabilityInfo::Root),
                         )
-                        .with_extension("entry.js".to_string()),
-                    Vc::upcast(ecmascript),
-                    runtime_entries
-                        .unwrap_or_else(EvaluatableAssets::empty)
-                        .with_entry(Vc::upcast(ecmascript)),
-                    Value::new(AvailabilityInfo::Root),
-                )])
+                        .await?
+                        .asset,
+                ])
             }
         }
     } else if let Some(chunkable) =
         Vc::try_resolve_downcast::<Box<dyn ChunkableModule>>(entry_module).await?
     {
-        chunking_context.root_chunk_group(chunkable)
+        chunking_context.root_chunk_group_assets(chunkable)
     } else {
         // TODO convert into a serve-able asset
         bail!("Entry module is not chunkable, so it can't be used to bootstrap the application")

--- a/crates/turbopack-tests/tests/snapshot.rs
+++ b/crates/turbopack-tests/tests/snapshot.rs
@@ -30,8 +30,8 @@ use turbopack_build::{BuildChunkingContext, MinifyType};
 use turbopack_core::{
     asset::Asset,
     chunk::{
-        ChunkableModule, ChunkingContext, ChunkingContextExt, EvaluatableAssetExt,
-        EvaluatableAssets,
+        availability_info::AvailabilityInfo, ChunkableModule, ChunkingContext, ChunkingContextExt,
+        EvaluatableAssetExt, EvaluatableAssets,
     },
     compile_time_defines,
     compile_time_info::CompileTimeInfo,
@@ -334,6 +334,7 @@ async fn run_test(resource: String) -> Result<Vc<FileSystemPath>> {
                 runtime_entries
                     .unwrap_or_else(EvaluatableAssets::empty)
                     .with_entry(Vc::upcast(ecmascript)),
+                Value::new(AvailabilityInfo::Root),
             ),
             Runtime::Build => {
                 Vc::cell(vec![Vc::try_resolve_downcast_type::<BuildChunkingContext>(

--- a/crates/turbopack-tests/tests/snapshot.rs
+++ b/crates/turbopack-tests/tests/snapshot.rs
@@ -360,6 +360,7 @@ async fn run_test(resource: String) -> Result<Vc<FileSystemPath>> {
                     runtime_entries
                         .unwrap_or_else(EvaluatableAssets::empty)
                         .with_entry(Vc::upcast(ecmascript)),
+                    Value::new(AvailabilityInfo::Root),
                 )])
             }
         }


### PR DESCRIPTION
### Description

This allows to create a chunk group based on another chunk group (which skips all available modules at this point)

Similar to `webpack` `dependOn`.


Closes PACK-2229