### PR TITLE
fix: override turbo_api env var

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -368,8 +368,9 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Run tests
+        # We manually set TURBO_API to an empty string to override Hetzner env
         run: |
-          turbo run check-types test --filter=docs --filter={./packages/*}...[${{ github.event.pull_request.base.sha || 'HEAD^1' }}] --color --env-mode=strict
+          TURBO_API= turbo run check-types test --filter=docs --filter={./packages/*}...[${{ github.event.pull_request.base.sha || 'HEAD^1' }}] --color --env-mode=strict
         env:
           EXPERIMENTAL_RUST_CODEPATH: true
 


### PR DESCRIPTION
### Description

For some reason Hetzner is setting `TURBO_API` which is causing us to not use the remote cache [e.g.](https://github.com/vercel/turbo/actions/runs/7757236744/job/21156328810?pr=7223#step:6:79)

### Testing Instructions

Verify that JS Packages now uses the correct remote cache (no remote cache warnings):
[job](https://github.com/vercel/turbo/actions/runs/7759230611/job/21162847801?pr=7234#step:6:1)


Closes TURBO-2226