### PR TITLE
fix: keep stdin open for persistent tasks

### DIFF
--- a/crates/turborepo-lib/src/task_graph/visitor.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor.rs
@@ -247,12 +247,14 @@ impl<'a> Visitor<'a> {
 
                     let workspace_directory = self.repo_root.resolve(workspace_info.package_path());
 
+                    let persistent = task_definition.persistent;
                     let mut exec_context = factory.exec_context(
                         info.clone(),
                         task_hash,
                         task_cache,
                         workspace_directory,
                         execution_env,
+                        persistent,
                     );
 
                     let output_client = self.output_client(&info);
@@ -563,6 +565,7 @@ impl<'a> ExecContextFactory<'a> {
         task_cache: TaskCache,
         workspace_directory: AbsoluteSystemPathBuf,
         execution_env: EnvironmentVariableMap,
+        persistent: bool,
     ) -> ExecContext {
         let task_id_for_display = self.visitor.display_task_id(&task_id);
         let pass_through_args = self.visitor.run_opts.args_for_task(&task_id);
@@ -586,6 +589,7 @@ impl<'a> ExecContextFactory<'a> {
             continue_on_error: self.visitor.run_opts.continue_on_error,
             pass_through_args,
             errors: self.errors.clone(),
+            persistent,
         }
     }
 
@@ -619,6 +623,7 @@ struct ExecContext {
     continue_on_error: bool,
     pass_through_args: Option<Vec<String>>,
     errors: Arc<Mutex<Vec<TaskError>>>,
+    persistent: bool,
 }
 
 enum ExecOutcome {
@@ -783,6 +788,13 @@ impl ExecContext {
         cmd.envs(self.execution_env.iter());
         // Always last to make sure it overwrites any user configured env var.
         cmd.env("TURBO_HASH", &self.task_hash);
+
+        // Many persistent tasks if started hooked up to a pseudoterminal
+        // will shut down if stdin is closed, so we open it even if we don't pass
+        // anything to it.
+        if self.persistent {
+            cmd.open_stdin();
+        }
 
         let mut stdout_writer = match self
             .task_cache


### PR DESCRIPTION
### Description

Fixes #7181

Some tools when they are connected to a TTY will take stdin being closed as a sign that they should shut down. This PR changes our behavior to keep stdin open for persistent tasks to avoid premature shutdowns.

<img width="649" alt="Screenshot 2024-01-31 at 10 13 00 AM" src="https://github.com/vercel/turbo/assets/4131117/e7c26b16-2813-428b-9fe3-6eb552d2f102">


### Testing Instructions

Verify that using `vite` no longer immediately exits when invoked using a pseudoterminal.
<img width="377" alt="Screenshot 2024-01-31 at 10 12 29 AM" src="https://github.com/vercel/turbo/assets/4131117/8a7f42d3-8a52-489a-9459-b6d711799512">

(`vite` outputs a clear screen sequence resulting in the run prelude being erased)


Closes TURBO-2208