### PR TITLE
feat: allow for faux comments at top level of turbo.json

### DIFF
--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -759,6 +759,7 @@ mod tests {
             ..TurboJson::default()
         }
     )]
+    #[test_case(r#"{ "//": "A comment"}"#, TurboJson::default() ; "faux comment")]
     fn test_get_root_turbo_no_synthesizing(
         turbo_json_content: &str,
         expected_turbo_json: TurboJson,

--- a/crates/turborepo-lib/src/turbo_json/parser.rs
+++ b/crates/turborepo-lib/src/turbo_json/parser.rs
@@ -595,6 +595,8 @@ impl DeserializationVisitor for RawTurboJsonVisitor {
                         result.remote_cache = Some(remote_cache);
                     }
                 }
+                // Allow for faux-comments at the top level
+                "//" => {}
                 unknown_key => {
                     diagnostics.push(create_unknown_key_diagnostic_from_struct(
                         &result,


### PR DESCRIPTION
### Description

Closes #7522

All this does is skip us throwing if we encounter a top level `//` key in the `turbo.json`. I personally thinks this makes some sense since the `//` key is used across the JS ecosystem for comments in JSON files. We do support JSONC for `turbo.json`, but that might not be immediately obvious without reading documentation.

### Testing Instructions

Added unit test


Closes TURBO-2462