### PR TITLE
fix: rewrite prefix after carriage return

### DIFF
--- a/crates/turborepo-ui/src/prefixed.rs
+++ b/crates/turborepo-ui/src/prefixed.rs
@@ -128,15 +128,18 @@ impl<W: Write> PrefixedWriter<W> {
 
 impl<W: Write> Write for PrefixedWriter<W> {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        // If we are about
         for chunk in buf.split_inclusive(|c| *c == b'\r') {
+            // Before we write the chunk we write the prefix as either:
+            // - this is the first iteration and we haven't written the prefix
+            // - the previous chunk ended with a \r and the cursor is currently as the start
+            //   of the line so we want to rewrite the prefix over the existing prefix in
+            //   the line
             self.writer.write_all(self.prefix.as_bytes())?;
             self.writer.write_all(chunk)?;
         }
         // We do end up writing more bytes than this to the underlying writer, but we
         // cannot report this to the callers as the amount of bytes we report
         // written must be less than or equal to the number of bytes in the buffer.
-        // if we encounter a \n
         Ok(buf.len())
     }
 


### PR DESCRIPTION
### Description

Fixes #6969

If we encounter a `\r` in a task's outputs we make sure we rewrite our prefix so it doesn't get overwritten by the output that follows the `\r`.

This does result in slightly more writing to stdout than strictly necessary on systems that use `CRLF` instead of just `LF` as we will now print out our prefix before processing `LF`. The user still sees the correct output and this keeps the implementation simple.

[`\r` reference](https://en.wikipedia.org/wiki/Carriage_return#Computers)

### Testing Instructions

Unit tests for a few scenarios, but primary way to test is to run `next` using `turbo`:
```
[0 olszewski@chriss-mbp] /tmp $ npx create-turbo@latest cr-test pnpm
[0 olszewski@chriss-mbp] /tmp $ cd cr-test 
[0 olszewski@chriss-mbp] /tmp/cr-test $ pnpm rm turbo # make sure we're using locally built turbo
```
<img width="612" alt="Screenshot 2024-01-11 at 10 11 46 AM" src="https://github.com/vercel/turbo/assets/4131117/20ad5bfd-176c-486b-8f05-d77206168af0">



Closes TURBO-2030