### PR TITLE
Documentation for `turbo info`.

### DIFF
--- a/docs/pages/repo/docs/reference/command-line-reference.mdx
+++ b/docs/pages/repo/docs/reference/command-line-reference.mdx
@@ -11,6 +11,7 @@ information about their usage on these pages:
 - [`run`](/repo/docs/reference/command-line-reference/run)
 - [`prune`](/repo/docs/reference/command-line-reference/prune)
 - [`gen`](/repo/docs/reference/command-line-reference/gen)
+- [`info`](/repo/docs/reference/command-line-reference/info)
 - [`login`](/repo/docs/reference/command-line-reference/login)
 - [`logout`](/repo/docs/reference/command-line-reference/logout)
 - [`link`](/repo/docs/reference/command-line-reference/link)

--- a/docs/pages/repo/docs/reference/command-line-reference/_meta.json
+++ b/docs/pages/repo/docs/reference/command-line-reference/_meta.json
@@ -2,6 +2,7 @@
   "run": "run",
   "prune": "prune",
   "gen": "gen",
+  "info": "info",
   "login": "login",
   "logout": "logout",
   "link": "link",

--- a/docs/pages/repo/docs/reference/command-line-reference/info.mdx
+++ b/docs/pages/repo/docs/reference/command-line-reference/info.mdx
@@ -1,0 +1,14 @@
+---
+title: "turbo gen"
+description: Turborepo CLI Reference for gen command
+---
+
+# `turbo info`
+
+List the packages in your workspace. Additionally, your authentication and linked state to [Remote Cache](/repo/docs/core-concepts/remote-caching) will be shown.
+
+## Usage
+
+### `turbo info <package>`
+
+When a package name is provided, `turbo info` will list the dependent packages for the requested package.


### PR DESCRIPTION
### Description

Looks like we were missing docs for `turbo info`!