### PR TITLE
feat: add ability to spawn child process with pty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1668,7 +1668,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5080df6b0f0ecb76cab30808f00d937ba725cebe266a3da8cd89dff92f2a9916"
 dependencies = [
  "async-trait",
- "nix",
+ "nix 0.26.2",
  "tokio",
  "winapi 0.3.9",
 ]
@@ -2279,7 +2279,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a011bbe2c35ce9c1f143b7af6f94f29a167beb4cd1d29e6740ce836f723120e"
 dependencies = [
- "nix",
+ "nix 0.26.2",
  "windows-sys 0.48.0",
 ]
 
@@ -2649,6 +2649,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
+
+[[package]]
 name = "drop_bomb"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2887,6 +2893,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9f0c14694cbd524c8720dd69b0e3179344f04ebb5f90f2e4a440c6ea3b2f1ee"
 dependencies = [
  "log 0.4.20",
+]
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7199d965852c3bac31f779ef99cbb4537f80e952e2d6aa0ffeb30cce00f4f46e"
+dependencies = [
+ "libc",
+ "thiserror",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -4024,6 +4041,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ioctl-rs"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7970510895cee30b3e9128319f2cefd4bde883a39f38baa279567ba3a7eb97d"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "iovec"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4076,7 +4102,7 @@ checksum = "334e04b4d781f436dc315cb1e7515bd96826426345d498149e4bde36b67f8ee9"
 dependencies = [
  "async-channel",
  "castaway",
- "crossbeam-utils 0.7.2",
+ "crossbeam-utils 0.8.16",
  "curl",
  "curl-sys",
  "encoding_rs",
@@ -4721,6 +4747,15 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg 1.1.0",
+]
+
+[[package]]
+name = "memoffset"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
@@ -5120,6 +5155,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f71d09d5c87634207f894c6b31b6a2b2c64ea3bdcf71bd5599fdbbe1600c00f"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "nix"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
+dependencies = [
+ "autocfg 1.1.0",
+ "bitflags 1.3.2",
+ "cfg-if 1.0.0",
+ "libc",
+ "memoffset 0.6.5",
+ "pin-utils",
 ]
 
 [[package]]
@@ -6005,6 +6054,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26f6a7b87c2e435a3241addceeeff740ff8b7e76b74c13bf9acb17fa454ea00b"
 
 [[package]]
+name = "portable-pty"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806ee80c2a03dbe1a9fb9534f8d19e4c0546b790cde8fd1fea9d6390644cb0be"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "downcast-rs",
+ "filedescriptor",
+ "lazy_static",
+ "libc",
+ "log 0.4.20",
+ "nix 0.25.1",
+ "serial",
+ "shared_library",
+ "shell-words",
+ "winapi 0.3.9",
+ "winreg 0.10.1",
+]
+
+[[package]]
 name = "portpicker"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6041,7 +6111,7 @@ dependencies = [
  "findshlibs",
  "libc",
  "log 0.4.20",
- "nix",
+ "nix 0.26.2",
  "once_cell",
  "parking_lot 0.12.1",
  "prost",
@@ -7363,6 +7433,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1237a96570fc377c13baa1b88c7589ab66edced652e43ffb17088f003db3e86"
+dependencies = [
+ "serial-core",
+ "serial-unix",
+ "serial-windows",
+]
+
+[[package]]
+name = "serial-core"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f46209b345401737ae2125fe5b19a77acce90cd53e1658cda928e4fe9a64581"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "serial-unix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f03fbca4c9d866e24a459cbca71283f545a37f8e3e002ad8c70593871453cab7"
+dependencies = [
+ "ioctl-rs",
+ "libc",
+ "serial-core",
+ "termios 0.2.2",
+]
+
+[[package]]
+name = "serial-windows"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15c6d3b776267a75d31bbdfd5d36c0ca051251caafc285827052bc53bcdc8162"
+dependencies = [
+ "libc",
+ "serial-core",
+]
+
+[[package]]
 name = "sha-1"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7449,6 +7561,16 @@ checksum = "b0d94659ad3c2137fef23ae75b03d5241d633f8acded53d672decfa0e6e0caef"
 dependencies = [
  "libc",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "shared_library"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
+dependencies = [
+ "lazy_static",
+ "libc",
 ]
 
 [[package]]
@@ -9575,6 +9697,15 @@ dependencies = [
 
 [[package]]
 name = "termios"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5d9cf598a6d7ce700a4e6a9199da127e6819a61e64b68609683cc9a01b5683a"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "termios"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
@@ -10724,7 +10855,7 @@ dependencies = [
  "dunce",
  "futures 0.3.28",
  "mime 0.3.17",
- "nix",
+ "nix 0.26.2",
  "once_cell",
  "owo-colors",
  "parking_lot 0.12.1",
@@ -11602,7 +11733,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "miette 5.10.0",
- "nix",
+ "nix 0.26.2",
  "node-semver",
  "notify 5.1.0",
  "num_cpus",
@@ -11611,6 +11742,7 @@ dependencies = [
  "petgraph",
  "pidlock",
  "port_scanner",
+ "portable-pty",
  "pprof",
  "pretty_assertions",
  "prost",
@@ -11859,7 +11991,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "rand 0.8.5",
  "static_assertions",
 ]
@@ -12680,7 +12812,7 @@ dependencies = [
  "shellexpand",
  "tempfile",
  "term_size",
- "termios",
+ "termios 0.3.3",
  "thiserror",
  "tokio",
  "tracing",

--- a/crates/turborepo-lib/Cargo.toml
+++ b/crates/turborepo-lib/Cargo.toml
@@ -64,6 +64,7 @@ notify = "5.1"
 path-clean = "1.0.1"
 petgraph = { workspace = true }
 pidlock = { path = "../turborepo-pidlock" }
+portable-pty = "0.8.1"
 prost = "0.11.6"
 rand = { workspace = true }
 reqwest = { workspace = true, default-features = false, features = ["json"] }

--- a/crates/turborepo-lib/src/process/child.rs
+++ b/crates/turborepo-lib/src/process/child.rs
@@ -754,6 +754,8 @@ mod test {
     use crate::process::child::{ChildExit, ShutdownStyle};
 
     const STARTUP_DELAY: Duration = Duration::from_millis(500);
+    // We skip testing PTY usage on Windows
+    const TEST_PTY: bool = !cfg!(windows);
 
     fn find_script_dir() -> AbsoluteSystemPathBuf {
         let cwd = AbsoluteSystemPathBuf::cwd().unwrap();
@@ -765,7 +767,7 @@ mod test {
     }
 
     #[test_case(false)]
-    #[test_case(true)]
+    #[test_case(TEST_PTY)]
     #[tokio::test]
     async fn test_pid(use_pty: bool) {
         let script = find_script_dir().join_component("hello_world.js");
@@ -781,7 +783,7 @@ mod test {
     }
 
     #[test_case(false)]
-    #[test_case(true)]
+    #[test_case(TEST_PTY)]
     #[tokio::test]
     #[traced_test]
     async fn test_spawn(use_pty: bool) {
@@ -809,7 +811,7 @@ mod test {
     }
 
     #[test_case(false)]
-    #[test_case(true)]
+    #[test_case(TEST_PTY)]
     #[tokio::test]
     #[traced_test]
     async fn test_stdout(use_pty: bool) {
@@ -849,13 +851,9 @@ mod test {
     }
 
     #[test_case(false)]
-    #[test_case(true)]
+    #[test_case(TEST_PTY)]
     #[tokio::test]
     async fn test_stdio(use_pty: bool) {
-        // TODO: we currently don't support Windows + PTY
-        if use_pty && cfg!(windows) {
-            return;
-        }
         let script = find_script_dir().join_component("stdin_stdout.js");
         let mut cmd = Command::new("node");
         cmd.args([script.as_std_path()]);
@@ -891,7 +889,7 @@ mod test {
     }
 
     #[test_case(false)]
-    #[test_case(true)]
+    #[test_case(TEST_PTY)]
     #[tokio::test]
     #[traced_test]
     async fn test_graceful_shutdown_timeout(use_pty: bool) {
@@ -928,7 +926,7 @@ mod test {
     }
 
     #[test_case(false)]
-    #[test_case(true)]
+    #[test_case(TEST_PTY)]
     #[tokio::test]
     #[traced_test]
     async fn test_graceful_shutdown(use_pty: bool) {
@@ -958,7 +956,7 @@ mod test {
     }
 
     #[test_case(false)]
-    #[test_case(true)]
+    #[test_case(TEST_PTY)]
     #[tokio::test]
     #[traced_test]
     async fn test_detect_killed_someone_else(use_pty: bool) {
@@ -1014,7 +1012,7 @@ mod test {
     }
 
     #[test_case(false)]
-    #[test_case(true)]
+    #[test_case(TEST_PTY)]
     #[tokio::test]
     async fn test_wait_with_output(use_pty: bool) {
         let script = find_script_dir().join_component("hello_world.js");
@@ -1056,13 +1054,9 @@ mod test {
     }
 
     #[test_case(false)]
-    #[test_case(true)]
+    #[test_case(TEST_PTY)]
     #[tokio::test]
     async fn test_wait_with_with_non_utf8_output(use_pty: bool) {
-        // TODO: fully support Windows + PTY
-        if cfg!(windows) && use_pty {
-            return;
-        }
         let script = find_script_dir().join_component("hello_non_utf8.js");
         let mut cmd = Command::new("node");
         cmd.args([script.as_std_path()]);
@@ -1083,7 +1077,7 @@ mod test {
 
     #[cfg(unix)]
     #[test_case(false)]
-    #[test_case(true)]
+    #[test_case(TEST_PTY)]
     #[tokio::test]
     async fn test_kill_process_group(use_pty: bool) {
         let mut cmd = Command::new("sh");
@@ -1103,7 +1097,7 @@ mod test {
     }
 
     #[test_case(false)]
-    #[test_case(true)]
+    #[test_case(TEST_PTY)]
     #[tokio::test]
     async fn test_multistop(use_pty: bool) {
         let script = find_script_dir().join_component("hello_world.js");

--- a/crates/turborepo-lib/src/process/child.rs
+++ b/crates/turborepo-lib/src/process/child.rs
@@ -140,9 +140,17 @@ impl ChildHandle {
 
         let command = portable_pty::CommandBuilder::from(command);
         let pty_system = native_pty_system();
-        // TODO we should forward the correct size
+        let size =
+            console::Term::stdout()
+                .size_checked()
+                .map_or_else(PtySize::default, |(rows, cols)| PtySize {
+                    rows,
+                    cols,
+                    pixel_width: 0,
+                    pixel_height: 0,
+                });
         let pair = pty_system
-            .openpty(PtySize::default())
+            .openpty(size)
             .map_err(|err| match err.downcast() {
                 Ok(err) => err,
                 Err(err) => io::Error::new(io::ErrorKind::Other, err),

--- a/crates/turborepo-lib/src/process/child.rs
+++ b/crates/turborepo-lib/src/process/child.rs
@@ -852,6 +852,10 @@ mod test {
     #[test_case(true)]
     #[tokio::test]
     async fn test_stdio(use_pty: bool) {
+        // TODO: we currently don't support Windows + PTY
+        if use_pty && cfg!(windows) {
+            return;
+        }
         let script = find_script_dir().join_component("stdin_stdout.js");
         let mut cmd = Command::new("node");
         cmd.args([script.as_std_path()]);

--- a/crates/turborepo-lib/src/process/child.rs
+++ b/crates/turborepo-lib/src/process/child.rs
@@ -1059,6 +1059,10 @@ mod test {
     #[test_case(true)]
     #[tokio::test]
     async fn test_wait_with_with_non_utf8_output(use_pty: bool) {
+        // TODO: fully support Windows + PTY
+        if cfg!(windows) && use_pty {
+            return;
+        }
         let script = find_script_dir().join_component("hello_non_utf8.js");
         let mut cmd = Command::new("node");
         cmd.args([script.as_std_path()]);

--- a/crates/turborepo-lib/src/process/command.rs
+++ b/crates/turborepo-lib/src/process/command.rs
@@ -95,6 +95,11 @@ impl Command {
             self.args.iter().map(|s| s.to_string_lossy()).join(" ")
         )
     }
+
+    /// If stdin is expected to be opened
+    pub fn will_open_stdin(&self) -> bool {
+        self.open_stdin
+    }
 }
 
 impl From<Command> for tokio::process::Command {
@@ -125,6 +130,31 @@ impl From<Command> for tokio::process::Command {
             });
         if let Some(cwd) = cwd {
             cmd.current_dir(cwd.as_std_path());
+        }
+        cmd
+    }
+}
+
+impl From<Command> for portable_pty::CommandBuilder {
+    fn from(value: Command) -> Self {
+        let Command {
+            program,
+            args,
+            cwd,
+            env,
+            env_clear,
+            ..
+        } = value;
+        let mut cmd = portable_pty::CommandBuilder::new(program);
+        if env_clear {
+            cmd.env_clear();
+        }
+        cmd.args(args);
+        if let Some(cwd) = cwd {
+            cmd.cwd(cwd.as_std_path());
+        }
+        for (key, value) in env {
+            cmd.env(key, value);
         }
         cmd
     }

--- a/crates/turborepo-lib/src/process/mod.rs
+++ b/crates/turborepo-lib/src/process/mod.rs
@@ -65,7 +65,8 @@ impl ProcessManager {
         if lock.is_closing {
             return None;
         }
-        let child = child::Child::spawn(command, child::ShutdownStyle::Graceful(stop_timeout));
+        let child =
+            child::Child::spawn(command, child::ShutdownStyle::Graceful(stop_timeout), false);
         if let Ok(child) = &child {
             lock.children.push(child.clone());
         }


### PR DESCRIPTION
### Description

This PR adds, but doesn't hook up, the ability to spawn a child process hooked up to a pseudo terminal.

I *highly* suggest reviewing each commit on its own. I tried my best to split out prefactoring work from any feature work.

### Testing Instructions

Adapt unit tests to cover all of them. It will be noted that switching to use a PTY does affect what programs output and so the tests were made to not check for identical output, but just that we got the expected output.
Closes TURBO-2128