### PR TITLE
fix: forward fixes for LSP

### DIFF
--- a/crates/turborepo-lib/src/daemon/connector.rs
+++ b/crates/turborepo-lib/src/daemon/connector.rs
@@ -714,7 +714,7 @@ mod test {
             .await
             .unwrap_err()
             .into();
-        assert_matches!(hello_resp, DaemonError::VersionMismatch);
+        assert_matches!(hello_resp, DaemonError::VersionMismatch(_));
         let client = DaemonClient::new(client);
 
         let shutdown_fut = conn.kill_live_server(client, Pid::from(1000));

--- a/crates/turborepo-lsp/Cargo.toml
+++ b/crates/turborepo-lsp/Cargo.toml
@@ -4,6 +4,11 @@ version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 
+[features]
+default = ["rustls-tls"]
+native-tls = ["turborepo-lib/native-tls"]
+rustls-tls = ["turborepo-lib/rustls-tls"]
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/crates/turborepo-lsp/src/lib.rs
+++ b/crates/turborepo-lsp/src/lib.rs
@@ -3,6 +3,7 @@
 
 use std::{
     collections::{HashMap, HashSet},
+    str::FromStr,
     sync::{Arc, Mutex},
 };
 

--- a/crates/turborepo-repository/src/package_json.rs
+++ b/crates/turborepo-repository/src/package_json.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, str::FromStr};
 
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
@@ -59,10 +59,6 @@ impl PackageJson {
         Self::from_str(&contents)
     }
 
-    pub fn from_str(contents: &str) -> Result<PackageJson, Error> {
-        Ok(serde_json::from_str(contents)?)
-    }
-
     // Utility method for easy construction of package.json during testing
     pub fn from_value(value: serde_json::Value) -> Result<PackageJson, Error> {
         let package_json: PackageJson = serde_json::from_value(value)?;
@@ -75,6 +71,14 @@ impl PackageJson {
             .flatten()
             .chain(self.optional_dependencies.iter().flatten())
             .chain(self.dependencies.iter().flatten())
+    }
+}
+
+impl FromStr for PackageJson {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(serde_json::from_str(s)?)
     }
 }
 

--- a/crates/turborepo/build.rs
+++ b/crates/turborepo/build.rs
@@ -8,7 +8,7 @@ fn main() {
 
     let invocation = std::env::var("RUSTC_WRAPPER").unwrap_or_default();
     if !is_ci_release && !invocation.ends_with("rust-analyzer") {
-        // build_local_go_binary(profile);
+        build_local_go_binary(profile);
     }
 }
 


### PR DESCRIPTION
### Description

#6543 accidentally broke some things. This PR:
 - adds back building the Go binary to `turbo`'s build script
 - Lifts TLS backend features from `turborepo-lib` to `turborepo-lsp` now that the LSP crate is an entry point to the crate. (Matters as `cargo-groups` prunes `check` runs to only run against the entry points and now errors complaining that the feature doesn't exist)
 - Fixes clippy warning about `FromStr`
 - Fixes test that didn't compile

### Testing Instructions

CI Passes 👀 


Closes TURBO-2056