### PR TITLE
fix: check vercel token is still valid

### DIFF
--- a/crates/turborepo-auth/src/auth/login.rs
+++ b/crates/turborepo-auth/src/auth/login.rs
@@ -38,12 +38,10 @@ pub async fn login<T: Client>(options: &LoginOptions<'_, T>) -> Result<Token, Er
 
     // If the user is logging into Vercel, check for an existing `vc` token.
     if login_url_configuration.contains("vercel.com") {
+        // The extraction can return an error, but we don't want to fail the login if
+        // the token is not found.
         if let Ok(token) = extract_vercel_token() {
-            println!(
-                "{}",
-                ui.apply(BOLD.apply_to("Existing Vercel token found!"))
-            );
-            return Ok(Token::Existing(token));
+            return check_token(&token, ui, api_client, "Existing Vercel token found!").await;
         }
     }
 

--- a/turborepo-tests/integration/tests/command-login.t
+++ b/turborepo-tests/integration/tests/command-login.t
@@ -4,8 +4,3 @@ Setup
 Login Test Run
   $ ${TURBO} login --__test-run
   Login test run successful
-
-Login reuses Vercel CLI token
-  $ . ${TESTDIR}/../../helpers/mock_existing_login.sh
-  $ ${TURBO} login
-  Existing Vercel token found!


### PR DESCRIPTION
### Description
We should _at least_ check to see if the token we see in `com.vercel.cli` is able to fetch the user.


Closes TURBO-2300