### PR TITLE
chore: allow unused for variables that don't get used on windows

### DIFF
--- a/crates/turborepo-cache/src/cache_archive/restore_directory.rs
+++ b/crates/turborepo-cache/src/cache_archive/restore_directory.rs
@@ -62,6 +62,8 @@ impl CachedDirTree {
         self.prefix.push(new_component);
     }
 
+    // Windows doesn't have file modes, so mode is unused
+    #[allow(unused_variables)]
     pub fn safe_mkdir_all(
         &mut self,
         anchor: &AbsoluteSystemPath,

--- a/crates/turborepo-cache/src/cache_archive/restore_regular.rs
+++ b/crates/turborepo-cache/src/cache_archive/restore_regular.rs
@@ -10,7 +10,6 @@ pub fn restore_regular(
     anchor: &AbsoluteSystemPath,
     entry: &mut Entry<impl Read>,
 ) -> Result<AnchoredSystemPathBuf, CacheError> {
-    let header = entry.header();
     // Assuming this was a `turbo`-created input, we currently have an
     // RelativeUnixPath. Assuming this is malicious input we don't really care
     // if we do the wrong thing.
@@ -32,6 +31,7 @@ pub fn restore_regular(
     #[cfg(unix)]
     {
         use std::os::unix::fs::OpenOptionsExt;
+        let header = entry.header();
         open_options.mode(header.mode()?);
     }
 

--- a/crates/turborepo-lib/src/process/child.rs
+++ b/crates/turborepo-lib/src/process/child.rs
@@ -326,6 +326,9 @@ impl ShutdownStyle {
     /// channel when the child process exits.
     async fn process(&self, child: &mut ChildHandle) -> ChildState {
         match self {
+            // Windows doesn't give the ability to send a signal to a process so we
+            // can't make use of the graceful shutdown timeout.
+            #[allow(unused)]
             ShutdownStyle::Graceful(timeout) => {
                 // try ro run the command for the given timeout
                 #[cfg(unix)]


### PR DESCRIPTION
### Description

These finally got to me. I'm tired of seeing
<img width="634" alt="Screenshot 2024-02-01 at 10 18 22 AM" src="https://github.com/vercel/turbo/assets/4131117/1f7deea8-9e77-4ec3-b00e-f32333617fe1">


### Testing Instructions

There shouldn't be any "unused code" warnings on this PR.
