### PR TITLE
chore(Turborepo): Remote CommandBase from Run

### DIFF
--- a/crates/turborepo-lib/src/config.rs
+++ b/crates/turborepo-lib/src/config.rs
@@ -607,9 +607,8 @@ mod test {
     use turbopath::AbsoluteSystemPathBuf;
 
     use crate::config::{
-        get_env_var_config, get_override_env_var_config, ConfigurationOptions, RawTurboJson,
-        ResolvedConfigurationOptions, TurborepoConfigBuilder, DEFAULT_API_URL, DEFAULT_LOGIN_URL,
-        DEFAULT_TIMEOUT,
+        get_env_var_config, get_override_env_var_config, ConfigurationOptions,
+        TurborepoConfigBuilder, DEFAULT_API_URL, DEFAULT_LOGIN_URL, DEFAULT_TIMEOUT,
     };
 
     #[test]

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -21,7 +21,6 @@ pub use cache::{ConfigCache, RunCache, TaskCache};
 use chrono::{DateTime, Local};
 use itertools::Itertools;
 use rayon::iter::ParallelBridge;
-use sha2::digest::typenum::Abs;
 use tracing::debug;
 use turbopath::{AbsoluteSystemPathBuf, AnchoredSystemPath};
 use turborepo_analytics::{start_analytics, AnalyticsHandle, AnalyticsSender};
@@ -75,6 +74,7 @@ pub struct Run {
     repo_root: AbsoluteSystemPathBuf,
     ui: UI,
     version: &'static str,
+    cwd: AbsoluteSystemPathBuf,
 }
 
 impl Run {
@@ -448,7 +448,7 @@ impl Run {
                 graph_opts,
                 &engine,
                 self.opts.run_opts.single_package,
-                self.base.cwd(),
+                &self.cwd,
             )?;
             return Ok(0);
         }

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -114,10 +114,6 @@ impl Run {
         });
     }
 
-    fn targets(&self) -> &[String] {
-        self.base.args().get_tasks()
-    }
-
     fn initialize_analytics(
         api_auth: Option<APIAuth>,
         api_client: APIClient,
@@ -347,7 +343,7 @@ impl Run {
             )?;
 
             if is_all_packages {
-                for target in self.targets() {
+                for target in self.opts.run_opts.tasks.iter() {
                     let mut task_name = TaskName::from(target.as_str());
                     // If it's not a package task, we convert to a root task
                     if !task_name.is_package_task() {


### PR DESCRIPTION
### Description

 - `Run` no longer requires a `CommandBase` instance, although the constructor still takes one.

### Testing Instructions

Existing test suite


Closes TURBO-2335