### PR TITLE
perf: remove duplicate git construction

### DIFF
--- a/crates/turborepo-lib/src/run/global_hash.rs
+++ b/crates/turborepo-lib/src/run/global_hash.rs
@@ -64,6 +64,7 @@ pub fn get_global_hash_inputs<'a, L: ?Sized + Lockfile>(
     env_mode: EnvMode,
     framework_inference: bool,
     dot_env: Option<&'a [RelativeUnixPathBuf]>,
+    hasher: &SCM,
 ) -> Result<GlobalHashableInputs<'a>, Error> {
     let global_hashable_env_vars =
         get_global_hashable_env_vars(env_at_execution_start, global_env)?;
@@ -83,8 +84,6 @@ pub fn get_global_hash_inputs<'a, L: ?Sized + Lockfile>(
             global_deps.insert(lockfile_path);
         }
     }
-
-    let hasher = SCM::new(root_path);
 
     let global_deps_paths = global_deps
         .iter()
@@ -222,6 +221,7 @@ mod tests {
     use turborepo_env::EnvironmentVariableMap;
     use turborepo_lockfiles::Lockfile;
     use turborepo_repository::package_manager::PackageManager;
+    use turborepo_scm::SCM;
 
     use super::get_global_hash_inputs;
     use crate::{cli::EnvMode, run::global_hash::collect_global_deps};
@@ -259,6 +259,7 @@ mod tests {
             EnvMode::Infer,
             false,
             None,
+            &SCM::new(&root),
         );
         assert!(result.is_ok());
     }

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -463,6 +463,7 @@ impl Run {
             api_client,
             self.api_auth.clone(),
             Vendor::get_user(),
+            &scm,
         );
 
         let mut visitor = Visitor::new(

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -378,6 +378,7 @@ impl Run {
             self.opts.run_opts.env_mode,
             self.opts.run_opts.framework_inference,
             root_turbo_json.global_dot_env.as_deref(),
+            &scm,
         )?;
 
         let global_hash = global_hash_inputs.calculate_global_hash_from_inputs();

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -201,6 +201,10 @@ impl Run {
         signal_handler: &SignalHandler,
         telemetry: CommandEventBuilder,
     ) -> Result<i32, Error> {
+        let scm = {
+            let repo_root = self.base.repo_root.clone();
+            tokio::task::spawn_blocking(move || SCM::new(&repo_root))
+        };
         let package_json_path = self.base.repo_root.join_component("package.json");
         let root_package_json = PackageJson::load(&package_json_path)?;
         let run_telemetry = GenericEventBuilder::new().with_parent(&telemetry);
@@ -313,7 +317,7 @@ impl Run {
 
         pkg_dep_graph.validate()?;
 
-        let scm = SCM::new(&self.base.repo_root);
+        let scm = scm.await.expect("detecting scm panicked");
 
         let filtered_pkgs = {
             let (mut filtered_pkgs, is_all_packages) = scope::resolve_packages(

--- a/crates/turborepo-lib/src/run/summary/mod.rs
+++ b/crates/turborepo-lib/src/run/summary/mod.rs
@@ -28,6 +28,7 @@ use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPath};
 use turborepo_api_client::{spaces::CreateSpaceRunPayload, APIAuth, APIClient};
 use turborepo_env::EnvironmentVariableMap;
 use turborepo_repository::package_graph::{PackageGraph, WorkspaceName};
+use turborepo_scm::SCM;
 use turborepo_ui::{color, cprintln, cwriteln, BOLD, BOLD_CYAN, GREY, UI};
 
 use self::{
@@ -154,8 +155,9 @@ impl RunTracker {
         spaces_api_client: APIClient,
         api_auth: Option<APIAuth>,
         user: String,
+        scm: &SCM,
     ) -> Self {
-        let scm = SCMState::get(env_at_execution_start, repo_root);
+        let scm = SCMState::get(env_at_execution_start, scm, repo_root);
 
         let spaces_client_handle =
             SpacesClient::new(spaces_id.clone(), spaces_api_client, api_auth).and_then(

--- a/crates/turborepo-lib/src/run/summary/scm.rs
+++ b/crates/turborepo-lib/src/run/summary/scm.rs
@@ -19,7 +19,7 @@ pub(crate) struct SCMState {
 }
 
 impl SCMState {
-    pub fn get(env_vars: &EnvironmentVariableMap, dir: &AbsoluteSystemPath) -> Self {
+    pub fn get(env_vars: &EnvironmentVariableMap, scm: &SCM, dir: &AbsoluteSystemPath) -> Self {
         let mut state = SCMState {
             ty: SCMType::Git,
             sha: None,
@@ -40,8 +40,6 @@ impl SCMState {
 
         // Fall back to using `git`
         if state.branch.is_none() && state.sha.is_none() {
-            let scm = SCM::new(dir);
-
             if state.branch.is_none() {
                 state.branch = scm.get_current_branch(dir).ok();
             }


### PR DESCRIPTION
### Description

I noticed in the profile that we were calling `SCM::new` multiple times which should be avoided since this results in FS.

This PR does 2 things:
 - Passes existing `SCM` instance around to all the places we were constructing a new instance
 - Kick of a thread to construct the `SCM` instance as soon as we start run, this means it will usually be ready by the time we need it.

### Testing Instructions

Old profile:
<img width="2321" alt="Screenshot 2024-01-31 at 9 19 56 AM" src="https://github.com/vercel/turbo/assets/4131117/bba04e6b-da2e-4051-9284-27abef6ea094">


New profile:
<img width="2319" alt="Screenshot 2024-01-31 at 9 17 51 AM" src="https://github.com/vercel/turbo/assets/4131117/907a67cd-327d-4a80-914d-2f99bec81c60">

Note how we now are able to construct the `SCM` before the package graph finishes building meaning it's available for filtering the graph immediately.



Closes TURBO-2206