### PR TITLE
fix(daemon): make sure cookie dir exists before writing cookie

### DIFF
--- a/crates/turborepo-filewatch/src/cookie_jar.rs
+++ b/crates/turborepo-filewatch/src/cookie_jar.rs
@@ -106,7 +106,8 @@ impl CookieJar {
             // dropping the resulting file closes the handle
             trace!("writing cookie {}", cookie_path);
             _ = cookie_path
-                .open_with_options(opts)
+                .ensure_dir()
+                .and_then(|_| cookie_path.open_with_options(opts))
                 .map_err(|io_err| CookieError::IO {
                     io_err,
                     path: cookie_path.clone(),


### PR DESCRIPTION
### Description

Fixes #6934

We weren't verifying that the cookie dir existed before trying to write the cookie file. This would cause cookie operations to fail if `.turbo/cookie` got deleted between runs. 

e.g.
```
[0 olszewski@chriss-mbp] /tmp/daemon-test $ turbo build --output-logs errors-only 
• Packages in scope: @repo/eslint-config, @repo/typescript-config, @repo/ui, docs, web
• Running build in 5 packages
• Remote caching disabled

 Tasks:    2 successful, 2 total
Cached:    0 cached, 2 total
  Time:    7.847s 

[0 olszewski@chriss-mbp] /tmp/daemon-test $ rm -rf .turbo/cookies 
[0 olszewski@chriss-mbp] /tmp/daemon-test $ turbo build --output-logs errors-only
• Packages in scope: @repo/eslint-config, @repo/typescript-config, @repo/ui, docs, web
• Running build in 5 packages
• Remote caching disabled
 WARNING  Failed to check if we can skip restoring outputs for web#build: server is unavailable: failed to write cookie file at /private/tmp/daemon-test/.turbo/cookies/4.cookie: No such file or directory (os error 2). Proceeding to check cache
 WARNING  Failed to check if we can skip restoring outputs for docs#build: server is unavailable: failed to write cookie file at /private/tmp/daemon-test/.turbo/cookies/5.cookie: No such file or directory (os error 2). Proceeding to check cache
web:build: Failed to mark outputs as cached for web#build: Unavailable("failed to write cookie file at /private/tmp/daemon-test/.turbo/cookies/6.cookie: No such file or directory (os error 2)")
docs:build: Failed to mark outputs as cached for docs#build: Unavailable("failed to write cookie file at /private/tmp/daemon-test/.turbo/cookies/7.cookie: No such file or directory (os error 2)")

 Tasks:    2 successful, 2 total
Cached:    2 cached, 2 total
  Time:    226ms >>> FULL TURBO
```

### Testing Instructions

Verify that we no longer fail to check if outputs have changed after deleting the cookies dir:
```
[0 olszewski@chriss-mbp] /tmp/daemon-test $ turbo_dev build --output-logs errors-only
• Packages in scope: @repo/eslint-config, @repo/typescript-config, @repo/ui, docs, web
• Running build in 5 packages
• Remote caching disabled

 Tasks:    2 successful, 2 total
Cached:    0 cached, 2 total
  Time:    6.968s 

[0 olszewski@chriss-mbp] /tmp/daemon-test $ rm -rf .turbo/cookies 
[0 olszewski@chriss-mbp] /tmp/daemon-test $ turbo_dev build --output-logs errors-only
• Packages in scope: @repo/eslint-config, @repo/typescript-config, @repo/ui, docs, web
• Running build in 5 packages
• Remote caching disabled

 Tasks:    2 successful, 2 total
Cached:    0 cached, 2 total
  Time:    6.822s 

```


Closes TURBO-2049