### PR TITLE
Ignore .d.ts files in tsconfig paths handling

### DIFF
--- a/crates/turbopack-ecmascript/src/typescript/resolve.rs
+++ b/crates/turbopack-ecmascript/src/typescript/resolve.rs
@@ -225,6 +225,7 @@ impl ValueDefault for TsConfigResolveOptions {
 #[turbo_tasks::function]
 pub async fn tsconfig_resolve_options(
     tsconfig: Vc<FileSystemPath>,
+    resolve_for_types: bool,
 ) -> Result<Vc<TsConfigResolveOptions>> {
     let configs = read_tsconfigs(
         tsconfig.read(),
@@ -271,7 +272,7 @@ pub async fn tsconfig_resolve_options(
                                 let s = entry.as_str()?;
 
                                 match s {
-                                    s if s.ends_with("d.ts") => None,
+                                    s if s.ends_with("d.ts") && !resolve_for_types => None,
                                     s if s.starts_with("./") || s.starts_with("../") => {
                                         Some(s.to_string())
                                     }

--- a/crates/turbopack-ecmascript/src/typescript/resolve.rs
+++ b/crates/turbopack-ecmascript/src/typescript/resolve.rs
@@ -268,14 +268,15 @@ pub async fn tsconfig_resolve_options(
                         let entries = vec
                             .iter()
                             .filter_map(|entry| {
-                                entry.as_str().map(|s| {
-                                    // tsconfig paths are always relative requests
-                                    if s.starts_with("./") || s.starts_with("../") {
-                                        s.to_string()
-                                    } else {
-                                        format!("./{s}")
+                                let s = entry.as_str()?;
+
+                                match s {
+                                    s if s.ends_with("d.ts") => None,
+                                    s if s.starts_with("./") || s.starts_with("../") => {
+                                        Some(s.to_string())
                                     }
-                                })
+                                    _ => Some(format!("./{s}")),
+                                }
                             })
                             .collect();
                         all_paths.insert(

--- a/crates/turbopack-ecmascript/src/typescript/resolve.rs
+++ b/crates/turbopack-ecmascript/src/typescript/resolve.rs
@@ -275,6 +275,7 @@ pub async fn tsconfig_resolve_options(
                                     s if s.starts_with("./") || s.starts_with("../") => {
                                         Some(s.to_string())
                                     }
+                                    // tsconfig paths are always relative requests
                                     _ => Some(format!("./{s}")),
                                 }
                             })

--- a/crates/turbopack-tests/tests/execution/turbopack/resolving/tsconfig/input/index.js
+++ b/crates/turbopack-tests/tests/execution/turbopack/resolving/tsconfig/input/index.js
@@ -1,0 +1,5 @@
+import value from "@package";
+
+it("should resolve the package", () => {
+  expect(value).toBe("value");
+});

--- a/crates/turbopack-tests/tests/execution/turbopack/resolving/tsconfig/input/package/index.d.ts
+++ b/crates/turbopack-tests/tests/execution/turbopack/resolving/tsconfig/input/package/index.d.ts
@@ -1,0 +1,3 @@
+declare const value: string;
+
+export default value;

--- a/crates/turbopack-tests/tests/execution/turbopack/resolving/tsconfig/input/package/index.js
+++ b/crates/turbopack-tests/tests/execution/turbopack/resolving/tsconfig/input/package/index.js
@@ -1,0 +1,1 @@
+export default "value";

--- a/crates/turbopack-tests/tests/execution/turbopack/resolving/tsconfig/input/tsconfig.json
+++ b/crates/turbopack-tests/tests/execution/turbopack/resolving/tsconfig/input/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "paths": {
+      "@package": ["./package/index.d.ts", "./package/index.js"]
+    }
+  }
+}

--- a/crates/turbopack/src/module_options/mod.rs
+++ b/crates/turbopack/src/module_options/mod.rs
@@ -352,6 +352,13 @@ impl ModuleOptions {
             ),
         ];
 
+        if !enable_types {
+            rules.push(ModuleRule::new(
+                ModuleRuleCondition::ResourcePathEndsWith(".d.ts".to_string()),
+                vec![ModuleRuleEffect::Ignore],
+            ));
+        }
+
         if enable_raw_css {
             rules.extend([
                 ModuleRule::new(

--- a/crates/turbopack/src/module_options/module_rule.rs
+++ b/crates/turbopack/src/module_options/module_rule.rs
@@ -85,6 +85,9 @@ impl ModuleRule {
 #[derive(Debug, Clone)]
 pub enum ModuleRuleEffect {
     ModuleType(ModuleType),
+    /// Ignore the module, and use different alternatives if possible. Otherwise
+    /// resolve to nothing.
+    Ignore,
     /// Allow to extend an existing Ecmascript module rules for the additional
     /// transforms. First argument will prepend the existing transforms, and
     /// the second argument will append the new transforms.


### PR DESCRIPTION
### Description

Currently Turbopack tries to handle the `.d.ts` file when resolving tsconfig.json `paths`. The `.d.ts` file should be ignored in that case.

<!--
  ✍️ Write a short summary of your work.
  If necessary, include relevant screenshots.
-->

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
