### PR TITLE
fix: vercel auth file borks login

### DIFF
--- a/crates/turborepo-auth/src/auth/login.rs
+++ b/crates/turborepo-auth/src/auth/login.rs
@@ -62,7 +62,7 @@ pub async fn login<T: Client + TokenClient + CacheClient>(
         } else if login_url_configuration.contains("vercel.com") {
             // The extraction can return an error, but we don't want to fail the login if
             // the token is not found.
-            if let Ok(token) = extract_vercel_token() {
+            if let Ok(Some(token)) = extract_vercel_token() {
                 let token = Token::existing(token);
                 if token
                     .is_valid(

--- a/crates/turborepo-auth/src/auth/mod.rs
+++ b/crates/turborepo-auth/src/auth/mod.rs
@@ -48,7 +48,7 @@ where
     }
 }
 
-fn extract_vercel_token() -> Result<String, Error> {
+fn extract_vercel_token() -> Result<Option<String>, Error> {
     let vercel_config_dir =
         turborepo_dirs::vercel_config_dir().ok_or_else(|| Error::ConfigDirNotFound)?;
 
@@ -61,7 +61,7 @@ fn extract_vercel_token() -> Result<String, Error> {
     struct VercelToken {
         // This isn't actually dead code, it's used by serde to deserialize the JSON.
         #[allow(dead_code)]
-        token: String,
+        token: Option<String>,
     }
 
     Ok(serde_json::from_str::<VercelToken>(&contents)?.token)

--- a/crates/turborepo-auth/src/auth/sso.rs
+++ b/crates/turborepo-auth/src/auth/sso.rs
@@ -73,7 +73,7 @@ pub async fn sso_login<'a, T: Client + TokenClient + CacheClient>(
         // No existing turbo token found. If the user is logging into Vercel, check for
         // an existing `vc` token with correct scope.
         if login_url_configuration.contains("vercel.com") {
-            if let Ok(token) = extract_vercel_token() {
+            if let Ok(Some(token)) = extract_vercel_token() {
                 let token = Token::existing(token);
                 if token
                     .is_valid_sso(

--- a/crates/turborepo-auth/src/lib.rs
+++ b/crates/turborepo-auth/src/lib.rs
@@ -55,14 +55,18 @@ impl Token {
     pub fn from_file(path: AbsoluteSystemPathBuf) -> Result<Self, Error> {
         #[derive(Deserialize)]
         struct TokenWrapper {
-            token: String,
+            token: Option<String>,
         }
 
         match path.read_existing_to_string()? {
             Some(content) => {
                 let wrapper = serde_json::from_str::<TokenWrapper>(&content)
                     .map_err(Error::InvalidTokenFileFormat)?;
-                Ok(Self::Existing(wrapper.token))
+                if let Some(token) = wrapper.token {
+                    Ok(Self::Existing(token))
+                } else {
+                    Err(Error::TokenNotFound)
+                }
             }
             None => Err(Error::TokenNotFound),
         }


### PR DESCRIPTION
### Description
Because `vc logout` doesn't remove it's pseudo-comments, deserialize breaks when trying to extract the token.
This PR fixes that by setting the deserialized struct to have an optional token field and then we make sure the extraction didn't encounter an error _and_ that the token is `Some`.

### Testing Instructions
First, make sure you build the branch.
1. `vc login && vc logout` -> make the Vercel auth file and then remove the `token` field. You could do this manually as well.
2. `turbo login` -> Shouldn't error and ask for a new login.


Closes TURBO-2485