### PR TITLE
feat(cache): bump default timeout and add docs

### DIFF
--- a/crates/turborepo-lib/src/config.rs
+++ b/crates/turborepo-lib/src/config.rs
@@ -125,7 +125,7 @@ macro_rules! create_builder {
 
 const DEFAULT_API_URL: &str = "https://vercel.com/api";
 const DEFAULT_LOGIN_URL: &str = "https://vercel.com";
-const DEFAULT_TIMEOUT: u64 = 20;
+const DEFAULT_TIMEOUT: u64 = 30;
 
 #[derive(Serialize, Deserialize, Default, Debug, PartialEq, Eq, Clone, Iterable)]
 #[serde(rename_all = "camelCase")]

--- a/docs/pages/repo/docs/reference/command-line-reference/run.mdx
+++ b/docs/pages/repo/docs/reference/command-line-reference/run.mdx
@@ -279,6 +279,14 @@ turbo run build --no-cache
 turbo run dev --no-cache
 ```
 
+### `--remote-cache-timeout`
+
+Default `30` seconds. Set the timeout for remote cache operations in seconds.
+
+```shell
+turbo run build --remote-cache-timeout=60
+```
+
 ### `--no-daemon`
 
 Default `false`. `turbo` can run a standalone process in some cases to precalculate values used for determining what work needs to be done.

--- a/docs/pages/repo/docs/reference/command-line-reference/run.mdx
+++ b/docs/pages/repo/docs/reference/command-line-reference/run.mdx
@@ -279,14 +279,6 @@ turbo run build --no-cache
 turbo run dev --no-cache
 ```
 
-### `--remote-cache-timeout`
-
-Default `30` seconds. Set the timeout for remote cache operations in seconds.
-
-```shell
-turbo run build --remote-cache-timeout=60
-```
-
 ### `--no-daemon`
 
 Default `false`. `turbo` can run a standalone process in some cases to precalculate values used for determining what work needs to be done.
@@ -360,6 +352,14 @@ You must provide a verbosity flag (`-v`, `-vv`, or `-vvv`) with the `--profile` 
 
 ```sh
 turbo run build --profile=profile.json
+```
+
+### `--remote-cache-timeout`
+
+Default `30` seconds. Set the timeout for remote cache operations in seconds.
+
+```shell
+turbo run build --remote-cache-timeout=60
 ```
 
 ### `--remote-only`


### PR DESCRIPTION
### Description

The Go timeout was being set to `0`, which meant there was _no_ timeout. We don't want to replicate that exactly, some timeout is good. This just increases the timeout a bit to reduce issues with large artifacts. 

Closes TURBO-2277