### PR TITLE
build: Update `swc_core` to `v0.90.8`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,9 +800,9 @@ dependencies = [
 
 [[package]]
 name = "binding_macros"
-version = "0.64.4"
+version = "0.64.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1170b86b43d48c750a4161dede3abeacdb5095132d1b8d74bed97129dda8ed6"
+checksum = "d85810af73121525ef4c70a6ca2d1b4fc8965c9fa8a0be61ab350794191b4821"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -4055,7 +4055,7 @@ checksum = "334e04b4d781f436dc315cb1e7515bd96826426345d498149e4bde36b67f8ee9"
 dependencies = [
  "async-channel",
  "castaway",
- "crossbeam-utils 0.7.2",
+ "crossbeam-utils 0.8.16",
  "curl",
  "curl-sys",
  "encoding_rs",
@@ -7965,9 +7965,9 @@ dependencies = [
 
 [[package]]
 name = "styled_jsx"
-version = "0.73.7"
+version = "0.73.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633be6a8f8ea8007a2b1fbe80c220193a9a9f603a8023c43f8987864081770f3"
+checksum = "9215277feaeb625e11469ca0e94f9f76b66c2b99b12fb3314b49f84403aa93f2"
 dependencies = [
  "anyhow",
  "lightningcss",
@@ -8067,9 +8067,9 @@ dependencies = [
 
 [[package]]
 name = "swc"
-version = "0.273.4"
+version = "0.273.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9ed398f8ab7a1acf17dec3d795df7ce23738326a871ab4785818bb8df1cc26b"
+checksum = "29662f45ba08ceab97868d7eae3d22d01f4373a4a9e1fdeb04146077a8d3a048"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -8144,9 +8144,9 @@ dependencies = [
 
 [[package]]
 name = "swc_bundler"
-version = "0.225.3"
+version = "0.225.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26491762e84ae1d0a2e179fe48066072834777a1b12e8e88a7f07c8f92cc0188"
+checksum = "feb8b6f3ad184a5ae21544411491bf136635237fc097d7c93ccd915449ebb2ba"
 dependencies = [
  "anyhow",
  "crc",
@@ -8223,9 +8223,9 @@ dependencies = [
 
 [[package]]
 name = "swc_compiler_base"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eebbfcc08363d11cae791e25f504342be79ca8e16bd807a85c71b0a5d97c8c7c"
+checksum = "e177f5ceb92119809c38c180fddb74e5f6261c6091e8f8a8bfc769f4744ba8ed"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -8275,9 +8275,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "0.90.7"
+version = "0.90.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "659de9837eef174a50130e3253bc0711cdbad980d9e941352c45075f3d4caf16"
+checksum = "28da75904d199c7bb0a7ae7a6e07955ac70be3e759028f575d0aa3b7faa74ea0"
 dependencies = [
  "binding_macros",
  "swc",
@@ -8514,9 +8514,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_bugfixes"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39c4b1f0a45fb1a560837afadbe77b547f5b1ca0f62ff52f7ca0d29ad22cb48b"
+checksum = "b1ef12773a83364fe9b934490e557164b3f23423bae346e67a323fbd9cbfbb95"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -8531,9 +8531,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_common"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55c0734e14443f2d5dfa0f933d4a7ff787a327d38b7cb4f10d4a7ee1fc8862bd"
+checksum = "29751a60f7e1c44bd9669f940b71957b8f17bfd837ca947f2425e7e971485648"
 dependencies = [
  "swc_common",
  "swc_ecma_ast",
@@ -8544,9 +8544,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2015"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320036897503534294155cfd7d47bdb583b06dbee95e71ff1d1ad6eef6be5442"
+checksum = "777c78abf582278d8403bb22fe34d8db7d47b2565fa6980e492c71ed070eb078"
 dependencies = [
  "arrayvec 0.7.4",
  "indexmap 2.2.3",
@@ -8570,9 +8570,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2016"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c0108162d1ab43f33d29faf93760efbda00d9cc96dd654f7f220662ca6d0871"
+checksum = "a885ffcbcd9600448d02feaffb154b86bbf2f0f3fc127dadd0747319ac0d7c16"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -8587,9 +8587,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2017"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "814460bff11f152184f794ac84309334ccfcad92404c5235412a88027e000c3f"
+checksum = "666cb581acaaca4d826a5cc5221dab2ded36a5d293d8af0c9fb56be933a267aa"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -8605,9 +8605,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2018"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "102f94b4677bf34b0890b03a13c59e67c18122d831d4e992c1111ccf48171aab"
+checksum = "906524e29978f030abd447427d9585e944950d0c179a5d5d7d66de7570c20add"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -8624,9 +8624,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2019"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ac4656b17a8d799620fb0cff099a10cf5d91b1853fc587f8d491e596b995a7a"
+checksum = "ef5fccb10fb2dd7e647a22c5af41c4b195d388be9da74a82b7c8f81c69147cd7"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -8640,9 +8640,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2020"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a30694e7afcfe2fa8feeab04b85003f230b3b5fe605934092d1423f3df0cb319"
+checksum = "904ce3a51613bd0b7e5eb09fad85ce5ef0a070469cb59f178428a4b7e9e65207"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -8658,9 +8658,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2021"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "172278873dc92590992024fd2efb6acdb167fe880d01d0d045ef25b548eaa6f5"
+checksum = "23b51a9648eb2d26b009842028fe60fc78387369ab708062b989f36140b52a15"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -8674,9 +8674,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2022"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43758b14ccc3bcef05b3ebef65853a85ea94b41b52033776b49dd36cf060b72c"
+checksum = "88be2d3c2653e42b1d798173c933f1483c7b3cb182635e2d344da40cb3d3627a"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -8693,9 +8693,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es3"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "400db8f07b31399f89f6bc306721fbb4a8b1a72a8eb61b2f888b4df2fe2d7b4c"
+checksum = "a53e83e16c984fda1d834c204f6e10af618f9759078220d6b82ced7431b9b733"
 dependencies = [
  "swc_common",
  "swc_ecma_ast",
@@ -8708,9 +8708,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ext_transforms"
-version = "0.113.3"
+version = "0.113.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1cca0a61b7d5a9df652eeef387fc551a188fd5d493720048dbbf87ff6bb6a75"
+checksum = "7e59defec08f67a137ec4341a68d8ed9263acb673cb8b47127ac5e4357780222"
 dependencies = [
  "phf 0.11.2",
  "swc_atoms",
@@ -8722,9 +8722,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_lints"
-version = "0.92.3"
+version = "0.92.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c5b6ee742fe3f9b2eff18173e7322757fec6008ba510bb58f9d31d1c3bdb13"
+checksum = "4195391d5838b2dbd842eaa0743880ec26365d9b8bc5c152e290448f1ea0c7cd"
 dependencies = [
  "auto_impl",
  "dashmap",
@@ -8764,9 +8764,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "0.192.3"
+version = "0.192.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bacdf661c989479adb95505f8c3898a243fa414d786c0b0bcb6531175e5704f8"
+checksum = "346fdd6d2e1204aac567a6c65590c1655a25deb11e8fb95fe7d6cf4fe6b54a5e"
 dependencies = [
  "arrayvec 0.7.4",
  "indexmap 2.2.3",
@@ -8820,9 +8820,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "0.206.3"
+version = "0.206.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cb7bf0b7f71571961b4b11825169121b5047b24824616e4ed95e5b8119c457e"
+checksum = "bb8c5afa66f972f2c4e5db77a76c20fef7d25da85b3df23d4e176d3ea3fd1838"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -8875,9 +8875,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.229.3"
+version = "0.229.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a35a7b4948bdfa6d0e08e2bbcf6ce1e9849122a2369083b4600bd539a650956"
+checksum = "f41bafb5edab36d4b65392c8b7c9c2ca937b6200153af337579c57859f648125"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -8895,9 +8895,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.137.3"
+version = "0.137.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfd47dd9ccb73a1f5d8d7eff9518554b752b1733b56503af090e78859abb42dd"
+checksum = "803bb435fdd532d5c931f0d487e48dbc94750d26c9336d79a6f1c04c62f08d93"
 dependencies = [
  "better_scoped_tls",
  "bitflags 2.4.0",
@@ -8919,9 +8919,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "0.126.3"
+version = "0.126.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecb31417e0d415d7f0ff026f1e7c909427e386b7d0af9a2a78678507e4d9d79"
+checksum = "486479e75907547d4c65ca6deed8faa465a2e9475cc9605be36a0e5eb609f578"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -8933,9 +8933,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "0.163.3"
+version = "0.163.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65b871359cbbdcd182d321a8905b0fc9839f2fcdd1fdde5dcd111fae3d85b365"
+checksum = "672a07faa42f9f2c1df4f79f380be772487488f594eedc666f3a7c1d43c563e4"
 dependencies = [
  "arrayvec 0.7.4",
  "indexmap 2.2.3",
@@ -8982,9 +8982,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "0.180.3"
+version = "0.180.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc3b29a2eafaff07a91be08b244bb0c2991e0579e4e7f4f40cdb9b4f828430ab"
+checksum = "9ce537861ab71efcf83a454132407235ccea86b3d7331d92b3af7fa142e1fb4b"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -9009,9 +9009,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.198.3"
+version = "0.198.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3920268ac8972b494067d0b7c088964b21d08f5d1f58d7151bd1eb7054a137b0"
+checksum = "f3c6fffe4d6e3609fdd6c768cc063dbc9f5101f9be0db1168ec76ace979cf616"
 dependencies = [
  "dashmap",
  "indexmap 2.2.3",
@@ -9034,9 +9034,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "0.171.3"
+version = "0.171.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "448c40c2a2b224cb5101cc6cdee81837c281a34f2a2aa6dd18d6d5cd8d492e60"
+checksum = "e2822bc6c28bb1a96090a3b2caa28f45efbaecb333714d30868a2390eaae943f"
 dependencies = [
  "either",
  "rustc-hash",
@@ -9054,9 +9054,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.183.3"
+version = "0.183.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2394dc3abceada246feeb709b8c4d23392973f49a24fcc59b2ee21737cb6c8"
+checksum = "8984ebb8955116c426457a0c70b0aa9a08a06656e245781ff617a9cd1e289697"
 dependencies = [
  "base64 0.21.4",
  "dashmap",
@@ -9079,9 +9079,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_testing"
-version = "0.140.3"
+version = "0.140.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbdef550cbff972c2fdad5d7f82e55127d47c0df54295596eb2c80f9cf2685ff"
+checksum = "74719bd3f5a1dc2927d0ed0ffdd44ec3430eb8561cc5d71f9f663d425a185062"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -9105,9 +9105,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.188.3"
+version = "0.188.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cff231437173e041e5a3be9b8c782fd297ffcb53ed16d805f853e4a68315c45"
+checksum = "a2e898fbab993abb60fb67009521908f2317f1d33f804e5b38d769f52e58572e"
 dependencies = [
  "ryu-js",
  "serde",
@@ -9122,9 +9122,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_usage_analyzer"
-version = "0.23.3"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae28fff745a9e581ede62de40f4452064426f137f53192691367439fff48a98"
+checksum = "a0950f5344e7125bdcd42055eec6c2c0abe44b6952749967b206832c65e27623"
 dependencies = [
  "indexmap 2.2.3",
  "rustc-hash",
@@ -9139,9 +9139,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.127.3"
+version = "0.127.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd185161161dfc65ee0d6f3044c901b766c3abb4efcd0b35c9e76c833724896"
+checksum = "8ff9e77ea18468895d26bd38656885860fede2acd24d1687f64363aaf8910441"
 dependencies = [
  "indexmap 2.2.3",
  "num_cpus",
@@ -11892,7 +11892,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "rand 0.8.5",
  "static_assertions",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,8 +99,8 @@ miette = { version = "5.10.0", features = ["fancy"] }
 mdxjs = "0.1.23"
 modularize_imports = { version = "0.68.5" }
 styled_components = { version = "0.96.6" }
-styled_jsx = { version = "0.73.7" }
-swc_core = { version = "0.90.7", features = [
+styled_jsx = { version = "0.73.8" }
+swc_core = { version = "0.90.8", features = [
   "ecma_loader_lru",
   "ecma_loader_parking_lot",
 ] }


### PR DESCRIPTION
### Description

Update swc crates one more time.

### Testing Instructions

See https://github.com/vercel/next.js/pull/61976

Closes PACK-2477