### PR TITLE
fix(turbopack): don't parse `.ts` files as `.tsx`

### DIFF
--- a/crates/turbopack-ecmascript/src/lib.rs
+++ b/crates/turbopack-ecmascript/src/lib.rs
@@ -137,9 +137,12 @@ pub enum EcmascriptModuleAssetType {
     /// Module with EcmaScript code
     Ecmascript,
     /// Module with TypeScript code without types
-    Typescript,
-    /// Module with TypeScript code with references to imported types
-    TypescriptWithTypes,
+    Typescript {
+        // parse JSX syntax.
+        tsx: bool,
+        // follow references to imported types.
+        analyze_types: bool,
+    },
     /// Module with TypeScript declaration code
     TypescriptDeclaration,
 }
@@ -148,8 +151,16 @@ impl Display for EcmascriptModuleAssetType {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             EcmascriptModuleAssetType::Ecmascript => write!(f, "ecmascript"),
-            EcmascriptModuleAssetType::Typescript => write!(f, "typescript"),
-            EcmascriptModuleAssetType::TypescriptWithTypes => write!(f, "typescript with types"),
+            EcmascriptModuleAssetType::Typescript { tsx, analyze_types } => {
+                write!(f, "typescript")?;
+                if *tsx {
+                    write!(f, "with JSX")?;
+                }
+                if *analyze_types {
+                    write!(f, "with types")?;
+                }
+                Ok(())
+            }
             EcmascriptModuleAssetType::TypescriptDeclaration => write!(f, "typescript declaration"),
         }
     }

--- a/crates/turbopack-ecmascript/src/parse.rs
+++ b/crates/turbopack-ecmascript/src/parse.rs
@@ -278,13 +278,12 @@ async fn parse_content(
                             auto_accessors: true,
                             explicit_resource_management: true,
                         }),
-                        EcmascriptModuleAssetType::Typescript
-                        | EcmascriptModuleAssetType::TypescriptWithTypes => {
+                        EcmascriptModuleAssetType::Typescript { tsx, .. } => {
                             Syntax::Typescript(TsConfig {
                                 decorators: true,
                                 dts: false,
                                 no_early_errors: true,
-                                tsx: true,
+                                tsx,
                                 disallow_ambiguous_jsx_like: false,
                             })
                         }
@@ -293,7 +292,7 @@ async fn parse_content(
                                 decorators: true,
                                 dts: true,
                                 no_early_errors: true,
-                                tsx: true,
+                                tsx: false,
                                 disallow_ambiguous_jsx_like: false,
                             })
                         }
@@ -330,8 +329,7 @@ async fn parse_content(
 
             let is_typescript = matches!(
                 ty,
-                EcmascriptModuleAssetType::Typescript
-                    | EcmascriptModuleAssetType::TypescriptWithTypes
+                EcmascriptModuleAssetType::Typescript { .. }
                     | EcmascriptModuleAssetType::TypescriptDeclaration
             );
             parsed_program.visit_mut_with(&mut resolver(

--- a/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/crates/turbopack-ecmascript/src/references/mod.rs
@@ -395,9 +395,9 @@ pub(crate) async fn analyse_ecmascript_module_internal(
 
     // Is this a typescript file that requires analzying type references?
     let analyze_types = match &*ty {
-        EcmascriptModuleAssetType::TypescriptWithTypes
-        | EcmascriptModuleAssetType::TypescriptDeclaration => true,
-        EcmascriptModuleAssetType::Typescript | EcmascriptModuleAssetType::Ecmascript => false,
+        EcmascriptModuleAssetType::Typescript { analyze_types, .. } => *analyze_types,
+        EcmascriptModuleAssetType::TypescriptDeclaration => true,
+        EcmascriptModuleAssetType::Ecmascript => false,
     };
 
     let parsed = if let Some(part) = part {

--- a/crates/turbopack-mdx/src/lib.rs
+++ b/crates/turbopack-mdx/src/lib.rs
@@ -134,7 +134,10 @@ async fn into_ecmascript_module_asset(
     Ok(EcmascriptModuleAsset::new(
         Vc::upcast(source),
         this.asset_context,
-        Value::new(EcmascriptModuleAssetType::Typescript),
+        Value::new(EcmascriptModuleAssetType::Typescript {
+            tsx: true,
+            analyze_types: false,
+        }),
         this.transforms,
         Value::new(Default::default()),
         this.asset_context.compile_time_info(),

--- a/crates/turbopack/src/module_options/mod.rs
+++ b/crates/turbopack/src/module_options/mod.rs
@@ -257,67 +257,70 @@ impl ModuleOptions {
                 })],
             ),
             ModuleRule::new_all(
-                ModuleRuleCondition::any(vec![
-                    ModuleRuleCondition::ResourcePathEndsWith(".ts".to_string()),
-                    ModuleRuleCondition::ResourcePathEndsWith(".tsx".to_string()),
-                ]),
-                vec![if enable_types {
-                    ModuleRuleEffect::ModuleType(ModuleType::TypescriptWithTypes {
-                        transforms: ts_app_transforms,
-                        options: ecmascript_options,
-                    })
-                } else {
-                    ModuleRuleEffect::ModuleType(ModuleType::Typescript {
-                        transforms: ts_app_transforms,
-                        options: ecmascript_options,
-                    })
-                }],
+                ModuleRuleCondition::ResourcePathEndsWith(".ts".to_string()),
+                vec![ModuleRuleEffect::ModuleType(ModuleType::Typescript {
+                    transforms: ts_app_transforms,
+                    tsx: false,
+                    analyze_types: enable_types,
+                    options: ecmascript_options,
+                })],
             ),
             ModuleRule::new_all(
-                ModuleRuleCondition::any(vec![
-                    ModuleRuleCondition::ResourcePathEndsWith(".mts".to_string()),
-                    ModuleRuleCondition::ResourcePathEndsWith(".mtsx".to_string()),
-                ]),
-                vec![if enable_types {
-                    ModuleRuleEffect::ModuleType(ModuleType::TypescriptWithTypes {
-                        transforms: ts_app_transforms,
-                        options: EcmascriptOptions {
-                            specified_module_type: SpecifiedModuleType::EcmaScript,
-                            ..ecmascript_options
-                        },
-                    })
-                } else {
-                    ModuleRuleEffect::ModuleType(ModuleType::Typescript {
-                        transforms: ts_app_transforms,
-                        options: EcmascriptOptions {
-                            specified_module_type: SpecifiedModuleType::EcmaScript,
-                            ..ecmascript_options
-                        },
-                    })
-                }],
+                ModuleRuleCondition::ResourcePathEndsWith(".tsx".to_string()),
+                vec![ModuleRuleEffect::ModuleType(ModuleType::Typescript {
+                    transforms: ts_app_transforms,
+                    tsx: true,
+                    analyze_types: enable_types,
+                    options: ecmascript_options,
+                })],
             ),
             ModuleRule::new_all(
-                ModuleRuleCondition::any(vec![
-                    ModuleRuleCondition::ResourcePathEndsWith(".cts".to_string()),
-                    ModuleRuleCondition::ResourcePathEndsWith(".ctsx".to_string()),
-                ]),
-                vec![if enable_types {
-                    ModuleRuleEffect::ModuleType(ModuleType::TypescriptWithTypes {
-                        transforms: ts_app_transforms,
-                        options: EcmascriptOptions {
-                            specified_module_type: SpecifiedModuleType::CommonJs,
-                            ..ecmascript_options
-                        },
-                    })
-                } else {
-                    ModuleRuleEffect::ModuleType(ModuleType::Typescript {
-                        transforms: ts_app_transforms,
-                        options: EcmascriptOptions {
-                            specified_module_type: SpecifiedModuleType::CommonJs,
-                            ..ecmascript_options
-                        },
-                    })
-                }],
+                ModuleRuleCondition::ResourcePathEndsWith(".mts".to_string()),
+                vec![ModuleRuleEffect::ModuleType(ModuleType::Typescript {
+                    transforms: ts_app_transforms,
+                    tsx: false,
+                    analyze_types: enable_types,
+                    options: EcmascriptOptions {
+                        specified_module_type: SpecifiedModuleType::EcmaScript,
+                        ..ecmascript_options
+                    },
+                })],
+            ),
+            ModuleRule::new_all(
+                ModuleRuleCondition::ResourcePathEndsWith(".mtsx".to_string()),
+                vec![ModuleRuleEffect::ModuleType(ModuleType::Typescript {
+                    transforms: ts_app_transforms,
+                    tsx: true,
+                    analyze_types: enable_types,
+                    options: EcmascriptOptions {
+                        specified_module_type: SpecifiedModuleType::EcmaScript,
+                        ..ecmascript_options
+                    },
+                })],
+            ),
+            ModuleRule::new_all(
+                ModuleRuleCondition::ResourcePathEndsWith(".cts".to_string()),
+                vec![ModuleRuleEffect::ModuleType(ModuleType::Typescript {
+                    transforms: ts_app_transforms,
+                    tsx: false,
+                    analyze_types: enable_types,
+                    options: EcmascriptOptions {
+                        specified_module_type: SpecifiedModuleType::CommonJs,
+                        ..ecmascript_options
+                    },
+                })],
+            ),
+            ModuleRule::new_all(
+                ModuleRuleCondition::ResourcePathEndsWith(".ctsx".to_string()),
+                vec![ModuleRuleEffect::ModuleType(ModuleType::Typescript {
+                    transforms: ts_app_transforms,
+                    tsx: true,
+                    analyze_types: enable_types,
+                    options: EcmascriptOptions {
+                        specified_module_type: SpecifiedModuleType::CommonJs,
+                        ..ecmascript_options
+                    },
+                })],
             ),
             ModuleRule::new(
                 ModuleRuleCondition::ResourcePathEndsWith(".d.ts".to_string()),

--- a/crates/turbopack/src/module_options/module_rule.rs
+++ b/crates/turbopack/src/module_options/module_rule.rs
@@ -99,11 +99,10 @@ pub enum ModuleType {
     },
     Typescript {
         transforms: Vc<EcmascriptInputTransforms>,
-        #[turbo_tasks(trace_ignore)]
-        options: EcmascriptOptions,
-    },
-    TypescriptWithTypes {
-        transforms: Vc<EcmascriptInputTransforms>,
+        // parse JSX syntax.
+        tsx: bool,
+        // follow references to imported types.
+        analyze_types: bool,
         #[turbo_tasks(trace_ignore)]
         options: EcmascriptOptions,
     },


### PR DESCRIPTION
### Description

We currently parse JSX syntax in all typescript files which is wrong.

Closes PACK-2302

Next.js PR: https://github.com/vercel/next.js/pull/61219