### PR TITLE
feat(tasks-fs): allow to skip subpath invalidation

### DIFF
--- a/crates/node-file-trace/src/lib.rs
+++ b/crates/node-file-trace/src/lib.rs
@@ -195,7 +195,7 @@ impl Args {
 }
 
 async fn create_fs(name: &str, root: &str, watch: bool) -> Result<Vc<Box<dyn FileSystem>>> {
-    let fs = DiskFileSystem::new(name.to_string(), root.to_string());
+    let fs = DiskFileSystem::new(name.to_string(), root.to_string(), vec![]);
     if watch {
         fs.await?.start_watching()?;
     } else {

--- a/crates/turbo-tasks-fetch/tests/fetch.rs
+++ b/crates/turbo-tasks-fetch/tests/fetch.rs
@@ -142,5 +142,5 @@ async fn errors_on_404() {
 }
 
 fn get_issue_context() -> Vc<FileSystemPath> {
-    DiskFileSystem::new("root".to_owned(), "/".to_owned()).root()
+    DiskFileSystem::new("root".to_owned(), "/".to_owned(), vec![]).root()
 }

--- a/crates/turbo-tasks-fs/examples/hash_directory.rs
+++ b/crates/turbo-tasks-fs/examples/hash_directory.rs
@@ -30,7 +30,7 @@ async fn main() -> Result<()> {
     let task = tt.spawn_root_task(|| {
         Box::pin(async {
             let root = current_dir().unwrap().to_str().unwrap().to_string();
-            let disk_fs = DiskFileSystem::new("project".to_string(), root);
+            let disk_fs = DiskFileSystem::new("project".to_string(), root, vec![]);
             disk_fs.await?.start_watching()?;
 
             // Smart Pointer cast

--- a/crates/turbo-tasks-fs/examples/hash_glob.rs
+++ b/crates/turbo-tasks-fs/examples/hash_glob.rs
@@ -27,7 +27,7 @@ async fn main() -> Result<()> {
     let task = tt.spawn_root_task(|| {
         Box::pin(async {
             let root = current_dir().unwrap().to_str().unwrap().to_string();
-            let disk_fs = DiskFileSystem::new("project".to_string(), root);
+            let disk_fs = DiskFileSystem::new("project".to_string(), root, vec![]);
             disk_fs.await?.start_watching()?;
 
             // Smart Pointer cast

--- a/crates/turbo-tasks-fs/src/embed/dir.rs
+++ b/crates/turbo-tasks-fs/src/embed/dir.rs
@@ -11,7 +11,7 @@ pub async fn directory_from_relative_path(
     name: String,
     path: String,
 ) -> Result<Vc<Box<dyn FileSystem>>> {
-    let disk_fs = DiskFileSystem::new(name, path);
+    let disk_fs = DiskFileSystem::new(name, path, vec![]);
     disk_fs.await?.start_watching()?;
 
     Ok(Vc::upcast(disk_fs))

--- a/crates/turbo-tasks-fs/src/embed/file.rs
+++ b/crates/turbo-tasks-fs/src/embed/file.rs
@@ -21,6 +21,7 @@ pub async fn content_from_relative_path(
     let disk_fs = DiskFileSystem::new(
         root_path.to_string_lossy().to_string(),
         root_path.to_string_lossy().to_string(),
+        vec![],
     );
     disk_fs.await?.start_watching()?;
 

--- a/crates/turbopack-cli/src/util.rs
+++ b/crates/turbopack-cli/src/util.rs
@@ -61,14 +61,14 @@ pub fn normalize_entries(entries: &Option<Vec<String>>) -> Vec<String> {
 
 #[turbo_tasks::function]
 pub async fn project_fs(project_dir: String) -> Result<Vc<Box<dyn FileSystem>>> {
-    let disk_fs = DiskFileSystem::new("project".to_string(), project_dir.to_string());
+    let disk_fs = DiskFileSystem::new("project".to_string(), project_dir.to_string(), vec![]);
     disk_fs.await?.start_watching()?;
     Ok(Vc::upcast(disk_fs))
 }
 
 #[turbo_tasks::function]
 pub async fn output_fs(project_dir: String) -> Result<Vc<Box<dyn FileSystem>>> {
-    let disk_fs = DiskFileSystem::new("output".to_string(), project_dir.to_string());
+    let disk_fs = DiskFileSystem::new("output".to_string(), project_dir.to_string(), vec![]);
     disk_fs.await?.start_watching()?;
     Ok(Vc::upcast(disk_fs))
 }

--- a/crates/turbopack-tests/tests/execution.rs
+++ b/crates/turbopack-tests/tests/execution.rs
@@ -187,8 +187,8 @@ async fn prepare_test(resource: String) -> Result<Vc<PreparedTest>> {
         resource_path.to_str().unwrap()
     );
 
-    let root_fs = DiskFileSystem::new("workspace".to_string(), REPO_ROOT.clone());
-    let project_fs = DiskFileSystem::new("project".to_string(), REPO_ROOT.clone());
+    let root_fs = DiskFileSystem::new("workspace".to_string(), REPO_ROOT.clone(), vec![]);
+    let project_fs = DiskFileSystem::new("project".to_string(), REPO_ROOT.clone(), vec![]);
     let project_root = project_fs.root();
 
     let relative_path = resource_path.strip_prefix(&*REPO_ROOT).context(format!(

--- a/crates/turbopack-tests/tests/snapshot.rs
+++ b/crates/turbopack-tests/tests/snapshot.rs
@@ -183,8 +183,8 @@ async fn run_test(resource: String) -> Result<Vc<FileSystemPath>> {
         Err(_) => SnapshotOptions::default(),
         Ok(options_str) => parse_json_with_source_context(&options_str).unwrap(),
     };
-    let root_fs = DiskFileSystem::new("workspace".to_string(), REPO_ROOT.clone());
-    let project_fs = DiskFileSystem::new("project".to_string(), REPO_ROOT.clone());
+    let root_fs = DiskFileSystem::new("workspace".to_string(), REPO_ROOT.clone(), vec![]);
+    let project_fs = DiskFileSystem::new("project".to_string(), REPO_ROOT.clone(), vec![]);
     let project_root = project_fs.root();
 
     let relative_path = test_path.strip_prefix(&*REPO_ROOT)?;

--- a/crates/turbopack/benches/node_file_trace.rs
+++ b/crates/turbopack/benches/node_file_trace.rs
@@ -71,7 +71,7 @@ fn bench_emit(b: &mut Bencher, bench_input: &BenchInput) {
         let input = bench_input.input.clone();
         async move {
             let task = tt.spawn_once_task(async move {
-                let input_fs = DiskFileSystem::new("tests".to_string(), tests_root.clone());
+                let input_fs = DiskFileSystem::new("tests".to_string(), tests_root.clone(), vec![]);
                 let input = input_fs.root().join(input.clone());
 
                 let input_dir = input.parent().parent();

--- a/crates/turbopack/examples/turbopack.rs
+++ b/crates/turbopack/examples/turbopack.rs
@@ -38,7 +38,7 @@ async fn main() -> Result<()> {
     let task = tt.spawn_root_task(|| {
         Box::pin(async {
             let root = current_dir().unwrap().to_str().unwrap().to_string();
-            let disk_fs = DiskFileSystem::new(PROJECT_FILESYSTEM_NAME.to_string(), root);
+            let disk_fs = DiskFileSystem::new(PROJECT_FILESYSTEM_NAME.to_string(), root, vec![]);
             disk_fs.await?.start_watching()?;
 
             // Smart Pointer cast

--- a/crates/turbopack/tests/node-file-trace.rs
+++ b/crates/turbopack/tests/node-file-trace.rs
@@ -403,6 +403,7 @@ fn node_file_trace<B: Backend + 'static>(
                 let workspace_fs: Vc<Box<dyn FileSystem>> = Vc::upcast(DiskFileSystem::new(
                     "workspace".to_string(),
                     package_root.clone(),
+                    vec![],
                 ));
                 let input_dir = workspace_fs.root();
                 let input = input_dir.join(format!("tests/{input_string}"));
@@ -410,7 +411,8 @@ fn node_file_trace<B: Backend + 'static>(
                 #[cfg(not(feature = "bench_against_node_nft"))]
                 let original_output = exec_node(package_root, input);
 
-                let output_fs = DiskFileSystem::new("output".to_string(), directory.clone());
+                let output_fs =
+                    DiskFileSystem::new("output".to_string(), directory.clone(), vec![]);
                 let output_dir = output_fs.root();
 
                 let source = FileSource::new(input);


### PR DESCRIPTION
### Description

This PR allows diskfilesystem to specify certain subpath to not to cause invalidations.

Notify doesn't support actively unwatching subpath yet, so this still setup the watcher normally - only the invalidation won't be notified for the turbopack.

Closes PACK-2495