### PR TITLE
fix: Revert `preset-env` mode of `styled-jsx` in turbopack

### DIFF
--- a/crates/turbopack-ecmascript-plugins/src/transform/styled_jsx.rs
+++ b/crates/turbopack-ecmascript-plugins/src/transform/styled_jsx.rs
@@ -1,14 +1,10 @@
-use anyhow::{bail, Result};
+use anyhow::Result;
 use async_trait::async_trait;
-use lightningcss::{
-    stylesheet::{PrinterOptions, StyleSheet},
-    targets::{Browsers, Targets},
-};
 use swc_core::{
     common::{util::take::Take, FileName},
     ecma::{
         ast::{Module, Program},
-        preset_env::{Version, Versions},
+        preset_env::Versions,
         visit::FoldWith,
     },
 };
@@ -41,57 +37,9 @@ impl CustomTransformer for StyledJsxTransformer {
                 use_lightningcss: self.use_lightningcss,
                 browsers: self.target_browsers,
             },
-            styled_jsx::visitor::NativeConfig {
-                process_css: if self.use_lightningcss || self.target_browsers.is_any_target() {
-                    None
-                } else {
-                    let targets = Targets {
-                        browsers: Some(convert_browsers(&self.target_browsers)),
-                        ..Default::default()
-                    };
-
-                    Some(Box::new(move |css| {
-                        let ss = StyleSheet::parse(css, Default::default());
-
-                        let ss = match ss {
-                            Ok(v) => v,
-                            Err(err) => {
-                                bail!("failed to parse css using lightningcss: {}", err)
-                            }
-                        };
-
-                        let output = ss.to_css(PrinterOptions {
-                            minify: true,
-                            source_map: None,
-                            project_root: None,
-                            targets,
-                            analyze_dependencies: None,
-                            pseudo_classes: None,
-                        })?;
-                        Ok(output.code)
-                    }))
-                },
-            },
+            styled_jsx::visitor::NativeConfig { process_css: None },
         ));
 
         Ok(())
-    }
-}
-
-fn convert_browsers(browsers: &Versions) -> Browsers {
-    fn convert(v: Option<Version>) -> Option<u32> {
-        v.map(|v| v.major << 16 | v.minor << 8 | v.patch)
-    }
-
-    Browsers {
-        android: convert(browsers.android),
-        chrome: convert(browsers.chrome),
-        edge: convert(browsers.edge),
-        firefox: convert(browsers.firefox),
-        ie: convert(browsers.ie),
-        ios_saf: convert(browsers.ios),
-        opera: convert(browsers.opera),
-        safari: convert(browsers.safari),
-        samsung: convert(browsers.samsung),
     }
 }


### PR DESCRIPTION
### Description

This PR partially reverts #7027 to fix build issues.

 - Reopens https://github.com/vercel/next.js/issues/57718

### Testing Instructions

Local override will work

Closes PACK-2322