### PR TITLE
chore: Change daemon log location to be in repo

### DIFF
--- a/crates/turborepo-lib/src/commands/daemon.rs
+++ b/crates/turborepo-lib/src/commands/daemon.rs
@@ -172,7 +172,6 @@ async fn get_log_file_from_folder(base: &CommandBase) -> Result<String, DaemonEr
     warn!("couldn't connect to daemon, looking for old log files");
     let log_folder = base.repo_root.join_components(&[".turbo", "daemon"]);
     let Ok(dir) = std::fs::read_dir(log_folder) else {
-        println!("could not find log file");
         return Err(DaemonError::LogFileNotFound);
     };
 

--- a/crates/turborepo-lib/src/commands/daemon.rs
+++ b/crates/turborepo-lib/src/commands/daemon.rs
@@ -123,10 +123,14 @@ pub async fn daemon_client(command: &DaemonCommand, base: &CommandBase) -> Resul
             }
         }
         DaemonCommand::Logs => {
-            let mut client = connector.connect().await?;
-            let status = client.status().await?;
-            let log_file = log_filename(&status.log_file)?;
+            let log_file = if let Ok(log_file) = get_log_file_from_daemon(connector).await {
+                log_file
+            } else {
+                get_log_file_from_folder(base).await?
+            };
+
             let tail = which("tail").map_err(|_| DaemonError::TailNotInstalled)?;
+
             std::process::Command::new(tail)
                 .arg("-f")
                 .arg(log_file)
@@ -156,6 +160,36 @@ pub async fn daemon_client(command: &DaemonCommand, base: &CommandBase) -> Resul
     };
 
     Ok(())
+}
+
+async fn get_log_file_from_daemon(connector: DaemonConnector) -> Result<String, DaemonError> {
+    let mut client = connector.connect().await?;
+    let status = client.status().await?;
+    Ok(log_filename(&status.log_file)?)
+}
+
+async fn get_log_file_from_folder(base: &CommandBase) -> Result<String, DaemonError> {
+    warn!("couldn't connect to daemon, looking for old log files");
+    let log_folder = base.repo_root.join_components(&[".turbo", "daemon"]);
+    let Ok(dir) = std::fs::read_dir(log_folder) else {
+        println!("could not find log file");
+        return Err(DaemonError::LogFileNotFound);
+    };
+
+    let (latest_file, _) = dir
+        .flatten()
+        .filter_map(|entry| {
+            let modified_time = entry.metadata().ok()?.modified().ok()?;
+            Some((entry, modified_time))
+        })
+        .max_by(|(_, mt1), (_, mt2)| mt1.cmp(mt2))
+        .ok_or(DaemonError::LogFileNotFound)?;
+
+    Ok(latest_file
+        .path()
+        .to_str()
+        .expect("log file should be utf-8")
+        .to_string())
 }
 
 async fn clean(

--- a/crates/turborepo-lib/src/daemon/client.rs
+++ b/crates/turborepo-lib/src/daemon/client.rs
@@ -218,6 +218,9 @@ pub enum DaemonError {
 
     #[error("`tail` is not installed. Please install it to use this feature.")]
     TailNotInstalled,
+
+    #[error("could not find log file")]
+    LogFileNotFound,
 }
 
 impl From<Status> for DaemonError {

--- a/crates/turborepo-lib/src/daemon/mod.rs
+++ b/crates/turborepo-lib/src/daemon/mod.rs
@@ -57,14 +57,11 @@ fn daemon_file_root(repo_hash: &str) -> AbsoluteSystemPathBuf {
         .join_component(repo_hash)
 }
 
-fn daemon_log_file_and_folder(repo_hash: &str) -> (AbsoluteSystemPathBuf, AbsoluteSystemPathBuf) {
-    let directories = directories::ProjectDirs::from("com", "turborepo", "turborepo")
-        .expect("user has a home dir");
-
-    let folder = AbsoluteSystemPathBuf::new(directories.data_dir().to_str().expect("UTF-8 path"))
-        .expect("absolute");
-
-    let log_folder = folder.join_component("logs");
+fn daemon_log_file_and_folder(
+    repo_root: &AbsoluteSystemPath,
+    repo_hash: &str,
+) -> (AbsoluteSystemPathBuf, AbsoluteSystemPathBuf) {
+    let log_folder = repo_root.join_components(&[".turbo", "daemon"]);
     let log_file = log_folder.join_component(format!("{}-turbo.log", repo_hash).as_str());
 
     (log_file, log_folder)
@@ -74,7 +71,7 @@ impl Paths {
     pub fn from_repo_root(repo_root: &AbsoluteSystemPath) -> Self {
         let repo_hash = repo_hash(repo_root);
         let daemon_root = daemon_file_root(&repo_hash);
-        let (log_file, log_folder) = daemon_log_file_and_folder(&repo_hash);
+        let (log_file, log_folder) = daemon_log_file_and_folder(repo_root, &repo_hash);
         Self {
             pid_file: daemon_root.join_component("turbod.pid"),
             lock_file: daemon_root.join_component("turbod.lock"),


### PR DESCRIPTION
### Description

We were previously logging to a file outside the repo. This made it rather annoying to find, especially if the daemon is not running. Now we log to the `.turbo/daemon` folder inside the repository. Also, on `turbo daemon logs`, if the daemon isn't running, we fall back to looking for the latest file in `.turbo/daemon`.

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->


Closes TURBO-2417