### PR TITLE
fix(turbopack-node): don't bundle postcss config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11344,6 +11344,7 @@ dependencies = [
  "futures 0.3.28",
  "futures-retry",
  "indexmap 1.9.3",
+ "indoc",
  "mime 0.3.17",
  "once_cell",
  "owo-colors",

--- a/crates/turbopack-css/src/global_asset.rs
+++ b/crates/turbopack-css/src/global_asset.rs
@@ -1,5 +1,6 @@
-use anyhow::{bail, Result};
+use anyhow::Result;
 use turbo_tasks::{Value, Vc};
+use turbo_tasks_fs::FileContent;
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::PassthroughModule,
@@ -71,7 +72,7 @@ impl Module for GlobalCssAsset {
 impl Asset for GlobalCssAsset {
     #[turbo_tasks::function]
     fn content(&self) -> Result<Vc<AssetContent>> {
-        bail!("CSS global asset has no contents")
+        Ok(AssetContent::file(FileContent::NotFound.cell()))
     }
 }
 

--- a/crates/turbopack-node/Cargo.toml
+++ b/crates/turbopack-node/Cargo.toml
@@ -24,6 +24,7 @@ const_format = "0.2.30"
 futures = { workspace = true }
 futures-retry = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }
+indoc = { workspace = true }
 mime = { workspace = true }
 once_cell = { workspace = true }
 owo-colors = { workspace = true }

--- a/crates/turbopack-node/js/src/transforms/postcss.ts
+++ b/crates/turbopack-node/js/src/transforms/postcss.ts
@@ -8,7 +8,8 @@ import { relative, isAbsolute, sep } from "path";
 import type { Ipc } from "../ipc/evaluate";
 
 const contextDir = process.cwd();
-const toPath = (file: string) => {
+
+function toPath(file: string) {
   const relPath = relative(contextDir, file);
   if (isAbsolute(relPath)) {
     throw new Error(
@@ -16,9 +17,13 @@ const toPath = (file: string) => {
     );
   }
   return sep !== "/" ? relPath.replaceAll(sep, "/") : relPath;
-};
+}
 
-const transform = async (ipc: Ipc, cssContent: string, name: string) => {
+export default async function transform(
+  ipc: Ipc,
+  cssContent: string,
+  name: string
+) {
   let config = importedConfig;
   if (typeof config === "function") {
     config = await config({ env: "development" });
@@ -119,6 +124,4 @@ const transform = async (ipc: Ipc, cssContent: string, name: string) => {
     map: JSON.stringify(map),
     assets,
   };
-};
-
-export { transform as default };
+}


### PR DESCRIPTION
### Description

It still gets bundled if it's not a JavaScript config, but if it is, we now import it via `__turbopack_external_import__` (`import()`).
We use `import()` instead of `require` to handle ESM configs (`.mjs`).

This is similar to `postcss-load-config`.

Closes PACK-2452