### PR TITLE
fix: add missing layer ident modifier to asset with inner assets

### DIFF
--- a/crates/turbopack-ecmascript/src/lib.rs
+++ b/crates/turbopack-ecmascript/src/lib.rs
@@ -509,6 +509,7 @@ impl Module for EcmascriptModuleAsset {
                 ident.add_asset(Vc::cell(name.clone()), asset.ident());
             }
             ident.add_modifier(modifier());
+            ident.layer = Some(self.asset_context.layer());
             Ok(AssetIdent::new(Value::new(ident)))
         } else {
             Ok(self


### PR DESCRIPTION
### Description

This is causing some chunk items to be loaded twice.
