### PR TITLE
Fix Svelte package export map

### DIFF
--- a/examples/with-svelte/packages/ui/package.json
+++ b/examples/with-svelte/packages/ui/package.json
@@ -6,6 +6,7 @@
   "main": "index.ts",
   "exports": {
     ".": {
+      "types": "./index.ts",
       "svelte": "./index.ts"
     }
   },


### PR DESCRIPTION
### Description

Adds a types field which is necessary in order for TS to pick up typings. SvelteKit 2 changes the default for `moduleResolution` to `bundler` (the new recommended setting from the TS team for most apps), which means the `package.json` export map is now used and needs this for TS to know where to look for the typings.
fixes #7003

### Testing Instructions

Open docs/routes/+page.svelte and see that there's no more type error
