### PR TITLE
chore(create-turbo): update chalk to v4

### DIFF
--- a/packages/create-turbo/package.json
+++ b/packages/create-turbo/package.json
@@ -23,7 +23,7 @@
     "lint:prettier": "prettier -c . --cache --ignore-path=../../.prettierignore"
   },
   "dependencies": {
-    "chalk": "2.4.2",
+    "chalk": "4.1.2",
     "commander": "^10.0.0",
     "fs-extra": "^11.1.1",
     "inquirer": "^8.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -294,8 +294,8 @@ importers:
   packages/create-turbo:
     dependencies:
       chalk:
-        specifier: 2.4.2
-        version: 2.4.2
+        specifier: 4.1.2
+        version: 4.1.2
       commander:
         specifier: ^10.0.0
         version: 10.0.0


### PR DESCRIPTION
We use inquirer@8 which has a nested dependency on chalk@4. Updating our
dependency to @4 means we can avoid shipping two versions of chalk to
end users.

Breaking changes notes:
- https://github.com/chalk/chalk/releases/tag/v4.0.0
- https://github.com/chalk/chalk/releases/tag/v3.0.0

## Results

🤔 . The build size looks the same before and after
CJS dist/cli.js 549.34 KB, 

but when I install the package into a test directory, I can see that
`du -sh node_modules` is 27Mb (before) vs 26mb (after).


Closes TURBO-2276