### PR TITLE
Print telemetry warning on stderr

### DIFF
--- a/crates/turborepo-telemetry/src/config.rs
+++ b/crates/turborepo-telemetry/src/config.rs
@@ -121,7 +121,7 @@ impl TelemetryConfig {
 
     pub fn show_alert(&mut self, ui: UI) {
         if !self.has_seen_alert() && self.is_enabled() && Self::is_telemetry_warning_enabled() {
-            println!(
+            eprintln!(
                 "\n{}\n{}\n{}\n{}\n{}\n",
                 color!(ui, BOLD, "{}", "Attention:"),
                 color!(


### PR DESCRIPTION
### Description

This fixes an issue with unparsable output from `--dry=json` that causes `turbo-ignore` to fail with a JSON parse error if the user has not disabled the message.


### Testing Instructions

To reproduce the issue this PR seeks to resolve run the following commands in any turbo enabled repo.

```
rm ~/.config/turborepo/telemetry.json
pnpx turbo-ignore # fails with JSON parse error
```

fixes #7185



<!--
  Give a quick description of steps to test your changes.
-->
