### PR TITLE
chore: add shutdown method for async cache

### DIFF
--- a/crates/turborepo-lib/src/run/cache.rs
+++ b/crates/turborepo-lib/src/run/cache.rs
@@ -108,8 +108,9 @@ impl RunCache {
         }
     }
 
-    pub async fn wait_for_cache(&self) {
-        self.cache.wait().await
+    pub async fn shutdown_cache(&self) {
+        // Ignore errors coming from cache already shutting down
+        self.cache.shutdown().await.ok();
     }
 }
 

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -416,7 +416,7 @@ impl Run {
             tokio::spawn(async move {
                 let _guard = subscriber.listen().await;
                 let spinner = turborepo_ui::start_spinner("...Finishing writing to cache...");
-                runcache.wait_for_cache().await;
+                runcache.shutdown_cache().await;
                 spinner.finish_and_clear();
             });
         }


### PR DESCRIPTION
### Description

As per discussion in #7293 we should probably have a shutdown method. This PR adds a method that will prevent any future writes from being queued.

### Testing Instructions

Added some shutdown tests to make sure that trying to use the cache post-shutdown will error. These probably should belong in their own testing methods, but considering the amount of work required to construct an AsyncCache I think this is acceptable.


Closes TURBO-2282