### PR TITLE
split graph_node_to_referenced_nodes into cacheable and non-cacheable parts

### DIFF
--- a/crates/turbopack-core/src/chunk/mod.rs
+++ b/crates/turbopack-core/src/chunk/mod.rs
@@ -10,7 +10,7 @@ pub mod optimize;
 pub(crate) mod passthrough_asset;
 
 use std::{
-    collections::HashSet,
+    collections::{HashMap, HashSet},
     fmt::{Debug, Display},
     future::Future,
     hash::Hash,
@@ -25,12 +25,12 @@ use turbo_tasks::{
     debug::ValueDebugFormat,
     graph::{AdjacencyMap, GraphTraversal, GraphTraversalResult, Visit, VisitControlFlow},
     trace::TraceRawVcs,
-    ReadRef, TaskInput, TryFlatJoinIterExt, TryJoinIterExt, Upcast, Value, ValueToString, Vc,
+    ReadRef, TaskInput, TryFlatJoinIterExt, TryJoinIterExt, Upcast, ValueToString, Vc,
 };
 use turbo_tasks_fs::FileSystemPath;
 use turbo_tasks_hash::DeterministicHash;
 
-use self::availability_info::AvailabilityInfo;
+use self::{availability_info::AvailabilityInfo, available_chunk_items::AvailableChunkItems};
 pub use self::{
     chunking_context::{ChunkGroupResult, ChunkingContext, ChunkingContextExt},
     data::{ChunkData, ChunkDataOption, ChunksData},
@@ -266,39 +266,77 @@ struct ChunkGraphEdge {
 #[turbo_tasks::value(transparent)]
 struct ChunkGraphEdges(Vec<ChunkGraphEdge>);
 
-#[derive(Debug, Clone)]
-#[turbo_tasks::value]
-struct ChunkContentContext {
+#[turbo_tasks::function]
+async fn graph_node_to_referenced_nodes_with_available_chunk_items(
+    node: ChunkGraphNodeToReferences,
     chunking_context: Vc<Box<dyn ChunkingContext>>,
-    availability_info: AvailabilityInfo,
-}
-
-#[turbo_tasks::value_impl]
-impl ChunkContentContext {
-    #[turbo_tasks::function]
-    fn new(
-        chunking_context: Vc<Box<dyn ChunkingContext>>,
-        availability_info: Value<AvailabilityInfo>,
-    ) -> Vc<Self> {
-        Self {
-            chunking_context,
-            availability_info: availability_info.into_value(),
+    available_chunk_items: Vc<AvailableChunkItems>,
+) -> Result<Vc<ChunkGraphEdges>> {
+    let edges = graph_node_to_referenced_nodes(node, chunking_context);
+    let edges_ref = edges.await?;
+    for (unchanged, edge) in edges_ref.iter().enumerate() {
+        if let ChunkContentGraphNode::ChunkItem { item, .. } = edge.node {
+            if let Some(info) = *available_chunk_items.get(item).await? {
+                let mut new_edges = Vec::with_capacity(edges_ref.len());
+                new_edges.extend(edges_ref[0..unchanged].iter().cloned());
+                let mut available_chunk_item_info = HashMap::new();
+                available_chunk_item_info.insert(item, info);
+                for edge in edges_ref[unchanged + 1..].iter() {
+                    match edge.node {
+                        ChunkContentGraphNode::ChunkItem { item, .. } => {
+                            if let Some(info) = *available_chunk_items.get(item).await? {
+                                available_chunk_item_info.insert(item, info);
+                                continue;
+                            }
+                        }
+                        ChunkContentGraphNode::InheritAsyncInfo {
+                            item,
+                            ref references,
+                        } => {
+                            let new_references = references
+                                .iter()
+                                .filter_map(|&(r, _)| {
+                                    if let Some(info) = available_chunk_item_info.get(&r) {
+                                        if info.is_async {
+                                            Some((r, InheritAsyncEdge::AvailableAsyncModule))
+                                        } else {
+                                            None
+                                        }
+                                    } else {
+                                        Some((r, InheritAsyncEdge::LocalModule))
+                                    }
+                                })
+                                .collect();
+                            new_edges.push(ChunkGraphEdge {
+                                key: edge.key,
+                                node: ChunkContentGraphNode::InheritAsyncInfo {
+                                    item,
+                                    references: new_references,
+                                },
+                            });
+                            continue;
+                        }
+                        _ => {}
+                    }
+                    new_edges.push(edge.clone())
+                }
+                return Ok(Vc::cell(new_edges));
+            }
         }
-        .cell()
     }
+    Ok(edges)
 }
 
 #[turbo_tasks::function]
 async fn graph_node_to_referenced_nodes(
     node: ChunkGraphNodeToReferences,
-    chunk_content_context: Vc<ChunkContentContext>,
+    chunking_context: Vc<Box<dyn ChunkingContext>>,
 ) -> Result<Vc<ChunkGraphEdges>> {
     let (parent, references) = match &node {
         ChunkGraphNodeToReferences::PassthroughModule(module) => (None, module.references()),
         ChunkGraphNodeToReferences::PassthroughChunkItem(item) => (None, item.references()),
         ChunkGraphNodeToReferences::ChunkItem(item) => (Some(*item), item.references()),
     };
-    let chunk_content_context = &*chunk_content_context.await?;
 
     let references = references.await?;
     let graph_nodes = references
@@ -358,18 +396,9 @@ async fn graph_node_to_referenced_nodes(
                     match chunking_type {
                         ChunkingType::Parallel => {
                             let chunk_item = chunkable_module
-                                .as_chunk_item(chunk_content_context.chunking_context)
+                                .as_chunk_item(chunking_context)
                                 .resolve()
                                 .await?;
-                            if let Some(available_chunk_items) = chunk_content_context
-                                .availability_info
-                                .available_chunk_items()
-                            {
-                                if available_chunk_items.get(chunk_item).await?.is_some() {
-                                    return Ok((None, None));
-                                }
-                            }
-
                             Ok((
                                 Some(ChunkGraphEdge {
                                     key: Some(module),
@@ -383,26 +412,9 @@ async fn graph_node_to_referenced_nodes(
                         }
                         ChunkingType::ParallelInheritAsync => {
                             let chunk_item = chunkable_module
-                                .as_chunk_item(chunk_content_context.chunking_context)
+                                .as_chunk_item(chunking_context)
                                 .resolve()
                                 .await?;
-                            if let Some(available_chunk_items) = chunk_content_context
-                                .availability_info
-                                .available_chunk_items()
-                            {
-                                if let Some(info) = &*available_chunk_items.get(chunk_item).await? {
-                                    if info.is_async {
-                                        return Ok((
-                                            None,
-                                            Some((
-                                                chunk_item,
-                                                InheritAsyncEdge::AvailableAsyncModule,
-                                            )),
-                                        ));
-                                    }
-                                    return Ok((None, None));
-                                }
-                            }
                             Ok((
                                 Some(ChunkGraphEdge {
                                     key: Some(module),
@@ -416,7 +428,7 @@ async fn graph_node_to_referenced_nodes(
                         }
                         ChunkingType::Passthrough => {
                             let chunk_item = chunkable_module
-                                .as_chunk_item(chunk_content_context.chunking_context)
+                                .as_chunk_item(chunking_context)
                                 .resolve()
                                 .await?;
 
@@ -431,24 +443,13 @@ async fn graph_node_to_referenced_nodes(
                             ))
                         }
                         ChunkingType::Async => {
-                            let chunk_loading = chunk_content_context
-                                .chunking_context
-                                .environment()
-                                .chunk_loading()
-                                .await?;
+                            let chunk_loading =
+                                chunking_context.environment().chunk_loading().await?;
                             if matches!(*chunk_loading, ChunkLoading::None) {
                                 let chunk_item = chunkable_module
-                                    .as_chunk_item(chunk_content_context.chunking_context)
+                                    .as_chunk_item(chunking_context)
                                     .resolve()
                                     .await?;
-                                if let Some(available_chunk_items) = chunk_content_context
-                                    .availability_info
-                                    .available_chunk_items()
-                                {
-                                    if available_chunk_items.get(chunk_item).await?.is_some() {
-                                        return Ok((None, None));
-                                    }
-                                }
                                 Ok((
                                     Some(ChunkGraphEdge {
                                         key: Some(module),
@@ -508,7 +509,8 @@ async fn graph_node_to_referenced_nodes(
 }
 
 struct ChunkContentVisit {
-    chunk_content_context: Vc<ChunkContentContext>,
+    chunking_context: Vc<Box<dyn ChunkingContext>>,
+    available_chunk_items: Option<Vc<AvailableChunkItems>>,
     processed_modules: HashSet<Vc<Box<dyn Module>>>,
 }
 
@@ -542,7 +544,8 @@ impl Visit<ChunkContentGraphNode, ()> for ChunkContentVisit {
     fn edges(&mut self, node: &ChunkContentGraphNode) -> Self::EdgesFuture {
         let node = node.clone();
 
-        let chunk_content_context = self.chunk_content_context;
+        let chunking_context = self.chunking_context;
+        let available_chunk_items = self.available_chunk_items;
 
         async move {
             let node = match node {
@@ -560,7 +563,16 @@ impl Visit<ChunkContentGraphNode, ()> for ChunkContentVisit {
                 }
             };
 
-            let nodes = graph_node_to_referenced_nodes(node, chunk_content_context).await?;
+            let nodes = if let Some(available_chunk_items) = available_chunk_items {
+                graph_node_to_referenced_nodes_with_available_chunk_items(
+                    node,
+                    chunking_context,
+                    available_chunk_items,
+                )
+            } else {
+                graph_node_to_referenced_nodes(node, chunking_context)
+            }
+            .await?;
             Ok(Some(nodes.into_iter().cloned()).into_iter().flatten())
         }
     }
@@ -602,11 +614,9 @@ async fn chunk_content_internal_parallel(
         .try_flat_join()
         .await?;
 
-    let chunk_content_context =
-        ChunkContentContext::new(chunking_context, Value::new(availability_info));
-
     let visit = ChunkContentVisit {
-        chunk_content_context,
+        chunking_context,
+        available_chunk_items: availability_info.available_chunk_items(),
         processed_modules: Default::default(),
     };
 


### PR DESCRIPTION
### Description

`graph_node_to_referenced_nodes` no longer depends on `available_chunk_items` (which change for every dynamic import/page)

Instead `graph_node_to_referenced_nodes_with_available_chunk_items` is used when there are `available_chunk_items`. This calls the cached `graph_node_to_referenced_nodes` and modifies the response to respect `available_chunk_items`

This allows to partially cache graph walk for chunking in case of async imports.

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->


Closes PACK-2585