### PR TITLE
Add Glossary to sidebar.

### DIFF
--- a/docs/pages/repo/docs/_meta.json
+++ b/docs/pages/repo/docs/_meta.json
@@ -17,5 +17,10 @@
   "upgrading-to-v1": "Upgrading to v1",
   "acknowledgements": "Acknowledgements",
   "support": "Support Policy",
-  "faq": "FAQ"
+  "faq": "FAQ",
+  "glossary": {
+    "title": "Glossary",
+    "href": "https://vercel.com/docs/vercel-platform/glossary",
+    "newWindow": true
+  }
 }


### PR DESCRIPTION
This PR adds an Easy Bake Oven to the Turborepo docs so I can easily reach for some tasty treats whenever I'm feeling snacky.

No, it doesn't. It just adds the Vercel Glossary to the sidebar.
