### PR TITLE
Audit daemon error paths and ensure we are doing everything we can to handle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -601,7 +601,7 @@ dependencies = [
  "futures-util",
  "http",
  "http-body",
- "hyper 0.14.25",
+ "hyper 0.14.28",
  "itoa",
  "matchit",
  "memchr",
@@ -659,7 +659,7 @@ dependencies = [
  "futures-util",
  "http",
  "http-body",
- "hyper 0.14.25",
+ "hyper 0.14.28",
  "tokio",
  "tower-service",
 ]
@@ -1699,9 +1699,9 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e57ff02e8ad8e06ab9731d5dc72dc23bef9200778eae1a89d555d8c42e5d4a86"
 dependencies = [
- "prost",
- "prost-types",
- "tonic",
+ "prost 0.11.8",
+ "prost-types 0.11.8",
+ "tonic 0.8.3",
  "tracing-core",
 ]
 
@@ -1717,13 +1717,13 @@ dependencies = [
  "futures 0.3.28",
  "hdrhistogram",
  "humantime",
- "prost-types",
+ "prost-types 0.11.8",
  "serde",
  "serde_json",
  "thread_local",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.8.3",
  "tracing",
  "tracing-core",
  "tracing-subscriber",
@@ -3400,9 +3400,9 @@ checksum = "558b88954871f5e5b2af0e62e2e176c8bde7a6c2c4ed41b13d138d96da2e2cbd"
 
 [[package]]
 name = "h2"
-version = "0.3.16"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be7b54589b581f624f566bf5d8eb2bab1db736c51528720b6bd36b96b55924d"
+checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
 dependencies = [
  "bytes 1.5.0",
  "fnv",
@@ -3410,7 +3410,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 1.9.3",
+ "indexmap 2.2.3",
  "slab",
  "tokio",
  "tokio-util",
@@ -3613,7 +3613,7 @@ dependencies = [
  "crossbeam-utils 0.8.16",
  "form_urlencoded",
  "futures-util",
- "hyper 0.14.25",
+ "hyper 0.14.28",
  "isahc",
  "lazy_static",
  "levenshtein",
@@ -3670,9 +3670,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.25"
+version = "0.14.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc5e554ff619822309ffd57d8734d77cd5ce6238bc956f037ea06c58238c9899"
+checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
 dependencies = [
  "bytes 1.5.0",
  "futures-channel",
@@ -3685,7 +3685,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.9",
+ "socket2 0.5.4",
  "tokio",
  "tower-service",
  "tracing",
@@ -3699,7 +3699,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
 dependencies = [
  "http",
- "hyper 0.14.25",
+ "hyper 0.14.28",
  "rustls 0.20.9",
  "tokio",
  "tokio-rustls",
@@ -3711,7 +3711,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper 0.14.25",
+ "hyper 0.14.28",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
@@ -3724,7 +3724,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes 1.5.0",
- "hyper 0.14.25",
+ "hyper 0.14.28",
  "native-tls",
  "tokio",
  "tokio-native-tls",
@@ -3736,7 +3736,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "880b8b1c98a5ec2a505c7c90db6d3f6f1f480af5655d9c5b55facc9382a5a5b5"
 dependencies = [
- "hyper 0.14.25",
+ "hyper 0.14.28",
  "pin-project",
  "tokio",
  "tokio-tungstenite",
@@ -6076,9 +6076,9 @@ dependencies = [
  "nix 0.26.2",
  "once_cell",
  "parking_lot 0.12.1",
- "prost",
+ "prost 0.11.8",
  "prost-build",
- "prost-derive",
+ "prost-derive 0.11.8",
  "sha2",
  "smallvec 1.13.1",
  "symbolic-demangle",
@@ -6234,7 +6234,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48e50df39172a3e7eb17e14642445da64996989bc212b583015435d39a58537"
 dependencies = [
  "bytes 1.5.0",
- "prost-derive",
+ "prost-derive 0.11.8",
+]
+
+[[package]]
+name = "prost"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c289cda302b98a28d40c8b3b90498d6e526dd24ac2ecea73e4e491685b94a"
+dependencies = [
+ "bytes 1.5.0",
+ "prost-derive 0.12.3",
 ]
 
 [[package]]
@@ -6251,8 +6261,8 @@ dependencies = [
  "multimap",
  "petgraph",
  "prettyplease 0.1.25",
- "prost",
- "prost-types",
+ "prost 0.11.8",
+ "prost-types 0.11.8",
  "regex",
  "syn 1.0.109",
  "tempfile",
@@ -6273,12 +6283,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efb6c9a1dd1def8e2124d17e83a20af56f1570d6c2d2bd9e266ccb768df3840e"
+dependencies = [
+ "anyhow",
+ "itertools 0.11.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.32",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "379119666929a1afd7a043aa6cf96fa67a6dce9af60c88095a4686dbce4c9c88"
 dependencies = [
- "prost",
+ "prost 0.11.8",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "193898f59edcf43c26227dcd4c8427f00d99d61e95dcde58dabd49fa291d470e"
+dependencies = [
+ "prost 0.12.3",
 ]
 
 [[package]]
@@ -6774,7 +6806,7 @@ dependencies = [
  "h2",
  "http",
  "http-body",
- "hyper 0.14.25",
+ "hyper 0.14.28",
  "hyper-rustls",
  "hyper-tls",
  "ipnet",
@@ -10159,12 +10191,12 @@ dependencies = [
  "h2",
  "http",
  "http-body",
- "hyper 0.14.25",
+ "hyper 0.14.28",
  "hyper-timeout",
  "percent-encoding 2.3.0",
  "pin-project",
- "prost",
- "prost-derive",
+ "prost 0.11.8",
+ "prost-derive 0.11.8",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -10173,6 +10205,33 @@ dependencies = [
  "tower-service",
  "tracing",
  "tracing-futures",
+]
+
+[[package]]
+name = "tonic"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64 0.21.4",
+ "bytes 1.5.0",
+ "h2",
+ "http",
+ "http-body",
+ "hyper 0.14.28",
+ "hyper-timeout",
+ "percent-encoding 2.3.0",
+ "pin-project",
+ "prost 0.12.3",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -10190,16 +10249,15 @@ dependencies = [
 
 [[package]]
 name = "tonic-reflection"
-version = "0.6.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67494bad4dda4c9bffae901dfe14e2b2c0f760adb4706dc10beeb81799f7f7b2"
+checksum = "548c227bd5c0fae5925812c4ec6c66ffcfced23ea370cb823f4d18f0fc1cb6a7"
 dependencies = [
- "bytes 1.5.0",
- "prost",
- "prost-types",
+ "prost 0.12.3",
+ "prost-types 0.12.3",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.11.0",
 ]
 
 [[package]]
@@ -11043,7 +11101,7 @@ dependencies = [
  "async-compression",
  "auto-hash-map",
  "futures 0.3.28",
- "hyper 0.14.25",
+ "hyper 0.14.28",
  "hyper-tungstenite",
  "indexmap 1.9.3",
  "mime 0.3.17",
@@ -11651,7 +11709,7 @@ dependencies = [
  "portable-pty",
  "pprof",
  "pretty_assertions",
- "prost",
+ "prost 0.12.3",
  "rand 0.8.5",
  "rayon",
  "regex",
@@ -11676,7 +11734,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tonic",
+ "tonic 0.11.0",
  "tonic-build",
  "tonic-reflection",
  "tower",

--- a/crates/turborepo-lib/Cargo.toml
+++ b/crates/turborepo-lib/Cargo.toml
@@ -67,7 +67,7 @@ path-clean = "1.0.1"
 petgraph = { workspace = true }
 pidlock = { path = "../turborepo-pidlock" }
 portable-pty = "0.8.1"
-prost = "0.11.6"
+prost = "0.12.3"
 rand = { workspace = true }
 reqwest = { workspace = true, default-features = false, features = ["json"] }
 rustc_version_runtime = "0.2.1"
@@ -84,8 +84,8 @@ tiny-gradient = { workspace = true }
 tokio = { workspace = true, features = ["full", "time"] }
 tokio-stream = { version = "0.1.12", features = ["net"] }
 tokio-util = { version = "0.7.7", features = ["compat"] }
-tonic = { version = "0.8.3", features = ["transport"] }
-tonic-reflection = { version = "0.6.0", optional = true }
+tonic = { version = "0.11.0", features = ["transport"] }
+tonic-reflection = { version = "0.11.0", optional = true }
 tower = "0.4.13"
 turborepo-analytics = { path = "../turborepo-analytics" }
 turborepo-auth = { path = "../turborepo-auth" }

--- a/crates/turborepo-lib/src/daemon/bump_timeout_layer.rs
+++ b/crates/turborepo-lib/src/daemon/bump_timeout_layer.rs
@@ -5,7 +5,7 @@
 
 use std::sync::Arc;
 
-use tonic::transport::NamedService;
+use tonic::server::NamedService;
 use tower::{Layer, Service};
 
 use super::bump_timeout::BumpTimeout;

--- a/crates/turborepo-lib/src/daemon/client.rs
+++ b/crates/turborepo-lib/src/daemon/client.rs
@@ -133,6 +133,18 @@ impl<T> DaemonClient<T> {
 
         Ok(response)
     }
+
+    pub async fn discover_packages_blocking(
+        &mut self,
+    ) -> Result<DiscoverPackagesResponse, DaemonError> {
+        let response = self
+            .client
+            .discover_packages_blocking(proto::DiscoverPackagesRequest {})
+            .await?
+            .into_inner();
+
+        Ok(response)
+    }
 }
 
 impl DaemonClient<DaemonConnector> {

--- a/crates/turborepo-lib/src/daemon/connector.rs
+++ b/crates/turborepo-lib/src/daemon/connector.rs
@@ -628,6 +628,13 @@ mod test {
         ) -> Result<tonic::Response<proto::DiscoverPackagesResponse>, tonic::Status> {
             unimplemented!()
         }
+
+        async fn discover_packages_blocking(
+            &self,
+            _req: tonic::Request<proto::DiscoverPackagesRequest>,
+        ) -> Result<tonic::Response<proto::DiscoverPackagesResponse>, tonic::Status> {
+            unimplemented!()
+        }
     }
 
     #[tokio::test]

--- a/crates/turborepo-lib/src/daemon/default_timeout_layer.rs
+++ b/crates/turborepo-lib/src/daemon/default_timeout_layer.rs
@@ -1,0 +1,147 @@
+//! default timeout layer
+//!
+//! This module provides some basic middleware that aims to
+//! improve the flexibility of the daemon server by doing
+//! two things:
+//!
+//! a) remove the server-wide timeout of 100ms in favour of
+//!    a less aggressive 30s. the way tonic works is the
+//!    lowest timeout (server vs request-specific) is always
+//!    used meaning clients' timeout requests were ignored
+//!    if set to >100ms
+//! b) add a middleware to reinstate the timeout, if the
+//!    client does not specify it, defaulting to 100ms for
+//!    'non-blocking' calls (requests in the hot path for
+//!    a run of turbo), and falling back to the server
+//!    limit for blocking ones (useful in cases like the
+//!    LSP)
+//!
+//! With this in place, it means that clients can specify
+//! a timeout that it wants (as long as it is less than 30s),
+//! and the server has sane defaults
+
+use std::time::Duration;
+
+use tonic::{codegen::http::Request, server::NamedService, transport::Body};
+use tower::{Layer, Service};
+
+#[derive(Clone, Debug)]
+pub struct DefaultTimeoutService<S> {
+    inner: S,
+}
+
+impl<S> Service<Request<Body>> for DefaultTimeoutService<S>
+where
+    S: Service<Request<Body>>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut req: Request<Body>) -> Self::Future {
+        if !req.uri().path().ends_with("Blocking") {
+            req.headers_mut()
+                .entry("grpc-timeout")
+                .or_insert_with(move || {
+                    let dur = Duration::from_millis(100);
+                    tonic::codegen::http::HeaderValue::from_str(&format!("{}u", dur.as_micros()))
+                        .expect("numbers are always valid ascii")
+                });
+        };
+
+        self.inner.call(req)
+    }
+}
+
+/// Provides a middleware that sets a default timeout for
+/// non-blocking calls. See the module documentation for
+/// more information.
+#[derive(Clone, Debug)]
+pub struct DefaultTimeoutLayer;
+
+impl<S> Layer<S> for DefaultTimeoutLayer {
+    type Service = DefaultTimeoutService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        DefaultTimeoutService { inner }
+    }
+}
+
+impl<T: NamedService> NamedService for DefaultTimeoutService<T> {
+    const NAME: &'static str = T::NAME;
+}
+
+#[cfg(test)]
+mod test {
+    use std::{
+        str::FromStr,
+        sync::{Arc, Mutex},
+    };
+
+    use axum::http::HeaderValue;
+    use test_case::test_case;
+
+    use super::*;
+
+    #[test_case("/ExampleBlocking", None, None ; "no default for blocking calls")]
+    #[test_case("/Example", None, Some("100000u") ; "default for non-blocking calls")]
+    #[test_case("/Example", Some("200u"), Some("200u") ; "respect client preference")]
+    #[tokio::test]
+    async fn overrides_timeout_for_non_blocking(
+        path: &str,
+        timeout: Option<&str>,
+        expected: Option<&str>,
+    ) {
+        #[derive(Clone, Debug)]
+        struct MockService(Arc<Mutex<Option<String>>>);
+
+        impl Service<Request<Body>> for MockService {
+            type Response = ();
+            type Error = ();
+            type Future = impl std::future::Future<Output = Result<(), ()>>;
+
+            fn poll_ready(
+                &mut self,
+                _cx: &mut std::task::Context<'_>,
+            ) -> std::task::Poll<Result<(), Self::Error>> {
+                std::task::Poll::Ready(Ok(()))
+            }
+
+            fn call(&mut self, req: Request<Body>) -> Self::Future {
+                // get the content of the header
+                let header = self.0.clone();
+                async move {
+                    let mut header = header.lock().unwrap();
+                    *header = req
+                        .headers()
+                        .get("grpc-timeout")
+                        .map(|h| h.to_str().unwrap().to_string());
+                    Ok(())
+                }
+            }
+        }
+
+        let inner = MockService(Arc::new(Mutex::new(None)));
+        let mut svc = DefaultTimeoutLayer.layer(inner.clone());
+        let mut req = Request::new(Body::empty());
+        let uri = req.uri_mut();
+        *uri = tonic::codegen::http::Uri::from_str(path).unwrap();
+        if let Some(timeout) = timeout {
+            req.headers_mut()
+                .insert("grpc-timeout", HeaderValue::from_str(timeout).unwrap());
+        }
+
+        svc.call(req).await.unwrap();
+
+        let header = inner.0.lock().unwrap();
+
+        assert_eq!(header.as_deref(), expected);
+    }
+}

--- a/crates/turborepo-lib/src/daemon/mod.rs
+++ b/crates/turborepo-lib/src/daemon/mod.rs
@@ -24,6 +24,7 @@ mod bump_timeout;
 mod bump_timeout_layer;
 mod client;
 mod connector;
+mod default_timeout_layer;
 pub(crate) mod endpoint;
 mod server;
 

--- a/crates/turborepo-lib/src/daemon/proto/turbod.proto
+++ b/crates/turborepo-lib/src/daemon/proto/turbod.proto
@@ -16,6 +16,15 @@ service Turbod {
   //
   // Since 1.11.0
   rpc DiscoverPackages (DiscoverPackagesRequest) returns (DiscoverPackagesResponse);
+
+  // Request the list of packages that the daemon is aware of.
+  // This is a blocking call that will wait for the daemon to finish
+  // discovering the packages, rather than returning 'unavailable'.
+  // It will _still_ report unavailable if a critical process in the
+  // daemon is not running, and the answer will never come.
+  //
+  // Since 1.12.0
+  rpc DiscoverPackagesBlocking (DiscoverPackagesRequest) returns (DiscoverPackagesResponse);
 }
 
 message HelloRequest {

--- a/crates/turborepo-lib/src/daemon/server.rs
+++ b/crates/turborepo-lib/src/daemon/server.rs
@@ -425,13 +425,13 @@ impl<PD: PackageDiscovery + Send + Sync + 'static> proto::turbod_server::Turbod
         let server_version = proto::VERSION;
 
         let passes_version_check = match (
-            proto::VersionRange::from_i32(request.supported_version_range),
+            proto::VersionRange::try_from(request.supported_version_range),
             Version::parse(&client_version),
             Version::parse(server_version),
         ) {
             // if we fail to parse, or the constraint is invalid, we have a version mismatch
-            (_, Err(_), _) | (_, _, Err(_)) | (None, _, _) => false,
-            (Some(range), Ok(client), Ok(server)) => compare_versions(client, server, range),
+            (_, Err(_), _) | (_, _, Err(_)) | (Err(DecodeError { .. }), _, _) => false,
+            (Ok(range), Ok(client), Ok(server)) => compare_versions(client, server, range),
         };
 
         if passes_version_check {

--- a/crates/turborepo-lib/src/engine/builder.rs
+++ b/crates/turborepo-lib/src/engine/builder.rs
@@ -483,6 +483,15 @@ mod test {
                 workspaces: vec![], // we don't care about this
             })
         }
+
+        async fn discover_packages_blocking(
+            &self,
+        ) -> Result<
+            turborepo_repository::discovery::DiscoveryResponse,
+            turborepo_repository::discovery::Error,
+        > {
+            self.discover_packages().await
+        }
     }
 
     macro_rules! package_jsons {

--- a/crates/turborepo-lib/src/engine/mod.rs
+++ b/crates/turborepo-lib/src/engine/mod.rs
@@ -335,6 +335,15 @@ mod test {
                 workspaces,
             })
         }
+
+        async fn discover_packages_blocking(
+            &self,
+        ) -> Result<
+            turborepo_repository::discovery::DiscoveryResponse,
+            turborepo_repository::discovery::Error,
+        > {
+            self.discover_packages().await
+        }
     }
 
     #[tokio::test]

--- a/crates/turborepo-lib/src/lib.rs
+++ b/crates/turborepo-lib/src/lib.rs
@@ -6,6 +6,7 @@
 #![feature(option_get_or_insert_default)]
 #![feature(once_cell_try)]
 #![feature(try_blocks)]
+#![feature(impl_trait_in_assoc_type)]
 #![deny(clippy::all)]
 // Clippy's needless mut lint is buggy: https://github.com/rust-lang/rust-clippy/issues/11299
 #![allow(clippy::needless_pass_by_ref_mut)]

--- a/crates/turborepo-lib/src/run/cache.rs
+++ b/crates/turborepo-lib/src/run/cache.rs
@@ -365,7 +365,7 @@ impl TaskCache {
             if let Err(err) = notify_result {
                 telemetry.track_error(TrackedErrors::DaemonFailedToMarkOutputsAsCached);
                 let task_id = &self.task_id;
-                debug!("Failed to mark outputs as cached for {task_id}: {err}");
+                debug!("failed to mark outputs as cached for {task_id}: {err}");
             }
         }
 

--- a/crates/turborepo-lib/src/run/package_discovery/mod.rs
+++ b/crates/turborepo-lib/src/run/package_discovery/mod.rs
@@ -37,7 +37,7 @@ impl<C: Clone + Send + Sync> PackageDiscovery for DaemonPackageDiscovery<C> {
                         .map(|t| AbsoluteSystemPathBuf::new(t).expect("absolute")),
                 })
                 .collect(),
-            package_manager: PackageManager::from_i32(response.package_manager)
+            package_manager: PackageManager::try_from(response.package_manager)
                 .expect("valid")
                 .into(),
         })
@@ -65,7 +65,7 @@ impl<C: Clone + Send + Sync> PackageDiscovery for DaemonPackageDiscovery<C> {
                         .map(|t| AbsoluteSystemPathBuf::new(t).expect("absolute")),
                 })
                 .collect(),
-            package_manager: PackageManager::from_i32(response.package_manager)
+            package_manager: PackageManager::try_from(response.package_manager)
                 .expect("valid")
                 .into(),
         })

--- a/crates/turborepo-lib/src/run/package_discovery/mod.rs
+++ b/crates/turborepo-lib/src/run/package_discovery/mod.rs
@@ -42,4 +42,32 @@ impl<C: Clone + Send + Sync> PackageDiscovery for DaemonPackageDiscovery<C> {
                 .into(),
         })
     }
+
+    async fn discover_packages_blocking(&self) -> Result<DiscoveryResponse, Error> {
+        tracing::debug!("discovering packages using daemon");
+
+        // clone here so we can make concurrent requests
+        let mut daemon = self.daemon.clone();
+
+        let response = daemon
+            .discover_packages_blocking()
+            .await
+            .map_err(|e| Error::Failed(Box::new(e)))?;
+
+        Ok(DiscoveryResponse {
+            workspaces: response
+                .package_files
+                .into_iter()
+                .map(|p| WorkspaceData {
+                    package_json: AbsoluteSystemPathBuf::new(p.package_json).expect("absolute"),
+                    turbo_json: p
+                        .turbo_json
+                        .map(|t| AbsoluteSystemPathBuf::new(t).expect("absolute")),
+                })
+                .collect(),
+            package_manager: PackageManager::from_i32(response.package_manager)
+                .expect("valid")
+                .into(),
+        })
+    }
 }

--- a/crates/turborepo-lib/src/run/scope/filter.rs
+++ b/crates/turborepo-lib/src/run/scope/filter.rs
@@ -631,6 +631,15 @@ mod test {
                 workspaces: vec![], // we don't care about this
             })
         }
+
+        async fn discover_packages_blocking(
+            &self,
+        ) -> Result<
+            turborepo_repository::discovery::DiscoveryResponse,
+            turborepo_repository::discovery::Error,
+        > {
+            self.discover_packages().await
+        }
     }
 
     /// Make a project resolver with the provided dependencies. Extras is for

--- a/crates/turborepo-lsp/src/lib.rs
+++ b/crates/turborepo-lsp/src/lib.rs
@@ -258,7 +258,12 @@ impl LanguageServer for Backend {
                 self.client
                     .log_message(MessageType::WARNING, e.to_string())
                     .await;
-                return Err(Error::internal_error());
+
+                // there aren't really any other errors we can return here, other than
+                // an internal error
+                let mut error = Error::internal_error();
+                error.message = "failed to get package list from the daemon".into();
+                return Err(error);
             }
         };
 
@@ -596,7 +601,7 @@ impl Backend {
         };
 
         DaemonPackageDiscovery::new(daemon)
-            .discover_packages()
+            .discover_packages_blocking()
             .await
     }
 

--- a/crates/turborepo-repository/src/discovery.rs
+++ b/crates/turborepo-repository/src/discovery.rs
@@ -11,6 +11,7 @@
 
 use std::sync::Arc;
 
+use tokio::time::error::Elapsed;
 use tokio_stream::{iter, StreamExt};
 use turbopath::AbsoluteSystemPathBuf;
 
@@ -270,7 +271,7 @@ impl<A: PackageDiscovery + Send + Sync, B: PackageDiscovery + Send + Sync> Packa
                     Err(err2) => Err(err2),
                 }
             }
-            Err(_) => {
+            Err(Elapsed { .. }) => {
                 tracing::debug!("primary strategy timed out, attempting fallback strategy");
                 self.fallback.discover_packages_blocking().await
             }

--- a/crates/turborepo-repository/src/discovery.rs
+++ b/crates/turborepo-repository/src/discovery.rs
@@ -42,7 +42,15 @@ pub enum Error {
 /// Defines a strategy for discovering packages on the filesystem.
 pub trait PackageDiscovery {
     // desugar to assert that the future is Send
+    /// Discover packages on the filesystem. In the event that this would block,
+    /// some strategies may return `Err(Error::Unavailable)`. If you want to
+    /// wait, use `discover_packages_blocking` which will wait for the result.
     fn discover_packages(
+        &self,
+    ) -> impl std::future::Future<Output = Result<DiscoveryResponse, Error>> + Send;
+
+    /// Discover packages on the filesystem, blocking until the result is ready.
+    fn discover_packages_blocking(
         &self,
     ) -> impl std::future::Future<Output = Result<DiscoveryResponse, Error>> + Send;
 }
@@ -71,11 +79,27 @@ impl<T: PackageDiscovery + Send + Sync> PackageDiscovery for Option<T> {
             }
         }
     }
+
+    async fn discover_packages_blocking(&self) -> Result<DiscoveryResponse, Error> {
+        tracing::debug!("discovering packages using optional strategy");
+
+        match self {
+            Some(d) => d.discover_packages_blocking().await,
+            None => {
+                tracing::debug!("no strategy available");
+                Err(Error::Unavailable)
+            }
+        }
+    }
 }
 
 impl<T: PackageDiscovery + Send + Sync> PackageDiscovery for Arc<T> {
     async fn discover_packages(&self) -> Result<DiscoveryResponse, Error> {
         self.as_ref().discover_packages().await
+    }
+
+    async fn discover_packages_blocking(&self) -> Result<DiscoveryResponse, Error> {
+        self.as_ref().discover_packages_blocking().await
     }
 }
 
@@ -171,6 +195,12 @@ impl PackageDiscovery for LocalPackageDiscovery {
                 package_manager: self.package_manager,
             })
     }
+
+    // there is no notion of waiting for upstream deps here, so this is the same as
+    // the non-blocking
+    async fn discover_packages_blocking(&self) -> Result<DiscoveryResponse, Error> {
+        self.discover_packages().await
+    }
 }
 
 /// Attempts to run the `primary` strategy for an amount of time
@@ -224,6 +254,28 @@ impl<A: PackageDiscovery + Send + Sync, B: PackageDiscovery + Send + Sync> Packa
             }
         }
     }
+
+    async fn discover_packages_blocking(&self) -> Result<DiscoveryResponse, Error> {
+        tracing::debug!("discovering packages using fallback strategy");
+
+        tracing::debug!("attempting primary strategy");
+        match tokio::time::timeout(self.timeout, self.primary.discover_packages_blocking()).await {
+            Ok(Ok(packages)) => Ok(packages),
+            Ok(Err(err1)) => {
+                tracing::debug!("primary strategy failed, attempting fallback strategy");
+                match self.fallback.discover_packages_blocking().await {
+                    Ok(packages) => Ok(packages),
+                    // if the backup is unavailable, return the original error
+                    Err(Error::Unavailable) => Err(err1),
+                    Err(err2) => Err(err2),
+                }
+            }
+            Err(_) => {
+                tracing::debug!("primary strategy timed out, attempting fallback strategy");
+                self.fallback.discover_packages_blocking().await
+            }
+        }
+    }
 }
 
 pub struct CachingPackageDiscovery<P: PackageDiscovery> {
@@ -247,6 +299,17 @@ impl<P: PackageDiscovery + Send + Sync> PackageDiscovery for CachingPackageDisco
             .get_or_try_init(async {
                 tracing::debug!("discovering packages using primary strategy");
                 self.primary.discover_packages().await
+            })
+            .await
+            .map(ToOwned::to_owned)
+    }
+
+    async fn discover_packages_blocking(&self) -> Result<DiscoveryResponse, Error> {
+        tracing::debug!("discovering packages using caching strategy");
+        self.data
+            .get_or_try_init(async {
+                tracing::debug!("discovering packages using primary strategy");
+                self.primary.discover_packages_blocking().await
             })
             .await
             .map(ToOwned::to_owned)
@@ -294,6 +357,12 @@ mod fallback_tests {
                     workspaces: vec![],
                 })
             }
+        }
+
+        async fn discover_packages_blocking(
+            &self,
+        ) -> Result<crate::discovery::DiscoveryResponse, crate::discovery::Error> {
+            self.discover_packages().await
         }
     }
 
@@ -362,6 +431,12 @@ mod caching_tests {
                 package_manager: PackageManager::Npm,
                 workspaces: vec![],
             })
+        }
+
+        async fn discover_packages_blocking(
+            &self,
+        ) -> Result<crate::discovery::DiscoveryResponse, crate::discovery::Error> {
+            self.discover_packages().await
         }
     }
 

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -773,6 +773,12 @@ mod test {
                 workspaces: vec![],
             })
         }
+
+        async fn discover_packages_blocking(
+            &self,
+        ) -> Result<crate::discovery::DiscoveryResponse, crate::discovery::Error> {
+            self.discover_packages().await
+        }
     }
 
     #[tokio::test]

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -462,6 +462,12 @@ mod test {
                 workspaces: vec![],
             })
         }
+
+        async fn discover_packages_blocking(
+            &self,
+        ) -> Result<crate::discovery::DiscoveryResponse, crate::discovery::Error> {
+            self.discover_packages().await
+        }
     }
 
     #[tokio::test]

--- a/crates/turborepo-telemetry/src/events/mod.rs
+++ b/crates/turborepo-telemetry/src/events/mod.rs
@@ -55,6 +55,11 @@ pub enum TrackedErrors {
     ErrorFetchingFromCache,
     FailedToPipeOutputs,
     UnknownChildExit,
+    /// Yielded when package discovery yields a
+    /// list of packages that fails downstream.
+    /// Currently only indicates a package being
+    /// reported when it does not exist.
+    InvalidPackageDiscovery,
 }
 
 impl Display for TrackedErrors {
@@ -72,6 +77,7 @@ impl Display for TrackedErrors {
             TrackedErrors::ErrorFetchingFromCache => write!(f, "error_fetching_from_cache"),
             TrackedErrors::FailedToPipeOutputs => write!(f, "failed_to_pipe_outputs"),
             TrackedErrors::UnknownChildExit => write!(f, "unknown_child_exit"),
+            TrackedErrors::InvalidPackageDiscovery => write!(f, "invalid_package_discovery"),
         }
     }
 }


### PR DESCRIPTION
### Description

We have a few integration points with the daemon, this PR ensures they are all nicely handled.

- [x] `cache.rs`: we emit a debug warning and a telemetry event in the case we are unable to mark outputs correctly
- [x] `lsp/lib.rs`: in the LSP, package discovery means we cannot fulfill the user's request, so we must return an internal error. the error message has been set. Additionally, the LSP is a case where waiting for an answer is actually desirable, so a new API to support this has been added.
- [x] package discovery: if we have a bug in watching, we may yield packages that don't exist. we need to report a telemetry event, in this case so that we can be aware of when this happens
- [x] daemon interaction in run codepath: when trying to use the daemon during run we want to debug log but not error
- [x] daemon connection in daemon codepath: when calling the daemon we want errors to be explicitly reported. in this case, the errors bubbles all the way up and is printed out as expected

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->


Closes TURBO-2319