### PR TITLE
fix: avoid grouping logs from tasks which ended in error

### DIFF
--- a/crates/turborepo-ci/src/vendor_behavior.rs
+++ b/crates/turborepo-ci/src/vendor_behavior.rs
@@ -4,4 +4,23 @@ type GroupPrefixFn = fn(group_name: &str) -> String;
 pub struct VendorBehavior {
     pub group_prefix: GroupPrefixFn,
     pub group_suffix: GroupPrefixFn,
+    pub error_group_prefix: Option<GroupPrefixFn>,
+    pub error_group_suffix: Option<GroupPrefixFn>,
+}
+
+impl VendorBehavior {
+    pub fn new(prefix: GroupPrefixFn, suffix: GroupPrefixFn) -> Self {
+        Self {
+            group_prefix: prefix,
+            group_suffix: suffix,
+            error_group_prefix: None,
+            error_group_suffix: None,
+        }
+    }
+
+    pub fn with_error(mut self, prefix: GroupPrefixFn, suffix: GroupPrefixFn) -> Self {
+        self.error_group_prefix = Some(prefix);
+        self.error_group_suffix = Some(suffix);
+        self
+    }
 }

--- a/crates/turborepo-ci/src/vendors.rs
+++ b/crates/turborepo-ci/src/vendors.rs
@@ -77,10 +77,10 @@ pub(crate) fn get_vendors() -> &'static [Vendor] {
                     sha_env_var: None,
                     branch_env_var: None,
                     username_env_var: None,
-                    behavior: Some(VendorBehavior {
-                        group_prefix: |group_name| format!("##[group]{group_name}\r\n"),
-                        group_suffix: |_| String::from("##[endgroup]\r\n"),
-                    }),
+                    behavior: Some(VendorBehavior::new(
+                        |group_name| format!("##[group]{group_name}\r\n"),
+                        |_| String::from("##[endgroup]\r\n"),
+                    )),
                 },
                 Vendor {
                     name: "Bamboo",
@@ -266,10 +266,16 @@ pub(crate) fn get_vendors() -> &'static [Vendor] {
                     sha_env_var: Some("GITHUB_SHA"),
                     branch_env_var: Some("GITHUB_REF_NAME"),
                     username_env_var: Some("GITHUB_ACTOR"),
-                    behavior: Some(VendorBehavior {
-                        group_prefix: |group_name| format!("::group::{group_name}\n"),
-                        group_suffix: |_| String::from("::endgroup::\n"),
-                    }),
+                    behavior: Some(
+                        VendorBehavior::new(
+                            |group_name| format!("::group::{group_name}\n"),
+                            |_| String::from("::endgroup::\n"),
+                        )
+                        .with_error(
+                            |group_name| format!("\x1B[;31m{group_name}\x1B[;0m\n"),
+                            |_| String::new(),
+                        ),
+                    ),
                 },
                 Vendor {
                     name: "GitLab CI",
@@ -546,14 +552,10 @@ pub(crate) fn get_vendors() -> &'static [Vendor] {
                     sha_env_var: None,
                     branch_env_var: None,
                     username_env_var: None,
-                    behavior: Some(VendorBehavior {
-                        group_prefix: |group_name| {
-                            format!("##teamcity[blockOpened name='{group_name}']")
-                        },
-                        group_suffix: |group_name| {
-                            format!("##teamcity[blockClosed name='{group_name}']")
-                        },
-                    }),
+                    behavior: Some(VendorBehavior::new(
+                        |group_name| format!("##teamcity[blockOpened name='{group_name}']"),
+                        |group_name| format!("##teamcity[blockClosed name='{group_name}']"),
+                    )),
                 },
                 Vendor {
                     name: "Travis CI",
@@ -566,10 +568,10 @@ pub(crate) fn get_vendors() -> &'static [Vendor] {
                     sha_env_var: None,
                     branch_env_var: None,
                     username_env_var: None,
-                    behavior: Some(VendorBehavior {
-                        group_prefix: |group_name| format!("travis_fold:start:{group_name}\r\n"),
-                        group_suffix: |group_name| format!("travis_fold:end:{group_name}\r\n"),
-                    }),
+                    behavior: Some(VendorBehavior::new(
+                        |group_name| format!("travis_fold:start:{group_name}\r\n"),
+                        |group_name| format!("travis_fold:end:{group_name}\r\n"),
+                    )),
                 },
                 Vendor {
                     name: "Vercel",

--- a/crates/turborepo-lib/src/task_graph/visitor.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor.rs
@@ -392,6 +392,12 @@ impl<'a> Visitor<'a> {
                 (vendor_behavior.group_suffix)(&group_name),
             );
             logger.with_header_footer(Some(header), Some(footer));
+
+            let (error_header, error_footer) = (
+                vendor_behavior.error_group_prefix.map(|f| f(&group_name)),
+                vendor_behavior.error_group_suffix.map(|f| f(&group_name)),
+            );
+            logger.with_error_header_footer(error_header, error_footer);
         }
         logger
     }
@@ -692,8 +698,8 @@ impl ExecContext {
 
         // If the task resulted in an error, do not group in order to better highlight
         // the error.
-        let keep_group = matches!(result, ExecOutcome::Success(_));
-        let logs = match output_client.finish(keep_group) {
+        let is_error = matches!(result, ExecOutcome::Task { .. });
+        let logs = match output_client.finish(is_error) {
             Ok(logs) => logs,
             Err(e) => {
                 telemetry.track_error(TrackedErrors::DaemonFailedToMarkOutputsAsCached);

--- a/crates/turborepo-lib/src/task_graph/visitor.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor.rs
@@ -690,7 +690,10 @@ impl ExecContext {
             .instrument(span)
             .await;
 
-        let logs = match output_client.finish() {
+        // If the task resulted in an error, do not group in order to better highlight
+        // the error.
+        let keep_group = matches!(result, ExecOutcome::Success(_));
+        let logs = match output_client.finish(keep_group) {
             Ok(logs) => logs,
             Err(e) => {
                 telemetry.track_error(TrackedErrors::DaemonFailedToMarkOutputsAsCached);

--- a/crates/turborepo-ui/src/output.rs
+++ b/crates/turborepo-ui/src/output.rs
@@ -409,7 +409,7 @@ mod test {
         // provided
         assert_eq!(
             out,
-            b"bad header\noutput for 1\nbad footer\ngood header\noutput for 2\ngood header\n"
+            b"bad header\noutput for 1\nbad footer\ngood header\noutput for 2\ngood footer\n"
         );
 
         Ok(())

--- a/crates/turborepo-ui/tests/threads.rs
+++ b/crates/turborepo-ui/tests/threads.rs
@@ -104,7 +104,7 @@ fn echo_task(
     }
     process.wait()?;
 
-    client.finish()?;
+    client.finish(true)?;
 
     Ok(())
 }

--- a/turborepo-tests/integration/tests/run-logging/log-order-github.t
+++ b/turborepo-tests/integration/tests/run-logging/log-order-github.t
@@ -56,7 +56,6 @@ Verify that errors are grouped properly
   \xe2\x80\xa2 Packages in scope: my-app, util (esc)
   \xe2\x80\xa2 Running fail in 2 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  ::group::util:fail
   cache miss, executing 122cca10fdcda4f0
   
   \> fail (re)
@@ -68,7 +67,6 @@ Verify that errors are grouped properly
   npm ERR!   in workspace: util 
   npm ERR\!   at location: (.*)(\/|\\)packages(\/|\\)util  (re)
   \[ERROR\] command finished with error: command \((.*)(\/|\\)packages(\/|\\)util\) (.*)npm(?:\.cmd)? run fail exited \(1\) (re)
-  ::endgroup::
   ::error::util#fail: command \(.*(\/|\\)packages(\/|\\)util\) (.*)npm(?:\.cmd)? run fail exited \(1\) (re)
   
    Tasks:    0 successful, 1 total

--- a/turborepo-tests/integration/tests/run-logging/log-order-github.t
+++ b/turborepo-tests/integration/tests/run-logging/log-order-github.t
@@ -56,6 +56,7 @@ Verify that errors are grouped properly
   \xe2\x80\xa2 Packages in scope: my-app, util (esc)
   \xe2\x80\xa2 Running fail in 2 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
+  \x1b[;31mutil:fail\x1b[;0m (esc)
   cache miss, executing 122cca10fdcda4f0
   
   \> fail (re)


### PR DESCRIPTION
### Description

Fixes https://github.com/vercel/turbo/issues/6709

Github Action doesn't provide a mechanism for grouping logs together and keeping them expanded which is helpful for highlighting errors.

This PR changes the behavior so we avoid emitting the grouping header/footer if task execution was a failure.

### Testing Instructions

Updated GH Action log grouping integration test


Closes TURBO-2320