### PR TITLE
feat(gitignore): break out gitignore util

### DIFF
--- a/crates/turborepo-lib/src/commands/link.rs
+++ b/crates/turborepo-lib/src/commands/link.rs
@@ -27,6 +27,7 @@ use crate::{
     cli::LinkTarget,
     commands::CommandBase,
     config,
+    gitignore::ensure_turbo_is_gitignored,
     rewrite_json::{self, set_path, unset_path},
 };
 
@@ -254,9 +255,11 @@ pub async fn link(
             };
 
             if modify_gitignore {
-                add_turbo_to_gitignore(base).map_err(|error| config::Error::FailedToSetConfig {
-                    config_path: base.repo_root.join_component(".gitignore"),
-                    error,
+                ensure_turbo_is_gitignored(&base.repo_root).map_err(|error| {
+                    config::Error::FailedToSetConfig {
+                        config_path: base.repo_root.join_component(".gitignore"),
+                        error,
+                    }
                 })?;
             }
 

--- a/crates/turborepo-lib/src/gitignore.rs
+++ b/crates/turborepo-lib/src/gitignore.rs
@@ -1,0 +1,141 @@
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+use std::{
+    fs::{File, OpenOptions},
+    io,
+    io::{BufRead, Write},
+};
+
+use turbopath::AbsoluteSystemPathBuf;
+
+const TURBO_GITIGNORE_ENTRY: &str = ".turbo";
+const GITIGNORE_FILE: &str = ".gitignore";
+
+pub fn ensure_turbo_is_gitignored(repo_root: &AbsoluteSystemPathBuf) -> Result<(), io::Error> {
+    let gitignore_path = repo_root.join_component(GITIGNORE_FILE);
+
+    if !gitignore_path.exists() {
+        let mut gitignore = File::create(gitignore_path)?;
+        #[cfg(unix)]
+        gitignore.metadata()?.permissions().set_mode(0o0644);
+        writeln!(gitignore, "{}", TURBO_GITIGNORE_ENTRY)?;
+    } else {
+        let gitignore = File::open(&gitignore_path)?;
+        let mut lines = io::BufReader::new(gitignore).lines();
+        let has_turbo =
+            lines.any(|line| line.map_or(false, |line| line.trim() == TURBO_GITIGNORE_ENTRY));
+        if !has_turbo {
+            let mut gitignore = OpenOptions::new()
+                .read(true)
+                .append(true)
+                .open(&gitignore_path)?;
+
+            // write with a preceding newline just in case the .gitignore file doesn't end
+            // with a newline
+            writeln!(gitignore, "\n{}", TURBO_GITIGNORE_ENTRY)?;
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Result;
+    use tempfile::tempdir;
+
+    use super::*;
+
+    fn has_turbo_gitignore_entry(gitignore_path: &AbsoluteSystemPathBuf) -> bool {
+        let gitignore = File::open(gitignore_path).expect("Failed to open .gitignore file");
+        let mut lines = io::BufReader::new(gitignore).lines();
+        lines.any(|line| line.map_or(false, |line| line.trim() == TURBO_GITIGNORE_ENTRY))
+    }
+
+    #[test]
+    fn test_no_gitignore() -> Result<()> {
+        let repo_root_tmp = tempdir()?;
+        let repo_root = AbsoluteSystemPathBuf::try_from(repo_root_tmp.path())?;
+
+        ensure_turbo_is_gitignored(&repo_root).expect("Failed to ensure turbo is gitignored");
+
+        // Verify that the .gitignore file exists and contains the expected entry
+        let gitignore_path = repo_root.join_component(GITIGNORE_FILE);
+        assert!(gitignore_path.exists());
+
+        assert!(has_turbo_gitignore_entry(&gitignore_path));
+
+        Ok(())
+    }
+
+    #[test]
+    fn gitignore_with_missing_turbo() -> Result<()> {
+        let repo_root_tmp = tempdir()?;
+        let repo_root = AbsoluteSystemPathBuf::try_from(repo_root_tmp.path())?;
+
+        // create gitignore with no turbo entry
+        let gitignore_path = repo_root.join_component(GITIGNORE_FILE);
+        let mut gitignore = File::create(gitignore_path)?;
+        #[cfg(unix)]
+        gitignore.metadata()?.permissions().set_mode(0o0644);
+        writeln!(gitignore, "node_modules/")?;
+
+        ensure_turbo_is_gitignored(&repo_root).expect("Failed to ensure turbo is gitignored");
+
+        // Verify that the .gitignore file exists and contains the expected entry
+        let gitignore_path = repo_root.join_component(GITIGNORE_FILE);
+        assert!(gitignore_path.exists());
+
+        assert!(has_turbo_gitignore_entry(&gitignore_path));
+
+        Ok(())
+    }
+
+    #[test]
+    fn gitignore_with_existing_turbo() -> Result<()> {
+        let repo_root_tmp = tempdir()?;
+        let repo_root = AbsoluteSystemPathBuf::try_from(repo_root_tmp.path())?;
+
+        // create gitignore with no turbo entry
+        let gitignore_path = repo_root.join_component(GITIGNORE_FILE);
+        let mut gitignore = File::create(gitignore_path)?;
+        #[cfg(unix)]
+        gitignore.metadata()?.permissions().set_mode(0o0644);
+        writeln!(gitignore, ".turbo")?;
+        writeln!(gitignore, ".node_modules/")?;
+
+        ensure_turbo_is_gitignored(&repo_root).expect("Failed to ensure turbo is gitignored");
+
+        // Verify that the .gitignore file exists and contains the expected entry
+        let gitignore_path = repo_root.join_component(GITIGNORE_FILE);
+        assert!(gitignore_path.exists());
+
+        assert!(has_turbo_gitignore_entry(&gitignore_path));
+
+        Ok(())
+    }
+
+    #[test]
+    fn gitignore_with_existing_turbo_no_newline() -> Result<()> {
+        let repo_root_tmp = tempdir()?;
+        let repo_root = AbsoluteSystemPathBuf::try_from(repo_root_tmp.path())?;
+
+        // create gitignore with no turbo entry
+        let gitignore_path = repo_root.join_component(GITIGNORE_FILE);
+        let mut gitignore = File::create(gitignore_path)?;
+        #[cfg(unix)]
+        gitignore.metadata()?.permissions().set_mode(0o0644);
+        writeln!(gitignore, ".node_modules/")?;
+        write!(gitignore, ".turbo")?;
+
+        ensure_turbo_is_gitignored(&repo_root).expect("Failed to ensure turbo is gitignored");
+
+        // Verify that the .gitignore file exists and contains the expected entry
+        let gitignore_path = repo_root.join_component(GITIGNORE_FILE);
+        assert!(gitignore_path.exists());
+
+        assert!(has_turbo_gitignore_entry(&gitignore_path));
+
+        Ok(())
+    }
+}

--- a/crates/turborepo-lib/src/gitignore.rs
+++ b/crates/turborepo-lib/src/gitignore.rs
@@ -1,38 +1,41 @@
-#[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
 use std::{
     fs::{File, OpenOptions},
     io,
     io::{BufRead, Write},
 };
 
-use turbopath::AbsoluteSystemPathBuf;
+use turbopath::AbsoluteSystemPath;
 
+const TURBO_GITIGNORE_COMMENT: &str = "# Turborepo";
 const TURBO_GITIGNORE_ENTRY: &str = ".turbo";
 const GITIGNORE_FILE: &str = ".gitignore";
 
-pub fn ensure_turbo_is_gitignored(repo_root: &AbsoluteSystemPathBuf) -> Result<(), io::Error> {
+fn has_turbo_gitignore_entry(mut lines: io::Lines<io::BufReader<File>>) -> bool {
+    lines.any(|line| line.map_or(false, |line| line.trim() == TURBO_GITIGNORE_ENTRY))
+}
+
+fn get_ignore_string() -> String {
+    format!("{}\n{}", TURBO_GITIGNORE_COMMENT, TURBO_GITIGNORE_ENTRY)
+}
+
+pub fn ensure_turbo_is_gitignored(repo_root: &AbsoluteSystemPath) -> Result<(), io::Error> {
     let gitignore_path = repo_root.join_component(GITIGNORE_FILE);
 
-    if !gitignore_path.exists() {
-        let mut gitignore = File::create(gitignore_path)?;
-        #[cfg(unix)]
-        gitignore.metadata()?.permissions().set_mode(0o0644);
-        writeln!(gitignore, "{}", TURBO_GITIGNORE_ENTRY)?;
+    if !gitignore_path.try_exists().unwrap_or(true) {
+        gitignore_path.create_with_contents(get_ignore_string())?;
+        gitignore_path.set_mode(0o0644)?;
     } else {
-        let gitignore = File::open(&gitignore_path)?;
-        let mut lines = io::BufReader::new(gitignore).lines();
-        let has_turbo =
-            lines.any(|line| line.map_or(false, |line| line.trim() == TURBO_GITIGNORE_ENTRY));
+        let gitignore = gitignore_path.open()?;
+        let lines = io::BufReader::new(gitignore).lines();
+        let has_turbo = has_turbo_gitignore_entry(lines);
         if !has_turbo {
-            let mut gitignore = OpenOptions::new()
-                .read(true)
-                .append(true)
-                .open(&gitignore_path)?;
+            let mut opts = OpenOptions::new();
+            opts.read(true).write(true).append(true);
+            let mut gitignore = &gitignore_path.open_with_options(opts)?;
 
             // write with a preceding newline just in case the .gitignore file doesn't end
             // with a newline
-            writeln!(gitignore, "\n{}", TURBO_GITIGNORE_ENTRY)?;
+            writeln!(gitignore, "\n{}", get_ignore_string())?;
         }
     }
 
@@ -46,16 +49,28 @@ mod tests {
 
     use super::*;
 
-    fn has_turbo_gitignore_entry(gitignore_path: &AbsoluteSystemPathBuf) -> bool {
-        let gitignore = File::open(gitignore_path).expect("Failed to open .gitignore file");
-        let mut lines = io::BufReader::new(gitignore).lines();
-        lines.any(|line| line.map_or(false, |line| line.trim() == TURBO_GITIGNORE_ENTRY))
+    fn check_for_turbo_in_gitignore_file(gitignore_path: &AbsoluteSystemPath) -> bool {
+        let gitignore = gitignore_path
+            .open()
+            .expect("Failed to open .gitignore file");
+
+        let lines = io::BufReader::new(gitignore).lines();
+        has_turbo_gitignore_entry(lines)
+    }
+
+    fn get_gitignore_size(gitignore_path: &AbsoluteSystemPath) -> usize {
+        let gitignore = gitignore_path
+            .open()
+            .expect("Failed to open .gitignore file");
+
+        let lines = io::BufReader::new(gitignore).lines();
+        lines.count()
     }
 
     #[test]
     fn test_no_gitignore() -> Result<()> {
         let repo_root_tmp = tempdir()?;
-        let repo_root = AbsoluteSystemPathBuf::try_from(repo_root_tmp.path())?;
+        let repo_root = AbsoluteSystemPath::from_std_path(repo_root_tmp.path())?;
 
         ensure_turbo_is_gitignored(&repo_root).expect("Failed to ensure turbo is gitignored");
 
@@ -63,22 +78,25 @@ mod tests {
         let gitignore_path = repo_root.join_component(GITIGNORE_FILE);
         assert!(gitignore_path.exists());
 
-        assert!(has_turbo_gitignore_entry(&gitignore_path));
-
+        /* Expected .gitignore file contents:
+        1. # Turborepo
+        2. .turbo
+         */
+        assert!(check_for_turbo_in_gitignore_file(&gitignore_path));
+        assert_eq!(get_gitignore_size(&gitignore_path), 2);
         Ok(())
     }
 
     #[test]
     fn gitignore_with_missing_turbo() -> Result<()> {
         let repo_root_tmp = tempdir()?;
-        let repo_root = AbsoluteSystemPathBuf::try_from(repo_root_tmp.path())?;
+        let repo_root = AbsoluteSystemPath::from_std_path(repo_root_tmp.path())?;
 
         // create gitignore with no turbo entry
         let gitignore_path = repo_root.join_component(GITIGNORE_FILE);
-        let mut gitignore = File::create(gitignore_path)?;
-        #[cfg(unix)]
-        gitignore.metadata()?.permissions().set_mode(0o0644);
-        writeln!(gitignore, "node_modules/")?;
+        gitignore_path.create_with_contents(format!("{}", "node_modules/\n"))?;
+        gitignore_path.set_mode(0o0644)?;
+        assert_eq!(get_gitignore_size(&gitignore_path), 1);
 
         ensure_turbo_is_gitignored(&repo_root).expect("Failed to ensure turbo is gitignored");
 
@@ -86,23 +104,27 @@ mod tests {
         let gitignore_path = repo_root.join_component(GITIGNORE_FILE);
         assert!(gitignore_path.exists());
 
-        assert!(has_turbo_gitignore_entry(&gitignore_path));
+        /* Expected .gitignore file contents:
+        1. node_modules/
+        2.
+        3. # Turborepo
+        4. .turbo
+         */
+        assert!(check_for_turbo_in_gitignore_file(&gitignore_path));
+        assert_eq!(get_gitignore_size(&gitignore_path), 4);
 
         Ok(())
     }
 
     #[test]
-    fn gitignore_with_existing_turbo() -> Result<()> {
+    fn gitignore_with_existing_turbo_without_comment() -> Result<()> {
         let repo_root_tmp = tempdir()?;
-        let repo_root = AbsoluteSystemPathBuf::try_from(repo_root_tmp.path())?;
+        let repo_root = AbsoluteSystemPath::from_std_path(repo_root_tmp.path())?;
 
         // create gitignore with no turbo entry
         let gitignore_path = repo_root.join_component(GITIGNORE_FILE);
-        let mut gitignore = File::create(gitignore_path)?;
-        #[cfg(unix)]
-        gitignore.metadata()?.permissions().set_mode(0o0644);
-        writeln!(gitignore, ".turbo")?;
-        writeln!(gitignore, ".node_modules/")?;
+        gitignore_path.create_with_contents(format!("{}", "node_modules/\n.turbo\n"))?;
+        assert_eq!(get_gitignore_size(&gitignore_path), 2);
 
         ensure_turbo_is_gitignored(&repo_root).expect("Failed to ensure turbo is gitignored");
 
@@ -110,23 +132,25 @@ mod tests {
         let gitignore_path = repo_root.join_component(GITIGNORE_FILE);
         assert!(gitignore_path.exists());
 
-        assert!(has_turbo_gitignore_entry(&gitignore_path));
+        /* Expected .gitignore file contents:
+        1. node_modules/
+        2..turbo/
+         */
+        assert!(check_for_turbo_in_gitignore_file(&gitignore_path));
+        assert_eq!(get_gitignore_size(&gitignore_path), 2);
 
         Ok(())
     }
 
     #[test]
-    fn gitignore_with_existing_turbo_no_newline() -> Result<()> {
+    fn gitignore_with_existing_turbo_with_comment() -> Result<()> {
         let repo_root_tmp = tempdir()?;
-        let repo_root = AbsoluteSystemPathBuf::try_from(repo_root_tmp.path())?;
+        let repo_root = AbsoluteSystemPath::from_std_path(repo_root_tmp.path())?;
 
         // create gitignore with no turbo entry
         let gitignore_path = repo_root.join_component(GITIGNORE_FILE);
-        let mut gitignore = File::create(gitignore_path)?;
-        #[cfg(unix)]
-        gitignore.metadata()?.permissions().set_mode(0o0644);
-        writeln!(gitignore, ".node_modules/")?;
-        write!(gitignore, ".turbo")?;
+        gitignore_path.create_with_contents(format!("{}", "node_modules/\n# Turborepo\n.turbo"))?;
+        assert_eq!(get_gitignore_size(&gitignore_path), 3);
 
         ensure_turbo_is_gitignored(&repo_root).expect("Failed to ensure turbo is gitignored");
 
@@ -134,7 +158,40 @@ mod tests {
         let gitignore_path = repo_root.join_component(GITIGNORE_FILE);
         assert!(gitignore_path.exists());
 
-        assert!(has_turbo_gitignore_entry(&gitignore_path));
+        /* Expected .gitignore file contents:
+        1. node_modules/
+        2. # Turborepo
+        3..turbo/
+         */
+        assert!(check_for_turbo_in_gitignore_file(&gitignore_path));
+        assert_eq!(get_gitignore_size(&gitignore_path), 3);
+
+        Ok(())
+    }
+
+    #[test]
+    fn gitignore_with_missing_turbo_no_newline() -> Result<()> {
+        let repo_root_tmp = tempdir()?;
+        let repo_root = AbsoluteSystemPath::from_std_path(repo_root_tmp.path())?;
+
+        // create gitignore with no turbo entry
+        let gitignore_path = repo_root.join_component(GITIGNORE_FILE);
+        gitignore_path.create_with_contents(format!("{}", "node_modules/"))?;
+        assert_eq!(get_gitignore_size(&gitignore_path), 1);
+
+        ensure_turbo_is_gitignored(&repo_root).expect("Failed to ensure turbo is gitignored");
+
+        // Verify that the .gitignore file exists and contains the expected entry
+        let gitignore_path = repo_root.join_component(GITIGNORE_FILE);
+        assert!(gitignore_path.exists());
+
+        /* Expected .gitignore file contents:
+        1. node_modules/
+        2. # Turborepo
+        3. .turbo
+         */
+        assert!(check_for_turbo_in_gitignore_file(&gitignore_path));
+        assert_eq!(get_gitignore_size(&gitignore_path), 3);
 
         Ok(())
     }

--- a/crates/turborepo-lib/src/gitignore.rs
+++ b/crates/turborepo-lib/src/gitignore.rs
@@ -23,7 +23,10 @@ pub fn ensure_turbo_is_gitignored(repo_root: &AbsoluteSystemPath) -> Result<(), 
 
     if !gitignore_path.try_exists().unwrap_or(true) {
         gitignore_path.create_with_contents(get_ignore_string())?;
-        gitignore_path.set_mode(0o0644)?;
+        #[cfg(unix)]
+        {
+            gitignore_path.set_mode(0o0644)?;
+        }
     } else {
         let gitignore = gitignore_path.open()?;
         let lines = io::BufReader::new(gitignore).lines();
@@ -95,7 +98,10 @@ mod tests {
         // create gitignore with no turbo entry
         let gitignore_path = repo_root.join_component(GITIGNORE_FILE);
         gitignore_path.create_with_contents(format!("{}", "node_modules/\n"))?;
-        gitignore_path.set_mode(0o0644)?;
+        #[cfg(unix)]
+        {
+            gitignore_path.set_mode(0o0644)?;
+        }
         assert_eq!(get_gitignore_size(&gitignore_path), 1);
 
         ensure_turbo_is_gitignored(&repo_root).expect("Failed to ensure turbo is gitignored");

--- a/crates/turborepo-lib/src/lib.rs
+++ b/crates/turborepo-lib/src/lib.rs
@@ -19,6 +19,7 @@ mod daemon;
 mod engine;
 
 mod framework;
+mod gitignore;
 pub(crate) mod globwatcher;
 mod hash;
 mod opts;


### PR DESCRIPTION
### Description

We need to make sure .turbo is ignored for task access. This pulls the existing util out of link, and re-uses it. 

Also - tests!

