### PR TITLE
feat: enable vt processing on windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11732,6 +11732,7 @@ dependencies = [
  "console",
  "const_format",
  "convert_case 0.6.0",
+ "crossterm 0.26.1",
  "ctrlc",
  "dialoguer",
  "directories 4.0.1",

--- a/crates/turborepo-lib/Cargo.toml
+++ b/crates/turborepo-lib/Cargo.toml
@@ -44,6 +44,7 @@ clap_complete = { workspace = true }
 command-group = { version = "2.1.0", features = ["with-tokio"] }
 console = { workspace = true }
 ctrlc = { version = "3.4.0", features = ["termination"] }
+crossterm = "0.26"
 dialoguer = { workspace = true, features = ["fuzzy-select"] }
 directories = "4.0.1"
 dirs-next = "2.0.0"

--- a/crates/turborepo-lib/src/shim.rs
+++ b/crates/turborepo-lib/src/shim.rs
@@ -290,10 +290,29 @@ impl ShimArgs {
         if self.no_color {
             UI::new(true)
         } else if self.color {
+            // Do our best to enable ansi colors, but even if the terminal doesn't support
+            // still emit ansi escape sequences.
+            Self::supports_ansi();
             UI::new(false)
-        } else {
+        } else if Self::supports_ansi() {
+            // If the terminal supports ansi colors, then we can infer if we should emit
+            // colors
             UI::infer()
+        } else {
+            UI::new(true)
         }
+    }
+
+    #[cfg(windows)]
+    fn supports_ansi() -> bool {
+        // This call has the side effect of setting ENABLE_VIRTUAL_TERMINAL_PROCESSING
+        // to true.
+        crossterm::ansi_support::supports_ansi()
+    }
+
+    #[cfg(not(windows))]
+    fn supports_ansi() -> bool {
+        true
     }
 }
 


### PR DESCRIPTION
### Description

If we're on windows and are attempting to emit colors, help our users by setting [`ENABLE_VIRTUAL_TERMINAL_PROCESSING`](https://learn.microsoft.com/en-us/windows/console/setconsolemode) which allows ANSI color escape sequences to be respected by the Windows console. This might already be set to true by some users, but it is not enabled by default by Windows.

### Testing Instructions

Look at the pretty colors on Windows!
![cmdp](https://github.com/vercel/turbo/assets/4131117/382fa484-03be-4005-9b95-0d4ab7a7aa26)
![pwsh](https://github.com/vercel/turbo/assets/4131117/08175677-1014-4264-b58f-26c991067ec5)
(My default powershell colors are horrible and end up making the `docs:build` prefix invisible)
![gitbash](https://github.com/vercel/turbo/assets/4131117/d119347b-7ecd-40e3-9102-c9e3c2e089cc)
