### PR TITLE
feat(lockfile): traverse lockfile in parallel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11798,6 +11798,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "pretty_assertions",
+ "rayon",
  "regex",
  "semver 1.0.18",
  "serde",

--- a/crates/turborepo-lockfiles/Cargo.toml
+++ b/crates/turborepo-lockfiles/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 nom = "7"
 pest = "2.5.6"
 pest_derive = "2.5.6"
+rayon = "1"
 regex = "1"
 semver = "1.0.17"
 serde = { version = "1.0.126", features = ["derive", "rc"] }

--- a/crates/turborepo-lockfiles/src/lib.rs
+++ b/crates/turborepo-lockfiles/src/lib.rs
@@ -18,6 +18,7 @@ pub use bun::BunLockfile;
 pub use error::Error;
 pub use npm::*;
 pub use pnpm::{pnpm_global_change, pnpm_subgraph, PnpmLockfile};
+use rayon::prelude::*;
 use serde::Serialize;
 use turbopath::RelativeUnixPathBuf;
 pub use yarn1::{yarn_subgraph, Yarn1Lockfile};
@@ -68,7 +69,7 @@ pub fn all_transitive_closures<L: Lockfile + ?Sized>(
     workspaces: HashMap<String, HashMap<String, String>>,
 ) -> Result<HashMap<String, HashSet<Package>>, Error> {
     workspaces
-        .into_iter()
+        .into_par_iter()
         .map(|(workspace, unresolved_deps)| {
             let closure = transitive_closure(lockfile, &workspace, unresolved_deps)?;
             Ok((workspace, closure))

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use petgraph::graph::{Graph, NodeIndex};
-use tracing::warn;
+use tracing::{warn, Instrument};
 use turbopath::{
     AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPath, AnchoredSystemPathBuf,
     RelativeUnixPathBuf,
@@ -470,6 +470,7 @@ impl<'a, T: PackageDiscovery> BuildState<'a, ResolvedLockfile, T> {
             .collect()
     }
 
+    #[tracing::instrument(skip_all)]
     fn populate_transitive_dependencies(&mut self) -> Result<(), Error> {
         let Some(lockfile) = self.lockfile.as_deref() else {
             return Ok(());
@@ -493,6 +494,7 @@ impl<'a, T: PackageDiscovery> BuildState<'a, ResolvedLockfile, T> {
         let package_manager = self
             .package_discovery
             .discover_packages()
+            .instrument(tracing::debug_span!("package discovery"))
             .await?
             .package_manager;
         let Self {


### PR DESCRIPTION
### Description

I remembered that the FFI interface was what was stopping me from throwing rayon at the lockfile graph traversal. This can be done easily since we already require that all lockfile implementations are `Send` and they don't mutate the underlying lockfile.

There's a more elegant way to do this and avoid calculating inner closures multiple times, but this is a straightforward win.

### Testing Instructions
From 
<img width="317" alt="Screenshot 2024-01-30 at 5 40 42 PM" src="https://github.com/vercel/turbo/assets/4131117/a6334c99-7c61-4bf3-8a24-b29999a74511">
To
<img width="328" alt="Screenshot 2024-01-30 at 5 40 32 PM" src="https://github.com/vercel/turbo/assets/4131117/5c0cd0c4-1818-4468-aaac-ce47b924f385">

[serial.json](https://github.com/vercel/turbo/files/14106106/profile.json)
[parallel.json](https://github.com/vercel/turbo/files/14106107/parallel.json)



Closes TURBO-2197