### PR TITLE
feat(turbopack): extend ecmatransform moduleeffect

### DIFF
--- a/crates/turbopack/src/lib.rs
+++ b/crates/turbopack/src/lib.rs
@@ -527,7 +527,7 @@ async fn process_default_internal(
                             }
                         };
                     }
-                    ModuleRuleEffect::ExtendEcmascriptTransforms((prepend, append)) => {
+                    ModuleRuleEffect::ExtendEcmascriptTransforms { prepend, append } => {
                         current_module_type = match current_module_type {
                             Some(ModuleType::Ecmascript {
                                 transforms,

--- a/crates/turbopack/src/lib.rs
+++ b/crates/turbopack/src/lib.rs
@@ -527,6 +527,67 @@ async fn process_default_internal(
                             }
                         };
                     }
+                    ModuleRuleEffect::ExtendEcmascriptTransforms((prepend, append)) => {
+                        current_module_type = match current_module_type {
+                            Some(ModuleType::Ecmascript {
+                                transforms,
+                                options,
+                            }) => Some(ModuleType::Ecmascript {
+                                transforms: prepend.extend(transforms).extend(*append),
+                                options,
+                            }),
+                            Some(ModuleType::Typescript {
+                                transforms,
+                                tsx,
+                                analyze_types,
+                                options,
+                            }) => Some(ModuleType::Typescript {
+                                transforms: prepend.extend(transforms).extend(*append),
+                                tsx,
+                                analyze_types,
+                                options,
+                            }),
+                            Some(ModuleType::Mdx {
+                                transforms,
+                                options,
+                            }) => Some(ModuleType::Mdx {
+                                transforms: prepend.extend(transforms).extend(*append),
+                                options,
+                            }),
+                            Some(module_type) => {
+                                ModuleIssue {
+                                    ident,
+                                    title: StyledString::Text("Invalid module type".to_string())
+                                        .cell(),
+                                    description: StyledString::Text(
+                                        "The module type must be Ecmascript or Typescript to add \
+                                         Ecmascript transforms"
+                                            .to_string(),
+                                    )
+                                    .cell(),
+                                }
+                                .cell()
+                                .emit();
+                                Some(module_type)
+                            }
+                            None => {
+                                ModuleIssue {
+                                    ident,
+                                    title: StyledString::Text("Missing module type".to_string())
+                                        .cell(),
+                                    description: StyledString::Text(
+                                        "The module type effect must be applied before adding \
+                                         Ecmascript transforms"
+                                            .to_string(),
+                                    )
+                                    .cell(),
+                                }
+                                .cell()
+                                .emit();
+                                None
+                            }
+                        };
+                    }
                 }
             }
         }

--- a/crates/turbopack/src/module_options/module_options_context.rs
+++ b/crates/turbopack/src/module_options/module_options_context.rs
@@ -152,6 +152,9 @@ pub struct ModuleOptionsContext {
     // however we might want to unify them in the future.
     pub enable_mdx_rs: Option<Vc<MdxTransformModuleOptions>>,
     pub preset_env_versions: Option<Vc<Environment>>,
+    #[deprecated(
+        note = "Use custom_rules with ModuleRuleEffect::ExtendEcmascriptTransforms instead"
+    )]
     pub custom_ecma_transform_plugins: Option<Vc<CustomEcmascriptTransformPlugins>>,
     /// Custom rules to be applied after all default rules.
     pub custom_rules: Vec<ModuleRule>,

--- a/crates/turbopack/src/module_options/module_rule.rs
+++ b/crates/turbopack/src/module_options/module_rule.rs
@@ -93,7 +93,10 @@ pub enum ModuleRuleEffect {
     /// Allow to extend an existing Ecmascript module rules for the additional
     /// transforms. First argument will prepend the existing transforms, and
     /// the second argument will append the new transforms.
-    ExtendEcmascriptTransforms((Vc<EcmascriptInputTransforms>, Vc<EcmascriptInputTransforms>)),
+    ExtendEcmascriptTransforms {
+        prepend: Vc<EcmascriptInputTransforms>,
+        append: Vc<EcmascriptInputTransforms>,
+    },
     SourceTransforms(Vc<SourceTransforms>),
 }
 

--- a/crates/turbopack/src/module_options/module_rule.rs
+++ b/crates/turbopack/src/module_options/module_rule.rs
@@ -85,7 +85,15 @@ impl ModuleRule {
 #[derive(Debug, Clone)]
 pub enum ModuleRuleEffect {
     ModuleType(ModuleType),
+    #[deprecated(
+        note = "ExtendEcmascriptTransforms provides equivalent features, as well as supporting an \
+                additional way to prepend transforms."
+    )]
     AddEcmascriptTransforms(Vc<EcmascriptInputTransforms>),
+    /// Allow to extend an existing Ecmascript module rules for the additional
+    /// transforms. First argument will prepend the existing transforms, and
+    /// the second argument will append the new transforms.
+    ExtendEcmascriptTransforms((Vc<EcmascriptInputTransforms>, Vc<EcmascriptInputTransforms>)),
     SourceTransforms(Vc<SourceTransforms>),
 }
 


### PR DESCRIPTION

Closes PACK-2356

This PR creates a new ModuleRuleEffect named `ExtendEcmascriptTransforms`. This is an extended version of `AddEcmascriptTransforms` effect, which will be removed once next.js replaces all of its references.

The change born in need of allowing custom rules in `ModuleOptionContext` to have a specific order of transform. This was been achieved by having a custom ecmatransform plugin in moduleoptions. However, it was not very clear for the distinction between rules & transforms, as well as there are some behavior differences we noticed (note: this still may need to be investigated separately later). After discussing with @sokra , we concluded it is better to deprecate custom ecmatransformplugin but use custom rules whereever possible.

One functional differences between current ecmatransformplugin to custom rules is custom rule always append to the main rules, so there wasn't way to adjust order of ecmatransform as we want. The change addresses that moduleeffect can specify if ecmatransform supposed to be prepended or not.