### PR TITLE
fix: strip out EOT sequence from PTY output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6073,7 +6073,7 @@ dependencies = [
  "shared_library",
  "shell-words",
  "winapi 0.3.9",
- "winreg 0.10.1",
+ "winreg",
 ]
 
 [[package]]

--- a/crates/turborepo-lib/src/process/mod.rs
+++ b/crates/turborepo-lib/src/process/mod.rs
@@ -11,6 +11,7 @@
 
 mod child;
 mod command;
+mod pty;
 
 use std::{
     io,

--- a/crates/turborepo-lib/src/process/pty.rs
+++ b/crates/turborepo-lib/src/process/pty.rs
@@ -1,0 +1,69 @@
+use std::io::BufRead;
+
+// Sequence produced by the receiving side of a PTY when receiving EOT
+// ^D and then 2 backspaces to overwrite the EOT representation
+pub const EOT_SEQUENCE: &[u8] = "^D\u{8}\u{8}".as_bytes();
+
+/// Wrapper for stripping out a single EOT sequence that might appear in a
+/// reader
+pub struct EotStripper<R> {
+    reader: R,
+    strip_eot: bool,
+}
+
+impl<R: BufRead> EotStripper<R> {
+    pub fn new(reader: R) -> Self {
+        Self {
+            reader,
+            strip_eot: true,
+        }
+    }
+
+    pub fn read_line(&mut self, buffer: &mut Vec<u8>) -> std::io::Result<usize> {
+        let bytes = self.reader.read_until(b'\n', buffer)?;
+        if self.strip_eot {
+            // We only check the prefix as EOT is only respected after a newline
+            // and portable_pty automatically sends a \n before sending EOT.
+            if let Some(trimmed) = buffer.strip_prefix(EOT_SEQUENCE) {
+                self.strip_eot = false;
+                // Line is just EOT, skip emitting it and move onto next line
+                if trimmed.iter().all(|byte| *byte == b'\r' || *byte == b'\n') {
+                    buffer.clear();
+                    return self.read_line(buffer);
+                } else {
+                    let mut new_buffer = Vec::with_capacity(trimmed.len());
+                    new_buffer.extend_from_slice(trimmed);
+                    std::mem::swap(buffer, &mut new_buffer);
+                }
+            }
+        }
+        Ok(bytes)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::io::Write;
+
+    use pretty_assertions::assert_eq;
+    use test_case::test_case;
+
+    use super::*;
+
+    #[test_case("no eot here\n", "no eot here\n" ; "no eot")]
+    #[test_case("^D\u{8}\u{8}", "" ; "just eot")]
+    #[test_case("^D\u{8}\u{8}\r\n", "" ; "just eot + whitespace")]
+    #[test_case("^D\u{8}\u{8}message\n", "message\n" ; "eot with output")]
+    #[test_case("^D\u{8}\u{8}\r\nmessage\n", "message\n" ; "eot with output on newline")]
+    #[test_case("^D\u{8}\u{8}\r\n^D\u{8}\u{8}\r\n", "^D\u{8}\u{8}\r\n" ; "double eot")]
+    fn test_eot_stripper(input: &str, expected: &str) {
+        let mut stripper = EotStripper::new(input.as_bytes());
+        let mut output = Vec::new();
+        let mut buffer = Vec::new();
+        while stripper.read_line(&mut buffer).unwrap() != 0 {
+            output.write_all(&buffer).unwrap()
+        }
+        let actual = String::from_utf8(output).unwrap();
+        assert_eq!(actual, expected)
+    }
+}


### PR DESCRIPTION
### Description

Currently the PTY device we're creating has `ECHOCTL` set which means that the EOT that gets sent when we drop stdin shows up as a `^D`:

> ECHOCTL
              (not in POSIX) If ECHO is also set, terminal special
              characters other than TAB, NL, START, and STOP are echoed
              as ^X, where X is the character with ASCII code 0x40
              greater than the special character.

This PR just looks for the sequence that gets generated in the output and strips it.

### Testing Instructions

Added unit tests and made existing unit tests that use the updated codepath more strict.


Closes TURBO-2159