### PR TITLE
feat: enable pty usage

### DIFF
--- a/crates/turborepo-lib/src/process/mod.rs
+++ b/crates/turborepo-lib/src/process/mod.rs
@@ -65,8 +65,14 @@ impl ProcessManager {
         if lock.is_closing {
             return None;
         }
-        let child =
-            child::Child::spawn(command, child::ShutdownStyle::Graceful(stop_timeout), false);
+        // Only use PTY if we're not on windows and we're currently hooked up to a
+        // in a TTY
+        let use_pty = !cfg!(windows) && atty::is(atty::Stream::Stdout);
+        let child = child::Child::spawn(
+            command,
+            child::ShutdownStyle::Graceful(stop_timeout),
+            use_pty,
+        );
         if let Ok(child) = &child {
             lock.children.push(child.clone());
         }


### PR DESCRIPTION
### Description

Enable PTY usage! Will wait until #7109 is merged so there isn't any `^D` in the output caused by stdin being dropped. Measurements of impact of PTY usage can be found in #7127

Current rules for our PTY usage:
 - User isn't on windows
 - stdout is hooked up to a TTY as this is where we send task logs

We could strengthen the condition by requiring that stderr is hooked up to a TTY, but IMO this is overkill as we don't send any task output to that stream.

### Testing Instructions

When running normally we get nice colors:
<img width="661" alt="Screenshot 2024-01-26 at 11 37 25 AM" src="https://github.com/vercel/turbo/assets/4131117/e569e693-292f-4a6c-8a31-c3ad54270449">

Verify that if we pipe our primary output to stdout, we don't use a PTY and get no colors:
<img width="727" alt="Screenshot 2024-01-26 at 11 38 09 AM" src="https://github.com/vercel/turbo/assets/4131117/51262262-8b5e-447b-abdb-b9ed13761988">


Closes TURBO-2176