### PR TITLE
fix(turbopack): Fix css var issue and font issue when using `lightningcss`

### DIFF
--- a/crates/turbopack-css/src/process.rs
+++ b/crates/turbopack-css/src/process.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result};
 use indexmap::IndexMap;
 use lightningcss::{
     css_modules::{CssModuleExport, CssModuleExports, CssModuleReference, Pattern, Segment},
-    dependencies::{Dependency, DependencyOptions, ImportDependency, Location, SourceRange},
+    dependencies::{Dependency, ImportDependency, Location, SourceRange},
     error::PrinterErrorKind,
     stylesheet::{ParserOptions, PrinterOptions, StyleSheet, ToCssResult},
     targets::{Features, Targets},
@@ -120,7 +120,7 @@ impl<'i, 'o> StyleSheetLike<'i, 'o> {
                     } else {
                         Default::default()
                     },
-                    analyze_dependencies: Some(DependencyOptions { remove_imports }),
+                    analyze_dependencies: None,
                     ..Default::default()
                 })?;
 

--- a/crates/turbopack-css/src/references/import.rs
+++ b/crates/turbopack-css/src/references/import.rs
@@ -154,7 +154,13 @@ impl ImportAttributes {
                 supports: supports
                     .as_ref()
                     .map(|s| s.to_css_string(Default::default()).unwrap()),
-                media: Some(media.to_css_string(Default::default()).unwrap()),
+                media: {
+                    if media.always_matches() {
+                        None
+                    } else {
+                        Some(media.to_css_string(Default::default()).unwrap())
+                    }
+                },
             },
             ImportAttributes::Swc {
                 layer_name,


### PR DESCRIPTION
### Description

Previously, an empty medialist was converted to `@media not all`, which is wrong.

### Testing Instructions

You can test it using internal sites

 - Closes PACK-2360
 - Closes PACK-2361