### PR TITLE
fix(Turborepo): Pass validated globs to daemon for watching

### DIFF
--- a/crates/turborepo-lib/src/daemon/client.rs
+++ b/crates/turborepo-lib/src/daemon/client.rs
@@ -72,7 +72,7 @@ impl<T> DaemonClient<T> {
     pub async fn get_changed_outputs(
         &mut self,
         hash: String,
-        output_globs: &Vec<ValidatedGlob>,
+        output_globs: &[ValidatedGlob],
     ) -> Result<Vec<String>, DaemonError> {
         let output_globs = output_globs
             .iter()
@@ -89,8 +89,8 @@ impl<T> DaemonClient<T> {
     pub async fn notify_outputs_written(
         &mut self,
         hash: String,
-        output_globs: &Vec<ValidatedGlob>,
-        output_exclusion_globs: &Vec<ValidatedGlob>,
+        output_globs: &[ValidatedGlob],
+        output_exclusion_globs: &[ValidatedGlob],
         time_saved: u64,
     ) -> Result<(), DaemonError> {
         let output_globs = output_globs

--- a/crates/turborepo-lib/src/daemon/client.rs
+++ b/crates/turborepo-lib/src/daemon/client.rs
@@ -72,11 +72,11 @@ impl<T> DaemonClient<T> {
     pub async fn get_changed_outputs(
         &mut self,
         hash: String,
-        output_globs: Vec<String>,
+        output_globs: &Vec<ValidatedGlob>,
     ) -> Result<Vec<String>, DaemonError> {
         let output_globs = output_globs
             .iter()
-            .map(|raw_glob| format_repo_relative_glob(raw_glob))
+            .map(|validated_glob| validated_glob.as_str().to_string())
             .collect();
         Ok(self
             .client
@@ -89,8 +89,8 @@ impl<T> DaemonClient<T> {
     pub async fn notify_outputs_written(
         &mut self,
         hash: String,
-        output_globs: Vec<ValidatedGlob>,
-        output_exclusion_globs: Vec<ValidatedGlob>,
+        output_globs: &Vec<ValidatedGlob>,
+        output_exclusion_globs: &Vec<ValidatedGlob>,
         time_saved: u64,
     ) -> Result<(), DaemonError> {
         let output_globs = output_globs

--- a/crates/turborepo-lib/src/daemon/client.rs
+++ b/crates/turborepo-lib/src/daemon/client.rs
@@ -1,5 +1,6 @@
 use std::io;
 
+use globwalk::ValidatedGlob;
 use thiserror::Error;
 use tonic::{Code, Status};
 use tracing::info;
@@ -88,17 +89,17 @@ impl<T> DaemonClient<T> {
     pub async fn notify_outputs_written(
         &mut self,
         hash: String,
-        output_globs: Vec<String>,
-        output_exclusion_globs: Vec<String>,
+        output_globs: Vec<ValidatedGlob>,
+        output_exclusion_globs: Vec<ValidatedGlob>,
         time_saved: u64,
     ) -> Result<(), DaemonError> {
         let output_globs = output_globs
             .iter()
-            .map(|raw_glob| format_repo_relative_glob(raw_glob))
+            .map(|validated_glob| validated_glob.as_str().to_string())
             .collect();
         let output_exclusion_globs = output_exclusion_globs
             .iter()
-            .map(|raw_glob| format_repo_relative_glob(raw_glob))
+            .map(|validated_glob| validated_glob.as_str().to_string())
             .collect();
         self.client
             .notify_outputs_written(proto::NotifyOutputsWrittenRequest {

--- a/crates/turborepo-lib/src/run/cache.rs
+++ b/crates/turborepo-lib/src/run/cache.rs
@@ -247,11 +247,15 @@ impl TaskCache {
             self.expanded_outputs = restored_files;
 
             if let Some(daemon_client) = &mut self.daemon_client {
+                // Do we want to error the process if we can't parse the globs? We probably
+                // won't have even gotten this far if this fails...
+                let validated_inclusions = self.repo_relative_globs.validated_inclusions()?;
+                let validated_exclusions = self.repo_relative_globs.validated_exclusions()?;
                 if let Err(err) = daemon_client
                     .notify_outputs_written(
                         self.hash.clone(),
-                        self.repo_relative_globs.inclusions.clone(),
-                        self.repo_relative_globs.exclusions.clone(),
+                        validated_inclusions,
+                        validated_exclusions,
                         cache_hit_metadata.time_saved,
                     )
                     .await
@@ -314,10 +318,12 @@ impl TaskCache {
 
         debug!("caching outputs: outputs: {:?}", &self.repo_relative_globs);
 
+        let validated_inclusions = self.repo_relative_globs.validated_inclusions()?;
+        let validated_exclusions = self.repo_relative_globs.validated_exclusions()?;
         let files_to_be_cached = globwalk::globwalk(
             &self.run_cache.repo_root,
-            &self.repo_relative_globs.validated_inclusions()?,
-            &self.repo_relative_globs.validated_exclusions()?,
+            &validated_inclusions,
+            &validated_exclusions,
             globwalk::WalkType::All,
         )?;
 
@@ -342,8 +348,8 @@ impl TaskCache {
             let notify_result = daemon_client
                 .notify_outputs_written(
                     self.hash.to_string(),
-                    self.repo_relative_globs.inclusions.clone(),
-                    self.repo_relative_globs.exclusions.clone(),
+                    validated_inclusions,
+                    validated_exclusions,
                     duration.as_millis() as u64,
                 )
                 .await

--- a/crates/turborepo-lib/src/run/cache.rs
+++ b/crates/turborepo-lib/src/run/cache.rs
@@ -195,12 +195,11 @@ impl TaskCache {
             return Ok(None);
         }
 
+        let validated_inclusions = self.repo_relative_globs.validated_inclusions()?;
+
         let changed_output_count = if let Some(daemon_client) = &mut self.daemon_client {
             match daemon_client
-                .get_changed_outputs(
-                    self.hash.to_string(),
-                    self.repo_relative_globs.inclusions.clone(),
-                )
+                .get_changed_outputs(self.hash.to_string(), &validated_inclusions)
                 .await
             {
                 Ok(changed_output_globs) => changed_output_globs.len(),
@@ -249,13 +248,12 @@ impl TaskCache {
             if let Some(daemon_client) = &mut self.daemon_client {
                 // Do we want to error the process if we can't parse the globs? We probably
                 // won't have even gotten this far if this fails...
-                let validated_inclusions = self.repo_relative_globs.validated_inclusions()?;
                 let validated_exclusions = self.repo_relative_globs.validated_exclusions()?;
                 if let Err(err) = daemon_client
                     .notify_outputs_written(
                         self.hash.clone(),
-                        validated_inclusions,
-                        validated_exclusions,
+                        &validated_inclusions,
+                        &validated_exclusions,
                         cache_hit_metadata.time_saved,
                     )
                     .await
@@ -348,8 +346,8 @@ impl TaskCache {
             let notify_result = daemon_client
                 .notify_outputs_written(
                     self.hash.to_string(),
-                    validated_inclusions,
-                    validated_exclusions,
+                    &validated_inclusions,
+                    &validated_exclusions,
                     duration.as_millis() as u64,
                 )
                 .await


### PR DESCRIPTION
### Description

 - Change type signature on daemon client to require `ValidatedGlob` instances be passed
 - Add some debug logging to `GlobTracker` about what globs we are tracking and what file paths invalidate a glob

### Testing Instructions

Existing test suite

Fixes #7131 

Closes TURBO-2301