### PR TITLE
fix: Remove extra login popup for Vercel

### DIFF
--- a/crates/turborepo-auth/src/auth/login.rs
+++ b/crates/turborepo-auth/src/auth/login.rs
@@ -58,10 +58,8 @@ pub async fn login<T: Client + TokenClient + CacheClient>(
             {
                 return Ok(token);
             }
-        }
-
         // If the user is logging into Vercel, check for an existing `vc` token.
-        if login_url_configuration.contains("vercel.com") {
+        } else if login_url_configuration.contains("vercel.com") {
             // The extraction can return an error, but we don't want to fail the login if
             // the token is not found.
             if let Ok(token) = extract_vercel_token() {


### PR DESCRIPTION
### Description
Conditionals are hard.

### Testing Instructions
`turbo logout`
`turbo login -f` <- Only 1 "authorize" popup (`-f` to skip checking for vc token)
`turbo login -f` <- Should still only be one login (`-f` to skip checking for vc token)


Closes TURBO-2418