### PR TITLE
chore: Adjusted error message for APIClient errors in cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11192,6 +11192,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "miette 5.10.0",
+ "nix",
  "node-semver",
  "notify 5.1.0",
  "num_cpus",

--- a/crates/turborepo-cache/src/lib.rs
+++ b/crates/turborepo-cache/src/lib.rs
@@ -42,7 +42,7 @@ pub enum CacheError {
     InvalidTag(#[backtrace] Backtrace),
     #[error("cannot untar file to {0}")]
     InvalidFilePath(String, #[backtrace] Backtrace),
-    #[error("artifact verification failed: {0}")]
+    #[error("failed to contact remote cache: {0}")]
     ApiClientError(Box<turborepo_api_client::Error>, #[backtrace] Backtrace),
     #[error("signing artifact failed: {0}")]
     SignatureError(#[from] SignatureError, #[backtrace] Backtrace),


### PR DESCRIPTION
### Description

`artifact verification failed` is confusing and implies that it's something to do with cache signature authentication when really it could be any `APIClient` issue.

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->


Closes TURBO-2037