### PR TITLE
Improve daemon startup times

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -373,6 +373,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-once-cell"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9338790e78aa95a416786ec8389546c4b6a1dfc3dc36071ed9518a9413a542eb"
+
+[[package]]
 name = "async-process"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11770,6 +11776,7 @@ name = "turborepo-repository"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-once-cell",
  "globwalk",
  "itertools 0.10.5",
  "lazy-regex",

--- a/crates/turborepo-filewatch/src/cookies.rs
+++ b/crates/turborepo-filewatch/src/cookies.rs
@@ -3,11 +3,13 @@ use std::{collections::BinaryHeap, fs::OpenOptions, time::Duration};
 use notify::EventKind;
 use thiserror::Error;
 use tokio::{
-    sync::{mpsc, oneshot},
+    sync::{broadcast, mpsc, oneshot},
     time::error::Elapsed,
 };
 use tracing::trace;
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, PathRelation};
+
+use crate::{NotifyError, OptionalWatch};
 
 #[derive(Debug, Error)]
 pub enum CookieError {
@@ -22,6 +24,8 @@ pub enum CookieError {
         io_err: std::io::Error,
         path: AbsoluteSystemPathBuf,
     },
+    #[error("cookie queue is not available")]
+    Unavailable,
 }
 
 /// CookieWriter is responsible for assigning filesystem cookies to a request
@@ -30,7 +34,7 @@ pub enum CookieError {
 pub struct CookieWriter {
     root: AbsoluteSystemPathBuf,
     timeout: Duration,
-    cookie_request_tx: mpsc::Sender<oneshot::Sender<Result<usize, CookieError>>>,
+    cookie_request_tx: OptionalWatch<mpsc::Sender<oneshot::Sender<Result<usize, CookieError>>>>,
     // _exit_ch exists to trigger a close on the receiver when all instances
     // of this struct are dropped. The task that is receiving events will exit,
     // dropping the other sender for the broadcast channel, causing all receivers
@@ -138,18 +142,40 @@ impl<T> CookieWatcher<T> {
 }
 
 impl CookieWriter {
-    pub fn new(root: &AbsoluteSystemPath, timeout: Duration) -> Self {
+    pub fn new(
+        root: &AbsoluteSystemPath,
+        timeout: Duration,
+        mut recv: OptionalWatch<broadcast::Receiver<Result<notify::Event, NotifyError>>>,
+    ) -> Self {
+        let (cookie_request_sender_tx, cookie_request_sender_rx) = OptionalWatch::new();
         let (exit_ch, exit_signal) = mpsc::channel(16);
-        let (cookie_requests_tx, cookie_requests_rx) = mpsc::channel(16);
-        tokio::spawn(watch_cookies(
-            root.to_owned(),
-            cookie_requests_rx,
-            exit_signal,
-        ));
+        tokio::spawn({
+            let root = root.to_owned();
+            async move {
+                if recv.get().await.is_err() {
+                    // here we need to wait for confirmation that the watching end is ready
+                    // before we start sending requests. this has the side effect of not
+                    // enabling the cookie writing mechanism until the watcher is ready
+                    return;
+                }
+
+                let (cookie_requests_tx, cookie_requests_rx) = mpsc::channel(16);
+
+                if cookie_request_sender_tx
+                    .send(Some(cookie_requests_tx))
+                    .is_err()
+                {
+                    // the receiver has already been dropped
+                    tracing::debug!("nobody listening for cookie requests, exiting");
+                    return;
+                };
+                watch_cookies(root.to_owned(), cookie_requests_rx, exit_signal).await;
+            }
+        });
         Self {
             root: root.to_owned(),
             timeout,
-            cookie_request_tx: cookie_requests_tx,
+            cookie_request_tx: cookie_request_sender_rx,
             _exit_ch: exit_ch,
         }
     }
@@ -164,7 +190,15 @@ impl CookieWriter {
     ) -> Result<CookiedRequest<T>, CookieError> {
         // we need to write the cookie from a single task so as to serialize them
         let (resp_tx, resp_rx) = oneshot::channel();
-        self.cookie_request_tx.clone().send(resp_tx).await?;
+
+        // make sure the cookie writer is ready
+        let mut cookie_request_tx = self.cookie_request_tx.clone();
+        let Ok(cookie_request_tx) = cookie_request_tx.get().await.map(|s| s.to_owned()) else {
+            // the cookie queue is not ready and will never be ready
+            return Err(CookieError::Unavailable);
+        };
+
+        cookie_request_tx.send(resp_tx).await?;
         let serial = tokio::time::timeout(self.timeout, resp_rx).await???;
         Ok(CookiedRequest { request, serial })
     }
@@ -224,7 +258,7 @@ mod test {
     use turbopath::AbsoluteSystemPathBuf;
 
     use super::{CookieWatcher, CookiedRequest};
-    use crate::{cookies::CookieWriter, NotifyError};
+    use crate::{cookies::CookieWriter, NotifyError, OptionalWatch};
 
     struct TestQuery {
         resp: oneshot::Sender<()>,
@@ -288,8 +322,9 @@ mod test {
             .unwrap();
 
         let (send_file_events, file_events) = broadcast::channel(16);
+        let recv = OptionalWatch::once(file_events.resubscribe());
         let (reqs_tx, reqs_rx) = mpsc::channel(16);
-        let cookie_writer = CookieWriter::new(&path, Duration::from_secs(2));
+        let cookie_writer = CookieWriter::new(&path, Duration::from_secs(2), recv);
         let (exit_tx, exit_rx) = oneshot::channel();
 
         let service = TestService {
@@ -351,8 +386,9 @@ mod test {
             .unwrap();
 
         let (send_file_events, file_events) = broadcast::channel(16);
+        let recv = OptionalWatch::once(file_events.resubscribe());
         let (reqs_tx, reqs_rx) = mpsc::channel(16);
-        let cookie_writer = CookieWriter::new(&path, Duration::from_secs(2));
+        let cookie_writer = CookieWriter::new(&path, Duration::from_secs(2), recv);
         let (exit_tx, exit_rx) = oneshot::channel();
 
         let service = TestService {

--- a/crates/turborepo-filewatch/src/globwatcher.rs
+++ b/crates/turborepo-filewatch/src/globwatcher.rs
@@ -10,12 +10,12 @@ use notify::Event;
 use thiserror::Error;
 use tokio::sync::{broadcast, mpsc, oneshot};
 use tracing::{debug, warn};
-use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, RelativeUnixPath};
+use turbopath::{AbsoluteSystemPathBuf, RelativeUnixPath};
 use wax::{Any, Glob, Program};
 
 use crate::{
     cookies::{CookieError, CookieWatcher, CookieWriter, CookiedRequest},
-    NotifyError,
+    NotifyError, OptionalWatch,
 };
 
 type Hash = String;
@@ -160,16 +160,24 @@ struct GlobTracker {
 
 impl GlobWatcher {
     pub fn new(
-        root: &AbsoluteSystemPath,
+        root: AbsoluteSystemPathBuf,
         cookie_jar: CookieWriter,
-        recv: broadcast::Receiver<Result<Event, NotifyError>>,
+        mut recv: OptionalWatch<broadcast::Receiver<Result<Event, NotifyError>>>,
     ) -> Self {
         let (exit_ch, exit_signal) = tokio::sync::oneshot::channel();
         let (query_ch, query_recv) = mpsc::channel(256);
         let cookie_root = cookie_jar.root().to_owned();
-        tokio::task::spawn(
-            GlobTracker::new(root.to_owned(), cookie_root, exit_signal, recv, query_recv).watch(),
-        );
+        tokio::task::spawn(async move {
+            let Ok(recv) = recv.get().await.map(|r| r.resubscribe()) else {
+                // if this fails, it means that the filewatcher is not available
+                // so starting the glob tracker is pointless
+                return;
+            };
+
+            GlobTracker::new(root, cookie_root, exit_signal, recv, query_recv)
+                .watch()
+                .await
+        });
         Self {
             cookie_jar,
             _exit_ch: exit_ch,
@@ -468,12 +476,10 @@ mod test {
         setup(&repo_root);
         let cookie_dir = repo_root.join_component(".git");
 
-        let watcher = FileSystemWatcher::new_with_default_cookie_dir(&repo_root)
-            .await
-            .unwrap();
-        let cookie_jar = CookieWriter::new(&cookie_dir, Duration::from_secs(2));
-
-        let glob_watcher = GlobWatcher::new(&repo_root, cookie_jar, watcher.subscribe());
+        let watcher = FileSystemWatcher::new_with_default_cookie_dir(&repo_root).unwrap();
+        let recv = watcher.watch();
+        let cookie_jar = CookieWriter::new(&cookie_dir, Duration::from_secs(2), recv.clone());
+        let glob_watcher = GlobWatcher::new(repo_root.clone(), cookie_jar, recv);
 
         let raw_includes = &["my-pkg/dist/**", "my-pkg/.next/**"];
         let raw_excludes = ["my-pkg/.next/cache/**"];
@@ -553,12 +559,11 @@ mod test {
         setup(&repo_root);
         let cookie_dir = repo_root.join_component(".git");
 
-        let watcher = FileSystemWatcher::new_with_default_cookie_dir(&repo_root)
-            .await
-            .unwrap();
-        let cookie_jar = CookieWriter::new(&cookie_dir, Duration::from_secs(2));
+        let watcher = FileSystemWatcher::new_with_default_cookie_dir(&repo_root).unwrap();
+        let recv = watcher.watch();
+        let cookie_jar = CookieWriter::new(&cookie_dir, Duration::from_secs(2), recv.clone());
 
-        let glob_watcher = GlobWatcher::new(&repo_root, cookie_jar, watcher.subscribe());
+        let glob_watcher = GlobWatcher::new(repo_root.clone(), cookie_jar, recv);
 
         let raw_includes = &["my-pkg/dist/**", "my-pkg/.next/**"];
         let raw_excludes: [&str; 0] = [];
@@ -649,12 +654,11 @@ mod test {
         setup(&repo_root);
         let cookie_dir = repo_root.join_component(".git");
 
-        let watcher = FileSystemWatcher::new_with_default_cookie_dir(&repo_root)
-            .await
-            .unwrap();
-        let cookie_jar = CookieWriter::new(&cookie_dir, Duration::from_secs(2));
+        let watcher = FileSystemWatcher::new_with_default_cookie_dir(&repo_root).unwrap();
+        let recv = watcher.watch();
+        let cookie_jar = CookieWriter::new(&cookie_dir, Duration::from_secs(2), recv.clone());
 
-        let glob_watcher = GlobWatcher::new(&repo_root, cookie_jar, watcher.subscribe());
+        let glob_watcher = GlobWatcher::new(repo_root.clone(), cookie_jar, recv);
 
         // On windows, we expect different sanitization before the
         // globs are passed in, due to alternative data streams in files.

--- a/crates/turborepo-filewatch/src/lib.rs
+++ b/crates/turborepo-filewatch/src/lib.rs
@@ -112,7 +112,7 @@ impl FileSystemWatcher {
             )));
         }
 
-        let (receiver_tx, receiver_rx) = OptionalWatch::new();
+        let (file_events_receiver_tx, file_events_receiver_lazy) = OptionalWatch::new();
         let (send_file_events, mut recv_file_events) = mpsc::channel(1024);
         let (exit_ch, exit_signal) = tokio::sync::oneshot::channel();
 
@@ -146,7 +146,7 @@ impl FileSystemWatcher {
 
                 let (sender, receiver) = broadcast::channel(1024);
 
-                if receiver_tx.send(Some(receiver)).is_err() {
+                if file_events_receiver_tx.send(Some(receiver)).is_err() {
                     // if this fails, it means that nobody is listening (and
                     // nobody ever will) likely because the
                     // watcher has been dropped. We can just exit early.
@@ -159,7 +159,7 @@ impl FileSystemWatcher {
         });
 
         Ok(Self {
-            receiver: receiver_rx,
+            receiver: file_events_receiver_lazy,
             _exit_ch: exit_ch,
             cookie_dir,
         })

--- a/crates/turborepo-filewatch/src/lib.rs
+++ b/crates/turborepo-filewatch/src/lib.rs
@@ -205,14 +205,8 @@ async fn watch_events(
     _watch_root: AbsoluteSystemPathBuf,
     mut recv_file_events: mpsc::Receiver<EventResult>,
     exit_signal: tokio::sync::oneshot::Receiver<()>,
-    mut broadcast_sender: OptionalWatch<broadcast::Sender<Result<Event, NotifyError>>>,
+    broadcast_sender: broadcast::Sender<Result<Event, NotifyError>>,
 ) {
-    let Ok(broadcast_sender) = broadcast_sender.get().await.map(|b| b.clone()) else {
-        // if we are never sent a sender, we should not run the watcher
-        tracing::debug!("no downstream listeners, exiting");
-        return;
-    };
-
     let mut exit_signal = exit_signal;
     'outer: loop {
         tokio::select! {

--- a/crates/turborepo-filewatch/src/optional_watch.rs
+++ b/crates/turborepo-filewatch/src/optional_watch.rs
@@ -1,0 +1,68 @@
+use tokio::sync::watch::{self, error::RecvError, Ref};
+
+#[derive(Debug)]
+pub struct OptionalWatch<T>(watch::Receiver<Option<T>>);
+
+impl<T> Clone for OptionalWatch<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+/// A handy wrapper around types that are watched and may be None.
+/// `SomeRef` is a reference type that is known to be `Some`.
+impl<T> OptionalWatch<T> {
+    /// Create a new `OptionalWatch` with no initial value.
+    ///
+    /// Keep in mind that when the sender is dropped, down stream
+    /// dependencies will get a RecvError.
+    pub fn new() -> (watch::Sender<Option<T>>, OptionalWatch<T>) {
+        let (tx, rx) = watch::channel(None);
+        (tx, OptionalWatch(rx))
+    }
+
+    /// Create a new `OptionalWatch` with an initial, unchanging value.
+    pub fn once(init: T) -> Self {
+        let (_tx, rx) = watch::channel(Some(init));
+        OptionalWatch(rx)
+    }
+
+    /// Wait for the value to be available and then return it.
+    ///
+    /// If you receive a `RecvError`, the sender has been dropped, meaning you
+    /// will not receive any more updates. For efficiencies sake, you should
+    /// exit the task and drop any senders to other dependencies so that the
+    /// exit can propagate up the chain.
+    pub async fn get(&mut self) -> Result<SomeRef<'_, T>, RecvError> {
+        let recv = self.0.wait_for(|f| f.is_some()).await?;
+        Ok(SomeRef(recv))
+    }
+}
+
+pub struct SomeRef<'a, T>(Ref<'a, Option<T>>);
+
+impl<'a, T> std::ops::Deref for SomeRef<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.as_ref().expect("checked")
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use futures::FutureExt;
+
+    /// Futures have a method that allow you to fetch the value of a future
+    /// if it is immediately available. This is useful for, for example,
+    /// allowing consumers to poll a future and get the value if it is
+    /// available, but otherwise just continue on, rather than wait.
+    #[tokio::test]
+    pub async fn now_or_never_works() {
+        let (tx, mut rx) = super::OptionalWatch::new();
+
+        tx.send(Some(42)).unwrap();
+
+        assert_eq!(*rx.get().now_or_never().unwrap().unwrap(), 42);
+    }
+}

--- a/crates/turborepo-filewatch/src/package_watcher.rs
+++ b/crates/turborepo-filewatch/src/package_watcher.rs
@@ -97,7 +97,7 @@ impl<T: PackageDiscovery + Send + 'static> Subscriber<T> {
         exit_rx: oneshot::Receiver<()>,
         repo_root: AbsoluteSystemPathBuf,
         recv: broadcast::Receiver<Result<Event, NotifyError>>,
-        mut discovery: T,
+        discovery: T,
     ) -> Result<Self, Error> {
         let initial_discovery = discovery.discover_packages().await?;
 
@@ -356,7 +356,7 @@ mod test {
     }
 
     impl super::PackageDiscovery for MockDiscovery {
-        async fn discover_packages(&mut self) -> Result<DiscoveryResponse, discovery::Error> {
+        async fn discover_packages(&self) -> Result<DiscoveryResponse, discovery::Error> {
             Ok(DiscoveryResponse {
                 package_manager: self.manager,
                 workspaces: self.package_data.lock().unwrap().clone(),

--- a/crates/turborepo-filewatch/src/package_watcher.rs
+++ b/crates/turborepo-filewatch/src/package_watcher.rs
@@ -253,14 +253,14 @@ impl<T: PackageDiscovery + Send + 'static> Subscriber<T> {
 
                 // if either of these fail, it means that there are no more subscribers and we
                 // should just ignore it, since we are likely closing
-                let a = if manager_tx.send(Some(state)).is_err() {
+                let manager_listeners = if manager_tx.send(Some(state)).is_err() {
                     tracing::debug!("no listeners for package manager");
                     false
                 } else {
                     true
                 };
 
-                let b = if package_data_tx
+                let package_data_listeners = if package_data_tx
                     .send(Some(
                         initial_discovery
                             .workspaces
@@ -277,7 +277,7 @@ impl<T: PackageDiscovery + Send + 'static> Subscriber<T> {
                 };
 
                 // if we have no listeners for either, we should just exit
-                if a || b {
+                if manager_listeners || package_data_listeners {
                     _ = recv_tx.send(Some(recv));
                 }
             }

--- a/crates/turborepo-filewatch/src/package_watcher.rs
+++ b/crates/turborepo-filewatch/src/package_watcher.rs
@@ -154,6 +154,7 @@ impl PackageWatcher {
 struct Subscriber<T: PackageDiscovery> {
     /// we need to hold on to this. dropping it will close the downstream
     /// data dependencies
+    #[allow(clippy::type_complexity)]
     _recv_tx: Arc<watch::Sender<Option<broadcast::Receiver<Result<Event, NotifyError>>>>>,
 
     recv: OptionalWatch<broadcast::Receiver<Result<Event, NotifyError>>>,

--- a/crates/turborepo-lib/src/daemon/server.rs
+++ b/crates/turborepo-lib/src/daemon/server.rs
@@ -591,7 +591,7 @@ mod test {
     struct MockDiscovery;
     impl PackageDiscovery for MockDiscovery {
         async fn discover_packages(
-            &mut self,
+            &self,
         ) -> Result<
             turborepo_repository::discovery::DiscoveryResponse,
             turborepo_repository::discovery::Error,

--- a/crates/turborepo-lib/src/daemon/server.rs
+++ b/crates/turborepo-lib/src/daemon/server.rs
@@ -279,10 +279,6 @@ where
         let _ = exit_root_watch.send(());
         let _ = watch_root_handle.await;
         trace!("root watching exited");
-        // Clean up the filewatching handle in the event that we never even got
-        // started with filewatching. Again, we don't care about the error here.
-        // let _ = fw_handle.await;
-        trace!("filewatching handle joined");
         Ok(close_reason)
     }
 }

--- a/crates/turborepo-lib/src/daemon/server.rs
+++ b/crates/turborepo-lib/src/daemon/server.rs
@@ -99,7 +99,7 @@ impl FileWatching {
     /// waiting for the filewatcher to be ready. Using `OptionalWatch`,
     /// dependent services can wait for resources they need to become
     /// available, and the server can start up without waiting for them.
-    pub fn new<PD: PackageDiscovery + Send + 'static>(
+    pub fn new<PD: PackageDiscovery + Send + Sync + 'static>(
         repo_root: AbsoluteSystemPathBuf,
         backup_discovery: PD,
     ) -> Result<FileWatching, WatchError> {

--- a/crates/turborepo-lib/src/daemon/server.rs
+++ b/crates/turborepo-lib/src/daemon/server.rs
@@ -26,7 +26,8 @@ use semver::Version;
 use thiserror::Error;
 use tokio::{
     select,
-    sync::{mpsc, oneshot, watch},
+    sync::{mpsc, oneshot},
+    task::JoinHandle,
 };
 use tonic::transport::{NamedService, Server};
 use tower::ServiceBuilder;
@@ -35,11 +36,11 @@ use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
 use turborepo_filewatch::{
     cookies::CookieWriter,
     globwatcher::{Error as GlobWatcherError, GlobError, GlobSet, GlobWatcher},
-    package_watcher::PackageWatcher,
+    package_watcher::{PackageWatcher, WatchingPackageDiscovery},
     FileSystemWatcher, WatchError,
 };
 use turborepo_repository::discovery::{
-    DiscoveryResponse, LocalPackageDiscoveryBuilder, PackageDiscovery, PackageDiscoveryBuilder,
+    LocalPackageDiscoveryBuilder, PackageDiscovery, PackageDiscoveryBuilder,
 };
 
 use super::{bump_timeout::BumpTimeout, endpoint::SocketOpenError, proto, Paths};
@@ -56,10 +57,14 @@ pub enum CloseReason {
     SocketOpenError(SocketOpenError),
 }
 
+/// We may need to pass out references to a subset of these, so
+/// we'll make them public Arcs. Eventually we can stabilize on
+/// a general API and close this up.
+#[derive(Clone)]
 pub struct FileWatching {
-    _watcher: FileSystemWatcher,
-    pub glob_watcher: GlobWatcher,
-    pub package_watcher: PackageWatcher,
+    watcher: Arc<FileSystemWatcher>,
+    pub glob_watcher: Arc<GlobWatcher>,
+    pub package_watcher: Arc<PackageWatcher>,
 }
 
 #[derive(Debug, Error)]
@@ -87,34 +92,47 @@ impl From<RpcError> for tonic::Status {
     }
 }
 
-async fn start_filewatching<PD: PackageDiscovery + Send + 'static>(
-    repo_root: AbsoluteSystemPathBuf,
-    watcher_tx: watch::Sender<Option<Arc<FileWatching>>>,
-    backup_discovery: PD,
-) -> Result<(), WatchError> {
-    let watcher = FileSystemWatcher::new_with_default_cookie_dir(&repo_root).await?;
-    let cookie_writer = CookieWriter::new(watcher.cookie_dir(), Duration::from_millis(100));
-    let glob_watcher = GlobWatcher::new(&repo_root, cookie_writer, watcher.subscribe());
-    let package_watcher =
-        PackageWatcher::new(repo_root.clone(), watcher.subscribe(), backup_discovery)
-            .await
-            .map_err(|e| WatchError::Setup(format!("{:?}", e)))?;
-    // We can ignore failures here, it means the server is shutting down and
-    // receivers have gone out of scope.
-    let _ = watcher_tx.send(Some(Arc::new(FileWatching {
-        _watcher: watcher,
-        glob_watcher,
-        package_watcher,
-    })));
-    Ok(())
+impl FileWatching {
+    /// This function is called in the constructor for the `TurboGrpcService`
+    /// and should defer ALL heavy computation to the background, making use
+    /// of `OptionalWatch` to ensure that the server can start up without
+    /// waiting for the filewatcher to be ready. Using `OptionalWatch`,
+    /// dependent services can wait for resources they need to become
+    /// available, and the server can start up without waiting for them.
+    pub fn new<PD: PackageDiscovery + Send + 'static>(
+        repo_root: AbsoluteSystemPathBuf,
+        backup_discovery: PD,
+    ) -> Result<FileWatching, WatchError> {
+        let watcher = Arc::new(FileSystemWatcher::new_with_default_cookie_dir(&repo_root)?);
+        let recv = watcher.watch();
+
+        let cookie_watcher = CookieWriter::new(
+            watcher.cookie_dir(),
+            Duration::from_millis(100),
+            recv.clone(),
+        );
+        let glob_watcher = Arc::new(GlobWatcher::new(
+            repo_root.clone(),
+            cookie_watcher,
+            recv.clone(),
+        ));
+        let package_watcher = Arc::new(
+            PackageWatcher::new(repo_root.clone(), recv.clone(), backup_discovery)
+                .map_err(|e| WatchError::Setup(format!("{:?}", e)))?,
+        );
+
+        Ok(FileWatching {
+            watcher,
+            glob_watcher,
+            package_watcher,
+        })
+    }
 }
 
 /// Timeout for every RPC the server handles
 const REQUEST_TIMEOUT: Duration = Duration::from_millis(100);
 
 pub struct TurboGrpcService<S, PDB> {
-    watcher_tx: watch::Sender<Option<Arc<FileWatching>>>,
-    watcher_rx: watch::Receiver<Option<Arc<FileWatching>>>,
     repo_root: AbsoluteSystemPathBuf,
     paths: Paths,
     timeout: Duration,
@@ -139,8 +157,6 @@ where
         timeout: Duration,
         external_shutdown: S,
     ) -> Self {
-        let (watcher_tx, watcher_rx) = watch::channel(None);
-
         let package_discovery_backup =
             LocalPackageDiscoveryBuilder::new(repo_root.clone(), None, None);
 
@@ -148,8 +164,6 @@ where
         // so we use a private struct with just the pieces of state needed to handle
         // RPCs.
         TurboGrpcService {
-            watcher_tx,
-            watcher_rx,
             repo_root,
             paths,
             timeout,
@@ -163,7 +177,7 @@ impl<S, PDB> TurboGrpcService<S, PDB>
 where
     S: Future<Output = CloseReason>,
     PDB: PackageDiscoveryBuilder,
-    PDB::Output: PackageDiscovery + Send + 'static,
+    PDB::Output: PackageDiscovery + Send + Sync + 'static,
 {
     /// If errors are encountered when loading the package discovery, this
     /// builder will be used as a backup to refresh the state.
@@ -176,8 +190,6 @@ where
             paths: self.paths,
             repo_root: self.repo_root,
             timeout: self.timeout,
-            watcher_rx: self.watcher_rx,
-            watcher_tx: self.watcher_tx,
             package_discovery_backup,
         }
     }
@@ -186,12 +198,26 @@ where
         let Self {
             watcher_tx,
             watcher_rx,
+            daemon_root,
             external_shutdown,
             paths,
             repo_root,
             timeout,
             package_discovery_backup,
         } = self;
+
+        // A channel to trigger the shutdown of the gRPC server. This is handed out
+        // to components internal to the server process such as root watching, as
+        // well as available to the gRPC server itself to handle the shutdown RPC.
+        let (trigger_shutdown, mut shutdown_signal) = mpsc::channel::<()>(1);
+
+        let package_discovery_backup = package_discovery_backup.build()?;
+        let (service, exit_root_watch, watch_root_handle) = TurboGrpcServiceInner::new(
+            package_discovery_backup,
+            repo_root.clone(),
+            trigger_shutdown,
+            log_file,
+        );
 
         let running = Arc::new(AtomicBool::new(true));
         let (_pid_lock, stream) =
@@ -200,37 +226,6 @@ where
                 Err(e) => return Ok(CloseReason::SocketOpenError(e)),
             };
         trace!("acquired connection stream for socket");
-
-        let watcher_repo_root = repo_root.to_owned();
-        // A channel to trigger the shutdown of the gRPC server. This is handed out
-        // to components internal to the server process such as root watching, as
-        // well as available to the gRPC server itself to handle the shutdown RPC.
-        let (trigger_shutdown, mut shutdown_signal) = mpsc::channel::<()>(1);
-
-        let backup_discovery = package_discovery_backup.build()?;
-
-        // watch receivers as a group own the filewatcher, which will exit when
-        // all references are dropped.
-        let fw_shutdown = trigger_shutdown.clone();
-        let fw_handle = tokio::task::spawn(async move {
-            if let Err(e) =
-                start_filewatching(watcher_repo_root, watcher_tx, backup_discovery).await
-            {
-                error!("filewatching failed to start: {}", e);
-                let _ = fw_shutdown.send(()).await;
-            }
-            info!("filewatching started");
-        });
-        // exit_root_watch delivers a signal to the root watch loop to exit.
-        // In the event that the server shuts down via some other mechanism, this
-        // cleans up root watching task.
-        let (exit_root_watch, root_watch_exit_signal) = oneshot::channel();
-        let watch_root_handle = tokio::task::spawn(watch_root(
-            watcher_rx.clone(),
-            repo_root.to_owned(),
-            trigger_shutdown.clone(),
-            root_watch_exit_signal,
-        ));
 
         let bump_timeout = Arc::new(BumpTimeout::new(timeout));
         let timeout_fut = bump_timeout.wait();
@@ -270,8 +265,9 @@ where
         };
         // Wait for the server to exit.
         // This can be triggered by timeout, root watcher, or an RPC
+        tracing::debug!("server started");
         let _ = server_fut.await;
-        info!("gRPC server exited");
+        tracing::debug!("server exited");
         // Ensure our timer will exit
         running.store(false, Ordering::SeqCst);
         // We expect to have a signal from the grpc server on what triggered the exit
@@ -285,29 +281,75 @@ where
         trace!("root watching exited");
         // Clean up the filewatching handle in the event that we never even got
         // started with filewatching. Again, we don't care about the error here.
-        let _ = fw_handle.await;
+        // let _ = fw_handle.await;
         trace!("filewatching handle joined");
         Ok(close_reason)
     }
 }
 
-struct TurboGrpcServiceInner {
+struct TurboGrpcServiceInner<PD> {
     shutdown: mpsc::Sender<()>,
-    watcher_rx: watch::Receiver<Option<Arc<FileWatching>>>,
+    file_watching: FileWatching,
     times_saved: Arc<Mutex<HashMap<String, u64>>>,
     start_time: Instant,
     log_file: AbsoluteSystemPathBuf,
+    package_discovery: PD,
 }
 
-impl TurboGrpcServiceInner {
+// we have a grpc service that uses watching package discovery, and where the
+// watching package hasher also uses watching package discovery as well as
+// falling back to a local package hasher
+impl TurboGrpcServiceInner<Arc<WatchingPackageDiscovery>> {
+    pub fn new<PD: Sync + PackageDiscovery + Send + 'static>(
+        package_discovery_backup: PD,
+        repo_root: AbsoluteSystemPathBuf,
+        trigger_shutdown: mpsc::Sender<()>,
+        log_file: AbsoluteSystemPathBuf,
+    ) -> (
+        Self,
+        oneshot::Sender<()>,
+        JoinHandle<Result<(), WatchError>>,
+    ) {
+        let file_watching = FileWatching::new(repo_root.clone(), package_discovery_backup).unwrap();
+
+        tracing::debug!("initing package discovery");
+        let package_discovery = Arc::new(WatchingPackageDiscovery::new(
+            file_watching.package_watcher.clone(),
+        ));
+
+        // exit_root_watch delivers a signal to the root watch loop to exit.
+        // In the event that the server shuts down via some other mechanism, this
+        // cleans up root watching task.
+        let (exit_root_watch, root_watch_exit_signal) = oneshot::channel();
+        let watch_root_handle = tokio::task::spawn(watch_root(
+            file_watching.clone(),
+            repo_root.clone(),
+            trigger_shutdown.clone(),
+            root_watch_exit_signal,
+        ));
+
+        (
+            TurboGrpcServiceInner {
+                package_discovery,
+                shutdown: trigger_shutdown,
+                file_watching,
+                times_saved: Arc::new(Mutex::new(HashMap::new())),
+                start_time: Instant::now(),
+                log_file,
+            },
+            exit_root_watch,
+            watch_root_handle,
+        )
+    }
+}
+
+impl<PD> TurboGrpcServiceInner<PD>
+where
+    PD: PackageDiscovery + Send + Sync + 'static,
+{
     async fn trigger_shutdown(&self) {
         info!("triggering shutdown");
         let _ = self.shutdown.send(()).await;
-    }
-
-    async fn wait_for_filewatching(&self) -> Result<Arc<FileWatching>, RpcError> {
-        let rx = self.watcher_rx.clone();
-        wait_for_filewatching(rx, Duration::from_millis(100)).await
     }
 
     async fn watch_globs(
@@ -318,8 +360,8 @@ impl TurboGrpcServiceInner {
         time_saved: u64,
     ) -> Result<(), RpcError> {
         let glob_set = GlobSet::from_raw(output_globs, output_glob_exclusions)?;
-        let fw = self.wait_for_filewatching().await?;
-        fw.glob_watcher
+        self.file_watching
+            .glob_watcher
             .watch_globs(hash.clone(), glob_set, REQUEST_TIMEOUT)
             .await?;
         {
@@ -338,59 +380,40 @@ impl TurboGrpcServiceInner {
             let times_saved = self.times_saved.lock().expect("times saved lock poisoned");
             times_saved.get(hash.as_str()).copied().unwrap_or_default()
         };
-        let fw = self.wait_for_filewatching().await?;
-        let changed_globs = fw
+        let changed_globs = self
+            .file_watching
             .glob_watcher
             .get_changed_globs(hash, candidates, REQUEST_TIMEOUT)
             .await?;
         Ok((changed_globs, time_saved))
     }
-
-    async fn discover_packages(&self) -> Result<DiscoveryResponse, RpcError> {
-        let fw = self.wait_for_filewatching().await?;
-        Ok(DiscoveryResponse {
-            workspaces: fw.package_watcher.get_package_data().await,
-            package_manager: fw.package_watcher.get_package_manager().await,
-        })
-    }
-}
-
-async fn wait_for_filewatching(
-    mut rx: watch::Receiver<Option<Arc<FileWatching>>>,
-    timeout: Duration,
-) -> Result<Arc<FileWatching>, RpcError> {
-    let fw = tokio::time::timeout(timeout, rx.wait_for(|opt| opt.is_some()))
-        .await
-        .map_err(|_| RpcError::DeadlineExceeded)? // timeout case
-        .map_err(|_| RpcError::NoFileWatching)?; // sender dropped
-
-    return Ok(fw.as_ref().expect("guaranteed some above").clone());
 }
 
 async fn watch_root(
-    filewatching_access: watch::Receiver<Option<Arc<FileWatching>>>,
+    filewatching_access: FileWatching,
     root: AbsoluteSystemPathBuf,
     trigger_shutdown: mpsc::Sender<()>,
     mut exit_signal: oneshot::Receiver<()>,
 ) -> Result<(), WatchError> {
-    let mut recv_events = {
-        let Ok(fw) = wait_for_filewatching(filewatching_access, Duration::from_secs(5)).await
-        else {
-            return Ok(());
-        };
+    let mut recv_events = filewatching_access
+        .watcher
+        .subscribe()
+        .await
+        // we can only encounter an error here if the file watcher is closed (a recv error)
+        .map_err(|_| WatchError::Setup("file watching shut down".to_string()))?;
 
-        fw._watcher.subscribe()
-    };
+    tracing::debug!("watching root: {:?}", root);
 
     loop {
         // Ignore the outer layer of Result, if the sender has closed, filewatching has
         // gone away and we can return.
         select! {
-            _ = &mut exit_signal => return Ok(()),
+            _ = &mut exit_signal => break,
             event = recv_events.recv() => {
                 let Ok(event) = event else {
-                    return Ok(());
+                    break;
                 };
+                tracing::debug!("root watcher received event: {:?}", event);
                 let should_trigger_shutdown = match event {
                     // filewatching can throw some weird events, so check that the root is actually gone
                     // before triggering a shutdown
@@ -403,15 +426,21 @@ async fn watch_root(
                     // We don't care if a shutdown has already been triggered,
                     // so we can ignore the error.
                     let _ = trigger_shutdown.send(()).await;
-                    return Ok(());
+                    break;
                 }
             }
         }
     }
+
+    tracing::debug!("no longer watching root");
+
+    Ok(())
 }
 
 #[tonic::async_trait]
-impl proto::turbod_server::Turbod for TurboGrpcServiceInner {
+impl<PD: PackageDiscovery + Send + Sync + 'static> proto::turbod_server::Turbod
+    for TurboGrpcServiceInner<PD>
+{
     async fn hello(
         &self,
         request: tonic::Request<proto::HelloRequest>,
@@ -499,18 +528,30 @@ impl proto::turbod_server::Turbod for TurboGrpcServiceInner {
         &self,
         _request: tonic::Request<proto::DiscoverPackagesRequest>,
     ) -> Result<tonic::Response<proto::DiscoverPackagesResponse>, tonic::Status> {
-        let resp = self.discover_packages().await?;
-        Ok(tonic::Response::new(proto::DiscoverPackagesResponse {
-            package_files: resp
-                .workspaces
-                .into_iter()
-                .map(|d| proto::PackageFiles {
-                    package_json: d.package_json.to_string(),
-                    turbo_json: d.turbo_json.map(|t| t.to_string()),
+        self.package_discovery
+            .discover_packages()
+            .await
+            .map(|packages| {
+                tonic::Response::new(proto::DiscoverPackagesResponse {
+                    package_files: packages
+                        .workspaces
+                        .into_iter()
+                        .map(|d| proto::PackageFiles {
+                            package_json: d.package_json.to_string(),
+                            turbo_json: d.turbo_json.map(|t| t.to_string()),
+                        })
+                        .collect(),
+                    package_manager: proto::PackageManager::from(packages.package_manager).into(),
                 })
-                .collect(),
-            package_manager: proto::PackageManager::from(resp.package_manager).into(),
-        }))
+            })
+            .map_err(|e| match e {
+                turborepo_repository::discovery::Error::Unavailable => {
+                    tonic::Status::unavailable("package discovery unavailable")
+                }
+                turborepo_repository::discovery::Error::Failed(e) => {
+                    tonic::Status::internal(format!("{}", e))
+                }
+            })
     }
 }
 
@@ -537,7 +578,7 @@ fn compare_versions(client: Version, server: Version, constraint: proto::Version
     }
 }
 
-impl NamedService for TurboGrpcServiceInner {
+impl<PD> NamedService for TurboGrpcServiceInner<PD> {
     const NAME: &'static str = "turborepo.Daemon";
 }
 

--- a/crates/turborepo-lib/src/engine/builder.rs
+++ b/crates/turborepo-lib/src/engine/builder.rs
@@ -473,7 +473,7 @@ mod test {
     struct MockDiscovery;
     impl PackageDiscovery for MockDiscovery {
         async fn discover_packages(
-            &mut self,
+            &self,
         ) -> Result<
             turborepo_repository::discovery::DiscoveryResponse,
             turborepo_repository::discovery::Error,

--- a/crates/turborepo-lib/src/engine/mod.rs
+++ b/crates/turborepo-lib/src/engine/mod.rs
@@ -294,7 +294,7 @@ mod test {
 
     impl<'a> PackageDiscovery for DummyDiscovery<'a> {
         async fn discover_packages(
-            &mut self,
+            &self,
         ) -> Result<
             turborepo_repository::discovery::DiscoveryResponse,
             turborepo_repository::discovery::Error,

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -304,7 +304,7 @@ impl Run {
                     )
                 };
                 let fallback_discovery = FallbackPackageDiscovery::new(
-                    daemon.as_mut().map(DaemonPackageDiscovery::new),
+                    daemon.clone().map(DaemonPackageDiscovery::new),
                     fallback,
                     duration,
                 );

--- a/crates/turborepo-lib/src/run/package_discovery/mod.rs
+++ b/crates/turborepo-lib/src/run/package_discovery/mod.rs
@@ -4,22 +4,24 @@ use turborepo_repository::discovery::{DiscoveryResponse, Error, PackageDiscovery
 use crate::daemon::{proto::PackageManager, DaemonClient};
 
 #[derive(Debug)]
-pub struct DaemonPackageDiscovery<'a, C: Clone> {
-    daemon: &'a mut DaemonClient<C>,
+pub struct DaemonPackageDiscovery<C> {
+    daemon: DaemonClient<C>,
 }
 
-impl<'a, C: Clone> DaemonPackageDiscovery<'a, C> {
-    pub fn new(daemon: &'a mut DaemonClient<C>) -> Self {
+impl<C> DaemonPackageDiscovery<C> {
+    pub fn new(daemon: DaemonClient<C>) -> Self {
         Self { daemon }
     }
 }
 
-impl<'a, C: Clone + Send> PackageDiscovery for DaemonPackageDiscovery<'a, C> {
-    async fn discover_packages(&mut self) -> Result<DiscoveryResponse, Error> {
+impl<C: Clone + Send + Sync> PackageDiscovery for DaemonPackageDiscovery<C> {
+    async fn discover_packages(&self) -> Result<DiscoveryResponse, Error> {
         tracing::debug!("discovering packages using daemon");
 
-        let response = self
-            .daemon
+        // clone here so we can make concurrent requests
+        let mut daemon = self.daemon.clone();
+
+        let response = daemon
             .discover_packages()
             .await
             .map_err(|e| Error::Failed(Box::new(e)))?;

--- a/crates/turborepo-lib/src/run/scope/filter.rs
+++ b/crates/turborepo-lib/src/run/scope/filter.rs
@@ -621,7 +621,7 @@ mod test {
     struct MockDiscovery;
     impl PackageDiscovery for MockDiscovery {
         async fn discover_packages(
-            &mut self,
+            &self,
         ) -> Result<
             turborepo_repository::discovery::DiscoveryResponse,
             turborepo_repository::discovery::Error,

--- a/crates/turborepo-lsp/src/lib.rs
+++ b/crates/turborepo-lsp/src/lib.rs
@@ -580,7 +580,7 @@ impl Backend {
     }
 
     pub async fn package_discovery(&self) -> Result<DiscoveryResponse, discovery::Error> {
-        let mut daemon = {
+        let daemon = {
             let mut daemon = self.daemon.clone();
             let daemon = daemon.wait_for(|d| d.is_some()).await;
             let daemon = daemon.as_ref().expect("only fails if self is dropped");
@@ -590,7 +590,7 @@ impl Backend {
                 .clone()
         };
 
-        DaemonPackageDiscovery::new(&mut daemon)
+        DaemonPackageDiscovery::new(daemon)
             .discover_packages()
             .await
     }

--- a/crates/turborepo-repository/Cargo.toml
+++ b/crates/turborepo-repository/Cargo.toml
@@ -9,6 +9,7 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+async-once-cell = "0.5.3"
 globwalk = { version = "0.1.0", path = "../turborepo-globwalk" }
 itertools = { workspace = true }
 lazy-regex = "2.5.0"

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -120,7 +120,7 @@ impl<'a, P> PackageGraphBuilder<'a, P> {
 impl<'a, T> PackageGraphBuilder<'a, T>
 where
     T: PackageDiscoveryBuilder,
-    T::Output: Send,
+    T::Output: Send + Sync,
     T::Error: Into<crate::package_manager::Error>,
 {
     /// Build the `PackageGraph`.
@@ -324,7 +324,7 @@ impl<'a, T: PackageDiscovery> BuildState<'a, ResolvedPackageManager, T> {
             workspace_graph,
             node_lookup,
             lockfile,
-            mut package_discovery,
+            package_discovery,
             ..
         } = self;
 
@@ -766,7 +766,7 @@ mod test {
     struct MockDiscovery;
     impl PackageDiscovery for MockDiscovery {
         async fn discover_packages(
-            &mut self,
+            &self,
         ) -> Result<crate::discovery::DiscoveryResponse, crate::discovery::Error> {
             Ok(crate::discovery::DiscoveryResponse {
                 package_manager: crate::package_manager::PackageManager::Npm,

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -455,7 +455,7 @@ mod test {
     struct MockDiscovery;
     impl PackageDiscovery for MockDiscovery {
         async fn discover_packages(
-            &mut self,
+            &self,
         ) -> Result<crate::discovery::DiscoveryResponse, crate::discovery::Error> {
             Ok(crate::discovery::DiscoveryResponse {
                 package_manager: PackageManager::Npm,

--- a/crates/turborepo-repository/src/package_json.rs
+++ b/crates/turborepo-repository/src/package_json.rs
@@ -55,6 +55,7 @@ pub enum Error {
 
 impl PackageJson {
     pub fn load(path: &AbsoluteSystemPath) -> Result<PackageJson, Error> {
+        tracing::debug!("loading package.json from {}", path);
         let contents = path.read_to_string()?;
         Self::from_str(&contents)
     }


### PR DESCRIPTION
### Description

This is a PR for speeding up the daemon startup and setting up good practices for differentiating between data and service dependencies. To clarify the difference, file watching _service_ should start up immediately in an unavailable state, while things that need it can immediately take dependencies on its 'potentially-available' data. This also has a side-effect of fixing up our package discovery watcher as it makes the data flow a lot cleaner and ensures that the daemon can report data is unavailable when it is recalculating (using [`FutureExt::now_or_never`](https://docs.rs/futures/latest/futures/future/trait.FutureExt.html#method.now_or_never)) as well as cascading unavailable when parts of the system are no longer up to date. If a dependency wishes to wait for the data, then it can do so by simply awaiting the future. Great we've reimplemented async salsa by hand... though our data-dependency-graph will probably not really ever be so large that it outgrows this DIY solution.

The part that specifically handles package discovery availability is demonstrated here:

https://github.com/vercel/turbo/blob/048d5f5ef313a705b22a37e3e83ff30952569faf/crates/turborepo-filewatch/src/package_watcher.rs#L589-L593

Downstream dependencies who attempt a 'now or never' request on the data will receive an empty value, which translates to package discovery being unavailable

https://github.com/vercel/turbo/blob/048d5f5ef313a705b22a37e3e83ff30952569faf/crates/turborepo-filewatch/src/package_watcher.rs#L43-L63

This mechanism also powers package hash discovery, which depends on multiple components all being active to produce accurate answers.

### Testing Instructions

Existing tests should suffice


Closes TURBO-2296