### PR TITLE
fix: declare version.txt as input

### DIFF
--- a/cli/turbo.json
+++ b/cli/turbo.json
@@ -12,8 +12,7 @@
       ],
 
       "inputs": [
-        "{internal,cmd}/**/*.go",
-        "!**/*_test.go",
+        "../version.txt",
         "../crates/turborepo*/**/*.rs", // Rust crates
         "../crates/turborepo*/Cargo.toml",
         "../Cargo.toml",


### PR DESCRIPTION
### Description

Previously we were relying on `cli/cmd/version.go` to get bumped when the version got changed, but now we just have `version.txt`. This PR declares that input and gets rid of the Go inputs.

This causes failures like [this one](https://github.com/vercel/turbo/actions/runs/7747210377/job/21127375688?pr=7205#step:7:881) where we're using an older binary due to a cache hit.

### Testing Instructions

Changing `version.txt` should now result in a cache miss
<img width="894" alt="Screenshot 2024-02-01 at 1 44 05 PM" src="https://github.com/vercel/turbo/assets/4131117/b6996dab-e40c-4021-a7f4-01cb74313e43">




Closes TURBO-2222