### PR TITLE
DOCS: Changed getting started to be "npm create turbo@latest"

### DIFF
--- a/docs/pages/repo/docs/getting-started/create-new.mdx
+++ b/docs/pages/repo/docs/getting-started/create-new.mdx
@@ -21,7 +21,7 @@ To create a new monorepo, use our [`create-turbo`](https://www.npmjs.com/package
 <Tabs items={['npm', 'yarn', 'pnpm']} storageKey="selected-pkg-manager">
   <Tab>
     ```sh
-    npx create-turbo@latest
+    npm create turbo@latest
     ```
   </Tab>
   <Tab>


### PR DESCRIPTION
### Description
Changed usage of turbo repo to be "npm create turbo@latest" instead of "npx create-turbo". These are the same but the former looks better

### Testing Instructions
Not that I am aware of. 
I tried to create a new project with `npm create` and that seem to work like a charm
