### PR TITLE
chore: update github actions

### DIFF
--- a/.github/actions/cargo-sweep/action.yml
+++ b/.github/actions/cargo-sweep/action.yml
@@ -1,6 +1,6 @@
 name: "cargo-sweep"
 description: "Runs cargo-sweep to clean old build artifacts"
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/main/index.js"
   post: "dist/post/index.js"

--- a/.github/actions/next-integration-stat/action.yml
+++ b/.github/actions/next-integration-stat/action.yml
@@ -3,20 +3,21 @@ author: Turbopack team
 description: "Display next.js integration test failure status"
 
 inputs:
-  # Github token to use to create test report comment. If not specified, the default token will be used with username 'github-actions'
   token:
+    description: "Github token to use to create test report comment. If not specified, the default token will be used with username 'github-actions'"
     default: ${{ github.token }}
 
-  # The base of the test results to compare against. If not specified, will try to compare with latest main branch's test results.
   diff_base:
+    description: "The base of the test results to compare against. If not specified, will try to compare with latest main branch's test results."
     default: "main"
 
-  # Include full test failure message in the report.
-  # This is currently disabled as we have too many failed test cases, causes
-  # too many report comment generated.
   expand_full_result_message:
+    description: |
+      Include full test failure message in the report.
+      This is currently disabled as we have too many failed test cases, leading to
+      too many report comments generated.
     default: "false"
 
 runs:
-  using: node16
+  using: node20
   main: index.js

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -1,10 +1,6 @@
 name: "Turborepo Node.js Setup"
 description: "Sets Node.js up for CI"
 inputs:
-  enable-corepack:
-    description: "Control turning on corepack."
-    required: false
-    default: "true"
   extra-flags:
     description: "Extra flags to pass to the pnpm install."
     required: false
@@ -16,34 +12,20 @@ inputs:
   node-version:
     description: "Node version to install"
     required: false
-    default: "18"
+    default: "20"
 
 runs:
   using: "composite"
   steps:
-    - name: Setup pnpm
-      uses: pnpm/action-setup@v2.2.4
+    - name: Configure corepack
+      shell: bash
+      run: corepack enable
 
     - name: Setup Node.js
-      uses: actions/setup-node@v3.6.0
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
         cache: pnpm
-
-    - name: Upgrade corepack
-      if: ${{ inputs.enable-corepack == 'true' && inputs.node-version == '16' }}
-      shell: bash
-      # Forcibly upgrade our available version of corepack.
-      # The bundled version in node 16 has known issues.
-      # Prepends the npm bin dir so that it is always first.
-      run: |
-        npm install --force --global corepack@latest
-        npm config get prefix >> $GITHUB_PATH
-
-    - name: Configure corepack
-      if: ${{ inputs.enable-corepack == 'true' }}
-      shell: bash
-      run: corepack enable
 
     - name: pnpm install
       id: install

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -9,23 +9,23 @@ inputs:
     description: "Don't run the install step."
     required: false
     default: "true"
-  node-version:
-    description: "Node version to install"
-    required: false
-    default: "20"
 
 runs:
   using: "composite"
   steps:
-    - name: Configure corepack
-      shell: bash
-      run: corepack enable
+    # TODO: remove when `actions/setup-node` supports corepack properly
+    - uses: pnpm/action-setup@v3
 
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: ${{ inputs.node-version }}
+        node-version-file: package.json
         cache: pnpm
+
+    - name: Configure corepack
+      shell: bash
+      run: |
+        corepack enable
 
     - name: pnpm install
       id: install

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -59,14 +59,14 @@ runs:
     - name: Set Up Protoc
       id: set-up-protoc
       continue-on-error: true
-      uses: arduino/setup-protoc@v1.2.0
+      uses: arduino/setup-protoc@v3.0.0
       with:
         version: "3.x"
         repo-token: ${{ inputs.github-token }}
 
     - name: Set Up Protoc (second try)
       if: steps.set-up-protoc.outcome == 'failure'
-      uses: arduino/setup-protoc@v1.2.0
+      uses: arduino/setup-protoc@v3.0.0
       with:
         version: "3.x"
         repo-token: ${{ inputs.github-token }}

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -61,14 +61,14 @@ runs:
       continue-on-error: true
       uses: arduino/setup-protoc@v3.0.0
       with:
-        version: "3.x"
+        version: "23.x"
         repo-token: ${{ inputs.github-token }}
 
     - name: Set Up Protoc (second try)
       if: steps.set-up-protoc.outcome == 'failure'
       uses: arduino/setup-protoc@v3.0.0
       with:
-        version: "3.x"
+        version: "23.x"
         repo-token: ${{ inputs.github-token }}
 
     - name: "Add cargo problem matchers"

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -82,10 +82,10 @@ runs:
       with:
         shared-key: ${{ inputs.shared-cache-key }}
         key: ${{ inputs.cache-key }}
-        # the cache is huge and we only get 10gb max, so we only save on master
+        # the cache is huge, and we only get 10gb max, so we only save on master
         save-if: ${{ github.ref == 'refs/heads/main' && inputs.save-cache || 'false' }}
 
-    - name: "Install cargo-sweep"
+    - name: "Install cargo-sweep,cargo-groups"
       uses: taiki-e/install-action@v2
       with:
         tool: cargo-sweep@0.6.2,cargo-groups

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -1,6 +1,10 @@
 name: "Turbo Rust Setup"
 description: "Sets up the Rust toolchain for CI"
 inputs:
+  windows:
+    description: 'Set to "true" if setting up for Windows'
+    required: false
+    default: "false"
   targets:
     description: "Comma-separated list of target triples to install for this toolchain"
     required: false
@@ -48,7 +52,7 @@ runs:
         components: ${{ inputs.components }}
 
     - name: "Set Windows default host to MinGW"
-      if: ${{ runner.os == 'Windows' }}
+      if: ${{ inputs.windows == 'true' }}
       shell: bash
       run: rustup set default-host x86_64-pc-windows-gnu && rustup show
 

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -1,10 +1,6 @@
 name: "Turbo Rust Setup"
 description: "Sets up the Rust toolchain for CI"
 inputs:
-  windows:
-    description: 'Set to "true" if setting up for Windows'
-    required: false
-    default: "false"
   targets:
     description: "Comma-separated list of target triples to install for this toolchain"
     required: false
@@ -12,7 +8,7 @@ inputs:
     description: "Comma-separated list of components to be additionally installed"
     required: false
   github-token:
-    description: "GitHub token. You can pass secrets.GITHUB_TOKEN"
+    description: "GitHub token to get around rate limits."
     required: false
     default: ${{ github.token }}
   shared-cache-key:
@@ -52,7 +48,7 @@ runs:
         components: ${{ inputs.components }}
 
     - name: "Set Windows default host to MinGW"
-      if: ${{ inputs.windows == 'true' }}
+      if: ${{ runner.os == 'Windows' }}
       shell: bash
       run: rustup set default-host x86_64-pc-windows-gnu && rustup show
 

--- a/.github/actions/setup-turborepo-environment/action.yml
+++ b/.github/actions/setup-turborepo-environment/action.yml
@@ -1,6 +1,10 @@
 name: "Setup Turborepo Environment"
 description: "Sets up development environment for turborepo"
 inputs:
+  windows:
+    description: 'Set to "true" if setting up for Windows'
+    required: false
+    default: "false"
   github-token:
     description: "GitHub token to get around rate limits."
     required: false
@@ -17,6 +21,7 @@ runs:
     - name: "Setup Rust"
       uses: ./.github/actions/setup-rust
       with:
+        windows: ${{ inputs.windows }}
         shared-cache-key: turborepo-debug-build
         cache-key: ${{ inputs.target }}
         save-cache: true

--- a/.github/actions/setup-turborepo-environment/action.yml
+++ b/.github/actions/setup-turborepo-environment/action.yml
@@ -1,13 +1,10 @@
 name: "Setup Turborepo Environment"
 description: "Sets up development environment for turborepo"
 inputs:
-  windows:
-    description: 'Set to "true" if setting up for Windows'
-    required: false
-    default: "false"
   github-token:
-    description: "GitHub token. You can pass secrets.GITHUB_TOKEN"
-    required: true
+    description: "GitHub token to get around rate limits."
+    required: false
+    default: ${{ github.token }}
 
 runs:
   using: "composite"
@@ -20,7 +17,6 @@ runs:
     - name: "Setup Rust"
       uses: ./.github/actions/setup-rust
       with:
-        windows: ${{ inputs.windows }}
         shared-cache-key: turborepo-debug-build
         cache-key: ${{ inputs.target }}
         save-cache: true

--- a/.github/actions/status-comment/action.yml
+++ b/.github/actions/status-comment/action.yml
@@ -1,0 +1,61 @@
+name: "Status Comment"
+description: "Creates and updates a comment"
+inputs:
+  id:
+    description: "A marker to uniquely identify the comment for future updates"
+    required: true
+  issue-number:
+    description: 'The number of the issue or pull request in which to create a comment.'
+    default: ${{ github.event.pull_request.number }}
+  body:
+    description: 'The comment body. Cannot be used in conjunction with `body-path`.'
+    required: false
+    default: ""
+  body-path:
+    description: 'The path to a file containing the comment body. Cannot be used in conjunction with `body`.'
+    required: false
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    - name: Generate Marker String
+      id: marker
+      shell: bash
+      run: |
+        echo "marker=<!-- CI COMMENT MARKER: ${{ inputs.id }} -->" >> "$GITHUB_OUTPUT"
+
+    - name: Create comment body
+      id: body
+      shell: bash
+      run: |
+        FILE="${{ inputs.body-path }}"
+        {
+          echo "body<<EOF"
+          if [[ -f "$FILE" ]]; then
+            cat "$FILE"
+          else
+            echo "${{ input.body }}"
+          fi
+          echo
+          echo "${{ steps.marker.outputs.marker }"
+          echo "EOF"
+        } >> "$GITHUB_OUTPUT"
+
+    - name: Find PR Comment
+      id: comment
+      if: github.event_name == 'pull_request'
+      uses: peter-evans/find-comment@v3
+      with:
+        issue-number: ${{ inputs.issue-number }}
+        comment-author: "github-actions[bot]"
+        body-includes: ${{ steps.marker.outputs.marker }
+
+    - name: Create or update PR comment
+      if: github.event_name == 'pull_request' && steps.comment.outputs.comment-id != ''
+      uses: peter-evans/create-or-update-comment@v3
+      with:
+        issue-number: ${{ inputs.issue-number }}
+        comment-id: ${{ steps.comment.outputs.comment-id }}
+        body: ${{ steps.body.outputs.body }}
+        edit-mode: replace

--- a/.github/actions/status-comment/action.yml
+++ b/.github/actions/status-comment/action.yml
@@ -35,7 +35,7 @@ runs:
           if [[ -f "$FILE" ]]; then
             cat "$FILE"
           else
-            echo "${{ input.body }}"
+            echo "${{ inputs.body }}"
           fi
           echo
           echo "${{ steps.marker.outputs.marker }"
@@ -49,7 +49,7 @@ runs:
       with:
         issue-number: ${{ inputs.issue-number }}
         comment-author: "github-actions[bot]"
-        body-includes: ${{ steps.marker.outputs.marker }
+        body-includes: ${{ steps.marker.outputs.marker }}
 
     - name: Create or update PR comment
       if: github.event_name == 'pull_request' && steps.comment.outputs.comment-id != ''

--- a/.github/actions/status-comment/action.yml
+++ b/.github/actions/status-comment/action.yml
@@ -38,7 +38,7 @@ runs:
             echo "${{ inputs.body }}"
           fi
           echo
-          echo "${{ steps.marker.outputs.marker }"
+          echo "${{ steps.marker.outputs.marker }}"
           echo "EOF"
         } >> "$GITHUB_OUTPUT"
 

--- a/.github/actions/status-comment/action.yml
+++ b/.github/actions/status-comment/action.yml
@@ -53,7 +53,7 @@ runs:
 
     - name: Create or update PR comment
       if: github.event_name == 'pull_request'
-      uses: peter-evans/create-or-update-comment@v3
+      uses: peter-evans/create-or-update-comment@v4
       with:
         issue-number: ${{ inputs.issue-number }}
         comment-id: ${{ steps.comment.outputs.comment-id }}

--- a/.github/actions/status-comment/action.yml
+++ b/.github/actions/status-comment/action.yml
@@ -52,7 +52,7 @@ runs:
         body-includes: ${{ steps.marker.outputs.marker }}
 
     - name: Create or update PR comment
-      if: github.event_name == 'pull_request' && steps.comment.outputs.comment-id != ''
+      if: github.event_name == 'pull_request'
       uses: peter-evans/create-or-update-comment@v3
       with:
         issue-number: ${{ inputs.issue-number }}

--- a/.github/actions/turbopack-bump/action.yml
+++ b/.github/actions/turbopack-bump/action.yml
@@ -1,7 +1,7 @@
 name: "turbopack-bump"
 description: "Releases Turbopack nightly"
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"
 inputs:
   github_token:

--- a/.github/workflows/bench-turbopack-scheduled.yml
+++ b/.github/workflows/bench-turbopack-scheduled.yml
@@ -125,7 +125,7 @@ jobs:
 
       - name: Upload results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.bench.name }}
           path: raw.json
@@ -149,7 +149,7 @@ jobs:
           ref: benchmark-data
 
       - name: Download benchmark data
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: data/${{ steps.date.outputs.year }}/${{ steps.date.outputs.month }}/ubuntu-latest-8-core/${{ steps.date.outputs.date }}-${{ github.sha }}
 

--- a/.github/workflows/bench-turbopack-scheduled.yml
+++ b/.github/workflows/bench-turbopack-scheduled.yml
@@ -86,7 +86,7 @@ jobs:
     name: Bench - ${{ matrix.bench.title }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: ./.github/actions/setup-node
 
@@ -111,7 +111,7 @@ jobs:
 
       - name: Install critcmp
         if: always()
-        uses: baptiste0928/cargo-install@v1
+        uses: baptiste0928/cargo-install@v3
         with:
           crate: critcmp
 
@@ -144,7 +144,7 @@ jobs:
           echo "date=$(date +'%s')" >> $GITHUB_OUTPUT
           echo "pretty=$(date +'%Y-%m-%d %H:%M')" >> $GITHUB_OUTPUT
       - name: Checkout benchmark-data
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: benchmark-data
 
@@ -157,6 +157,6 @@ jobs:
         run: git pull --depth=1 --no-tags origin benchmark-data
 
       - name: Push data to branch
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: Benchmark result for ${{ steps.date.outputs.pretty }} (${{ github.sha }})

--- a/.github/workflows/bench-turbopack-scheduled.yml
+++ b/.github/workflows/bench-turbopack-scheduled.yml
@@ -93,7 +93,6 @@ jobs:
       - uses: ./.github/actions/setup-rust
         with:
           shared-cache-key: benchmark-bundlers
-          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Clear potentially cached benchmarks
         run: rm -rf target/criterion

--- a/.github/workflows/bench-turbopack.yml
+++ b/.github/workflows/bench-turbopack.yml
@@ -281,7 +281,7 @@ jobs:
         run: |
           find artifacts -size 0 -delete
           mkdir -p data/${{ steps.date.outputs.year }}/${{ steps.date.outputs.month }}/ubuntu-latest-8-core/${{ steps.date.outputs.date }}-${{ github.sha }}/
-          mv artifacts/bench_* data/${{ steps.date.outputs.year }}/${{ steps.date.outputs.month }}/ubuntu-latest-8-core/${{ steps.date.outputs.date }}-${{ github.sha }}/
+          mv artifacts/bench-* data/${{ steps.date.outputs.year }}/${{ steps.date.outputs.month }}/ubuntu-latest-8-core/${{ steps.date.outputs.date }}-${{ github.sha }}/
 
       - name: Git pull
         run: git pull --depth=1 --no-tags origin benchmark-data

--- a/.github/workflows/bench-turbopack.yml
+++ b/.github/workflows/bench-turbopack.yml
@@ -21,33 +21,18 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - name: Find PR Comment
-        id: comment
-        if: github.event_name == 'pull_request'
-        uses: peter-evans/find-comment@v2
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: "github-actions[bot]"
-          body-includes: "<!-- CI TURBOPACK BENCH COMMENT -->"
-
-      - name: Create or update PR comment
-        if: github.event_name == 'pull_request' && steps.comment.outputs.comment-id != ''
-        uses: peter-evans/create-or-update-comment@v2
+      - name: Set PR status comment
+        uses: ./.github/actions/status-comment
         continue-on-error: true
         with:
-          comment-id: ${{ steps.comment.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
+          id: "bench-status"
           body: |
             ## ⏳ Turbopack Benchmark CI is running again... ⏳
 
             [Wait for it...](https://github.com/vercel/turbo/actions/runs/${{ github.run_id }})
 
-            <!-- CI TURBOPACK BENCH COMMENT -->
-
-          edit-mode: replace
-
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: CI related changes
         id: ci
@@ -131,7 +116,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
@@ -193,7 +178,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
         uses: ./.github/actions/setup-node
@@ -219,7 +204,7 @@ jobs:
 
       - name: Install critcmp
         if: always()
-        uses: baptiste0928/cargo-install@v1
+        uses: baptiste0928/cargo-install@v3
         with:
           crate: critcmp
 
@@ -283,7 +268,7 @@ jobs:
           echo "pretty=$(date +'%Y-%m-%d %H:%M')" >> $GITHUB_OUTPUT
 
       - name: Checkout benchmark-data
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: benchmark-data
 
@@ -303,7 +288,7 @@ jobs:
 
       - name: Push data to branch
         if: needs.determine_jobs.outputs.main_push == 'true'
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@v5
         with:
           file_pattern: data/**
           commit_message: Benchmark result for ${{ steps.date.outputs.pretty }} (${{ github.sha }})
@@ -339,7 +324,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Fetch the base branch
         run: git -c protocol.version=2 fetch --no-tags --progress --no-recurse-submodules --depth=1 origin +${{ github.base_ref }}:base
@@ -424,24 +409,12 @@ jobs:
           echo >> comment.md
           echo "<!-- CI TURBOPACK BENCH COMMENT -->" >> comment.md
 
-      - name: Find PR Comment
-        id: comment
-        if: always() && github.event_name == 'pull_request' && steps.info.outputs.cancelled != 'true'
-        uses: peter-evans/find-comment@v2
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: "github-actions[bot]"
-          body-includes: "<!-- CI TURBOPACK BENCH COMMENT -->"
-
-      - name: Create or update PR comment
-        if: always() && github.event_name == 'pull_request' && steps.info.outputs.cancelled != 'true'
-        uses: peter-evans/create-or-update-comment@v2
+      - name: Set PR status comment
+        uses: ./.github/actions/status-comment
         continue-on-error: true
         with:
-          comment-id: ${{ steps.comment.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body-file: "comment.md"
-          edit-mode: replace
+          id: "bench-status"
+          body-path: "comment.md"
 
       - name: It's not fine
         if: steps.info.outputs.failure == 'true'

--- a/.github/workflows/bench-turbopack.yml
+++ b/.github/workflows/bench-turbopack.yml
@@ -21,6 +21,9 @@ jobs:
       contents: read
       pull-requests: write
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Set PR status comment
         uses: ./.github/actions/status-comment
         continue-on-error: true
@@ -30,9 +33,6 @@ jobs:
             ## ⏳ Turbopack Benchmark CI is running again... ⏳
 
             [Wait for it...](https://github.com/vercel/turbo/actions/runs/${{ github.run_id }})
-
-      - name: Checkout
-        uses: actions/checkout@v4
 
       - name: CI related changes
         id: ci
@@ -359,6 +359,11 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout actions
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github
+
       - name: Compute info
         id: info
         if: always()

--- a/.github/workflows/bench-turbopack.yml
+++ b/.github/workflows/bench-turbopack.yml
@@ -242,9 +242,9 @@ jobs:
 
       - name: Upload results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: bench_${{ matrix.bench.name }}
+          name: bench-${{ matrix.bench.name }}
           path: raw.json
 
       # This avoids putting this data into the rust-cache
@@ -273,7 +273,7 @@ jobs:
           ref: benchmark-data
 
       - name: Download benchmark data
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: artifacts
 

--- a/.github/workflows/bench-turbopack.yml
+++ b/.github/workflows/bench-turbopack.yml
@@ -304,7 +304,7 @@ jobs:
           - name: linux
             title: Linux
             quiet: false
-            runs-on:
+            runner:
               - "self-hosted"
               - "linux"
               - "x64"

--- a/.github/workflows/bench-turbopack.yml
+++ b/.github/workflows/bench-turbopack.yml
@@ -416,6 +416,7 @@ jobs:
 
       - name: Set PR status comment
         uses: ./.github/actions/status-comment
+        if: steps.info.outputs.cancelled != 'true'
         continue-on-error: true
         with:
           id: "bench-status"

--- a/.github/workflows/bench-turbopack.yml
+++ b/.github/workflows/bench-turbopack.yml
@@ -123,7 +123,6 @@ jobs:
         with:
           components: clippy
           targets: wasm32-unknown-unknown
-          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run cargo check release
         run: |
@@ -188,7 +187,6 @@ jobs:
         with:
           shared-cache-key: benchmark-${{ matrix.bench.cache_key }}
           save-cache: true
-          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Clear benchmarks
         run: rm -rf target/criterion
@@ -336,7 +334,6 @@ jobs:
         uses: ./.github/actions/setup-rust
         with:
           shared-cache-key: benchmark-${{ matrix.os.name }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Benchmark and compare with base branch
         uses: sokra/criterion-compare-action@main

--- a/.github/workflows/bench-turborepo.yml
+++ b/.github/workflows/bench-turborepo.yml
@@ -92,9 +92,9 @@ jobs:
         run: pnpm -F @turbo/benchmark ttft "${{ steps.filename.outputs.filename }}"
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: profiles # This name will be the folder each file gets downloaded to
+          name: profiles-${{ matrix.os.name }} # This name will be the folder each file gets downloaded to
           if-no-files-found: error
           # cwd is root of the repository, so we need the benchmark/ prefixed path
           path: |
@@ -117,9 +117,10 @@ jobs:
         uses: ./.github/actions/setup-node
 
       - name: Download profiles
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: profiles
+          pattern: profiles-*
+          merge-multiple: true
           path: packages/turbo-benchmark/profiles/
 
       - name: Display TTFT Data
@@ -151,9 +152,10 @@ jobs:
         uses: ./.github/actions/setup-node
 
       - name: Download profiles
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: profiles
+          pattern: profiles-*
+          merge-multiple: true
           path: packages/turbo-benchmark/profiles/
 
       - name: Display TTFT Data

--- a/.github/workflows/bench-turborepo.yml
+++ b/.github/workflows/bench-turborepo.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node
 
       - uses: ./.github/actions/setup-turborepo-environment
@@ -60,7 +60,7 @@ jobs:
             runner: windows-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set filename for profile
         id: filename
         shell: bash
@@ -111,7 +111,7 @@ jobs:
       TINYBIRD_TOKEN: ${{secrets.TINYBIRD_TOKEN}}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Node
         uses: ./.github/actions/setup-node
@@ -145,7 +145,7 @@ jobs:
     needs: [send-to-tinybird]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Node
         uses: ./.github/actions/setup-node
@@ -179,7 +179,7 @@ jobs:
         run: cat packages/turbo-benchmark/slack-payload.json | jq
 
       - name: Send payload to slack
-        uses: slackapi/slack-github-action@v1.23.0
+        uses: slackapi/slack-github-action@v1.25.0
         with:
           payload-file-path: "packages/turbo-benchmark/slack-payload.json"
         env:

--- a/.github/workflows/bench-turborepo.yml
+++ b/.github/workflows/bench-turborepo.yml
@@ -26,8 +26,6 @@ jobs:
       - uses: ./.github/actions/setup-node
 
       - uses: ./.github/actions/setup-turborepo-environment
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Build
         run: cd cli && make turbo-prod
@@ -79,9 +77,6 @@ jobs:
         run: rustup target add x86_64-pc-windows-gnu
 
       - uses: ./.github/actions/setup-turborepo-environment
-        with:
-          windows: ${{ matrix.os.name == 'windows' }}
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Build Turborepo from source
         run: cd cli && make turbo-prod

--- a/.github/workflows/bench-turborepo.yml
+++ b/.github/workflows/bench-turborepo.yml
@@ -77,6 +77,8 @@ jobs:
         run: rustup target add x86_64-pc-windows-gnu
 
       - uses: ./.github/actions/setup-turborepo-environment
+        with:
+          windows: ${{ matrix.os.name == 'windows' }}
 
       - name: Build Turborepo from source
         run: cd cli && make turbo-prod

--- a/.github/workflows/bench-turbotrace-against-node-nft.yml
+++ b/.github/workflows/bench-turbotrace-against-node-nft.yml
@@ -24,7 +24,7 @@ jobs:
       BENCH_ARGS: --release -p turbopack --features bench_against_node_nft bench_against_node_nft
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: ./.github/actions/setup-node
         with:

--- a/.github/workflows/bench-turbotrace-against-node-nft.yml
+++ b/.github/workflows/bench-turbotrace-against-node-nft.yml
@@ -31,8 +31,6 @@ jobs:
           package-install: false
 
       - uses: ./.github/actions/setup-rust
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install hoisted npm dependencies
         working-directory: crates/turbopack/tests/node-file-trace

--- a/.github/workflows/lsp.yml
+++ b/.github/workflows/lsp.yml
@@ -70,7 +70,7 @@ jobs:
         run: ${{ matrix.settings.rust-build-env }} cargo build --profile release-turborepo-lsp -p turborepo-lsp --target ${{ matrix.settings.target }}
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: turborepo-lsp-${{ matrix.settings.target }}
           path: target/${{ matrix.settings.target }}/release-turborepo-lsp/turborepo-lsp*

--- a/.github/workflows/lsp.yml
+++ b/.github/workflows/lsp.yml
@@ -46,25 +46,20 @@ jobs:
       options: ${{ matrix.settings.container-options }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
       - name: Setup Container
         if: ${{ matrix.settings.container-setup }}
         run: ${{ matrix.settings.container-setup }}
 
-      - name: Setup Protoc
-        uses: arduino/setup-protoc@v1.2.0
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          targets: ${{ matrix.settings.target }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup capnproto
         uses: ./.github/actions/setup-capnproto
-
-      - name: Rust Setup
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          override: true
-          target: ${{ matrix.settings.target }}
 
       - name: Build Setup
         shell: bash

--- a/.github/workflows/lsp.yml
+++ b/.github/workflows/lsp.yml
@@ -28,10 +28,10 @@ jobs:
             setup: "sudo apt-get update && sudo apt-get install -y build-essential musl-tools clang llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu"
           - host: windows-latest
             target: x86_64-pc-windows-msvc
-            setup: "rustup set default-host x86_64-pc-windows-msvc"
           - host: windows-latest
             target: aarch64-pc-windows-msvc
-            setup: "rustup set default-host x86_64-pc-windows-msvc"
+            setup: |
+              echo "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\Llvm\x64\bin" >> $GITHUB_PATH
     runs-on: ${{ matrix.settings.host }}
     steps:
       - name: Checkout repo

--- a/.github/workflows/lsp.yml
+++ b/.github/workflows/lsp.yml
@@ -30,8 +30,6 @@ jobs:
             target: x86_64-pc-windows-msvc
           - host: windows-latest
             target: aarch64-pc-windows-msvc
-            setup: |
-              echo "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\Llvm\x64\bin" >> $GITHUB_PATH
     runs-on: ${{ matrix.settings.host }}
     steps:
       - name: Checkout repo

--- a/.github/workflows/lsp.yml
+++ b/.github/workflows/lsp.yml
@@ -31,7 +31,7 @@ jobs:
             setup: "rustup set default-host x86_64-pc-windows-msvc"
           - host: windows-latest
             target: aarch64-pc-windows-msvc
-            setup: "rustup set default-host aarch64-pc-windows-msvc"
+            setup: "rustup set default-host x86_64-pc-windows-msvc"
     runs-on: ${{ matrix.settings.host }}
     steps:
       - name: Checkout repo

--- a/.github/workflows/lsp.yml
+++ b/.github/workflows/lsp.yml
@@ -17,40 +17,25 @@ jobs:
         settings:
           - host: macos-latest
             target: "x86_64-apple-darwin"
-            container-options: "--rm"
           - host: macos-latest
             target: "aarch64-apple-darwin"
-            container-options: "--rm"
           - host: ubuntu-latest
-            container: ubuntu:xenial
-            container-options: "--platform=linux/amd64 --rm"
-            container-setup: "apt-get update && apt-get install -y curl musl-tools sudo"
             target: "x86_64-unknown-linux-musl"
-            setup: "apt-get install -y build-essential clang-5.0 lldb-5.0 llvm-5.0-dev libclang-5.0-dev"
+            setup: "sudo apt-get update && sudo apt-get install -y build-essential musl-tools clang llvm"
           - host: ubuntu-latest
-            container-options: "--rm"
             target: "aarch64-unknown-linux-musl"
             rust-build-env: 'CC_aarch64_unknown_linux_musl=clang AR_aarch64_unknown_linux_musl=llvm-ar RUSTFLAGS="-Clink-self-contained=yes -Clinker=rust-lld"'
             setup: "sudo apt-get update && sudo apt-get install -y build-essential musl-tools clang llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu"
           - host: windows-latest
             target: x86_64-pc-windows-msvc
             setup: "rustup set default-host x86_64-pc-windows-msvc"
-            container-options: "--rm"
           - host: windows-latest
             target: aarch64-pc-windows-msvc
             setup: "rustup set default-host aarch64-pc-windows-msvc"
-            container-options: "--rm"
     runs-on: ${{ matrix.settings.host }}
-    container:
-      image: ${{ matrix.settings.container }}
-      options: ${{ matrix.settings.container-options }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
-
-      - name: Setup Container
-        if: ${{ matrix.settings.container-setup }}
-        run: ${{ matrix.settings.container-setup }}
 
       - name: Setup Rust
         uses: ./.github/actions/setup-rust

--- a/.github/workflows/lsp.yml
+++ b/.github/workflows/lsp.yml
@@ -25,7 +25,7 @@ jobs:
           - host: ubuntu-latest
             target: "aarch64-unknown-linux-musl"
             rust-build-env: 'CC_aarch64_unknown_linux_musl=clang AR_aarch64_unknown_linux_musl=llvm-ar RUSTFLAGS="-Clink-self-contained=yes -Clinker=rust-lld"'
-            setup: "sudo apt-get update && sudo apt-get install -y build-essential musl-tools clang llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu"
+            setup: "sudo apt-get update && sudo apt-get install -y crossbuild-essential-arm64 musl-tools clang llvm"
           - host: windows-latest
             target: x86_64-pc-windows-msvc
           - host: windows-latest
@@ -47,15 +47,6 @@ jobs:
         shell: bash
         if: ${{ matrix.settings.setup }}
         run: ${{ matrix.settings.setup }}
-
-      - name: Print Rust toolchain
-        shell: bash
-        run: |
-          rustup show
-          which cargo
-          cargo --version --verbose
-          which rustc
-          rustc --version --verbose
 
       - name: Build
         shell: bash

--- a/.github/workflows/lsp.yml
+++ b/.github/workflows/lsp.yml
@@ -49,6 +49,7 @@ jobs:
         run: ${{ matrix.settings.setup }}
 
       - name: Build
+        shell: bash
         run: ${{ matrix.settings.rust-build-env }} cargo build --profile release-turborepo-lsp -p turborepo-lsp --target ${{ matrix.settings.target }}
 
       - name: Upload Artifacts

--- a/.github/workflows/lsp.yml
+++ b/.github/workflows/lsp.yml
@@ -39,7 +39,6 @@ jobs:
         uses: ./.github/actions/setup-rust
         with:
           targets: ${{ matrix.settings.target }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup capnproto
         uses: ./.github/actions/setup-capnproto

--- a/.github/workflows/lsp.yml
+++ b/.github/workflows/lsp.yml
@@ -48,6 +48,15 @@ jobs:
         if: ${{ matrix.settings.setup }}
         run: ${{ matrix.settings.setup }}
 
+      - name: Print Rust toolchain
+        shell: bash
+        run: |
+          rustup show
+          which cargo
+          cargo --version --verbose
+          which rustc
+          rustc --version --verbose
+
       - name: Build
         shell: bash
         run: ${{ matrix.settings.rust-build-env }} cargo build --profile release-turborepo-lsp -p turborepo-lsp --target ${{ matrix.settings.target }}

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -10,7 +10,7 @@ jobs:
     if: "startsWith(github.event.head_commit.message, 'chore: release npm packages')"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: ./.github/actions/setup-node
       - uses: ./.github/actions/setup-rust

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -14,8 +14,6 @@ jobs:
 
       - uses: ./.github/actions/setup-node
       - uses: ./.github/actions/setup-rust
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build packages
         run: pnpx turbo@canary run build:ts

--- a/.github/workflows/test-turbopack-rust-bench-test.yml
+++ b/.github/workflows/test-turbopack-rust-bench-test.yml
@@ -26,17 +26,16 @@ jobs:
         if: inputs.os == 'windows'
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
         with:
           save-cache: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
         uses: ./.github/actions/setup-node
-        with:
-          node-version: 18
 
       - name: Build benchmarks for tests
         timeout-minutes: 120

--- a/.github/workflows/test-turbopack-rust-bench-test.yml
+++ b/.github/workflows/test-turbopack-rust-bench-test.yml
@@ -32,7 +32,6 @@ jobs:
         uses: ./.github/actions/setup-rust
         with:
           save-cache: true
-          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
         uses: ./.github/actions/setup-node

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1074,6 +1074,7 @@ jobs:
 
       - name: Set PR status comment
         uses: ./.github/actions/status-comment
+        if: steps.info.outputs.cancelled != 'true'
         continue-on-error: true
         with:
           id: "ci-status"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,9 @@ jobs:
       contents: read
       pull-requests: write
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Set PR status comment
         uses: ./.github/actions/status-comment
         continue-on-error: true
@@ -30,9 +33,6 @@ jobs:
             ## ⏳ CI is running again... ⏳
 
             [Wait for it...](https://github.com/vercel/turbo/actions/runs/${{ github.run_id }})
-
-      - name: Checkout
-        uses: actions/checkout@v4
 
       - name: CI related changes
         id: ci
@@ -863,6 +863,11 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout actions
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github
+
       - name: Compute info
         id: info
         if: always()
@@ -1000,6 +1005,11 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout actions
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github
+
       - name: Compute info
         id: info
         if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,33 +21,18 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - name: Find PR Comment
-        id: comment
-        if: github.event_name == 'pull_request'
-        uses: peter-evans/find-comment@v2
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: "github-actions[bot]"
-          body-includes: "<!-- CI COMMENT -->"
-
-      - name: Create or update PR comment
-        if: github.event_name == 'pull_request' && steps.comment.outputs.comment-id != ''
-        uses: peter-evans/create-or-update-comment@v2
+      - name: Set PR status comment
+        uses: ./.github/actions/status-comment
         continue-on-error: true
         with:
-          comment-id: ${{ steps.comment.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
+          id: "ci-status"
           body: |
             ## ⏳ CI is running again... ⏳
 
             [Wait for it...](https://github.com/vercel/turbo/actions/runs/${{ github.run_id }})
 
-            <!-- CI COMMENT -->
-
-          edit-mode: replace
-
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: CI related changes
         id: ci
@@ -212,17 +197,18 @@ jobs:
             runner: windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.3
+        uses: mozilla-actions/sccache-action@v0.0.4
 
       - uses: ./.github/actions/setup-turborepo-environment
         with:
           windows: ${{ matrix.os.name == 'windows' }}
           github-token: "${{ secrets.GITHUB_TOKEN }}"
+
       # We explicitly unset RUSTC_WRAPPER if it is an empty string as causes build issues
       - run: |
           if [ -z "${RUSTC_WRAPPER}" ]; then
@@ -268,7 +254,7 @@ jobs:
         if: matrix.os.runner == 'windows-latest'
         shell: bash
         run: git config --global core.autocrlf input
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-turborepo-environment
         with:
           windows: ${{ matrix.os.runner == 'windows-latest' }}
@@ -283,7 +269,7 @@ jobs:
 
       - name: Cache Prysk
         id: cache-prysk
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: cli/.cram_env
           key: prysk-venv-${{ matrix.os.runner }}
@@ -300,7 +286,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Disable corepack. actions/setup-node invokes other package managers and
       # that causes corepack to throw an error, so we disable it first.
@@ -359,7 +345,7 @@ jobs:
           echo "depth=$(( ${{ github.event.pull_request.commits || 1 }} + 1 ))" >> $GITHUB_OUTPUT
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
           fetch-depth: ${{ steps.fetch-depth.outputs.depth  }}
@@ -389,7 +375,7 @@ jobs:
     if: needs.determine_jobs.outputs.turbopack_typescript == 'true'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
         uses: ./.github/actions/setup-node
@@ -420,13 +406,13 @@ jobs:
       - "metal"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
         with:
           components: rustfmt
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run cargo fmt check
         run: |
@@ -455,7 +441,7 @@ jobs:
       - "metal"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Turborepo Environment
         uses: ./.github/actions/setup-turborepo-environment
@@ -477,7 +463,7 @@ jobs:
       - "metal"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Turborepo Environment
         uses: ./.github/actions/setup-turborepo-environment
@@ -508,13 +494,14 @@ jobs:
       - "metal"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
         with:
           components: clippy
           targets: wasm32-unknown-unknown,wasm32-wasi-preview1-threads
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run cargo check release
         run: |
@@ -534,14 +521,14 @@ jobs:
       - "metal"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
         with:
           components: clippy
           targets: wasm32-unknown-unknown
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run cargo clippy
         run: |
@@ -564,14 +551,14 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout Next.js
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: vercel/next.js
 
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
         with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build next-swc
         run: |
@@ -618,14 +605,13 @@ jobs:
           See [job summary]($job_url) for details
           " > out.log
 
-      - name: PR comment with file
-        uses: thollander/actions-comment-pull-request@v2
+      - name: Set PR status comment
+        uses: ./.github/actions/status-comment
         if: always() && github.repository == 'vercel/turbo'
-        # We'll not block CI on this step
         continue-on-error: true
         with:
-          filePath: ./out.log
-          comment_tag: check_next_swc_turbopack
+          id: "next-swc-status"
+          body-path: "out.log"
 
   turborepo_rust_test:
     needs: [turborepo_rust_check]
@@ -656,7 +642,7 @@ jobs:
         if: matrix.os.name == 'windows'
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Turborepo Environment
         uses: ./.github/actions/setup-turborepo-environment
@@ -679,18 +665,16 @@ jobs:
     name: Turbopack Rust testing on ubuntu
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
         with:
           save-cache: true
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
         uses: ./.github/actions/setup-node
-        with:
-          node-version: 18
 
       - name: Install tests dependencies
         working-directory: crates/turbopack/tests/node-file-trace
@@ -741,10 +725,10 @@ jobs:
         if: matrix.os.name == 'windows'
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           # TODO: Remove this specific version constraint once pnpm ships with
           # node-gyp that's compatible with Python 3.12+
@@ -754,12 +738,10 @@ jobs:
         uses: ./.github/actions/setup-rust
         with:
           save-cache: true
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
         uses: ./.github/actions/setup-node
-        with:
-          node-version: 18
 
       - name: Prepare toolchain on Windows
         run: |
@@ -847,7 +829,7 @@ jobs:
       TURBO_REMOTE_ONLY: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - uses: ./.github/actions/setup-turborepo-environment
         with:
@@ -943,24 +925,12 @@ jobs:
           echo >> comment.md
           echo "<!-- CI COMMENT -->" >> comment.md
 
-      - name: Find PR Comment
-        id: comment
-        if: always() && github.event_name == 'pull_request' && steps.info.outputs.cancelled != 'true'
-        uses: peter-evans/find-comment@v2
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: "github-actions[bot]"
-          body-includes: "<!-- CI COMMENT -->"
-
-      - name: Create or update PR comment
-        if: always() && github.event_name == 'pull_request' && steps.info.outputs.cancelled != 'true'
-        uses: peter-evans/create-or-update-comment@v2
+      - name: Set PR status comment
+        uses: ./.github/actions/status-comment
         continue-on-error: true
         with:
-          comment-id: ${{ steps.comment.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body-file: "comment.md"
-          edit-mode: replace
+          id: "ci-status"
+          body-path: "comment.md"
 
       - name: It's not fine
         if: steps.info.outputs.failure == 'true'
@@ -983,12 +953,10 @@ jobs:
       # Uploading test results does not require turbopack's src codes, but this
       # allows datadog uploader to sync with git information.
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3.6.0
-        with:
-          node-version: 18
+        uses: actions/setup-node@v4
 
       - name: Install datadog
         run: npm install -g @datadog/datadog-ci@2.18.1
@@ -1092,24 +1060,12 @@ jobs:
           echo >> comment.md
           echo "<!-- CI COMMENT -->" >> comment.md
 
-      - name: Find PR Comment
-        id: comment
-        if: always() && github.event_name == 'pull_request' && steps.info.outputs.cancelled != 'true'
-        uses: peter-evans/find-comment@v2
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: "github-actions[bot]"
-          body-includes: "<!-- CI COMMENT -->"
-
-      - name: Create or update PR comment
-        if: always() && github.event_name == 'pull_request' && steps.info.outputs.cancelled != 'true'
-        uses: peter-evans/create-or-update-comment@v2
+      - name: Set PR status comment
+        uses: ./.github/actions/status-comment
         continue-on-error: true
         with:
-          comment-id: ${{ steps.comment.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body-file: "comment.md"
-          edit-mode: replace
+          id: "ci-status"
+          body-path: "comment.md"
 
       - name: It's not fine
         if: steps.info.outputs.failure == 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -700,9 +700,9 @@ jobs:
 
       - name: Upload results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: test_reports
+          name: test-reports-linux
           path: target/nextest/**/*.xml
 
   turbopack_rust_test2:
@@ -781,9 +781,9 @@ jobs:
 
       - name: Upload results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: test_reports
+          name: test-reports-${{ matrix.os.name }}
           path: target/nextest/**/*.xml
 
   turbopack_rust_test_bench1:
@@ -962,16 +962,18 @@ jobs:
         run: npm install -g @datadog/datadog-ci@2.18.1
 
       - name: Download test results
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          path: artifacts
+          pattern: test-reports-*
+          merge-multiple: true
+          path: artifacts/test-reports
 
       - name: Upload
         continue-on-error: true
         env:
           DATADOG_API_KEY: ${{ secrets.DD_KEY_TURBOPACK }}
         run: |
-          DD_ENV=ci datadog-ci junit upload --service Turbopack ./artifacts/test_reports/**/*.xml
+          DD_ENV=ci datadog-ci junit upload --service Turbopack ./artifacts/test-reports/**/*.xml
 
   done:
     name: Done

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -261,7 +261,7 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Setup Graphviz
-        uses: ts-graphviz/setup-graphviz@v1
+        uses: ts-graphviz/setup-graphviz@v2
         with:
           macos-skip-brew-update: "true"
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -605,8 +605,14 @@ jobs:
           See [job summary]($job_url) for details
           " > out.log
 
+      - name: Checkout local actions
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github
+          path: turbo-actions
+
       - name: Set PR status comment
-        uses: ./.github/actions/status-comment
+        uses: ./turbo-actions/.github/actions/status-comment
         if: always() && github.repository == 'vercel/turbo'
         continue-on-error: true
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -451,7 +451,7 @@ jobs:
 
       - name: Run cargo check
         run: |
-          cargo groups check turborepo-libraries --features rustls-tls
+          cargo groups check turborepo --features rustls-tls
 
   turborepo_rust_clippy:
     needs: [turborepo_rust_check]
@@ -473,11 +473,11 @@ jobs:
 
       - name: Run cargo clippy
         run: |
-          cargo groups clippy turborepo-libraries --features rustls-tls -- --deny clippy::all
+          cargo groups clippy turborepo --features rustls-tls -- --deny clippy::all
 
       - name: Run ast-grep lints
         run: |
-          npx --package @ast-grep/cli -- ast-grep scan $(cargo groups list turborepo-libraries | awk '{ print $2 }' | tr '\n' ' ')
+          npx --package @ast-grep/cli -- ast-grep scan $(cargo groups list turborepo | awk '{ print $2 }' | tr '\n' ' ')
 
   turbopack_rust_check:
     needs: [determine_jobs]
@@ -659,7 +659,7 @@ jobs:
       - name: Run tests
         timeout-minutes: 120
         run: |
-          cargo groups test turborepo-libraries
+          cargo groups test turborepo
 
   turbopack_rust_test1:
     needs: [turbopack_rust_check]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -205,9 +205,6 @@ jobs:
         uses: mozilla-actions/sccache-action@v0.0.4
 
       - uses: ./.github/actions/setup-turborepo-environment
-        with:
-          windows: ${{ matrix.os.name == 'windows' }}
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       # We explicitly unset RUSTC_WRAPPER if it is an empty string as causes build issues
       - run: |
@@ -256,9 +253,6 @@ jobs:
         run: git config --global core.autocrlf input
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-turborepo-environment
-        with:
-          windows: ${{ matrix.os.runner == 'windows-latest' }}
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Setup Graphviz
         uses: ts-graphviz/setup-graphviz@v2
@@ -295,9 +289,6 @@ jobs:
         run: corepack disable
 
       - uses: ./.github/actions/setup-turborepo-environment
-        with:
-          windows: ${{ matrix.os.runner == 'windows-latest' }}
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Check examples
         shell: bash
@@ -352,9 +343,6 @@ jobs:
 
       - name: Build turborepo CLI from source
         uses: ./.github/actions/setup-turborepo-environment
-        with:
-          windows: ${{ matrix.os.name == 'windows' }}
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Run tests
         # We manually set TURBO_API to an empty string to override Hetzner env
@@ -412,7 +400,6 @@ jobs:
         uses: ./.github/actions/setup-rust
         with:
           components: rustfmt
-          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run cargo fmt check
         run: |
@@ -445,9 +432,6 @@ jobs:
 
       - name: Setup Turborepo Environment
         uses: ./.github/actions/setup-turborepo-environment
-        with:
-          windows: ${{ matrix.os.name == 'windows' }}
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Run cargo check
         run: |
@@ -467,9 +451,6 @@ jobs:
 
       - name: Setup Turborepo Environment
         uses: ./.github/actions/setup-turborepo-environment
-        with:
-          windows: ${{ matrix.os.name == 'windows' }}
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Run cargo clippy
         run: |
@@ -501,7 +482,6 @@ jobs:
         with:
           components: clippy
           targets: wasm32-unknown-unknown,wasm32-wasi-preview1-threads
-          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run cargo check release
         run: |
@@ -528,7 +508,6 @@ jobs:
         with:
           components: clippy
           targets: wasm32-unknown-unknown
-          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run cargo clippy
         run: |
@@ -557,8 +536,6 @@ jobs:
 
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build next-swc
         run: |
@@ -652,9 +629,6 @@ jobs:
 
       - name: Setup Turborepo Environment
         uses: ./.github/actions/setup-turborepo-environment
-        with:
-          windows: ${{ matrix.os.name == 'windows' }}
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Run tests
         timeout-minutes: 120
@@ -677,7 +651,6 @@ jobs:
         uses: ./.github/actions/setup-rust
         with:
           save-cache: true
-          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
         uses: ./.github/actions/setup-node
@@ -744,7 +717,6 @@ jobs:
         uses: ./.github/actions/setup-rust
         with:
           save-cache: true
-          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
         uses: ./.github/actions/setup-node
@@ -838,8 +810,6 @@ jobs:
         uses: actions/checkout@v4
 
       - uses: ./.github/actions/setup-turborepo-environment
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Lint
         # Filters some workspaces out:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -205,6 +205,8 @@ jobs:
         uses: mozilla-actions/sccache-action@v0.0.4
 
       - uses: ./.github/actions/setup-turborepo-environment
+        with:
+          windows: ${{ matrix.os.name == 'windows' }}
 
       # We explicitly unset RUSTC_WRAPPER if it is an empty string as causes build issues
       - run: |
@@ -253,6 +255,8 @@ jobs:
         run: git config --global core.autocrlf input
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-turborepo-environment
+        with:
+          windows: ${{ matrix.os.runner == 'windows-latest' }}
 
       - name: Setup Graphviz
         uses: ts-graphviz/setup-graphviz@v2
@@ -289,6 +293,8 @@ jobs:
         run: corepack disable
 
       - uses: ./.github/actions/setup-turborepo-environment
+        with:
+          windows: ${{ matrix.os.runner == 'windows-latest' }}
 
       - name: Check examples
         shell: bash
@@ -343,6 +349,8 @@ jobs:
 
       - name: Build turborepo CLI from source
         uses: ./.github/actions/setup-turborepo-environment
+        with:
+          windows: ${{ matrix.os.name == 'windows' }}
 
       - name: Run tests
         # We manually set TURBO_API to an empty string to override Hetzner env
@@ -432,6 +440,8 @@ jobs:
 
       - name: Setup Turborepo Environment
         uses: ./.github/actions/setup-turborepo-environment
+        with:
+          windows: ${{ matrix.os.name == 'windows' }}
 
       - name: Run cargo check
         run: |
@@ -451,6 +461,8 @@ jobs:
 
       - name: Setup Turborepo Environment
         uses: ./.github/actions/setup-turborepo-environment
+        with:
+          windows: ${{ matrix.os.name == 'windows' }}
 
       - name: Run cargo clippy
         run: |
@@ -629,6 +641,8 @@ jobs:
 
       - name: Setup Turborepo Environment
         uses: ./.github/actions/setup-turborepo-environment
+        with:
+          windows: ${{ matrix.os.name == 'windows' }}
 
       - name: Run tests
         timeout-minutes: 120

--- a/.github/workflows/turbopack-nightly-release.yml
+++ b/.github/workflows/turbopack-nightly-release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Tag nightly
         id: tag_version

--- a/.github/workflows/turborepo-compare-cache-item.yml
+++ b/.github/workflows/turborepo-compare-cache-item.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       - name: create-turbo
         run: |
@@ -53,7 +53,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       - name: create-turbo
         run: |

--- a/.github/workflows/turborepo-compare-cache-item.yml
+++ b/.github/workflows/turborepo-compare-cache-item.yml
@@ -32,7 +32,7 @@ jobs:
           turbo run build --filter=docs --filter=web --summarize --skip-infer -vvv
 
       - name: Grab Turborepo artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cache-item-${{ matrix.os }}-${{ inputs.version }}
           path: |
@@ -61,7 +61,7 @@ jobs:
           pnpm dlx create-turbo@${{ inputs.version }} my-turborepo pnpm
 
       - name: Download cache artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: cache-item-${{ matrix.cache_os }}-${{ inputs.version }}
           path: my-turborepo

--- a/.github/workflows/turborepo-compare-cache-item.yml
+++ b/.github/workflows/turborepo-compare-cache-item.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
 
@@ -51,7 +51,7 @@ jobs:
 
     steps:
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
 

--- a/.github/workflows/turborepo-library-release.yml
+++ b/.github/workflows/turborepo-library-release.yml
@@ -66,13 +66,13 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup Node
+        uses: ./.github/actions/setup-node
+
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
         with:
           targets: ${{ matrix.settings.target }}
-
-      - name: Setup Node
-        uses: ./.github/actions/setup-node
 
       - name: Setup toolchain
         shell: bash

--- a/.github/workflows/turborepo-library-release.yml
+++ b/.github/workflows/turborepo-library-release.yml
@@ -62,7 +62,7 @@ jobs:
     runs-on: ${{ matrix.settings.host }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -70,6 +70,7 @@ jobs:
         uses: ./.github/actions/setup-rust
         with:
           targets: ${{ matrix.settings.target }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node
         uses: ./.github/actions/setup-node
@@ -97,7 +98,7 @@ jobs:
     needs: [build]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/turborepo-library-release.yml
+++ b/.github/workflows/turborepo-library-release.yml
@@ -66,13 +66,13 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Node
-        uses: ./.github/actions/setup-node
-
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
         with:
           targets: ${{ matrix.settings.target }}
+
+      - name: Setup Node
+        uses: ./.github/actions/setup-node
 
       - name: Setup toolchain
         shell: bash
@@ -81,7 +81,12 @@ jobs:
 
       - name: Print Rust toolchain
         shell: bash
-        run: rustup show
+        run: |
+          rustup show
+          which cargo
+          cargo --version --verbose
+          which rustc
+          rustc --version --verbose
 
       - name: Build native library
         shell: bash

--- a/.github/workflows/turborepo-library-release.yml
+++ b/.github/workflows/turborepo-library-release.yml
@@ -79,15 +79,6 @@ jobs:
         run: ${{ matrix.settings.setup }}
         if: ${{ matrix.settings.setup }}
 
-      - name: Print Rust toolchain
-        shell: bash
-        run: |
-          rustup show
-          which cargo
-          cargo --version --verbose
-          which rustc
-          rustc --version --verbose
-
       - name: Build native library
         shell: bash
         run: |

--- a/.github/workflows/turborepo-library-release.yml
+++ b/.github/workflows/turborepo-library-release.yml
@@ -70,7 +70,6 @@ jobs:
         uses: ./.github/actions/setup-rust
         with:
           targets: ${{ matrix.settings.target }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node
         uses: ./.github/actions/setup-node

--- a/.github/workflows/turborepo-library-release.yml
+++ b/.github/workflows/turborepo-library-release.yml
@@ -87,7 +87,7 @@ jobs:
           ${{ matrix.settings.rust_env }} pnpm build:release --target=${{ matrix.settings.target }}
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: turbo-library-${{ matrix.settings.target }}
           path: packages/turbo-repository/native
@@ -108,7 +108,7 @@ jobs:
           git config --global user.email 'turbobot@vercel.com'
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: native-packages
 
@@ -143,7 +143,7 @@ jobs:
           mv *.tgz tarballs/
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Upload Tarballs
           path: tarballs

--- a/.github/workflows/turborepo-library-release.yml
+++ b/.github/workflows/turborepo-library-release.yml
@@ -79,6 +79,10 @@ jobs:
         run: ${{ matrix.settings.setup }}
         if: ${{ matrix.settings.setup }}
 
+      - name: Print Rust toolchain
+        shell: bash
+        run: rustup show
+
       - name: Build native library
         shell: bash
         run: |

--- a/.github/workflows/turborepo-native-lib-test.yml
+++ b/.github/workflows/turborepo-native-lib-test.yml
@@ -45,6 +45,8 @@ jobs:
 
       - name: Build turborepo CLI from source
         uses: ./.github/actions/setup-turborepo-environment
+        with:
+          windows: ${{ matrix.os.name == 'windows' }}
 
       - name: Run tests
         # Manually set TURBO_API to an empty string to override Hetzner env

--- a/.github/workflows/turborepo-native-lib-test.yml
+++ b/.github/workflows/turborepo-native-lib-test.yml
@@ -45,9 +45,6 @@ jobs:
 
       - name: Build turborepo CLI from source
         uses: ./.github/actions/setup-turborepo-environment
-        with:
-          windows: ${{ matrix.os.name == 'windows' }}
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Run tests
         # Manually set TURBO_API to an empty string to override Hetzner env

--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -102,29 +102,19 @@ jobs:
         settings:
           - host: macos-latest
             target: "x86_64-apple-darwin"
-            container-options: "--rm"
           - host: macos-latest
             target: "aarch64-apple-darwin"
-            container-options: "--rm"
           - host: ubuntu-latest
-            container: ubuntu:xenial
-            container-options: "--platform=linux/amd64 --rm"
-            container-setup: "apt-get update && apt-get install -y curl musl-tools sudo"
             target: "x86_64-unknown-linux-musl"
-            setup: "apt-get install -y build-essential clang-5.0 lldb-5.0 llvm-5.0-dev libclang-5.0-dev"
+            setup: "sudo apt-get update && sudo apt-get install -y build-essential musl-tools clang llvm"
           - host: ubuntu-latest
-            container-options: "--rm"
             target: "aarch64-unknown-linux-musl"
             rust-build-env: 'CC_aarch64_unknown_linux_musl=clang AR_aarch64_unknown_linux_musl=llvm-ar RUSTFLAGS="-Clink-self-contained=yes -Clinker=rust-lld"'
             setup: "sudo apt-get update && sudo apt-get install -y build-essential musl-tools clang llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu"
           - host: windows-latest
             target: x86_64-pc-windows-gnu
             setup: "rustup set default-host x86_64-pc-windows-gnu"
-            container-options: "--rm"
     runs-on: ${{ matrix.settings.host }}
-    container:
-      image: ${{ matrix.settings.container }}
-      options: ${{ matrix.settings.container-options }}
     steps:
       - name: Show Stage Commit
         run: echo "${{ needs.stage.outputs.stage-branch }}"
@@ -132,10 +122,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: "${{ needs.stage.outputs.stage-branch }}"
-
-      - name: Setup Container
-        if: ${{ matrix.settings.container-setup }}
-        run: ${{ matrix.settings.container-setup }}
 
       - name: Setup Rust
         uses: ./.github/actions/setup-rust

--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -182,7 +182,6 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: rust-artifacts
-          merge-multiple: true
 
       - name: Move Rust artifacts into place
         run: |

--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -155,7 +155,7 @@ jobs:
         run: ${{ matrix.settings.rust-build-env }} cargo build --profile release-turborepo -p turbo --target ${{ matrix.settings.target }}
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: turbo-${{ matrix.settings.target }}
           path: target/${{ matrix.settings.target }}/release-turborepo/turbo*
@@ -193,9 +193,10 @@ jobs:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
 
       - name: Download Rust artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: rust-artifacts
+          merge-multiple: true
 
       - name: Move Rust artifacts into place
         run: |
@@ -214,7 +215,7 @@ jobs:
 
       # Upload published artifacts in case they are needed for debugging later
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: turbo-combined
           path: cli/dist

--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -41,10 +41,8 @@ jobs:
   stage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node
-        with:
-          enable-corepack: false
       - name: Configure git
         run: |
           git config --global user.name 'Turbobot'
@@ -68,7 +66,7 @@ jobs:
     steps:
       - name: Show Stage Commit
         run: echo "${{ needs.stage.outputs.stage-branch }}"
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ needs.stage.outputs.stage-branch }}
       - name: Build turborepo CLI from source
@@ -85,7 +83,7 @@ jobs:
     steps:
       - name: Show Stage Commit
         run: echo "${{ needs.stage.outputs.stage-branch }}"
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ needs.stage.outputs.stage-branch }}
       - name: Build turborepo CLI from source
@@ -131,7 +129,7 @@ jobs:
       - name: Show Stage Commit
         run: echo "${{ needs.stage.outputs.stage-branch }}"
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: "${{ needs.stage.outputs.stage-branch }}"
 
@@ -139,20 +137,14 @@ jobs:
         if: ${{ matrix.settings.container-setup }}
         run: ${{ matrix.settings.container-setup }}
 
-      - name: Setup Protoc
-        uses: arduino/setup-protoc@v1.2.0
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          targets: ${{ matrix.settings.target }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup capnproto
         uses: ./.github/actions/setup-capnproto
-
-      - name: Rust Setup
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          override: true
-          target: ${{ matrix.settings.target }}
 
       - name: Build Setup
         shell: bash
@@ -175,13 +167,11 @@ jobs:
     steps:
       - name: Show Stage Commit
         run: echo "${{ needs.stage.outputs.stage-branch }}"
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: "${{ needs.stage.outputs.stage-branch }}"
       - run: git fetch origin --tags
       - uses: ./.github/actions/setup-node
-        with:
-          enable-corepack: false
 
       - name: Configure git
         run: |
@@ -194,7 +184,7 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Install GoReleaser
-        uses: goreleaser/goreleaser-action@v3
+        uses: goreleaser/goreleaser-action@v5
         with:
           distribution: goreleaser-pro
           version: v1.18.2
@@ -236,7 +226,7 @@ jobs:
     steps:
       - name: Show Stage Commit
         run: echo "${{ needs.stage.outputs.stage-branch }}"
-      - uses: actions/checkout@1.0.0
+      - uses: actions/checkout@4
         with:
           ref: ${{ needs.stage.outputs.stage-branch }}
       - name: Get version

--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -212,7 +212,7 @@ jobs:
     steps:
       - name: Show Stage Commit
         run: echo "${{ needs.stage.outputs.stage-branch }}"
-      - uses: actions/checkout@4
+      - uses: actions/checkout@v4
         with:
           ref: ${{ needs.stage.outputs.stage-branch }}
       - name: Get version

--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -71,8 +71,6 @@ jobs:
           ref: ${{ needs.stage.outputs.stage-branch }}
       - name: Build turborepo CLI from source
         uses: ./.github/actions/setup-turborepo-environment
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Run Rust Unit Tests
         run: cargo groups test turborepo
 
@@ -88,8 +86,6 @@ jobs:
           ref: ${{ needs.stage.outputs.stage-branch }}
       - name: Build turborepo CLI from source
         uses: ./.github/actions/setup-turborepo-environment
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Run JS Package Tests
         run: turbo run check-types test --filter="./packages/*" --color
 
@@ -127,7 +123,6 @@ jobs:
         uses: ./.github/actions/setup-rust
         with:
           targets: ${{ matrix.settings.target }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup capnproto
         uses: ./.github/actions/setup-capnproto
@@ -166,8 +161,6 @@ jobs:
 
       - name: Setup turborepo environment
         uses: ./.github/actions/setup-turborepo-environment
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@v5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12054,7 +12054,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "rand 0.8.5",
  "static_assertions",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,9 +55,6 @@ default-members = [
 ]
 
 [workspace.metadata.groups]
-# Only the libraries, does not include the turborepo binary.
-# That way we don't have to build the Go code
-turborepo-libraries = ["path:crates/turborepo-*"]
 turborepo = ["path:crates/turborepo*"]
 turbopack = [
   "path:crates/turbopack*",


### PR DESCRIPTION
### Description

The `node16` runner is deprecated, I updated all the actions I could here.

Still missing:
~~https://github.com/pnpm/action-setup~~ (removed in favor of corepack, but that needs to be tested)
https://github.com/technote-space/get-diff-action (archived, needs to be replaced)
https://github.com/dependabot/fetch-metadata (has PR: https://github.com/dependabot/fetch-metadata/pull/443)
~~https://github.com/ts-graphviz/setup-graphviz (has PR: https://github.com/ts-graphviz/setup-graphviz/pull/558)~~
https://github.com/thomaseizinger/create-pull-request

