### PR TITLE
fix(Turborepo): Start moving cookie watching to downstream services

### DIFF
--- a/crates/turborepo-filewatch/src/cookies.rs
+++ b/crates/turborepo-filewatch/src/cookies.rs
@@ -266,14 +266,14 @@ mod test {
     #[derive(Clone)]
     struct TestClient {
         reqs_tx: mpsc::Sender<CookiedRequest<TestQuery>>,
-        cookie_jar: CookieWriter,
+        cookie_writer: CookieWriter,
     }
 
     impl TestClient {
         async fn request(&self) {
             let (resp_tx, resp_rx) = oneshot::channel();
             let query = TestQuery { resp: resp_tx };
-            let req = self.cookie_jar.cookie_request(query).await.unwrap();
+            let req = self.cookie_writer.cookie_request(query).await.unwrap();
             self.reqs_tx.send(req).await.unwrap();
             resp_rx.await.unwrap();
         }
@@ -289,7 +289,7 @@ mod test {
 
         let (send_file_events, file_events) = broadcast::channel(16);
         let (reqs_tx, reqs_rx) = mpsc::channel(16);
-        let cookie_jar = CookieWriter::new(&path, Duration::from_millis(100));
+        let cookie_writer = CookieWriter::new(&path, Duration::from_secs(2));
         let (exit_tx, exit_rx) = oneshot::channel();
 
         let service = TestService {
@@ -301,7 +301,7 @@ mod test {
 
         let client = TestClient {
             reqs_tx,
-            cookie_jar,
+            cookie_writer,
         };
         // race request and file event. Either order should work.
         tokio_scoped::scope(|scope| {
@@ -352,7 +352,7 @@ mod test {
 
         let (send_file_events, file_events) = broadcast::channel(16);
         let (reqs_tx, reqs_rx) = mpsc::channel(16);
-        let cookie_jar = CookieWriter::new(&path, Duration::from_millis(100));
+        let cookie_writer = CookieWriter::new(&path, Duration::from_secs(2));
         let (exit_tx, exit_rx) = oneshot::channel();
 
         let service = TestService {
@@ -364,7 +364,7 @@ mod test {
 
         let client = TestClient {
             reqs_tx,
-            cookie_jar,
+            cookie_writer,
         };
 
         let mut join_set = JoinSet::new();

--- a/crates/turborepo-filewatch/src/globwatcher.rs
+++ b/crates/turborepo-filewatch/src/globwatcher.rs
@@ -13,7 +13,7 @@ use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, RelativeUnixPath};
 use wax::{Any, Glob, Program};
 
 use crate::{
-    cookie_jar::{CookieError, CookieJar, CookieWatcher, CookiedRequest},
+    cookie_jar::{CookieError, CookieWatcher, CookieWriter, CookiedRequest},
     NotifyError,
 };
 
@@ -99,7 +99,7 @@ impl From<oneshot::error::RecvError> for Error {
 }
 
 pub struct GlobWatcher {
-    cookie_jar: CookieJar,
+    cookie_jar: CookieWriter,
     // _exit_ch exists to trigger a close on the receiver when an instance
     // of this struct is dropped. The task that is receiving events will exit,
     // dropping the other sender for the broadcast channel, causing all receivers
@@ -144,7 +144,7 @@ struct GlobTracker {
 impl GlobWatcher {
     pub fn new(
         root: &AbsoluteSystemPath,
-        cookie_jar: CookieJar,
+        cookie_jar: CookieWriter,
         recv: broadcast::Receiver<Result<Event, NotifyError>>,
     ) -> Self {
         let (exit_ch, exit_signal) = tokio::sync::oneshot::channel();
@@ -370,7 +370,7 @@ mod test {
     use wax::{any, Glob};
 
     use crate::{
-        cookie_jar::CookieJar,
+        cookie_jar::CookieWriter,
         globwatcher::{GlobSet, GlobWatcher},
         FileSystemWatcher,
     };
@@ -445,7 +445,7 @@ mod test {
         let watcher = FileSystemWatcher::new_with_default_cookie_dir(&repo_root)
             .await
             .unwrap();
-        let cookie_jar = CookieJar::new(&cookie_dir, Duration::from_secs(2), watcher.subscribe());
+        let cookie_jar = CookieWriter::new(&cookie_dir, Duration::from_secs(2));
 
         let glob_watcher = GlobWatcher::new(&repo_root, cookie_jar, watcher.subscribe());
 
@@ -525,7 +525,7 @@ mod test {
         let watcher = FileSystemWatcher::new_with_default_cookie_dir(&repo_root)
             .await
             .unwrap();
-        let cookie_jar = CookieJar::new(&cookie_dir, Duration::from_secs(2), watcher.subscribe());
+        let cookie_jar = CookieWriter::new(&cookie_dir, Duration::from_secs(2));
 
         let glob_watcher = GlobWatcher::new(&repo_root, cookie_jar, watcher.subscribe());
 
@@ -615,7 +615,7 @@ mod test {
         let watcher = FileSystemWatcher::new_with_default_cookie_dir(&repo_root)
             .await
             .unwrap();
-        let cookie_jar = CookieJar::new(&cookie_dir, Duration::from_secs(2), watcher.subscribe());
+        let cookie_jar = CookieWriter::new(&cookie_dir, Duration::from_secs(2));
 
         let glob_watcher = GlobWatcher::new(&repo_root, cookie_jar, watcher.subscribe());
 

--- a/crates/turborepo-filewatch/src/lib.rs
+++ b/crates/turborepo-filewatch/src/lib.rs
@@ -35,7 +35,7 @@ use {
     walkdir::WalkDir,
 };
 
-pub mod cookie_jar;
+pub mod cookies;
 #[cfg(target_os = "macos")]
 mod fsevent;
 pub mod globwatcher;

--- a/crates/turborepo-lib/src/daemon/server.rs
+++ b/crates/turborepo-lib/src/daemon/server.rs
@@ -97,12 +97,8 @@ async fn start_filewatching<PD: PackageDiscovery + Send + 'static>(
     backup_discovery: PD,
 ) -> Result<(), WatchError> {
     let watcher = FileSystemWatcher::new_with_default_cookie_dir(&repo_root).await?;
-    let cookie_jar = CookieWriter::new(
-        watcher.cookie_dir(),
-        Duration::from_millis(100),
-        watcher.subscribe(),
-    );
-    let glob_watcher = GlobWatcher::new(&repo_root, cookie_jar, watcher.subscribe());
+    let cookie_writer = CookieWriter::new(watcher.cookie_dir(), Duration::from_millis(100));
+    let glob_watcher = GlobWatcher::new(&repo_root, cookie_writer, watcher.subscribe());
     let package_watcher =
         PackageWatcher::new(repo_root.clone(), watcher.subscribe(), backup_discovery)
             .await

--- a/crates/turborepo-lib/src/daemon/server.rs
+++ b/crates/turborepo-lib/src/daemon/server.rs
@@ -33,7 +33,7 @@ use tower::ServiceBuilder;
 use tracing::{error, info, trace, warn};
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
 use turborepo_filewatch::{
-    cookie_jar::CookieWriter,
+    cookies::CookieWriter,
     globwatcher::{Error as GlobWatcherError, GlobError, GlobSet, GlobWatcher},
     package_watcher::PackageWatcher,
     FileSystemWatcher, WatchError,

--- a/crates/turborepo-lib/src/daemon/server.rs
+++ b/crates/turborepo-lib/src/daemon/server.rs
@@ -33,7 +33,7 @@ use tower::ServiceBuilder;
 use tracing::{error, info, trace, warn};
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
 use turborepo_filewatch::{
-    cookie_jar::CookieJar,
+    cookie_jar::CookieWriter,
     globwatcher::{Error as GlobWatcherError, GlobError, GlobSet, GlobWatcher},
     package_watcher::PackageWatcher,
     FileSystemWatcher, WatchError,
@@ -97,7 +97,7 @@ async fn start_filewatching<PD: PackageDiscovery + Send + 'static>(
     backup_discovery: PD,
 ) -> Result<(), WatchError> {
     let watcher = FileSystemWatcher::new_with_default_cookie_dir(&repo_root).await?;
-    let cookie_jar = CookieJar::new(
+    let cookie_jar = CookieWriter::new(
         watcher.cookie_dir(),
         Duration::from_millis(100),
         watcher.subscribe(),

--- a/crates/turborepo-lib/src/daemon/server.rs
+++ b/crates/turborepo-lib/src/daemon/server.rs
@@ -327,7 +327,9 @@ impl TurboGrpcServiceInner {
     ) -> Result<(), RpcError> {
         let glob_set = GlobSet::from_raw(output_globs, output_glob_exclusions)?;
         let fw = self.wait_for_filewatching().await?;
-        fw.glob_watcher.watch_globs(hash.clone(), glob_set).await?;
+        fw.glob_watcher
+            .watch_globs(hash.clone(), glob_set, REQUEST_TIMEOUT)
+            .await?;
         {
             let mut times_saved = self.times_saved.lock().expect("times saved lock poisoned");
             times_saved.insert(hash, time_saved);
@@ -345,7 +347,10 @@ impl TurboGrpcServiceInner {
             times_saved.get(hash.as_str()).copied().unwrap_or_default()
         };
         let fw = self.wait_for_filewatching().await?;
-        let changed_globs = fw.glob_watcher.get_changed_globs(hash, candidates).await?;
+        let changed_globs = fw
+            .glob_watcher
+            .get_changed_globs(hash, candidates, REQUEST_TIMEOUT)
+            .await?;
         Ok((changed_globs, time_saved))
     }
 

--- a/crates/turborepo-paths/src/absolute_system_path.rs
+++ b/crates/turborepo-paths/src/absolute_system_path.rs
@@ -401,6 +401,10 @@ impl AbsoluteSystemPath {
         self.0.parent().map(Self::new_unchecked)
     }
 
+    pub fn file_name(&self) -> Option<&str> {
+        self.0.file_name()
+    }
+
     /// Opens file and sets the `FILE_FLAG_SEQUENTIAL_SCAN` flag on Windows to
     /// help with performance
     pub fn open(&self) -> Result<File, io::Error> {


### PR DESCRIPTION
### Description

Filewatching cookies were ensuring that the filewatching task was up to date, but not downstream, filewatching-backed services. This change moves the filesystem cookie synchronization into a downstream service (glob watching) to ensure that RPCs are serviced by a task that has seen at least all of the operations that a client has done.

The process is as follows:
 1. A client of a filewatching-backed service uses a `CookieWriter` to stamp its request with a serial. 
 2. The CookieWriter requests a cookie file be written, and the serial returned to the client
 3. The client forwards the request, now with a serial, to the filewatching-backed service
 4. The service observes cookie files being created, and keeps track of the highest serial it has seen via a `CookieWatcher`. When a cookie file is observed, some pending requests may be returned as ready for servicing.
 5. When the service gets a request, it checks via `CookieWatcher` if it has already seen the serial. If so, the request is handled immediately
 6. If not, the service, again via the `CookieWatcher`, saves the request until the correct serial has been observed (step 4).

This means that timeouts need to be handled by clients, but also gives clients the freedom to set their own timeouts.

### Testing Instructions

Most cookie watching tests are gone, as is most of the logic. Instead, the mechanism is exercised via tests of downstream services.


Closes TURBO-2244