### PR TITLE
chore(ci): Update to actions/checkout@v4

### DIFF
--- a/.github/workflows/bench-turbopack-scheduled.yml
+++ b/.github/workflows/bench-turbopack-scheduled.yml
@@ -86,7 +86,7 @@ jobs:
     name: Bench - ${{ matrix.bench.title }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: ./.github/actions/setup-node
 
@@ -144,7 +144,7 @@ jobs:
           echo "date=$(date +'%s')" >> $GITHUB_OUTPUT
           echo "pretty=$(date +'%Y-%m-%d %H:%M')" >> $GITHUB_OUTPUT
       - name: Checkout benchmark-data
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: benchmark-data
 

--- a/.github/workflows/bench-turbopack.yml
+++ b/.github/workflows/bench-turbopack.yml
@@ -47,7 +47,7 @@ jobs:
           edit-mode: replace
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: CI related changes
         id: ci
@@ -131,7 +131,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
@@ -193,7 +193,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
         uses: ./.github/actions/setup-node
@@ -283,7 +283,7 @@ jobs:
           echo "pretty=$(date +'%Y-%m-%d %H:%M')" >> $GITHUB_OUTPUT
 
       - name: Checkout benchmark-data
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: benchmark-data
 
@@ -339,7 +339,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Fetch the base branch
         run: git -c protocol.version=2 fetch --no-tags --progress --no-recurse-submodules --depth=1 origin +${{ github.base_ref }}:base

--- a/.github/workflows/bench-turborepo.yml
+++ b/.github/workflows/bench-turborepo.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node
 
       - uses: ./.github/actions/setup-turborepo-environment
@@ -60,7 +60,7 @@ jobs:
             runner: windows-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set filename for profile
         id: filename
         shell: bash
@@ -111,7 +111,7 @@ jobs:
       TINYBIRD_TOKEN: ${{secrets.TINYBIRD_TOKEN}}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Node
         uses: ./.github/actions/setup-node
@@ -143,7 +143,7 @@ jobs:
     needs: [time-to-first-task]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Node
         uses: ./.github/actions/setup-node

--- a/.github/workflows/bench-turbotrace-against-node-nft.yml
+++ b/.github/workflows/bench-turbotrace-against-node-nft.yml
@@ -24,7 +24,7 @@ jobs:
       BENCH_ARGS: --release -p turbopack --features bench_against_node_nft bench_against_node_nft
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: ./.github/actions/setup-node
         with:

--- a/.github/workflows/lsp.yml
+++ b/.github/workflows/lsp.yml
@@ -46,7 +46,7 @@ jobs:
       options: ${{ matrix.settings.container-options }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Container
         if: ${{ matrix.settings.container-setup }}
         run: ${{ matrix.settings.container-setup }}

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -10,7 +10,7 @@ jobs:
     if: "startsWith(github.event.head_commit.message, 'chore: release npm packages')"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: ./.github/actions/setup-node
       - uses: ./.github/actions/setup-rust

--- a/.github/workflows/test-turbopack-rust-bench-test.yml
+++ b/.github/workflows/test-turbopack-rust-bench-test.yml
@@ -26,7 +26,7 @@ jobs:
         if: inputs.os == 'windows'
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Rust
         uses: ./.github/actions/setup-rust

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
           edit-mode: replace
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: CI related changes
         id: ci
@@ -212,7 +212,7 @@ jobs:
             runner: windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -264,7 +264,7 @@ jobs:
         if: matrix.os.runner == 'windows-latest'
         shell: bash
         run: git config --global core.autocrlf input
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-turborepo-environment
         with:
           windows: ${{ matrix.os.runner == 'windows-latest' }}
@@ -298,7 +298,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Disable corepack. actions/setup-node invokes other package managers and
       # that causes corepack to throw an error, so we disable it first.
@@ -357,7 +357,7 @@ jobs:
           echo "depth=$(( ${{ github.event.pull_request.commits || 1 }} + 1 ))" >> $GITHUB_OUTPUT
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
           fetch-depth: ${{ steps.fetch-depth.outputs.depth  }}
@@ -386,7 +386,7 @@ jobs:
     if: needs.determine_jobs.outputs.turbopack_typescript == 'true'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
         uses: ./.github/actions/setup-node
@@ -417,7 +417,7 @@ jobs:
       - "metal"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
@@ -452,7 +452,7 @@ jobs:
       - "metal"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Turborepo Environment
         uses: ./.github/actions/setup-turborepo-environment
@@ -474,7 +474,7 @@ jobs:
       - "metal"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Turborepo Environment
         uses: ./.github/actions/setup-turborepo-environment
@@ -505,7 +505,7 @@ jobs:
       - "metal"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
@@ -531,7 +531,7 @@ jobs:
       - "metal"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
@@ -561,7 +561,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout Next.js
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: vercel/next.js
 
@@ -653,7 +653,7 @@ jobs:
         if: matrix.os.name == 'windows'
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Turborepo Environment
         uses: ./.github/actions/setup-turborepo-environment
@@ -676,7 +676,7 @@ jobs:
     name: Turbopack Rust testing on ubuntu
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
@@ -738,7 +738,7 @@ jobs:
         if: matrix.os.name == 'windows'
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -844,7 +844,7 @@ jobs:
       TURBO_REMOTE_ONLY: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - uses: ./.github/actions/setup-turborepo-environment
         with:
@@ -982,7 +982,7 @@ jobs:
       # Uploading test results does not require turbopack's src codes, but this
       # allows datadog uploader to sync with git information.
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v3.6.0

--- a/.github/workflows/turbopack-nightly-release.yml
+++ b/.github/workflows/turbopack-nightly-release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Tag nightly
         id: tag_version

--- a/.github/workflows/turborepo-library-release.yml
+++ b/.github/workflows/turborepo-library-release.yml
@@ -52,7 +52,7 @@ jobs:
         if: ${{ matrix.settings.install }}
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -89,7 +89,7 @@ jobs:
     needs: [build]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -41,7 +41,7 @@ jobs:
   stage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node
         with:
           enable-corepack: false
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Show Stage Commit
         run: echo "${{ needs.stage.outputs.stage-branch }}"
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ needs.stage.outputs.stage-branch }}
       - name: Build turborepo CLI from source
@@ -85,7 +85,7 @@ jobs:
     steps:
       - name: Show Stage Commit
         run: echo "${{ needs.stage.outputs.stage-branch }}"
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ needs.stage.outputs.stage-branch }}
       - name: Build turborepo CLI from source
@@ -131,7 +131,7 @@ jobs:
       - name: Show Stage Commit
         run: echo "${{ needs.stage.outputs.stage-branch }}"
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: "${{ needs.stage.outputs.stage-branch }}"
 
@@ -175,7 +175,7 @@ jobs:
     steps:
       - name: Show Stage Commit
         run: echo "${{ needs.stage.outputs.stage-branch }}"
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: "${{ needs.stage.outputs.stage-branch }}"
       - run: git fetch origin --tags


### PR DESCRIPTION
v3 uses node 16 which is EOL. The latest update only has
that one breaking change. Since we do not know or care about this
node version in our scripts, we can safely update this.

https://github.com/actions/checkout

Closes TURBO-2284