### PR TITLE
Update `swc_core` to `v0.89.x`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -818,9 +818,9 @@ dependencies = [
  "serde-wasm-bindgen",
  "swc",
  "swc_common",
- "swc_ecma_ast 0.111.1",
+ "swc_ecma_ast",
  "swc_ecma_transforms",
- "swc_ecma_visit 0.97.1",
+ "swc_ecma_visit",
  "wasm-bindgen",
  "wasm-bindgen-futures",
 ]
@@ -4714,13 +4714,13 @@ dependencies = [
 
 [[package]]
 name = "mdxjs"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5a92219a0cd59dad0c894e6600f56cab2def3cd7a3752c66af2800e4db2548c"
+checksum = "11f1fdfd589b67270763c68ac2ca9ab5203cd96c1b3da2d7a82b72135e07346b"
 dependencies = [
  "markdown",
  "serde",
- "swc_core 0.87.28",
+ "swc_core",
 ]
 
 [[package]]
@@ -5003,8 +5003,8 @@ dependencies = [
  "serde",
  "swc_cached",
  "swc_common",
- "swc_ecma_ast 0.111.1",
- "swc_ecma_visit 0.97.1",
+ "swc_ecma_ast",
+ "swc_ecma_visit",
 ]
 
 [[package]]
@@ -8060,9 +8060,9 @@ dependencies = [
  "serde",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.111.1",
- "swc_ecma_utils 0.126.1",
- "swc_ecma_visit 0.97.1",
+ "swc_ecma_ast",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "tracing",
 ]
 
@@ -8084,11 +8084,11 @@ dependencies = [
  "swc_css_parser",
  "swc_css_prefixer",
  "swc_css_visit",
- "swc_ecma_ast 0.111.1",
+ "swc_ecma_ast",
  "swc_ecma_minifier",
- "swc_ecma_parser 0.142.1",
- "swc_ecma_utils 0.126.1",
- "swc_ecma_visit 0.97.1",
+ "swc_ecma_parser",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_plugin_macro",
  "tracing",
 ]
@@ -8196,20 +8196,20 @@ dependencies = [
  "swc_common",
  "swc_compiler_base",
  "swc_config",
- "swc_ecma_ast 0.111.1",
- "swc_ecma_codegen 0.147.1",
+ "swc_ecma_ast",
+ "swc_ecma_codegen",
  "swc_ecma_ext_transforms",
  "swc_ecma_lints",
  "swc_ecma_loader",
  "swc_ecma_minifier",
- "swc_ecma_parser 0.142.1",
+ "swc_ecma_parser",
  "swc_ecma_preset_env",
  "swc_ecma_transforms",
- "swc_ecma_transforms_base 0.136.1",
+ "swc_ecma_transforms_base",
  "swc_ecma_transforms_compat",
  "swc_ecma_transforms_optimization",
- "swc_ecma_utils 0.126.1",
- "swc_ecma_visit 0.97.1",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_error_reporters",
  "swc_node_comments",
  "swc_plugin_proxy",
@@ -8228,7 +8228,7 @@ dependencies = [
  "clap 4.4.2",
  "owo-colors",
  "regex",
- "swc_core 0.89.1",
+ "swc_core",
 ]
 
 [[package]]
@@ -8264,14 +8264,14 @@ dependencies = [
  "relative-path",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.111.1",
- "swc_ecma_codegen 0.147.1",
+ "swc_ecma_ast",
+ "swc_ecma_codegen",
  "swc_ecma_loader",
- "swc_ecma_parser 0.142.1",
- "swc_ecma_transforms_base 0.136.1",
+ "swc_ecma_parser",
+ "swc_ecma_transforms_base",
  "swc_ecma_transforms_optimization",
- "swc_ecma_utils 0.126.1",
- "swc_ecma_visit 0.97.1",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_fast_graph",
  "swc_graph_analyzer",
  "tracing",
@@ -8341,11 +8341,11 @@ dependencies = [
  "swc_atoms",
  "swc_common",
  "swc_config",
- "swc_ecma_ast 0.111.1",
- "swc_ecma_codegen 0.147.1",
+ "swc_ecma_ast",
+ "swc_ecma_codegen",
  "swc_ecma_minifier",
- "swc_ecma_parser 0.142.1",
- "swc_ecma_visit 0.97.1",
+ "swc_ecma_parser",
+ "swc_ecma_visit",
  "swc_timer",
 ]
 
@@ -8378,22 +8378,6 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "0.87.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b3e389aed344d9d738f7e0901a1778a8402f10e459556c6d3a7a5b4501bf4cf"
-dependencies = [
- "swc_atoms",
- "swc_common",
- "swc_ecma_ast 0.110.17",
- "swc_ecma_codegen 0.146.55",
- "swc_ecma_parser 0.141.37",
- "swc_ecma_transforms_base 0.135.12",
- "swc_ecma_visit 0.96.17",
- "vergen",
-]
-
-[[package]]
-name = "swc_core"
 version = "0.89.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed64351a7664c694b9274a613b6a36702f85da29bdbf5194059b19a73217a00a"
@@ -8410,22 +8394,22 @@ dependencies = [
  "swc_css_modules",
  "swc_css_parser",
  "swc_css_visit",
- "swc_ecma_ast 0.111.1",
- "swc_ecma_codegen 0.147.1",
+ "swc_ecma_ast",
+ "swc_ecma_codegen",
  "swc_ecma_loader",
  "swc_ecma_minifier",
- "swc_ecma_parser 0.142.1",
+ "swc_ecma_parser",
  "swc_ecma_preset_env",
  "swc_ecma_quote_macros",
- "swc_ecma_transforms_base 0.136.1",
+ "swc_ecma_transforms_base",
  "swc_ecma_transforms_module",
  "swc_ecma_transforms_optimization",
  "swc_ecma_transforms_proposal",
  "swc_ecma_transforms_react",
  "swc_ecma_transforms_testing",
  "swc_ecma_transforms_typescript",
- "swc_ecma_utils 0.126.1",
- "swc_ecma_visit 0.97.1",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_malloc",
  "swc_nodejs_common",
  "swc_plugin_proxy",
@@ -8582,23 +8566,6 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.110.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79401a45da704f4fb2552c5bf86ee2198e8636b121cb81f8036848a300edd53b"
-dependencies = [
- "bitflags 2.4.0",
- "is-macro",
- "num-bigint",
- "phf 0.11.2",
- "scoped-tls",
- "string_enum",
- "swc_atoms",
- "swc_common",
- "unicode-id",
-]
-
-[[package]]
-name = "swc_ecma_ast"
 version = "0.111.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e12b4d0f3b31d293dac16fc13a50f8a282a3bdb658f2a000ffe09b1b638f45c9"
@@ -8619,25 +8586,6 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.146.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa20d5c61563c5ec9ba469a7701512f4d6bc29790718cd198f43e61148e8aff2"
-dependencies = [
- "memchr",
- "num-bigint",
- "once_cell",
- "rustc-hash",
- "serde",
- "sourcemap",
- "swc_atoms",
- "swc_common",
- "swc_ecma_ast 0.110.17",
- "swc_ecma_codegen_macros",
- "tracing",
-]
-
-[[package]]
-name = "swc_ecma_codegen"
 version = "0.147.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71cf965b2cda4683eaf37ef4e238c0ca14a509ee76948638d815ccffb85bcd8b"
@@ -8650,7 +8598,7 @@ dependencies = [
  "sourcemap",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.111.1",
+ "swc_ecma_ast",
  "swc_ecma_codegen_macros",
  "tracing",
 ]
@@ -8675,11 +8623,11 @@ checksum = "da6853a4c19b5d71bffb3f41c7494f4be556e026614f8b9fe473281fa4e286e5"
 dependencies = [
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.111.1",
+ "swc_ecma_ast",
  "swc_ecma_compat_es2015",
- "swc_ecma_transforms_base 0.136.1",
- "swc_ecma_utils 0.126.1",
- "swc_ecma_visit 0.97.1",
+ "swc_ecma_transforms_base",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_trace_macro",
  "tracing",
 ]
@@ -8691,9 +8639,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9a41339c6306d8e569c33c48ab8d586146757ab217583b73d9c725b229e6913"
 dependencies = [
  "swc_common",
- "swc_ecma_ast 0.111.1",
- "swc_ecma_utils 0.126.1",
- "swc_ecma_visit 0.97.1",
+ "swc_ecma_ast",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_trace_macro",
 ]
 
@@ -8712,13 +8660,13 @@ dependencies = [
  "swc_atoms",
  "swc_common",
  "swc_config",
- "swc_ecma_ast 0.111.1",
+ "swc_ecma_ast",
  "swc_ecma_compat_common",
- "swc_ecma_transforms_base 0.136.1",
+ "swc_ecma_transforms_base",
  "swc_ecma_transforms_classes",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils 0.126.1",
- "swc_ecma_visit 0.97.1",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_trace_macro",
  "tracing",
 ]
@@ -8731,11 +8679,11 @@ checksum = "f70d0854d74205a8c9cdf9a614a935a5204259ae0a2dbb595614111df4e3ee57"
 dependencies = [
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.111.1",
- "swc_ecma_transforms_base 0.136.1",
+ "swc_ecma_ast",
+ "swc_ecma_transforms_base",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils 0.126.1",
- "swc_ecma_visit 0.97.1",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_trace_macro",
  "tracing",
 ]
@@ -8749,11 +8697,11 @@ dependencies = [
  "serde",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.111.1",
- "swc_ecma_transforms_base 0.136.1",
+ "swc_ecma_ast",
+ "swc_ecma_transforms_base",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils 0.126.1",
- "swc_ecma_visit 0.97.1",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_trace_macro",
  "tracing",
 ]
@@ -8767,12 +8715,12 @@ dependencies = [
  "serde",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.111.1",
+ "swc_ecma_ast",
  "swc_ecma_compat_common",
- "swc_ecma_transforms_base 0.136.1",
+ "swc_ecma_transforms_base",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils 0.126.1",
- "swc_ecma_visit 0.97.1",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_trace_macro",
  "tracing",
 ]
@@ -8785,10 +8733,10 @@ checksum = "3ff30a4f95ac263b5006c5883123c1d0658565df98ef9364a9f9b83b381b3bb2"
 dependencies = [
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.111.1",
- "swc_ecma_transforms_base 0.136.1",
- "swc_ecma_utils 0.126.1",
- "swc_ecma_visit 0.97.1",
+ "swc_ecma_ast",
+ "swc_ecma_transforms_base",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_trace_macro",
  "tracing",
 ]
@@ -8802,11 +8750,11 @@ dependencies = [
  "serde",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.111.1",
+ "swc_ecma_ast",
  "swc_ecma_compat_es2022",
- "swc_ecma_transforms_base 0.136.1",
- "swc_ecma_utils 0.126.1",
- "swc_ecma_visit 0.97.1",
+ "swc_ecma_transforms_base",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_trace_macro",
  "tracing",
 ]
@@ -8819,10 +8767,10 @@ checksum = "f1cfa09a6e3d916ea6e7c116cafbea5c37cae67045a6e205c447168faa62e67f"
 dependencies = [
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.111.1",
- "swc_ecma_transforms_base 0.136.1",
- "swc_ecma_utils 0.126.1",
- "swc_ecma_visit 0.97.1",
+ "swc_ecma_ast",
+ "swc_ecma_transforms_base",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_trace_macro",
  "tracing",
 ]
@@ -8835,13 +8783,13 @@ checksum = "01a150a7cf16861d17973a70088a7b173da15e9ae2d74063d1ba47d2c88ad732"
 dependencies = [
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.111.1",
+ "swc_ecma_ast",
  "swc_ecma_compat_common",
- "swc_ecma_transforms_base 0.136.1",
+ "swc_ecma_transforms_base",
  "swc_ecma_transforms_classes",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils 0.126.1",
- "swc_ecma_visit 0.97.1",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_trace_macro",
  "tracing",
 ]
@@ -8853,10 +8801,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1ec402b2125bbca532f0d7fb50536c54259d5b76f21b2ac47ce541661693732"
 dependencies = [
  "swc_common",
- "swc_ecma_ast 0.111.1",
- "swc_ecma_transforms_base 0.136.1",
- "swc_ecma_utils 0.126.1",
- "swc_ecma_visit 0.97.1",
+ "swc_ecma_ast",
+ "swc_ecma_transforms_base",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_trace_macro",
  "tracing",
 ]
@@ -8870,9 +8818,9 @@ dependencies = [
  "phf 0.11.2",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.111.1",
- "swc_ecma_utils 0.126.1",
- "swc_ecma_visit 0.97.1",
+ "swc_ecma_ast",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
 ]
 
 [[package]]
@@ -8890,9 +8838,9 @@ dependencies = [
  "swc_atoms",
  "swc_common",
  "swc_config",
- "swc_ecma_ast 0.111.1",
- "swc_ecma_utils 0.126.1",
- "swc_ecma_visit 0.97.1",
+ "swc_ecma_ast",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
 ]
 
 [[package]]
@@ -8939,38 +8887,16 @@ dependencies = [
  "swc_atoms",
  "swc_common",
  "swc_config",
- "swc_ecma_ast 0.111.1",
- "swc_ecma_codegen 0.147.1",
- "swc_ecma_parser 0.142.1",
- "swc_ecma_transforms_base 0.136.1",
+ "swc_ecma_ast",
+ "swc_ecma_codegen",
+ "swc_ecma_parser",
+ "swc_ecma_transforms_base",
  "swc_ecma_transforms_optimization",
  "swc_ecma_usage_analyzer",
- "swc_ecma_utils 0.126.1",
- "swc_ecma_visit 0.97.1",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_timer",
  "tracing",
-]
-
-[[package]]
-name = "swc_ecma_parser"
-version = "0.141.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4d17401dd95048a6a62b777d533c0999dabdd531ef9d667e22f8ae2a2a0d294"
-dependencies = [
- "either",
- "new_debug_unreachable",
- "num-bigint",
- "num-traits",
- "phf 0.11.2",
- "serde",
- "smallvec 1.11.1",
- "smartstring",
- "stacker",
- "swc_atoms",
- "swc_common",
- "swc_ecma_ast 0.110.17",
- "tracing",
- "typed-arena",
 ]
 
 [[package]]
@@ -8990,7 +8916,7 @@ dependencies = [
  "stacker",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.111.1",
+ "swc_ecma_ast",
  "tracing",
  "typed-arena",
 ]
@@ -9014,10 +8940,10 @@ dependencies = [
  "string_enum",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.111.1",
+ "swc_ecma_ast",
  "swc_ecma_transforms",
- "swc_ecma_utils 0.126.1",
- "swc_ecma_visit 0.97.1",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
 ]
 
 [[package]]
@@ -9031,8 +8957,8 @@ dependencies = [
  "quote",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.111.1",
- "swc_ecma_parser 0.142.1",
+ "swc_ecma_ast",
+ "swc_ecma_parser",
  "swc_macros_common",
  "syn 2.0.32",
 ]
@@ -9058,39 +8984,16 @@ checksum = "6d7b37d02a0b2a70834588cb46b40c53d0154cf9970d27a12f65f87fe68c3f50"
 dependencies = [
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.111.1",
- "swc_ecma_transforms_base 0.136.1",
+ "swc_ecma_ast",
+ "swc_ecma_transforms_base",
  "swc_ecma_transforms_compat",
  "swc_ecma_transforms_module",
  "swc_ecma_transforms_optimization",
  "swc_ecma_transforms_proposal",
  "swc_ecma_transforms_react",
  "swc_ecma_transforms_typescript",
- "swc_ecma_utils 0.126.1",
- "swc_ecma_visit 0.97.1",
-]
-
-[[package]]
-name = "swc_ecma_transforms_base"
-version = "0.135.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f0efec63cc56f3f2b93d1367d16e684d1c6f4a6cb85436db2c91448867df2b"
-dependencies = [
- "better_scoped_tls",
- "bitflags 2.4.0",
- "indexmap 2.0.0",
- "once_cell",
- "phf 0.11.2",
- "rustc-hash",
- "serde",
- "smallvec 1.11.1",
- "swc_atoms",
- "swc_common",
- "swc_ecma_ast 0.110.17",
- "swc_ecma_parser 0.141.37",
- "swc_ecma_utils 0.125.4",
- "swc_ecma_visit 0.96.17",
- "tracing",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
 ]
 
 [[package]]
@@ -9110,10 +9013,10 @@ dependencies = [
  "smallvec 1.11.1",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.111.1",
- "swc_ecma_parser 0.142.1",
- "swc_ecma_utils 0.126.1",
- "swc_ecma_visit 0.97.1",
+ "swc_ecma_ast",
+ "swc_ecma_parser",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "tracing",
 ]
 
@@ -9125,10 +9028,10 @@ checksum = "a86a29952848e12bcdd788fa6922d3a9c79603c26a38278effd63c98c532d069"
 dependencies = [
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.111.1",
- "swc_ecma_transforms_base 0.136.1",
- "swc_ecma_utils 0.126.1",
- "swc_ecma_visit 0.97.1",
+ "swc_ecma_ast",
+ "swc_ecma_transforms_base",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
 ]
 
 [[package]]
@@ -9147,7 +9050,7 @@ dependencies = [
  "swc_atoms",
  "swc_common",
  "swc_config",
- "swc_ecma_ast 0.111.1",
+ "swc_ecma_ast",
  "swc_ecma_compat_bugfixes",
  "swc_ecma_compat_common",
  "swc_ecma_compat_es2015",
@@ -9159,11 +9062,11 @@ dependencies = [
  "swc_ecma_compat_es2021",
  "swc_ecma_compat_es2022",
  "swc_ecma_compat_es3",
- "swc_ecma_transforms_base 0.136.1",
+ "swc_ecma_transforms_base",
  "swc_ecma_transforms_classes",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils 0.126.1",
- "swc_ecma_visit 0.97.1",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_trace_macro",
  "tracing",
 ]
@@ -9198,12 +9101,12 @@ dependencies = [
  "swc_atoms",
  "swc_cached",
  "swc_common",
- "swc_ecma_ast 0.111.1",
+ "swc_ecma_ast",
  "swc_ecma_loader",
- "swc_ecma_parser 0.142.1",
- "swc_ecma_transforms_base 0.136.1",
- "swc_ecma_utils 0.126.1",
- "swc_ecma_visit 0.97.1",
+ "swc_ecma_parser",
+ "swc_ecma_transforms_base",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "tracing",
 ]
 
@@ -9222,12 +9125,12 @@ dependencies = [
  "serde_json",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.111.1",
- "swc_ecma_parser 0.142.1",
- "swc_ecma_transforms_base 0.136.1",
+ "swc_ecma_ast",
+ "swc_ecma_parser",
+ "swc_ecma_transforms_base",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils 0.126.1",
- "swc_ecma_visit 0.97.1",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_fast_graph",
  "tracing",
 ]
@@ -9244,12 +9147,12 @@ dependencies = [
  "smallvec 1.11.1",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.111.1",
- "swc_ecma_transforms_base 0.136.1",
+ "swc_ecma_ast",
+ "swc_ecma_transforms_base",
  "swc_ecma_transforms_classes",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils 0.126.1",
- "swc_ecma_visit 0.97.1",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
 ]
 
 [[package]]
@@ -9269,12 +9172,12 @@ dependencies = [
  "swc_atoms",
  "swc_common",
  "swc_config",
- "swc_ecma_ast 0.111.1",
- "swc_ecma_parser 0.142.1",
- "swc_ecma_transforms_base 0.136.1",
+ "swc_ecma_ast",
+ "swc_ecma_parser",
+ "swc_ecma_transforms_base",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils 0.126.1",
- "swc_ecma_visit 0.97.1",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
 ]
 
 [[package]]
@@ -9292,13 +9195,13 @@ dependencies = [
  "sha2",
  "sourcemap",
  "swc_common",
- "swc_ecma_ast 0.111.1",
- "swc_ecma_codegen 0.147.1",
- "swc_ecma_parser 0.142.1",
+ "swc_ecma_ast",
+ "swc_ecma_codegen",
+ "swc_ecma_parser",
  "swc_ecma_testing",
- "swc_ecma_transforms_base 0.136.1",
- "swc_ecma_utils 0.126.1",
- "swc_ecma_visit 0.97.1",
+ "swc_ecma_transforms_base",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "tempfile",
  "testing",
 ]
@@ -9313,11 +9216,11 @@ dependencies = [
  "serde",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.111.1",
- "swc_ecma_transforms_base 0.136.1",
+ "swc_ecma_ast",
+ "swc_ecma_transforms_base",
  "swc_ecma_transforms_react",
- "swc_ecma_utils 0.126.1",
- "swc_ecma_visit 0.97.1",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
 ]
 
 [[package]]
@@ -9330,29 +9233,11 @@ dependencies = [
  "rustc-hash",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.111.1",
- "swc_ecma_utils 0.126.1",
- "swc_ecma_visit 0.97.1",
+ "swc_ecma_ast",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_timer",
  "tracing",
-]
-
-[[package]]
-name = "swc_ecma_utils"
-version = "0.125.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cead1083e46b0f072a82938f16d366014468f7510350957765bb4d013496890"
-dependencies = [
- "indexmap 2.0.0",
- "num_cpus",
- "once_cell",
- "rustc-hash",
- "swc_atoms",
- "swc_common",
- "swc_ecma_ast 0.110.17",
- "swc_ecma_visit 0.96.17",
- "tracing",
- "unicode-id",
 ]
 
 [[package]]
@@ -9368,24 +9253,10 @@ dependencies = [
  "rustc-hash",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.111.1",
- "swc_ecma_visit 0.97.1",
+ "swc_ecma_ast",
+ "swc_ecma_visit",
  "tracing",
  "unicode-id",
-]
-
-[[package]]
-name = "swc_ecma_visit"
-version = "0.96.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d0100c383fb08b6f34911ab6f925950416a5d14404c1cd520d59fb8dfbb3bf"
-dependencies = [
- "num-bigint",
- "swc_atoms",
- "swc_common",
- "swc_ecma_ast 0.110.17",
- "swc_visit",
- "tracing",
 ]
 
 [[package]]
@@ -9398,7 +9269,7 @@ dependencies = [
  "serde",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.111.1",
+ "swc_ecma_ast",
  "swc_visit",
  "tracing",
 ]
@@ -9419,10 +9290,10 @@ dependencies = [
  "sourcemap",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.111.1",
- "swc_ecma_codegen 0.147.1",
- "swc_ecma_utils 0.126.1",
- "swc_ecma_visit 0.97.1",
+ "swc_ecma_ast",
+ "swc_ecma_codegen",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_trace_macro",
  "tracing",
 ]
@@ -9542,7 +9413,7 @@ dependencies = [
  "better_scoped_tls",
  "rkyv",
  "swc_common",
- "swc_ecma_ast 0.111.1",
+ "swc_ecma_ast",
  "swc_trace_macro",
  "tracing",
 ]
@@ -9561,7 +9432,7 @@ dependencies = [
  "serde",
  "serde_json",
  "swc_common",
- "swc_ecma_ast 0.111.1",
+ "swc_ecma_ast",
  "swc_plugin_proxy",
  "tokio",
  "tracing",
@@ -9583,9 +9454,9 @@ dependencies = [
  "serde_json",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast 0.111.1",
- "swc_ecma_utils 0.126.1",
- "swc_ecma_visit 0.97.1",
+ "swc_ecma_ast",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "tracing",
 ]
 
@@ -11032,7 +10903,7 @@ dependencies = [
  "styled_components",
  "styled_jsx",
  "swc-ast-explorer",
- "swc_core 0.89.1",
+ "swc_core",
  "swc_emotion",
  "swc_relay",
  "testing",
@@ -11086,7 +10957,7 @@ dependencies = [
  "serde_json",
  "serde_qs",
  "sourcemap",
- "swc_core 0.89.1",
+ "swc_core",
  "tracing",
  "turbo-tasks",
  "turbo-tasks-build",
@@ -11195,7 +11066,7 @@ dependencies = [
  "serde_json",
  "serde_qs",
  "sourcemap",
- "swc_core 0.89.1",
+ "swc_core",
  "tokio",
  "tracing",
  "turbo-tasks",
@@ -11234,7 +11105,7 @@ dependencies = [
  "regex",
  "serde",
  "smallvec 1.11.1",
- "swc_core 0.89.1",
+ "swc_core",
  "tracing",
  "turbo-tasks",
  "turbo-tasks-build",
@@ -11255,7 +11126,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_qs",
- "swc_core 0.89.1",
+ "swc_core",
  "tracing",
  "turbo-tasks",
  "turbo-tasks-build",
@@ -11328,7 +11199,7 @@ dependencies = [
  "serde_json",
  "serde_qs",
  "sourcemap",
- "swc_core 0.89.1",
+ "swc_core",
  "tokio",
  "tracing",
  "turbo-tasks",
@@ -11366,7 +11237,7 @@ dependencies = [
  "serde_json",
  "styled_components",
  "styled_jsx",
- "swc_core 0.89.1",
+ "swc_core",
  "swc_emotion",
  "swc_relay",
  "turbo-tasks",
@@ -11383,7 +11254,7 @@ dependencies = [
  "anyhow",
  "indoc",
  "serde",
- "swc_core 0.89.1",
+ "swc_core",
  "turbo-tasks",
  "turbo-tasks-build",
  "turbo-tasks-fs",
@@ -11507,7 +11378,7 @@ dependencies = [
 name = "turbopack-swc-utils"
 version = "0.1.0"
 dependencies = [
- "swc_core 0.89.1",
+ "swc_core",
  "turbo-tasks",
  "turbo-tasks-build",
  "turbopack-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -806,9 +806,9 @@ dependencies = [
 
 [[package]]
 name = "binding_macros"
-version = "0.61.26"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5ccc161009146c42b3c0d5a3f1d66666b0ea16301d89b0292bc61ee4d3a0039"
+checksum = "22807c7bb39e743a80a3ee19e1ea8db3f54a41b3c7d93c9a0ad253a2ab840b4c"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -818,9 +818,9 @@ dependencies = [
  "serde-wasm-bindgen",
  "swc",
  "swc_common",
- "swc_ecma_ast",
+ "swc_ecma_ast 0.111.1",
  "swc_ecma_transforms",
- "swc_ecma_visit",
+ "swc_ecma_visit 0.97.1",
  "wasm-bindgen",
  "wasm-bindgen-futures",
 ]
@@ -4720,7 +4720,7 @@ checksum = "d5a92219a0cd59dad0c894e6600f56cab2def3cd7a3752c66af2800e4db2548c"
 dependencies = [
  "markdown",
  "serde",
- "swc_core",
+ "swc_core 0.87.28",
 ]
 
 [[package]]
@@ -4992,9 +4992,9 @@ dependencies = [
 
 [[package]]
 name = "modularize_imports"
-version = "0.66.0"
+version = "0.68.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ba62fb8ab2a603ee6e85470f5dd9563a4809dc0b6f749c721b5c0ef313c83f"
+checksum = "33ac0edf8641e481ae132ce791c86c7941414eb9863a8c14c9094b4dededa30a"
 dependencies = [
  "convert_case 0.5.0",
  "handlebars",
@@ -5003,8 +5003,8 @@ dependencies = [
  "serde",
  "swc_cached",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_visit",
+ "swc_ecma_ast 0.111.1",
+ "swc_ecma_visit 0.97.1",
 ]
 
 [[package]]
@@ -8050,9 +8050,9 @@ checksum = "e9426b2a0c03e6cc2ea8dbc0168dbbf943f88755e409fb91bcb8f6a268305f4a"
 
 [[package]]
 name = "styled_components"
-version = "0.94.0"
+version = "0.96.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c5c51bb8528cceebba8f28b82dcdbc811ba2f8934e85c519e815c6756206a8"
+checksum = "0d020b203225068a63edc9b58ff7ff4bf9d83109a860cd896377a8d0223c25af"
 dependencies = [
  "Inflector",
  "once_cell",
@@ -8060,17 +8060,17 @@ dependencies = [
  "serde",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_ast 0.111.1",
+ "swc_ecma_utils 0.126.1",
+ "swc_ecma_visit 0.97.1",
  "tracing",
 ]
 
 [[package]]
 name = "styled_jsx"
-version = "0.68.1"
+version = "0.73.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8ba4b5878a8de959cc40fdbcbe2b4e74b206db55dbb71b17f07fcd8007e26bb"
+checksum = "ef365009ffea9054f2f59569adf3daeb286688de7b966702569b34532f9946ac"
 dependencies = [
  "anyhow",
  "lightningcss",
@@ -8084,11 +8084,11 @@ dependencies = [
  "swc_css_parser",
  "swc_css_prefixer",
  "swc_css_visit",
- "swc_ecma_ast",
+ "swc_ecma_ast 0.111.1",
  "swc_ecma_minifier",
- "swc_ecma_parser",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_parser 0.142.1",
+ "swc_ecma_utils 0.126.1",
+ "swc_ecma_visit 0.97.1",
  "swc_plugin_macro",
  "tracing",
 ]
@@ -8170,9 +8170,9 @@ dependencies = [
 
 [[package]]
 name = "swc"
-version = "0.270.26"
+version = "0.272.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "722794f5f68ffaba34e0ef7e0c0fc04208d7e1c284f4df2f827890cdd20d0ca7"
+checksum = "c7a3f13725f06e0a889de3a74ab3eb0102cd21ffd456f1ff2660c218029ff39b"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -8196,20 +8196,20 @@ dependencies = [
  "swc_common",
  "swc_compiler_base",
  "swc_config",
- "swc_ecma_ast",
- "swc_ecma_codegen",
+ "swc_ecma_ast 0.111.1",
+ "swc_ecma_codegen 0.147.1",
  "swc_ecma_ext_transforms",
  "swc_ecma_lints",
  "swc_ecma_loader",
  "swc_ecma_minifier",
- "swc_ecma_parser",
+ "swc_ecma_parser 0.142.1",
  "swc_ecma_preset_env",
  "swc_ecma_transforms",
- "swc_ecma_transforms_base",
+ "swc_ecma_transforms_base 0.136.1",
  "swc_ecma_transforms_compat",
  "swc_ecma_transforms_optimization",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_utils 0.126.1",
+ "swc_ecma_visit 0.97.1",
  "swc_error_reporters",
  "swc_node_comments",
  "swc_plugin_proxy",
@@ -8228,7 +8228,7 @@ dependencies = [
  "clap 4.4.2",
  "owo-colors",
  "regex",
- "swc_core",
+ "swc_core 0.89.0",
 ]
 
 [[package]]
@@ -8247,9 +8247,9 @@ dependencies = [
 
 [[package]]
 name = "swc_bundler"
-version = "0.223.23"
+version = "0.224.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fefa09161d201f04a2d6c553c4b726819ec44dcfff6e40dc1a68342803b8cd12"
+checksum = "dbe8d841d74ab7a1cd753db053b238f88707a39ebf25b02306c762a888fdc92a"
 dependencies = [
  "anyhow",
  "crc",
@@ -8264,14 +8264,14 @@ dependencies = [
  "relative-path",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_codegen",
+ "swc_ecma_ast 0.111.1",
+ "swc_ecma_codegen 0.147.1",
  "swc_ecma_loader",
- "swc_ecma_parser",
- "swc_ecma_transforms_base",
+ "swc_ecma_parser 0.142.1",
+ "swc_ecma_transforms_base 0.136.1",
  "swc_ecma_transforms_optimization",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_utils 0.126.1",
+ "swc_ecma_visit 0.97.1",
  "swc_fast_graph",
  "swc_graph_analyzer",
  "tracing",
@@ -8279,9 +8279,9 @@ dependencies = [
 
 [[package]]
 name = "swc_cached"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b357b80879f6c4f4f34879d02eeae63aafc7730293e6eda3686f990d160486"
+checksum = "630c761c74ac8021490b78578cc2223aa4a568241e26505c27bf0e4fd4ad8ec2"
 dependencies = [
  "ahash 0.8.6",
  "anyhow",
@@ -8293,9 +8293,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.33.12"
+version = "0.33.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b3ae36feceded27f0178dc9dabb49399830847ffb7f866af01798844de8f973"
+checksum = "3792c10fa5d3e93a705b31f13fdea4a6e68c3c20d4351e84ed1741b7864399cd"
 dependencies = [
  "ahash 0.8.6",
  "anyhow",
@@ -8326,37 +8326,41 @@ dependencies = [
 
 [[package]]
 name = "swc_compiler_base"
-version = "0.4.24"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b68297972f09d21dea054f1ba5ee611faaf43d6ff3903ba34a52bfa00342d7d7"
+checksum = "acf4a9fcd82f924e8693be713a56a33f9ac8504931b4843c3ec41853a1f373b6"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
  "napi",
  "napi-derive",
+ "once_cell",
  "pathdiff",
  "serde",
  "sourcemap",
  "swc_atoms",
  "swc_common",
  "swc_config",
- "swc_ecma_ast",
- "swc_ecma_codegen",
+ "swc_ecma_ast 0.111.1",
+ "swc_ecma_codegen 0.147.1",
  "swc_ecma_minifier",
- "swc_ecma_parser",
- "swc_ecma_visit",
+ "swc_ecma_parser 0.142.1",
+ "swc_ecma_visit 0.97.1",
  "swc_timer",
 ]
 
 [[package]]
 name = "swc_config"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112884e66b60e614c0f416138b91b8b82b7fea6ed0ecc5e26bad4726c57a6c99"
+checksum = "c29e3b76a63111ef318f161bc413dfc093f21da1afca9ba5cdd6442b7069d65b"
 dependencies = [
+ "anyhow",
  "indexmap 2.0.0",
  "serde",
  "serde_json",
+ "sourcemap",
+ "swc_cached",
  "swc_config_macro",
 ]
 
@@ -8378,6 +8382,22 @@ version = "0.87.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b3e389aed344d9d738f7e0901a1778a8402f10e459556c6d3a7a5b4501bf4cf"
 dependencies = [
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast 0.110.17",
+ "swc_ecma_codegen 0.146.55",
+ "swc_ecma_parser 0.141.37",
+ "swc_ecma_transforms_base 0.135.12",
+ "swc_ecma_visit 0.96.17",
+ "vergen",
+]
+
+[[package]]
+name = "swc_core"
+version = "0.89.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1dca261b95fe38a879a3998b6ecf1f583ca87401bef7e1de83f1997272585f1"
+dependencies = [
  "binding_macros",
  "swc",
  "swc_atoms",
@@ -8390,22 +8410,22 @@ dependencies = [
  "swc_css_modules",
  "swc_css_parser",
  "swc_css_visit",
- "swc_ecma_ast",
- "swc_ecma_codegen",
+ "swc_ecma_ast 0.111.1",
+ "swc_ecma_codegen 0.147.1",
  "swc_ecma_loader",
  "swc_ecma_minifier",
- "swc_ecma_parser",
+ "swc_ecma_parser 0.142.1",
  "swc_ecma_preset_env",
  "swc_ecma_quote_macros",
- "swc_ecma_transforms_base",
+ "swc_ecma_transforms_base 0.136.1",
  "swc_ecma_transforms_module",
  "swc_ecma_transforms_optimization",
  "swc_ecma_transforms_proposal",
  "swc_ecma_transforms_react",
  "swc_ecma_transforms_testing",
  "swc_ecma_transforms_typescript",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_utils 0.126.1",
+ "swc_ecma_visit 0.97.1",
  "swc_malloc",
  "swc_nodejs_common",
  "swc_plugin_proxy",
@@ -8416,9 +8436,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_ast"
-version = "0.140.14"
+version = "0.140.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eb09e34d7a6e1869897b4aa884c739c5f5320aea00b35b589d2e4391e47868"
+checksum = "3d2251abcf11f599746478404886cbc50479130b7e0da378f15d8b8f0a0d56ab"
 dependencies = [
  "is-macro",
  "string_enum",
@@ -8428,9 +8448,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_codegen"
-version = "0.151.23"
+version = "0.151.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d292d3dbf611b6be21980919f8896852af40bbb0d430d6008f4283685137e64"
+checksum = "1a1b6a92955f14f325e856146e624124d722e6ccb4864e607419609b4ae25347"
 dependencies = [
  "auto_impl",
  "bitflags 2.4.0",
@@ -8457,9 +8477,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_compat"
-version = "0.27.24"
+version = "0.27.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a544c80e5b481dab958e4bdd1286349b7583b1412e53993fbcf1aeb83d0e585e"
+checksum = "5dfc8848fc3a730aebaecf26ccfa16a659c253700570d3f66ffc4f83f77f5350"
 dependencies = [
  "bitflags 2.4.0",
  "once_cell",
@@ -8474,9 +8494,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_minifier"
-version = "0.116.24"
+version = "0.116.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9807dea905a6c4696076ff642e507ecaf63e624ef20c55a303017d3e6f301e9"
+checksum = "9809f65a7389829c2cafb9f9b9f02fc8a06347f8fcb68cceb7665beba5eb7e11"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -8488,9 +8508,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_modules"
-version = "0.29.26"
+version = "0.29.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caceeba805e5123dbbe9f4210bb28644ea026bdd7a6f407046c7b3c941573332"
+checksum = "7882efb7a6a12d0872edd1dfd9397d8f3ba3ba9392413ff385a9b3196035b205"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -8504,9 +8524,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_parser"
-version = "0.150.22"
+version = "0.150.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8221a52f2f50cd23c6b70fa024f4ef21a3dd737a67965292fdac49f391036"
+checksum = "2c370f7a814bc9cd4553cb686373d4a4931d308d2aec05684b9f5ed8662c9479"
 dependencies = [
  "lexical",
  "serde",
@@ -8517,9 +8537,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_prefixer"
-version = "0.153.25"
+version = "0.153.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74adc2822de64d5215ad253ce360dc39f99686dbb46840b6ae374aad69133cfa"
+checksum = "e8eb7b5aee50481d81b93a4ef2eee4985d6c6589f7f2cc78d2f2ff5c44a080a1"
 dependencies = [
  "once_cell",
  "preset_env_base",
@@ -8534,9 +8554,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_utils"
-version = "0.137.14"
+version = "0.137.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "426952c65332d750820cc4cb2b8e21955d6315c57b30939e43def2c48f36c55f"
+checksum = "7b71af680ab24a76c54e0cbd9ce99f2d688fa3d7c847220b331e095820a63510"
 dependencies = [
  "once_cell",
  "serde",
@@ -8549,9 +8569,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_visit"
-version = "0.139.14"
+version = "0.139.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0653b91d85ef5415bfd7b205d03d7a4772ec8e324c980873523294bc2e827717"
+checksum = "b68d6996acce5884e9c9c3b954f54929140068692a006108bfe75a208dc45e0a"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -8565,6 +8585,23 @@ name = "swc_ecma_ast"
 version = "0.110.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79401a45da704f4fb2552c5bf86ee2198e8636b121cb81f8036848a300edd53b"
+dependencies = [
+ "bitflags 2.4.0",
+ "is-macro",
+ "num-bigint",
+ "phf 0.11.2",
+ "scoped-tls",
+ "string_enum",
+ "swc_atoms",
+ "swc_common",
+ "unicode-id",
+]
+
+[[package]]
+name = "swc_ecma_ast"
+version = "0.111.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e12b4d0f3b31d293dac16fc13a50f8a282a3bdb658f2a000ffe09b1b638f45c9"
 dependencies = [
  "bitflags 2.4.0",
  "bytecheck",
@@ -8594,7 +8631,26 @@ dependencies = [
  "sourcemap",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
+ "swc_ecma_ast 0.110.17",
+ "swc_ecma_codegen_macros",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_codegen"
+version = "0.147.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71cf965b2cda4683eaf37ef4e238c0ca14a509ee76948638d815ccffb85bcd8b"
+dependencies = [
+ "memchr",
+ "num-bigint",
+ "once_cell",
+ "rustc-hash",
+ "serde",
+ "sourcemap",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast 0.111.1",
  "swc_ecma_codegen_macros",
  "tracing",
 ]
@@ -8613,39 +8669,39 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_bugfixes"
-version = "0.2.17"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b51b895bd387f4c1e3aa5de21936d12a02a4de7d2b88b8efea0949ac0220c2a2"
+checksum = "da6853a4c19b5d71bffb3f41c7494f4be556e026614f8b9fe473281fa4e286e5"
 dependencies = [
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
+ "swc_ecma_ast 0.111.1",
  "swc_ecma_compat_es2015",
- "swc_ecma_transforms_base",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_transforms_base 0.136.1",
+ "swc_ecma_utils 0.126.1",
+ "swc_ecma_visit 0.97.1",
  "swc_trace_macro",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_compat_common"
-version = "0.2.5"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b0a57bd134c03dd545263ee41824a8cb06af1553016dccf8ac1ad8cbbb940c3"
+checksum = "f9a41339c6306d8e569c33c48ab8d586146757ab217583b73d9c725b229e6913"
 dependencies = [
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_ast 0.111.1",
+ "swc_ecma_utils 0.126.1",
+ "swc_ecma_visit 0.97.1",
  "swc_trace_macro",
 ]
 
 [[package]]
 name = "swc_ecma_compat_es2015"
-version = "0.2.17"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b85ca741acb73cbc79d5bf7716dfd502fd43a035a1f3509cc5ddfff1995477a4"
+checksum = "ccb9e19ab3ec1e2ec9f752e06f18a95ce5228fbaa7dea3c3d5613f23236ccfe5"
 dependencies = [
  "arrayvec 0.7.4",
  "indexmap 2.0.0",
@@ -8656,174 +8712,174 @@ dependencies = [
  "swc_atoms",
  "swc_common",
  "swc_config",
- "swc_ecma_ast",
+ "swc_ecma_ast 0.111.1",
  "swc_ecma_compat_common",
- "swc_ecma_transforms_base",
+ "swc_ecma_transforms_base 0.136.1",
  "swc_ecma_transforms_classes",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_utils 0.126.1",
+ "swc_ecma_visit 0.97.1",
  "swc_trace_macro",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_compat_es2016"
-version = "0.2.12"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c60d1e68eed4bce1ac480a95694b200fc1482d98adb22dcd8aa174472df8eb42"
+checksum = "f70d0854d74205a8c9cdf9a614a935a5204259ae0a2dbb595614111df4e3ee57"
 dependencies = [
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_transforms_base",
+ "swc_ecma_ast 0.111.1",
+ "swc_ecma_transforms_base 0.136.1",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_utils 0.126.1",
+ "swc_ecma_visit 0.97.1",
  "swc_trace_macro",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_compat_es2017"
-version = "0.2.13"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad96684e095c793c44989c63d7195f309ac4bfed66d4fa8ab3b1e2a79d641bc2"
+checksum = "226d0342e624a8c9a090968978b6b855894eb87b0666d12dbbfaacf463e00484"
 dependencies = [
  "serde",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_transforms_base",
+ "swc_ecma_ast 0.111.1",
+ "swc_ecma_transforms_base 0.136.1",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_utils 0.126.1",
+ "swc_ecma_visit 0.97.1",
  "swc_trace_macro",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_compat_es2018"
-version = "0.2.14"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c25b188098603928dd3f310ea029b5ca3e52cb0f7b20698cf9328ea6fab3425"
+checksum = "04c2dfd594215aba9bb6376dddb8f98f2ad5a55ec4b65562242bb2a53a1becea"
 dependencies = [
  "serde",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
+ "swc_ecma_ast 0.111.1",
  "swc_ecma_compat_common",
- "swc_ecma_transforms_base",
+ "swc_ecma_transforms_base 0.136.1",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_utils 0.126.1",
+ "swc_ecma_visit 0.97.1",
  "swc_trace_macro",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_compat_es2019"
-version = "0.2.13"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2689f136599fddd7be1f4e2f665ecce539d7f9bd04c314fa2ad4304f63ed965"
+checksum = "3ff30a4f95ac263b5006c5883123c1d0658565df98ef9364a9f9b83b381b3bb2"
 dependencies = [
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_transforms_base",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_ast 0.111.1",
+ "swc_ecma_transforms_base 0.136.1",
+ "swc_ecma_utils 0.126.1",
+ "swc_ecma_visit 0.97.1",
  "swc_trace_macro",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_compat_es2020"
-version = "0.2.14"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6388c05a061570b00f453be00fcf9703e5b7d5f33b8d8457ea3b20d134ff50a3"
+checksum = "abc0da73b918cea136f2fe5e0eb6a2ff8fdf71a2473c611c4923f18ac7346c65"
 dependencies = [
  "serde",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
+ "swc_ecma_ast 0.111.1",
  "swc_ecma_compat_es2022",
- "swc_ecma_transforms_base",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_transforms_base 0.136.1",
+ "swc_ecma_utils 0.126.1",
+ "swc_ecma_visit 0.97.1",
  "swc_trace_macro",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_compat_es2021"
-version = "0.2.12"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5752c00c792e92c8ce56b2a656058d554a104599e9f4b5c3675b02223f217ee0"
+checksum = "f1cfa09a6e3d916ea6e7c116cafbea5c37cae67045a6e205c447168faa62e67f"
 dependencies = [
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_transforms_base",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_ast 0.111.1",
+ "swc_ecma_transforms_base 0.136.1",
+ "swc_ecma_utils 0.126.1",
+ "swc_ecma_visit 0.97.1",
  "swc_trace_macro",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_compat_es2022"
-version = "0.2.13"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0169d78892b5185d0b3195326a65b34b306a9f802c978deba660227675fb4004"
+checksum = "01a150a7cf16861d17973a70088a7b173da15e9ae2d74063d1ba47d2c88ad732"
 dependencies = [
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
+ "swc_ecma_ast 0.111.1",
  "swc_ecma_compat_common",
- "swc_ecma_transforms_base",
+ "swc_ecma_transforms_base 0.136.1",
  "swc_ecma_transforms_classes",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_utils 0.126.1",
+ "swc_ecma_visit 0.97.1",
  "swc_trace_macro",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_compat_es3"
-version = "0.2.12"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76988033af2b8b94629d60a1a86d9463e3cd0298820dd54bccda57c1d9e40a46"
+checksum = "e1ec402b2125bbca532f0d7fb50536c54259d5b76f21b2ac47ce541661693732"
 dependencies = [
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_transforms_base",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_ast 0.111.1",
+ "swc_ecma_transforms_base 0.136.1",
+ "swc_ecma_utils 0.126.1",
+ "swc_ecma_visit 0.97.1",
  "swc_trace_macro",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_ext_transforms"
-version = "0.111.4"
+version = "0.112.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e728d14119048a95e023c3c5c0ad5ddddb1f405bfef3bd55f81dc5fc3c9e95a"
+checksum = "8847cdc48901afa16204bfde6ed3de668b53c4ca41df55bd6254aac4d2452fda"
 dependencies = [
  "phf 0.11.2",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_ast 0.111.1",
+ "swc_ecma_utils 0.126.1",
+ "swc_ecma_visit 0.97.1",
 ]
 
 [[package]]
 name = "swc_ecma_lints"
-version = "0.90.11"
+version = "0.91.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e407eb2703a200d6eed65ad4444afb029bf6979fda6c99007ca0a638a99696"
+checksum = "6b6a5cef803cc7140788a23caeb70ad0b503d32e72f74e11927da04f6347dcb8"
 dependencies = [
  "auto_impl",
  "dashmap",
@@ -8834,16 +8890,16 @@ dependencies = [
  "swc_atoms",
  "swc_common",
  "swc_config",
- "swc_ecma_ast",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_ast 0.111.1",
+ "swc_ecma_utils 0.126.1",
+ "swc_ecma_visit 0.97.1",
 ]
 
 [[package]]
 name = "swc_ecma_loader"
-version = "0.45.13"
+version = "0.45.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5713ab3429530c10bdf167170ebbde75b046c8003558459e4de5aaec62ce0f1"
+checksum = "53d557b6a53b0db00e36cd24359adcf52f4c6d4446c83ecaad3e2b8195696f7b"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -8855,6 +8911,7 @@ dependencies = [
  "pathdiff",
  "serde",
  "serde_json",
+ "swc_atoms",
  "swc_cached",
  "swc_common",
  "tracing",
@@ -8862,9 +8919,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "0.190.23"
+version = "0.191.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efcbaa6db6fb13d485139e2e8b831326b99055a61dd0c1b3c4e9c94e5439c4d"
+checksum = "d7ed693be413eb44171ce48d794a3124477d8bb9de6af3740c4def6e8b02a216"
 dependencies = [
  "arrayvec 0.7.4",
  "indexmap 2.0.0",
@@ -8880,17 +8937,16 @@ dependencies = [
  "serde",
  "serde_json",
  "swc_atoms",
- "swc_cached",
  "swc_common",
  "swc_config",
- "swc_ecma_ast",
- "swc_ecma_codegen",
- "swc_ecma_parser",
- "swc_ecma_transforms_base",
+ "swc_ecma_ast 0.111.1",
+ "swc_ecma_codegen 0.147.1",
+ "swc_ecma_parser 0.142.1",
+ "swc_ecma_transforms_base 0.136.1",
  "swc_ecma_transforms_optimization",
  "swc_ecma_usage_analyzer",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_utils 0.126.1",
+ "swc_ecma_visit 0.97.1",
  "swc_timer",
  "tracing",
 ]
@@ -8912,16 +8968,38 @@ dependencies = [
  "stacker",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
+ "swc_ecma_ast 0.110.17",
+ "tracing",
+ "typed-arena",
+]
+
+[[package]]
+name = "swc_ecma_parser"
+version = "0.142.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3eedda441af51ca25caebb88837649a40e2a39b763344a53cfedd869740c71"
+dependencies = [
+ "either",
+ "new_debug_unreachable",
+ "num-bigint",
+ "num-traits",
+ "phf 0.11.2",
+ "serde",
+ "smallvec 1.11.1",
+ "smartstring",
+ "stacker",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast 0.111.1",
  "tracing",
  "typed-arena",
 ]
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "0.204.20"
+version = "0.205.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a9037704b83704a517d6c6b88f0b4f519d77cd6acaa25fe3db97fc4ca77d784"
+checksum = "6445a30a5ad1569df582c75b867e3e74f1900eade38d8ad4d2227c6dfd875543"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -8936,34 +9014,34 @@ dependencies = [
  "string_enum",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
+ "swc_ecma_ast 0.111.1",
  "swc_ecma_transforms",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_utils 0.126.1",
+ "swc_ecma_visit 0.97.1",
 ]
 
 [[package]]
 name = "swc_ecma_quote_macros"
-version = "0.52.37"
+version = "0.53.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2bd72fda3eb232e08ac6ce9766edb59791dab5f588377c151a1da6c1862b734"
+checksum = "a24a9f5024cc5dd803acb14e22474c889c982ca19f306bc574704dafc4c1d6fb"
 dependencies = [
  "anyhow",
  "proc-macro2",
  "quote",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_parser",
+ "swc_ecma_ast 0.111.1",
+ "swc_ecma_parser 0.142.1",
  "swc_macros_common",
  "syn 2.0.32",
 ]
 
 [[package]]
 name = "swc_ecma_testing"
-version = "0.22.15"
+version = "0.22.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b02a3eafe6cecb8a63618c21edc31dda5baefa829c3e0ffb386da73a5f94d8"
+checksum = "8b73fd79980ad3182437a62dc0413bcd00e6157a7fcf5a64a86fa264ec6672ba"
 dependencies = [
  "anyhow",
  "hex",
@@ -8974,22 +9052,22 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.227.20"
+version = "0.228.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03f5ad7385ba6664106fc60c8b147d2c7ea2f2630d62ccb4a29a6d86f9fa1e4e"
+checksum = "6d7b37d02a0b2a70834588cb46b40c53d0154cf9970d27a12f65f87fe68c3f50"
 dependencies = [
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_transforms_base",
+ "swc_ecma_ast 0.111.1",
+ "swc_ecma_transforms_base 0.136.1",
  "swc_ecma_transforms_compat",
  "swc_ecma_transforms_module",
  "swc_ecma_transforms_optimization",
  "swc_ecma_transforms_proposal",
  "swc_ecma_transforms_react",
  "swc_ecma_transforms_typescript",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_utils 0.126.1",
+ "swc_ecma_visit 0.97.1",
 ]
 
 [[package]]
@@ -9003,38 +9081,61 @@ dependencies = [
  "indexmap 2.0.0",
  "once_cell",
  "phf 0.11.2",
+ "rustc-hash",
+ "serde",
+ "smallvec 1.11.1",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast 0.110.17",
+ "swc_ecma_parser 0.141.37",
+ "swc_ecma_utils 0.125.4",
+ "swc_ecma_visit 0.96.17",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_transforms_base"
+version = "0.136.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db269d6b55688960fc214cac4c31026dff482e9355afa3c7417316b86c685452"
+dependencies = [
+ "better_scoped_tls",
+ "bitflags 2.4.0",
+ "indexmap 2.0.0",
+ "once_cell",
+ "phf 0.11.2",
  "rayon",
  "rustc-hash",
  "serde",
  "smallvec 1.11.1",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_parser",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_ast 0.111.1",
+ "swc_ecma_parser 0.142.1",
+ "swc_ecma_utils 0.126.1",
+ "swc_ecma_visit 0.97.1",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "0.124.12"
+version = "0.125.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65a3a39bc56f271afba7e48be14f43a071226c27890da2fabaefa822cc89e3f2"
+checksum = "a86a29952848e12bcdd788fa6922d3a9c79603c26a38278effd63c98c532d069"
 dependencies = [
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_transforms_base",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_ast 0.111.1",
+ "swc_ecma_transforms_base 0.136.1",
+ "swc_ecma_utils 0.126.1",
+ "swc_ecma_visit 0.97.1",
 ]
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "0.161.17"
+version = "0.162.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26bfa9040b0ff31ff2b50b47b72ff02f4cd3e090a156e587e43fdc08ce1a7d36"
+checksum = "c1824310b8b2c6918153c9866353ad0e7887a1a395e8fc85d90280669bdc6362"
 dependencies = [
  "arrayvec 0.7.4",
  "indexmap 2.0.0",
@@ -9046,7 +9147,7 @@ dependencies = [
  "swc_atoms",
  "swc_common",
  "swc_config",
- "swc_ecma_ast",
+ "swc_ecma_ast 0.111.1",
  "swc_ecma_compat_bugfixes",
  "swc_ecma_compat_common",
  "swc_ecma_compat_es2015",
@@ -9058,11 +9159,11 @@ dependencies = [
  "swc_ecma_compat_es2021",
  "swc_ecma_compat_es2022",
  "swc_ecma_compat_es3",
- "swc_ecma_transforms_base",
+ "swc_ecma_transforms_base 0.136.1",
  "swc_ecma_transforms_classes",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_utils 0.126.1",
+ "swc_ecma_visit 0.97.1",
  "swc_trace_macro",
  "tracing",
 ]
@@ -9081,9 +9182,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "0.178.19"
+version = "0.179.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "684e80a3e847ae41c79c2c4af005c464ff9b0b0bb636009f588f64d14070ca35"
+checksum = "2a1cd0b9482c098d26e9743ece8ad01811d00cfed8f0646d49359f9e4c78bf27"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -9097,20 +9198,20 @@ dependencies = [
  "swc_atoms",
  "swc_cached",
  "swc_common",
- "swc_ecma_ast",
+ "swc_ecma_ast 0.111.1",
  "swc_ecma_loader",
- "swc_ecma_parser",
- "swc_ecma_transforms_base",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_parser 0.142.1",
+ "swc_ecma_transforms_base 0.136.1",
+ "swc_ecma_utils 0.126.1",
+ "swc_ecma_visit 0.97.1",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.196.19"
+version = "0.197.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b3b63a290c20600a3844fe3f842cad19eddc3e05b58752a9cd967978d54574"
+checksum = "45400b4e4ba30142b0a8f5b498b000d6b5687ffc5e449f49d9253005549c430c"
 dependencies = [
  "dashmap",
  "indexmap 2.0.0",
@@ -9121,21 +9222,21 @@ dependencies = [
  "serde_json",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_parser",
- "swc_ecma_transforms_base",
+ "swc_ecma_ast 0.111.1",
+ "swc_ecma_parser 0.142.1",
+ "swc_ecma_transforms_base 0.136.1",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_utils 0.126.1",
+ "swc_ecma_visit 0.97.1",
  "swc_fast_graph",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "0.169.17"
+version = "0.170.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d71a5d911918e4d7698df9f08925071e6993179e5e9331932051ff4e6ecf93"
+checksum = "424819468d5198d42034c3b5659aff91ad854c035cb0342e6e7f10916422de1f"
 dependencies = [
  "either",
  "rustc-hash",
@@ -9143,19 +9244,19 @@ dependencies = [
  "smallvec 1.11.1",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_transforms_base",
+ "swc_ecma_ast 0.111.1",
+ "swc_ecma_transforms_base 0.136.1",
  "swc_ecma_transforms_classes",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_utils 0.126.1",
+ "swc_ecma_visit 0.97.1",
 ]
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.181.19"
+version = "0.182.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c6f16101c8eda9420435b62fc50f127e15fb58ae73ce99df293609d23fb9b7"
+checksum = "52069f1ff08f6efe9d88ebbaa4974a33892e791fd00c70fc3f025053693d00ae"
 dependencies = [
  "base64 0.21.4",
  "dashmap",
@@ -9168,19 +9269,19 @@ dependencies = [
  "swc_atoms",
  "swc_common",
  "swc_config",
- "swc_ecma_ast",
- "swc_ecma_parser",
- "swc_ecma_transforms_base",
+ "swc_ecma_ast 0.111.1",
+ "swc_ecma_parser 0.142.1",
+ "swc_ecma_transforms_base 0.136.1",
  "swc_ecma_transforms_macros",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_utils 0.126.1",
+ "swc_ecma_visit 0.97.1",
 ]
 
 [[package]]
 name = "swc_ecma_transforms_testing"
-version = "0.138.12"
+version = "0.139.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecfd5d3bdcb529c4db2ac27fac59a9e1ce66975543d34f9ce60e7ee2cbc73f78"
+checksum = "529425edc510c3e766d7a0dba16909a1b42f932a88ffb89442e3071325c067ce"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -9191,47 +9292,47 @@ dependencies = [
  "sha2",
  "sourcemap",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_codegen",
- "swc_ecma_parser",
+ "swc_ecma_ast 0.111.1",
+ "swc_ecma_codegen 0.147.1",
+ "swc_ecma_parser 0.142.1",
  "swc_ecma_testing",
- "swc_ecma_transforms_base",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_transforms_base 0.136.1",
+ "swc_ecma_utils 0.126.1",
+ "swc_ecma_visit 0.97.1",
  "tempfile",
  "testing",
 ]
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.186.19"
+version = "0.187.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e951251870f036f549145c8eb6226d5b6bf7dac83b68b959cf2cca6b511f4b3f"
+checksum = "801c4f46b872b22aed626d28457440774decade9773d40064118e5842d9dc94b"
 dependencies = [
  "ryu-js",
  "serde",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_transforms_base",
+ "swc_ecma_ast 0.111.1",
+ "swc_ecma_transforms_base 0.136.1",
  "swc_ecma_transforms_react",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_utils 0.126.1",
+ "swc_ecma_visit 0.97.1",
 ]
 
 [[package]]
 name = "swc_ecma_usage_analyzer"
-version = "0.21.5"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bf6ae5dd022ac6f39034896dd94eaeb590bf1fc6ab6e4f302fc9cdd8569e9b7"
+checksum = "ffb8472c2bad83d26db456b6b0f933669aea6549271eb8bea683ed0dab326d13"
 dependencies = [
  "indexmap 2.0.0",
  "rustc-hash",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_ast 0.111.1",
+ "swc_ecma_utils 0.126.1",
+ "swc_ecma_visit 0.97.1",
  "swc_timer",
  "tracing",
 ]
@@ -9245,12 +9346,30 @@ dependencies = [
  "indexmap 2.0.0",
  "num_cpus",
  "once_cell",
+ "rustc-hash",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast 0.110.17",
+ "swc_ecma_visit 0.96.17",
+ "tracing",
+ "unicode-id",
+]
+
+[[package]]
+name = "swc_ecma_utils"
+version = "0.126.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f44fc2b597f6429631231b083a6019b8400c9d524eff4b82ece4b7dfffdbe787"
+dependencies = [
+ "indexmap 2.0.0",
+ "num_cpus",
+ "once_cell",
  "rayon",
  "rustc-hash",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_visit",
+ "swc_ecma_ast 0.111.1",
+ "swc_ecma_visit 0.97.1",
  "tracing",
  "unicode-id",
 ]
@@ -9262,19 +9381,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d0100c383fb08b6f34911ab6f925950416a5d14404c1cd520d59fb8dfbb3bf"
 dependencies = [
  "num-bigint",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast 0.110.17",
+ "swc_visit",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_visit"
+version = "0.97.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26ecefeec816318f1d449b4bac2e28a4243a167cc16620e15c3c1f2d91085770"
+dependencies = [
+ "num-bigint",
  "serde",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
+ "swc_ecma_ast 0.111.1",
  "swc_visit",
  "tracing",
 ]
 
 [[package]]
 name = "swc_emotion"
-version = "0.70.1"
+version = "0.72.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e10ea9a961413be44879c2b16d04b6bb8f8d9f9ca09ef2772c363d81dee0fe6"
+checksum = "b794190a05f827bc4758db38ce657a0105fa828bab47796678fd90696ce9f287"
 dependencies = [
  "base64 0.13.1",
  "byteorder",
@@ -9286,10 +9419,10 @@ dependencies = [
  "sourcemap",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_codegen",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_ast 0.111.1",
+ "swc_ecma_codegen 0.147.1",
+ "swc_ecma_utils 0.126.1",
+ "swc_ecma_visit 0.97.1",
  "swc_trace_macro",
  "tracing",
 ]
@@ -9307,9 +9440,9 @@ dependencies = [
 
 [[package]]
 name = "swc_error_reporters"
-version = "0.17.12"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e00fa7c3009268d8ab2ca69d22ac3c3fe777297215fa128bc0ef42dcdf230ab"
+checksum = "be42e786ee9bda3f72f7d7de791e1d7b49ab7f86ed54fdc5808681ae04406080"
 dependencies = [
  "anyhow",
  "miette 4.7.1",
@@ -9320,9 +9453,9 @@ dependencies = [
 
 [[package]]
 name = "swc_fast_graph"
-version = "0.21.13"
+version = "0.21.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acfc056067a0fbfe26a4763c1eb246e813fdbe6b376415d07915e96e15481b6"
+checksum = "0c9c9e567014e157af520f74b1a5bc151fece681136754b80b3fec6b908e26a0"
 dependencies = [
  "indexmap 2.0.0",
  "petgraph",
@@ -9332,9 +9465,9 @@ dependencies = [
 
 [[package]]
 name = "swc_graph_analyzer"
-version = "0.22.15"
+version = "0.22.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c6e0110c0433c27221f03e45419b7e18d1db4d472db309088caa458ac2f304e"
+checksum = "4b95d7a2b5712b1bcd4ccc4757e9028026a775d27ae07aec491bb371bd73b2c0"
 dependencies = [
  "auto_impl",
  "petgraph",
@@ -9366,9 +9499,9 @@ dependencies = [
 
 [[package]]
 name = "swc_node_comments"
-version = "0.20.12"
+version = "0.20.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86a67c8fb9735b17b2cdf7b5dd539dc1625f73d05c794566b98e65be39cee5b1"
+checksum = "a8058148241150b482cbe8f690f1005663994dc22c9f8f9a651c7aeca9263f35"
 dependencies = [
  "dashmap",
  "swc_atoms",
@@ -9391,9 +9524,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_macro"
-version = "0.9.15"
+version = "0.9.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "785309d342a69df4c929ee59e14e36889ca832f1d2a3c1d03c47c93126c72dbc"
+checksum = "3232db481484070637b20a155c064096c0ea1ba04fa2247b89b618661b3574f4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9402,23 +9535,23 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_proxy"
-version = "0.39.17"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f00d9e79d36925854ce4de73acf397a6882a0dccb5b248d1ec48202ac3f72ad"
+checksum = "d64191ea46b8156c495b77fce87759003d520109535d2fd524fe6d9e4de6238b"
 dependencies = [
  "better_scoped_tls",
  "rkyv",
  "swc_common",
- "swc_ecma_ast",
+ "swc_ecma_ast 0.111.1",
  "swc_trace_macro",
  "tracing",
 ]
 
 [[package]]
 name = "swc_plugin_runner"
-version = "0.104.41"
+version = "0.105.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26ed41b8a0e1a6afa4bca94c7e78329cccdce9271ec44cd3c4d67d097ce6c03f"
+checksum = "a16505b9e3773c2d5c76c5ae27545091ff1e382ac6b14644e6a8ab048dbfbd92"
 dependencies = [
  "anyhow",
  "enumset",
@@ -9428,7 +9561,7 @@ dependencies = [
  "serde",
  "serde_json",
  "swc_common",
- "swc_ecma_ast",
+ "swc_ecma_ast 0.111.1",
  "swc_plugin_proxy",
  "tokio",
  "tracing",
@@ -9440,9 +9573,9 @@ dependencies = [
 
 [[package]]
 name = "swc_relay"
-version = "0.42.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08b37cd8b8acc422343aae385f29a51a59a22d1bb0087c7ea3ee05ea51b87088"
+checksum = "28ae7a666d65809ebbcf58ee4c7d751ed5ff6d6304734d23aa5e084b1368cce9"
 dependencies = [
  "once_cell",
  "regex",
@@ -9450,17 +9583,17 @@ dependencies = [
  "serde_json",
  "swc_atoms",
  "swc_common",
- "swc_ecma_ast",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_ast 0.111.1",
+ "swc_ecma_utils 0.126.1",
+ "swc_ecma_visit 0.97.1",
  "tracing",
 ]
 
 [[package]]
 name = "swc_timer"
-version = "0.21.14"
+version = "0.21.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b37010da5874d241c9e11ef020b8e4473f3af4e5d2e19219e92d99c04f12e0c6"
+checksum = "9d15ec9bca22690ba9a373af069e366c9f43e48dd4d328aea6ba138f93ff0276"
 dependencies = [
  "tracing",
 ]
@@ -9769,9 +9902,9 @@ dependencies = [
 
 [[package]]
 name = "testing"
-version = "0.35.14"
+version = "0.35.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "293dc0c2fc5e51a67cde205832476cf205758168f9966312ea05a97c8fb2230c"
+checksum = "42599f638bd2b48c2892cf330862aca433c86286ae776d75c5074ba3b4935ed8"
 dependencies = [
  "ansi_term",
  "cargo_metadata",
@@ -10899,7 +11032,7 @@ dependencies = [
  "styled_components",
  "styled_jsx",
  "swc-ast-explorer",
- "swc_core",
+ "swc_core 0.89.0",
  "swc_emotion",
  "swc_relay",
  "testing",
@@ -10953,7 +11086,7 @@ dependencies = [
  "serde_json",
  "serde_qs",
  "sourcemap",
- "swc_core",
+ "swc_core 0.89.0",
  "tracing",
  "turbo-tasks",
  "turbo-tasks-build",
@@ -11062,7 +11195,7 @@ dependencies = [
  "serde_json",
  "serde_qs",
  "sourcemap",
- "swc_core",
+ "swc_core 0.89.0",
  "tokio",
  "tracing",
  "turbo-tasks",
@@ -11101,7 +11234,7 @@ dependencies = [
  "regex",
  "serde",
  "smallvec 1.11.1",
- "swc_core",
+ "swc_core 0.89.0",
  "tracing",
  "turbo-tasks",
  "turbo-tasks-build",
@@ -11122,7 +11255,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_qs",
- "swc_core",
+ "swc_core 0.89.0",
  "tracing",
  "turbo-tasks",
  "turbo-tasks-build",
@@ -11195,7 +11328,7 @@ dependencies = [
  "serde_json",
  "serde_qs",
  "sourcemap",
- "swc_core",
+ "swc_core 0.89.0",
  "tokio",
  "tracing",
  "turbo-tasks",
@@ -11233,7 +11366,7 @@ dependencies = [
  "serde_json",
  "styled_components",
  "styled_jsx",
- "swc_core",
+ "swc_core 0.89.0",
  "swc_emotion",
  "swc_relay",
  "turbo-tasks",
@@ -11250,7 +11383,7 @@ dependencies = [
  "anyhow",
  "indoc",
  "serde",
- "swc_core",
+ "swc_core 0.89.0",
  "turbo-tasks",
  "turbo-tasks-build",
  "turbo-tasks-fs",
@@ -11374,7 +11507,7 @@ dependencies = [
 name = "turbopack-swc-utils"
 version = "0.1.0"
 dependencies = [
- "swc_core",
+ "swc_core 0.89.0",
  "turbo-tasks",
  "turbo-tasks-build",
  "turbopack-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -806,9 +806,9 @@ dependencies = [
 
 [[package]]
 name = "binding_macros"
-version = "0.63.1"
+version = "0.63.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c23b57c7f17038ccd252bcff5806b362cce26e3c846ec17c9c5ad7044e4e7f0f"
+checksum = "39d293955e03cf750bf0025b4d5ccda67f56973281e312037ae96728978c5574"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -2239,7 +2239,7 @@ dependencies = [
  "cssparser-macros",
  "dtoa-short",
  "itoa",
- "phf 0.11.2",
+ "phf 0.10.1",
  "serde",
  "smallvec 1.11.1",
 ]
@@ -4095,7 +4095,7 @@ checksum = "334e04b4d781f436dc315cb1e7515bd96826426345d498149e4bde36b67f8ee9"
 dependencies = [
  "async-channel",
  "castaway",
- "crossbeam-utils 0.8.16",
+ "crossbeam-utils 0.7.2",
  "curl",
  "curl-sys",
  "encoding_rs",
@@ -5818,7 +5818,9 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
 dependencies = [
+ "phf_macros 0.10.0",
  "phf_shared 0.10.0",
+ "proc-macro-hack",
 ]
 
 [[package]]
@@ -5827,7 +5829,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
 dependencies = [
- "phf_macros",
+ "phf_macros 0.11.2",
  "phf_shared 0.11.2",
 ]
 
@@ -5859,6 +5861,20 @@ checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
 dependencies = [
  "phf_shared 0.11.2",
  "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58fdf3184dd560f160dd73922bea2d5cd6e8f064bf4b13110abd81b03697b4e0"
+dependencies = [
+ "phf_generator 0.10.0",
+ "phf_shared 0.10.0",
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -8170,9 +8186,9 @@ dependencies = [
 
 [[package]]
 name = "swc"
-version = "0.272.1"
+version = "0.272.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96059cbc8a4c20cbc43852c6a1d45ad1d4349e25823fb07079162284c824bc10"
+checksum = "4a5a28ad9c6b4e191bc09940c8dca68ad6edea404a7177d26db4905b4a853644"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -8247,9 +8263,9 @@ dependencies = [
 
 [[package]]
 name = "swc_bundler"
-version = "0.224.2"
+version = "0.224.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbe8d841d74ab7a1cd753db053b238f88707a39ebf25b02306c762a888fdc92a"
+checksum = "af7f1886fbbc63aa548d9005ce4a8093e1e5d32403407fd9ee63ddde95607ef3"
 dependencies = [
  "anyhow",
  "crc",
@@ -8326,9 +8342,9 @@ dependencies = [
 
 [[package]]
 name = "swc_compiler_base"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acf4a9fcd82f924e8693be713a56a33f9ac8504931b4843c3ec41853a1f373b6"
+checksum = "c53834a5890f8b994c873bb3138de60ad90aa7f7c2d64f4d93abe0c8a6bb035a"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -8867,9 +8883,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "0.191.2"
+version = "0.191.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7ed693be413eb44171ce48d794a3124477d8bb9de6af3740c4def6e8b02a216"
+checksum = "83a2011c5b8b3f118a13811fd1a00f30f1da88945a8132574dd68bcc27947449"
 dependencies = [
  "arrayvec 0.7.4",
  "indexmap 2.0.0",
@@ -8923,9 +8939,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "0.205.2"
+version = "0.205.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6445a30a5ad1569df582c75b867e3e74f1900eade38d8ad4d2227c6dfd875543"
+checksum = "284fdfb08e90025c10aec5efb3c4990191bc0c6ddeb81f28a98e489fa79450fb"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -8978,9 +8994,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.228.2"
+version = "0.228.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d7b37d02a0b2a70834588cb46b40c53d0154cf9970d27a12f65f87fe68c3f50"
+checksum = "d4f02226b45c2ab5a3e8ea4960c389b2eddb305a743d1c9e43b66a9f86cb56b1"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -9085,9 +9101,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "0.179.2"
+version = "0.179.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a1cd0b9482c098d26e9743ece8ad01811d00cfed8f0646d49359f9e4c78bf27"
+checksum = "860d840f79bd9d5af2d4bdc09cf3a866bb0c93b30d154f33f53687de45fee6c9"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -9112,9 +9128,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.197.2"
+version = "0.197.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45400b4e4ba30142b0a8f5b498b000d6b5687ffc5e449f49d9253005549c430c"
+checksum = "58d45e00b8d69a04c566f1de51187e079dd563ac8e1a3ddb77b0bf300be9dc20"
 dependencies = [
  "dashmap",
  "indexmap 2.0.0",
@@ -9137,9 +9153,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "0.170.2"
+version = "0.170.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "424819468d5198d42034c3b5659aff91ad854c035cb0342e6e7f10916422de1f"
+checksum = "c27c737126d0cafea2b2d5702260ef700e1dc86b475490fdf2e1371becd40a1b"
 dependencies = [
  "either",
  "rustc-hash",
@@ -9208,9 +9224,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.187.2"
+version = "0.187.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "801c4f46b872b22aed626d28457440774decade9773d40064118e5842d9dc94b"
+checksum = "b6a3369ba3663083f956c6a4810b05b259288c3c55ad8263daa994425117947f"
 dependencies = [
  "ryu-js",
  "serde",
@@ -9276,9 +9292,9 @@ dependencies = [
 
 [[package]]
 name = "swc_emotion"
-version = "0.72.0"
+version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b794190a05f827bc4758db38ce657a0105fa828bab47796678fd90696ce9f287"
+checksum = "7695a666a2b3b1dac06a097464cd7852f6cec303aa2ddf7e3f82fc8fa2659cf2"
 dependencies = [
  "base64 0.13.1",
  "byteorder",
@@ -12011,8 +12027,8 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
- "rand 0.8.5",
+ "cfg-if 0.1.10",
+ "rand 0.4.6",
  "static_assertions",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -806,9 +806,9 @@ dependencies = [
 
 [[package]]
 name = "binding_macros"
-version = "0.63.0"
+version = "0.63.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22807c7bb39e743a80a3ee19e1ea8db3f54a41b3c7d93c9a0ad253a2ab840b4c"
+checksum = "c23b57c7f17038ccd252bcff5806b362cce26e3c846ec17c9c5ad7044e4e7f0f"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -8068,9 +8068,9 @@ dependencies = [
 
 [[package]]
 name = "styled_jsx"
-version = "0.73.0"
+version = "0.73.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef365009ffea9054f2f59569adf3daeb286688de7b966702569b34532f9946ac"
+checksum = "1011d28e2c9b5e4bf83250af70b984c12228029ebf7f8acb564404500ccc9177"
 dependencies = [
  "anyhow",
  "lightningcss",
@@ -8170,9 +8170,9 @@ dependencies = [
 
 [[package]]
 name = "swc"
-version = "0.272.0"
+version = "0.272.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7a3f13725f06e0a889de3a74ab3eb0102cd21ffd456f1ff2660c218029ff39b"
+checksum = "96059cbc8a4c20cbc43852c6a1d45ad1d4349e25823fb07079162284c824bc10"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -8228,7 +8228,7 @@ dependencies = [
  "clap 4.4.2",
  "owo-colors",
  "regex",
- "swc_core 0.89.0",
+ "swc_core 0.89.1",
 ]
 
 [[package]]
@@ -8394,9 +8394,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "0.89.0"
+version = "0.89.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1dca261b95fe38a879a3998b6ecf1f583ca87401bef7e1de83f1997272585f1"
+checksum = "ed64351a7664c694b9274a613b6a36702f85da29bdbf5194059b19a73217a00a"
 dependencies = [
  "binding_macros",
  "swc",
@@ -11032,7 +11032,7 @@ dependencies = [
  "styled_components",
  "styled_jsx",
  "swc-ast-explorer",
- "swc_core 0.89.0",
+ "swc_core 0.89.1",
  "swc_emotion",
  "swc_relay",
  "testing",
@@ -11086,7 +11086,7 @@ dependencies = [
  "serde_json",
  "serde_qs",
  "sourcemap",
- "swc_core 0.89.0",
+ "swc_core 0.89.1",
  "tracing",
  "turbo-tasks",
  "turbo-tasks-build",
@@ -11195,7 +11195,7 @@ dependencies = [
  "serde_json",
  "serde_qs",
  "sourcemap",
- "swc_core 0.89.0",
+ "swc_core 0.89.1",
  "tokio",
  "tracing",
  "turbo-tasks",
@@ -11234,7 +11234,7 @@ dependencies = [
  "regex",
  "serde",
  "smallvec 1.11.1",
- "swc_core 0.89.0",
+ "swc_core 0.89.1",
  "tracing",
  "turbo-tasks",
  "turbo-tasks-build",
@@ -11255,7 +11255,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_qs",
- "swc_core 0.89.0",
+ "swc_core 0.89.1",
  "tracing",
  "turbo-tasks",
  "turbo-tasks-build",
@@ -11328,7 +11328,7 @@ dependencies = [
  "serde_json",
  "serde_qs",
  "sourcemap",
- "swc_core 0.89.0",
+ "swc_core 0.89.1",
  "tokio",
  "tracing",
  "turbo-tasks",
@@ -11366,7 +11366,7 @@ dependencies = [
  "serde_json",
  "styled_components",
  "styled_jsx",
- "swc_core 0.89.0",
+ "swc_core 0.89.1",
  "swc_emotion",
  "swc_relay",
  "turbo-tasks",
@@ -11383,7 +11383,7 @@ dependencies = [
  "anyhow",
  "indoc",
  "serde",
- "swc_core 0.89.0",
+ "swc_core 0.89.1",
  "turbo-tasks",
  "turbo-tasks-build",
  "turbo-tasks-fs",
@@ -11507,7 +11507,7 @@ dependencies = [
 name = "turbopack-swc-utils"
 version = "0.1.0"
 dependencies = [
- "swc_core 0.89.0",
+ "swc_core 0.89.1",
  "turbo-tasks",
  "turbo-tasks-build",
  "turbopack-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6073,7 +6073,7 @@ dependencies = [
  "shared_library",
  "shell-words",
  "winapi 0.3.9",
- "winreg 0.10.1",
+ "winreg",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,16 +90,16 @@ async-recursion = "1.0.2"
 browserslist-rs = { version = "0.14.0" }
 miette = { version = "5.10.0", features = ["fancy"] }
 mdxjs = "0.1.21"
-modularize_imports = { version = "0.66.0" }
-styled_components = { version = "0.94.0" }
-styled_jsx = { version = "0.68.1" }
-swc_core = { version = "0.87.28", features = [
+modularize_imports = { version = "0.68.0" }
+styled_components = { version = "0.96.1" }
+styled_jsx = { version = "0.73.0" }
+swc_core = { version = "0.89.0", features = [
   "ecma_loader_lru",
   "ecma_loader_parking_lot",
 ] }
-swc_emotion = { version = "0.70.1" }
-swc_relay = { version = "0.42.0" }
-testing = { version = "0.35.14" }
+swc_emotion = { version = "0.72.0" }
+swc_relay = { version = "0.44.0" }
+testing = { version = "0.35.16" }
 
 auto-hash-map = { path = "crates/turbo-tasks-auto-hash-map" }
 node-file-trace = { path = "crates/node-file-trace", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ async-recursion = "1.0.2"
 # Keep consistent with preset_env_base through swc_core
 browserslist-rs = { version = "0.14.0" }
 miette = { version = "5.10.0", features = ["fancy"] }
-mdxjs = "0.1.21"
+mdxjs = "0.1.22"
 modularize_imports = { version = "0.68.0" }
 styled_components = { version = "0.96.1" }
 styled_jsx = { version = "0.73.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,8 +92,8 @@ miette = { version = "5.10.0", features = ["fancy"] }
 mdxjs = "0.1.21"
 modularize_imports = { version = "0.68.0" }
 styled_components = { version = "0.96.1" }
-styled_jsx = { version = "0.73.0" }
-swc_core = { version = "0.89.0", features = [
+styled_jsx = { version = "0.73.1" }
+swc_core = { version = "0.89.1", features = [
   "ecma_loader_lru",
   "ecma_loader_parking_lot",
 ] }

--- a/crates/turbopack-ecmascript-plugins/src/transform/directives/server_to_client_proxy.rs
+++ b/crates/turbopack-ecmascript-plugins/src/transform/directives/server_to_client_proxy.rs
@@ -39,6 +39,7 @@ pub fn create_proxy_module(transition_name: &str, target_import: &str) -> Progra
                     })))],
                 })),
                 span: DUMMY_SP,
+                phase: Default::default(),
             })),
             ModuleItem::Stmt(quote!(
                 "__turbopack_export_namespace__($proxy);" as Stmt,

--- a/crates/turbopack-ecmascript-plugins/src/transform/styled_jsx.rs
+++ b/crates/turbopack-ecmascript-plugins/src/transform/styled_jsx.rs
@@ -56,7 +56,7 @@ impl CustomTransformer for StyledJsxTransformer {
                         let ss = match ss {
                             Ok(v) => v,
                             Err(err) => {
-                                bail!("failed to parse css: {}", err)
+                                bail!("failed to parse css using lightningcss: {}", err)
                             }
                         };
 

--- a/crates/turbopack-ecmascript/src/tree_shake/graph.rs
+++ b/crates/turbopack-ecmascript/src/tree_shake/graph.rs
@@ -300,6 +300,7 @@ impl DepGraph {
                         src: Box::new(uri_of_module.clone().into()),
                         type_only: false,
                         with: Some(Box::new(create_turbopack_chunk_id_assert(dep))),
+                        phase: Default::default(),
                     })));
             }
 

--- a/crates/turbopack-tests/tests/snapshot/basic/ecmascript_minify/output/crates_turbopack-tests_tests_snapshot_basic_ecmascript_minify_input_index_dc5b16.js.map
+++ b/crates/turbopack-tests/tests/snapshot/basic/ecmascript_minify/output/crates_turbopack-tests_tests_snapshot_basic_ecmascript_minify_input_index_dc5b16.js.map
@@ -1,6 +1,6 @@
 {
   "version": 3,
   "sections": [
-    {"offset": {"line": 0, "column": 0}, "map": {"version":3,"sources":["/turbopack/[project]/crates/turbopack-tests/tests/snapshot/basic/ecmascript_minify/input/index.js","/turbopack/crates/turbopack-tests/tests/snapshot/basic/ecmascript_minify/output/crates_turbopack-tests_tests_snapshot_basic_ecmascript_minify_input_index_dc5b16.js"],"sourcesContent":["const inlined = 3;\nconst message = getMessage();\n\nconsole.log(\"Hello,\" + \" world!\", inlined, message);\nconsole.log(message);\n\nfunction getMessage() {\n  return \"Hello\";\n}\n",null],"names":[],"mappings":"iOACA,IAAM,EAMG,QAJT,QAAQ,GAAG,CAAC,gBAHI,EAG2B,GAC3C,QAAQ,GAAG,CAAC"}},
+    {"offset": {"line": 0, "column": 0}, "map": {"version":3,"sources":["/turbopack/[project]/crates/turbopack-tests/tests/snapshot/basic/ecmascript_minify/input/index.js"],"sourcesContent":["const inlined = 3;\nconst message = getMessage();\n\nconsole.log(\"Hello,\" + \" world!\", inlined, message);\nconsole.log(message);\n\nfunction getMessage() {\n  return \"Hello\";\n}\n"],"names":[],"mappings":"iOACA,IAAM,EAMG,QAJT,QAAQ,GAAG,CAAC,gBAHI,EAG2B,GAC3C,QAAQ,GAAG,CAAC"}},
     {"offset": {"line": 0, "column": 302}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}}]
 }

--- a/crates/turbopack-tests/tests/snapshot/emotion/emotion/output/crates_turbopack-tests_tests_snapshot_b36339._.js
+++ b/crates/turbopack-tests/tests/snapshot/emotion/emotion/output/crates_turbopack-tests_tests_snapshot_b36339._.js
@@ -12,7 +12,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests
 ;
 ;
 const StyledButton = __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$node_modules$2f40$emotion$2f$styled$2f$index$2e$js__$5b$test$5d$__$28$ecmascript$29$__["default"]("button", {
-    target: "eqxscy0"
+    target: "e1xogxlp0"
 })("background:blue;");
 function ClassNameButton({ children }) {
     return /*#__PURE__*/ __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$node_modules$2f40$emotion$2f$react$2f$jsx$2d$dev$2d$runtime$2e$js__$5b$test$5d$__$28$ecmascript$29$__["jsxDEV"]("button", {
@@ -21,7 +21,7 @@ function ClassNameButton({ children }) {
       `,
         children: children
     }, void 0, false, {
-        fileName: "<[project]/crates/turbopack-tests/tests/snapshot/emotion/emotion/input/index.js>",
+        fileName: "[project]/crates/turbopack-tests/tests/snapshot/emotion/emotion/input/index.js",
         lineNumber: 12,
         columnNumber: 5
     }, this);

--- a/crates/turbopack-tests/tests/snapshot/swc_transforms/mono_transforms/output/crates_turbopack-tests_tests_snapshot_9cde7b._.js
+++ b/crates/turbopack-tests/tests/snapshot/swc_transforms/mono_transforms/output/crates_turbopack-tests_tests_snapshot_9cde7b._.js
@@ -13,7 +13,7 @@ function MyApp() {
     return /*#__PURE__*/ __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$node_modules$2f$react$2f$jsx$2d$dev$2d$runtime$2e$js__$5b$test$5d$__$28$ecmascript$29$__["jsxDEV"]("div", {
         children: "App"
     }, void 0, false, {
-        fileName: "<[project]/crates/turbopack-tests/tests/snapshot/swc_transforms/mono_transforms/input/packages/component/index.js>",
+        fileName: "[project]/crates/turbopack-tests/tests/snapshot/swc_transforms/mono_transforms/input/packages/component/index.js",
         lineNumber: 2,
         columnNumber: 10
     }, this);


### PR DESCRIPTION
### Description

Update SWC crates.

### Testing Instructions

 - next.js counterpart: https://github.com/vercel/next.js/pull/61086



Closes PACK-2286