### PR TITLE
chore: add read_existing_to_string

### DIFF
--- a/crates/turborepo-paths/src/absolute_system_path.rs
+++ b/crates/turborepo-paths/src/absolute_system_path.rs
@@ -451,9 +451,18 @@ impl AbsoluteSystemPath {
     where
         I: Into<String>,
     {
-        fs::read_to_string(&self.0).or_else(|e| {
+        match self.read_existing_to_string()? {
+            Some(contents) => Ok(contents),
+            None => default_value.map(|value| value.into()),
+        }
+    }
+
+    /// Attempts to read a file returning None if the file does not exist
+    /// For all other scenarios passes through the `read_to_string` results.
+    pub fn read_existing_to_string(&self) -> Result<Option<String>, io::Error> {
+        fs::read_to_string(&self.0).map(Some).or_else(|e| {
             if e.kind() == std::io::ErrorKind::NotFound {
-                default_value.map(|intoable| intoable.into())
+                Ok(None)
             } else {
                 Err(e)
             }
@@ -589,6 +598,28 @@ mod tests {
         .unwrap();
 
         assert_eq!(base.contains(&other), expected);
+    }
+
+    #[test]
+    fn test_read_non_existing_to_string() -> Result<()> {
+        let test_dir = tempdir::TempDir::new("read-existing")?;
+        let test_path = test_dir.path().join("foo");
+        let path = AbsoluteSystemPathBuf::new(test_path.to_str().unwrap())?;
+        assert_eq!(path.read_existing_to_string()?, None);
+        Ok(())
+    }
+
+    #[test]
+    fn test_read_existing_to_string() -> Result<()> {
+        let test_dir = tempdir::TempDir::new("read-existing")?;
+        let test_path = test_dir.path().join("foo");
+        let path = AbsoluteSystemPathBuf::new(test_path.to_str().unwrap())?;
+        path.create_with_contents("hi there!")?;
+        assert_eq!(
+            path.read_existing_to_string()?.as_deref(),
+            Some("hi there!")
+        );
+        Ok(())
     }
 
     // Constructing a windows permissions struct is only possible by calling


### PR DESCRIPTION
### Description

For parsing `.npmrc` we don't want to error if it isn't there. Using `read_existing_to_string_or` doesn't feel right to me as it would require using a magic value to signify none e.g. `npmrc_path.read_existing_to_string_or(Ok("missing"))?` and then checking that value.

If nobody objects, I'm happy moving uses of `read_existing_to_string_or` to `read_existing_to_string` in a future PR.

### Testing Instructions

Existing unit tests, new unit tests


Closes TURBO-2452