### PR TITLE
Fix a typo in docs page for github actions

### DIFF
--- a/docs/pages/repo/docs/ci/github-actions.mdx
+++ b/docs/pages/repo/docs/ci/github-actions.mdx
@@ -235,7 +235,7 @@ jobs:
 
 ## Caching with github actions/cache
 
-The following steps exemplify how you could use [actions/cache](https://github.com/actions/cache) to cache your monorepo artefacts on github.
+The following steps exemplify how you could use [actions/cache](https://github.com/actions/cache) to cache your monorepo artifacts on github.
 
 1. Supply the desired cache output location with the `--cache-dir` flag to your `turbo build` command
 


### PR DESCRIPTION
### Description

When reading the documentation, I noticed this word was ~mispelled~ using the British spelling rather than the American spelling which other pages use. Since there's an edit on github button, figured I'd just submit a fix!

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
