### PR TITLE
refactor(turbopack): remove deprecated options

### DIFF
--- a/crates/turbopack/src/lib.rs
+++ b/crates/turbopack/src/lib.rs
@@ -466,67 +466,6 @@ async fn process_default_internal(
                     ModuleRuleEffect::ModuleType(module) => {
                         current_module_type = Some(*module);
                     }
-                    ModuleRuleEffect::AddEcmascriptTransforms(additional_transforms) => {
-                        current_module_type = match current_module_type {
-                            Some(ModuleType::Ecmascript {
-                                transforms,
-                                options,
-                            }) => Some(ModuleType::Ecmascript {
-                                transforms: transforms.extend(*additional_transforms),
-                                options,
-                            }),
-                            Some(ModuleType::Typescript {
-                                transforms,
-                                tsx,
-                                analyze_types,
-                                options,
-                            }) => Some(ModuleType::Typescript {
-                                transforms: transforms.extend(*additional_transforms),
-                                tsx,
-                                analyze_types,
-                                options,
-                            }),
-                            Some(ModuleType::Mdx {
-                                transforms,
-                                options,
-                            }) => Some(ModuleType::Mdx {
-                                transforms: transforms.extend(*additional_transforms),
-                                options,
-                            }),
-                            Some(module_type) => {
-                                ModuleIssue {
-                                    ident,
-                                    title: StyledString::Text("Invalid module type".to_string())
-                                        .cell(),
-                                    description: StyledString::Text(
-                                        "The module type must be Ecmascript or Typescript to add \
-                                         Ecmascript transforms"
-                                            .to_string(),
-                                    )
-                                    .cell(),
-                                }
-                                .cell()
-                                .emit();
-                                Some(module_type)
-                            }
-                            None => {
-                                ModuleIssue {
-                                    ident,
-                                    title: StyledString::Text("Missing module type".to_string())
-                                        .cell(),
-                                    description: StyledString::Text(
-                                        "The module type effect must be applied before adding \
-                                         Ecmascript transforms"
-                                            .to_string(),
-                                    )
-                                    .cell(),
-                                }
-                                .cell()
-                                .emit();
-                                None
-                            }
-                        };
-                    }
                     ModuleRuleEffect::ExtendEcmascriptTransforms { prepend, append } => {
                         current_module_type = match current_module_type {
                             Some(ModuleType::Ecmascript {

--- a/crates/turbopack/src/module_options/mod.rs
+++ b/crates/turbopack/src/module_options/mod.rs
@@ -72,7 +72,6 @@ impl ModuleOptions {
             ref enable_postcss_transform,
             ref enable_webpack_loaders,
             preset_env_versions,
-            ref custom_ecma_transform_plugins,
             ref custom_rules,
             execution_context,
             ref rules,
@@ -91,28 +90,7 @@ impl ModuleOptions {
             }
         }
 
-        let (before_transform_plugins, after_transform_plugins) =
-            if let Some(transform_plugins) = custom_ecma_transform_plugins {
-                let transform_plugins = transform_plugins.await?;
-                (
-                    transform_plugins
-                        .source_transforms
-                        .iter()
-                        .cloned()
-                        .map(EcmascriptInputTransform::Plugin)
-                        .collect(),
-                    transform_plugins
-                        .output_transforms
-                        .iter()
-                        .cloned()
-                        .map(EcmascriptInputTransform::Plugin)
-                        .collect(),
-                )
-            } else {
-                (vec![], vec![])
-            };
-
-        let mut transforms = before_transform_plugins;
+        let mut transforms = vec![];
 
         // Order of transforms is important. e.g. if the React transform occurs before
         // Styled JSX, there won't be JSX nodes for Styled JSX to transform.
@@ -176,7 +154,6 @@ impl ModuleOptions {
                     .iter()
                     .cloned()
                     .chain(transforms.iter().cloned())
-                    .chain(after_transform_plugins.iter().cloned())
                     .collect(),
             )
         } else {
@@ -196,7 +173,6 @@ impl ModuleOptions {
             .iter()
             .cloned()
             .chain(transforms.iter().cloned())
-            .chain(after_transform_plugins.iter().cloned())
             .collect(),
         );
 
@@ -217,7 +193,6 @@ impl ModuleOptions {
             .iter()
             .cloned()
             .chain(transforms.iter().cloned())
-            .chain(after_transform_plugins.iter().cloned())
             .collect(),
         );
 

--- a/crates/turbopack/src/module_options/module_options_context.rs
+++ b/crates/turbopack/src/module_options/module_options_context.rs
@@ -2,7 +2,7 @@ use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use turbo_tasks::{trace::TraceRawVcs, ValueDefault, Vc};
 use turbopack_core::{environment::Environment, resolve::options::ImportMapping};
-use turbopack_ecmascript::{references::esm::UrlRewriteBehavior, TransformPlugin, TreeShakingMode};
+use turbopack_ecmascript::{references::esm::UrlRewriteBehavior, TreeShakingMode};
 use turbopack_node::{
     execution_context::ExecutionContext,
     transforms::{postcss::PostCssTransformOptions, webpack::WebpackLoaderItems},
@@ -99,18 +99,6 @@ pub struct JsxTransformOptions {
     pub runtime: Option<String>,
 }
 
-/// Configuration options for the custom ecma transform to be applied.
-#[turbo_tasks::value(shared)]
-#[derive(Default, Clone)]
-pub struct CustomEcmascriptTransformPlugins {
-    /// List of plugins to be applied before the main transform.
-    /// Transform will be applied in the order of the list.
-    pub source_transforms: Vec<Vc<TransformPlugin>>,
-    /// List of plugins to be applied after the main transform.
-    /// Transform will be applied in the order of the list.
-    pub output_transforms: Vec<Vc<TransformPlugin>>,
-}
-
 #[turbo_tasks::value(shared)]
 #[derive(Default, Clone)]
 #[serde(default)]
@@ -152,10 +140,6 @@ pub struct ModuleOptionsContext {
     // however we might want to unify them in the future.
     pub enable_mdx_rs: Option<Vc<MdxTransformModuleOptions>>,
     pub preset_env_versions: Option<Vc<Environment>>,
-    #[deprecated(
-        note = "Use custom_rules with ModuleRuleEffect::ExtendEcmascriptTransforms instead"
-    )]
-    pub custom_ecma_transform_plugins: Option<Vc<CustomEcmascriptTransformPlugins>>,
     /// Custom rules to be applied after all default rules.
     pub custom_rules: Vec<ModuleRule>,
     pub execution_context: Option<Vc<ExecutionContext>>,

--- a/crates/turbopack/src/module_options/module_rule.rs
+++ b/crates/turbopack/src/module_options/module_rule.rs
@@ -85,11 +85,6 @@ impl ModuleRule {
 #[derive(Debug, Clone)]
 pub enum ModuleRuleEffect {
     ModuleType(ModuleType),
-    #[deprecated(
-        note = "ExtendEcmascriptTransforms provides equivalent features, as well as supporting an \
-                additional way to prepend transforms."
-    )]
-    AddEcmascriptTransforms(Vc<EcmascriptInputTransforms>),
     /// Allow to extend an existing Ecmascript module rules for the additional
     /// transforms. First argument will prepend the existing transforms, and
     /// the second argument will append the new transforms.


### PR DESCRIPTION

### Description

https://github.com/vercel/next.js/pull/61481 cleans up the usage of deprecated options, remove it from turbopack itself.

Closes PACK-2370