### PR TITLE
chore: Add Yarn 4 to Github Issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/0-turborepo-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/0-turborepo-bug-report.yml
@@ -38,8 +38,7 @@ body:
         - npm
         - pnpm
         - Yarn v1
-        - Yarn v2/v3 (node_modules linker only)
-        - Yarn v4
+        - Yarn v2/v3/v4 (node_modules linker only)
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/0-turborepo-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/0-turborepo-bug-report.yml
@@ -39,6 +39,7 @@ body:
         - pnpm
         - Yarn v1
         - Yarn v2/v3 (node_modules linker only)
+        - Yarn v4
     validations:
       required: true
 


### PR DESCRIPTION
We are receiving bug reports for Yarn for and they are incorrectly categorized

ref: https://github.com/vercel/turbo/issues/6805

Closes TURBO-2262