### PR TITLE
chore: add tracing to pty usage

### DIFF
--- a/crates/turborepo-lib/src/process/child.rs
+++ b/crates/turborepo-lib/src/process/child.rs
@@ -92,6 +92,7 @@ enum ChildHandleImpl {
 }
 
 impl ChildHandle {
+    #[tracing::instrument(skip(command))]
     pub fn spawn_normal(command: Command) -> io::Result<SpawnResult> {
         let mut command = TokioCommand::from(command);
 
@@ -133,6 +134,7 @@ impl ChildHandle {
         })
     }
 
+    #[tracing::instrument(skip(command))]
     pub fn spawn_pty(command: Command) -> io::Result<SpawnResult> {
         use portable_pty::PtySize;
 
@@ -409,6 +411,7 @@ pub enum ChildCommand {
 impl Child {
     /// Start a child process, returning a handle that can be used to interact
     /// with it. The command will be started immediately.
+    #[tracing::instrument(skip(command), fields(command = command.label()))]
     pub fn spawn(
         command: Command,
         shutdown_style: ShutdownStyle,
@@ -550,6 +553,7 @@ impl Child {
 
     /// Wait for the `Child` to exit and pipe any stdout and stderr to the
     /// provided writer.
+    #[tracing::instrument(skip_all)]
     pub async fn wait_with_piped_outputs<W: Write>(
         &mut self,
         stdout_pipe: W,
@@ -571,6 +575,7 @@ impl Child {
         }
     }
 
+    #[tracing::instrument(skip_all)]
     async fn wait_with_piped_sync_output<R: BufRead + Send + 'static>(
         &mut self,
         mut stdout_pipe: impl Write,
@@ -618,6 +623,7 @@ impl Child {
         Ok(status)
     }
 
+    #[tracing::instrument(skip_all)]
     async fn wait_with_piped_async_outputs<R1: AsyncBufRead + Unpin, R2: AsyncBufRead + Unpin>(
         &mut self,
         mut stdout_pipe: impl Write,


### PR DESCRIPTION
### Description

Adding some tracing to our spawning code to measure impact of PTY usage. Quick tests make it look like the `openpty` call has a minimal impact (~.2ms) on the time it takes to spawn a process.
<img width="228" alt="Screenshot 2024-01-26 at 10 42 12 AM" src="https://github.com/vercel/turbo/assets/4131117/fbb11622-7a1d-4638-b733-c6aa12ff1bb2">
<img width="238" alt="Screenshot 2024-01-26 at 10 42 19 AM" src="https://github.com/vercel/turbo/assets/4131117/b54162ec-7974-40e0-bfb0-4789a45e48c7">


### Testing Instructions

Look at the profiles:
[normal.json](https://github.com/vercel/turbo/files/14068301/normal.json)
[pty.json](https://github.com/vercel/turbo/files/14068303/pty.json)



Closes TURBO-2175