### PR TITLE
Fix sourcemap PR compile error

### DIFF
--- a/crates/turbopack-dev/src/ecmascript/content_entry.rs
+++ b/crates/turbopack-dev/src/ecmascript/content_entry.rs
@@ -22,7 +22,7 @@ use turbopack_ecmascript::chunk::{
 /// computing updates.
 #[turbo_tasks::value]
 #[derive(Debug)]
-pub(super) struct EcmascriptDevChunkContentEntry {
+pub struct EcmascriptDevChunkContentEntry {
     pub code: Vc<Code>,
     pub hash: Vc<u64>,
 }
@@ -41,7 +41,7 @@ impl EcmascriptDevChunkContentEntry {
 }
 
 #[turbo_tasks::value(transparent)]
-pub(super) struct EcmascriptDevChunkContentEntries(
+pub struct EcmascriptDevChunkContentEntries(
     IndexMap<ReadRef<ModuleId>, EcmascriptDevChunkContentEntry>,
 );
 


### PR DESCRIPTION
### Description

Fixes the error on https://github.com/vercel/next.js/pull/61369

Test run: https://github.com/vercel/turbo/blob/08e09624524425db1530381941d1fedbed27fe4f/crates/turbopack-dev/src/ecmascript/content_entry.rs#L44 

Excerpt:

```
  error: type `turbopack_binding::turbopack::turbopack_dev::ecmascript::content_entry::EcmascriptDevChunkContentEntries` is private
     --> packages/next-swc/crates/napi/src/next_api/project.rs:856:35
      |
  856 |                     let entries = content.entries().await?;
      |                                   ^^^^^^^^^^^^^^^^^^^^^^^^ private type
  
  error: type `turbopack_binding::turbopack::turbopack_dev::ecmascript::content_entry::EcmascriptDevChunkContentEntry` is private
     --> packages/next-swc/crates/napi/src/next_api/project.rs:857:33
      |
  857 |                     let entry = entries.get(&ModuleId::String(module).cell().await?);
      |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ private type
  
  error: type `turbopack_binding::turbopack::turbopack_dev::ecmascript::content_entry::EcmascriptDevChunkContentEntry` is private
     --> packages/next-swc/crates/napi/src/next_api/project.rs:858:37
      |
  858 |                     let map = match entry {
      |                                     ^^^^^ private type
  
  error: could not compile `next-swc-napi` (lib) due to 3 previous errors

```

<!--
  ✍️ Write a short summary of your work.
  If necessary, include relevant screenshots.
-->

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
