### PR TITLE
fix(Turborepo): Handle spaces in path names in git status

### DIFF
--- a/crates/turborepo-scm/src/package_deps.rs
+++ b/crates/turborepo-scm/src/package_deps.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, hash::Hash, str::FromStr};
+use std::{collections::HashMap, str::FromStr};
 
 use globwalk::ValidatedGlob;
 use tracing::debug;

--- a/crates/turborepo-scm/src/status.rs
+++ b/crates/turborepo-scm/src/status.rs
@@ -91,7 +91,7 @@ fn nom_parse_status(i: &[u8]) -> nom::IResult<&[u8], StatusEntry<'_>> {
     let (i, x) = nom::bytes::complete::take(1usize)(i)?;
     let (i, y) = nom::bytes::complete::take(1usize)(i)?;
     let (i, _) = nom::character::complete::space1(i)?;
-    let (i, filename) = nom::bytes::complete::is_not(" \0")(i)?;
+    let (i, filename) = nom::bytes::complete::is_not("\0")(i)?;
     // We explicitly support a missing terminator
     let (i, _) = nom::combinator::opt(nom::bytes::complete::tag(&[b'\0']))(i)?;
     Ok((
@@ -125,6 +125,11 @@ mod tests {
             ),
             ("M  package.json\0", "", ("package.json", false)),
             ("A  some-pkg/some-file\0", "some-pkg", ("some-file", false)),
+            (
+                "M  some-pkg/file with spaces\0",
+                "some-pkg",
+                ("file with spaces", false),
+            ),
         ];
         for (input, prefix, (expected_filename, expect_delete)) in tests {
             let prefix = RelativeUnixPathBuf::new(*prefix).unwrap();

--- a/turborepo-tests/integration/tests/run/path-with-spaces.t
+++ b/turborepo-tests/integration/tests/run/path-with-spaces.t
@@ -1,0 +1,12 @@
+Setup
+  $ . ${TESTDIR}/../../../helpers/setup_integration_test.sh
+
+Force git status to show a file with spaces in the name
+  $ echo "new file" > packages/util/with\ spaces.txt
+
+Verify we have a file with spaces in the name
+  $ git status | grep -q "with spaces"
+
+Do a dry run to verify we can hash it
+  $ ${TURBO} run build --dry -F util | grep "Inputs Files Considered"
+    Inputs Files Considered        = 2


### PR DESCRIPTION
### Description

 - Don't stop `git status` parsing when encountering a space

### Testing Instructions

 - Added a unit test for `git status` testing
 - Added an integration test for a dry run with an added file with a space in the path name

Closes TURBO-2209