### PR TITLE
improve HMR performance

### DIFF
--- a/crates/turbopack-core/src/chunk/mod.rs
+++ b/crates/turbopack-core/src/chunk/mod.rs
@@ -745,6 +745,9 @@ impl AsyncModuleInfo {
 
 pub type ChunkItemWithAsyncModuleInfo = (Vc<Box<dyn ChunkItem>>, Option<Vc<AsyncModuleInfo>>);
 
+#[turbo_tasks::value(transparent)]
+pub struct ChunkItemsWithAsyncModuleInfo(Vec<ChunkItemWithAsyncModuleInfo>);
+
 pub trait ChunkItemExt: Send {
     /// Returns the module id of this chunk item.
     fn id(self: Vc<Self>) -> Vc<ModuleId>;


### PR DESCRIPTION
### Description

change make_chunks into a turbo_tasks function to isloate graph walk from chunk item size changes

Before any file change caused module graph walk and chunking to be reexecuted. After this change module graph walk is only reexecuted when module references change.

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->


Closes PACK-2431