### PR TITLE
feat(@turbo/repository): add affectedPackages API

### DIFF
--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -36,7 +36,7 @@ pub struct PackageGraph {
 /// There are other structs in this module that have "Workspace" in the name,
 /// but they do NOT follow the glossary, and instead mean "package" when they
 /// say Workspace. Some of these are labeled as such.
-#[derive(Eq, PartialEq, Hash)]
+#[derive(Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct WorkspacePackage {
     pub name: WorkspaceName,
     pub path: AnchoredSystemPathBuf,
@@ -91,6 +91,15 @@ type PackageVersion = String;
 pub enum WorkspaceName {
     Root,
     Other(String),
+}
+
+impl From<WorkspaceName> for String {
+    fn from(workspace_name: WorkspaceName) -> Self {
+        match workspace_name {
+            WorkspaceName::Root => ROOT_PKG_NAME.to_string(),
+            WorkspaceName::Other(name) => name,
+        }
+    }
 }
 
 impl Serialize for WorkspaceName {

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -91,15 +91,6 @@ pub enum WorkspaceName {
     Other(String),
 }
 
-impl From<WorkspaceName> for String {
-    fn from(workspace_name: WorkspaceName) -> Self {
-        match workspace_name {
-            WorkspaceName::Root => ROOT_PKG_NAME.to_string(),
-            WorkspaceName::Other(name) => name,
-        }
-    }
-}
-
 impl Serialize for WorkspaceName {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         match self {

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -36,7 +36,7 @@ pub struct PackageGraph {
 /// There are other structs in this module that have "Workspace" in the name,
 /// but they do NOT follow the glossary, and instead mean "package" when they
 /// say Workspace. Some of these are labeled as such.
-#[derive(Eq, PartialEq, Hash, Ord, PartialOrd)]
+#[derive(Eq, PartialEq, Hash)]
 pub struct WorkspacePackage {
     pub name: WorkspaceName,
     pub path: AnchoredSystemPathBuf,

--- a/packages/turbo-repository/__tests__/find.test.ts
+++ b/packages/turbo-repository/__tests__/find.test.ts
@@ -3,7 +3,7 @@ import { Workspace, Package, PackageManager } from "../js/dist/index.js";
 
 interface AffectedPackagesTestParams {
   files: string[];
-  expected: string[];
+  expected: Package[];
   description: string;
 }
 
@@ -40,17 +40,23 @@ describe("Workspace", () => {
     const tests: AffectedPackagesTestParams[] = [
       {
         files: ["apps/app/file.txt"],
-        expected: ["app-a"],
+        expected: [{ name: "app-a", relativePath: "apps/app" }],
         description: "app change",
       },
       {
         files: ["packages/ui/a.txt"],
-        expected: ["app-a", "ui"],
+        expected: [
+          { name: "app-a", relativePath: "apps/app" },
+          { name: "ui", relativePath: "packages/ui" },
+        ],
         description: "lib change",
       },
       {
         files: ["package.json"],
-        expected: ["app-a", "ui"],
+        expected: [
+          { name: "app-a", relativePath: "apps/app" },
+          { name: "ui", relativePath: "packges/ui" },
+        ],
         description: "global change",
       },
       {
@@ -66,7 +72,10 @@ describe("Workspace", () => {
         const { files, expected } = testParams;
         const dir = path.resolve(__dirname, "./fixtures/monorepo");
         const workspace = await Workspace.find(dir);
-        const changedPackages = await workspace.changedPackages(files);
+        let changedPackages = await workspace.changedPackages(files);
+        changedPackages = changedPackages.map((pkg) => {
+          return { name: pkg.name, relativePath: pkg.relativePath } as Package;
+        });
         expect(changedPackages).toEqual(expected);
       }
     );

--- a/packages/turbo-repository/__tests__/find.test.ts
+++ b/packages/turbo-repository/__tests__/find.test.ts
@@ -1,6 +1,12 @@
 import * as path from "node:path";
 import { Workspace, Package, PackageManager } from "../js/dist/index.js";
 
+interface AffectedPackagesTestParams {
+  files: string[];
+  expected: string[];
+  description: string;
+}
+
 describe("Workspace", () => {
   it("finds a workspace", async () => {
     const workspace = await Workspace.find();
@@ -28,5 +34,41 @@ describe("Workspace", () => {
       "apps/app": [],
       "packages/ui": ["apps/app"],
     });
+  });
+
+  describe("affectedPackages", () => {
+    const tests: AffectedPackagesTestParams[] = [
+      {
+        files: ["apps/app/file.txt"],
+        expected: ["app-a"],
+        description: "app change",
+      },
+      {
+        files: ["packages/ui/a.txt"],
+        expected: ["app-a", "ui"],
+        description: "lib change",
+      },
+      {
+        files: ["package.json"],
+        expected: ["app-a", "ui"],
+        description: "global change",
+      },
+      {
+        files: ["README.md"],
+        expected: [],
+        description: "global change that can be ignored",
+      },
+    ];
+
+    test.each(tests)(
+      "$description",
+      async (testParams: AffectedPackagesTestParams) => {
+        const { files, expected } = testParams;
+        const dir = path.resolve(__dirname, "./fixtures/monorepo");
+        const workspace = await Workspace.find(dir);
+        const changedPackages = await workspace.changedPackages(files);
+        expect(changedPackages).toEqual(expected);
+      }
+    );
   });
 });

--- a/packages/turbo-repository/__tests__/find.test.ts
+++ b/packages/turbo-repository/__tests__/find.test.ts
@@ -48,10 +48,7 @@ describe("Workspace", () => {
       {
         description: "lib change",
         files: ["packages/ui/a.txt"],
-        expected: [
-          // { name: "app-a", relativePath: "apps/app" }, // TODO: this should be included
-          { name: "ui", relativePath: "packages/ui" },
-        ],
+        expected: [{ name: "ui", relativePath: "packages/ui" }],
       },
       {
         description: "global change",

--- a/packages/turbo-repository/__tests__/find.test.ts
+++ b/packages/turbo-repository/__tests__/find.test.ts
@@ -49,7 +49,7 @@ describe("Workspace", () => {
         description: "lib change",
         files: ["packages/ui/a.txt"],
         expected: [
-          { name: "app-a", relativePath: "apps/app" },
+          // { name: "app-a", relativePath: "apps/app" }, // TODO: this should be included
           { name: "ui", relativePath: "packages/ui" },
         ],
       },
@@ -74,8 +74,9 @@ describe("Workspace", () => {
         const { files, expected } = testParams;
         const dir = path.resolve(__dirname, "./fixtures/monorepo");
         const workspace = await Workspace.find(dir);
-        let changedPackages = await workspace.changedPackages(files);
-        const reduced: PackageReduced[] = changedPackages.map((pkg) => {
+        const reduced: PackageReduced[] = (
+          await workspace.affectedPackages(files)
+        ).map((pkg) => {
           return {
             name: pkg.name,
             relativePath: pkg.relativePath,

--- a/packages/turbo-repository/__tests__/find.test.ts
+++ b/packages/turbo-repository/__tests__/find.test.ts
@@ -1,9 +1,11 @@
 import * as path from "node:path";
 import { Workspace, Package, PackageManager } from "../js/dist/index.js";
 
+type PackageReduced = Pick<Package, "name" | "relativePath">;
+
 interface AffectedPackagesTestParams {
   files: string[];
-  expected: Package[];
+  expected: PackageReduced[];
   description: string;
 }
 
@@ -39,30 +41,30 @@ describe("Workspace", () => {
   describe("affectedPackages", () => {
     const tests: AffectedPackagesTestParams[] = [
       {
+        description: "app change",
         files: ["apps/app/file.txt"],
         expected: [{ name: "app-a", relativePath: "apps/app" }],
-        description: "app change",
       },
       {
+        description: "lib change",
         files: ["packages/ui/a.txt"],
         expected: [
           { name: "app-a", relativePath: "apps/app" },
           { name: "ui", relativePath: "packages/ui" },
         ],
-        description: "lib change",
       },
       {
+        description: "global change",
         files: ["package.json"],
         expected: [
           { name: "app-a", relativePath: "apps/app" },
-          { name: "ui", relativePath: "packges/ui" },
+          { name: "ui", relativePath: "packages/ui" },
         ],
-        description: "global change",
       },
       {
+        description: "global change that can be ignored",
         files: ["README.md"],
         expected: [],
-        description: "global change that can be ignored",
       },
     ];
 
@@ -73,10 +75,14 @@ describe("Workspace", () => {
         const dir = path.resolve(__dirname, "./fixtures/monorepo");
         const workspace = await Workspace.find(dir);
         let changedPackages = await workspace.changedPackages(files);
-        changedPackages = changedPackages.map((pkg) => {
-          return { name: pkg.name, relativePath: pkg.relativePath } as Package;
+        const reduced: PackageReduced[] = changedPackages.map((pkg) => {
+          return {
+            name: pkg.name,
+            relativePath: pkg.relativePath,
+          };
         });
-        expect(changedPackages).toEqual(expected);
+
+        expect(reduced).toEqual(expected);
       }
     );
   });

--- a/packages/turbo-repository/js/index.d.ts
+++ b/packages/turbo-repository/js/index.d.ts
@@ -35,7 +35,9 @@ export class Workspace {
   findPackagesAndDependents(): Promise<Record<string, Array<string>>>;
   /**
    * Given a set of "changed" files, returns a set of packages that are
-   * "affected" by the changes.
+   * "affected" by the changes. The `files` argument is expected to be a list
+   * of strings relative to the monorepo root and use the current system's
+   * path separator.
    */
   affectedPackages(files: Array<string>): Promise<Array<Package>>;
 }

--- a/packages/turbo-repository/js/index.d.ts
+++ b/packages/turbo-repository/js/index.d.ts
@@ -33,4 +33,5 @@ export class Workspace {
    * dependents (i.e. the packages that depend on each of those packages).
    */
   findPackagesAndDependents(): Promise<Record<string, Array<string>>>;
+  changedPackages(files: Array<string>): Promise<Array<string>>;
 }

--- a/packages/turbo-repository/js/index.d.ts
+++ b/packages/turbo-repository/js/index.d.ts
@@ -33,5 +33,5 @@ export class Workspace {
    * dependents (i.e. the packages that depend on each of those packages).
    */
   findPackagesAndDependents(): Promise<Record<string, Array<string>>>;
-  changedPackages(files: Array<string>): Promise<Array<string>>;
+  changedPackages(files: Array<string>): Promise<Array<Package>>;
 }

--- a/packages/turbo-repository/js/index.d.ts
+++ b/packages/turbo-repository/js/index.d.ts
@@ -33,5 +33,5 @@ export class Workspace {
    * dependents (i.e. the packages that depend on each of those packages).
    */
   findPackagesAndDependents(): Promise<Record<string, Array<string>>>;
-  changedPackages(files: Array<string>): Promise<Array<Package>>;
+  affectedPackages(files: Array<string>): Promise<Array<Package>>;
 }

--- a/packages/turbo-repository/js/index.d.ts
+++ b/packages/turbo-repository/js/index.d.ts
@@ -33,5 +33,9 @@ export class Workspace {
    * dependents (i.e. the packages that depend on each of those packages).
    */
   findPackagesAndDependents(): Promise<Record<string, Array<string>>>;
+  /**
+   * Given a set of "changed" files, returns a set of packages that are
+   * "affected" by the changes.
+   */
   affectedPackages(files: Array<string>): Promise<Array<Package>>;
 }

--- a/packages/turbo-repository/rust/src/lib.rs
+++ b/packages/turbo-repository/rust/src/lib.rs
@@ -150,10 +150,7 @@ impl Workspace {
             .filter_map(|path| {
                 let path_components = path.split(std::path::MAIN_SEPARATOR).collect::<Vec<&str>>();
                 let absolute_path = workspace_root.join_components(&path_components);
-                match workspace_root.anchor(&absolute_path) {
-                    Ok(path) => Some(path),
-                    Err(_) => None,
-                }
+               workspace_root.anchor(&absolute_path).ok()
             })
             .collect();
 

--- a/packages/turbo-repository/rust/src/lib.rs
+++ b/packages/turbo-repository/rust/src/lib.rs
@@ -179,7 +179,7 @@ impl Workspace {
                 let package_path = workspace_root.resolve(&p.path);
                 Package::new(p.name.to_string(), &workspace_root, &package_path)
             })
-            .filter(|p| p.name != ROOT_PKG_NAME.to_string())
+            .filter(|p| p.name != ROOT_PKG_NAME)
             .collect();
 
         serializable_packages.sort();

--- a/packages/turbo-repository/rust/src/lib.rs
+++ b/packages/turbo-repository/rust/src/lib.rs
@@ -14,7 +14,7 @@ use turborepo_repository::{
 mod internal;
 
 #[napi]
-#[derive(PartialEq, Eq, Hash, Clone, Ord, PartialOrd)]
+#[derive(PartialEq, Eq, Hash, Clone)]
 pub struct Package {
     pub name: String,
     /// The absolute path to the package root.

--- a/packages/turbo-repository/rust/src/lib.rs
+++ b/packages/turbo-repository/rust/src/lib.rs
@@ -149,12 +149,12 @@ impl Workspace {
 
         let hash_set_of_paths: HashSet<AnchoredSystemPathBuf> = files
             .into_iter()
-            .filter_map(|s| {
-                let split = s.split(std::path::MAIN_SEPARATOR).collect::<Vec<&str>>();
-                let xx = workspace_root.join_components(&split);
-                match workspace_root.anchor(&xx) {
+            .filter_map(|path| {
+                let path_components = path.split(std::path::MAIN_SEPARATOR).collect::<Vec<&str>>();
+                let absolute_path = workspace_root.join_components(&path_components);
+                match workspace_root.anchor(&absolute_path) {
                     Ok(path) => Some(path),
-                    Err(e) => None,
+                    Err(_) => None,
                 }
             })
             .collect();

--- a/packages/turbo-repository/rust/src/lib.rs
+++ b/packages/turbo-repository/rust/src/lib.rs
@@ -171,16 +171,6 @@ impl Workspace {
                     path: info.package_path().to_owned(),
                 })
                 .collect::<Vec<WorkspacePackage>>(),
-            // PackageChanges::All => self
-            //     .find_packages()
-            //     .await
-            //     .unwrap_or_else(|_| vec![])
-            //     .into_iter()
-            //     .map(|p| WorkspacePackage {
-            //         name: WorkspaceName::Other(p.name),
-            //         path: AnchoredSystemPathBuf::new(p.relative_path),
-            //     })
-            //     .collect::<Vec<WorkspacePackage>>(),
             PackageChanges::Some(packages) => packages.into_iter().collect(),
         };
 

--- a/packages/turbo-repository/rust/src/lib.rs
+++ b/packages/turbo-repository/rust/src/lib.rs
@@ -137,7 +137,9 @@ impl Workspace {
     }
 
     /// Given a set of "changed" files, returns a set of packages that are
-    /// "affected" by the changes.
+    /// "affected" by the changes. The `files` argument is expected to be a list
+    /// of strings relative to the monorepo root and use the current system's
+    /// path separator.
     #[napi]
     pub async fn affected_packages(&self, files: Vec<String>) -> Result<Vec<Package>, Error> {
         let workspace_root = match AbsoluteSystemPath::new(&self.absolute_path) {

--- a/packages/turbo-repository/rust/src/lib.rs
+++ b/packages/turbo-repository/rust/src/lib.rs
@@ -140,8 +140,6 @@ impl Workspace {
     /// "affected" by the changes.
     #[napi]
     pub async fn affected_packages(&self, files: Vec<String>) -> Result<Vec<Package>, Error> {
-        let mapper = ChangeMapper::new(&self.graph, vec![], vec![]);
-
         let workspace_root = match AbsoluteSystemPath::new(&self.absolute_path) {
             Ok(path) => path,
             Err(e) => return Err(Error::from_reason(e.to_string())),
@@ -159,6 +157,8 @@ impl Workspace {
             })
             .collect();
 
+        // Create a ChangeMapper with no custom global deps or ignore patterns
+        let mapper = ChangeMapper::new(&self.graph, vec![], vec![]);
         let package_changes = match mapper.changed_packages(hash_set_of_paths, None) {
             Ok(changes) => changes,
             Err(e) => return Err(Error::from_reason(e.to_string())),

--- a/packages/turbo-repository/rust/src/lib.rs
+++ b/packages/turbo-repository/rust/src/lib.rs
@@ -136,6 +136,8 @@ impl Workspace {
         Ok(map)
     }
 
+    /// Given a set of "changed" files, returns a set of packages that are
+    /// "affected" by the changes.
     #[napi]
     pub async fn affected_packages(&self, files: Vec<String>) -> Result<Vec<Package>, Error> {
         let mapper = ChangeMapper::new(&self.graph, vec![], vec![]);

--- a/packages/turbo-repository/rust/src/lib.rs
+++ b/packages/turbo-repository/rust/src/lib.rs
@@ -187,7 +187,7 @@ impl Workspace {
             })
             .collect();
 
-        serializable_packages.sort();
+        serializable_packages.sort_by_key(|p| p.name.clone());
 
         Ok(serializable_packages)
     }

--- a/packages/turbo-repository/rust/src/lib.rs
+++ b/packages/turbo-repository/rust/src/lib.rs
@@ -137,7 +137,7 @@ impl Workspace {
     }
 
     #[napi]
-    pub async fn changed_packages(&self, files: Vec<String>) -> Result<Vec<Package>, Error> {
+    pub async fn affected_packages(&self, files: Vec<String>) -> Result<Vec<Package>, Error> {
         let mapper = ChangeMapper::new(&self.graph, vec![], vec![]);
 
         let workspace_root = match AbsoluteSystemPath::new(&self.absolute_path) {

--- a/packages/turbo-repository/rust/src/lib.rs
+++ b/packages/turbo-repository/rust/src/lib.rs
@@ -14,7 +14,7 @@ use turborepo_repository::{
 mod internal;
 
 #[napi]
-#[derive(PartialEq, Eq, Hash, Clone)]
+#[derive(PartialEq, Eq, Hash, Clone, Ord, PartialOrd)]
 pub struct Package {
     pub name: String,
     /// The absolute path to the package root.
@@ -174,13 +174,16 @@ impl Workspace {
             PackageChanges::Some(packages) => packages.into_iter().collect(),
         };
 
-        let serializable_packages = packages
+        let mut serializable_packages: Vec<Package> = packages
             .into_iter()
             .map(|p| {
                 let package_path = workspace_root.resolve(&p.path);
                 Package::new(p.name.to_string(), &workspace_root, &package_path)
             })
+            .filter(|p| p.name != "//")
             .collect();
+
+        serializable_packages.sort();
 
         Ok(serializable_packages)
     }

--- a/packages/turbo-repository/rust/src/lib.rs
+++ b/packages/turbo-repository/rust/src/lib.rs
@@ -9,7 +9,7 @@ use turbopath::{AbsoluteSystemPath, AnchoredSystemPathBuf};
 use turborepo_repository::{
     change_mapper::{ChangeMapper, PackageChanges},
     inference::RepoState as WorkspaceState,
-    package_graph::{PackageGraph, WorkspaceName, WorkspaceNode, WorkspacePackage},
+    package_graph::{PackageGraph, WorkspaceName, WorkspaceNode, WorkspacePackage, ROOT_PKG_NAME},
 };
 mod internal;
 
@@ -182,7 +182,7 @@ impl Workspace {
                 let package_path = workspace_root.resolve(&p.path);
                 Package::new(p.name.to_string(), &workspace_root, &package_path)
             })
-            .filter(|p| p.name != "//")
+            .filter(|p| p.name != ROOT_PKG_NAME.to_string())
             .collect();
 
         serializable_packages.sort();

--- a/packages/turbo-repository/rust/src/lib.rs
+++ b/packages/turbo-repository/rust/src/lib.rs
@@ -175,6 +175,10 @@ impl Workspace {
 
         let mut serializable_packages: Vec<Package> = packages
             .into_iter()
+            .filter(|p| match &p.name {
+                WorkspaceName::Root => false,
+                WorkspaceName::Other(name) => name != ROOT_PKG_NAME,
+            })
             .map(|p| {
                 let package_path = workspace_root.resolve(&p.path);
                 Package::new(p.name.to_string(), &workspace_root, &package_path)

--- a/packages/turbo-repository/rust/src/lib.rs
+++ b/packages/turbo-repository/rust/src/lib.rs
@@ -150,7 +150,7 @@ impl Workspace {
             .filter_map(|path| {
                 let path_components = path.split(std::path::MAIN_SEPARATOR).collect::<Vec<&str>>();
                 let absolute_path = workspace_root.join_components(&path_components);
-               workspace_root.anchor(&absolute_path).ok()
+                workspace_root.anchor(&absolute_path).ok()
             })
             .collect();
 
@@ -183,7 +183,6 @@ impl Workspace {
                 let package_path = workspace_root.resolve(&p.path);
                 Package::new(p.name.to_string(), &workspace_root, &package_path)
             })
-            .filter(|p| p.name != ROOT_PKG_NAME)
             .collect();
 
         serializable_packages.sort();


### PR DESCRIPTION
This API maps a list of files (strings anchored to the root of the workspace) to a set of packages that were affected by that change. This will include the packages the files belong to ~~as well as an dependents~~.

Since this doesn't include dependents, users will have to use it with `findPackagesAndDependents()` API:

```js
const files = [/*...*/];
const w = await new Workspace(".");
const [reverseGraph, affected] = await Promise.all([
  w.findPackagesAndDependents(),
  w.affectedPackages(files);
]);

// For each affected package, include all the dependents as well.
// Use a set to avoid dupes.
const allAffected = new Set(affected);
for (const p of affected) {
  reverseGraph[p].forEach(x => allAffected.add(x));
}

return [...allAffected] // spread into an array
```