### PR TITLE
Make `EcmascriptDevChunkContent` public to other crates

### DIFF
--- a/crates/turbopack-dev/src/ecmascript/content.rs
+++ b/crates/turbopack-dev/src/ecmascript/content.rs
@@ -21,7 +21,7 @@ use super::{
 use crate::DevChunkingContext;
 
 #[turbo_tasks::value(serialization = "none")]
-pub(super) struct EcmascriptDevChunkContent {
+pub struct EcmascriptDevChunkContent {
     pub(super) entries: Vc<EcmascriptDevChunkContentEntries>,
     pub(super) chunking_context: Vc<DevChunkingContext>,
     pub(super) chunk: Vc<EcmascriptDevChunk>,
@@ -44,6 +44,13 @@ impl EcmascriptDevChunkContent {
             chunk,
         }
         .cell())
+    }
+
+    #[turbo_tasks::function]
+    pub async fn entries(
+        self: Vc<EcmascriptDevChunkContent>,
+    ) -> Result<Vc<EcmascriptDevChunkContentEntries>> {
+        Ok(self.await?.entries)
     }
 }
 

--- a/crates/turbopack-dev/src/ecmascript/mod.rs
+++ b/crates/turbopack-dev/src/ecmascript/mod.rs
@@ -6,3 +6,5 @@ pub(crate) mod list;
 pub(crate) mod merged;
 pub(crate) mod update;
 pub(crate) mod version;
+
+pub use content::EcmascriptDevChunkContent;

--- a/crates/turbopack-dev/src/lib.rs
+++ b/crates/turbopack-dev/src/lib.rs
@@ -4,7 +4,7 @@
 #![feature(arbitrary_self_types)]
 
 pub(crate) mod chunking_context;
-pub(crate) mod ecmascript;
+pub mod ecmascript;
 pub mod react_refresh;
 
 pub use chunking_context::{DevChunkingContext, DevChunkingContextBuilder};


### PR DESCRIPTION
This is needed to read source map data to trace sourcemaps in Next.js


Closes PACK-2317