### PR TITLE
fix(turbopack): catch invalid source map paths

### DIFF
--- a/crates/turbo-tasks-fs/src/lib.rs
+++ b/crates/turbo-tasks-fs/src/lib.rs
@@ -332,7 +332,9 @@ impl FileSystem for DiskFileSystem {
             .await
         {
             Ok(file) => FileContent::new(file),
-            Err(e) if e.kind() == ErrorKind::NotFound => FileContent::NotFound,
+            Err(e) if e.kind() == ErrorKind::NotFound || e.kind() == ErrorKind::InvalidFilename => {
+                FileContent::NotFound
+            }
             Err(e) => {
                 bail!(anyhow!(e).context(format!("reading file {}", full_path.display())))
             }


### PR DESCRIPTION
### Description

Fixes the apollo `node_file_trace` test on Windows
It includes a source map with `"sourceRoot":"c:/Projects/decorators/deprecated/src/"` which would get joined to the current directory, leading to an invalid path on Windows.


Closes PACK-2562