### PR TITLE
Add client_root for edge

### DIFF
--- a/crates/turbopack-cli/src/dev/mod.rs
+++ b/crates/turbopack-cli/src/dev/mod.rs
@@ -252,6 +252,7 @@ async fn source(
     let build_chunking_context = DevChunkingContext::builder(
         project_path,
         build_output_root,
+        build_output_root,
         build_output_root.join("chunks".to_string()),
         build_output_root.join("assets".to_string()),
         node_build_environment(),

--- a/crates/turbopack-cli/src/dev/web_entry_source.rs
+++ b/crates/turbopack-cli/src/dev/web_entry_source.rs
@@ -39,6 +39,7 @@ pub fn get_client_chunking_context(
         DevChunkingContext::builder(
             project_path,
             server_root,
+            server_root,
             server_root.join("/_chunks".to_string()),
             server_root.join("/_assets".to_string()),
             environment,

--- a/crates/turbopack-dev/src/chunking_context.rs
+++ b/crates/turbopack-dev/src/chunking_context.rs
@@ -77,8 +77,10 @@ pub struct DevChunkingContext {
     /// This path get stripped off of chunk paths before generating output asset
     /// paths.
     context_path: Vc<FileSystemPath>,
-    /// This path is used to compute the url to request chunks or assets from
+    /// This path is used to compute the url to request chunks from
     output_root: Vc<FileSystemPath>,
+    /// This path is used to compute the url to request assets from
+    client_root: Vc<FileSystemPath>,
     /// Chunks are placed at this path
     chunk_root_path: Vc<FileSystemPath>,
     /// Chunks reference source maps assets
@@ -105,6 +107,7 @@ impl DevChunkingContext {
     pub fn builder(
         context_path: Vc<FileSystemPath>,
         output_root: Vc<FileSystemPath>,
+        client_root: Vc<FileSystemPath>,
         chunk_root_path: Vc<FileSystemPath>,
         asset_root_path: Vc<FileSystemPath>,
         environment: Vc<Environment>,
@@ -113,6 +116,7 @@ impl DevChunkingContext {
             chunking_context: DevChunkingContext {
                 context_path,
                 output_root,
+                client_root,
                 chunk_root_path,
                 reference_chunk_source_maps: true,
                 reference_css_chunk_source_maps: true,
@@ -235,8 +239,8 @@ impl ChunkingContext for DevChunkingContext {
         let this = self.await?;
         let asset_path = ident.path().await?.to_string();
         let asset_path = asset_path
-            .strip_prefix(&format!("{}/", this.output_root.await?.path))
-            .context("expected output_root to contain asset path")?;
+            .strip_prefix(&format!("{}/", this.client_root.await?.path))
+            .context("expected asset_path to contain client_root")?;
 
         Ok(Vc::cell(format!(
             "{}{}",

--- a/crates/turbopack-tests/tests/execution.rs
+++ b/crates/turbopack-tests/tests/execution.rs
@@ -292,7 +292,8 @@ async fn run_test(prepared_test: Vc<PreparedTest>) -> Result<Vc<RunTestResult>> 
 
     let chunking_context = DevChunkingContext::builder(
         project_root,
-        chunk_root_path,
+        path,
+        path,
         chunk_root_path,
         static_root_path,
         env,

--- a/crates/turbopack-tests/tests/execution.rs
+++ b/crates/turbopack-tests/tests/execution.rs
@@ -292,8 +292,8 @@ async fn run_test(prepared_test: Vc<PreparedTest>) -> Result<Vc<RunTestResult>> 
 
     let chunking_context = DevChunkingContext::builder(
         project_root,
-        path,
-        path,
+        chunk_root_path,
+        static_root_path,
         chunk_root_path,
         static_root_path,
         env,

--- a/crates/turbopack-tests/tests/snapshot.rs
+++ b/crates/turbopack-tests/tests/snapshot.rs
@@ -292,9 +292,16 @@ async fn run_test(resource: String) -> Result<Vc<FileSystemPath>> {
 
     let chunking_context: Vc<Box<dyn ChunkingContext>> = match options.runtime {
         Runtime::Dev => Vc::upcast(
-            DevChunkingContext::builder(project_root, path, chunk_root_path, static_root_path, env)
-                .runtime_type(options.runtime_type)
-                .build(),
+            DevChunkingContext::builder(
+                project_root,
+                path,
+                path,
+                chunk_root_path,
+                static_root_path,
+                env,
+            )
+            .runtime_type(options.runtime_type)
+            .build(),
         ),
         Runtime::Build => Vc::upcast(
             BuildChunkingContext::builder(


### PR DESCRIPTION
### Description

Ensures edge compilation outputs the right asset urls. Currently in Next.js with Turbopack enabled they show `/assets/file.hash.png` but it should be relative to the `asset_prefix` and client path.

<!--
  ✍️ Write a short summary of your work.
  If necessary, include relevant screenshots.
-->

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
