### PR TITLE
fix: process manager tests tty

### DIFF
--- a/crates/turborepo-lib/src/process/command.rs
+++ b/crates/turborepo-lib/src/process/command.rs
@@ -152,6 +152,11 @@ impl From<Command> for portable_pty::CommandBuilder {
         cmd.args(args);
         if let Some(cwd) = cwd {
             cmd.cwd(cwd.as_std_path());
+        } else if let Ok(cwd) = std::env::current_dir() {
+            // portably_pty defaults to a users home directory instead of cwd if one isn't
+            // configured on the command builder.
+            // We explicitly set the cwd if one exists to avoid this behavior
+            cmd.cwd(&cwd);
         }
         for (key, value) in env {
             cmd.env(key, value);

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -69,7 +69,7 @@ pub struct Run {
 
 impl Run {
     pub fn new(base: CommandBase, api_auth: Option<APIAuth>) -> Result<Self, Error> {
-        let processes = ProcessManager::new();
+        let processes = ProcessManager::infer();
         let mut opts: Opts = base.args().try_into()?;
         let config = base.config()?;
         let is_linked = turborepo_api_client::is_linked(&api_auth);


### PR DESCRIPTION
### Description

I realized that the process manager tests were broken if they were run from a TTY on non-windows. This PR does a few things:

- Switches `use_pty` calculation to happen once during process manager construction. This saves a `isatty` syscall from each process getting spawned.
- Fixes how we constructed `portable_pty::CommandBuilder` as it differs from the stdlib where if `cwd` isn't specified it uses the user home dir instead of the current process cwd [source](https://docs.rs/portable-pty/latest/src/portable_pty/cmdbuilder.rs.html#458). This came up because process manager tests don't use absolute paths to specify script paths where the child tests use absolute paths so cwd doesn't matter.

We could update the process manager tests to cover both codepaths, but the spawn method shouldn't impact the process manager behavior and should be captured by the child tests.

### Testing Instructions

Pull onto your machine and verify that `cargo tr-test` passes now.


Closes TURBO-2185