### PR TITLE
Update `swc_core` to `v0.90.12`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -812,9 +812,9 @@ dependencies = [
 
 [[package]]
 name = "binding_macros"
-version = "0.64.7"
+version = "0.64.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4515ccc8fde4619e153530b387da186ee522d4a644bd9389e0988c4b78cfe1d"
+checksum = "c3b6c000a57aea4ecefdcb53af40566dc4ad5e5958488cb82afe95f60ada9d66"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -4997,9 +4997,9 @@ dependencies = [
 
 [[package]]
 name = "modularize_imports"
-version = "0.68.5"
+version = "0.68.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b554d4032a7bc4d1546b2962ec3f80efd28a78734e72e3466096b075be1fa8b"
+checksum = "f4a35410b7d39a3cde7711b460053a604733bfcbf94b54e8edfdc3bcdd5b967e"
 dependencies = [
  "convert_case 0.5.0",
  "handlebars",
@@ -8150,9 +8150,9 @@ dependencies = [
 
 [[package]]
 name = "swc"
-version = "0.273.7"
+version = "0.273.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad60af6e9e53f5cae6eddafe2cef50723b3dc3d7a671cdade29ea59823f7466a"
+checksum = "8844e0b9878036ae662416540fbbea76df689e6fb1c2c82e44b6a648bdc661eb"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -8227,9 +8227,9 @@ dependencies = [
 
 [[package]]
 name = "swc_bundler"
-version = "0.225.6"
+version = "0.225.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a10c82d574fd928182f90962e280967b23b692d7e21ec9484dc6cbdaa73bab"
+checksum = "a95366ff13c5f3dc6cc5536ae526d52732e8c036981bc242e970b8a1c0bfdd31"
 dependencies = [
  "anyhow",
  "crc",
@@ -8273,9 +8273,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.33.17"
+version = "0.33.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "095c158fe55b36faeebb4274692643a6d7cdc5b7902e1d5968ddbe52b7de1d1c"
+checksum = "c85e8b15d0fb87691e27c8f3cf953748db3ccd2a39e165d6d5275a48fb0d29e3"
 dependencies = [
  "ahash 0.8.9",
  "anyhow",
@@ -8306,9 +8306,9 @@ dependencies = [
 
 [[package]]
 name = "swc_compiler_base"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabf24f2007bf124a4905eb03ccd70a0f367d766e4a7349d38919414b5ee30d1"
+checksum = "6f802931f76a7bc64b8b61eec0a10225044c58b6c0dbbe135c0ca2840e964170"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -8358,9 +8358,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "0.90.10"
+version = "0.90.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de87b2886fc539c81c3e1222e6077fb489ce5b12734b7ee4632e7395d69c37e"
+checksum = "229d3ae620f7ed70f7974aab8c254018102c4e5d8e7d8ced4a36f43b00f76dcb"
 dependencies = [
  "binding_macros",
  "swc",
@@ -8401,9 +8401,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_ast"
-version = "0.140.18"
+version = "0.140.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b76c897da44202c51ab07f7252e58f3a052e9452f0b1885328e301da708cce2"
+checksum = "45b8331cb612ef16fe542e13fc32fc837c76b9bd839959b111084b5fd9879ffb"
 dependencies = [
  "is-macro",
  "string_enum",
@@ -8413,9 +8413,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_codegen"
-version = "0.151.27"
+version = "0.151.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66c8b7934005032083fd2bccb6331011fd5cb603109a60084a940dd183381e25"
+checksum = "f692691e90c0625c4291b3c647b6498a64ef31f7b4667464249730aefa8807bb"
 dependencies = [
  "auto_impl",
  "bitflags 2.4.0",
@@ -8442,9 +8442,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_compat"
-version = "0.27.28"
+version = "0.27.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acc684e2bb086383e96708147cfa8c5145356cf391e5722a34de409d7a2f300e"
+checksum = "746e57c5b2bc767d77d169233490d4e80776230a8975c98f71b0344b29d2a603"
 dependencies = [
  "bitflags 2.4.0",
  "once_cell",
@@ -8473,9 +8473,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_modules"
-version = "0.29.30"
+version = "0.29.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2db84a27aca6bbacef6f61971cd175f6ca42f98f32c70494080fb6d8f962be99"
+checksum = "b1dda2baf3ead2bfc849ee6b011b60493cdeb656ea2f53f7bc614fa4af003f9f"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -8489,9 +8489,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_parser"
-version = "0.150.26"
+version = "0.150.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8749e4b8095a62cd3b92b8a1f134e6223663fa206d9d6acdad1bd37590a96f4c"
+checksum = "32f75a26449ceb7116b153a03b5bcf7efca7313b1b25b75fba9bc4c54499966d"
 dependencies = [
  "lexical",
  "serde",
@@ -8519,9 +8519,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_utils"
-version = "0.137.18"
+version = "0.137.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b3aba20d236330bc9947a030c127417771696457698197eefc5437949ce5455"
+checksum = "4e5d00a90feb74a4269ac7576155009969b4c3bf1918a741399bcb795cb32698"
 dependencies = [
  "once_cell",
  "serde",
@@ -8534,9 +8534,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_visit"
-version = "0.139.18"
+version = "0.139.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0601f86127d76307bdeb763626feea14c355d4ac52b2e43ccb0af8654c203ba5"
+checksum = "687ed841a88fb59e10797e5bb95a3686564cfbbdd97ed7cd96b2fdaa59bbf831"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -8547,9 +8547,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.112.2"
+version = "0.112.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852a48a24a2533de88298c6b25355bc68fdee31ac21cb4fb8939b7001715353c"
+checksum = "36226eb87bfd2f5620bde04f149a4b869ab34e78496d60cb0d8eb9da765d0732"
 dependencies = [
  "bitflags 2.4.0",
  "bytecheck",
@@ -8567,9 +8567,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.148.3"
+version = "0.148.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d79df3f8c5ed028fce5dc24acb83002c0854f8b9d7e893292aeee394a6b9eaf4"
+checksum = "5b2ef19844772a0ebc3f73a0a4766cacda8de05f1cbf1450bb9e407ee40914fb"
 dependencies = [
  "memchr",
  "num-bigint",
@@ -8598,9 +8598,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_bugfixes"
-version = "0.4.6"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a01e62654001f83be145d43d26dfd9fadea443581621221c7ab7c31379182f8a"
+checksum = "1abefb0666428266f65e63f4dbc44a0f2301d0965554478c75d5db9624044bb7"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -8615,9 +8615,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_common"
-version = "0.4.5"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504c13071d4eacb38bb4de640a564935c4b5225ecf6514e3842e9c8c41e9de89"
+checksum = "e8352713fb242e37afe051a241cc5263ea65b87003e124e3972c2a365a0e0f81"
 dependencies = [
  "swc_common",
  "swc_ecma_ast",
@@ -8628,9 +8628,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2015"
-version = "0.4.6"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e1f00f81f0e5993e2351fd9fad7b465c4aa78b7104fb8619f49b89e6aaf358a"
+checksum = "96f68e7cb9b4de6205bef9a5cad752af2941723951f7507b948caaf19e5084f7"
 dependencies = [
  "arrayvec 0.7.4",
  "indexmap 2.2.3",
@@ -8654,9 +8654,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2016"
-version = "0.4.6"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3422ab9696acc8f68c97b3129ed318a57b9d3e610052daa4b602bfe46536afd0"
+checksum = "8ebff320bd89c5622b89af3ec7b07d69304080b2f163d64e27b24e33bd180a2e"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -8671,9 +8671,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2017"
-version = "0.4.6"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b96b8fd02229d0b14362e9b670a34db0368e62bab75945d16a740cae95a7a35"
+checksum = "23c9847bc30e779ffcd59a44149b75db62d1806efbf439025266c89020379932"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -8689,9 +8689,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2018"
-version = "0.4.6"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1902ef5abd89b7b561c6177b118d103af13608519e4fcf4e654c1bdb99af587"
+checksum = "f3b0a6a76c8724ede825324e877b2335c229db150f4b137d2389e174243c1e0c"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -8708,9 +8708,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2019"
-version = "0.4.6"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab877d25ed7cea79f389300e770ba3ec7ab9c663c4f262b097644b22c5578cab"
+checksum = "e270eb5db417dede961a2a04d36043081d1aad7e72a209c1af60a173ee489c77"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -8724,9 +8724,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2020"
-version = "0.4.6"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a41863da4eadb1cccc31dd433b1282048189d7abeedb4e2fafd7f1f0689d19d"
+checksum = "47e30dbd6f613ec6078fab98081cd34674bd965fb18adaa5ca523323a698642e"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -8742,9 +8742,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2021"
-version = "0.4.6"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "772a062a46b1a2a03cfc2feed71e6b0f1d700babc59ed3cb6f6293144170a934"
+checksum = "950a7be39f2ba15cebf7aa960c437acb6d588e5caa117857f93c7e08ce5082a9"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -8758,9 +8758,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2022"
-version = "0.4.6"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7b98b6ab90fffe3d2a817e4e353cc664470d011d51a9a3cfeb373c17bb72b3"
+checksum = "5d528535bf4dcd9b60ec3ca7fe8b771e088dd895a936434e828f497f8c0dc576"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -8777,9 +8777,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es3"
-version = "0.4.6"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63eed64e6363ba0a7be17b24ab8dc887f109b06ef8f7224363780f405debc0d9"
+checksum = "a1ad7683fd759478494f7c7f262aecc8f04214150cae71561fc8498842a9118f"
 dependencies = [
  "swc_common",
  "swc_ecma_ast",
@@ -8792,9 +8792,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ext_transforms"
-version = "0.113.5"
+version = "0.113.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c153f2ad8e4349c603435c2c22e02c00173b73a431447ea860a2d34a28a802cd"
+checksum = "88cf49887af60725033369f1df34e26e848671da42c80ac44d85afbf484678e8"
 dependencies = [
  "phf 0.11.2",
  "swc_atoms",
@@ -8806,9 +8806,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_lints"
-version = "0.92.6"
+version = "0.92.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afd6d8b2b8012571b081f00c4e988ce25cbd61d1792a1ab5856a315aaaede5ea"
+checksum = "2e5dbb15abb0330aab2e0fdc754636eefe34ac559f3c080923caf83def83023d"
 dependencies = [
  "auto_impl",
  "dashmap",
@@ -8826,9 +8826,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_loader"
-version = "0.45.19"
+version = "0.45.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c16051bce5421992a1b49350735bf4d110f761fd68ae7098af17a64ad639b8d"
+checksum = "d0058cf970880f5382effe43eb2b727a73ba09ae41922fa140c2c3fa6ca9b2d1"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -8848,9 +8848,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "0.192.6"
+version = "0.192.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc3f9c79f78330f88b0055c315f90251966cece004f1ca4548b53fdb404474db"
+checksum = "1a0cde8672384cbcebfc52bc95e8f13a13544f9fd71b3ab5d2ba41663b93c420"
 dependencies = [
  "arrayvec 0.7.4",
  "indexmap 2.2.3",
@@ -8882,9 +8882,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.143.3"
+version = "0.143.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ff55811ed5de14b05e9a2979bae2bce3c807582f559b4325948463265307d9"
+checksum = "20823cac99a9adbd4c03fb5e126aaccbf92446afedad99252a0e1fc76e2ffc43"
 dependencies = [
  "either",
  "new_debug_unreachable",
@@ -8904,9 +8904,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "0.206.6"
+version = "0.206.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf439560691c588e38a49ae1b2ea491ed05ac22020f90349591593d0e4e2d5c"
+checksum = "8f3bc4e8b136aeca82e083ad6ade0feeacfbc6a963e8be5660dbdf569dfc7cce"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -8929,9 +8929,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_quote_macros"
-version = "0.54.6"
+version = "0.54.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f7dbd0bc30a25ccd16d7b4cdacefa599c81f6372b097ef4684c34c1c1552f0a"
+checksum = "92d9ea2ed08ee795b3bcee0f53198ec1409a54d634d43dd311ca5e23e2dbbea8"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -8946,9 +8946,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_testing"
-version = "0.22.19"
+version = "0.22.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b41fb62ef85a23515889fc99eac156f9afc4eb10c8eaadf70ffee53982b2ab82"
+checksum = "e1279bd6336c901852146c05a0dbae09f78056b0ab32ffa64b5a1088da073d48"
 dependencies = [
  "anyhow",
  "hex",
@@ -8959,9 +8959,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.229.6"
+version = "0.229.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e30b05b9a9fa3d5df974ee00a04603a5b51d636d9af64da7cf31c734ab62cb"
+checksum = "feadab31e91f17cd6784f79e9f8f89e3813aa329aa5d37febe4d4344dfa47104"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -8979,9 +8979,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.137.6"
+version = "0.137.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9489f8f5c6c08e8291bd93eb354aa91903d4eba5eeb72e1b90adf43c8fe7a29"
+checksum = "c366819cc98d0d09bc80748c89172eeea3c8e2a988561aece9ebe7486b4c9660"
 dependencies = [
  "better_scoped_tls",
  "bitflags 2.4.0",
@@ -9003,9 +9003,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "0.126.6"
+version = "0.126.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c00fecbd333497362f75f475ca467beb486ae381968c9bd67315dddacc9ee67c"
+checksum = "1883875b228dd98478378ffb6516a38817769ff44dd5c389fed4dfb23439f547"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -9017,9 +9017,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "0.163.6"
+version = "0.163.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "834769e0e61813114ec2a2a733225cd6b10882cf22f9e816e2c73ef9bb95b4a3"
+checksum = "12ecf0f5fa4cec49a841e5f1876c7f0c10ab3162abea901f0e4c343d9db0d447"
 dependencies = [
  "arrayvec 0.7.4",
  "indexmap 2.2.3",
@@ -9066,9 +9066,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "0.180.6"
+version = "0.180.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "526a316efa0c2514aef5654f675f5336e3953371b6bc24baf7c9f8e935000a2c"
+checksum = "8c844a3f96d0ddf2c5471e17fe3d9e3ee6828ca4d4f9f7d9c581b0b6567f016e"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -9093,9 +9093,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.198.6"
+version = "0.198.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db73c718c737c58ed7265fea79aff38578012269398d856264ddc4e764dfb192"
+checksum = "86a1fb0406545e5151a99d076361a3bf9e8acff974cce3f858d1f25ee8e9454e"
 dependencies = [
  "dashmap",
  "indexmap 2.2.3",
@@ -9118,9 +9118,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "0.171.6"
+version = "0.171.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39920f44aa30ab997dd7cfdc364addd54e4a5fcc3807ae69a6fe283f306bc5a5"
+checksum = "c34bb6d42cde48a405f02b601ab283570f588fc5f7d0726a6251e2158691e8ea"
 dependencies = [
  "either",
  "rustc-hash",
@@ -9138,9 +9138,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.183.6"
+version = "0.183.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d8d36fc8dbfd96dd1ef17f989175e60a291399c6168b20a74951085b0075df"
+checksum = "45dbfc343e47028c39ec90f4761db2e1625594ef69e113a0e5f9eb3db2115a69"
 dependencies = [
  "base64 0.21.4",
  "dashmap",
@@ -9163,9 +9163,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_testing"
-version = "0.140.6"
+version = "0.140.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "376b321d4007382d9c0f7a4b34d27002c87109c33550ce4dd46293e8bb32d9a9"
+checksum = "3a856597c336f89d68a63e5c7cb85075abd0fe425f4fad9bf86d6eecfc2745aa"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -9189,9 +9189,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.188.6"
+version = "0.188.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "432cf63b05d3ec435199bfbf7ba50793c6cb777bfcd8ad9f055f501aa9048d9c"
+checksum = "e238be27d09b45ddf6c7cc99e7cfe16ac41cfaefcf4fa675da783102a59ae18b"
 dependencies = [
  "ryu-js",
  "serde",
@@ -9206,9 +9206,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_usage_analyzer"
-version = "0.23.5"
+version = "0.23.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54a5f4cbd55fa6c4071d92e09e12a1103b8b17573ab131dd9335f302cbd444c"
+checksum = "a1386fca4907fb146ae54f0a3bd93e461563d9e63a728c2c78b7bbfd3055334f"
 dependencies = [
  "indexmap 2.2.3",
  "rustc-hash",
@@ -9223,9 +9223,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.127.5"
+version = "0.127.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2de25ac5cc8c8375476985e854054f05d9e841886f3c290716a0eec32eedce3"
+checksum = "14482e455df85486d68a51533a31645d511e56df93a35cadf0eabbe7abe96b98"
 dependencies = [
  "indexmap 2.2.3",
  "num_cpus",
@@ -9242,9 +9242,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.98.2"
+version = "0.98.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb71511a816c7c84ddc96e6939389be261caf20858486a5e76948551f110e1f"
+checksum = "df0127694c36d656ea9eab5c170cdd8ab398246ae2a335de26961c913a4aca47"
 dependencies = [
  "num-bigint",
  "serde",
@@ -9292,9 +9292,9 @@ dependencies = [
 
 [[package]]
 name = "swc_error_reporters"
-version = "0.17.16"
+version = "0.17.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87dd7ff934a74cee8f2328c4fdd22113a36358ff390845f565bef1e1cf3b0f90"
+checksum = "5a76d4fb0aae65d68fd03b44d8ee0d66fa6b08c5fe0d9bb34c150ec0cad5a998"
 dependencies = [
  "anyhow",
  "miette 4.7.1",
@@ -9305,9 +9305,9 @@ dependencies = [
 
 [[package]]
 name = "swc_fast_graph"
-version = "0.21.17"
+version = "0.21.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffd32eda2dd2c725f8d4448d0013c3b5466118e4ff5c30aff2c04f6750f7238b"
+checksum = "91bea847755eb7b131edb83c1a437d353e9d25cabd92ac27655420dd13c7267b"
 dependencies = [
  "indexmap 2.2.3",
  "petgraph",
@@ -9317,9 +9317,9 @@ dependencies = [
 
 [[package]]
 name = "swc_graph_analyzer"
-version = "0.22.19"
+version = "0.22.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ae1172960aa3b0cdbe94a1d5edf3efa9f1199cbd8384f48dedd0c5bdb5d6bd"
+checksum = "1f1469d9d6d5c6f3b469348262ab6bda2c8a9d8e3db7298d9f71f6d17986895d"
 dependencies = [
  "auto_impl",
  "petgraph",
@@ -9351,9 +9351,9 @@ dependencies = [
 
 [[package]]
 name = "swc_node_comments"
-version = "0.20.16"
+version = "0.20.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ada6f7dfc9ab0b1b8030b9ae2b132438604a2f6eb2f36f57a1fa3ac958795991"
+checksum = "a27a57648ed7f0bb07c2de3f84d06514092be664401570ddde8e094cc5f3f26b"
 dependencies = [
  "dashmap",
  "swc_atoms",
@@ -9387,9 +9387,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_proxy"
-version = "0.41.2"
+version = "0.41.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0481ceefd2f896c792692b18043e45b68614ae0266c65d4addbcf7f6c8090d6"
+checksum = "3c1a30d289547b936d33a8e5222e049c89b9c84ab706aac0a5c224ecf1b21bcb"
 dependencies = [
  "better_scoped_tls",
  "rkyv",
@@ -9401,9 +9401,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_runner"
-version = "0.106.4"
+version = "0.106.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c8d6c8a1b7708f814c743b591c0244e4a39d69bf21efe24f59f7d898e5a5feb"
+checksum = "e84fe854b1fdb4172c1f22bc09332ccd9fb9dacd8c15fe5c960b6051fe6e9af1"
 dependencies = [
  "anyhow",
  "enumset",
@@ -9443,9 +9443,9 @@ dependencies = [
 
 [[package]]
 name = "swc_timer"
-version = "0.21.18"
+version = "0.21.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247df8abb51666eede165577d93c1476b6aca7ab7bf58e0fff6015fad6fb1b5"
+checksum = "1b730008d5ba049c9736a7f141731598b937f95408453b2cc90235a280be3026"
 dependencies = [
  "tracing",
 ]
@@ -9463,9 +9463,9 @@ dependencies = [
 
 [[package]]
 name = "swc_visit"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b27078d8571abe23aa52ef608dd1df89096a37d867cf691cbb4f4c392322b7c9"
+checksum = "358e246dedeb4ae8efacebcce1360dc2f9b6c0b4c1ad8b737cc60f5b6633691a"
 dependencies = [
  "either",
  "swc_visit_macros",
@@ -9473,9 +9473,9 @@ dependencies = [
 
 [[package]]
 name = "swc_visit_macros"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa8bb05975506741555ea4d10c3a3bdb0e2357cd58e1a4a4332b8ebb4b44c34d"
+checksum = "fbbbb9d77d5112f90ed7ea00477135b16c4370c872b93a0b63b766e8710650ad"
 dependencies = [
  "Inflector",
  "pmutil",
@@ -9754,9 +9754,9 @@ dependencies = [
 
 [[package]]
 name = "testing"
-version = "0.35.18"
+version = "0.35.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d90b0f069d03bcee35190a27083f968d93ca6359dcea51ba274a583dc2a3ec56"
+checksum = "bd2a7fea73e3b4693c08cbdf71806e4a51effdcbe82bebdb12532b49784232e8"
 dependencies = [
  "ansi_term",
  "cargo_metadata",
@@ -12008,7 +12008,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "rand 0.8.5",
  "static_assertions",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -812,9 +812,9 @@ dependencies = [
 
 [[package]]
 name = "binding_macros"
-version = "0.64.10"
+version = "0.64.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3b6c000a57aea4ecefdcb53af40566dc4ad5e5958488cb82afe95f60ada9d66"
+checksum = "36aa65b41d9c786a4b864637013f03dae8aac480e8e4311788a9fbeeb65c79d1"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -4997,15 +4997,16 @@ dependencies = [
 
 [[package]]
 name = "modularize_imports"
-version = "0.68.6"
+version = "0.68.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a35410b7d39a3cde7711b460053a604733bfcbf94b54e8edfdc3bcdd5b967e"
+checksum = "ca835b60f32cd43b7bcd21ba77563bee0c08f336700463e03eb086d15e46608a"
 dependencies = [
  "convert_case 0.5.0",
  "handlebars",
  "once_cell",
  "regex",
  "serde",
+ "swc_atoms",
  "swc_cached",
  "swc_common",
  "swc_ecma_ast",
@@ -8150,9 +8151,9 @@ dependencies = [
 
 [[package]]
 name = "swc"
-version = "0.273.10"
+version = "0.273.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8844e0b9878036ae662416540fbbea76df689e6fb1c2c82e44b6a648bdc661eb"
+checksum = "fa0196ea65eaa65291495510665639e5d045608973dace96d344c5352c58a9a3"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -8227,9 +8228,9 @@ dependencies = [
 
 [[package]]
 name = "swc_bundler"
-version = "0.225.8"
+version = "0.225.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a95366ff13c5f3dc6cc5536ae526d52732e8c036981bc242e970b8a1c0bfdd31"
+checksum = "21736fd17b258d4324f576e1d151d997fd5370a04b68dcb59f3e5050828de33f"
 dependencies = [
  "anyhow",
  "crc",
@@ -8306,9 +8307,9 @@ dependencies = [
 
 [[package]]
 name = "swc_compiler_base"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f802931f76a7bc64b8b61eec0a10225044c58b6c0dbbe135c0ca2840e964170"
+checksum = "04e0e79b1bea627ffbc3a8fdc2f9633ce91991204f4520baa24761bae04ae8a3"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -8358,9 +8359,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "0.90.11"
+version = "0.90.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229d3ae620f7ed70f7974aab8c254018102c4e5d8e7d8ced4a36f43b00f76dcb"
+checksum = "5fcbc95073ce6099a5f63b5bb847be2baf43e153c12ee4d01ac4644f1eaf9057"
 dependencies = [
  "binding_macros",
  "swc",
@@ -8567,9 +8568,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.148.6"
+version = "0.148.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b2ef19844772a0ebc3f73a0a4766cacda8de05f1cbf1450bb9e407ee40914fb"
+checksum = "5ba8669ab28bb5d1e65c1e8690257c026745ac368e0101c2c6544d4a03afc95e"
 dependencies = [
  "memchr",
  "num-bigint",
@@ -8598,9 +8599,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_bugfixes"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1abefb0666428266f65e63f4dbc44a0f2301d0965554478c75d5db9624044bb7"
+checksum = "a477a05b1289fc445d35dc86d1558dd94964d09ea2344807142ee26ad4380702"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -8628,9 +8629,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2015"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96f68e7cb9b4de6205bef9a5cad752af2941723951f7507b948caaf19e5084f7"
+checksum = "be559e986e9eef83a063dd3964675fa01328adbd8d1ed210a540ac0c515b5ffc"
 dependencies = [
  "arrayvec 0.7.4",
  "indexmap 2.2.3",
@@ -8654,9 +8655,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2016"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ebff320bd89c5622b89af3ec7b07d69304080b2f163d64e27b24e33bd180a2e"
+checksum = "3da81d5e15fd85cefe6c804621cd5379b8e17339c37db17bece113bf358c7e90"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -8671,9 +8672,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2017"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23c9847bc30e779ffcd59a44149b75db62d1806efbf439025266c89020379932"
+checksum = "b3fff137914c3aa35119e0759cbc4bfa3f54d70ef8c7f61b84d0d124a37309f7"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -8689,9 +8690,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2018"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3b0a6a76c8724ede825324e877b2335c229db150f4b137d2389e174243c1e0c"
+checksum = "fa200a2206617e8e0634125b15bdc4e514b825a5ebd59388658f324cc5d8eb0b"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -8708,9 +8709,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2019"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e270eb5db417dede961a2a04d36043081d1aad7e72a209c1af60a173ee489c77"
+checksum = "e72e7003fd258ef656dd75919812076272f94c2dbefd812525e3573cb9fabbcd"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -8724,9 +8725,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2020"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47e30dbd6f613ec6078fab98081cd34674bd965fb18adaa5ca523323a698642e"
+checksum = "2e2f8ebd693454be56ba4c9509aabdc16b374411e6599f5c86ea23eabe8fc566"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -8742,9 +8743,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2021"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "950a7be39f2ba15cebf7aa960c437acb6d588e5caa117857f93c7e08ce5082a9"
+checksum = "bf86003d75d2f0108b5a32c49370ca1b62597476330ee263fdbf567775602294"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -8758,9 +8759,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2022"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d528535bf4dcd9b60ec3ca7fe8b771e088dd895a936434e828f497f8c0dc576"
+checksum = "c4f0752172781d811ce454962ba70d162153786569c40ca5f5eb3cc69fb5e133"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -8777,9 +8778,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es3"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ad7683fd759478494f7c7f262aecc8f04214150cae71561fc8498842a9118f"
+checksum = "46f2b26b2bc553bca1e14a7e230fcf19e8c7e5efee8c531b86cd38dbda9d4b8c"
 dependencies = [
  "swc_common",
  "swc_ecma_ast",
@@ -8806,9 +8807,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_lints"
-version = "0.92.9"
+version = "0.92.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5dbb15abb0330aab2e0fdc754636eefe34ac559f3c080923caf83def83023d"
+checksum = "653fb70335ffc8edb00e0b921056ed331492971518e4953d830e62f4f43f9e5a"
 dependencies = [
  "auto_impl",
  "dashmap",
@@ -8848,9 +8849,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "0.192.9"
+version = "0.192.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a0cde8672384cbcebfc52bc95e8f13a13544f9fd71b3ab5d2ba41663b93c420"
+checksum = "7b89be89785499cbd824210e50f00b2e3e458474b99bdaf18c3ab1cd57404e79"
 dependencies = [
  "arrayvec 0.7.4",
  "indexmap 2.2.3",
@@ -8904,9 +8905,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "0.206.9"
+version = "0.206.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3bc4e8b136aeca82e083ad6ade0feeacfbc6a963e8be5660dbdf569dfc7cce"
+checksum = "bea1cd70fb8e3cae08cf6e1e74b4c0531a4ed6dc3b3afb24708865501a567b50"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -8959,9 +8960,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.229.9"
+version = "0.229.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feadab31e91f17cd6784f79e9f8f89e3813aa329aa5d37febe4d4344dfa47104"
+checksum = "238dea3590683d7dff20831c2a63267cda8303a03a9b206268b7912649f5a4f2"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -8979,9 +8980,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.137.9"
+version = "0.137.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c366819cc98d0d09bc80748c89172eeea3c8e2a988561aece9ebe7486b4c9660"
+checksum = "66539401f619730b26d380a120b91b499f80cbdd9bb15d00aa73bc3a4d4cc394"
 dependencies = [
  "better_scoped_tls",
  "bitflags 2.4.0",
@@ -9003,9 +9004,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "0.126.9"
+version = "0.126.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1883875b228dd98478378ffb6516a38817769ff44dd5c389fed4dfb23439f547"
+checksum = "ebf9048e687b746d2bbe6149601c3eedd819fef08d7657e5fddcef99b22febba"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -9017,9 +9018,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "0.163.9"
+version = "0.163.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12ecf0f5fa4cec49a841e5f1876c7f0c10ab3162abea901f0e4c343d9db0d447"
+checksum = "52f0a03b60f0122f935880ef47e38d98c681b4b5c3f0cf62718787bc4781a123"
 dependencies = [
  "arrayvec 0.7.4",
  "indexmap 2.2.3",
@@ -9066,9 +9067,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "0.180.9"
+version = "0.180.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c844a3f96d0ddf2c5471e17fe3d9e3ee6828ca4d4f9f7d9c581b0b6567f016e"
+checksum = "69446b9e4f839632d07bbe74bfbf13e6120f1f567f0e02e5f3d5d2c767fc050e"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -9093,9 +9094,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.198.9"
+version = "0.198.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86a1fb0406545e5151a99d076361a3bf9e8acff974cce3f858d1f25ee8e9454e"
+checksum = "17889816334ce9d05ab0c292f93514fdd863b8537a35852dda609ebe3f48071d"
 dependencies = [
  "dashmap",
  "indexmap 2.2.3",
@@ -9118,9 +9119,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "0.171.9"
+version = "0.171.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34bb6d42cde48a405f02b601ab283570f588fc5f7d0726a6251e2158691e8ea"
+checksum = "35f0a72ee781aa9208836046fd2c12e483f5515898858511b68863290cb97b45"
 dependencies = [
  "either",
  "rustc-hash",
@@ -9138,9 +9139,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.183.9"
+version = "0.183.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45dbfc343e47028c39ec90f4761db2e1625594ef69e113a0e5f9eb3db2115a69"
+checksum = "f0ec75c1194365abe4d44d94e58f918ec853469ecd39733b381a089cfdcdee1a"
 dependencies = [
  "base64 0.21.4",
  "dashmap",
@@ -9163,9 +9164,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_testing"
-version = "0.140.9"
+version = "0.140.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a856597c336f89d68a63e5c7cb85075abd0fe425f4fad9bf86d6eecfc2745aa"
+checksum = "d70d13125e86b0aa940ba326930447a43e0640fa6fed1ca512a1ae78ecafc278"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -9189,9 +9190,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.188.9"
+version = "0.188.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e238be27d09b45ddf6c7cc99e7cfe16ac41cfaefcf4fa675da783102a59ae18b"
+checksum = "fec5e95a9c840eb13562884123eaa627cb6e05e0461c94a2ce69ae7e70313010"
 dependencies = [
  "ryu-js",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,16 +97,16 @@ async-recursion = "1.0.2"
 browserslist-rs = { version = "0.15.0" }
 miette = { version = "5.10.0", features = ["fancy"] }
 mdxjs = "0.1.23"
-modularize_imports = { version = "0.68.5" }
+modularize_imports = { version = "0.68.6" }
 styled_components = { version = "0.96.6" }
 styled_jsx = { version = "0.73.8" }
-swc_core = { version = "0.90.10", features = [
+swc_core = { version = "0.90.11", features = [
   "ecma_loader_lru",
   "ecma_loader_parking_lot",
 ] }
 swc_emotion = { version = "0.72.6" }
 swc_relay = { version = "0.44.5" }
-testing = { version = "0.35.18" }
+testing = { version = "0.35.19" }
 
 auto-hash-map = { path = "crates/turbo-tasks-auto-hash-map" }
 node-file-trace = { path = "crates/node-file-trace", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,10 +97,10 @@ async-recursion = "1.0.2"
 browserslist-rs = { version = "0.15.0" }
 miette = { version = "5.10.0", features = ["fancy"] }
 mdxjs = "0.1.23"
-modularize_imports = { version = "0.68.6" }
+modularize_imports = { version = "0.68.7" }
 styled_components = { version = "0.96.6" }
 styled_jsx = { version = "0.73.8" }
-swc_core = { version = "0.90.11", features = [
+swc_core = { version = "0.90.12", features = [
   "ecma_loader_lru",
   "ecma_loader_parking_lot",
 ] }

--- a/crates/turbopack-tests/tests/snapshot/css/css-legacy-nesting/output/crates_turbopack-tests_tests_snapshot_css_css-legacy-nesting_input_index_8e60f2.js
+++ b/crates/turbopack-tests/tests/snapshot/css/css-legacy-nesting/output/crates_turbopack-tests_tests_snapshot_css_css-legacy-nesting_input_index_8e60f2.js
@@ -1,6 +1,6 @@
 (globalThis.TURBOPACK = globalThis.TURBOPACK || []).push(["output/crates_turbopack-tests_tests_snapshot_css_css-legacy-nesting_input_index_8e60f2.js", {
 
-"[project]/crates/turbopack-tests/tests/snapshot/css/css-legacy-nesting/input/index.js [test] (ecmascript)": (function({ r: __turbopack_require__, f: __turbopack_require_context__, i: __turbopack_import__, s: __turbopack_esm__, v: __turbopack_export_value__, n: __turbopack_export_namespace__, c: __turbopack_cache__, M: __turbopack_modules__, l: __turbopack_load__, j: __turbopack_dynamic__, p: __turbopack_lookup__, P: __turbopack_resolve_absolute_path__, U: __turbopack_relative_url__, R: __turbopack_resolve_module_id_path__, g: global, __dirname, k: __turbopack_refresh__, m: module, e: exports, t: require }) { !function() {
+"[project]/crates/turbopack-tests/tests/snapshot/css/css-legacy-nesting/input/index.js [test] (ecmascript)": (function({ r: __turbopack_require__, f: __turbopack_module_context__, i: __turbopack_import__, s: __turbopack_esm__, v: __turbopack_export_value__, n: __turbopack_export_namespace__, c: __turbopack_cache__, M: __turbopack_modules__, l: __turbopack_load__, j: __turbopack_dynamic__, P: __turbopack_resolve_absolute_path__, U: __turbopack_relative_url__, R: __turbopack_resolve_module_id_path__, g: global, __dirname, k: __turbopack_refresh__, m: module, e: exports, t: require }) { !function() {
 
 __turbopack_esm__({});
 ;


### PR DESCRIPTION
### Description


Update swc crates to apply https://github.com/swc-project/swc/pull/8657


### Testing Instructions

next.js counterpart: https://github.com/vercel/next.js/pull/62518

Closes PACK-2595