### PR TITLE
chore(Turborepo): Move daemon paths off of CommandBase

### DIFF
--- a/crates/turborepo-lib/src/daemon/client.rs
+++ b/crates/turborepo-lib/src/daemon/client.rs
@@ -9,6 +9,7 @@ use super::{
     connector::{DaemonConnector, DaemonConnectorError},
     endpoint::SocketOpenError,
     proto::DiscoverPackagesResponse,
+    Paths,
 };
 use crate::{daemon::proto, globwatcher::HashGlobSetupError};
 
@@ -139,12 +140,8 @@ impl DaemonClient<DaemonConnector> {
         self.stop().await?.connect().await.map_err(Into::into)
     }
 
-    pub fn pid_file(&self) -> &turbopath::AbsoluteSystemPathBuf {
-        &self.connect_settings.pid_file
-    }
-
-    pub fn sock_file(&self) -> &turbopath::AbsoluteSystemPathBuf {
-        &self.connect_settings.sock_file
+    pub fn paths(&self) -> &Paths {
+        &self.connect_settings.paths
     }
 }
 

--- a/crates/turborepo-lib/src/daemon/mod.rs
+++ b/crates/turborepo-lib/src/daemon/mod.rs
@@ -111,24 +111,16 @@ pub(crate) mod proto {
 
 #[cfg(test)]
 mod test {
-    use test_case::test_case;
     use turbopath::AbsoluteSystemPathBuf;
 
     use super::repo_hash;
 
-    #[cfg(not(target_os = "windows"))]
-    #[test_case("/tmp/turborepo", "6e0cfa616f75a61c"; "basic example")]
-    fn test_repo_hash(path: &str, expected_hash: &str) {
-        let repo_root = AbsoluteSystemPathBuf::new(path).unwrap();
-        let hash = repo_hash(&repo_root);
-
-        assert_eq!(hash, expected_hash);
-        assert_eq!(hash.len(), 16);
-    }
-
-    #[cfg(target_os = "windows")]
-    #[test_case("C:\\\\tmp\\turborepo", "0103736e6883e35f"; "basic example")]
-    fn test_repo_hash_win(path: &str, expected_hash: &str) {
+    #[test]
+    fn test_repo_hash() {
+        #[cfg(not(target_os = "windows"))]
+        let (path, expected_hash) = ("/tmp/turborepo", "6e0cfa616f75a61c");
+        #[cfg(target_os = "windows")]
+        let (path, expected_hash) = ("C:\\\\tmp\\turborepo", "0103736e6883e35f");
         let repo_root = AbsoluteSystemPathBuf::new(path).unwrap();
         let hash = repo_hash(&repo_root);
 

--- a/crates/turborepo-lib/src/daemon/mod.rs
+++ b/crates/turborepo-lib/src/daemon/mod.rs
@@ -8,6 +8,60 @@ mod server;
 pub use client::{DaemonClient, DaemonError};
 pub use connector::{DaemonConnector, DaemonConnectorError};
 pub use server::{CloseReason, TurboGrpcService};
+use sha2::{Digest, Sha256};
+use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
+
+#[derive(Clone, Debug)]
+pub struct Paths {
+    pub pid_file: AbsoluteSystemPathBuf,
+    pub lock_file: AbsoluteSystemPathBuf,
+    pub sock_file: AbsoluteSystemPathBuf,
+    pub lsp_pid_file: AbsoluteSystemPathBuf,
+    pub log_file: AbsoluteSystemPathBuf,
+    pub log_folder: AbsoluteSystemPathBuf,
+}
+
+fn repo_hash(repo_root: &AbsoluteSystemPath) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(repo_root.to_string().as_bytes());
+    hex::encode(&hasher.finalize()[..8])
+}
+
+fn daemon_file_root(repo_hash: &str) -> AbsoluteSystemPathBuf {
+    AbsoluteSystemPathBuf::new(std::env::temp_dir().to_str().expect("UTF-8 path"))
+        .expect("temp dir is valid")
+        .join_component("turbod")
+        .join_component(repo_hash)
+}
+
+fn daemon_log_file_and_folder(repo_hash: &str) -> (AbsoluteSystemPathBuf, AbsoluteSystemPathBuf) {
+    let directories = directories::ProjectDirs::from("com", "turborepo", "turborepo")
+        .expect("user has a home dir");
+
+    let folder = AbsoluteSystemPathBuf::new(directories.data_dir().to_str().expect("UTF-8 path"))
+        .expect("absolute");
+
+    let log_folder = folder.join_component("logs");
+    let log_file = log_folder.join_component(format!("{}-turbo.log", repo_hash).as_str());
+
+    (log_file, log_folder)
+}
+
+impl Paths {
+    pub fn from_repo_root(repo_root: &AbsoluteSystemPath) -> Self {
+        let repo_hash = repo_hash(repo_root);
+        let daemon_root = daemon_file_root(&repo_hash);
+        let (log_file, log_folder) = daemon_log_file_and_folder(&repo_hash);
+        Self {
+            pid_file: daemon_root.join_component("turbod.pid"),
+            lock_file: daemon_root.join_component("turbod.lock"),
+            sock_file: daemon_root.join_component("turbod.sock"),
+            lsp_pid_file: daemon_root.join_component("lsp.pid"),
+            log_file,
+            log_folder,
+        }
+    }
+}
 
 pub(crate) mod proto {
 
@@ -52,5 +106,33 @@ pub(crate) mod proto {
                 turborepo_repository::package_manager::PackageManager::Bun => Self::Bun,
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use test_case::test_case;
+    use turbopath::AbsoluteSystemPathBuf;
+
+    use super::repo_hash;
+
+    #[cfg(not(target_os = "windows"))]
+    #[test_case("/tmp/turborepo", "6e0cfa616f75a61c"; "basic example")]
+    fn test_repo_hash(path: &str, expected_hash: &str) {
+        let repo_root = AbsoluteSystemPathBuf::new(path).unwrap();
+        let hash = repo_hash(&repo_root);
+
+        assert_eq!(hash, expected_hash);
+        assert_eq!(hash.len(), 16);
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test_case("C:\\\\tmp\\turborepo", "0103736e6883e35f"; "basic example")]
+    fn test_repo_hash_win(path: &str, expected_hash: &str) {
+        let repo_root = AbsoluteSystemPathBuf::new(path).unwrap();
+        let hash = repo_hash(&repo_root);
+
+        assert_eq!(hash, expected_hash);
+        assert_eq!(hash.len(), 16);
     }
 }

--- a/crates/turborepo-lib/src/daemon/server.rs
+++ b/crates/turborepo-lib/src/daemon/server.rs
@@ -42,11 +42,7 @@ use turborepo_repository::discovery::{
     DiscoveryResponse, LocalPackageDiscoveryBuilder, PackageDiscovery, PackageDiscoveryBuilder,
 };
 
-use super::{
-    bump_timeout::BumpTimeout,
-    endpoint::SocketOpenError,
-    proto::{self},
-};
+use super::{bump_timeout::BumpTimeout, endpoint::SocketOpenError, proto, Paths};
 use crate::daemon::{bump_timeout_layer::BumpTimeoutLayer, endpoint::listen_socket};
 
 #[derive(Debug)]
@@ -124,8 +120,7 @@ pub struct TurboGrpcService<S, PDB> {
     watcher_tx: watch::Sender<Option<Arc<FileWatching>>>,
     watcher_rx: watch::Receiver<Option<Arc<FileWatching>>>,
     repo_root: AbsoluteSystemPathBuf,
-    daemon_root: AbsoluteSystemPathBuf,
-    log_file: AbsoluteSystemPathBuf,
+    paths: Paths,
     timeout: Duration,
     external_shutdown: S,
 
@@ -144,8 +139,7 @@ where
     /// state if the filewatcher encounters errors.
     pub fn new(
         repo_root: AbsoluteSystemPathBuf,
-        daemon_root: AbsoluteSystemPathBuf,
-        log_file: AbsoluteSystemPathBuf,
+        paths: Paths,
         timeout: Duration,
         external_shutdown: S,
     ) -> Self {
@@ -161,8 +155,7 @@ where
             watcher_tx,
             watcher_rx,
             repo_root,
-            daemon_root,
-            log_file,
+            paths,
             timeout,
             external_shutdown,
             package_discovery_backup,
@@ -183,9 +176,8 @@ where
         package_discovery_backup: PDB2,
     ) -> TurboGrpcService<S, PDB2> {
         TurboGrpcService {
-            daemon_root: self.daemon_root,
             external_shutdown: self.external_shutdown,
-            log_file: self.log_file,
+            paths: self.paths,
             repo_root: self.repo_root,
             timeout: self.timeout,
             watcher_rx: self.watcher_rx,
@@ -198,19 +190,19 @@ where
         let Self {
             watcher_tx,
             watcher_rx,
-            daemon_root,
             external_shutdown,
-            log_file,
+            paths,
             repo_root,
             timeout,
             package_discovery_backup,
         } = self;
 
         let running = Arc::new(AtomicBool::new(true));
-        let (_pid_lock, stream) = match listen_socket(&daemon_root, running.clone()).await {
-            Ok((pid_lock, stream)) => (pid_lock, stream),
-            Err(e) => return Ok(CloseReason::SocketOpenError(e)),
-        };
+        let (_pid_lock, stream) =
+            match listen_socket(&paths.pid_file, &paths.sock_file, running.clone()).await {
+                Ok((pid_lock, stream)) => (pid_lock, stream),
+                Err(e) => return Ok(CloseReason::SocketOpenError(e)),
+            };
         trace!("acquired connection stream for socket");
 
         let watcher_repo_root = repo_root.to_owned();
@@ -265,7 +257,7 @@ where
             watcher_rx,
             times_saved: Arc::new(Mutex::new(HashMap::new())),
             start_time: Instant::now(),
-            log_file: log_file.to_owned(),
+            log_file: paths.log_file.clone(),
         };
         let server_fut = {
             let service = ServiceBuilder::new()
@@ -566,7 +558,7 @@ mod test {
     };
 
     use super::compare_versions;
-    use crate::daemon::{proto::VersionRange, CloseReason, TurboGrpcService};
+    use crate::daemon::{proto::VersionRange, CloseReason, Paths, TurboGrpcService};
 
     #[test_case("1.2.3", "1.2.3", VersionRange::Exact, true ; "exact match")]
     #[test_case("1.2.3", "1.2.3", VersionRange::Patch, true ; "patch match")]
@@ -622,19 +614,15 @@ mod test {
             .unwrap();
 
         let repo_root = path.join_component("repo");
-        let daemon_root = path.join_component("daemon");
-        let log_file = daemon_root.join_component("log");
+        let paths = Paths::from_repo_root(&repo_root);
         tracing::info!("start");
-
-        let pid_path = daemon_root.join_component("turbod.pid");
 
         let (tx, rx) = oneshot::channel::<CloseReason>();
         let exit_signal = rx.map(|_result| CloseReason::Interrupt);
 
         let service = TurboGrpcService::new(
             repo_root.clone(),
-            daemon_root,
-            log_file,
+            paths.clone(),
             Duration::from_secs(60 * 60),
             exit_signal,
         )
@@ -650,9 +638,9 @@ mod test {
 
         tokio::time::sleep(Duration::from_millis(2000)).await;
         assert!(
-            pid_path.exists(),
+            paths.pid_file.exists(),
             "pid file must be present at {:?}",
-            pid_path
+            paths.pid_file
         );
         // signal server exit
         tx.send(CloseReason::Interrupt).unwrap();
@@ -661,7 +649,7 @@ mod test {
         // The serve future should be dropped here, closing the server.
         tracing::info!("yay we are done");
 
-        assert!(!pid_path.exists(), "pid file must be deleted");
+        assert!(!paths.pid_file.exists(), "pid file must be deleted");
 
         tracing::info!("and files cleaned up");
     }
@@ -678,10 +666,7 @@ mod test {
             .unwrap();
 
         let repo_root = path.join_component("repo");
-        let daemon_root = path.join_component("daemon");
-        let log_file = daemon_root.join_component("log");
-
-        let pid_path = daemon_root.join_component("turbod.pid");
+        let paths = Paths::from_repo_root(&repo_root);
 
         let now = Instant::now();
         let (_tx, rx) = oneshot::channel::<CloseReason>();
@@ -689,8 +674,7 @@ mod test {
 
         let server = TurboGrpcService::new(
             repo_root.clone(),
-            daemon_root,
-            log_file,
+            paths.clone(),
             Duration::from_millis(10),
             exit_signal,
         )
@@ -713,7 +697,7 @@ mod test {
             Ok(CloseReason::Timeout),
             "must close due to timeout"
         );
-        assert!(!pid_path.exists(), "pid file must be deleted");
+        assert!(!paths.pid_file.exists(), "pid file must be deleted");
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -726,17 +710,14 @@ mod test {
             .unwrap();
 
         let repo_root = path.join_component("repo");
-        let daemon_root = path.join_component("daemon");
-        daemon_root.create_dir_all().unwrap();
-        let log_file = daemon_root.join_component("log");
+        let paths = Paths::from_repo_root(&repo_root);
 
         let (_tx, rx) = oneshot::channel::<CloseReason>();
         let exit_signal = rx.map(|_result| CloseReason::Interrupt);
 
         let server = TurboGrpcService::new(
             repo_root.clone(),
-            daemon_root,
-            log_file,
+            paths,
             Duration::from_secs(60 * 60),
             exit_signal,
         )

--- a/crates/turborepo-lib/src/lib.rs
+++ b/crates/turborepo-lib/src/lib.rs
@@ -36,8 +36,7 @@ mod unescape;
 pub use crate::{
     child::spawn_child,
     cli::Args,
-    commands::DaemonRootHasher,
-    daemon::{DaemonClient, DaemonConnector},
+    daemon::{DaemonClient, DaemonConnector, Paths as DaemonPaths},
     run::package_discovery::DaemonPackageDiscovery,
 };
 

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -246,13 +246,10 @@ impl Run {
                 None
             }
             (_, Some(true)) | (false, None) => {
-                let connector = DaemonConnector {
-                    can_start_server: true,
-                    can_kill_server: true,
-                    pid_file: self.base.daemon_file_root().join_component("turbod.pid"),
-                    sock_file: self.base.daemon_file_root().join_component("turbod.sock"),
-                };
-
+                let can_start_server = true;
+                let can_kill_server = true;
+                let connector =
+                    DaemonConnector::new(can_start_server, can_kill_server, &self.base.repo_root);
                 match (connector.connect().await, self.opts.run_opts.daemon) {
                     (Ok(client), _) => {
                         run_telemetry.track_daemon_init(DaemonInitStatus::Started);

--- a/packages/turbo-repository/npm/linux-x64-musl/package.json
+++ b/packages/turbo-repository/npm/linux-x64-musl/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@turbo/repository-linux-x64-musl",
+  "version": "0.0.1-canary.5",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel/turbo",
+    "directory": "packages/turbo-repository/npm/linux-x64-musl"
+  },
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "libc": [
+    "musl"
+  ],
+  "main": "repository.linux-x64-musl.node",
+  "files": [
+    "repository.linux-x64-musl.node"
+  ],
+  "license": "MPL-2.0",
+  "engines": {
+    "node": ">= 10"
+  }
+}


### PR DESCRIPTION
### Description

Stepping stone to moving `CommandBase` out of `run` 
- Move daemon path handling into the daemon module

### Testing Instructions

Updated existing test suite


Closes TURBO-2323