### PR TITLE
dedupe primary_modules to avoid deduping in chunking, reduce memory usage

### DIFF
--- a/crates/turbopack-core/src/chunk/mod.rs
+++ b/crates/turbopack-core/src/chunk/mod.rs
@@ -321,15 +321,12 @@ async fn graph_node_to_referenced_nodes(
                 }]);
             };
 
-            // Dedupe modules to avoid duplicate work in the following loop
-            let mut modules = IndexSet::new();
-            for module in reference.resolve_reference().primary_modules().await? {
-                modules.insert(module.resolve().await?);
-            }
-
-            let module_data = modules
+            let module_data = reference
+                .resolve_reference()
+                .primary_modules()
+                .await?
                 .into_iter()
-                .map(|module| async move {
+                .map(|&module| async move {
                     if Vc::try_resolve_sidecast::<Box<dyn PassthroughModule>>(module)
                         .await?
                         .is_some()


### PR DESCRIPTION
### Description

This allows to avoid a clone into an IndexSet in `graph_node_to_referenced_nodes`, so improves performance and avoids temporary memory consumption.

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
