### PR TITLE
chore: update docs to no longer suggest verbosity for `--profile`

### DIFF
--- a/docs/pages/repo/docs/reference/command-line-reference/run.mdx
+++ b/docs/pages/repo/docs/reference/command-line-reference/run.mdx
@@ -348,8 +348,6 @@ turbo run dev --parallel --no-cache
 Generates a trace of the run in Chrome Tracing format that you can use to analyze performance.
 The profile can be viewed in [Perfetto](https://ui.perfetto.dev/).
 
-You must provide a verbosity flag (`-v`, `-vv`, or `-vvv`) with the `--profile` to produce a trace.
-
 ```sh
 turbo run build --profile=profile.json
 ```


### PR DESCRIPTION
### Description

As of https://github.com/vercel/turbo/pull/6779 we no longer need verbosity to be set when generating a profile.

### Testing Instructions

👀 


Closes TURBO-2447