### PR TITLE
feat: More errors work

### DIFF
--- a/crates/turborepo-errors/src/lib.rs
+++ b/crates/turborepo-errors/src/lib.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use biome_deserialize::{Deserializable, DeserializableValue, DeserializationDiagnostic};
-use miette::SourceSpan;
+use miette::{NamedSource, SourceSpan};
 use serde::Serialize;
 
 pub const TURBO_SITE: &str = "https://turbo.build";
@@ -76,10 +76,11 @@ impl<T> Spanned<T> {
     /// Gets the span and the text if both exist. If either doesn't exist, we
     /// return `None` for the span and an empty string for the text, since
     /// miette doesn't accept an `Option<String>` for `#[source_code]`
-    pub fn span_and_text(&self) -> (Option<SourceSpan>, String) {
+    pub fn span_and_text(&self, default_path: &str) -> (Option<SourceSpan>, NamedSource) {
+        let path = self.path.as_ref().map_or(default_path, |p| p.as_ref());
         match self.range.clone().zip(self.text.as_ref()) {
-            Some((range, text)) => (Some(range.into()), text.to_string()),
-            None => (None, String::new()),
+            Some((range, text)) => (Some(range.into()), NamedSource::new(path, text.to_string())),
+            None => (None, NamedSource::new(path, String::new())),
         }
     }
 

--- a/crates/turborepo-errors/src/lib.rs
+++ b/crates/turborepo-errors/src/lib.rs
@@ -5,11 +5,11 @@ use std::{
 
 use biome_deserialize::{Deserializable, DeserializableValue, DeserializationDiagnostic};
 use miette::{NamedSource, SourceSpan};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 pub const TURBO_SITE: &str = "https://turbo.build";
 
-#[derive(Debug, Default, Clone, PartialEq, Serialize)]
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize, Eq)]
 #[serde(transparent)]
 pub struct Spanned<T> {
     pub value: T,
@@ -71,6 +71,43 @@ impl<T> Spanned<T> {
 
     pub fn into_inner(self) -> T {
         self.value
+    }
+
+    pub fn as_ref(&self) -> Spanned<&T> {
+        Spanned {
+            value: &self.value,
+            range: self.range.clone(),
+            path: self.path.clone(),
+            text: self.text.clone(),
+        }
+    }
+
+    /// Splits out the span info from the value.
+    pub fn split(self) -> (T, Spanned<()>) {
+        (
+            self.value,
+            Spanned {
+                value: (),
+                range: self.range,
+                path: self.path,
+                text: self.text,
+            },
+        )
+    }
+
+    /// Gets a ref to the inner value
+    pub fn as_inner(&self) -> &T {
+        &self.value
+    }
+
+    /// Replaces the old value with a new one
+    pub fn to<U>(&self, value: U) -> Spanned<U> {
+        Spanned {
+            value,
+            range: self.range.clone(),
+            path: self.path.clone(),
+            text: self.text.clone(),
+        }
     }
 
     /// Gets the span and the text if both exist. If either doesn't exist, we

--- a/crates/turborepo-lib/src/config.rs
+++ b/crates/turborepo-lib/src/config.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, ffi::OsString, io};
 
 use convert_case::{Case, Casing};
-use miette::{Diagnostic, SourceSpan};
+use miette::{Diagnostic, NamedSource, SourceSpan};
 use serde::Deserialize;
 use struct_iterable::Iterable;
 use thiserror::Error;
@@ -55,7 +55,7 @@ pub enum Error {
     PackageTaskInSinglePackageMode {
         task_id: String,
         #[source_code]
-        text: String,
+        text: NamedSource,
         #[label("package task found here")]
         span: Option<SourceSpan>,
     },
@@ -68,7 +68,7 @@ pub enum Error {
         value: String,
         key: String,
         #[source_code]
-        text: String,
+        text: NamedSource,
         #[label("variable with invalid prefix declared here")]
         span: Option<SourceSpan>,
         env_pipeline_delimiter: &'static str,
@@ -86,14 +86,14 @@ pub enum Error {
         #[label("unnecessary package syntax found here")]
         span: Option<SourceSpan>,
         #[source_code]
-        text: String,
+        text: NamedSource,
     },
     #[error("You can only extend from the root workspace")]
     ExtendFromNonRoot {
         #[label("non-root workspace found here")]
         span: Option<SourceSpan>,
         #[source_code]
-        text: String,
+        text: NamedSource,
     },
     #[error("`{field}` cannot contain an absolute path")]
     AbsolutePathInConfig {
@@ -101,10 +101,15 @@ pub enum Error {
         #[label("absolute path found here")]
         span: Option<SourceSpan>,
         #[source_code]
-        text: String,
+        text: NamedSource,
     },
-    #[error("No \"extends\" key found in {path}")]
-    NoExtends { path: String },
+    #[error("No \"extends\" key found")]
+    NoExtends {
+        #[label("add extends key here")]
+        span: Option<SourceSpan>,
+        #[source_code]
+        text: NamedSource,
+    },
     #[error("Failed to create APIClient: {0}")]
     ApiClient(#[source] turborepo_api_client::Error),
     #[error("{0} is not UTF8.")]

--- a/crates/turborepo-lib/src/engine/builder.rs
+++ b/crates/turborepo-lib/src/engine/builder.rs
@@ -2,9 +2,9 @@ use std::collections::{HashMap, HashSet, VecDeque};
 
 use convert_case::{Case, Casing};
 use itertools::Itertools;
-use miette::Diagnostic;
+use miette::{Diagnostic, NamedSource, SourceSpan};
 use turbopath::AbsoluteSystemPath;
-use turborepo_errors::TURBO_SITE;
+use turborepo_errors::{Spanned, TURBO_SITE};
 use turborepo_graph_utils as graph;
 use turborepo_repository::package_graph::{PackageGraph, PackageName, PackageNode, ROOT_PKG_NAME};
 
@@ -17,23 +17,39 @@ use crate::{
 };
 
 #[derive(Debug, thiserror::Error, Diagnostic)]
+#[error("could not find task `{name}` in project")]
+pub struct MissingTaskError {
+    name: String,
+    #[label]
+    span: Option<SourceSpan>,
+    #[source_code]
+    text: NamedSource,
+}
+
+#[derive(Debug, thiserror::Error, Diagnostic)]
 pub enum Error {
-    #[error("Could not find the following tasks in project: {0}")]
-    MissingTasks(String),
+    #[error("missing tasks in project")]
+    MissingTasks(#[related] Vec<MissingTaskError>),
     #[error("No package.json for {workspace}")]
     MissingPackageJson { workspace: PackageName },
     #[error(
         "{task_id} needs an entry in turbo.json before it can be depended on because it is a task \
-         run from the root package"
+         declared in the root package.json"
     )]
     #[diagnostic(
-        code(missing_task_for_root),
+        code(missing_root_task_in_turbo_json),
         url(
             "{}/messages/{}",
             TURBO_SITE, self.code().unwrap().to_string().to_case(Case::Kebab)
         )
     )]
-    MissingTaskForRoot { task_id: String },
+    MissingRootTaskInTurboJson {
+        task_id: String,
+        #[label("add an entry in turbo.json for this task")]
+        span: Option<SourceSpan>,
+        #[source_code]
+        text: NamedSource,
+    },
     #[error("Could not find workspace \"{package}\" from task \"{task_id}\" in project")]
     MissingWorkspaceFromTask { package: String, task_id: String },
     #[error("Could not find \"{task_id}\" in root turbo.json or \"{task_name}\" in workspace")]
@@ -58,7 +74,7 @@ pub struct EngineBuilder<'a> {
     is_single: bool,
     turbo_jsons: Option<HashMap<PackageName, TurboJson>>,
     workspaces: Vec<PackageName>,
-    tasks: Vec<TaskName<'static>>,
+    tasks: Vec<Spanned<TaskName<'static>>>,
     root_enabled_tasks: HashSet<TaskName<'static>>,
     tasks_only: bool,
 }
@@ -108,7 +124,10 @@ impl<'a> EngineBuilder<'a> {
         self
     }
 
-    pub fn with_tasks<I: IntoIterator<Item = TaskName<'static>>>(mut self, tasks: I) -> Self {
+    pub fn with_tasks<I: IntoIterator<Item = Spanned<TaskName<'static>>>>(
+        mut self,
+        tasks: I,
+    ) -> Self {
         self.tasks = tasks.into_iter().collect();
         self
     }
@@ -122,8 +141,8 @@ impl<'a> EngineBuilder<'a> {
         }
 
         let mut turbo_jsons = self.turbo_jsons.take().unwrap_or_default();
-        let mut missing_tasks: HashSet<&TaskName<'_>, std::collections::hash_map::RandomState> =
-            HashSet::from_iter(self.tasks.iter());
+        let mut missing_tasks: HashMap<&TaskName<'_>, Spanned<()>> =
+            HashMap::from_iter(self.tasks.iter().map(|spanned| spanned.as_ref().split()));
         let mut traversal_queue = VecDeque::with_capacity(1);
         for (workspace, task) in self.workspaces.iter().cartesian_product(self.tasks.iter()) {
             let task_id = task
@@ -131,7 +150,7 @@ impl<'a> EngineBuilder<'a> {
                 .unwrap_or_else(|| TaskId::new(workspace.as_ref(), task.task()));
 
             if self.has_task_definition(&mut turbo_jsons, workspace, task, &task_id)? {
-                missing_tasks.remove(task);
+                missing_tasks.remove(task.as_inner());
 
                 // Even if a task definition was found, we _only_ want to add it as an entry
                 // point to the task graph (i.e. the traversalQueue), if
@@ -141,7 +160,7 @@ impl<'a> EngineBuilder<'a> {
                 //   workspace is acceptable)
                 if !matches!(workspace, PackageName::Root) || self.root_enabled_tasks.contains(task)
                 {
-                    traversal_queue.push_back(task_id);
+                    traversal_queue.push_back(task.to(task_id));
                 }
             }
         }
@@ -149,12 +168,19 @@ impl<'a> EngineBuilder<'a> {
         if !missing_tasks.is_empty() {
             let mut missing_tasks = missing_tasks
                 .into_iter()
-                .map(|task_name| task_name.to_string())
+                .map(|(task_name, span)| (task_name.to_string(), span))
                 .collect::<Vec<_>>();
             // We sort the tasks mostly to keep it deterministic for our tests
-            missing_tasks.sort();
+            missing_tasks.sort_by(|a, b| a.0.cmp(&b.0));
+            let errors = missing_tasks
+                .into_iter()
+                .map(|(name, span)| {
+                    let (span, text) = span.span_and_text("turbo.json");
+                    MissingTaskError { name, span, text }
+                })
+                .collect();
 
-            return Err(Error::MissingTasks(missing_tasks.into_iter().join(", ")));
+            return Err(Error::MissingTasks(errors));
         }
 
         let mut visited = HashSet::new();
@@ -166,7 +192,10 @@ impl<'a> EngineBuilder<'a> {
                     .root_enabled_tasks
                     .contains(&task_id.as_non_workspace_task_name())
             {
-                return Err(Error::MissingTaskForRoot {
+                let (span, text) = task_id.span_and_text("turbo.json");
+                return Err(Error::MissingRootTaskInTurboJson {
+                    span,
+                    text,
                     task_id: task_id.to_string(),
                 });
             }
@@ -197,11 +226,11 @@ impl<'a> EngineBuilder<'a> {
             let task_definition = TaskDefinition::try_from(raw_task_definition)?;
 
             // Skip this iteration of the loop if we've already seen this taskID
-            if visited.contains(&task_id) {
+            if visited.contains(task_id.as_inner()) {
                 continue;
             }
 
-            visited.insert(task_id.clone());
+            visited.insert(task_id.as_inner().clone());
 
             // Note that the Go code has a whole if/else statement for putting stuff into
             // deps or calling e.AddDep the bool is cannot be true so we skip to
@@ -209,20 +238,22 @@ impl<'a> EngineBuilder<'a> {
             let mut deps = task_definition
                 .task_dependencies
                 .iter()
-                .collect::<HashSet<_>>();
+                .map(|spanned| spanned.as_ref().split())
+                .collect::<HashMap<_, _>>();
             let mut topo_deps = task_definition
                 .topological_dependencies
                 .iter()
-                .collect::<HashSet<_>>();
+                .map(|spanned| spanned.as_ref().split())
+                .collect::<HashMap<_, _>>();
 
             if self.tasks_only {
-                deps.retain(|task_name| self.tasks.contains(*task_name));
-                topo_deps.retain(|task_name| self.tasks.contains(*task_name))
+                deps.retain(|task_name, _| self.tasks.iter().any(|t| &t.value == *task_name));
+                topo_deps.retain(|task_name, _| self.tasks.iter().any(|t| &t.value == *task_name));
             }
 
             // Don't ask why, but for some reason we refer to the source as "to"
             // and the target node as "from"
-            let to_task_id = task_id.clone().into_owned();
+            let to_task_id = task_id.as_inner().clone().into_owned();
             let to_task_index = engine.get_index(&to_task_id);
 
             let dep_pkgs = self
@@ -235,7 +266,7 @@ impl<'a> EngineBuilder<'a> {
             topo_deps
                 .iter()
                 .cartesian_product(dep_pkgs.iter().flatten())
-                .for_each(|(from, dependency_workspace)| {
+                .for_each(|((from, span), dependency_workspace)| {
                     // We don't need to add an edge from the root node if we're in this branch
                     if let PackageNode::Workspace(dependency_workspace) = dependency_workspace {
                         has_topo_deps = true;
@@ -244,11 +275,11 @@ impl<'a> EngineBuilder<'a> {
                         engine
                             .task_graph
                             .add_edge(to_task_index, from_task_index, ());
-                        traversal_queue.push_back(from_task_id);
+                        traversal_queue.push_back(span.to(from_task_id));
                     }
                 });
 
-            for dep in deps {
+            for (dep, span) in deps {
                 has_deps = true;
                 let from_task_id = dep
                     .task_id()
@@ -258,10 +289,10 @@ impl<'a> EngineBuilder<'a> {
                 engine
                     .task_graph
                     .add_edge(to_task_index, from_task_index, ());
-                traversal_queue.push_back(from_task_id);
+                traversal_queue.push_back(span.to(from_task_id));
             }
 
-            engine.add_definition(task_id.clone().into_owned(), task_definition);
+            engine.add_definition(task_id.as_inner().clone().into_owned(), task_definition);
 
             if !has_deps && !has_topo_deps {
                 engine.connect_to_root(&to_task_id);
@@ -312,7 +343,7 @@ impl<'a> EngineBuilder<'a> {
     fn task_definition_chain(
         &self,
         turbo_jsons: &mut HashMap<PackageName, TurboJson>,
-        task_id: &TaskId,
+        task_id: &Spanned<TaskId>,
         task_name: &TaskName,
     ) -> Result<Vec<RawTaskDefinition>, Error> {
         let mut task_definitions = Vec::new();
@@ -327,9 +358,14 @@ impl<'a> EngineBuilder<'a> {
 
         if self.is_single {
             return match task_definitions.is_empty() {
-                true => Err(Error::MissingTaskForRoot {
-                    task_id: task_id.to_string(),
-                }),
+                true => {
+                    let (span, text) = task_id.span_and_text("turbo.json");
+                    Err(Error::MissingRootTaskInTurboJson {
+                        span,
+                        text,
+                        task_id: task_id.to_string(),
+                    })
+                }
                 false => Ok(task_definitions),
             };
         }
@@ -926,7 +962,7 @@ mod test {
             .with_root_tasks(vec![TaskName::from("libA#build"), TaskName::from("build")])
             .build();
 
-        assert_matches!(engine, Err(Error::MissingTaskForRoot { .. }));
+        assert_matches!(engine, Err(Error::MissingRootTaskInTurboJson { .. }));
     }
 
     #[test]
@@ -1010,7 +1046,7 @@ mod test {
             ])
             .build();
 
-        assert_matches!(engine, Err(Error::MissingTaskForRoot { .. }));
+        assert_matches!(engine, Err(Error::MissingRootTaskInTurboJson { .. }));
     }
 
     #[test]

--- a/crates/turborepo-lib/src/engine/builder.rs
+++ b/crates/turborepo-lib/src/engine/builder.rs
@@ -1,8 +1,10 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 
+use convert_case::{Case, Casing};
 use itertools::Itertools;
 use miette::Diagnostic;
 use turbopath::AbsoluteSystemPath;
+use turborepo_errors::TURBO_SITE;
 use turborepo_graph_utils as graph;
 use turborepo_repository::package_graph::{PackageGraph, PackageName, PackageNode, ROOT_PKG_NAME};
 
@@ -23,6 +25,13 @@ pub enum Error {
     #[error(
         "{task_id} needs an entry in turbo.json before it can be depended on because it is a task \
          run from the root package"
+    )]
+    #[diagnostic(
+        code(missing_task_for_root),
+        url(
+            "{}/messages/{}",
+            TURBO_SITE, self.code().unwrap().to_string().to_case(Case::Kebab)
+        )
     )]
     MissingTaskForRoot { task_id: String },
     #[error("Could not find workspace \"{package}\" from task \"{task_id}\" in project")]

--- a/crates/turborepo-lib/src/engine/builder.rs
+++ b/crates/turborepo-lib/src/engine/builder.rs
@@ -730,7 +730,7 @@ mod test {
         .collect();
         let engine = EngineBuilder::new(&repo_root, &package_graph, false)
             .with_turbo_jsons(Some(turbo_jsons))
-            .with_tasks(Some(TaskName::from("test")))
+            .with_tasks(Some(Spanned::new(TaskName::from("test"))))
             .with_workspaces(vec![
                 PackageName::from("a"),
                 PackageName::from("b"),
@@ -787,7 +787,7 @@ mod test {
         .collect();
         let engine = EngineBuilder::new(&repo_root, &package_graph, false)
             .with_turbo_jsons(Some(turbo_jsons))
-            .with_tasks(Some(TaskName::from("test")))
+            .with_tasks(Some(Spanned::new(TaskName::from("test"))))
             .with_workspaces(vec![PackageName::from("app2")])
             .build()
             .unwrap();
@@ -826,7 +826,7 @@ mod test {
         .collect();
         let engine = EngineBuilder::new(&repo_root, &package_graph, false)
             .with_turbo_jsons(Some(turbo_jsons))
-            .with_tasks(Some(TaskName::from("special")))
+            .with_tasks(Some(Spanned::new(TaskName::from("special"))))
             .with_workspaces(vec![PackageName::from("app1"), PackageName::from("libA")])
             .build()
             .unwrap();
@@ -864,7 +864,10 @@ mod test {
         .collect();
         let engine = EngineBuilder::new(&repo_root, &package_graph, false)
             .with_turbo_jsons(Some(turbo_jsons))
-            .with_tasks(vec![TaskName::from("build"), TaskName::from("test")])
+            .with_tasks(vec![
+                Spanned::new(TaskName::from("build")),
+                Spanned::new(TaskName::from("test")),
+            ])
             .with_workspaces(vec![
                 PackageName::Root,
                 PackageName::from("app1"),
@@ -914,7 +917,7 @@ mod test {
         .collect();
         let engine = EngineBuilder::new(&repo_root, &package_graph, false)
             .with_turbo_jsons(Some(turbo_jsons))
-            .with_tasks(Some(TaskName::from("build")))
+            .with_tasks(Some(Spanned::new(TaskName::from("build"))))
             .with_workspaces(vec![PackageName::from("app1")])
             .with_root_tasks(vec![
                 TaskName::from("//#root-task"),
@@ -957,7 +960,7 @@ mod test {
         .collect();
         let engine = EngineBuilder::new(&repo_root, &package_graph, false)
             .with_turbo_jsons(Some(turbo_jsons))
-            .with_tasks(Some(TaskName::from("build")))
+            .with_tasks(Some(Spanned::new(TaskName::from("build"))))
             .with_workspaces(vec![PackageName::from("app1")])
             .with_root_tasks(vec![TaskName::from("libA#build"), TaskName::from("build")])
             .build();
@@ -992,7 +995,7 @@ mod test {
         .collect();
         let engine = EngineBuilder::new(&repo_root, &package_graph, false)
             .with_turbo_jsons(Some(turbo_jsons))
-            .with_tasks(Some(TaskName::from("build")))
+            .with_tasks(Some(Spanned::new(TaskName::from("build"))))
             .with_workspaces(vec![PackageName::from("app1")])
             .with_root_tasks(vec![
                 TaskName::from("libA#build"),
@@ -1037,7 +1040,7 @@ mod test {
         .collect();
         let engine = EngineBuilder::new(&repo_root, &package_graph, false)
             .with_turbo_jsons(Some(turbo_jsons))
-            .with_tasks(Some(TaskName::from("build")))
+            .with_tasks(Some(Spanned::new(TaskName::from("build"))))
             .with_workspaces(vec![PackageName::from("app1")])
             .with_root_tasks(vec![
                 TaskName::from("libA#build"),
@@ -1077,7 +1080,7 @@ mod test {
         let engine = EngineBuilder::new(&repo_root, &package_graph, false)
             .with_turbo_jsons(Some(turbo_jsons))
             .with_tasks_only(true)
-            .with_tasks(Some(TaskName::from("test")))
+            .with_tasks(Some(Spanned::new(TaskName::from("test"))))
             .with_workspaces(vec![
                 PackageName::from("a"),
                 PackageName::from("b"),

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -28,6 +28,7 @@ use turborepo_api_client::{APIAuth, APIClient};
 use turborepo_cache::{AsyncCache, RemoteCacheOpts};
 use turborepo_ci::Vendor;
 use turborepo_env::EnvironmentVariableMap;
+use turborepo_errors::Spanned;
 use turborepo_repository::{
     package_graph::{self, PackageGraph, PackageName},
     package_json::{self, PackageJson},
@@ -576,13 +577,10 @@ impl Run {
         ))
         .with_tasks_only(self.opts.run_opts.only)
         .with_workspaces(filtered_pkgs.clone().into_iter().collect())
-        .with_tasks(
-            self.opts
-                .run_opts
-                .tasks
-                .iter()
-                .map(|task| TaskName::from(task.as_str()).into_owned()),
-        )
+        .with_tasks(self.opts.run_opts.tasks.iter().map(|task| {
+            // TODO: Pull span info from command
+            Spanned::new(TaskName::from(task.as_str()).into_owned())
+        }))
         .build()?;
 
         if !self.opts.run_opts.parallel {

--- a/crates/turborepo-lib/src/run/summary/task.rs
+++ b/crates/turborepo-lib/src/run/summary/task.rs
@@ -295,7 +295,7 @@ impl From<TaskDefinition> for TaskSummaryTaskDefinition {
             depends_on.push(task_dependency.to_string());
         }
         for topological_dependency in topological_dependencies {
-            depends_on.push(format!("^{topological_dependency}"));
+            depends_on.push(format!("^{}", topological_dependency.as_inner()));
         }
 
         // These _should_ already be sorted when the TaskDefinition struct was

--- a/crates/turborepo-lib/src/task_graph/mod.rs
+++ b/crates/turborepo-lib/src/task_graph/mod.rs
@@ -5,6 +5,7 @@ use std::str::FromStr;
 use globwalk::{GlobError, ValidatedGlob};
 use serde::{Deserialize, Serialize};
 use turbopath::{AnchoredSystemPath, AnchoredSystemPathBuf, RelativeUnixPathBuf};
+use turborepo_errors::Spanned;
 pub use visitor::{Error as VisitorError, Visitor};
 
 use crate::{
@@ -54,13 +55,13 @@ pub struct TaskDefinition {
     // E.g. "build" is a topological dependency in:
     // dependsOn: ['^build'].
     // This field is custom-marshalled from rawTask.DependsOn
-    pub topological_dependencies: Vec<TaskName<'static>>,
+    pub topological_dependencies: Vec<Spanned<TaskName<'static>>>,
 
     // TaskDependencies are anything that is not a topological dependency
     // E.g. both something and //whatever are TaskDependencies in:
     // dependsOn: ['something', '//whatever']
     // This field is custom-marshalled from rawTask.DependsOn
-    pub task_dependencies: Vec<TaskName<'static>>,
+    pub task_dependencies: Vec<Spanned<TaskName<'static>>>,
 
     // Inputs indicate the list of files this Task depends on. If any of those files change
     // we can conclude that any cached outputs or logs for this Task should be invalidated.

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -15,7 +15,7 @@ use turborepo_repository::{package_graph::ROOT_PKG_NAME, package_json::PackageJs
 
 use crate::{
     cli::OutputLogsMode,
-    config::{ConfigurationOptions, Error},
+    config::{ConfigurationOptions, Error, InvalidEnvPrefixError},
     run::{
         task_access::{TaskAccessTraceFile, TASK_ACCESS_CONFIG_PATH},
         task_id::{TaskId, TaskName},
@@ -702,13 +702,13 @@ fn gather_env_vars(
                 .path
                 .as_ref()
                 .map_or_else(|| "turbo.json".to_string(), |p| p.to_string());
-            return Err(Error::InvalidEnvPrefix {
+            return Err(Error::InvalidEnvPrefix(Box::new(InvalidEnvPrefixError {
                 key: key.to_string(),
                 value: value.into_inner(),
                 span,
                 text: NamedSource::new(path, text),
                 env_pipeline_delimiter: ENV_PIPELINE_DELIMITER,
-            });
+            })));
         }
 
         into.insert(value.into_inner());

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -910,7 +910,7 @@ mod tests {
           "persistent": true
         }"#,
         RawTaskDefinition {
-            depends_on: Some(Spanned::new(vec!["cli#build".into()]).with_range(25..38)),
+            depends_on: Some(Spanned::new(vec![Spanned::<UnescapedString>::new("cli#build".into()).with_range(26..37)]).with_range(25..38)),
             dot_env: Some(Spanned::new(vec!["package/a/.env".into()]).with_range(60..78)),
             env: Some(vec![Spanned::<UnescapedString>::new("OS".into()).with_range(98..102)]),
             pass_through_env: Some(vec![Spanned::<UnescapedString>::new("AWS_SECRET_KEY".into()).with_range(134..150)]),
@@ -931,7 +931,7 @@ mod tests {
           inputs: vec!["package/a/src/**".to_string()],
           output_mode: OutputLogsMode::Full,
           pass_through_env: Some(vec!["AWS_SECRET_KEY".to_string()]),
-          task_dependencies: vec!["cli#build".into()],
+          task_dependencies: vec![Spanned::<TaskName<'_>>::new("cli#build".into()).with_range(26..37)],
           topological_dependencies: vec![],
           persistent: true,
         }
@@ -950,7 +950,7 @@ mod tests {
               "persistent": true
             }"#,
         RawTaskDefinition {
-            depends_on: Some(Spanned::new(vec!["cli#build".into()]).with_range(29..42)),
+            depends_on: Some(Spanned::new(vec![Spanned::<UnescapedString>::new("cli#build".into()).with_range(30..41)]).with_range(29..42)),
             dot_env: Some(Spanned::new(vec!["package\\a\\.env".into()]).with_range(68..88)),
             env: Some(vec![Spanned::<UnescapedString>::new("OS".into()).with_range(112..116)]),
             pass_through_env: Some(vec![Spanned::<UnescapedString>::new("AWS_SECRET_KEY".into()).with_range(152..168)]),
@@ -971,7 +971,7 @@ mod tests {
             inputs: vec!["package\\a\\src\\**".to_string()],
             output_mode: OutputLogsMode::Full,
             pass_through_env: Some(vec!["AWS_SECRET_KEY".to_string()]),
-            task_dependencies: vec!["cli#build".into()],
+            task_dependencies: vec![Spanned::<TaskName<'_>>::new("cli#build".into()).with_range(30..41)],
             topological_dependencies: vec![],
             persistent: true,
         }

--- a/crates/turborepo-lib/src/turbo_json/parser.rs
+++ b/crates/turborepo-lib/src/turbo_json/parser.rs
@@ -647,6 +647,9 @@ impl WithMetadata for Pipeline {
 impl WithMetadata for RawTaskDefinition {
     fn add_text(&mut self, text: Arc<str>) {
         self.depends_on.add_text(text.clone());
+        if let Some(depends_on) = &mut self.depends_on {
+            depends_on.value.add_text(text.clone());
+        }
         self.dot_env.add_text(text.clone());
         self.env.add_text(text.clone());
         self.inputs.add_text(text.clone());
@@ -658,6 +661,9 @@ impl WithMetadata for RawTaskDefinition {
 
     fn add_path(&mut self, path: Arc<str>) {
         self.depends_on.add_path(path.clone());
+        if let Some(depends_on) = &mut self.depends_on {
+            depends_on.value.add_path(path.clone());
+        }
         self.dot_env.add_path(path.clone());
         self.env.add_path(path.clone());
         self.inputs.add_path(path.clone());

--- a/docs/pages/messages/missing-root-task-in-turbo-json.mdx
+++ b/docs/pages/messages/missing-root-task-in-turbo-json.mdx
@@ -7,8 +7,7 @@ description: Missing root task in turbo.json error
 
 ## Why This Error Occurred
 
-We call the scripts defined in the monorepo's root `package.json` the root tasks. These tasks often call `turbo`
-themselves. For example:
+Root tasks are the scripts defined in the monorepo's root `package.json`. These tasks often call `turbo`. For example:
 
 ```json package.json
 {
@@ -18,11 +17,8 @@ themselves. For example:
 }
 ```
 
-This creates a problem when we declare task dependencies with `^`. A quick recap, `^<task>` means all of the `<task>`
-entries in the package's dependencies, e.g. if package `a` depends on packages `b` and `c`, and `a#build` depends on
-`^build`, then its dependencies will be `b#build` and `c#build`. We call these topological dependencies. Topological
-dependencies work well for many common situations, such as when you want to build your dependencies before building
-your own package.
+This creates a problem when we declare [topological dependencies](/repo/docs/reference/configuration#dependson). Topological
+dependencies specify that your package's dependencies should execute their tasks before your package executes its own task.
 
 ```json turbo.json
 {
@@ -34,14 +30,8 @@ your own package.
 }
 ```
 
-However, following package dependency relations is slightly problematic because the root package is an implicit dependency
-for all the packages inside the monorepo. If you're wondering why that is, well, it wasn't our choice. This is just
-how JavaScript monorepos work. If you define a dependency in the root `package.json`, it becomes available to all
-packages in the monorepo.
-
-Therefore, if we were to follow `^build` literally, it'd cause an infinite loop, because we'd execute the root `build`
-task, which would execute `turbo`, which would execute `^build`...and so on. Instead of wasting everybody's time,
-we decided that `turbo` would not execute root tasks by default.
+Because the root package is a dependency for all packages inside your workspace, its task would get executed first.
+But since its task calls `turbo`, this would cause an infinite loop.
 
 ## Solution
 

--- a/docs/pages/messages/missing-root-task-in-turbo-json.mdx
+++ b/docs/pages/messages/missing-root-task-in-turbo-json.mdx
@@ -7,8 +7,8 @@ description: Missing root task in turbo.json error
 
 ## Why This Error Occurred
 
-Scripts defined in the monorepo's root `package.json`, i.e. root tasks, often call `turbo` themselves.
-For example:
+We call the scripts defined in the monorepo's root `package.json` the root tasks. These tasks often call `turbo`
+themselves. For example:
 
 ```json package.json
 {
@@ -18,13 +18,11 @@ For example:
 }
 ```
 
-This creates a problem when we declare task dependencies with `^`. A quick recap, `^<task>` declares that the
-task depends on the same task in the package's dependencies, e.g. if package `a` depends on packages `b` and `c`,
-and `a#build` depends on `^build`, then its dependencies will be `b#build` and `c#build`. We call these topological
-dependencies.
-
-However, this creates a problem, because the root package is an implicit dependency for all the packages
-inside the monorepo.
+This creates a problem when we declare task dependencies with `^`. A quick recap, `^<task>` means all of the `<task>`
+entries in the package's dependencies, e.g. if package `a` depends on packages `b` and `c`, and `a#build` depends on
+`^build`, then its dependencies will be `b#build` and `c#build`. We call these topological dependencies. Topological
+dependencies work well for many common situations, such as when you want to build your dependencies before building
+your own package.
 
 ```json turbo.json
 {
@@ -36,7 +34,14 @@ inside the monorepo.
 }
 ```
 
-Therefore, by default, Turborepo does not include root tasks in its task dependency graph.
+However, following package dependency relations is slightly problematic because the root package is an implicit dependency
+for all the packages inside the monorepo. If you're wondering why that is, well, it wasn't our choice. This is just
+how JavaScript monorepos work. If you define a dependency in the root `package.json`, it becomes available to all
+packages in the monorepo.
+
+Therefore, if we were to follow `^build` literally, it'd cause an infinite loop, because we'd execute the root `build`
+task, which would execute `turbo`, which would execute `^build`...and so on. Instead of wasting everybody's time,
+we decided that `turbo` would not execute root tasks by default.
 
 ## Solution
 
@@ -50,8 +55,8 @@ As long as the root task does _not_ call `turbo`, you can add it to the `pipelin
 }
 ```
 
-This will allow other tasks to depend on `//#build`.
+This will permit tasks to depend on `//#build`.
 
 However, if the root task does call `turbo`, this can cause infinite recursion. In this case, we don't recommend depending
 on the root task. Instead, you can determine the tasks that this root task depends on, and depend on those directly.
-For instance, if `//#build` depends on `app#lint` and `docs#lint`, then you can declare those as dependencies
+For instance, if `//#build` depends on `app#lint` and `docs#lint`, then you can declare those as dependencies.

--- a/docs/pages/messages/missing-root-task-in-turbo-json.mdx
+++ b/docs/pages/messages/missing-root-task-in-turbo-json.mdx
@@ -1,0 +1,57 @@
+---
+title: Missing root task in turbo.json
+description: Missing root task in turbo.json error
+---
+
+# Missing root task in turbo.json
+
+## Why This Error Occurred
+
+Scripts defined in the monorepo's root `package.json`, i.e. root tasks, often call `turbo` themselves.
+For example:
+
+```json package.json
+{
+  "scripts": {
+    "build": "turbo run build"
+  }
+}
+```
+
+This creates a problem when we declare task dependencies with `^`. A quick recap, `^<task>` declares that the
+task depends on the same task in the package's dependencies, e.g. if package `a` depends on packages `b` and `c`,
+and `a#build` depends on `^build`, then its dependencies will be `b#build` and `c#build`. We call these topological
+dependencies.
+
+However, this creates a problem, because the root package is an implicit dependency for all the packages
+inside the monorepo.
+
+```json turbo.json
+{
+  "pipeline": {
+    "build": {
+      "dependsOn": ["^build"]
+    }
+  }
+}
+```
+
+Therefore, by default, Turborepo does not include root tasks in its task dependency graph.
+
+## Solution
+
+As long as the root task does _not_ call `turbo`, you can add it to the `pipeline` field in `turbo.json`:
+
+```json
+{
+  "pipeline": {
+    "//#build": {}
+  }
+}
+```
+
+This will allow other tasks to depend on `//#build`.
+
+However, if the root task does call `turbo`, this can cause infinite recursion. In this case, we don't recommend depending
+on the root task. Instead, you can determine the tasks that this root task depends on, and depend on those directly.
+For instance, if `//#build` depends on `app#lint` and `docs#lint`, then you can declare those as dependencies

--- a/turborepo-tests/integration/tests/bad-turbo-json.t
+++ b/turborepo-tests/integration/tests/bad-turbo-json.t
@@ -11,7 +11,7 @@ Run build with package task in non-root turbo.json
   Error: unnecessary_package_task_syntax (https://turbo.build/messages/unnecessary-package-task-syntax)
   
     x "my-app#build". Use "build" instead
-      ,-[7:1]
+      ,-[apps/my-app/turbo.json:7:1]
     7 |         // this comment verifies that turbo can read .json files with comments
     8 | ,->     "my-app#build": {
     9 | |         "outputs": ["banana.txt", "apple.json"],
@@ -37,7 +37,7 @@ Run build with invalid env var
   invalid_env_prefix (https://turbo.build/messages/invalid-env-prefix)
   
     x Environment variables should not be prefixed with "$"
-     ,-[6:1]
+     ,-[turbo.json:6:1]
    6 |     "build": {
    7 |       "env": ["NODE_ENV", "$FOOBAR"],
      :                           ^^^^|^^^^
@@ -55,7 +55,7 @@ Run in single package mode even though we have a task with package syntax
   
     x Package tasks (<package>#<task>) are not allowed in single-package
     | repositories: found //#something
-      ,-[16:1]
+      ,-[turbo.json:16:1]
    16 |     "something": {},
    17 |     "//#something": {},
       :                     ^|

--- a/turborepo-tests/integration/tests/bad-turbo-json.t
+++ b/turborepo-tests/integration/tests/bad-turbo-json.t
@@ -11,7 +11,7 @@ Run build with package task in non-root turbo.json
   Error: unnecessary_package_task_syntax (https://turbo.build/messages/unnecessary-package-task-syntax)
   
     x "my-app#build". Use "build" instead
-      ,-[apps/my-app/turbo.json:7:1]
+      ,-\[apps[\\/]my-app[\\/]turbo.json:7:1\] (re)
     7 |         // this comment verifies that turbo can read .json files with comments
     8 | ,->     "my-app#build": {
     9 | |         "outputs": ["banana.txt", "apple.json"],

--- a/turborepo-tests/integration/tests/config.t
+++ b/turborepo-tests/integration/tests/config.t
@@ -52,7 +52,7 @@ Run build with invalid env var
   invalid_env_prefix (https://turbo.build/messages/invalid-env-prefix)
   
     x Environment variables should not be prefixed with "$"
-     ,-[6:1]
+     ,-[turbo.json:6:1]
    6 |     "build": {
    7 |       "env": ["NODE_ENV", "$FOOBAR"],
      :                           ^^^^|^^^^

--- a/turborepo-tests/integration/tests/dry-json/monorepo.t
+++ b/turborepo-tests/integration/tests/dry-json/monorepo.t
@@ -179,6 +179,8 @@ Run again with NODE_ENV set and see the value in the summary. --filter=util work
 
 Tasks that don't exist throw an error
   $ ${TURBO} run doesnotexist --dry=json
-    x Could not find the following tasks in project: doesnotexist
+    x missing tasks in project
+  
+  Error:   x could not find task `doesnotexist` in project
   
   [1]

--- a/turborepo-tests/integration/tests/run/missing-tasks.t
+++ b/turborepo-tests/integration/tests/run/missing-tasks.t
@@ -3,19 +3,26 @@ Setup
 
 # Running non-existent tasks errors
   $ ${TURBO} run doesnotexist
-    x Could not find the following tasks in project: doesnotexist
+    x missing tasks in project
+  
+  Error:   x could not find task `doesnotexist` in project
   
   [1]
 
 # Multiple non-existent tasks also error
   $ ${TURBO} run doesnotexist alsono
-    x Could not find the following tasks in project: alsono, doesnotexist
+    x missing tasks in project
+  
+  Error:   x could not find task `alsono` in project
+  Error:   x could not find task `doesnotexist` in project
   
   [1]
 
 # One good and one bad task does not error
   $ ${TURBO} run build doesnotexist
-    x Could not find the following tasks in project: doesnotexist
+    x missing tasks in project
+  
+  Error:   x could not find task `doesnotexist` in project
   
   [1]
 

--- a/turborepo-tests/integration/tests/task-dependencies/workspace-tasks.t
+++ b/turborepo-tests/integration/tests/task-dependencies/workspace-tasks.t
@@ -38,7 +38,7 @@ Can't depend on a missing root task
   $ ${TURBO} run build3 --graph > BUILD3 2>&1
   [1]
   $ cat BUILD3 | grep --quiet --only-match 'x //#not-exists needs an entry in turbo.json before it can be depended on'
-  $ cat BUILD3 | grep --quiet --only-match 'because it is a task run from the root package'
+  $ cat BUILD3 | grep --quiet --only-match 'because it is a task declared in the root package.json'
 
 Package tasks can depend on things
   $ ${TURBO} run special --graph


### PR DESCRIPTION
### Description

Improved error printing a little bit.

- Ported some engine/package graph errors around task dependencies. Involved threading through span info into the engine. We have to be a little careful to not hash `Span<TaskDefinition>` because sometimes the tasks are equal, but the span info is *not*.
- Added a file name to the error output. Right now we only use error output for turbo.json but eventually we might show errors in package.json

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->


Closes TURBO-2393