### PR TITLE
fix(ecmascript): collect recoverable error after parse

### DIFF
--- a/crates/turbopack-ecmascript/src/parse.rs
+++ b/crates/turbopack-ecmascript/src/parse.rs
@@ -304,6 +304,7 @@ async fn parse_content(
                 );
 
                 let mut parser = Parser::new_from(lexer);
+                let program_result = parser.parse_program();
 
                 let mut has_errors = false;
                 for e in parser.take_errors() {
@@ -315,7 +316,7 @@ async fn parse_content(
                     return Ok(ParseResult::Unparseable);
                 }
 
-                match parser.parse_program() {
+                match program_result {
                     Ok(parsed_program) => parsed_program,
                     Err(e) => {
                         e.into_diagnostic(&handler).emit();


### PR DESCRIPTION
### Description

Turbopack in next.js does not report parse errors for the input like 

```
function xyz() {
...
```

which expects to report 
```
Expected '}', got '<eof>'
```

Comparing upstream swc, the only difference is turbopack collect recoveable error eagerly _before_ actual parsing, and then parse returns a parsed program. (ref: https://github.com/swc-project/swc/blob/979061f6babbbf855027b13eb574c5f3f7e24727/crates/swc_compiler_base/src/lib.rs#L62-L77)

PR fixes ordering of error collection as same as swc does. 

Confirmed next.js with this change now reports expected error. (Note: doesn't mean tests are actually fixed, the output is not matching with snapshot still)


Closes PACK-2274