### PR TITLE
feature: Add invalidate flag to logout

### DIFF
--- a/crates/turborepo-api-client/src/error.rs
+++ b/crates/turborepo-api-client/src/error.rs
@@ -36,6 +36,17 @@ pub enum Error {
         err: serde_json::Error,
         text: String,
     },
+    #[error(
+        "[HTTP {status}] request to {url} returned \"{message}\" \ntry logging in again, or force \
+         a new token (turbo login <--sso-team your_team> -f)."
+    )]
+    InvalidToken {
+        status: u16,
+        url: String,
+        message: String,
+    },
+    #[error("[HTTP 403] token is forbidden from accessing {url}")]
+    ForbiddenToken { url: String },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/turborepo-auth/src/auth/login.rs
+++ b/crates/turborepo-auth/src/auth/login.rs
@@ -45,6 +45,7 @@ pub async fn login<T: Client + TokenClient + CacheClient>(
             ui::print_cli_authorized(user_email, &ui);
         }
     };
+
     // Check if passed in token exists first.
     if !force {
         if let Some(token) = existing_token {
@@ -296,6 +297,9 @@ mod tests {
                 active_at: 0,
                 created_at: 123456,
             })
+        }
+        async fn delete_token(&self, _token: &str) -> turborepo_api_client::Result<()> {
+            Ok(())
         }
     }
 

--- a/crates/turborepo-auth/src/auth/mod.rs
+++ b/crates/turborepo-auth/src/auth/mod.rs
@@ -50,6 +50,8 @@ pub struct LogoutOptions<'a, T> {
 
     /// The path where we should look for the token to logout.
     pub path: &'a AbsoluteSystemPath,
+    /// If we should invalidate the token on the server.
+    pub invalidate: bool,
 }
 
 fn extract_vercel_token() -> Result<Option<String>, Error> {

--- a/crates/turborepo-auth/src/auth/sso.rs
+++ b/crates/turborepo-auth/src/auth/sso.rs
@@ -295,6 +295,9 @@ mod tests {
                 created_at: 123456,
             })
         }
+        async fn delete_token(&self, _token: &str) -> turborepo_api_client::Result<()> {
+            Ok(())
+        }
     }
 
     #[async_trait]

--- a/crates/turborepo-lib/src/commands/logout.rs
+++ b/crates/turborepo-lib/src/commands/logout.rs
@@ -3,11 +3,17 @@ use turborepo_telemetry::events::command::CommandEventBuilder;
 
 use crate::{cli::Error, commands::CommandBase};
 
-pub fn logout(base: &mut CommandBase, _telemetry: CommandEventBuilder) -> Result<(), Error> {
+pub async fn logout(
+    base: &mut CommandBase,
+    invalidate: bool,
+    _telemetry: CommandEventBuilder,
+) -> Result<(), Error> {
     auth_logout(&LogoutOptions {
         ui: &base.ui,
         api_client: &base.api_client()?,
         path: &base.global_config_path()?,
+        invalidate,
     })
+    .await
     .map_err(Error::from)
 }

--- a/turborepo-tests/integration/tests/turbo-help.t
+++ b/turborepo-tests/integration/tests/turbo-help.t
@@ -288,6 +288,7 @@ Test help flag for logout command
   Usage: turbo(\.exe)? logout \[OPTIONS\] (re)
   
   Options:
+        --invalidate                      Invalidate the token on the server
         --version                         
         --skip-infer                      Skip any attempts to infer which version of Turbo the project is configured to use
         --no-update-notifier              Disable the turbo update notification


### PR DESCRIPTION
### Description
Allows for `turbo logout --invalidate` which should call to the API to actually remove the token from the account.



Closes TURBO-2406