### PR TITLE
fix: More robust token validation

### DIFF
--- a/crates/turborepo-auth/src/auth/mod.rs
+++ b/crates/turborepo-auth/src/auth/mod.rs
@@ -5,17 +5,17 @@ mod sso;
 pub use login::*;
 pub use logout::*;
 pub use sso::*;
-use turborepo_api_client::{Client, TokenClient};
-use turborepo_ui::{BOLD, UI};
+use turborepo_api_client::{CacheClient, Client, TokenClient};
+use turborepo_ui::UI;
 
-use crate::{ui, LoginServer, Token};
+use crate::LoginServer;
 
 const VERCEL_TOKEN_DIR: &str = "com.vercel.cli";
 const VERCEL_TOKEN_FILE: &str = "auth.json";
 
 pub struct LoginOptions<'a, T>
 where
-    T: Client + TokenClient,
+    T: Client + TokenClient + CacheClient,
 {
     pub ui: &'a UI,
     pub login_url: &'a str,
@@ -28,7 +28,7 @@ where
 }
 impl<'a, T> LoginOptions<'a, T>
 where
-    T: Client + TokenClient,
+    T: Client + TokenClient + CacheClient,
 {
     pub fn new(
         ui: &'a UI,
@@ -45,52 +45,6 @@ where
             existing_token: None,
             force: false,
         }
-    }
-}
-
-async fn check_user_token(
-    token: &str,
-    ui: &UI,
-    api_client: &(impl Client + TokenClient),
-    message: &str,
-) -> Result<Token, Error> {
-    let response_user = api_client.get_user(token).await?;
-    println!("{}", ui.apply(BOLD.apply_to(message)));
-    ui::print_cli_authorized(&response_user.user.email, ui);
-    Ok(Token::Existing(token.to_string()))
-}
-
-async fn check_sso_token(
-    token: &str,
-    sso_team: &str,
-    ui: &UI,
-    api_client: &(impl Client + TokenClient),
-    message: &str,
-) -> Result<Token, Error> {
-    let (result_user, result_teams) =
-        tokio::join!(api_client.get_user(token), api_client.get_teams(token),);
-
-    let token = Token::existing(token.into());
-
-    match (result_user, result_teams) {
-        (Ok(response_user), Ok(response_teams)) => {
-            if response_teams
-                .teams
-                .iter()
-                .any(|team| team.slug == sso_team)
-            {
-                if token.is_valid(api_client).await? {
-                    println!("{}", ui.apply(BOLD.apply_to(message)));
-                    ui::print_cli_authorized(&response_user.user.email, ui);
-                    Ok(token)
-                } else {
-                    Err(Error::SSOTokenExpired(sso_team.to_string()))
-                }
-            } else {
-                Err(Error::SSOTeamNotFound(sso_team.to_string()))
-            }
-        }
-        (Err(e), _) | (_, Err(e)) => Err(Error::APIError(e)),
     }
 }
 


### PR DESCRIPTION
### Description
Some more modularization and better checking of validity for tokens.

### Testing Instructions
Try logins as normal, then login while logged in. If you can expire a token manually, try logging in again and it should do the normal login route again.


Closes TURBO-2391