### PR TITLE
fix(turbopack): Fix `pure` lint for CSS Modules in lightningcss mode

### DIFF
--- a/crates/turbopack-css/src/process.rs
+++ b/crates/turbopack-css/src/process.rs
@@ -695,19 +695,19 @@ impl lightningcss::visitor::Visitor<'_> for CssModuleValidator {
         visit_types!(SELECTORS)
     }
 
-    fn visit_selector_list(
+    fn visit_selector(
         &mut self,
-        selector: &mut lightningcss::selector::SelectorList<'_>,
+        selector: &mut lightningcss::selector::Selector<'_>,
     ) -> Result<(), Self::Error> {
-        if selector.0.iter().all(|sel| {
-            sel.iter_raw_parse_order_from(0)
-                .all(|component| match component {
-                    parcel_selectors::parser::Component::LocalName(local) => {
-                        !matches!(&*local.name.0, "html" | "body")
-                    }
-                    _ => false,
-                })
-        }) {
+        if selector
+            .iter_raw_parse_order_from(0)
+            .all(|component| match component {
+                parcel_selectors::parser::Component::LocalName(local) => {
+                    !matches!(&*local.name.0, "html" | "body")
+                }
+                _ => false,
+            })
+        {
             ParsingIssue {
                 file: self.file,
                 msg: Vc::cell(format!("{CSS_MODULE_ERROR} (lightningcss, {:?})", selector)),

--- a/crates/turbopack-css/src/process.rs
+++ b/crates/turbopack-css/src/process.rs
@@ -697,12 +697,14 @@ impl lightningcss::visitor::Visitor<'_> for CssModuleValidator {
         &mut self,
         selector: &mut lightningcss::selector::Selector<'_>,
     ) -> Result<(), Self::Error> {
-        if selector.iter().all(|component| match component {
-            parcel_selectors::parser::Component::LocalName(local) => {
-                !matches!(&*local.name.0, "html" | "body")
-            }
-            _ => false,
-        }) {
+        if selector.iter().count() != 0
+            && selector.iter().all(|component| match component {
+                parcel_selectors::parser::Component::LocalName(local) => {
+                    matches!(&*local.name.0, "html" | "body")
+                }
+                _ => false,
+            })
+        {
             ParsingIssue {
                 file: self.file,
                 msg: Vc::cell(format!("{CSS_MODULE_ERROR} (lightningcss, {:?})", selector)),

--- a/crates/turbopack-css/src/process.rs
+++ b/crates/turbopack-css/src/process.rs
@@ -520,11 +520,13 @@ async fn process_content(
     let stylesheet = if use_lightningcss {
         StyleSheetLike::LightningCss(match StyleSheet::parse(&code, config.clone()) {
             Ok(mut ss) => {
-                ss.visit(&mut CssModuleValidator {
-                    source,
-                    file: fs_path_vc,
-                })
-                .unwrap();
+                if matches!(ty, CssModuleAssetType::Module) {
+                    ss.visit(&mut CssModuleValidator {
+                        source,
+                        file: fs_path_vc,
+                    })
+                    .unwrap();
+                }
 
                 stylesheet_into_static(&ss, without_warnings(config.clone()))
             }

--- a/crates/turbopack-css/src/process.rs
+++ b/crates/turbopack-css/src/process.rs
@@ -693,18 +693,18 @@ impl lightningcss::visitor::Visitor<'_> for CssModuleValidator {
         visit_types!(SELECTORS)
     }
 
-    fn visit_selector(
+    fn visit_selector_list(
         &mut self,
-        selector: &mut lightningcss::selector::Selector<'_>,
+        selector: &mut lightningcss::selector::SelectorList<'_>,
     ) -> Result<(), Self::Error> {
-        if selector.iter().count() != 0
-            && selector.iter().all(|component| match component {
+        if selector.0.iter().all(|sel| {
+            sel.iter().all(|component| match component {
                 parcel_selectors::parser::Component::LocalName(local) => {
                     matches!(&*local.name.0, "html" | "body")
                 }
                 _ => false,
             })
-        {
+        }) {
             ParsingIssue {
                 file: self.file,
                 msg: Vc::cell(format!("{CSS_MODULE_ERROR} (lightningcss, {:?})", selector)),

--- a/crates/turbopack-css/src/process.rs
+++ b/crates/turbopack-css/src/process.rs
@@ -700,7 +700,7 @@ impl lightningcss::visitor::Visitor<'_> for CssModuleValidator {
         if selector.0.iter().all(|sel| {
             sel.iter().all(|component| match component {
                 parcel_selectors::parser::Component::LocalName(local) => {
-                    matches!(&*local.name.0, "html" | "body")
+                    !matches!(&*local.name.0, "html" | "body")
                 }
                 _ => false,
             })

--- a/crates/turbopack-css/src/process.rs
+++ b/crates/turbopack-css/src/process.rs
@@ -698,12 +698,13 @@ impl lightningcss::visitor::Visitor<'_> for CssModuleValidator {
         selector: &mut lightningcss::selector::SelectorList<'_>,
     ) -> Result<(), Self::Error> {
         if selector.0.iter().all(|sel| {
-            sel.iter().all(|component| match component {
-                parcel_selectors::parser::Component::LocalName(local) => {
-                    !matches!(&*local.name.0, "html" | "body")
-                }
-                _ => false,
-            })
+            sel.iter_raw_parse_order_from(0)
+                .all(|component| match component {
+                    parcel_selectors::parser::Component::LocalName(local) => {
+                        !matches!(&*local.name.0, "html" | "body")
+                    }
+                    _ => false,
+                })
         }) {
             ParsingIssue {
                 file: self.file,

--- a/crates/turbopack-css/src/process.rs
+++ b/crates/turbopack-css/src/process.rs
@@ -689,8 +689,6 @@ impl swc_core::css::visit::Visit for CssModuleValidator {
 impl lightningcss::visitor::Visitor<'_> for CssModuleValidator {
     type Error = ();
 
-    // TODO: Skip some
-
     fn visit_types(&self) -> lightningcss::visitor::VisitTypes {
         visit_types!(SELECTORS)
     }
@@ -699,9 +697,7 @@ impl lightningcss::visitor::Visitor<'_> for CssModuleValidator {
         &mut self,
         selector: &mut lightningcss::selector::Selector<'_>,
     ) -> Result<(), Self::Error> {
-        if selector.iter().all(|component| !match component {
-            parcel_selectors::parser::Component::ID(_)
-            | parcel_selectors::parser::Component::Class(_) => true,
+        if selector.iter().all(|component| match component {
             parcel_selectors::parser::Component::LocalName(local) => {
                 !matches!(&*local.name.0, "html" | "body")
             }
@@ -709,7 +705,7 @@ impl lightningcss::visitor::Visitor<'_> for CssModuleValidator {
         }) {
             ParsingIssue {
                 file: self.file,
-                msg: Vc::cell(CSS_MODULE_ERROR.to_string()),
+                msg: Vc::cell(format!("{CSS_MODULE_ERROR} (lightningcss, {:?})", selector)),
                 source: Vc::cell(None),
             }
             .cell()


### PR DESCRIPTION
### Description

Fix `pure` lint in `lightningcss` mode. `lightningcss` does not provide location information of selectors, so we cannot provide source location. That's limitation of `cssparser` and `selectors` from `servo` project. It was the reason I didn't use them while building `swc_css`. As a last resort, we can use `Debug` implementation to print the selectors.


### Testing Instructions

Trying it on the internal apps is the best way.

Closes PACK-2546