### PR TITLE
Break up Client trait

### DIFF
--- a/crates/turborepo-api-client/src/lib.rs
+++ b/crates/turborepo-api-client/src/lib.rs
@@ -37,14 +37,29 @@ pub trait Client {
     async fn get_teams(&self, token: &str) -> Result<TeamsResponse>;
     async fn get_team(&self, token: &str, team_id: &str) -> Result<Option<Team>>;
     fn add_ci_header(request_builder: RequestBuilder) -> RequestBuilder;
-    async fn get_caching_status(
+    async fn get_spaces(&self, token: &str, team_id: Option<&str>) -> Result<SpacesResponse>;
+    async fn verify_sso_token(&self, token: &str, token_name: &str) -> Result<VerifiedSsoUser>;
+    async fn handle_403(response: Response) -> Error;
+    fn make_url(&self, endpoint: &str) -> Result<Url>;
+}
+
+#[async_trait]
+pub trait CacheClient {
+    async fn get_artifact(
         &self,
+        hash: &str,
         token: &str,
         team_id: Option<&str>,
         team_slug: Option<&str>,
-    ) -> Result<CachingStatusResponse>;
-    async fn get_spaces(&self, token: &str, team_id: Option<&str>) -> Result<SpacesResponse>;
-    async fn verify_sso_token(&self, token: &str, token_name: &str) -> Result<VerifiedSsoUser>;
+        method: Method,
+    ) -> Result<Option<Response>>;
+    async fn fetch_artifact(
+        &self,
+        hash: &str,
+        token: &str,
+        team_id: Option<&str>,
+        team_slug: Option<&str>,
+    ) -> Result<Option<Response>>;
     #[allow(clippy::too_many_arguments)]
     async fn put_artifact(
         &self,
@@ -56,14 +71,6 @@ pub trait Client {
         team_id: Option<&str>,
         team_slug: Option<&str>,
     ) -> Result<()>;
-    async fn handle_403(response: Response) -> Error;
-    async fn fetch_artifact(
-        &self,
-        hash: &str,
-        token: &str,
-        team_id: Option<&str>,
-        team_slug: Option<&str>,
-    ) -> Result<Option<Response>>;
     async fn artifact_exists(
         &self,
         hash: &str,
@@ -71,15 +78,12 @@ pub trait Client {
         team_id: Option<&str>,
         team_slug: Option<&str>,
     ) -> Result<Option<Response>>;
-    async fn get_artifact(
+    async fn get_caching_status(
         &self,
-        hash: &str,
         token: &str,
         team_id: Option<&str>,
         team_slug: Option<&str>,
-        method: Method,
-    ) -> Result<Option<Response>>;
-    fn make_url(&self, endpoint: &str) -> Result<Url>;
+    ) -> Result<CachingStatusResponse>;
 }
 
 #[async_trait]
@@ -164,28 +168,6 @@ impl Client for APIClient {
         request_builder
     }
 
-    async fn get_caching_status(
-        &self,
-        token: &str,
-        team_id: Option<&str>,
-        team_slug: Option<&str>,
-    ) -> Result<CachingStatusResponse> {
-        let request_builder = self
-            .client
-            .get(self.make_url("/v8/artifacts/status")?)
-            .header("User-Agent", self.user_agent.clone())
-            .header("Content-Type", "application/json")
-            .header("Authorization", format!("Bearer {}", token));
-
-        let request_builder = Self::add_team_params(request_builder, team_id, team_slug);
-
-        let response = retry::make_retryable_request(request_builder)
-            .await?
-            .error_for_status()?;
-
-        Ok(response.json().await?)
-    }
-
     async fn get_spaces(&self, token: &str, team_id: Option<&str>) -> Result<SpacesResponse> {
         // create url with teamId if provided
         let endpoint = match team_id {
@@ -224,6 +206,130 @@ impl Client for APIClient {
             token: verification_response.token,
             team_id: verification_response.team_id,
         })
+    }
+
+    async fn handle_403(response: Response) -> Error {
+        #[derive(Deserialize)]
+        struct WrappedAPIError {
+            error: APIError,
+        }
+        let body = match response.text().await {
+            Ok(body) => body,
+            Err(e) => return Error::ReqwestError(e),
+        };
+
+        let WrappedAPIError { error: api_error } = match serde_json::from_str(&body) {
+            Ok(api_error) => api_error,
+            Err(err) => {
+                return Error::InvalidJson {
+                    err,
+                    text: body.clone(),
+                }
+            }
+        };
+
+        if let Some(status_string) = api_error.code.strip_prefix("remote_caching_") {
+            let status = match status_string {
+                "disabled" => CachingStatus::Disabled,
+                "enabled" => CachingStatus::Enabled,
+                "over_limit" => CachingStatus::OverLimit,
+                "paused" => CachingStatus::Paused,
+                _ => {
+                    return Error::UnknownCachingStatus(
+                        status_string.to_string(),
+                        Backtrace::capture(),
+                    )
+                }
+            };
+
+            Error::CacheDisabled {
+                status,
+                message: api_error.message,
+            }
+        } else {
+            Error::UnknownStatus {
+                code: api_error.code,
+                message: api_error.message,
+                backtrace: Backtrace::capture(),
+            }
+        }
+    }
+
+    fn make_url(&self, endpoint: &str) -> Result<Url> {
+        let url = format!("{}{}", self.base_url, endpoint);
+        Url::parse(&url).map_err(|err| Error::InvalidUrl { url, err })
+    }
+}
+
+#[async_trait]
+impl CacheClient for APIClient {
+    async fn get_artifact(
+        &self,
+        hash: &str,
+        token: &str,
+        team_id: Option<&str>,
+        team_slug: Option<&str>,
+        method: Method,
+    ) -> Result<Option<Response>> {
+        let mut request_url = self.make_url(&format!("/v8/artifacts/{}", hash))?;
+        let mut allow_auth = true;
+
+        if self.use_preflight {
+            let preflight_response = self
+                .do_preflight(
+                    token,
+                    request_url.clone(),
+                    "GET",
+                    "Authorization, User-Agent",
+                )
+                .await?;
+
+            allow_auth = preflight_response.allow_authorization_header;
+            request_url = preflight_response.location;
+        };
+
+        let mut request_builder = self
+            .client
+            .request(method, request_url)
+            .header("User-Agent", self.user_agent.clone());
+
+        if allow_auth {
+            request_builder = request_builder.header("Authorization", format!("Bearer {}", token));
+        }
+
+        request_builder = Self::add_team_params(request_builder, team_id, team_slug);
+
+        let response = retry::make_retryable_request(request_builder).await?;
+
+        match response.status() {
+            StatusCode::FORBIDDEN => Err(Self::handle_403(response).await),
+            StatusCode::NOT_FOUND => Ok(None),
+            _ => Ok(Some(response.error_for_status()?)),
+        }
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn artifact_exists(
+        &self,
+        hash: &str,
+        token: &str,
+        team_id: Option<&str>,
+        team_slug: Option<&str>,
+    ) -> Result<Option<Response>> {
+        self.get_artifact(hash, token, team_id, team_slug, Method::HEAD)
+            .await
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn fetch_artifact(
+        &self,
+        hash: &str,
+        token: &str,
+        team_id: Option<&str>,
+        team_slug: Option<&str>,
+    ) -> Result<Option<Response>> {
+        self.get_artifact(hash, token, team_id, team_slug, Method::GET)
+            .await
     }
 
     #[tracing::instrument(skip_all)]
@@ -284,125 +390,26 @@ impl Client for APIClient {
         Ok(())
     }
 
-    async fn handle_403(response: Response) -> Error {
-        #[derive(Deserialize)]
-        struct WrappedAPIError {
-            error: APIError,
-        }
-        let body = match response.text().await {
-            Ok(body) => body,
-            Err(e) => return Error::ReqwestError(e),
-        };
-
-        let WrappedAPIError { error: api_error } = match serde_json::from_str(&body) {
-            Ok(api_error) => api_error,
-            Err(err) => {
-                return Error::InvalidJson {
-                    err,
-                    text: body.clone(),
-                }
-            }
-        };
-
-        if let Some(status_string) = api_error.code.strip_prefix("remote_caching_") {
-            let status = match status_string {
-                "disabled" => CachingStatus::Disabled,
-                "enabled" => CachingStatus::Enabled,
-                "over_limit" => CachingStatus::OverLimit,
-                "paused" => CachingStatus::Paused,
-                _ => {
-                    return Error::UnknownCachingStatus(
-                        status_string.to_string(),
-                        Backtrace::capture(),
-                    )
-                }
-            };
-
-            Error::CacheDisabled {
-                status,
-                message: api_error.message,
-            }
-        } else {
-            Error::UnknownStatus {
-                code: api_error.code,
-                message: api_error.message,
-                backtrace: Backtrace::capture(),
-            }
-        }
-    }
-
-    #[tracing::instrument(skip_all)]
-    async fn fetch_artifact(
+    async fn get_caching_status(
         &self,
-        hash: &str,
         token: &str,
         team_id: Option<&str>,
         team_slug: Option<&str>,
-    ) -> Result<Option<Response>> {
-        self.get_artifact(hash, token, team_id, team_slug, Method::GET)
-            .await
-    }
-
-    #[tracing::instrument(skip_all)]
-    async fn artifact_exists(
-        &self,
-        hash: &str,
-        token: &str,
-        team_id: Option<&str>,
-        team_slug: Option<&str>,
-    ) -> Result<Option<Response>> {
-        self.get_artifact(hash, token, team_id, team_slug, Method::HEAD)
-            .await
-    }
-
-    async fn get_artifact(
-        &self,
-        hash: &str,
-        token: &str,
-        team_id: Option<&str>,
-        team_slug: Option<&str>,
-        method: Method,
-    ) -> Result<Option<Response>> {
-        let mut request_url = self.make_url(&format!("/v8/artifacts/{}", hash))?;
-        let mut allow_auth = true;
-
-        if self.use_preflight {
-            let preflight_response = self
-                .do_preflight(
-                    token,
-                    request_url.clone(),
-                    "GET",
-                    "Authorization, User-Agent",
-                )
-                .await?;
-
-            allow_auth = preflight_response.allow_authorization_header;
-            request_url = preflight_response.location;
-        };
-
-        let mut request_builder = self
+    ) -> Result<CachingStatusResponse> {
+        let request_builder = self
             .client
-            .request(method, request_url)
-            .header("User-Agent", self.user_agent.clone());
+            .get(self.make_url("/v8/artifacts/status")?)
+            .header("User-Agent", self.user_agent.clone())
+            .header("Content-Type", "application/json")
+            .header("Authorization", format!("Bearer {}", token));
 
-        if allow_auth {
-            request_builder = request_builder.header("Authorization", format!("Bearer {}", token));
-        }
+        let request_builder = Self::add_team_params(request_builder, team_id, team_slug);
 
-        request_builder = Self::add_team_params(request_builder, team_id, team_slug);
+        let response = retry::make_retryable_request(request_builder)
+            .await?
+            .error_for_status()?;
 
-        let response = retry::make_retryable_request(request_builder).await?;
-
-        match response.status() {
-            StatusCode::FORBIDDEN => Err(Self::handle_403(response).await),
-            StatusCode::NOT_FOUND => Ok(None),
-            _ => Ok(Some(response.error_for_status()?)),
-        }
-    }
-
-    fn make_url(&self, endpoint: &str) -> Result<Url> {
-        let url = format!("{}{}", self.base_url, endpoint);
-        Url::parse(&url).map_err(|err| Error::InvalidUrl { url, err })
+        Ok(response.json().await?)
     }
 }
 

--- a/crates/turborepo-auth/src/auth/login.rs
+++ b/crates/turborepo-auth/src/auth/login.rs
@@ -104,12 +104,11 @@ mod tests {
     use std::{assert_matches::assert_matches, sync::atomic::AtomicUsize};
 
     use async_trait::async_trait;
-    use reqwest::{Method, RequestBuilder, Response};
+    use reqwest::{RequestBuilder, Response};
     use turborepo_api_client::Client;
     use turborepo_ui::UI;
     use turborepo_vercel_api::{
-        CachingStatusResponse, Membership, Role, SpacesResponse, Team, TeamsResponse, User,
-        UserResponse, VerifiedSsoUser,
+        Membership, Role, SpacesResponse, Team, TeamsResponse, User, UserResponse, VerifiedSsoUser,
     };
     use turborepo_vercel_api_mock::start_test_server;
 
@@ -209,14 +208,6 @@ mod tests {
         fn add_ci_header(_request_builder: RequestBuilder) -> RequestBuilder {
             unimplemented!("add_ci_header")
         }
-        async fn get_caching_status(
-            &self,
-            _token: &str,
-            _team_id: Option<&str>,
-            _team_slug: Option<&str>,
-        ) -> turborepo_api_client::Result<CachingStatusResponse> {
-            unimplemented!("get_caching_status")
-        }
         async fn get_spaces(
             &self,
             _token: &str,
@@ -234,48 +225,8 @@ mod tests {
                 team_id: Some("team_id".to_string()),
             })
         }
-        async fn put_artifact(
-            &self,
-            _hash: &str,
-            _artifact_body: &[u8],
-            _duration: u64,
-            _tag: Option<&str>,
-            _token: &str,
-            _team_id: Option<&str>,
-            _team_slug: Option<&str>,
-        ) -> turborepo_api_client::Result<()> {
-            unimplemented!("put_artifact")
-        }
         async fn handle_403(_response: Response) -> turborepo_api_client::Error {
             unimplemented!("handle_403")
-        }
-        async fn fetch_artifact(
-            &self,
-            _hash: &str,
-            _token: &str,
-            _team_id: Option<&str>,
-            _team_slug: Option<&str>,
-        ) -> turborepo_api_client::Result<Option<Response>> {
-            unimplemented!("fetch_artifact")
-        }
-        async fn artifact_exists(
-            &self,
-            _hash: &str,
-            _token: &str,
-            _team_id: Option<&str>,
-            _team_slug: Option<&str>,
-        ) -> turborepo_api_client::Result<Option<Response>> {
-            unimplemented!("artifact_exists")
-        }
-        async fn get_artifact(
-            &self,
-            _hash: &str,
-            _token: &str,
-            _team_id: Option<&str>,
-            _team_slug: Option<&str>,
-            _method: Method,
-        ) -> turborepo_api_client::Result<Option<Response>> {
-            unimplemented!("get_artifact")
         }
         fn make_url(&self, endpoint: &str) -> turborepo_api_client::Result<Url> {
             let url = format!("{}{}", self.base_url, endpoint);

--- a/crates/turborepo-auth/src/auth/sso.rs
+++ b/crates/turborepo-auth/src/auth/sso.rs
@@ -121,12 +121,11 @@ mod tests {
     use std::sync::atomic::AtomicUsize;
 
     use async_trait::async_trait;
-    use reqwest::{Method, RequestBuilder, Response};
+    use reqwest::{RequestBuilder, Response};
     use turborepo_api_client::Client;
     use turborepo_ui::UI;
     use turborepo_vercel_api::{
-        CachingStatusResponse, Membership, Role, SpacesResponse, Team, TeamsResponse, User,
-        UserResponse, VerifiedSsoUser,
+        Membership, Role, SpacesResponse, Team, TeamsResponse, User, UserResponse, VerifiedSsoUser,
     };
     use turborepo_vercel_api_mock::start_test_server;
 
@@ -215,14 +214,6 @@ mod tests {
         fn add_ci_header(_request_builder: RequestBuilder) -> RequestBuilder {
             unimplemented!("add_ci_header")
         }
-        async fn get_caching_status(
-            &self,
-            _token: &str,
-            _team_id: Option<&str>,
-            _team_slug: Option<&str>,
-        ) -> turborepo_api_client::Result<CachingStatusResponse> {
-            unimplemented!("get_caching_status")
-        }
         async fn get_spaces(
             &self,
             _token: &str,
@@ -240,48 +231,8 @@ mod tests {
                 team_id: Some("team_id".to_string()),
             })
         }
-        async fn put_artifact(
-            &self,
-            _hash: &str,
-            _artifact_body: &[u8],
-            _duration: u64,
-            _tag: Option<&str>,
-            _token: &str,
-            _team_id: Option<&str>,
-            _team_slug: Option<&str>,
-        ) -> turborepo_api_client::Result<()> {
-            unimplemented!("put_artifact")
-        }
         async fn handle_403(_response: Response) -> turborepo_api_client::Error {
             unimplemented!("handle_403")
-        }
-        async fn fetch_artifact(
-            &self,
-            _hash: &str,
-            _token: &str,
-            _team_id: Option<&str>,
-            _team_slug: Option<&str>,
-        ) -> turborepo_api_client::Result<Option<Response>> {
-            unimplemented!("fetch_artifact")
-        }
-        async fn artifact_exists(
-            &self,
-            _hash: &str,
-            _token: &str,
-            _team_id: Option<&str>,
-            _team_slug: Option<&str>,
-        ) -> turborepo_api_client::Result<Option<Response>> {
-            unimplemented!("artifact_exists")
-        }
-        async fn get_artifact(
-            &self,
-            _hash: &str,
-            _token: &str,
-            _team_id: Option<&str>,
-            _team_slug: Option<&str>,
-            _method: Method,
-        ) -> turborepo_api_client::Result<Option<Response>> {
-            unimplemented!("get_artifact")
         }
         fn make_url(&self, endpoint: &str) -> turborepo_api_client::Result<Url> {
             let url = format!("{}{}", self.base_url, endpoint);

--- a/crates/turborepo-cache/src/http.rs
+++ b/crates/turborepo-cache/src/http.rs
@@ -4,7 +4,8 @@ use tracing::debug;
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPathBuf};
 use turborepo_analytics::AnalyticsSender;
 use turborepo_api_client::{
-    analytics, analytics::AnalyticsEvent, APIAuth, APIClient, Client, Response,
+    analytics::{self, AnalyticsEvent},
+    APIAuth, APIClient, CacheClient, Response,
 };
 
 use crate::{

--- a/crates/turborepo-lib/src/commands/link.rs
+++ b/crates/turborepo-lib/src/commands/link.rs
@@ -17,7 +17,7 @@ use dirs_next::home_dir;
 #[cfg(test)]
 use rand::Rng;
 use thiserror::Error;
-use turborepo_api_client::Client;
+use turborepo_api_client::{CacheClient, Client};
 #[cfg(not(test))]
 use turborepo_ui::CYAN;
 use turborepo_ui::{BOLD, GREY, UNDERLINE};
@@ -109,7 +109,7 @@ pub(crate) const SPACES_URL: &str = "https://vercel.com/docs/workflow-collaborat
 ///
 /// returns: Result<(), Error>
 pub(crate) async fn verify_caching_enabled<'a>(
-    api_client: &impl Client,
+    api_client: &(impl Client + CacheClient),
     team_id: &str,
     token: &str,
     selected_team: Option<SelectedTeam<'a>>,


### PR DESCRIPTION
### Description
In an effort to make things more modular and easier to implement for tests, we should make a less heavy client and instead have a base client with multiple specialty clients.

### Testing Instructions
All tests currently pass - all logic should essentially be the same


Closes TURBO-2365