### PR TITLE
fix(examples): fontSize type is number not string

### DIFF
--- a/examples/with-react-native-web/packages/ui/src/button.tsx
+++ b/examples/with-react-native-web/packages/ui/src/button.tsx
@@ -28,7 +28,7 @@ const styles = StyleSheet.create({
     paddingBottom: 14,
     paddingLeft: 30,
     paddingRight: 30,
-    fontSize: "15px",
+    fontSize: 15,
     backgroundColor: "#2f80ed",
   },
   text: {


### PR DESCRIPTION
- ref: https://reactnative.dev/docs/text-style-props#fontsize

This PR fixes the wrong type within examples.

![Screenshot 2024-01-16 at 3 24 49 AM](https://github.com/vercel/turbo/assets/120007119/838f89d2-7a25-4add-bef0-e4eaa65dacf9)

![Screenshot 2024-01-16 at 3 25 27 AM](https://github.com/vercel/turbo/assets/120007119/101ad6f5-9d60-4cbd-a71e-85d883dbd910)

