### PR TITLE
Use `exports`  in Internal Packages doc.

### DIFF
--- a/docs/pages/repo/docs/handbook/sharing-code.mdx
+++ b/docs/pages/repo/docs/handbook/sharing-code.mdx
@@ -19,16 +19,17 @@ The fact is that they're very similar. A package is just a piece of shared code.
 
 Each package contains a `package.json`. You're likely familiar with using these to manage dependencies and scripts in your applications.
 
-However, you may not have noticed the `main` and `name` fields before:
+However, you may not have noticed the `name` and `exports` fields before:
 
 ```jsonc filename="packages/my-lib/package.json"
 {
   // The name of your package
   "name": "my-lib",
 
-  // When this package is used, this file is actually
-  // the thing that gets imported
-  "main": "./index.js"
+  // When this package is used, this file is what gets imported
+  "exports": {
+    ".": "./src/index.ts"
+  },
 }
 ```
 
@@ -50,15 +51,13 @@ myFunc(); // Hello!
 
 Then we'll be able to use the code inside the `my-lib` folder inside our applications.
 
-To summarize, **each package must have a `name` and a `main`** declared inside its `package.json`.
+To summarize, **each package must have a `name` and `exports`** declared inside its `package.json`.
 
 <Callout type="info">
 
-Package resolution in `package.json` is a very complicated topic, and we can't do justice to it here. Other fields in your `package.json` may take precedence over `main` depending on how the package is being imported.
+Package resolution in `package.json` is a very complicated topic, and we can't do justice to it here. Other fields in your `package.json` may take precedence over `exports` depending on how the package is being imported - but you should be good to go in the majority of cases.
 
-Check the [npm docs](https://docs.npmjs.com/cli/v8/configuring-npm/package-json/#main) for a guide.
-
-For our purposes, using `main` will be good enough.
+Check the [Node.js docs](https://nodejs.org/api/packages.html#package-entry-points) for a guide.
 
 </Callout>
 

--- a/docs/pages/repo/docs/handbook/sharing-code/internal-packages.mdx
+++ b/docs/pages/repo/docs/handbook/sharing-code/internal-packages.mdx
@@ -137,15 +137,16 @@ Cannot find module 'math-helpers' or its corresponding type declarations.
 
 That's because we've missed a step. We haven't told our `math-helpers/package.json` what the entry point to our package is.
 
-### 4. Fix `main` and `types`
+### 4. Fix `exports`
 
-Go back to `packages/math-helpers/package.json` and add two fields, `main` and `types`:
+Go back to `packages/math-helpers/package.json` and add a field: `exports`:
 
 ```json filename="packages/math-helpers/package.json"
 {
   "name": "math-helpers",
-  "main": "src/index.ts",
-  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
   "dependencies": {
     "typescript": "latest"
   }


### PR DESCRIPTION
### Description

While `main` and `types` works, it often corners our users into using barrel files. Instead, let's start our users off on a path that allows them to create many entrypoints to their packages if their repo were to grow to need it).
