### PR TITLE
fix(hashing): include gitignored files in fallback

### DIFF
--- a/cli/internal/hashing/package_deps_hash_test.go
+++ b/cli/internal/hashing/package_deps_hash_test.go
@@ -473,6 +473,9 @@ func Test_getPackageFileHashesFromProcessingGitIgnore(t *testing.T) {
 		t.Errorf("found extra hashes in %v", hashes)
 	}
 
+	// expect the ignored file for manual hashing
+	files[turbopath.AnchoredUnixPath("child-dir/libA/pkgignorethisdir/file")] = fileHash{contents: "anything", hash: "67aed78ea231bdee3de45b6d47d8f32a0a792f6d"}
+
 	count = 0
 	justFileHashes, err := GetPackageFileHashes(repoRoot, pkg.Dir, []string{filepath.FromSlash("**/*file"), "!" + filepath.FromSlash("some-dir/excluded-file")})
 	if err != nil {

--- a/crates/turborepo-scm/src/manual.rs
+++ b/crates/turborepo-scm/src/manual.rs
@@ -84,7 +84,9 @@ pub(crate) fn get_package_file_hashes_from_processing_gitignore<S: AsRef<str>>(
     };
     let walker = walker_builder
         .follow_links(false)
-        .git_ignore(true)
+        // if inputs have been provided manually, we shouldn't skip ignored files to mimic the
+        // regular behavior
+        .git_ignore(inputs.is_empty())
         .require_git(false)
         .hidden(false) // this results in yielding hidden files (e.g. .gitignore)
         .build();
@@ -259,7 +261,7 @@ mod tests {
 
         let pkg_path = AnchoredSystemPathBuf::from_raw("child-dir/libA").unwrap();
         let unix_pkg_path = pkg_path.to_unix();
-        let file_hash: Vec<(&str, &str, Option<&str>)> = vec![
+        let mut file_hash: Vec<(&str, &str, Option<&str>)> = vec![
             ("top-level-file", "top-level-file-contents", None),
             ("other-dir/other-dir-file", "other-dir-file-contents", None),
             ("ignoreme", "anything", None),
@@ -323,6 +325,14 @@ mod tests {
                 .unwrap();
         assert_eq!(hashes, expected);
 
+        // set a hash for an ignored file
+        for tuple in file_hash.iter_mut() {
+            if tuple.0 == "child-dir/libA/pkgignorethisdir/file" {
+                tuple.2 = Some("67aed78ea231bdee3de45b6d47d8f32a0a792f6d");
+                break;
+            }
+        }
+
         expected = GitHashes::new();
         for (raw_unix_path, contents, expected_hash) in file_hash.iter() {
             let unix_path = RelativeUnixPath::new(raw_unix_path).unwrap();
@@ -345,6 +355,7 @@ mod tests {
             &["**/*file", "!some-dir/excluded-file"],
         )
         .unwrap();
+
         assert_eq!(hashes, expected);
     }
 }

--- a/crates/turborepo-scm/src/manual.rs
+++ b/crates/turborepo-scm/src/manual.rs
@@ -326,9 +326,9 @@ mod tests {
         assert_eq!(hashes, expected);
 
         // set a hash for an ignored file
-        for tuple in file_hash.iter_mut() {
-            if tuple.0 == "child-dir/libA/pkgignorethisdir/file" {
-                tuple.2 = Some("67aed78ea231bdee3de45b6d47d8f32a0a792f6d");
+        for (raw_unix_path, _, expected_hash) in file_hash.iter_mut() {
+            if *raw_unix_path == "child-dir/libA/pkgignorethisdir/file" {
+                *expected_hash = Some("67aed78ea231bdee3de45b6d47d8f32a0a792f6d");
                 break;
             }
         }


### PR DESCRIPTION
### Description

If inputs have been provided, we allow git-ignored files to be included in the hash. This behavior wasn't respected for the fallback hashing (when git isn't available). This fixes that. 


Closes TURBO-2156