### PR TITLE
fix(ecmascript): parse as module by default

### DIFF
--- a/crates/turbopack-ecmascript/src/parse.rs
+++ b/crates/turbopack-ecmascript/src/parse.rs
@@ -303,7 +303,7 @@ async fn parse_content(
                 );
 
                 let mut parser = Parser::new_from(lexer);
-                let program_result = parser.parse_program();
+                let program_result = parser.parse_module().map(Program::Module);
 
                 let mut has_errors = false;
                 for e in parser.take_errors() {


### PR DESCRIPTION
### Description

https://github.com/vercel/next.js/pull/61922

It looks like next-swc treats parse as module by default, follow the same practice.

Closes [PACK-2460](https://linear.app/vercel/issue/PACK-2460)


Closes PACK-2483