### PR TITLE
fix: unset RUSTC_WRAPPER when empty

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -223,8 +223,13 @@ jobs:
         with:
           windows: ${{ matrix.os.name == 'windows' }}
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-
-      - run: turbo run build --filter=cli --color --env-mode=strict --token=${{ secrets.TURBO_TOKEN }} --team=${{ vars.TURBO_TEAM }}
+      # We explicitly unset RUSTC_WRAPPER if it is an empty string as causes build issues
+      - run: |
+          if [ -z "${RUSTC_WRAPPER}" ]; then
+            unset RUSTC_WRAPPER
+          fi
+          turbo run build --filter=cli --color --env-mode=strict --token=${{ secrets.TURBO_TOKEN }} --team=${{ vars.TURBO_TEAM }}
+        shell: bash
         env:
           SCCACHE_BUCKET: turborepo-sccache
           SCCACHE_REGION: us-east-2


### PR DESCRIPTION
### Description

It seems that setting `RUSTC_WRAPPER` to an empty string results in [weird failures](https://github.com/vercel/turbo/actions/runs/7823191751/job/21343720629?pr=7315#step:6:461)

### Testing Instructions

This is an external PR so as long as this PR can successfully build `turbo` this fix should work. 

Closes TURBO-2290