### PR TITLE
ci(test): add wasi target check for the supported packages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -511,11 +511,15 @@ jobs:
         uses: ./.github/actions/setup-rust
         with:
           components: clippy
-          targets: wasm32-unknown-unknown
+          targets: wasm32-unknown-unknown,wasm32-wasi-preview1-threads
 
       - name: Run cargo check release
         run: |
           RUSTFLAGS="-D warnings -A deprecated" cargo groups check turbopack --features rustls-tls --release
+
+      - name: Run cargo check for the wasi targets
+        run: |
+          RUSTFLAGS="-D warnings -A deprecated" cargo groups check turbopack-wasi --release
 
   turbopack_rust_clippy:
     needs: [turbopack_rust_check]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,11 @@ turbopack = [
   "path:crates/node-file-trace",
 ]
 
+# List of the packages can be compiled against wasm32-wasi target.
+turbopack-wasi = [
+  "path:crates/turbo-tasks-hash"
+]
+
 [workspace.lints.clippy]
 too_many_arguments = "allow"
 


### PR DESCRIPTION
next-swc requires upstream pkg support for the wasi target. We can't just build everything, but PR enables check against few packages which 'just works'.

Closes PACK-2436