### PR TITLE
Sokra/fix hanging

### DIFF
--- a/crates/turbo-tasks-memory/src/task.rs
+++ b/crates/turbo-tasks-memory/src/task.rs
@@ -35,7 +35,7 @@ use turbo_tasks::{
 };
 
 use crate::{
-    aggregation_tree::{aggregation_info, ensure_thresholds},
+    aggregation_tree::{aggregation_info, ensure_thresholds, AggregationInfoGuard},
     cell::Cell,
     gc::{to_exp_u8, GcPriority, GcStats, GcTaskState},
     output::{Output, OutputContent},
@@ -417,7 +417,7 @@ enum TaskStateType {
 use TaskStateType::*;
 
 use self::{
-    aggregation::{RootInfoType, RootType, TaskAggregationTreeLeaf, TaskGuard},
+    aggregation::{Aggregated, RootInfoType, RootType, TaskAggregationTreeLeaf, TaskGuard},
     meta_state::{
         FullTaskWriteGuard, TaskMetaState, TaskMetaStateReadGuard, TaskMetaStateWriteGuard,
     },
@@ -490,7 +490,11 @@ impl Task {
     ) {
         let mut aggregation_context = TaskAggregationContext::new(turbo_tasks, backend);
         {
-            aggregation_context.aggregation_info(id).lock().root_type = Some(RootType::Root);
+            Self::set_root_type(
+                &aggregation_context,
+                &mut aggregation_context.aggregation_info(id).lock(),
+                RootType::Root,
+            );
         }
         aggregation_context.apply_queued_updates();
     }
@@ -502,9 +506,30 @@ impl Task {
     ) {
         let mut aggregation_context = TaskAggregationContext::new(turbo_tasks, backend);
         {
-            aggregation_context.aggregation_info(id).lock().root_type = Some(RootType::Once);
+            let aggregation_info = &aggregation_context.aggregation_info(id);
+            Self::set_root_type(
+                &aggregation_context,
+                &mut aggregation_info.lock(),
+                RootType::Once,
+            );
         }
         aggregation_context.apply_queued_updates();
+    }
+
+    fn set_root_type(
+        aggregation_context: &TaskAggregationContext,
+        aggregation: &mut AggregationInfoGuard<Aggregated>,
+        root_type: RootType,
+    ) {
+        aggregation.root_type = Some(root_type);
+        let dirty_tasks = aggregation
+            .dirty_tasks
+            .iter()
+            .filter_map(|(&id, &count)| (count > 0).then_some(id));
+        let mut tasks_to_schedule = aggregation_context.dirty_tasks_to_schedule.lock();
+        tasks_to_schedule
+            .get_or_insert_default()
+            .extend(dirty_tasks);
     }
 
     pub(crate) fn unset_root(
@@ -601,7 +626,7 @@ impl Task {
                 });
             }
             TaskDependency::Collectibles(task, trait_type) => {
-                let mut aggregation_context = TaskAggregationContext::new(turbo_tasks, backend);
+                let aggregation_context = TaskAggregationContext::new(turbo_tasks, backend);
                 let aggregation = aggregation_context.aggregation_info(task);
                 aggregation
                     .lock()
@@ -1518,14 +1543,26 @@ impl Task {
         let mut state = self.full_state_mut();
         if let Some(aggregation) = aggregation_when_strongly_consistent {
             {
-                let aggregation = aggregation.lock();
+                let mut aggregation = aggregation.lock();
                 if aggregation.unfinished > 0 {
+                    if aggregation.root_type.is_none() {
+                        Self::set_root_type(
+                            &mut aggregation_context,
+                            &mut aggregation,
+                            RootType::ReadingStronglyConsistent,
+                        );
+                    }
                     let listener = aggregation.unfinished_event.listen_with_note(note);
                     drop(aggregation);
                     drop(state);
                     aggregation_context.apply_queued_updates();
 
                     return Ok(Err(listener));
+                } else if matches!(
+                    aggregation.root_type,
+                    Some(RootType::ReadingStronglyConsistent)
+                ) {
+                    aggregation.root_type = None;
                 }
             }
         }
@@ -1576,7 +1613,7 @@ impl Task {
         backend: &MemoryBackend,
         turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackend>,
     ) -> AutoMap<RawVc, i32> {
-        let mut aggregation_context = TaskAggregationContext::new(turbo_tasks, backend);
+        let aggregation_context = TaskAggregationContext::new(turbo_tasks, backend);
         aggregation_context
             .aggregation_info(id)
             .lock()

--- a/crates/turbo-tasks-memory/src/task/aggregation.rs
+++ b/crates/turbo-tasks-memory/src/task/aggregation.rs
@@ -238,7 +238,7 @@ impl<'a> AggregationContext for TaskAggregationContext<'a> {
         let mut unfinished = 0;
         if info.unfinished > 0 {
             info.unfinished += change.unfinished;
-            if info.unfinished == 0 {
+            if info.unfinished <= 0 {
                 info.unfinished_event.notify(usize::MAX);
                 unfinished = -1;
             }

--- a/crates/turbo-tasks-memory/src/task/aggregation.rs
+++ b/crates/turbo-tasks-memory/src/task/aggregation.rs
@@ -21,6 +21,7 @@ use crate::{
 pub enum RootType {
     Once,
     Root,
+    ReadingStronglyConsistent,
 }
 
 #[derive(Debug, Default)]
@@ -59,8 +60,9 @@ pub struct Aggregated {
 
     /// Only used for the aggregation root. Which kind of root is this?
     /// [RootType::Once] for OnceTasks or [RootType::Root] for Root Tasks.
-    /// It's set to None for other tasks, when the once task is done or when the
-    /// root task is disposed.
+    /// [RootType::ReadingStronglyConsistent] while currently reading a task
+    /// strongly consistent. It's set to None for other tasks, when the once
+    /// task is done or when the root task is disposed.
     pub root_type: Option<RootType>,
 }
 
@@ -189,7 +191,7 @@ impl<'a> TaskAggregationContext<'a> {
         }
     }
 
-    pub fn aggregation_info(&mut self, id: TaskId) -> AggregationInfoReference<Aggregated> {
+    pub fn aggregation_info(&self, id: TaskId) -> AggregationInfoReference<Aggregated> {
         aggregation_info(self, &id)
     }
 }
@@ -250,12 +252,10 @@ impl<'a> AggregationContext for TaskAggregationContext<'a> {
         for &(task, count) in change.unfinished_tasks_update.iter() {
             update_count_entry(info.unfinished_tasks.entry(task), count);
         }
+        let is_root = matches!(info.root_type, Some(_));
         for &(task, count) in change.dirty_tasks_update.iter() {
             let value = update_count_entry(info.dirty_tasks.entry(task), count);
-            if value > 0
-                && value <= count
-                && matches!(info.root_type, Some(RootType::Root) | Some(RootType::Once))
-            {
+            if is_root && value > 0 && value <= count {
                 let mut tasks_to_schedule = self.dirty_tasks_to_schedule.lock();
                 tasks_to_schedule.get_or_insert_default().insert(task);
             }


### PR DESCRIPTION
### Description

This fixes a bug where inactive tasks get stuck in "in progress" which causes the updateInfo stream to be incorrect (not ending).

It can happen when
* a task reads something strongly consistent
* the task (subgraph) is not active (e.g. was removed due to changes)

In this case the strongly consistent read will never finish as it waits for the subgraph to finish, but dirty tasks in that subgraph won't be scheduled as the subgraph is not active.

This PR fixes that by making a subgraph that is currently strongly consistently read temporarily active (while being read).

That's similar to normal read scheduling dirty tasks.

We never want in progress tasks to be blocked by anything. Any blocker should be resolved by executing tasks.

Potential alternative: We could also change dirty tasks to not count as pending. That would also allow any strongly consistent read to complete, but it won't be consistent with changes that caused these tasks to be dirty.
