### PR TITLE
chore: modularize vercel api crate

### DIFF
--- a/crates/turborepo-api-client/src/telemetry.rs
+++ b/crates/turborepo-api-client/src/telemetry.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use reqwest::Method;
-use turborepo_vercel_api::TelemetryEvent;
+use turborepo_vercel_api::telemetry::TelemetryEvent;
 
 use crate::{retry, AnonAPIClient, Error};
 

--- a/crates/turborepo-telemetry/src/events/command.rs
+++ b/crates/turborepo-telemetry/src/events/command.rs
@@ -1,7 +1,7 @@
 use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
-use turborepo_vercel_api::{TelemetryCommandEvent, TelemetryEvent};
+use turborepo_vercel_api::telemetry::{TelemetryCommandEvent, TelemetryEvent};
 use uuid::Uuid;
 
 use super::{Event, EventBuilder, EventType, Identifiable};

--- a/crates/turborepo-telemetry/src/events/generic.rs
+++ b/crates/turborepo-telemetry/src/events/generic.rs
@@ -1,7 +1,7 @@
 use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
-use turborepo_vercel_api::{TelemetryEvent, TelemetryGenericEvent};
+use turborepo_vercel_api::telemetry::{TelemetryEvent, TelemetryGenericEvent};
 use uuid::Uuid;
 
 use super::{Event, EventBuilder, EventType, Identifiable, TrackedErrors};

--- a/crates/turborepo-telemetry/src/events/mod.rs
+++ b/crates/turborepo-telemetry/src/events/mod.rs
@@ -12,7 +12,7 @@ pub mod task;
 /// These events must be added to the backend (telemetry.vercel.com)
 /// before they can be tracked - invalid or unknown events will be
 /// ignored.
-pub use turborepo_vercel_api::TelemetryEvent;
+pub use turborepo_vercel_api::telemetry::TelemetryEvent;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum EventType {

--- a/crates/turborepo-telemetry/src/events/repo.rs
+++ b/crates/turborepo-telemetry/src/events/repo.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use turborepo_vercel_api::{TelemetryEvent, TelemetryRepoEvent};
+use turborepo_vercel_api::telemetry::{TelemetryEvent, TelemetryRepoEvent};
 use uuid::Uuid;
 
 use super::{Event, EventBuilder, EventType, Identifiable};

--- a/crates/turborepo-telemetry/src/events/task.rs
+++ b/crates/turborepo-telemetry/src/events/task.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use turborepo_vercel_api::{TelemetryEvent, TelemetryTaskEvent};
+use turborepo_vercel_api::telemetry::{TelemetryEvent, TelemetryTaskEvent};
 use uuid::Uuid;
 
 use super::{Event, EventBuilder, EventType, Identifiable, TrackedErrors};

--- a/crates/turborepo-telemetry/src/lib.rs
+++ b/crates/turborepo-telemetry/src/lib.rs
@@ -262,7 +262,7 @@ mod tests {
     };
     use turborepo_api_client::telemetry::TelemetryClient;
     use turborepo_ui::UI;
-    use turborepo_vercel_api::{TelemetryEvent, TelemetryGenericEvent};
+    use turborepo_vercel_api::telemetry::{TelemetryEvent, TelemetryGenericEvent};
 
     use crate::init;
 

--- a/crates/turborepo-vercel-api/src/lib.rs
+++ b/crates/turborepo-vercel-api/src/lib.rs
@@ -3,6 +3,8 @@
 //! mock server (`turborepo-vercel-api-mock`)
 use serde::{Deserialize, Serialize};
 use url::Url;
+pub mod telemetry;
+pub mod token;
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct VerifiedSsoUser {
@@ -156,58 +158,6 @@ impl AnalyticsEvent {
     pub fn set_session_id(&mut self, id: String) {
         self.session_id = Some(id);
     }
-}
-
-// telemetry events
-
-/// All possible telemetry events must be included in this enum.
-///
-/// These events must be added to the backend (telemetry.vercel.com)
-/// before they can be tracked - invalid or unknown events will be
-/// ignored.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub enum TelemetryEvent {
-    Task(TelemetryTaskEvent),
-    Command(TelemetryCommandEvent),
-    Repo(TelemetryRepoEvent),
-    Generic(TelemetryGenericEvent),
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TelemetryCommandEvent {
-    pub id: String,
-    pub command: String,
-    pub key: String,
-    pub value: String,
-    pub parent_id: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TelemetryRepoEvent {
-    pub id: String,
-    pub repo: String,
-    pub key: String,
-    pub value: String,
-    pub parent_id: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TelemetryTaskEvent {
-    pub id: String,
-    pub package: String,
-    pub task: String,
-    pub key: String,
-    pub value: String,
-    pub parent_id: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TelemetryGenericEvent {
-    pub id: String,
-    pub key: String,
-    pub value: String,
-    pub parent_id: Option<String>,
 }
 
 #[cfg(test)]

--- a/crates/turborepo-vercel-api/src/telemetry.rs
+++ b/crates/turborepo-vercel-api/src/telemetry.rs
@@ -1,0 +1,53 @@
+// telemetry events
+
+use serde::{Deserialize, Serialize};
+
+/// All possible telemetry events must be included in this enum.
+///
+/// These events must be added to the backend (telemetry.vercel.com)
+/// before they can be tracked - invalid or unknown events will be
+/// ignored.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum TelemetryEvent {
+    Task(TelemetryTaskEvent),
+    Command(TelemetryCommandEvent),
+    Repo(TelemetryRepoEvent),
+    Generic(TelemetryGenericEvent),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TelemetryCommandEvent {
+    pub id: String,
+    pub command: String,
+    pub key: String,
+    pub value: String,
+    pub parent_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TelemetryRepoEvent {
+    pub id: String,
+    pub repo: String,
+    pub key: String,
+    pub value: String,
+    pub parent_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TelemetryTaskEvent {
+    pub id: String,
+    pub package: String,
+    pub task: String,
+    pub key: String,
+    pub value: String,
+    pub parent_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TelemetryGenericEvent {
+    pub id: String,
+    pub key: String,
+    pub value: String,
+    pub parent_id: Option<String>,
+}

--- a/crates/turborepo-vercel-api/src/token.rs
+++ b/crates/turborepo-vercel-api/src/token.rs
@@ -1,0 +1,28 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResponseTokenMetadata {
+    id: String,
+    name: String,
+    #[serde(rename = "type")]
+    token_type: String,
+    origin: String,
+    scopes: Vec<Scope>,
+    #[serde(rename = "activeAt")]
+    active_at: u64,
+    #[serde(rename = "createdAt")]
+    created_at: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Scope {
+    #[serde(rename = "type")]
+    scope_type: String,
+    origin: String,
+    #[serde(rename = "createdAt")]
+    created_at: u64,
+    #[serde(rename = "expiresAt")]
+    expires_at: Option<u64>,
+    #[serde(rename = "teamId")]
+    team_id: Option<String>,
+}


### PR DESCRIPTION
### Description
I think it's logical to group the kinds of Vercel responses into their own files, keeping generic stuff in `lib.rs`.


Closes TURBO-2303