### PR TITLE
chore(daemon): swap fallback logs to debug

### DIFF
--- a/crates/turborepo-lib/src/task_graph/visitor.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor.rs
@@ -840,10 +840,7 @@ impl ExecContext {
             ChildExit::Finished(Some(0)) => {
                 if let Err(e) = stdout_writer.flush() {
                     error!("{e}");
-                } else if let Err(e) = self
-                    .task_cache
-                    .save_outputs(&mut prefixed_ui, task_duration, telemetry)
-                    .await
+                } else if let Err(e) = self.task_cache.save_outputs(task_duration, telemetry).await
                 {
                     error!("error caching output: {e}");
                 } else {


### PR DESCRIPTION
### Description

These are warnings about an optimization that fails. This isn't blocking, and turbo will work even if these fail. 

Removing these logs to reduce confusion when these are seen. Plus once telemetry is enabled globally we will have these metrics internally. 
