### PR TITLE
chore: update Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3509,7 +3509,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
- "ahash 0.8.6",
+ "ahash 0.8.9",
  "allocator-api2",
 ]
 


### PR DESCRIPTION
### Description

#7470 sat too long and ended up with a `Cargo.lock` with an out of date dependency

### Testing Instructions

👀 

Closes TURBO-2454