### PR TITLE
feat(Turborepo): Add spaces_id to layered config

### DIFF
--- a/crates/turborepo-lib/src/commands/info.rs
+++ b/crates/turborepo-lib/src/commands/info.rs
@@ -14,10 +14,42 @@ use turborepo_ui::GREY;
 
 use crate::{cli, commands::CommandBase, config::ConfigurationOptions};
 
-//#[derive(Serialize)]
-//#[serde(rename_all = "camelCase")]
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct InfoConfig {
+    api_url: Option<String>,
+    login_url: Option<String>,
+    team_slug: Option<String>,
+    team_id: Option<String>,
+    token: Option<String>,
+    signature: Option<bool>,
+    preflight: Option<bool>,
+    timeout: Option<u64>,
+    enabled: Option<bool>,
+    spaces_id: Option<String>,
+}
+
+impl<'a> From<&'a ConfigurationOptions> for InfoConfig {
+    fn from(config: &'a ConfigurationOptions) -> Self {
+        Self {
+            api_url: config.api_url.clone(),
+            login_url: config.login_url.clone(),
+            team_slug: config.team_slug.clone(),
+            team_id: config.team_id.clone(),
+            token: config.token.clone(),
+            signature: config.signature,
+            preflight: config.preflight,
+            timeout: config.timeout,
+            enabled: config.enabled,
+            spaces_id: config.spaces_id.clone(),
+        }
+    }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 struct RepositoryDetails<'a> {
-    config: &'a ConfigurationOptions,
+    config: InfoConfig,
     package_manager: &'a PackageManager,
     workspaces: Vec<(&'a WorkspaceName, RepositoryWorkspaceDetails<'a>)>,
 }
@@ -57,7 +89,7 @@ pub async fn run(
     } else {
         let repo_details = RepositoryDetails::new(&package_graph, config);
         if json {
-            //println!("{}", serde_json::to_string_pretty(&repo_details)?);
+            println!("{}", serde_json::to_string_pretty(&repo_details)?);
         } else {
             repo_details.print()?;
         }
@@ -81,7 +113,7 @@ impl<'a> RepositoryDetails<'a> {
         workspaces.sort_by(|a, b| a.0.cmp(b.0));
 
         Self {
-            config,
+            config: config.into(),
             package_manager: package_graph.package_manager(),
             workspaces,
         }

--- a/crates/turborepo-lib/src/commands/info.rs
+++ b/crates/turborepo-lib/src/commands/info.rs
@@ -14,8 +14,8 @@ use turborepo_ui::GREY;
 
 use crate::{cli, commands::CommandBase, config::ConfigurationOptions};
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
+//#[derive(Serialize)]
+//#[serde(rename_all = "camelCase")]
 struct RepositoryDetails<'a> {
     config: &'a ConfigurationOptions,
     package_manager: &'a PackageManager,
@@ -57,7 +57,7 @@ pub async fn run(
     } else {
         let repo_details = RepositoryDetails::new(&package_graph, config);
         if json {
-            println!("{}", serde_json::to_string_pretty(&repo_details)?);
+            //println!("{}", serde_json::to_string_pretty(&repo_details)?);
         } else {
             repo_details.print()?;
         }

--- a/crates/turborepo-lib/src/commands/run.rs
+++ b/crates/turborepo-lib/src/commands/run.rs
@@ -31,7 +31,7 @@ pub async fn run(base: CommandBase, telemetry: CommandEventBuilder) -> Result<i3
 
     let api_auth = base.api_auth()?;
     let api_client = base.api_client()?;
-    let mut run = Run::new(base, api_auth)?;
+    let run = Run::new(base, api_auth)?;
     let run_fut = run.run(&handler, telemetry, api_client);
     let handler_fut = handler.done();
     tokio::select! {

--- a/crates/turborepo-lib/src/config.rs
+++ b/crates/turborepo-lib/src/config.rs
@@ -135,7 +135,7 @@ const DEFAULT_API_URL: &str = "https://vercel.com/api";
 const DEFAULT_LOGIN_URL: &str = "https://vercel.com";
 const DEFAULT_TIMEOUT: u64 = 30;
 
-#[derive(Serialize, Deserialize, Default, Debug, PartialEq, Eq, Clone, Iterable)]
+#[derive(Deserialize, Default, Debug, PartialEq, Eq, Clone, Iterable)]
 #[serde(rename_all = "camelCase")]
 pub struct ConfigurationOptions {
     #[serde(alias = "apiurl")]
@@ -244,8 +244,8 @@ impl ResolvedConfigurationOptions for PackageJson {
 
 impl ResolvedConfigurationOptions for RawTurboJson {
     fn get_configuration_options(self) -> Result<ConfigurationOptions, Error> {
-        let mut opts = if let Some(configuration_options) = &self.remote_cache {
-            configuration_options.clone()
+        let mut opts = if let Some(remote_cache_options) = &self.remote_cache {
+            remote_cache_options.into()
         } else {
             ConfigurationOptions::default()
         };

--- a/crates/turborepo-lib/src/config.rs
+++ b/crates/turborepo-lib/src/config.rs
@@ -585,6 +585,9 @@ impl TurborepoConfigBuilder {
                     if let Some(timeout) = current_source_config.timeout {
                         acc.timeout = Some(timeout);
                     }
+                    if let Some(spaces_id) = current_source_config.spaces_id {
+                        acc.spaces_id = Some(spaces_id);
+                    }
 
                     acc
                 })
@@ -691,11 +694,17 @@ mod test {
 
     #[test]
     fn test_env_layering() {
-        let repo_root = AbsoluteSystemPathBuf::try_from(TempDir::new().unwrap().path()).unwrap();
+        let tmp_dir = TempDir::new().unwrap();
+        let repo_root = AbsoluteSystemPathBuf::try_from(tmp_dir.path()).unwrap();
         let global_config_path = AbsoluteSystemPathBuf::try_from(
             TempDir::new().unwrap().path().join("nonexistent.json"),
         )
         .unwrap();
+
+        repo_root
+            .join_component("turbo.json")
+            .create_with_contents(r#"{"experimentalSpaces": {"id": "my-spaces-id"}}"#)
+            .unwrap();
 
         let turbo_teamid = "team_nLlpyC6REAqxydlFKbrMDlud";
         let turbo_token = "abcdef1234567890abcdef";
@@ -730,6 +739,7 @@ mod test {
         let config = builder.build().unwrap();
         assert_eq!(config.team_id().unwrap(), vercel_artifacts_owner);
         assert_eq!(config.token().unwrap(), vercel_artifacts_token);
+        assert_eq!(config.spaces_id().unwrap(), "my-spaces-id");
     }
 
     #[test]

--- a/crates/turborepo-lib/src/config.rs
+++ b/crates/turborepo-lib/src/config.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, ffi::OsString, io};
 
 use convert_case::{Case, Casing};
 use miette::{Diagnostic, SourceSpan};
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use struct_iterable::Iterable;
 use thiserror::Error;
 use turbopath::{AbsoluteSystemPathBuf, AnchoredSystemPath};
@@ -135,6 +135,9 @@ const DEFAULT_API_URL: &str = "https://vercel.com/api";
 const DEFAULT_LOGIN_URL: &str = "https://vercel.com";
 const DEFAULT_TIMEOUT: u64 = 30;
 
+// We intentionally don't derive Serialize so that different parts
+// of the code that want to display the config can tune how they
+// want to display and what fields they want to include.
 #[derive(Deserialize, Default, Debug, PartialEq, Eq, Clone, Iterable)]
 #[serde(rename_all = "camelCase")]
 pub struct ConfigurationOptions {

--- a/crates/turborepo-lib/src/config.rs
+++ b/crates/turborepo-lib/src/config.rs
@@ -744,22 +744,4 @@ mod test {
         assert_eq!(config.token().unwrap(), vercel_artifacts_token);
         assert_eq!(config.spaces_id().unwrap(), "my-spaces-id");
     }
-
-    #[test]
-    fn test_shared_no_token() {
-        let mut test_shared_config: RawTurboJson = Default::default();
-        let configuration_options = ConfigurationOptions {
-            token: Some("IF YOU CAN SEE THIS WE HAVE PROBLEMS".to_string()),
-            ..Default::default()
-        };
-        test_shared_config.remote_cache = Some(configuration_options);
-
-        assert_eq!(
-            test_shared_config
-                .get_configuration_options()
-                .unwrap()
-                .token(),
-            None
-        );
-    }
 }

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -339,10 +339,6 @@ impl Run {
             is_single_package,
         )?;
 
-        // if self.opts.run_opts.experimental_space_id.is_none() {
-        //     self.opts.run_opts.experimental_space_id =
-        // root_turbo_json.space_id.clone(); }
-
         pkg_dep_graph.validate()?;
 
         let filtered_pkgs = {

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -161,7 +161,7 @@ impl Run {
 
     #[tracing::instrument(skip(self, signal_handler, api_client))]
     pub async fn run(
-        &mut self,
+        &self,
         signal_handler: &SignalHandler,
         telemetry: CommandEventBuilder,
         api_client: APIClient,
@@ -202,7 +202,7 @@ impl Run {
     // We split this into a separate function because we need
     // to close the AnalyticsHandle regardless of whether the run succeeds or not
     async fn run_with_analytics(
-        &mut self,
+        &self,
         start_at: DateTime<Local>,
         api_client: APIClient,
         analytics_sender: Option<AnalyticsSender>,

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -95,6 +95,9 @@ impl Run {
             unused_remote_cache_opts_team_id,
             signature,
         ));
+        if opts.run_opts.experimental_space_id.is_none() {
+            opts.run_opts.experimental_space_id = config.spaces_id().map(|s| s.to_owned());
+        }
         Ok(Self {
             base,
             processes,
@@ -336,9 +339,9 @@ impl Run {
             is_single_package,
         )?;
 
-        if self.opts.run_opts.experimental_space_id.is_none() {
-            self.opts.run_opts.experimental_space_id = root_turbo_json.space_id.clone();
-        }
+        // if self.opts.run_opts.experimental_space_id.is_none() {
+        //     self.opts.run_opts.experimental_space_id =
+        // root_turbo_json.space_id.clone(); }
 
         pkg_dep_graph.validate()?;
 

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -84,10 +84,10 @@ impl From<&RawRemoteCacheOptions> for ConfigurationOptions {
             login_url: remote_cache_opts.login_url.clone(),
             team_slug: remote_cache_opts.team_slug.clone(),
             team_id: remote_cache_opts.team_id.clone(),
-            signature: remote_cache_opts.signature.clone(),
-            preflight: remote_cache_opts.preflight.clone(),
-            timeout: remote_cache_opts.timeout.clone(),
-            enabled: remote_cache_opts.enabled.clone(),
+            signature: remote_cache_opts.signature,
+            preflight: remote_cache_opts.preflight,
+            timeout: remote_cache_opts.timeout,
+            enabled: remote_cache_opts.enabled,
             ..Self::default()
         }
     }

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -59,13 +59,21 @@ pub struct TurboJson {
 #[derive(Clone, Debug, Default, Iterable, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct RawRemoteCacheOptions {
+    #[serde(skip_serializing_if = "Option::is_none")]
     api_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     login_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     team_slug: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     team_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     signature: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     preflight: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     timeout: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     enabled: Option<bool>,
 }
 

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -55,7 +55,35 @@ pub struct TurboJson {
     pub(crate) pipeline: Pipeline,
 }
 
-#[derive(Serialize, Default, Debug, PartialEq, Clone, Iterable)]
+#[derive(Clone, Debug, Serialize)]
+struct RawRemoteCacheOptions {
+    api_url: Option<String>,
+    login_url: Option<String>,
+    team_slug: Option<String>,
+    team_id: Option<String>,
+    signature: Option<bool>,
+    preflight: Option<bool>,
+    timeout: Option<u64>,
+    enabled: Option<bool>,
+}
+
+impl From<&RawRemoteCacheOptions> for ConfigurationOptions {
+    fn from(remote_cache_opts: &RawRemoteCacheOptions) -> Self {
+        Self {
+            api_url: remote_cache_opts.api_url.clone(),
+            login_url: remote_cache_opts.login_url.clone(),
+            team_slug: remote_cache_opts.team_slug.clone(),
+            team_id: remote_cache_opts.team_id.clone(),
+            signature: remote_cache_opts.signature.clone(),
+            preflight: remote_cache_opts.preflight.clone(),
+            timeout: remote_cache_opts.timeout.clone(),
+            enabled: remote_cache_opts.enabled.clone(),
+            ..Self::default()
+        }
+    }
+}
+
+#[derive(Serialize, Default, Debug, Clone, Iterable)]
 #[serde(rename_all = "camelCase")]
 // The raw deserialized turbo.json file.
 pub struct RawTurboJson {
@@ -88,7 +116,7 @@ pub struct RawTurboJson {
     pub pipeline: Option<Pipeline>,
     // Configuration options when interfacing with the remote cache
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) remote_cache: Option<ConfigurationOptions>,
+    pub(crate) remote_cache: Option<RawRemoteCacheOptions>,
 }
 
 #[derive(Serialize, Default, Debug, PartialEq, Clone)]

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -55,8 +55,10 @@ pub struct TurboJson {
     pub(crate) pipeline: Pipeline,
 }
 
-#[derive(Clone, Debug, Serialize)]
-struct RawRemoteCacheOptions {
+// Iterable is required to enumerate allowed keys
+#[derive(Clone, Debug, Default, Iterable, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct RawRemoteCacheOptions {
     api_url: Option<String>,
     login_url: Option<String>,
     team_slug: Option<String>,

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -39,7 +39,11 @@ pub struct SpacesJson {
 // turbo.json files into a single definition. Therefore we keep the
 // `RawTaskDefinition` type so we can determine which fields are actually
 // set when we resolve the configuration.
-#[derive(Debug, Default, Clone, PartialEq, Serialize)]
+//
+// Note that the values here are limited to pipeline configuration.
+// Configuration that needs to account for flags, env vars, etc. is
+// handled via layered config.
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct TurboJson {
     text: Option<Arc<str>>,
     path: Option<Arc<str>>,
@@ -49,8 +53,6 @@ pub struct TurboJson {
     pub(crate) global_env: Vec<String>,
     pub(crate) global_pass_through_env: Option<Vec<String>>,
     pub(crate) pipeline: Pipeline,
-    pub(crate) remote_cache: Option<ConfigurationOptions>,
-    pub(crate) space_id: Option<String>,
 }
 
 #[derive(Serialize, Default, Debug, PartialEq, Clone, Iterable)]
@@ -460,16 +462,11 @@ impl TryFrom<RawTurboJson> for TurboJson {
                 .transpose()?,
             pipeline: raw_turbo.pipeline.unwrap_or_default(),
             // copy these over, we don't need any changes here.
-            remote_cache: raw_turbo.remote_cache,
             extends: raw_turbo
                 .extends
                 .unwrap_or_default()
                 .map(|s| s.into_iter().map(|s| s.into()).collect()),
-            // Directly to space_id, we don't need to keep the struct
-            space_id: raw_turbo
-                .experimental_spaces
-                .and_then(|s| s.id)
-                .map(|s| s.into()),
+            // Spaces and Remote Cache config is handled through layered config
         })
     }
 }

--- a/crates/turborepo-lib/src/turbo_json/parser.rs
+++ b/crates/turborepo-lib/src/turbo_json/parser.rs
@@ -20,6 +20,7 @@ use thiserror::Error;
 use turbopath::AnchoredSystemPath;
 use turborepo_errors::WithMetadata;
 
+use super::RawRemoteCacheOptions;
 use crate::{
     cli::OutputLogsMode,
     config::ConfigurationOptions,
@@ -320,6 +321,36 @@ impl Deserializable for ConfigurationOptions {
     }
 }
 
+impl Deserializable for RawRemoteCacheOptions {
+    fn deserialize(
+        value: &impl DeserializableValue,
+        name: &str,
+        diagnostics: &mut Vec<DeserializationDiagnostic>,
+    ) -> Option<Self> {
+        value.deserialize(RawRemoteCacheOptionsVisitor, name, diagnostics)
+    }
+}
+
+struct RawRemoteCacheOptionsVisitor;
+
+impl DeserializationVisitor for RawRemoteCacheOptionsVisitor {
+    type Output = RawRemoteCacheOptions;
+
+    const EXPECTED_TYPE: VisitableType = VisitableType::MAP;
+
+    fn visit_map(
+        self,
+        // Iterator of key-value pairs.
+        members: impl Iterator<Item = Option<(impl DeserializableValue, impl DeserializableValue)>>,
+        // range of the map in the source text.
+        _: TextRange,
+        _name: &str,
+        diagnostics: &mut Vec<DeserializationDiagnostic>,
+    ) -> Option<Self::Output> {
+        todo!()
+    }
+}
+
 struct ConfigurationOptionsVisitor;
 
 impl DeserializationVisitor for ConfigurationOptionsVisitor {
@@ -495,7 +526,7 @@ impl DeserializationVisitor for RawTurboJsonVisitor {
                 }
                 "remoteCache" => {
                     if let Some(remote_cache) =
-                        ConfigurationOptions::deserialize(&value, &key_text, diagnostics)
+                        RawRemoteCacheOptions::deserialize(&value, &key_text, diagnostics)
                     {
                         result.remote_cache = Some(remote_cache);
                     }

--- a/crates/turborepo-lib/src/turbo_json/parser.rs
+++ b/crates/turborepo-lib/src/turbo_json/parser.rs
@@ -347,7 +347,71 @@ impl DeserializationVisitor for RawRemoteCacheOptionsVisitor {
         _name: &str,
         diagnostics: &mut Vec<DeserializationDiagnostic>,
     ) -> Option<Self::Output> {
-        todo!()
+        let mut result = RawRemoteCacheOptions::default();
+        for (key, value) in members.flatten() {
+            // Try to deserialize the key as a string.
+            // We use `Text` to avoid an heap-allocation.
+            let Some(key_text) = Text::deserialize(&key, "", diagnostics) else {
+                // If this failed, then pass to the next key-value pair.
+                continue;
+            };
+            match key_text.text() {
+                "apiUrl" => {
+                    if let Some(api_url) =
+                        UnescapedString::deserialize(&value, &key_text, diagnostics)
+                    {
+                        result.api_url = Some(api_url.into());
+                    }
+                }
+                "loginUrl" => {
+                    if let Some(login_url) =
+                        UnescapedString::deserialize(&value, &key_text, diagnostics)
+                    {
+                        result.login_url = Some(login_url.into());
+                    }
+                }
+                "teamSlug" => {
+                    if let Some(team_slug) =
+                        UnescapedString::deserialize(&value, &key_text, diagnostics)
+                    {
+                        result.team_slug = Some(team_slug.into());
+                    }
+                }
+                "teamId" => {
+                    if let Some(team_id) =
+                        UnescapedString::deserialize(&value, &key_text, diagnostics)
+                    {
+                        result.team_id = Some(team_id.into());
+                    }
+                }
+                "signature" => {
+                    if let Some(signature) = bool::deserialize(&value, &key_text, diagnostics) {
+                        result.signature = Some(signature);
+                    }
+                }
+                "preflight" => {
+                    if let Some(preflight) = bool::deserialize(&value, &key_text, diagnostics) {
+                        result.preflight = Some(preflight);
+                    }
+                }
+                "timeout" => {
+                    if let Some(timeout) = u64::deserialize(&value, &key_text, diagnostics) {
+                        result.timeout = Some(timeout);
+                    }
+                }
+                "enabled" => {
+                    if let Some(enabled) = bool::deserialize(&value, &key_text, diagnostics) {
+                        result.enabled = Some(enabled);
+                    }
+                }
+                unknown_key => diagnostics.push(create_unknown_key_diagnostic_from_struct(
+                    &result,
+                    unknown_key,
+                    key.range(),
+                )),
+            }
+        }
+        Some(result)
     }
 }
 

--- a/turborepo-tests/integration/tests/config.t
+++ b/turborepo-tests/integration/tests/config.t
@@ -12,7 +12,8 @@ Run test run
     "signature": null,
     "preflight": null,
     "timeout": null,
-    "enabled": null
+    "enabled": null,
+    "spacesId": null
   }
 
 Run test run with api overloaded

--- a/turborepo-tests/integration/tests/prune/produces-valid-turbo-json.t
+++ b/turborepo-tests/integration/tests/prune/produces-valid-turbo-json.t
@@ -28,26 +28,25 @@ Verify turbo can read the produced turbo.json
     "util"
   ]
 
-Modify turbo.json to add a remoteCache.enabled field set to true and add a spaceId
+Modify turbo.json to add some fields to remoteCache and add a spaceId
   $ rm -rf out
-  $ cat turbo.json | jq '.remoteCache.enabled = true' > turbo.json.tmp
-  $ cat turbo.json.tmp | jq '.experimentalSpaces.id = "my-space-id"' > turbo.json
+  $ cat turbo.json | jq '.remoteCache.enabled = true | .remoteCache.timeout = 1000 | .remoteCache.apiUrl = "my-domain.com/cache" | .experimentalSpaces.id = "my-space-id"' > turbo.json.tmp
+  $ mv turbo.json.tmp turbo.json
   $ ${TURBO} prune docs > /dev/null
   $ cat out/turbo.json | jq '.remoteCache | keys'
   [
     "apiUrl",
     "enabled",
-    "loginUrl",
-    "preflight",
-    "signature",
-    "teamId",
-    "teamSlug",
     "timeout"
   ]
   $ cat out/turbo.json | jq '.remoteCache.enabled'
   true
   $ cat out/turbo.json | jq '.experimentalSpaces.id'
   "my-space-id"
+  $ cat out/turbo.json | jq '.remoteCache.timeout'
+  1000
+  $ cat out/turbo.json | jq '.remoteCache.apiUrl'
+  "my-domain.com/cache"
 
 Modify turbo.json to add a remoteCache.enabled field set to false
   $ rm -rf out
@@ -58,11 +57,6 @@ Modify turbo.json to add a remoteCache.enabled field set to false
   [
     "apiUrl",
     "enabled",
-    "loginUrl",
-    "preflight",
-    "signature",
-    "teamId",
-    "teamSlug",
     "timeout"
   ]
   $ cat out/turbo.json | jq '.remoteCache.enabled'

--- a/turborepo-tests/integration/tests/prune/produces-valid-turbo-json.t
+++ b/turborepo-tests/integration/tests/prune/produces-valid-turbo-json.t
@@ -28,10 +28,10 @@ Verify turbo can read the produced turbo.json
     "util"
   ]
 
-Modify turbo.json to add a remoteCache.enabled field set to true
+Modify turbo.json to add a remoteCache.enabled field set to true and add a spaceId
   $ rm -rf out
   $ cat turbo.json | jq '.remoteCache.enabled = true' > turbo.json.tmp
-  $ mv turbo.json.tmp turbo.json
+  $ cat turbo.json.tmp | jq '.experimentalSpaces.id = "my-space-id"' > turbo.json
   $ ${TURBO} prune docs > /dev/null
   $ cat out/turbo.json | jq '.remoteCache | keys'
   [
@@ -42,11 +42,12 @@ Modify turbo.json to add a remoteCache.enabled field set to true
     "signature",
     "teamId",
     "teamSlug",
-    "timeout",
-    "token"
+    "timeout"
   ]
   $ cat out/turbo.json | jq '.remoteCache.enabled'
   true
+  $ cat out/turbo.json | jq '.experimentalSpaces.id'
+  "my-space-id"
 
 Modify turbo.json to add a remoteCache.enabled field set to false
   $ rm -rf out
@@ -62,8 +63,7 @@ Modify turbo.json to add a remoteCache.enabled field set to false
     "signature",
     "teamId",
     "teamSlug",
-    "timeout",
-    "token"
+    "timeout"
   ]
   $ cat out/turbo.json | jq '.remoteCache.enabled'
   false


### PR DESCRIPTION
### Description

The core goal of this PR is to make `run.run` immutable. This enforces that our config and options are all resolved before we start a run. The last remaining piece of that was picking up the `spaces_id` from the layered config system. 

Adding `spaces_id` to the layered config system necessitated a bunch of other changes due to the fact that it is not contained within the `remoteCache` field in `turbo.json`. The config system previously assumed that any config file could contain the entirety of the config, which wasn't strictly true, but now is even less true. 

To that end, I created a separate struct to represent just the `remoteCache` field in `turbo.json`. It shares much, but not all of the parser for a config file. I split the rendering of `ConfigurationOptions` into two structs, since we want to render them differently in different circumstances (`turbo info` vs `turbo.json` synthesis in `turbo prune`). This had the upshot of letting us skip rendering a) empty fields in pruned repos and b) a non-functional `token` field in pruned repos.


### Testing Instructions

Updated integration tests for expected renderings of the config. Added unit tests for spaces_id.
Deleted the test for not parsing a token from the `remoteCache` field in `turbo.json`, the type system no longer allows us to parse a token since it's no longer directly a `ConfigurationOptions` instance.


Closes TURBO-2313