### PR TITLE
add lazy_remove_children feature flag

### DIFF
--- a/crates/turbo-tasks-memory/Cargo.toml
+++ b/crates/turbo-tasks-memory/Cargo.toml
@@ -54,7 +54,8 @@ print_scope_updates = []
 print_task_invalidation = []
 inline_add_to_scope = []
 inline_remove_from_scope = []
-default = []
+lazy_remove_children = []
+default = ["lazy_remove_children"]
 
 [[bench]]
 name = "mod"

--- a/crates/turbo-tasks-memory/src/task.rs
+++ b/crates/turbo-tasks-memory/src/task.rs
@@ -724,6 +724,7 @@ impl Task {
             {
                 remove_job();
             }
+            #[allow(clippy::let_and_return)]
             result
         };
         aggregation_context.apply_queued_updates();


### PR DESCRIPTION
### Description

Add a feature flag to make it easy to disable lazy removal of children. Just in case I want to figure out if this is causing a specific problem in future.

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->


Closes PACK-2269