### PR TITLE
chore: add reason for service being unavailable

### DIFF
--- a/crates/turborepo-lib/src/daemon/client.rs
+++ b/crates/turborepo-lib/src/daemon/client.rs
@@ -164,8 +164,8 @@ fn format_repo_relative_glob(glob: &str) -> String {
 #[derive(Error, Debug)]
 pub enum DaemonError {
     /// The server was connected but is now unavailable.
-    #[error("server is unavailable")]
-    Unavailable,
+    #[error("server is unavailable: {0}")]
+    Unavailable(String),
     #[error("error opening socket: {0}")]
     SocketOpen(#[from] SocketOpenError),
     /// The server is running a different version of turborepo.
@@ -211,7 +211,7 @@ impl From<Status> for DaemonError {
     fn from(status: Status) -> DaemonError {
         match status.code() {
             Code::FailedPrecondition | Code::Unimplemented => DaemonError::VersionMismatch,
-            Code::Unavailable => DaemonError::Unavailable,
+            Code::Unavailable => DaemonError::Unavailable(status.message().to_string()),
             c => DaemonError::GrpcFailure(c),
         }
     }

--- a/crates/turborepo-lib/src/daemon/connector.rs
+++ b/crates/turborepo-lib/src/daemon/connector.rs
@@ -116,7 +116,7 @@ impl DaemonConnector {
                 Err(DaemonError::VersionMismatch) if self.can_kill_server => {
                     self.kill_live_server(client, pid).await?
                 }
-                Err(DaemonError::Unavailable) => self.kill_dead_server(pid).await?,
+                Err(DaemonError::Unavailable(_)) => self.kill_dead_server(pid).await?,
                 Err(e) => return Err(DaemonConnectorError::Handshake(Box::new(e))),
             };
         }

--- a/crates/turborepo-lib/src/run/cache.rs
+++ b/crates/turborepo-lib/src/run/cache.rs
@@ -204,8 +204,8 @@ impl TaskCache {
                 Ok(changed_output_globs) => changed_output_globs.len(),
                 Err(err) => {
                     warn!(
-                        "Failed to check if we can skip restoring outputs for {}: {:?}. \
-                         Proceeding to check cache",
+                        "Failed to check if we can skip restoring outputs for {}: {}. Proceeding \
+                         to check cache",
                         self.task_id, err
                     );
                     self.repo_relative_globs.inclusions.len()


### PR DESCRIPTION
### Description

Having trouble making progress on #6934 and the daemon logs aren't especially helpful. Tonic is saying the service is unavailable, but I'm unsure of what would cause it to become unavailable. From the docs:

> The service is currently unavailable. This is a most likely a transient condition and may be corrected by retrying with a back-off.

From our server code, I'm not seeing us explicitly throw this anywhere.

This PR does a few things:
 - Change the warning to use the default formatter for the error instead of the debug formatter
 - Plumb the message from the `tonic::Status` event into our `Unavailable` error variant

### Testing Instructions

👀 

Closes TURBO-2034