### PR TITLE
fix: do better validation for existing tokens

### DIFF
--- a/crates/turborepo-auth/src/auth/mod.rs
+++ b/crates/turborepo-auth/src/auth/mod.rs
@@ -5,7 +5,7 @@ mod sso;
 pub use login::*;
 pub use logout::*;
 pub use sso::*;
-use turborepo_api_client::Client;
+use turborepo_api_client::{Client, TokenClient};
 use turborepo_ui::{BOLD, UI};
 
 use crate::{ui, LoginServer, Token};
@@ -15,7 +15,7 @@ const VERCEL_TOKEN_FILE: &str = "auth.json";
 
 pub struct LoginOptions<'a, T>
 where
-    T: Client,
+    T: Client + TokenClient,
 {
     pub ui: &'a UI,
     pub login_url: &'a str,
@@ -27,7 +27,7 @@ where
 }
 impl<'a, T> LoginOptions<'a, T>
 where
-    T: Client,
+    T: Client + TokenClient,
 {
     pub fn new(
         ui: &'a UI,
@@ -46,16 +46,50 @@ where
     }
 }
 
-async fn check_token(
+async fn check_user_token(
     token: &str,
     ui: &UI,
-    api_client: &impl Client,
+    api_client: &(impl Client + TokenClient),
     message: &str,
 ) -> Result<Token, Error> {
-    let response = api_client.get_user(token).await?;
+    let response_user = api_client.get_user(token).await?;
     println!("{}", ui.apply(BOLD.apply_to(message)));
-    ui::print_cli_authorized(&response.user.email, ui);
+    ui::print_cli_authorized(&response_user.user.email, ui);
     Ok(Token::Existing(token.to_string()))
+}
+
+async fn check_sso_token(
+    token: &str,
+    sso_team: &str,
+    ui: &UI,
+    api_client: &(impl Client + TokenClient),
+    message: &str,
+) -> Result<Token, Error> {
+    let (result_user, result_teams) =
+        tokio::join!(api_client.get_user(token), api_client.get_teams(token),);
+
+    let token = Token::existing(token.into());
+
+    match (result_user, result_teams) {
+        (Ok(response_user), Ok(response_teams)) => {
+            if response_teams
+                .teams
+                .iter()
+                .any(|team| team.slug == sso_team)
+            {
+                if token.is_valid(api_client).await? {
+                    println!("{}", ui.apply(BOLD.apply_to(message)));
+                    ui::print_cli_authorized(&response_user.user.email, ui);
+                    Ok(token)
+                } else {
+                    Err(Error::SSOTokenExpired(sso_team.to_string()))
+                }
+            } else {
+                Err(Error::SSOTeamNotFound(sso_team.to_string()))
+            }
+        }
+        (Err(e), _) | (_, Err(e)) => Err(Error::APIError(e)),
+    }
 }
 
 fn extract_vercel_token() -> Result<String, Error> {

--- a/crates/turborepo-auth/src/auth/sso.rs
+++ b/crates/turborepo-auth/src/auth/sso.rs
@@ -3,10 +3,13 @@ use std::sync::Arc;
 use reqwest::Url;
 use tokio::sync::OnceCell;
 use tracing::warn;
-use turborepo_api_client::Client;
-use turborepo_ui::{start_spinner, BOLD};
+use turborepo_api_client::{Client, TokenClient};
+use turborepo_ui::start_spinner;
 
-use crate::{auth::extract_vercel_token, error, ui, Error, LoginOptions, Token};
+use crate::{
+    auth::{check_sso_token, extract_vercel_token},
+    error, ui, Error, LoginOptions, Token,
+};
 
 const DEFAULT_HOST_NAME: &str = "127.0.0.1";
 const DEFAULT_PORT: u16 = 9789;
@@ -24,50 +27,42 @@ fn make_token_name() -> Result<String, Error> {
 /// Perform an SSO login flow. If an existing token is present, and the token
 /// has access to the provided `sso_team`, we do not overwrite it and instead
 /// log that we found an existing token.
-pub async fn sso_login<'a, T: Client>(options: &LoginOptions<'_, T>) -> Result<Token, Error> {
+pub async fn sso_login<'a, T: Client + TokenClient>(
+    options: &LoginOptions<'_, T>,
+) -> Result<Token, Error> {
     let LoginOptions {
         api_client,
         ui,
         login_url: login_url_configuration,
         login_server,
         sso_team,
-        existing_token: _,
+        existing_token,
     } = *options;
 
     let sso_team = sso_team.ok_or(Error::EmptySSOTeam)?;
     // Check if token exists first. Must be there for the user and contain the
     // sso_team passed into this function.
-    if let Some(token) = options.existing_token {
-        let (result_user, result_teams) =
-            tokio::join!(api_client.get_user(token), api_client.get_teams(token));
-
-        if let (Ok(response_user), Ok(response_teams)) = (result_user, result_teams) {
-            if response_teams
-                .teams
-                .iter()
-                .any(|team| team.slug == sso_team)
-            {
-                println!("{}", ui.apply(BOLD.apply_to("Existing token found!")));
-                ui::print_cli_authorized(&response_user.user.email, ui);
-                return Ok(Token::Existing(token.into()));
-            }
+    if let Some(token) = existing_token {
+        if Token::existing(token.to_string())
+            .is_valid(api_client)
+            .await?
+        {
+            return check_sso_token(token, sso_team, ui, api_client, "Existing token found!").await;
         }
     }
 
-    // No existing token found. If the user is logging into Vercel, check for an
-    // existing `vc` token with correct scope.
+    // No existing turbo token found. If the user is logging into Vercel, check for
+    // an existing `vc` token with correct scope.
     if login_url_configuration.contains("vercel.com") {
-        match extract_vercel_token() {
-            Ok(token) => {
-                println!(
-                    "{}",
-                    ui.apply(BOLD.apply_to("Existing Vercel token found!"))
-                );
-                return Ok(Token::Existing(token));
-            }
-            Err(e) => {
-                dbg!("Failed to extract Vercel token: ", e);
-            }
+        if let Ok(token) = extract_vercel_token() {
+            return check_sso_token(
+                &token,
+                sso_team,
+                ui,
+                api_client,
+                "Existing Vercel token found!",
+            )
+            .await;
         }
     }
 
@@ -294,6 +289,33 @@ mod tests {
         }
     }
 
+    #[async_trait]
+    impl TokenClient for MockApiClient {
+        async fn get_metadata(
+            &self,
+            token: &str,
+        ) -> turborepo_api_client::Result<turborepo_vercel_api::token::ResponseTokenMetadata>
+        {
+            if token.is_empty() {
+                return Err(MockApiError::EmptyToken.into());
+            }
+            Ok(turborepo_vercel_api::token::ResponseTokenMetadata {
+                id: "id".to_string(),
+                name: "name".to_string(),
+                token_type: "token".to_string(),
+                origin: "github".to_string(),
+                scopes: vec![turborepo_vercel_api::token::Scope {
+                    scope_type: "team".to_string(),
+                    origin: "saml".to_string(),
+                    team_id: Some("team_vozisthebest".to_string()),
+                    created_at: 1111111111111,
+                    expires_at: Some(9999999990000),
+                }],
+                active_at: 0,
+                created_at: 123456,
+            })
+        }
+    }
     #[derive(Clone)]
     struct MockSSOLoginServer {
         hits: Arc<AtomicUsize>,

--- a/crates/turborepo-auth/src/error.rs
+++ b/crates/turborepo-auth/src/error.rs
@@ -30,4 +30,8 @@ pub enum Error {
     ConfigDirNotFound,
     #[error("sso team cannot be empty for login")]
     EmptySSOTeam,
+    #[error("sso team not found: {0}")]
+    SSOTeamNotFound(String),
+    #[error("sso token expired for team: {0}")]
+    SSOTokenExpired(String),
 }

--- a/crates/turborepo-auth/src/lib.rs
+++ b/crates/turborepo-auth/src/lib.rs
@@ -12,19 +12,150 @@ mod ui;
 pub use auth::*;
 pub use error::Error;
 pub use login_server::*;
+use turborepo_api_client::TokenClient;
+use turborepo_vercel_api::token::ResponseTokenMetadata;
 
 /// Token is the result of a successful login. It contains the token string and
-/// a boolean indicating whether the token already existed on the filesystem.
-#[derive(Debug)]
+/// potentially metadata about the token.
+#[derive(Debug, Clone)]
 pub enum Token {
+    /// An existing token on the filesystem
     Existing(String),
+    /// A token that was just created, but not yet written to the filesystem
     New(String),
 }
 impl Token {
-    pub fn into_inner(self) -> String {
+    pub fn new(token: String) -> Self {
+        Self::New(token)
+    }
+    pub fn existing(token: String) -> Self {
+        Self::Existing(token)
+    }
+    /// Checks if the token is valid. We do a few checks:
+    /// 1. Fetch the token metadata.
+    /// 2. From the metadata, check if the token is active.
+    /// 3. If the token is a SAML SSO token, check if it's expired.
+    pub async fn is_valid(&self, client: &impl TokenClient) -> Result<bool, Error> {
+        let metadata = self.fetch_metadata(client).await?;
+        let current_time = current_unix_time();
+        let active = is_token_active(&metadata, current_time);
+        Ok(active)
+    }
+
+    async fn fetch_metadata(
+        &self,
+        client: &impl TokenClient,
+    ) -> Result<ResponseTokenMetadata, Error> {
+        client
+            .get_metadata(self.into_inner())
+            .await
+            .map_err(Error::from)
+    }
+    /// Returns the underlying token string.
+    pub fn into_inner(&self) -> &str {
         match self {
-            Self::Existing(s) => s,
-            Self::New(s) => s,
+            Self::Existing(token) | Self::New(token) => token.as_str(),
+        }
+    }
+}
+
+fn current_unix_time() -> u128 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("Time went backwards")
+        .as_millis()
+}
+
+// As of the time of writing, this should always be true, since a token that
+// isn't active returns an error when fetching metadata for the token.
+fn is_token_active(metadata: &ResponseTokenMetadata, current_time: u128) -> bool {
+    let active_at = metadata.active_at;
+
+    let earliest_expiration = metadata
+        .scopes
+        .iter()
+        .filter_map(|scope| scope.expires_at)
+        .min();
+
+    // Not all scopes have an expiration date, so we need to check if all of them
+    // are expired. If there isn't an expiration date, we assume they are infinite
+    // and therefore cannot be expired.
+    let all_scopes_active =
+        earliest_expiration.map_or(true, |expiration| current_time < expiration);
+
+    all_scopes_active && (active_at <= current_time)
+}
+
+#[cfg(test)]
+mod tests {
+    use turborepo_vercel_api::token::Scope;
+
+    use super::*;
+
+    #[test]
+    fn test_is_token_active() {
+        let current_time = current_unix_time();
+        let quick_scope = |expiry| Scope {
+            expires_at: expiry,
+            scope_type: "".to_string(),
+            origin: "".to_string(),
+            created_at: 0,
+            team_id: None,
+        };
+        let mock_response = |active_at, scopes| ResponseTokenMetadata {
+            active_at,
+            scopes,
+            // These fields don't matter in the test
+            id: "".to_string(),
+            name: "".to_string(),
+            token_type: "".to_string(),
+            origin: "".to_string(),
+            created_at: 0,
+        };
+
+        let cases = vec![
+            // Case: Token active, no scopes (implicitly infinite)
+            (current_time - 100, vec![], true),
+            // Case: Token active, one scope without expiration
+            (current_time - 100, vec![quick_scope(None)], true),
+            // Case: Token active, one scope expired
+            (
+                current_time - 100,
+                vec![quick_scope(Some(current_time - 1))],
+                false,
+            ),
+            // Case: Token active, one scope not expired
+            (
+                current_time - 100,
+                vec![quick_scope(Some(current_time + 11))],
+                true,
+            ),
+            // Case: Token active, all scopes not expired
+            (
+                current_time - 100,
+                vec![
+                    quick_scope(Some(current_time + 11)),
+                    quick_scope(Some(current_time + 10)),
+                ],
+                true,
+            ),
+            // Case: Token inactive (future `active_at`)
+            (
+                current_time + 1000,
+                vec![quick_scope(Some(current_time + 20))],
+                false,
+            ),
+        ];
+
+        for (active_at, scopes, expected) in cases {
+            let metadata = mock_response(active_at, scopes);
+            assert_eq!(
+                is_token_active(&metadata, current_time),
+                expected,
+                "Test failed for active_at: {}",
+                active_at
+            );
         }
     }
 }

--- a/crates/turborepo-auth/src/ui/mod.rs
+++ b/crates/turborepo-auth/src/ui/mod.rs
@@ -1,3 +1,3 @@
 mod messages;
 
-pub use messages::*;
+pub use messages::print_cli_authorized;

--- a/crates/turborepo-vercel-api/src/token.rs
+++ b/crates/turborepo-vercel-api/src/token.rs
@@ -2,27 +2,27 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ResponseTokenMetadata {
-    id: String,
-    name: String,
+    pub id: String,
+    pub name: String,
     #[serde(rename = "type")]
-    token_type: String,
-    origin: String,
-    scopes: Vec<Scope>,
+    pub token_type: String,
+    pub origin: String,
+    pub scopes: Vec<Scope>,
     #[serde(rename = "activeAt")]
-    active_at: u64,
+    pub active_at: u128,
     #[serde(rename = "createdAt")]
-    created_at: u64,
+    pub created_at: u128,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Scope {
     #[serde(rename = "type")]
-    scope_type: String,
-    origin: String,
+    pub scope_type: String,
+    pub origin: String,
     #[serde(rename = "createdAt")]
-    created_at: u64,
+    pub created_at: u128,
     #[serde(rename = "expiresAt")]
-    expires_at: Option<u64>,
+    pub expires_at: Option<u128>,
     #[serde(rename = "teamId")]
-    team_id: Option<String>,
+    pub team_id: Option<String>,
 }


### PR DESCRIPTION
### Description
Found a path in which a token can be invalid but we claim it isn't. The user would have to run `turbo logout` and then login to get a new token.

### Testing Instructions
1. Login
2. Go to Vercel account or whatever API issues tokens and delete the token (invalidate it)
3. run `turbo login` again
4. Ensure that login process proceeds as normal


Closes TURBO-2334