### PR TITLE
Fix trailing comma in exapmle react-library.json

### DIFF
--- a/examples/basic/packages/typescript-config/react-library.json
+++ b/examples/basic/packages/typescript-config/react-library.json
@@ -3,6 +3,6 @@
   "display": "React Library",
   "extends": "./base.json",
   "compilerOptions": {
-    "jsx": "react-jsx",
+    "jsx": "react-jsx"
   }
 }


### PR DESCRIPTION
### Description

In the example tsconfig for a react library there is a trailing comma inside the compiler options which would make it invalid JSON.
