### PR TITLE
fix(Turborepo): Don't block forever if we have already gotten a parse error

### DIFF
--- a/crates/turborepo-scm/src/lib.rs
+++ b/crates/turborepo-scm/src/lib.rs
@@ -312,7 +312,9 @@ mod tests {
             let script_path = root.join_component("hanging.sh");
             script_path.create_with_contents(sh).unwrap();
             script_path.set_mode(0x755).unwrap();
-            Command::new(&bash).arg(script_path.as_str())
+            let mut cmd = Command::new(bash);
+            cmd.arg(script_path.as_str());
+            cmd
         };
 
         let mut cmd = cmd

--- a/crates/turborepo-scm/src/lib.rs
+++ b/crates/turborepo-scm/src/lib.rs
@@ -317,8 +317,9 @@ mod tests {
         // Previously, this would hang forever trying to read from stderr
         let err =
             wait_for_success(cmd, &mut stderr, "hanging.sh", &root, parse_result).unwrap_err();
-        // Ensure we captured stderr from the script above.
-        let error_text = format!("{:?}", err);
-        assert!(error_text.contains("some error text"));
+        // Note that we aren't guaranteed to have captured stderr, notably on windows.
+        // We should, however, have our injected error of "any error" in the error
+        // message.
+        assert!(err.to_string().contains("any error"));
     }
 }

--- a/crates/turborepo-scm/src/lib.rs
+++ b/crates/turborepo-scm/src/lib.rs
@@ -287,8 +287,8 @@ mod tests {
     fn test_wait_for_success() {
         // Shell script to simulate a command that hangs
         let sh = r#"
-            echo "started"
             echo "some error text" >&2
+            echo "started"
             read -p "Press enter to stop hanging"
         "#;
 

--- a/crates/turborepo-scm/src/lib.rs
+++ b/crates/turborepo-scm/src/lib.rs
@@ -287,19 +287,20 @@ mod tests {
     fn test_wait_for_success() {
         // Shell script to simulate a command that hangs
         let sh = r#"
-            #!/bin/bash
             echo "started"
             echo "some error text" >&2
             read -p "Press enter to stop hanging"
         "#;
 
+        let bash = which::which("bash").unwrap();
         let tmp_dir = tempfile::tempdir().unwrap();
         let root = AbsoluteSystemPathBuf::try_from(tmp_dir.path()).unwrap();
         let script_path = root.join_component("hanging.sh");
         script_path.create_with_contents(sh).unwrap();
         #[cfg(unix)]
         script_path.set_mode(0x755).unwrap();
-        let mut cmd = Command::new(script_path.as_std_path())
+        let mut cmd = Command::new(&bash)
+            .arg(script_path.as_str())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .stdin(Stdio::piped())

--- a/turborepo-tests/integration/tests/run/big-status.t
+++ b/turborepo-tests/integration/tests/run/big-status.t
@@ -1,0 +1,13 @@
+Setup
+  $ . ${TESTDIR}/../../../helpers/setup_integration_test.sh
+
+Force git status to show a file with spaces in the name
+  $ for i in {1..10000}; do echo "new file" > packages/util/with\ spaces\ ${i}.txt; done
+
+Verify we have a file with spaces in the name
+  $ git status | grep "with spaces" | wc -l
+     10000
+
+Do a dry run to verify we can hash it
+  $ ${TURBO} run build --dry -F util | grep "Inputs Files Considered"
+    Inputs Files Considered        = 10001

--- a/turborepo-tests/integration/tests/run/big-status.t
+++ b/turborepo-tests/integration/tests/run/big-status.t
@@ -6,7 +6,7 @@ Force git status to show a file with spaces in the name
 
 Verify we have a file with spaces in the name
   $ git status | grep "with spaces" | wc -l
-     10000
+  \s*10000 (re)
 
 Do a dry run to verify we can hash it
   $ ${TURBO} run build --dry -F util | grep "Inputs Files Considered"


### PR DESCRIPTION
### Description

 - If we've already encountered a parse error, don't wait for the child process to exit cleanly, just kill it. Waiting nicely could mean waiting forever.
 - Only read from `stderr` after we've killed the process, otherwise that could block forever if there is nothing available.

### Testing Instructions

Added new unit test simulating a parse error with a script that would hang forever under the old method.

Closes TURBO-2212