### PR TITLE
feat: Re-enable `preset-env` mode of `styled-jsx` in turbopack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8046,9 +8046,9 @@ dependencies = [
 
 [[package]]
 name = "styled_jsx"
-version = "0.73.1"
+version = "0.73.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1011d28e2c9b5e4bf83250af70b984c12228029ebf7f8acb564404500ccc9177"
+checksum = "6abe58236ecb0d0e3c2dd078b5eee0216eac9bedf2502342dc0b357d17e55ef7"
 dependencies = [
  "anyhow",
  "lightningcss",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ miette = { version = "5.10.0", features = ["fancy"] }
 mdxjs = "0.1.22"
 modularize_imports = { version = "0.68.0" }
 styled_components = { version = "0.96.1" }
-styled_jsx = { version = "0.73.1" }
+styled_jsx = { version = "0.73.3" }
 swc_core = { version = "0.89.4", features = [
   "ecma_loader_lru",
   "ecma_loader_parking_lot",

--- a/crates/turbopack-ecmascript-plugins/src/transform/styled_jsx.rs
+++ b/crates/turbopack-ecmascript-plugins/src/transform/styled_jsx.rs
@@ -1,10 +1,14 @@
-use anyhow::Result;
+use anyhow::{bail, Result};
 use async_trait::async_trait;
+use lightningcss::{
+    stylesheet::{PrinterOptions, StyleSheet},
+    targets::{Browsers, Targets},
+};
 use swc_core::{
     common::{util::take::Take, FileName},
     ecma::{
         ast::{Module, Program},
-        preset_env::Versions,
+        preset_env::{Version, Versions},
         visit::FoldWith,
     },
 };
@@ -37,9 +41,57 @@ impl CustomTransformer for StyledJsxTransformer {
                 use_lightningcss: self.use_lightningcss,
                 browsers: self.target_browsers,
             },
-            styled_jsx::visitor::NativeConfig { process_css: None },
+            styled_jsx::visitor::NativeConfig {
+                process_css: if self.use_lightningcss || self.target_browsers.is_any_target() {
+                    None
+                } else {
+                    let targets = Targets {
+                        browsers: Some(convert_browsers(&self.target_browsers)),
+                        ..Default::default()
+                    };
+
+                    Some(Box::new(move |css| {
+                        let ss = StyleSheet::parse(css, Default::default());
+
+                        let ss = match ss {
+                            Ok(v) => v,
+                            Err(err) => {
+                                bail!("failed to parse css using lightningcss: {}", err)
+                            }
+                        };
+
+                        let output = ss.to_css(PrinterOptions {
+                            minify: true,
+                            source_map: None,
+                            project_root: None,
+                            targets,
+                            analyze_dependencies: None,
+                            pseudo_classes: None,
+                        })?;
+                        Ok(output.code)
+                    }))
+                },
+            },
         ));
 
         Ok(())
+    }
+}
+
+fn convert_browsers(browsers: &Versions) -> Browsers {
+    fn convert(v: Option<Version>) -> Option<u32> {
+        v.map(|v| v.major << 16 | v.minor << 8 | v.patch)
+    }
+
+    Browsers {
+        android: convert(browsers.android),
+        chrome: convert(browsers.chrome),
+        edge: convert(browsers.edge),
+        firefox: convert(browsers.firefox),
+        ie: convert(browsers.ie),
+        ios_saf: convert(browsers.ios),
+        opera: convert(browsers.opera),
+        safari: convert(browsers.safari),
+        samsung: convert(browsers.samsung),
     }
 }


### PR DESCRIPTION
### Description

Re-enable `preset-env` mode of `styled-jsx`


### Testing Instructions

Tested with https://github.com/swc-project/plugins/pull/259

Closes PACK-2330