### PR TITLE
fix(turbopack-core): don't resolve exports field in folders

### DIFF
--- a/crates/turbopack-core/src/resolve/mod.rs
+++ b/crates/turbopack-core/src/resolve/mod.rs
@@ -7,7 +7,7 @@ use std::{
     pin::Pin,
 };
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{bail, Result};
 use indexmap::{indexmap, IndexMap, IndexSet};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
@@ -1563,7 +1563,7 @@ async fn resolve_internal_inline(
                         }
                         PatternMatch::Directory(matched_pattern, path) => {
                             results.push(
-                                resolve_into_folder(*path, options, *query)
+                                resolve_into_folder(*path, options)
                                     .with_request(matched_pattern.clone()),
                             );
                         }
@@ -1727,29 +1727,12 @@ async fn resolve_internal_inline(
 async fn resolve_into_folder(
     package_path: Vc<FileSystemPath>,
     options: Vc<ResolveOptions>,
-    query: Vc<String>,
 ) -> Result<Vc<ResolveResult>> {
     let package_json_path = package_path.join("package.json".to_string());
     let options_value = options.await?;
+
     for resolve_into_package in options_value.into_package.iter() {
         match resolve_into_package {
-            ResolveIntoPackage::Default(req) => {
-                let str = "./".to_string()
-                    + &*normalize_path(req).ok_or_else(|| {
-                        anyhow!(
-                            "ResolveIntoPackage::Default can't be used with a request that \
-                             escapes the current directory"
-                        )
-                    })?;
-                let request = Request::parse(Value::new(str.into()));
-                return Ok(resolve_internal_inline(
-                    package_path,
-                    request.resolve().await?,
-                    options,
-                )
-                .await?
-                .with_request(".".to_string()));
-            }
             ResolveIntoPackage::MainField {
                 field: name,
                 extensions,
@@ -1786,30 +1769,19 @@ async fn resolve_into_folder(
                     }
                 };
             }
-            ResolveIntoPackage::ExportsField {
-                conditions,
-                unspecified_conditions,
-            } => {
-                if let ExportsFieldResult::Some(exports_field) =
-                    &*exports_field(package_json_path).await?
-                {
-                    // other options do not apply anymore when an exports field exist
-                    return handle_exports_imports_field(
-                        package_path,
-                        package_json_path,
-                        options,
-                        exports_field,
-                        ".",
-                        conditions,
-                        unspecified_conditions,
-                        query,
-                    )
-                    .await;
-                }
-            }
+            ResolveIntoPackage::ExportsField { .. } => {}
         }
     }
-    Ok(ResolveResult::unresolveable().into())
+
+    // fall back to dir/index.[js,ts,...]
+    let str = "./index".to_string();
+    let request = Request::parse(Value::new(str.into()));
+
+    Ok(
+        resolve_internal_inline(package_path, request.resolve().await?, options)
+            .await?
+            .with_request(".".to_string()),
+    )
 }
 
 #[tracing::instrument(level = Level::TRACE, skip_all)]
@@ -1888,9 +1860,7 @@ async fn resolve_relative_request(
     // Directory matches must be resolved AFTER file matches
     for m in matches.iter() {
         if let PatternMatch::Directory(matched_pattern, path) = m {
-            results.push(
-                resolve_into_folder(*path, options, query).with_request(matched_pattern.clone()),
-            );
+            results.push(resolve_into_folder(*path, options).with_request(matched_pattern.clone()));
         }
     }
 
@@ -2025,56 +1995,64 @@ async fn resolve_into_package(
     let options_value = options.await?;
     let mut results = Vec::new();
 
-    let is_match = path.is_match("");
+    let is_root_match = path.is_match("") || path.is_match("/");
     let could_match_others = path.could_match_others("");
-    if is_match {
-        results.push(resolve_into_folder(package_path, options, query));
-    }
-    if could_match_others {
-        for resolve_into_package in options_value.into_package.iter() {
-            match resolve_into_package {
-                ResolveIntoPackage::Default(_) | ResolveIntoPackage::MainField { .. } => {
-                    // doesn't affect packages with subpath
-                    if path.is_match("/") {
-                        results.push(resolve_into_folder(package_path, options, query));
-                    }
-                }
-                ResolveIntoPackage::ExportsField {
-                    conditions,
-                    unspecified_conditions,
-                } => {
-                    let package_json_path = package_path.join("package.json".to_string());
-                    let ExportsFieldResult::Some(exports_field) =
-                        &*exports_field(package_json_path).await?
-                    else {
-                        continue;
-                    };
 
-                    let Some(path) = path.clone().into_string() else {
-                        todo!("pattern into an exports field is not implemented yet");
-                    };
+    let mut has_match = false;
 
-                    results.push(
-                        handle_exports_imports_field(
-                            package_path,
-                            package_json_path,
-                            options,
-                            exports_field,
-                            &format!(".{path}"),
-                            conditions,
-                            unspecified_conditions,
-                            query,
-                        )
-                        .await?,
-                    );
+    for resolve_into_package in options_value.into_package.iter() {
+        match resolve_into_package {
+            // handled by the `resolve_into_folder` call below
+            ResolveIntoPackage::MainField { .. } => {}
+            ResolveIntoPackage::ExportsField {
+                conditions,
+                unspecified_conditions,
+            } => {
+                let package_json_path = package_path.join("package.json".to_string());
+                let ExportsFieldResult::Some(exports_field) =
+                    &*exports_field(package_json_path).await?
+                else {
+                    continue;
+                };
 
-                    // other options do not apply anymore when an exports
-                    // field exist
-                    break;
-                }
+                let Some(path) = path.clone().into_string() else {
+                    todo!("pattern into an exports field is not implemented yet");
+                };
+
+                let path = if path == "/" {
+                    ".".to_string()
+                } else {
+                    format!(".{path}")
+                };
+
+                results.push(
+                    handle_exports_imports_field(
+                        package_path,
+                        package_json_path,
+                        options,
+                        exports_field,
+                        &path,
+                        conditions,
+                        unspecified_conditions,
+                        query,
+                    )
+                    .await?,
+                );
+
+                // other options do not apply anymore when an exports
+                // field exist
+                has_match = true;
+                break;
             }
         }
+    }
 
+    // apply main field(s) or fallback to index.js if there's no subpath
+    if is_root_match && !has_match {
+        results.push(resolve_into_folder(package_path, options));
+    }
+
+    if could_match_others {
         let mut new_pat = path.clone();
         new_pat.push_front(".".to_string().into());
 
@@ -2082,6 +2060,7 @@ async fn resolve_into_package(
         results
             .push(resolve_internal_inline(package_path, relative.resolve().await?, options).await?);
     }
+
     Ok(merge_results(results))
 }
 

--- a/crates/turbopack-core/src/resolve/node.rs
+++ b/crates/turbopack-core/src/resolve/node.rs
@@ -29,7 +29,6 @@ pub fn node_cjs_resolve_options(root: Vc<FileSystemPath>) -> Vc<ResolveOptions> 
                 field: "main".to_string(),
                 extensions: None,
             },
-            ResolveIntoPackage::Default("index".to_string()),
         ],
         in_package: vec![ResolveInPackage::ImportsField {
             conditions,
@@ -63,7 +62,6 @@ pub fn node_esm_resolve_options(root: Vc<FileSystemPath>) -> Vc<ResolveOptions> 
                 field: "main".to_string(),
                 extensions: Some(extensions),
             },
-            ResolveIntoPackage::Default("index".to_string()),
         ],
         in_package: vec![ResolveInPackage::ImportsField {
             conditions,

--- a/crates/turbopack-core/src/resolve/options.rs
+++ b/crates/turbopack-core/src/resolve/options.rs
@@ -71,8 +71,6 @@ pub enum ResolveIntoPackage {
         field: String,
         extensions: Option<Vec<String>>,
     },
-    /// Default behavior of using the index.js file at the root of the package.
-    Default(String),
 }
 
 // The different ways to resolve a request withing a package

--- a/crates/turbopack-ecmascript/src/typescript/resolve.rs
+++ b/crates/turbopack-ecmascript/src/typescript/resolve.rs
@@ -474,9 +474,6 @@ async fn apply_typescript_types_options(
             field: "types".to_string(),
             extensions: Some(vec![".d.ts".to_string(), ".ts".to_string()]),
         });
-    resolve_options
-        .into_package
-        .push(ResolveIntoPackage::Default("index".to_string()));
     for item in resolve_options.in_package.iter_mut() {
         if let ResolveInPackage::ImportsField { conditions, .. } = item {
             conditions.insert("types".to_string(), ConditionValue::Set);

--- a/crates/turbopack/src/resolve.rs
+++ b/crates/turbopack/src/resolve.rs
@@ -238,7 +238,6 @@ async fn base_resolve_options(
                 field: "main".to_string(),
                 extensions: None,
             });
-            resolve_into.push(ResolveIntoPackage::Default("index".to_string()));
             resolve_into
         },
         in_package: {


### PR DESCRIPTION
### Description

only main fields should be resolved in folders, the exports field should only be resolved for module requests

Closes PACK-2524