### PR TITLE
fix(turbopack): support reloading typescript tailwind config

### DIFF
--- a/crates/turbopack-node/src/transforms/postcss.rs
+++ b/crates/turbopack-node/src/transforms/postcss.rs
@@ -166,9 +166,13 @@ async fn extra_configs(
     asset_context: Vc<Box<dyn AssetContext>>,
     postcss_config_path: Vc<FileSystemPath>,
 ) -> Result<Vc<Completion>> {
-    let config_paths = [postcss_config_path
-        .parent()
-        .join("tailwind.config.js".to_string())];
+    let parent_path = postcss_config_path.parent();
+
+    let config_paths = [
+        parent_path.join("tailwind.config.js".to_string()),
+        parent_path.join("tailwind.config.ts".to_string()),
+    ];
+
     let configs = config_paths
         .into_iter()
         .map(|path| async move {


### PR DESCRIPTION
### Description

Just needed to be added to the array so turbopack knows that it needs to watch it.

Closes PACK-2393
Fixes https://github.com/vercel/next.js/issues/61607