### PR TITLE
docs: fix link in telemetry

### DIFF
--- a/docs/pages/repo/docs/telemetry.mdx
+++ b/docs/pages/repo/docs/telemetry.mdx
@@ -32,7 +32,7 @@ We track general usage information, specifically, we track the following with an
 
 You can view exactly what is being collected by setting the following environment variable: `TURBO_TELEMETRY_DEBUG=1`.
 
-Additionally, all possible events can be viewed by browsing the [events](https://github.com/vercel/turbo/blob/main/crates/turborepo-telemetry/src/events.rs) file directly.
+Additionally, all possible events can be viewed by browsing the [events](https://github.com/vercel/turbo/blob/main/crates/turborepo-telemetry/src/events) file directly.
 
 ## How do I opt out?
 


### PR DESCRIPTION
`events` is a dir not a .rs file