### PR TITLE
chore: remove usage of command groups

### DIFF
--- a/crates/turborepo-lib/Cargo.toml
+++ b/crates/turborepo-lib/Cargo.toml
@@ -59,6 +59,7 @@ json_comments = "0.2.1"
 jsonc-parser = { version = "0.21.0" }
 lazy_static = { workspace = true }
 libc = "0.2.140"
+nix = "0.26.2"
 notify = "5.1"
 path-clean = "1.0.1"
 petgraph = { workspace = true }

--- a/crates/turborepo-lib/src/process/child.rs
+++ b/crates/turborepo-lib/src/process/child.rs
@@ -147,7 +147,6 @@ impl ShutdownStyle {
 #[derive(Clone, Debug)]
 pub struct Child {
     pid: Option<u32>,
-    gid: Option<u32>,
     state: Arc<RwLock<ChildState>>,
     exit_channel: watch::Receiver<Option<ChildExit>>,
     stdin: Arc<Mutex<Option<tokio::process::ChildStdin>>>,
@@ -197,7 +196,6 @@ impl Child {
 
         let group = command.group().spawn()?;
 
-        let gid = group.id();
         let mut child = group.into_inner();
         let pid = child.id();
 
@@ -278,7 +276,6 @@ impl Child {
 
         Ok(Self {
             pid,
-            gid,
             state,
             exit_channel: exit_rx,
             stdin: Arc::new(Mutex::new(stdin)),


### PR DESCRIPTION
### Description

Remove usage of the `command-groups` crate in favor of directly working with `tokio::process::Command`. This PR just inlines what the `spawn` call on unix systems was doing.

This PR doesn't add any "process group" handling for Windows as we weren't using `command-groups` Windows specialization at all:
 - On Windows the `spawn` call will [actually generate](https://github.com/watchexec/command-group/blob/main/src/tokio/windows.rs#L27) a [JobObject](https://learn.microsoft.com/en-us/windows/win32/procthread/job-objects).
 - Immediately after spawning through we called `into_inner` which [drops all references](https://github.com/watchexec/command-group/blob/main/src/tokio/child/windows.rs#L55) to the JobObject (keeping it open though as closing it would kill the child)
 - Our kill implementation on windows doesn't send any signals, but simply calls `kill` on the child which on windows calls [TerminateProcess](https://github.com/rust-lang/rust/blob/master/library/std/src/sys/windows/process.rs#L646C34-L646C50), which is independent of job objects.

Note, this doesn't remove the dependency completely as it is currently used when spawning the daemon process and in that case we actually use the Windows implementation from what I can grok.

### Testing Instructions

Existing unit test for killing process groups on Unix systems.

Manual test on Windows (create a new project, `turbo dev`, Ctrl-C, verify that the two processes get killed)


Closes TURBO-2033