### PR TITLE
fix(ci) remove filter when running @turbo/repository tests

### DIFF
--- a/.github/workflows/turborepo-native-lib-test.yml
+++ b/.github/workflows/turborepo-native-lib-test.yml
@@ -52,4 +52,4 @@ jobs:
       - name: Run tests
         # Manually set TURBO_API to an empty string to override Hetzner env
         run: |
-          TURBO_API= turbo run test --color --env-mode=strict
+          TURBO_API= turbo run test --filter "turborepo-repository" --color --env-mode=strict

--- a/.github/workflows/turborepo-native-lib-test.yml
+++ b/.github/workflows/turborepo-native-lib-test.yml
@@ -52,4 +52,4 @@ jobs:
       - name: Run tests
         # Manually set TURBO_API to an empty string to override Hetzner env
         run: |
-          TURBO_API= turbo run test --filter={./packages/turborepo-repository}...[${{ github.event.pull_request.base.sha || 'HEAD^1' }}] --color --env-mode=strict
+          TURBO_API= turbo run test --color --env-mode=strict


### PR DESCRIPTION
This was preventing these tests from running when turbo core source code changes.

Follow up from: #7374

Discovered in https://github.com/vercel/turbo/pull/7549 that these tests are never running when source changes :(

Closes TURBO-2477