### PR TITLE
fix(turbopack): encode source map urls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10955,6 +10955,7 @@ dependencies = [
  "turbopack-css",
  "turbopack-ecmascript",
  "turbopack-ecmascript-runtime",
+ "urlencoding",
 ]
 
 [[package]]
@@ -11102,6 +11103,7 @@ dependencies = [
  "turbopack-core",
  "turbopack-ecmascript",
  "turbopack-swc-utils",
+ "urlencoding",
 ]
 
 [[package]]
@@ -11125,6 +11127,7 @@ dependencies = [
  "turbopack-css",
  "turbopack-ecmascript",
  "turbopack-ecmascript-runtime",
+ "urlencoding",
 ]
 
 [[package]]

--- a/crates/turbopack-build/Cargo.toml
+++ b/crates/turbopack-build/Cargo.toml
@@ -32,6 +32,7 @@ swc_core = { workspace = true, features = [
   "ecma_minifier_concurrent",
 ] }
 tracing = { workspace = true }
+urlencoding = { workspace = true }
 
 turbo-tasks = { workspace = true }
 turbo-tasks-fs = { workspace = true }

--- a/crates/turbopack-build/src/ecmascript/minify.rs
+++ b/crates/turbopack-build/src/ecmascript/minify.rs
@@ -102,7 +102,11 @@ pub async fn minify(path: Vc<FileSystemPath>, code: Vc<Code>) -> Result<Vc<Code>
         )),
     );
 
-    write!(builder, "\n\n//# sourceMappingURL={}.map", path.file_name())?;
+    write!(
+        builder,
+        "\n\n//# sourceMappingURL={}.map",
+        urlencoding::encode(path.file_name())
+    )?;
     Ok(builder.build().cell())
 }
 

--- a/crates/turbopack-build/src/ecmascript/node/content.rs
+++ b/crates/turbopack-build/src/ecmascript/node/content.rs
@@ -89,7 +89,11 @@ impl EcmascriptBuildNodeChunkContent {
 
         if code.has_source_map() {
             let filename = chunk_path.file_name();
-            write!(code, "\n\n//# sourceMappingURL={}.map", filename)?;
+            write!(
+                code,
+                "\n\n//# sourceMappingURL={}.map",
+                urlencoding::encode(filename)
+            )?;
         }
 
         let code = code.build().cell();

--- a/crates/turbopack-css/Cargo.toml
+++ b/crates/turbopack-css/Cargo.toml
@@ -22,6 +22,8 @@ once_cell = { workspace = true }
 parcel_selectors = { workspace = true }
 regex = { workspace = true }
 serde = { workspace = true }
+urlencoding = { workspace = true }
+
 tracing = { workspace = true }
 turbo-tasks = { workspace = true }
 turbo-tasks-fs = { workspace = true }

--- a/crates/turbopack-css/src/chunk/mod.rs
+++ b/crates/turbopack-css/src/chunk/mod.rs
@@ -125,7 +125,7 @@ impl CssChunk {
             writeln!(
                 code,
                 "/*# sourceMappingURL={}.map*/",
-                chunk_path.file_name()
+                urlencoding::encode(chunk_path.file_name())
             )?;
         }
 

--- a/crates/turbopack-css/src/chunk/single_item_chunk/chunk.rs
+++ b/crates/turbopack-css/src/chunk/single_item_chunk/chunk.rs
@@ -66,7 +66,7 @@ impl SingleItemCssChunk {
             write!(
                 code,
                 "\n/*# sourceMappingURL={}.map*/",
-                chunk_path.file_name()
+                urlencoding::encode(chunk_path.file_name())
             )?;
         }
 

--- a/crates/turbopack-dev/Cargo.toml
+++ b/crates/turbopack-dev/Cargo.toml
@@ -26,6 +26,8 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_qs = { workspace = true }
 tracing = { workspace = true }
+urlencoding = { workspace = true }
+
 turbo-tasks = { workspace = true }
 turbo-tasks-fs = { workspace = true }
 turbo-tasks-hash = { workspace = true }

--- a/crates/turbopack-dev/src/ecmascript/content.rs
+++ b/crates/turbopack-dev/src/ecmascript/content.rs
@@ -107,7 +107,11 @@ impl EcmascriptDevChunkContent {
 
         if code.has_source_map() {
             let filename = chunk_path.file_name();
-            write!(code, "\n\n//# sourceMappingURL={}.map", filename)?;
+            write!(
+                code,
+                "\n\n//# sourceMappingURL={}.map",
+                urlencoding::encode(filename)
+            )?;
         }
 
         Ok(code.build().cell())

--- a/crates/turbopack-dev/src/ecmascript/evaluate/chunk.rs
+++ b/crates/turbopack-dev/src/ecmascript/evaluate/chunk.rs
@@ -158,7 +158,11 @@ impl EcmascriptDevEvaluateChunk {
 
         if code.has_source_map() {
             let filename = chunk_path.file_name();
-            write!(code, "\n\n//# sourceMappingURL={}.map", filename)?;
+            write!(
+                code,
+                "\n\n//# sourceMappingURL={}.map",
+                urlencoding::encode(filename)
+            )?;
         }
 
         Ok(Code::cell(code.build()))


### PR DESCRIPTION
### Description

Some source maps weren't loading for me, might be a firefox issue, but it really didn't like spaces in the source map url (e.g. `[root of the server]`)


Closes PACK-2357