### PR TITLE
fix: tasks with no newline

### DIFF
--- a/crates/turborepo-lib/test/scripts/hello_no_line.js
+++ b/crates/turborepo-lib/test/scripts/hello_no_line.js
@@ -1,0 +1,2 @@
+const process = require("node:process");
+process.stdout.write("look ma, no newline!", () => {});


### PR DESCRIPTION
### Description

Some programs might not output a trailing newline. This results in us possibly writing another task's' output on the same line. In this case we should add a trailing newline.

e.g. a task of `echo -n 'building'` previously would cause output like:
```
foo:build > building bar:build > building
```
Should now look like:
```
foo:build > building
bar:build > building
```


### Testing Instructions

Added unit test


Closes TURBO-2195