### PR TITLE
fix(ci): fix reference to created branch during release

### DIFF
--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -57,7 +57,7 @@ jobs:
         id: stage
         run: cd cli && make stage-release && echo "STAGE_BRANCH=$(git branch --show-current)" >> $GITHUB_OUTPUT
       - name: Show Stage Commit
-        run: echo "${{ needs.stage.outputs.stage-branch }}"
+        run: echo "${{ steps.stage.outputs.STAGE_BRANCH }}"
     outputs:
       stage-branch: "${{ steps.stage.outputs.STAGE_BRANCH }}"
 


### PR DESCRIPTION
Example of where this was not showing anything: https://github.com/vercel/turbo/actions/runs/7905083773/job/21576872573#step:7:1

Closes TURBO-2366