### PR TITLE
fix: update Cargo.lock with correct workspace dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10913,6 +10913,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "turbo-tasks-malloc",
 ]
 
 [[package]]


### PR DESCRIPTION
### Description

Update `Cargo.lock` to match changes made to `Cargo.toml` in  #6866

### Testing Instructions

👀 


Closes TURBO-2032