### PR TITLE
chore(turbo): remove EXPERIMENTAL_RUST_CODEPATH env var

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -238,7 +238,6 @@ jobs:
           CARGO_INCREMENTAL: 0
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          EXPERIMENTAL_RUST_CODEPATH: true
 
       - name: Run sccache stat for check
         shell: bash
@@ -291,8 +290,6 @@ jobs:
 
       - name: Integration Tests
         run: turbo run test --filter=turborepo-tests-integration --color --env-mode=strict --token=${{ secrets.TURBO_TOKEN }} --team=${{ vars.TURBO_TEAM }}
-        env:
-          EXPERIMENTAL_RUST_CODEPATH: true
 
   turborepo_examples:
     name: Turborepo Examples
@@ -377,8 +374,6 @@ jobs:
         # We manually set TURBO_API to an empty string to override Hetzner env
         run: |
           TURBO_API= turbo run check-types test --filter=docs --filter={./packages/*}...[${{ github.event.pull_request.base.sha || 'HEAD^1' }}] --color --env-mode=strict
-        env:
-          EXPERIMENTAL_RUST_CODEPATH: true
 
   turbopack_typescript:
     name: Turbopack TypeScript files
@@ -859,8 +854,6 @@ jobs:
         # Filters some workspaces out:
         # - Other `@vercel/*` packages because ??
         run: turbo run lint --filter=!@vercel/devlow-bench --filter=!@vercel/experimental-nft-next-plugin --filter=!@vercel/experimental-nft-next-plugin --filter=!turbopack-bump-action --filter=!next-integration-stat --env-mode=strict
-        env:
-          EXPERIMENTAL_RUST_CODEPATH: true
 
   final:
     name: Ok

--- a/turborepo-tests/integration/tests/bad-turbo-json.t
+++ b/turborepo-tests/integration/tests/bad-turbo-json.t
@@ -5,7 +5,7 @@ Add turbo.json with unnecessary package task syntax to a package
   $ . ${TESTDIR}/../../helpers/replace_turbo_json.sh $(pwd)/apps/my-app "package-task.json"
 
 Run build with package task in non-root turbo.json
-  $ EXPERIMENTAL_RUST_CODEPATH=true ${TURBO} build
+  $ ${TURBO} build
     x invalid turbo json
   
   Error: unnecessary_package_task_syntax (https://turbo.build/messages/unnecessary-package-task-syntax)
@@ -33,7 +33,7 @@ Use our custom turbo config with an invalid env var
   $ . ${TESTDIR}/../../helpers/replace_turbo_json.sh $(pwd) "invalid-env-var.json"
 
 Run build with invalid env var
-  $ EXPERIMENTAL_RUST_CODEPATH=true ${TURBO} build
+  $ ${TURBO} build
   invalid_env_prefix (https://turbo.build/messages/invalid-env-prefix)
   
     x Environment variables should not be prefixed with "$"
@@ -50,7 +50,7 @@ Run build with invalid env var
 
 
 Run in single package mode even though we have a task with package syntax
-  $ EXPERIMENTAL_RUST_CODEPATH=true ${TURBO} build --single-package
+  $ ${TURBO} build --single-package
   package_task_in_single_package_mode (https://turbo.build/messages/package-task-in-single-package-mode)
   
     x Package tasks (<package>#<task>) are not allowed in single-package
@@ -71,7 +71,7 @@ Use our custom turbo config with syntax errors
   $ . ${TESTDIR}/../../helpers/replace_turbo_json.sh $(pwd) "syntax-error.json"
 
 Run build with syntax errors in turbo.json
-  $ EXPERIMENTAL_RUST_CODEPATH=true ${TURBO} build
+  $ ${TURBO} build
   turbo_json_parse_error
   
     x failed to parse turbo json

--- a/turborepo-tests/integration/tests/config.t
+++ b/turborepo-tests/integration/tests/config.t
@@ -48,7 +48,7 @@ Use our custom turbo config with an invalid env var
   $ . ${TESTDIR}/../../helpers/replace_turbo_json.sh $(pwd) "invalid-env-var.json"
 
 Run build with invalid env var
-  $ EXPERIMENTAL_RUST_CODEPATH=true ${TURBO} build
+  $ ${TURBO} build
   invalid_env_prefix (https://turbo.build/messages/invalid-env-prefix)
   
     x Environment variables should not be prefixed with "$"

--- a/turborepo-tests/integration/tests/dry-json/monorepo-no-changes.t
+++ b/turborepo-tests/integration/tests/dry-json/monorepo-no-changes.t
@@ -8,7 +8,7 @@ Setup
   []
 
 # Save JSON to tmp file so we don't need to keep re-running the build
-  $ EXPERIMENTAL_RUST_CODEPATH=true ${TURBO} run build --dry=json --filter=main > tmpjson.log
+  $ ${TURBO} run build --dry=json --filter=main > tmpjson.log
 
   $ cat tmpjson.log | jq .packages
   []

--- a/turborepo-tests/integration/tests/run-summary/monorepo.t
+++ b/turborepo-tests/integration/tests/run-summary/monorepo.t
@@ -125,7 +125,7 @@ Setup
 # Delete all run summaries
   $ rm -rf .turbo/runs
 
-  $ EXPERIMENTAL_RUST_CODEPATH=true ${TURBO} run build --summarize --no-daemon -- someargs > /dev/null # first run (should be cache miss)
+  $ ${TURBO} run build --summarize --no-daemon -- someargs > /dev/null # first run (should be cache miss)
 
 # HACK: Generated run summaries are named with a ksuid, which is a time-sorted ID. This _generally_ works
 # but we're seeing in this test that sometimes a summary file is not sorted (with /bin/ls) in the order we expect
@@ -137,7 +137,7 @@ Setup
 # If you find this sleep statement, try running this test 10 times in a row. If there are no
 # failures, it *should* be safe to remove.
   $ sleep 1
-  $ EXPERIMENTAL_RUST_CODEPATH=true ${TURBO} run build --summarize --no-daemon -- someargs > /dev/null # run again (expecting full turbo here)
+  $ ${TURBO} run build --summarize --no-daemon -- someargs > /dev/null # run again (expecting full turbo here)
 
 # no output, just check for 0 status code, which means the directory was created
   $ test -d .turbo/runs

--- a/turborepo-tests/integration/tests/run-summary/single-package.t
+++ b/turborepo-tests/integration/tests/run-summary/single-package.t
@@ -112,7 +112,7 @@ Check
 
   $ rm -r .turbo/runs
 Check Rust implementation
-  $ EXPERIMENTAL_RUST_CODEPATH=true ${TURBO} run build --summarize --no-daemon > /dev/null
+  $ ${TURBO} run build --summarize --no-daemon > /dev/null
   $ test -d .turbo/runs
   $ ls .turbo/runs/*.json | wc -l
   \s*1 (re)

--- a/turborepo-tests/integration/tests/shim-errors.t
+++ b/turborepo-tests/integration/tests/shim-errors.t
@@ -2,7 +2,7 @@ Setup
   $ . ${TESTDIR}/../../helpers/setup.sh
 
 Should error if `--cwd` flag doesn't have path passed along with it
-  $ EXPERIMENTAL_RUST_CODEPATH=true ${TURBO} foo bar --cwd
+  $ ${TURBO} foo bar --cwd
   turbo::shim::empty_cwd
   
     \xc3\x97 No value assigned to `--cwd` flag (esc)
@@ -15,7 +15,7 @@ Should error if `--cwd` flag doesn't have path passed along with it
   [1]
 
 Should error if multiple `--cwd` flags are passed
-  $ EXPERIMENTAL_RUST_CODEPATH=true ${TURBO} --cwd foo --cwd --bar --cwd baz --cwd qux
+  $ ${TURBO} --cwd foo --cwd --bar --cwd baz --cwd qux
   turbo::shim::multiple_cwd
   
     \xc3\x97 cannot have multiple `--cwd` flags in command (esc)


### PR DESCRIPTION
Ran into this while working on https://github.com/vercel/turbo/pull/7374

Closes TURBO-2348