### PR TITLE
feat(async_cache): support cloning

### DIFF
--- a/crates/turborepo-lib/src/commands/run.rs
+++ b/crates/turborepo-lib/src/commands/run.rs
@@ -1,4 +1,3 @@
-use tracing::debug;
 use turborepo_telemetry::events::command::CommandEventBuilder;
 
 use crate::{commands::CommandBase, run, run::Run, signal::SignalHandler};


### PR DESCRIPTION
### Description

Remove the `writer_thread` reference in `AsyncCache` so we can easily clone it. 

Precursor to https://github.com/vercel/turbo/pull/7074/files

Closes TURBO-2271