### PR TITLE
feat(turbo): task access trace & cached configs

### DIFF
--- a/crates/turborepo-cache/src/lib.rs
+++ b/crates/turborepo-cache/src/lib.rs
@@ -74,6 +74,10 @@ pub enum CacheError {
     MetadataWriteFailure(serde_json::Error, #[backtrace] Backtrace),
     #[error("Unable to perform write as cache is shutting down")]
     CacheShuttingDown,
+    #[error("Unable to determine config cache base")]
+    ConfigCacheInvalidBase,
+    #[error("Unable to hash config cache inputs")]
+    ConfigCacheError,
 }
 
 impl From<turborepo_api_client::Error> for CacheError {

--- a/crates/turborepo-lib/src/run/cache.rs
+++ b/crates/turborepo-lib/src/run/cache.rs
@@ -400,33 +400,36 @@ impl ConfigCache {
         }
     }
 
+    pub fn hash(&self) -> &str {
+        &self.hash
+    }
+
     pub fn exists(&self) -> bool {
-        return self.config_file.try_exists().unwrap_or(false);
+        self.config_file.try_exists().unwrap_or(false)
     }
 
     pub async fn restore(
         &self,
     ) -> Result<Option<(CacheHitMetadata, Vec<AnchoredSystemPathBuf>)>, CacheError> {
-        return self.cache.fetch(&self.repo_root, &self.hash).await;
+        self.cache.fetch(&self.repo_root, &self.hash).await
     }
 
     pub async fn save(&self) -> Result<(), CacheError> {
         match self.exists() {
             true => {
                 debug!("config file exists, caching");
-                return self
-                    .cache
+                self.cache
                     .put(
                         self.repo_root.clone(),
                         self.hash.clone(),
                         vec![self.anchored_path.clone()],
                         0,
                     )
-                    .await;
+                    .await
             }
             false => {
                 debug!("config file does not exist, skipping cache save");
-                return Ok(());
+                Ok(())
             }
         }
     }
@@ -445,11 +448,11 @@ impl ConfigCache {
 
         // empty inputs to get all files
         let inputs: Vec<String> = vec![];
-        let hash_object =
-            match scm.get_package_file_hashes(&repo_root, &anchored_root, &inputs, None) {
-                Ok(hash_object) => hash_object,
-                Err(_) => return Err(CacheError::ConfigCacheError),
-            };
+        let hash_object = match scm.get_package_file_hashes(repo_root, anchored_root, &inputs, None)
+        {
+            Ok(hash_object) => hash_object,
+            Err(_) => return Err(CacheError::ConfigCacheError),
+        };
 
         // return the hash
         Ok(FileHashes(hash_object).hash())

--- a/crates/turborepo-lib/src/run/cache.rs
+++ b/crates/turborepo-lib/src/run/cache.rs
@@ -44,7 +44,7 @@ pub enum Error {
 
 pub struct RunCache {
     task_output_mode: Option<OutputLogsMode>,
-    cache: Arc<AsyncCache>,
+    cache: AsyncCache,
     reads_disabled: bool,
     writes_disabled: bool,
     repo_root: AbsoluteSystemPathBuf,
@@ -55,7 +55,7 @@ pub struct RunCache {
 
 impl RunCache {
     pub fn new(
-        cache: Arc<AsyncCache>,
+        cache: AsyncCache,
         repo_root: &AbsoluteSystemPath,
         opts: &RunCacheOpts,
         color_selector: ColorSelector,
@@ -380,7 +380,7 @@ pub struct ConfigCache {
     repo_root: AbsoluteSystemPathBuf,
     config_file: AbsoluteSystemPathBuf,
     anchored_path: AnchoredSystemPathBuf,
-    cache: Arc<AsyncCache>,
+    cache: AsyncCache,
 }
 
 impl ConfigCache {
@@ -388,7 +388,7 @@ impl ConfigCache {
         hash: String,
         repo_root: AbsoluteSystemPathBuf,
         config_path: &[&str],
-        cache: Arc<AsyncCache>,
+        cache: AsyncCache,
     ) -> Self {
         let config_file = repo_root.join_components(config_path);
         ConfigCache {

--- a/crates/turborepo-lib/src/run/cache.rs
+++ b/crates/turborepo-lib/src/run/cache.rs
@@ -2,9 +2,12 @@ use std::{io::Write, sync::Arc, time::Duration};
 
 use console::StyledObject;
 use tracing::debug;
-use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPathBuf};
+use turbopath::{
+    AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPath, AnchoredSystemPathBuf,
+};
 use turborepo_cache::{AsyncCache, CacheError, CacheHitMetadata, CacheSource};
 use turborepo_repository::package_graph::WorkspaceInfo;
+use turborepo_scm::SCM;
 use turborepo_telemetry::events::{task::PackageTaskEventBuilder, TrackedErrors};
 use turborepo_ui::{
     color, replay_logs, ColorSelector, LogWriter, PrefixedUI, PrefixedWriter, GREY, UI,
@@ -13,6 +16,7 @@ use turborepo_ui::{
 use crate::{
     cli::OutputLogsMode,
     daemon::{DaemonClient, DaemonConnector},
+    hash::{FileHashes, TurboHash},
     opts::RunCacheOpts,
     run::task_id::TaskId,
     task_graph::{TaskDefinition, TaskOutputs},
@@ -32,11 +36,15 @@ pub enum Error {
     Daemon(#[from] crate::daemon::DaemonError),
     #[error("no connection to daemon")]
     NoDaemon,
+    #[error(transparent)]
+    Scm(#[from] turborepo_scm::Error),
+    #[error(transparent)]
+    Path(#[from] turbopath::PathError),
 }
 
 pub struct RunCache {
     task_output_mode: Option<OutputLogsMode>,
-    cache: AsyncCache,
+    cache: Arc<AsyncCache>,
     reads_disabled: bool,
     writes_disabled: bool,
     repo_root: AbsoluteSystemPathBuf,
@@ -47,7 +55,7 @@ pub struct RunCache {
 
 impl RunCache {
     pub fn new(
-        cache: AsyncCache,
+        cache: Arc<AsyncCache>,
         repo_root: &AbsoluteSystemPath,
         opts: &RunCacheOpts,
         color_selector: ColorSelector,
@@ -363,5 +371,87 @@ impl TaskCache {
 
     pub fn expanded_outputs(&self) -> &[AnchoredSystemPathBuf] {
         &self.expanded_outputs
+    }
+}
+
+#[derive(Clone)]
+pub struct ConfigCache {
+    hash: String,
+    repo_root: AbsoluteSystemPathBuf,
+    config_file: AbsoluteSystemPathBuf,
+    anchored_path: AnchoredSystemPathBuf,
+    cache: Arc<AsyncCache>,
+}
+
+impl ConfigCache {
+    pub fn new(
+        hash: String,
+        repo_root: AbsoluteSystemPathBuf,
+        config_path: &[&str],
+        cache: Arc<AsyncCache>,
+    ) -> Self {
+        let config_file = repo_root.join_components(config_path);
+        ConfigCache {
+            hash,
+            repo_root: repo_root.clone(),
+            config_file: config_file.clone(),
+            anchored_path: AnchoredSystemPathBuf::relative_path_between(&repo_root, &config_file),
+            cache,
+        }
+    }
+
+    pub fn exists(&self) -> bool {
+        return self.config_file.try_exists().unwrap_or(false);
+    }
+
+    pub async fn restore(
+        &self,
+    ) -> Result<Option<(CacheHitMetadata, Vec<AnchoredSystemPathBuf>)>, CacheError> {
+        return self.cache.fetch(&self.repo_root, &self.hash).await;
+    }
+
+    pub async fn save(&self) -> Result<(), CacheError> {
+        match self.exists() {
+            true => {
+                debug!("config file exists, caching");
+                return self
+                    .cache
+                    .put(
+                        self.repo_root.clone(),
+                        self.hash.clone(),
+                        vec![self.anchored_path.clone()],
+                        0,
+                    )
+                    .await;
+            }
+            false => {
+                debug!("config file does not exist, skipping cache save");
+                return Ok(());
+            }
+        }
+    }
+
+    // The config hash is used for task access tracing, and is keyed off of all
+    // files in the repository
+    pub fn calculate_config_hash(
+        scm: &SCM,
+        repo_root: &AbsoluteSystemPathBuf,
+    ) -> Result<String, CacheError> {
+        // empty path to get all files
+        let anchored_root = match AnchoredSystemPath::new("") {
+            Ok(anchored_root) => anchored_root,
+            Err(_) => return Err(CacheError::ConfigCacheInvalidBase),
+        };
+
+        // empty inputs to get all files
+        let inputs: Vec<String> = vec![];
+        let hash_object =
+            match scm.get_package_file_hashes(&repo_root, &anchored_root, &inputs, None) {
+                Ok(hash_object) => hash_object,
+                Err(_) => return Err(CacheError::ConfigCacheError),
+            };
+
+        // return the hash
+        Ok(FileHashes(hash_object).hash())
     }
 }

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -317,13 +317,13 @@ impl Run {
         run_telemetry.track_run_type(self.opts.run_opts.dry_run.is_some());
 
         let scm = scm.await.expect("detecting scm panicked");
-        let async_cache = Arc::new(AsyncCache::new(
+        let async_cache = AsyncCache::new(
             &self.opts.cache_opts,
             &self.base.repo_root,
             api_client.clone(),
             self.api_auth.clone(),
             analytics_sender,
-        )?);
+        )?;
 
         // restore config from task access trace if it's enabled
         let task_access = TaskAccess::new(self.base.repo_root.clone(), async_cache.clone(), &scm);

--- a/crates/turborepo-lib/src/run/task_access.rs
+++ b/crates/turborepo-lib/src/run/task_access.rs
@@ -1,0 +1,188 @@
+use std::{
+    collections::HashMap,
+    fs::{self, File},
+    io::{Error, Write},
+    sync::{Arc, Mutex},
+};
+
+use serde::Deserialize;
+use tracing::{debug, error, warn};
+use turbopath::{AbsoluteSystemPathBuf, PathRelation};
+
+// Environment variable key that will be used to enable, and set the expected
+// trace location
+pub const TASK_ACCESS_ENV_KEY: &str = "TURBOREPO_TRACE_FILE";
+/// File name where the task is expected to leave a trace result
+pub const TASK_ACCESS_TRACE_NAME: &str = "trace.json";
+// Path to the config file that will be used to store the trace results
+pub const TASK_ACCESS_CONFIG_PATH: [&str; 2] = [".turbo", "traced-config.json"];
+
+use super::ConfigCache;
+use crate::{config::RawTurboJson, unescape::UnescapedString};
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct TaskAccessTraceAccess {
+    pub network: bool,
+    pub file_paths: Vec<UnescapedString>,
+    pub env_var_keys: Vec<UnescapedString>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct TaskAccessTraceFile {
+    pub accessed: TaskAccessTraceAccess,
+    pub outputs: Vec<UnescapedString>,
+}
+
+#[derive(Deserialize, Debug)]
+struct PackageJson {
+    scripts: Option<std::collections::HashMap<String, String>>,
+}
+
+pub fn trace_file_path(
+    repo_root: &AbsoluteSystemPathBuf,
+    task_hash: &str,
+) -> AbsoluteSystemPathBuf {
+    return repo_root.join_components(&[".turbo", task_hash, TASK_ACCESS_TRACE_NAME]);
+}
+
+pub fn task_access_trace_enabled(repo_root: &AbsoluteSystemPathBuf) -> Result<bool, Error> {
+    // read package.json at root
+    let package_json_path = repo_root.join_components(&["package.json"]);
+    // parse Json
+    let package_json_content = fs::read_to_string(package_json_path)?;
+    let package: PackageJson = serde_json::from_str(&package_json_content)?;
+
+    if let Some(scripts) = package.scripts {
+        return match scripts.get("build") {
+            Some(script) => Ok(script == "next build"),
+            _ => Ok(false),
+        };
+    }
+
+    Ok(false)
+}
+
+impl TaskAccessTraceFile {
+    pub fn read(repo_root: &AbsoluteSystemPathBuf, task_hash: &str) -> Option<TaskAccessTraceFile> {
+        let trace_file = trace_file_path(repo_root, task_hash);
+
+        let Ok(f) = trace_file.open() else {
+            return None;
+        };
+
+        return match serde_json::from_reader(f) {
+            Ok(trace) => Some(Self::from(trace)),
+            Err(e) => {
+                warn!("failed to parse trace file {trace_file}: {e}");
+                return None;
+            }
+        };
+    }
+
+    pub fn can_cache(&self, repo_root: &AbsoluteSystemPathBuf) -> bool {
+        // network
+        if self.accessed.network {
+            warn!(
+                "skipping automatic task caching - detected network
+        access",
+            );
+            return false;
+        }
+
+        // file system
+        for unescaped_str in &self.accessed.file_paths {
+            match AbsoluteSystemPathBuf::new(unescaped_str.to_string()) {
+                Ok(path) => {
+                    let relation = path.relation_to_path(repo_root);
+                    // only paths within the repo can be automatically cached
+                    if relation == PathRelation::Parent || relation == PathRelation::Divergent {
+                        warn!(
+                            "skipping automatic task caching - file accessed outside of repo root \
+                             ({})",
+                            unescaped_str
+                        );
+                        return false;
+                    }
+                }
+                Err(e) => {
+                    debug!("failed to parse path {unescaped_str}: {e}");
+                }
+            }
+        }
+
+        true
+    }
+}
+
+#[derive(Clone)]
+pub struct TaskAccess {
+    pub repo_root: AbsoluteSystemPathBuf,
+    trace_by_task: Arc<Mutex<HashMap<String, TaskAccessTraceFile>>>,
+    config_cache: Option<ConfigCache>,
+}
+
+impl TaskAccess {
+    pub fn new(repo_root: AbsoluteSystemPathBuf, config_cache: Option<ConfigCache>) -> Self {
+        Self {
+            repo_root,
+            config_cache,
+            trace_by_task: Arc::new(Mutex::new(HashMap::<String, TaskAccessTraceFile>::new())),
+        }
+    }
+
+    pub fn save_trace(&self, trace: TaskAccessTraceFile, task_id: String) {
+        let trace_by_task = self.trace_by_task.lock();
+        match trace_by_task {
+            Ok(mut trace_by_task) => {
+                trace_by_task.insert(task_id, trace);
+            }
+            Err(e) => {
+                error!("Failed to save trace result - {e}");
+            }
+        }
+    }
+
+    pub fn get_env_var(&self, task_hash: &str) -> (String, AbsoluteSystemPathBuf) {
+        let trace_file_path = trace_file_path(&self.repo_root, task_hash);
+        return (TASK_ACCESS_ENV_KEY.to_string(), trace_file_path);
+    }
+
+    pub async fn to_turbo_json(&self) -> Result<(), std::io::Error> {
+        if let Some(config_cache) = &self.config_cache {
+            let traced_config =
+                RawTurboJson::from_task_access_trace(&self.trace_by_task.lock().unwrap());
+            if traced_config.is_some() {
+                // convert the traced_config to json and write the file to disk
+                let traced_config_json = serde_json::to_string_pretty(&traced_config);
+                match traced_config_json {
+                    Ok(json) => {
+                        let file_path = self.repo_root.join_components(&TASK_ACCESS_CONFIG_PATH);
+                        let file = File::create(file_path);
+                        match file {
+                            Ok(mut file) => {
+                                write!(file, "{}", json)?;
+                                file.flush()?;
+                                let result = config_cache.save().await;
+                                if result.is_err() {
+                                    debug!("error saving config cache: {:#?}", result);
+                                }
+                            }
+                            Err(e) => {
+                                debug!("error creating traced_config file: {:#?}", e);
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        debug!("error converting traced_config to json: {:#?}", e);
+                    }
+                }
+            }
+        } else {
+            debug!("unable to cache config");
+        }
+
+        Ok(())
+    }
+}

--- a/crates/turborepo-lib/src/run/task_access.rs
+++ b/crates/turborepo-lib/src/run/task_access.rs
@@ -27,11 +27,11 @@ const TURBO_CONFIG_FILE: &str = "turbo.json";
 #[derive(Debug, thiserror::Error)]
 pub enum ToFileError {
     #[error("Unable to serialize traced config: {0}")]
-    ConfigSerializeError(#[from] serde_json::Error),
+    Serialize(#[from] serde_json::Error),
     #[error("Unable to write traced config: {0}")]
-    ConfigIOError(#[from] std::io::Error),
+    IO(#[from] std::io::Error),
     #[error("Unable to cache traced config: {0}")]
-    ConfigCacheError(#[from] turborepo_cache::CacheError),
+    Cache(#[from] turborepo_cache::CacheError),
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -212,7 +212,7 @@ impl TaskAccess {
         (TASK_ACCESS_ENV_KEY.to_string(), trace_file_path)
     }
 
-    pub async fn save(&self) -> () {
+    pub async fn save(&self) {
         match self.to_file().await {
             Ok(_) => (),
             Err(e) => {

--- a/crates/turborepo-lib/src/task_graph/visitor.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor.rs
@@ -871,22 +871,19 @@ impl ExecContext {
                 // Attempt to flush stdout_writer and log any errors encountered
                 if let Err(e) = stdout_writer.flush() {
                     error!("{e}");
-                } else {
-                    if self
-                        .task_access
-                        .can_cache(&self.task_hash, &self.task_id_for_display)
-                        .unwrap_or(true)
-                    {
-                        if let Err(e) = self.task_cache.save_outputs(task_duration, telemetry).await
-                        {
-                            error!("error caching output: {e}");
-                        } else {
-                            // If no errors, update hash tracker with expanded outputs
-                            self.hash_tracker.insert_expanded_outputs(
-                                self.task_id.clone(),
-                                self.task_cache.expanded_outputs().to_vec(),
-                            );
-                        }
+                } else if self
+                    .task_access
+                    .can_cache(&self.task_hash, &self.task_id_for_display)
+                    .unwrap_or(true)
+                {
+                    if let Err(e) = self.task_cache.save_outputs(task_duration, telemetry).await {
+                        error!("error caching output: {e}");
+                    } else {
+                        // If no errors, update hash tracker with expanded outputs
+                        self.hash_tracker.insert_expanded_outputs(
+                            self.task_id.clone(),
+                            self.task_cache.expanded_outputs().to_vec(),
+                        );
                     }
                 }
 

--- a/crates/turborepo-lib/src/task_graph/visitor.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor.rs
@@ -899,10 +899,7 @@ impl ExecContext {
 
                     if cacheable {
                         // Attempt to save task outputs and log any errors encountered
-                        if let Err(e) = self
-                            .task_cache
-                            .save_outputs(&mut prefixed_ui, task_duration, telemetry)
-                            .await
+                        if let Err(e) = self.task_cache.save_outputs(task_duration, telemetry).await
                         {
                             error!("error caching output: {e}");
                         } else {

--- a/crates/turborepo-lib/src/task_graph/visitor.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor.rs
@@ -565,6 +565,7 @@ impl<'a> ExecContextFactory<'a> {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn exec_context(
         &self,
         task_id: TaskId<'static>,

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -355,16 +355,19 @@ impl RawTurboJson {
         let mut pipeline = Pipeline::default();
 
         for (task_name, trace_file) in trace {
-            let mut task_definition = RawTaskDefinition::default();
-            task_definition.outputs = Some(Spanned::new(trace_file.outputs.clone()));
-            task_definition.env = Some(
-                trace_file
-                    .accessed
-                    .env_var_keys
-                    .iter()
-                    .map(|unescaped_string| Spanned::new(unescaped_string.clone()))
-                    .collect(),
-            );
+            let task_definition = RawTaskDefinition {
+                outputs: Some(Spanned::new(trace_file.outputs.clone())),
+                env: Some(
+                    trace_file
+                        .accessed
+                        .env_var_keys
+                        .iter()
+                        .map(|unescaped_string| Spanned::new(unescaped_string.clone()))
+                        .collect(),
+                ),
+                ..Default::default()
+            };
+
             let name = TaskName::from(task_name.as_str());
             let root_task = name.into_root_task();
             pipeline.insert(root_task, task_definition);

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     ops::{Deref, DerefMut},
     sync::Arc,
 };
@@ -7,6 +7,7 @@ use std::{
 use camino::Utf8Path;
 use serde::{Deserialize, Serialize};
 use struct_iterable::Iterable;
+use tracing::debug;
 use turbopath::{AbsoluteSystemPath, AnchoredSystemPath, RelativeUnixPathBuf};
 use turborepo_errors::Spanned;
 use turborepo_repository::{package_graph::ROOT_PKG_NAME, package_json::PackageJson};
@@ -14,7 +15,10 @@ use turborepo_repository::{package_graph::ROOT_PKG_NAME, package_json::PackageJs
 use crate::{
     cli::OutputLogsMode,
     config::{ConfigurationOptions, Error},
-    run::task_id::{TaskId, TaskName},
+    run::{
+        task_access::{TaskAccessTraceFile, TASK_ACCESS_CONFIG_PATH},
+        task_id::{TaskId, TaskName},
+    },
     task_graph::{TaskDefinition, TaskOutputs},
     unescape::UnescapedString,
 };
@@ -35,7 +39,7 @@ pub struct SpacesJson {
 // turbo.json files into a single definition. Therefore we keep the
 // `RawTaskDefinition` type so we can determine which fields are actually
 // set when we resolve the configuration.
-#[derive(Debug, Default, Clone, PartialEq)]
+#[derive(Debug, Default, Clone, PartialEq, Serialize)]
 pub struct TurboJson {
     text: Option<Arc<str>>,
     path: Option<Arc<str>>,
@@ -342,6 +346,35 @@ impl RawTurboJson {
 
         this
     }
+
+    pub fn from_task_access_trace(trace: &HashMap<String, TaskAccessTraceFile>) -> Option<Self> {
+        if trace.is_empty() {
+            return None;
+        }
+
+        let mut pipeline = Pipeline::default();
+
+        for (task_name, trace_file) in trace {
+            let mut task_definition = RawTaskDefinition::default();
+            task_definition.outputs = Some(Spanned::new(trace_file.outputs.clone()));
+            task_definition.env = Some(
+                trace_file
+                    .accessed
+                    .env_var_keys
+                    .iter()
+                    .map(|unescaped_string| Spanned::new(unescaped_string.clone()))
+                    .collect(),
+            );
+            let name = TaskName::from(task_name.as_str());
+            let root_task = name.into_root_task();
+            pipeline.insert(root_task, task_definition);
+        }
+
+        Some(RawTurboJson {
+            pipeline: Some(pipeline),
+            ..RawTurboJson::default()
+        })
+    }
 }
 
 impl TryFrom<RawTurboJson> for TurboJson {
@@ -451,6 +484,15 @@ impl TurboJson {
         }
 
         let turbo_from_files = Self::read(repo_root, &dir.join_component(CONFIG_FILE));
+        let turbo_from_trace = Self::read(&dir.join_components(&TASK_ACCESS_CONFIG_PATH));
+
+        // check the zero config case (turbo trace file, but no turbo.json file)
+        if let Ok(turbo_from_trace) = turbo_from_trace {
+            if turbo_from_files.is_err() {
+                debug!("Using turbo.json synthesized from trace file");
+                return Ok(turbo_from_trace);
+            }
+        }
 
         let mut turbo_json = match (include_synthesized_from_root_package_json, turbo_from_files) {
             // If the file didn't exist, throw a custom error here instead of propagating

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -370,7 +370,7 @@ impl RawTurboJson {
 
             let name = TaskName::from(task_name.as_str());
             let root_task = name.into_root_task();
-            pipeline.insert(root_task, task_definition);
+            pipeline.insert(root_task, Spanned::new(task_definition.clone()));
         }
 
         Some(RawTurboJson {
@@ -487,7 +487,8 @@ impl TurboJson {
         }
 
         let turbo_from_files = Self::read(repo_root, &dir.join_component(CONFIG_FILE));
-        let turbo_from_trace = Self::read(&dir.join_components(&TASK_ACCESS_CONFIG_PATH));
+        let turbo_from_trace =
+            Self::read(repo_root, &dir.join_components(&TASK_ACCESS_CONFIG_PATH));
 
         // check the zero config case (turbo trace file, but no turbo.json file)
         if let Ok(turbo_from_trace) = turbo_from_trace {

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -355,8 +355,13 @@ impl RawTurboJson {
         let mut pipeline = Pipeline::default();
 
         for (task_name, trace_file) in trace {
+            let spanned_outputs: Vec<Spanned<UnescapedString>> = trace_file
+                .outputs
+                .iter()
+                .map(|output| Spanned::new(output.clone()))
+                .collect();
             let task_definition = RawTaskDefinition {
-                outputs: Some(Spanned::new(trace_file.outputs.clone())),
+                outputs: Some(spanned_outputs),
                 env: Some(
                     trace_file
                         .accessed

--- a/crates/turborepo-paths/src/anchored_system_path.rs
+++ b/crates/turborepo-paths/src/anchored_system_path.rs
@@ -1,6 +1,7 @@
 use std::{fmt, path::Path};
 
 use camino::{Utf8Component, Utf8Path};
+use path_clean::PathClean;
 use serde::Serialize;
 
 use crate::{AnchoredSystemPathBuf, PathError, RelativeUnixPathBuf};
@@ -98,5 +99,19 @@ impl AnchoredSystemPath {
     pub fn join_component(&self, segment: &str) -> AnchoredSystemPathBuf {
         debug_assert!(!segment.contains(std::path::MAIN_SEPARATOR));
         AnchoredSystemPathBuf(self.0.join(segment))
+    }
+
+    pub fn join_components(&self, segments: &[&str]) -> AnchoredSystemPathBuf {
+        debug_assert!(!segments
+            .iter()
+            .any(|segment| segment.contains(std::path::MAIN_SEPARATOR)));
+        AnchoredSystemPathBuf(
+            self.0
+                .join(segments.join(std::path::MAIN_SEPARATOR_STR))
+                .as_std_path()
+                .clean()
+                .try_into()
+                .unwrap(),
+        )
     }
 }


### PR DESCRIPTION
### Description

v0 of work required for zero config (experimental):
1. Support config caching
2. Support task tracing

Requires: https://github.com/vercel/next.js/pull/59553

#### TODO
- [ ] Testing
- [ ] Support caching outputs on first run instead of second (turbo.json uncoupling)
