### PR TITLE
fix: avoid expensive globwalk in examples

### DIFF
--- a/examples/turbo.json
+++ b/examples/turbo.json
@@ -3,6 +3,10 @@
   "pipeline": {
     // This needs to exist because upstream packages depend on it and
     // it's not defined at the root level.
-    "topo": {}
+    "topo": {},
+    // We override inputs to avoid a costly globwalk
+    "lint:prettier": {
+      "inputs": []
+    }
   }
 }


### PR DESCRIPTION
### Description

Q: how long would a `turbo lint` call would take in our repository?
A: 13 minutes

12 minutes of that is collecting inputs for `turborepo-examples:lint-prettier` which it inherits from the root definition.
<img width="1613" alt="Screenshot 2024-02-02 at 11 36 38 AM" src="https://github.com/vercel/turbo/assets/4131117/6edaf9c4-5e18-40d1-a55c-63f05f633bf5">


This PR overrides that input list and now it only takes ~200ms to do nothing. 

### Testing Instructions

<img width="1050" alt="Screenshot 2024-02-02 at 11 39 08 AM" src="https://github.com/vercel/turbo/assets/4131117/c8b22f67-fe40-4d8c-9f87-db52d12a51e0">


Closes TURBO-2231