### PR TITLE
fix(cache): truncate metadata file when writing

### DIFF
--- a/crates/turborepo-cache/src/fs.rs
+++ b/crates/turborepo-cache/src/fs.rs
@@ -169,7 +169,7 @@ impl FSCache {
         };
 
         let mut metadata_options = OpenOptions::new();
-        metadata_options.create(true).write(true);
+        metadata_options.create(true).write(true).truncate(true);
 
         let metadata_file = metadata_path.open_with_options(metadata_options)?;
 


### PR DESCRIPTION
### Description

I noticed on a test project that I couldn't get a cache hit even after a successful run. This came from a malformed metadata file of the form: `{"hash":"20a9a381f9d0b615","duration":5824}}` which I believe got created due to the lack of `truncate` in the open option when we write the metadata file. I believe this can get created from a `--force` run where the first run had a duration that took n+1 digits to express, but the forced run has a duration that only requires n digits to express.

The outcome of having a file like this is that you can never successfully get a cache read and thus never FULL TURBO:
```
[0 olszewski@chriss-mbp] /tmp/daemon-test $ turbo_dev build --output-logs errors-only --no-daemon   
• Packages in scope: @repo/eslint-config, @repo/typescript-config, @repo/ui, docs, web
• Running build in 5 packages
• Remote caching disabled

 Tasks:    2 successful, 2 total
Cached:    1 cached, 2 total
  Time:    6.393s 

[0 olszewski@chriss-mbp] /tmp/daemon-test $ cat node_modules/.cache/turbo/20a9a381f9d0b615-meta.json
{"hash":"20a9a381f9d0b615","duration":5750}somejunk
[0 olszewski@chriss-mbp] /tmp/daemon-test $ turbo_dev build --output-logs errors-only --no-daemon   
• Packages in scope: @repo/eslint-config, @repo/typescript-config, @repo/ui, docs, web
• Running build in 5 packages
• Remote caching disabled

 Tasks:    2 successful, 2 total
Cached:    1 cached, 2 total
  Time:    6.23s 

[0 olszewski@chriss-mbp] /tmp/daemon-test $ cat node_modules/.cache/turbo/20a9a381f9d0b615-meta.json
{"hash":"20a9a381f9d0b615","duration":5822}somejunk
```
Note that the duration is changing when we populate the cache, but since we aren't truncating the file it is invalid JSON and will result in a failed cache read.

The PR just makes sure we truncate the metadata file if we are overwriting it.

### Testing Instructions

Verify that a bad metadata file now gets truncated when getting written over and we can get a cache hit.
```
[0 olszewski@chriss-mbp] /tmp/daemon-test $ cat node_modules/.cache/turbo/20a9a381f9d0b615-meta.json
{"hash":"20a9a381f9d0b615","duration":5822}somejunk
[0 olszewski@chriss-mbp] /tmp/daemon-test $ cat node_modules/.cache/turbo/20a9a381f9d0b615-meta.json
{"hash":"20a9a381f9d0b615","duration":5822}somejunk
[0 olszewski@chriss-mbp] /tmp/daemon-test $ turbo_dev build --output-logs errors-only --no-daemon   
• Packages in scope: @repo/eslint-config, @repo/typescript-config, @repo/ui, docs, web
• Running build in 5 packages
• Remote caching disabled

 Tasks:    2 successful, 2 total
Cached:    1 cached, 2 total
  Time:    6.776s 

[0 olszewski@chriss-mbp] /tmp/daemon-test $ cat node_modules/.cache/turbo/20a9a381f9d0b615-meta.json
{"hash":"20a9a381f9d0b615","duration":6140}%                                                                                          
[0 olszewski@chriss-mbp] /tmp/daemon-test $ turbo_dev build --output-logs errors-only --no-daemon   
• Packages in scope: @repo/eslint-config, @repo/typescript-config, @repo/ui, docs, web
• Running build in 5 packages
• Remote caching disabled

 Tasks:    2 successful, 2 total
Cached:    2 cached, 2 total
  Time:    669ms >>> FULL TURBO
```


Closes TURBO-2051