### PR TITLE
fix: correctly call teams api

### DIFF
--- a/crates/turborepo-api-client/src/lib.rs
+++ b/crates/turborepo-api-client/src/lib.rs
@@ -145,10 +145,10 @@ impl Client for APIClient {
     }
 
     async fn get_team(&self, token: &str, team_id: &str) -> Result<Option<Team>> {
+        let endpoint = format!("/v2/teams/{team_id}");
         let response = self
             .client
-            .get(self.make_url("/v2/team")?)
-            .query(&[("teamId", team_id)])
+            .get(self.make_url(&endpoint)?)
             .header("User-Agent", self.user_agent.clone())
             .header("Content-Type", "application/json")
             .header("Authorization", format!("Bearer {}", token))


### PR DESCRIPTION
### Description

I was getting the following error
```
[0 olszewski@chriss-mbp] /Users/olszewski/code/vercel/turborepo $ turbo_dev logout                 
>>> Logged out
[0 olszewski@chriss-mbp] /Users/olszewski/code/vercel/turborepo $ turbo_dev login --sso-team=vercel
  × Error making HTTP request: HTTP status server error (508 Loop Detected) for url (https://vercel.com/api/v2/team?teamId=vercel)
  ╰─▶ HTTP status server error (508 Loop Detected) for url (https://vercel.com/api/v2/team?teamId=vercel)
```

Checking the [docs](https://vercel.com/docs/rest-api/endpoints/teams#get-a-team) we're hitting a non-existent endpoint and incorrectly passing path parameters as query parameters. This PR fixes our `get_team` API usage.


Note: this does not fix other issues with the Vercel token workflow as `turbo link` and `turbo run` don't use it so users can get in states where `turbo login` will claim you're logged in, but trying `turbo link` will fail as there isn't a token found.


### Testing Instructions
In order to hit this codepath you need to be in the correct state of having a Vercel token, but not a Turbo token.
Setup:
```
[0 olszewski@chriss-mbp] /Users/olszewski/code/vercel/turborepo $ turbo logout
>>> Logged out
[0 olszewski@chriss-mbp] /Users/olszewski/code/vercel/turborepo $ vc login
Vercel CLI 29.3.0
? Log in to Vercel saml
? Enter your Team slug: vercel
> Success! SAML Single Sign-On authentication complete for chris.olszewski@vercel.com
Congratulations! You are now logged in. In order to deploy something, run `vercel`.
💡  Connect your Git Repositories to deploy every branch push automatically (https://vercel.link/git).
```
Testing:
```
# on main
[0 olszewski@chriss-mbp] /Users/olszewski/code/vercel/turborepo $ turbo_dev login --sso-team=vercel 
  × Error making HTTP request: HTTP status server error (508 Loop Detected) for url (https://vercel.com/api/v2/team?teamId=vercel)
  ╰─▶ HTTP status server error (508 Loop Detected) for url (https://vercel.com/api/v2/team?teamId=vercel)
# Checkout PR and rebuild
[0 olszewski@chriss-mbp] /Users/olszewski/code/vercel/turborepo $ git co olszewski/fix_usage_of_vercel_token
[0 olszewski@chriss-mbp] /Users/olszewski/code/vercel/turborepo $ cargo build -p turbo
...
# Try to login again
[0 olszewski@chriss-mbp] /Users/olszewski/code/vercel/turborepo $ turbo_dev login --sso-team=vercel         
Existing Vercel token found!

>>> Success! Turborepo CLI authorized for chris.olszewski@vercel.com
To connect to your Remote Cache, run the following in any turborepo:
  npx turbo link

```


Closes TURBO-2453