### PR TITLE
Refactor/package discovery hardiness

### DIFF
--- a/crates/turborepo-filewatch/src/package_watcher.rs
+++ b/crates/turborepo-filewatch/src/package_watcher.rs
@@ -554,6 +554,8 @@ mod test {
             package_data
                 .lock()
                 .unwrap()
+                .as_ref()
+                .unwrap()
                 .values()
                 .cloned()
                 .sorted_by_key(|f| f.package_json.clone())
@@ -601,6 +603,8 @@ mod test {
         assert_eq!(
             package_data
                 .lock()
+                .unwrap()
+                .as_ref()
                 .unwrap()
                 .values()
                 .cloned()
@@ -681,6 +685,8 @@ mod test {
             package_data
                 .lock()
                 .unwrap()
+                .as_ref()
+                .unwrap()
                 .values()
                 .cloned()
                 .sorted_by_key(|f| f.package_json.clone())
@@ -741,6 +747,8 @@ mod test {
         assert_eq!(
             package_data
                 .lock()
+                .unwrap()
+                .as_ref()
                 .unwrap()
                 .values()
                 .cloned()

--- a/crates/turborepo-lib/src/commands/run.rs
+++ b/crates/turborepo-lib/src/commands/run.rs
@@ -1,4 +1,3 @@
-use tracing::debug;
 use turborepo_telemetry::events::command::CommandEventBuilder;
 
 use crate::{commands::CommandBase, run, run::Run, signal::SignalHandler};

--- a/crates/turborepo-lib/src/daemon/server.rs
+++ b/crates/turborepo-lib/src/daemon/server.rs
@@ -531,7 +531,14 @@ where
                     package_manager: proto::PackageManager::from(packages.package_manager).into(),
                 })
             })
-            .map_err(|e| tonic::Status::internal(format!("{}", e)))
+            .map_err(|e| match e {
+                turborepo_repository::discovery::Error::Unavailable => {
+                    tonic::Status::unavailable("package discovery unavailable")
+                }
+                turborepo_repository::discovery::Error::Failed(e) => {
+                    tonic::Status::internal(format!("{}", e))
+                }
+            })
     }
 }
 


### PR DESCRIPTION
### Description

Rework the package discovery a little to:
- improve error handling
- enforce 'readiness' by setting the calculated fields to `None` when the watcher does not have up to date info
- clean up some logic
- add better docs

### Testing Instructions

Existing tests should cover it


Closes TURBO-2260