### PR TITLE
chore(turbo): rename workspace -> package in PackageGraph module

### DIFF
--- a/crates/turborepo-lib/src/commands/info.rs
+++ b/crates/turborepo-lib/src/commands/info.rs
@@ -101,7 +101,7 @@ pub async fn run(
 impl<'a> RepositoryDetails<'a> {
     fn new(package_graph: &'a PackageGraph, config: &'a ConfigurationOptions) -> Self {
         let mut workspaces: Vec<_> = package_graph
-            .workspaces()
+            .packages()
             .map(|(workspace_name, workspace_info)| {
                 let workspace_details = RepositoryWorkspaceDetails {
                     path: workspace_info.package_path(),

--- a/crates/turborepo-lib/src/commands/prune.rs
+++ b/crates/turborepo-lib/src/commands/prune.rs
@@ -132,7 +132,7 @@ pub async fn prune(
     for workspace in workspaces {
         let entry = prune
             .package_graph
-            .workspace_info(&workspace)
+            .package_info(&workspace)
             .ok_or_else(|| Error::MissingWorkspace(workspace.clone()))?;
 
         // We don't want to do any copying for the root workspace
@@ -282,7 +282,7 @@ impl<'a> Prune<'a> {
 
         for target in scope {
             let workspace = PackageName::Other(target.clone());
-            let Some(info) = package_graph.workspace_info(&workspace) else {
+            let Some(info) = package_graph.package_info(&workspace) else {
                 return Err(Error::MissingWorkspace(workspace));
             };
             trace!(

--- a/crates/turborepo-lib/src/engine/builder.rs
+++ b/crates/turborepo-lib/src/engine/builder.rs
@@ -377,11 +377,12 @@ impl<'a> EngineBuilder<'a> {
                 workspace: workspace.clone(),
             }
         })?;
-        let workspace_dir = self.package_graph.workspace_dir(workspace).ok_or_else(|| {
-            Error::MissingPackageJson {
-                workspace: workspace.clone(),
-            }
-        })?;
+        let workspace_dir =
+            self.package_graph
+                .package_dir(workspace)
+                .ok_or_else(|| Error::MissingPackageJson {
+                    workspace: workspace.clone(),
+                })?;
         Ok(TurboJson::load(
             self.repo_root,
             workspace_dir,

--- a/crates/turborepo-lib/src/engine/mod.rs
+++ b/crates/turborepo-lib/src/engine/mod.rs
@@ -201,7 +201,7 @@ impl Engine<Built> {
 
                 // check if the package for the task has that task in its package.json
                 let info = package_graph
-                    .workspace_info(&PackageName::from(task_id.package().to_string()))
+                    .package_info(&PackageName::from(task_id.package().to_string()))
                     .expect("package graph should contain workspace info for task package");
 
                 let package_has_task = info

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -429,7 +429,7 @@ impl Run {
             global_env_mode = EnvMode::Strict;
         }
 
-        let workspaces = pkg_dep_graph.workspaces().collect();
+        let workspaces = pkg_dep_graph.packages().collect();
         let package_inputs_hashes = PackageInputsHashes::calculate_file_hashes(
             &scm,
             engine.tasks().par_bridge(),

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -374,7 +374,7 @@ impl Run {
         }
 
         let root_workspace = pkg_dep_graph
-            .workspace_info(&PackageName::Root)
+            .package_info(&PackageName::Root)
             .expect("must have root workspace");
 
         let is_monorepo = !self.opts.run_opts.single_package;

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -440,7 +440,7 @@ impl Run {
         )?;
 
         if self.opts.run_opts.parallel {
-            pkg_dep_graph.remove_workspace_dependencies();
+            pkg_dep_graph.remove_package_dependencies();
             engine = self.build_engine(&pkg_dep_graph, &root_turbo_json, &filtered_pkgs)?;
         }
 

--- a/crates/turborepo-lib/src/run/scope/change_detector.rs
+++ b/crates/turborepo-lib/src/run/scope/change_detector.rs
@@ -92,7 +92,7 @@ impl<'a> GitChangeDetector for ScopeChangeDetector<'a> {
         {
             PackageChanges::All => Ok(self
                 .pkg_graph
-                .workspaces()
+                .packages()
                 .map(|(name, _)| name.to_owned())
                 .collect()),
             PackageChanges::Some(packages) => Ok(packages

--- a/crates/turborepo-lib/src/run/scope/filter.rs
+++ b/crates/turborepo-lib/src/run/scope/filter.rs
@@ -268,7 +268,7 @@ impl<'a, T: GitChangeDetector> FilterResolver<'a, T> {
                     let dependencies = dependencies
                         .iter()
                         .flatten()
-                        .map(|i| i.as_workspace().to_owned())
+                        .map(|i| i.as_package_name().to_owned())
                         .collect::<Vec<_>>();
 
                     // flatmap through the option, the set, and then the optional package name
@@ -277,7 +277,7 @@ impl<'a, T: GitChangeDetector> FilterResolver<'a, T> {
 
                 if selector.include_dependents {
                     let dependents = self.pkg_graph.ancestors(&node);
-                    for dependent in dependents.iter().map(|i| i.as_workspace()) {
+                    for dependent in dependents.iter().map(|i| i.as_package_name()) {
                         walked_dependents.insert(dependent.clone());
 
                         // get the dependent's dependencies
@@ -291,7 +291,7 @@ impl<'a, T: GitChangeDetector> FilterResolver<'a, T> {
                             let dependent_dependencies = dependent_dependencies
                                 .iter()
                                 .flatten()
-                                .map(|i| i.as_workspace().to_owned())
+                                .map(|i| i.as_package_name().to_owned())
                                 .collect::<HashSet<_>>();
 
                             walked_dependent_dependencies.extend(dependent_dependencies);

--- a/crates/turborepo-lib/src/run/scope/filter.rs
+++ b/crates/turborepo-lib/src/run/scope/filter.rs
@@ -41,7 +41,7 @@ impl PackageInference {
             pkg_inference_path
         );
         let full_inference_path = turbo_root.resolve(pkg_inference_path);
-        for (workspace_name, workspace_entry) in pkg_graph.workspaces() {
+        for (workspace_name, workspace_entry) in pkg_graph.packages() {
             let pkg_path = turbo_root.resolve(workspace_entry.package_path());
             let inferred_path_is_below = pkg_path.contains(&full_inference_path);
             // We skip over the root package as the inferred path will always be below it
@@ -158,7 +158,7 @@ impl<'a, T: GitChangeDetector> FilterResolver<'a, T> {
         let filter_patterns = if is_all_packages {
             // return all packages in the workspace
             self.pkg_graph
-                .workspaces()
+                .packages()
                 .filter(|(name, _)| matches!(name, PackageName::Other(_)))
                 .map(|(name, _)| name.to_owned())
                 .collect()
@@ -228,7 +228,7 @@ impl<'a, T: GitChangeDetector> FilterResolver<'a, T> {
             self.filter_graph_with_selectors(include_selectors)?
         } else {
             self.pkg_graph
-                .workspaces()
+                .packages()
                 // todo: a type-level way of dealing with non-root packages
                 .filter(|(name, _)| !PackageName::Root.eq(name)) // the root package has to be explicitly included
                 .map(|(name, _)| name.to_owned())
@@ -348,7 +348,7 @@ impl<'a, T: GitChangeDetector> FilterResolver<'a, T> {
     ) -> Result<HashSet<PackageName>, ResolutionError> {
         let mut entry_packages = HashSet::new();
 
-        for (name, info) in self.pkg_graph.workspaces() {
+        for (name, info) in self.pkg_graph.packages() {
             if selector.parent_dir == AnchoredSystemPathBuf::default() {
                 entry_packages.insert(name.to_owned());
             } else {
@@ -427,7 +427,7 @@ impl<'a, T: GitChangeDetector> FilterResolver<'a, T> {
                 self.packages_changed_in_range(&selector.from_ref, selector.to_ref())?;
             let package_path_lookup = self
                 .pkg_graph
-                .workspaces()
+                .packages()
                 .map(|(name, entry)| (name, entry.package_path()))
                 .collect::<HashMap<_, _>>();
 
@@ -459,7 +459,7 @@ impl<'a, T: GitChangeDetector> FilterResolver<'a, T> {
             {
                 entry_packages.insert(PackageName::Root);
             } else {
-                let packages = self.pkg_graph.workspaces();
+                let packages = self.pkg_graph.packages();
                 for (name, _) in packages.filter(|(_name, info)| {
                     let path = info.package_path().as_path();
                     parent_dir_globber.is_match(path)
@@ -474,7 +474,7 @@ impl<'a, T: GitChangeDetector> FilterResolver<'a, T> {
                 entry_packages = self.match_package_names_to_vertices(
                     &selector.name_pattern,
                     self.pkg_graph
-                        .workspaces()
+                        .packages()
                         .map(|(name, _)| name.to_owned())
                         .collect(),
                 )?;

--- a/crates/turborepo-lib/src/run/summary/mod.rs
+++ b/crates/turborepo-lib/src/run/summary/mod.rs
@@ -467,7 +467,7 @@ impl<'a> RunSummary<'a> {
                     continue;
                 }
                 let dir = pkg_dep_graph
-                    .workspace_info(pkg)
+                    .package_info(pkg)
                     .ok_or_else(|| Error::MissingWorkspace(pkg.clone()))?
                     .package_path();
 

--- a/crates/turborepo-lib/src/run/summary/task_factory.rs
+++ b/crates/turborepo-lib/src/run/summary/task_factory.rs
@@ -205,7 +205,7 @@ impl<'a> TaskSummaryFactory<'a> {
     fn workspace_info(&self, task_id: &TaskId) -> Result<&PackageInfo, Error> {
         let workspace_name = PackageName::from(task_id.package());
         self.package_graph
-            .workspace_info(&workspace_name)
+            .package_info(&workspace_name)
             .ok_or_else(|| Error::MissingWorkspace(workspace_name.to_string()))
     }
 

--- a/crates/turborepo-lib/src/task_graph/visitor.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor.rs
@@ -153,13 +153,13 @@ impl<'a> Visitor<'a> {
             let crate::engine::Message { info, callback } = message;
             let package_name = PackageName::from(info.package());
 
-            let workspace_info = self
-                .package_graph
-                .workspace_info(&package_name)
-                .ok_or_else(|| Error::MissingPackage {
-                    package_name: package_name.clone(),
-                    task_id: info.clone(),
-                })?;
+            let workspace_info =
+                self.package_graph
+                    .package_info(&package_name)
+                    .ok_or_else(|| Error::MissingPackage {
+                        package_name: package_name.clone(),
+                        task_id: info.clone(),
+                    })?;
 
             let package_task_event =
                 PackageTaskEventBuilder::new(info.package(), info.task()).with_parent(telemetry);

--- a/crates/turborepo-repository/src/change_mapper.rs
+++ b/crates/turborepo-repository/src/change_mapper.rs
@@ -106,7 +106,7 @@ impl<'a> ChangeMapper<'a> {
         let mut changed_packages = HashSet::new();
         for file in files {
             let mut found = false;
-            for (name, entry) in graph.workspaces() {
+            for (name, entry) in graph.packages() {
                 if name == &PackageName::Root {
                     continue;
                 }

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -334,7 +334,7 @@ impl<'a, T: PackageDiscovery> BuildState<'a, ResolvedPackageManager, T> {
         Ok(PackageGraph {
             workspace_graph,
             node_lookup,
-            workspaces,
+            packages: workspaces,
             lockfile,
             package_manager,
         })
@@ -516,7 +516,7 @@ impl<'a, T: PackageDiscovery> BuildState<'a, ResolvedLockfile, T> {
         Ok(PackageGraph {
             workspace_graph,
             node_lookup,
-            workspaces,
+            packages: workspaces,
             package_manager,
             lockfile,
         })

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -332,7 +332,7 @@ impl<'a, T: PackageDiscovery> BuildState<'a, ResolvedPackageManager, T> {
 
         debug_assert!(single, "expected single package graph");
         Ok(PackageGraph {
-            workspace_graph,
+            graph: workspace_graph,
             node_lookup,
             packages: workspaces,
             lockfile,
@@ -514,7 +514,7 @@ impl<'a, T: PackageDiscovery> BuildState<'a, ResolvedLockfile, T> {
             ..
         } = self;
         Ok(PackageGraph {
-            workspace_graph,
+            graph: workspace_graph,
             node_lookup,
             packages: workspaces,
             package_manager,

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -179,7 +179,7 @@ impl PackageGraph {
         self.workspaces.get(workspace)
     }
 
-    pub fn workspaces(&self) -> impl Iterator<Item = (&PackageName, &PackageInfo)> {
+    pub fn packages(&self) -> impl Iterator<Item = (&PackageName, &PackageInfo)> {
         self.workspaces.iter()
     }
 
@@ -332,7 +332,7 @@ impl PackageGraph {
         let current = self.lockfile().ok_or(ChangedPackagesError::NoLockfile)?;
 
         let external_deps = self
-            .workspaces()
+            .packages()
             .filter_map(|(_name, info)| {
                 info.unresolved_external_dependencies.as_ref().map(|dep| {
                     (

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -196,8 +196,8 @@ impl PackageGraph {
     /// a -> b -> c
     ///
     /// immediate_dependencies(a) -> {b}
-    pub fn immediate_dependencies(&self, workspace: &PackageNode) -> Option<HashSet<&PackageNode>> {
-        let index = self.node_lookup.get(workspace)?;
+    pub fn immediate_dependencies(&self, package: &PackageNode) -> Option<HashSet<&PackageNode>> {
+        let index = self.node_lookup.get(package)?;
         Some(
             self.workspace_graph
                 .neighbors_directed(*index, petgraph::Outgoing)
@@ -219,8 +219,8 @@ impl PackageGraph {
     ///
     /// immediate_ancestors(c) -> {b}
     #[allow(dead_code)]
-    pub fn immediate_ancestors(&self, workspace: &PackageNode) -> Option<HashSet<&PackageNode>> {
-        let index = self.node_lookup.get(workspace)?;
+    pub fn immediate_ancestors(&self, package: &PackageNode) -> Option<HashSet<&PackageNode>> {
+        let index = self.node_lookup.get(package)?;
         Some(
             self.workspace_graph
                 .neighbors_directed(*index, petgraph::Incoming)
@@ -312,11 +312,11 @@ impl PackageGraph {
 
     pub fn transitive_external_dependencies<'a, I: IntoIterator<Item = &'a PackageName>>(
         &self,
-        workspaces: I,
+        packages: I,
     ) -> HashSet<&turborepo_lockfiles::Package> {
-        workspaces
+        packages
             .into_iter()
-            .filter_map(|workspace| self.packages.get(workspace))
+            .filter_map(|package| self.packages.get(package))
             .filter_map(|entry| entry.transitive_dependencies.as_ref())
             .flatten()
             .collect()
@@ -416,7 +416,7 @@ impl fmt::Display for PackageNode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             PackageNode::Root => f.write_str("___ROOT___"),
-            PackageNode::Workspace(workspace) => workspace.fmt(f),
+            PackageNode::Workspace(package) => package.fmt(f),
         }
     }
 }
@@ -439,7 +439,7 @@ impl AsRef<str> for PackageName {
     fn as_ref(&self) -> &str {
         match self {
             PackageName::Root => "//",
-            PackageName::Other(workspace) => workspace,
+            PackageName::Other(package) => package,
         }
     }
 }

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -25,7 +25,7 @@ pub struct PackageGraph {
     workspace_graph: petgraph::Graph<PackageNode, ()>,
     #[allow(dead_code)]
     node_lookup: HashMap<PackageNode, petgraph::graph::NodeIndex>,
-    workspaces: HashMap<PackageName, PackageInfo>,
+    packages: HashMap<PackageName, PackageInfo>,
     package_manager: PackageManager,
     lockfile: Option<Box<dyn Lockfile>>,
 }
@@ -145,11 +145,11 @@ impl PackageGraph {
     /// Returns the number of workspaces in the repo
     /// *including* the root workspace.
     pub fn len(&self) -> usize {
-        self.workspaces.len()
+        self.packages.len()
     }
 
     pub fn is_empty(&self) -> bool {
-        self.workspaces.is_empty()
+        self.packages.is_empty()
     }
 
     pub fn package_manager(&self) -> &PackageManager {
@@ -161,12 +161,12 @@ impl PackageGraph {
     }
 
     pub fn package_json(&self, package: &PackageName) -> Option<&PackageJson> {
-        let entry = self.workspaces.get(package)?;
+        let entry = self.packages.get(package)?;
         Some(&entry.package_json)
     }
 
     pub fn package_dir(&self, package: &PackageName) -> Option<&AnchoredSystemPath> {
-        let entry = self.workspaces.get(package)?;
+        let entry = self.packages.get(package)?;
         Some(
             entry
                 .package_json_path()
@@ -176,11 +176,11 @@ impl PackageGraph {
     }
 
     pub fn package_info(&self, package: &PackageName) -> Option<&PackageInfo> {
-        self.workspaces.get(package)
+        self.packages.get(package)
     }
 
     pub fn packages(&self) -> impl Iterator<Item = (&PackageName, &PackageInfo)> {
-        self.workspaces.iter()
+        self.packages.iter()
     }
 
     pub fn root_package_json(&self) -> &PackageJson {
@@ -316,7 +316,7 @@ impl PackageGraph {
     ) -> HashSet<&turborepo_lockfiles::Package> {
         workspaces
             .into_iter()
-            .filter_map(|workspace| self.workspaces.get(workspace))
+            .filter_map(|workspace| self.packages.get(workspace))
             .filter_map(|entry| entry.transitive_dependencies.as_ref())
             .flatten()
             .collect()
@@ -352,7 +352,7 @@ impl PackageGraph {
         let changed = if global_change {
             None
         } else {
-            self.workspaces
+            self.packages
                 .iter()
                 .filter(|(_name, info)| {
                     closures.get(info.package_path().to_unix().as_str())
@@ -374,7 +374,7 @@ impl PackageGraph {
         };
 
         Ok(changed.unwrap_or_else(|| {
-            self.workspaces
+            self.packages
                 .iter()
                 .map(|(name, info)| WorkspacePackage {
                     name: name.clone(),
@@ -390,7 +390,7 @@ impl PackageGraph {
         &self,
         package: &PackageName,
     ) -> Option<&BTreeMap<PackageKey, PackageVersion>> {
-        let entry = self.workspaces.get(package)?;
+        let entry = self.packages.get(package)?;
         entry.unresolved_external_dependencies.as_ref()
     }
 }

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -165,8 +165,8 @@ impl PackageGraph {
         Some(&entry.package_json)
     }
 
-    pub fn workspace_dir(&self, workspace: &PackageName) -> Option<&AnchoredSystemPath> {
-        let entry = self.workspaces.get(workspace)?;
+    pub fn package_dir(&self, package: &PackageName) -> Option<&AnchoredSystemPath> {
+        let entry = self.workspaces.get(package)?;
         Some(
             entry
                 .package_json_path()

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -531,7 +531,7 @@ mod test {
             .collect::<HashSet<_>>()
         );
         let b_external = pkg_graph
-            .workspaces
+            .packages
             .get(&PackageName::from("b"))
             .unwrap()
             .unresolved_external_dependencies
@@ -643,14 +643,14 @@ mod test {
         let bar = PackageName::from("bar");
 
         let foo_deps = pkg_graph
-            .workspaces
+            .packages
             .get(&foo)
             .unwrap()
             .transitive_dependencies
             .as_ref()
             .unwrap();
         let bar_deps = pkg_graph
-            .workspaces
+            .packages
             .get(&bar)
             .unwrap()
             .transitive_dependencies

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -175,8 +175,8 @@ impl PackageGraph {
         )
     }
 
-    pub fn workspace_info(&self, workspace: &PackageName) -> Option<&PackageInfo> {
-        self.workspaces.get(workspace)
+    pub fn package_info(&self, package: &PackageName) -> Option<&PackageInfo> {
+        self.workspaces.get(package)
     }
 
     pub fn packages(&self) -> impl Iterator<Item = (&PackageName, &PackageInfo)> {

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -142,7 +142,7 @@ impl PackageGraph {
         });
     }
 
-    /// Returns the number of workspaces in the repo
+    /// Returns the number of packages in the repo
     /// *including* the root package.
     pub fn len(&self) -> usize {
         self.packages.len()
@@ -233,7 +233,7 @@ impl PackageGraph {
         )
     }
 
-    /// For a given package in the repo, returns the set of workspaces
+    /// For a given package in the repo, returns the set of packages
     /// that this one depends on, excluding those that are unresolved.
     ///
     /// Example:
@@ -249,7 +249,7 @@ impl PackageGraph {
         dependencies
     }
 
-    /// For a given package in the repo, returns the set of workspaces
+    /// For a given package in the repo, returns the set of packages
     /// that depend on this one, excluding those that are unresolved.
     ///
     /// Example:

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -108,7 +108,7 @@ pub enum PackageNode {
 }
 
 impl PackageNode {
-    pub fn as_workspace(&self) -> &PackageName {
+    pub fn as_package_name(&self) -> &PackageName {
         match self {
             PackageNode::Workspace(name) => name,
             PackageNode::Root => &PackageName::Root,

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -160,8 +160,8 @@ impl PackageGraph {
         self.lockfile.as_deref()
     }
 
-    pub fn package_json(&self, workspace: &PackageName) -> Option<&PackageJson> {
-        let entry = self.workspaces.get(workspace)?;
+    pub fn package_json(&self, package: &PackageName) -> Option<&PackageJson> {
+        let entry = self.workspaces.get(package)?;
         Some(&entry.package_json)
     }
 
@@ -388,9 +388,9 @@ impl PackageGraph {
     #[allow(dead_code)]
     fn external_dependencies(
         &self,
-        workspace: &PackageName,
+        package: &PackageName,
     ) -> Option<&BTreeMap<PackageKey, PackageVersion>> {
-        let entry = self.workspaces.get(workspace)?;
+        let entry = self.workspaces.get(package)?;
         entry.unresolved_external_dependencies.as_ref()
     }
 }

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -69,7 +69,7 @@ impl PackageInfo {
         &self.package_json_path
     }
 
-    /// Get the path to this workspace.
+    /// Get the path to this package.
     ///
     /// note: This is infallible because `package_json_path` is guaranteed to
     /// have       at least one segment
@@ -133,7 +133,7 @@ impl PackageGraph {
         let root_index = self
             .node_lookup
             .get(&PackageNode::Root)
-            .expect("graph should have root workspace node");
+            .expect("graph should have root package node");
         self.workspace_graph.retain_edges(|graph, index| {
             let Some((_src, dst)) = graph.edge_endpoints(index) else {
                 return false;
@@ -143,7 +143,7 @@ impl PackageGraph {
     }
 
     /// Returns the number of workspaces in the repo
-    /// *including* the root workspace.
+    /// *including* the root package.
     pub fn len(&self) -> usize {
         self.packages.len()
     }
@@ -189,7 +189,7 @@ impl PackageGraph {
     }
 
     /// Gets all the nodes that directly depend on this one, that is to say
-    /// have a edge to `workspace`.
+    /// have a edge to `package`.
     ///
     /// Example:
     ///
@@ -211,7 +211,7 @@ impl PackageGraph {
     }
 
     /// Gets all the nodes that directly depend on this one, that is to say
-    /// have a edge to `workspace`.
+    /// have a edge to `package`.
     ///
     /// Example:
     ///
@@ -233,7 +233,7 @@ impl PackageGraph {
         )
     }
 
-    /// For a given workspace in the repo, returns the set of workspaces
+    /// For a given package in the repo, returns the set of workspaces
     /// that this one depends on, excluding those that are unresolved.
     ///
     /// Example:
@@ -249,7 +249,7 @@ impl PackageGraph {
         dependencies
     }
 
-    /// For a given workspace in the repo, returns the set of workspaces
+    /// For a given package in the repo, returns the set of workspaces
     /// that depend on this one, excluding those that are unresolved.
     ///
     /// Example:
@@ -264,7 +264,7 @@ impl PackageGraph {
         dependents
     }
 
-    /// Returns the transitive closure of the given nodes in the workspace
+    /// Returns the transitive closure of the given nodes in the package
     /// graph. Note that this includes the nodes themselves. If you want just
     /// the dependencies, or the dependents, use `dependencies` or `ancestors`.
     /// Alternatively, if you need just direct dependents, use
@@ -323,7 +323,7 @@ impl PackageGraph {
     }
 
     /// Returns a list of changed packages based on the contents of a previous
-    /// `Lockfile`. This assumes that none of the package.json in the workspace
+    /// `Lockfile`. This assumes that none of the package.json in the package
     /// change, it is the responsibility of the caller to verify this.
     pub fn changed_packages_from_lockfile(
         &self,

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -129,7 +129,7 @@ impl PackageGraph {
         graph::validate_graph(&self.graph).map_err(Error::InvalidPackageGraph)
     }
 
-    pub fn remove_workspace_dependencies(&mut self) {
+    pub fn remove_package_dependencies(&mut self) {
         let root_index = self
             .node_lookup
             .get(&PackageNode::Root)

--- a/packages/turbo-repository/rust/src/lib.rs
+++ b/packages/turbo-repository/rust/src/lib.rs
@@ -81,7 +81,7 @@ impl Package {
         ancestors
             .iter()
             .filter_map(|node| {
-                let info = graph.workspace_info(node.as_workspace())?;
+                let info = graph.package_info(node.as_package_name())?;
                 // If we don't get a package name back, we'll just skip it.
                 let name = info.package_name()?;
                 let anchored_package_path = info.package_path();
@@ -166,7 +166,7 @@ impl Workspace {
         let packages = match package_changes {
             PackageChanges::All => self
                 .graph
-                .workspaces()
+                .packages()
                 .map(|(name, info)| WorkspacePackage {
                     name: name.to_owned(),
                     path: info.package_path().to_owned(),

--- a/packages/turbo-repository/rust/src/lib.rs
+++ b/packages/turbo-repository/rust/src/lib.rs
@@ -9,7 +9,7 @@ use turbopath::{AbsoluteSystemPath, AnchoredSystemPathBuf};
 use turborepo_repository::{
     change_mapper::{ChangeMapper, PackageChanges},
     inference::RepoState as WorkspaceState,
-    package_graph::{PackageGraph, PackageNode, WorkspaceName, WorkspacePackage, ROOT_PKG_NAME},
+    package_graph::{PackageGraph, PackageName, PackageNode, WorkspacePackage, ROOT_PKG_NAME},
 };
 mod internal;
 
@@ -72,7 +72,7 @@ impl Package {
         graph: &PackageGraph,
         workspace_path: &AbsoluteSystemPath,
     ) -> Vec<Package> {
-        let node = PackageNode::Workspace(WorkspaceName::Other(self.name.clone()));
+        let node = PackageNode::Workspace(PackageName::Other(self.name.clone()));
         let ancestors = match graph.immediate_ancestors(&node) {
             Some(ancestors) => ancestors,
             None => return vec![],
@@ -81,7 +81,7 @@ impl Package {
         ancestors
             .iter()
             .filter_map(|node| {
-                let info = graph.workspace_info(node.as_workspace())?;
+                let info = graph.package_info(node.as_package_name())?;
                 // If we don't get a package name back, we'll just skip it.
                 let name = info.package_name()?;
                 let anchored_package_path = info.package_path();
@@ -166,7 +166,7 @@ impl Workspace {
         let packages = match package_changes {
             PackageChanges::All => self
                 .graph
-                .workspaces()
+                .packages()
                 .map(|(name, info)| WorkspacePackage {
                     name: name.to_owned(),
                     path: info.package_path().to_owned(),
@@ -178,8 +178,8 @@ impl Workspace {
         let mut serializable_packages: Vec<Package> = packages
             .into_iter()
             .filter(|p| match &p.name {
-                WorkspaceName::Root => false,
-                WorkspaceName::Other(name) => name != ROOT_PKG_NAME,
+                PackageName::Root => false,
+                PackageName::Other(name) => name != ROOT_PKG_NAME,
             })
             .map(|p| {
                 let package_path = workspace_root.resolve(&p.path);


### PR DESCRIPTION
This PR renames `workspace` -> `package` in the `package_graph` module of the `turborepo-repository` crate. There are many other references to update, but since this is the canonical representation of packages in a workspace, this is an important one to define the lexicon.

You can review each commit if you want to see smaller diff

Closes TURBO-2345