### PR TITLE
fix: Respect globalDependencies when determining changed packages

### DIFF
--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -362,6 +362,7 @@ impl Run {
                 &self.repo_root,
                 &pkg_dep_graph,
                 &scm,
+                &root_turbo_json,
             )?;
 
             if is_all_packages {

--- a/crates/turborepo-lib/src/run/scope/filter.rs
+++ b/crates/turborepo-lib/src/run/scope/filter.rs
@@ -18,7 +18,7 @@ use super::{
     simple_glob::{Match, SimpleGlob},
     target_selector::{InvalidSelectorError, TargetSelector},
 };
-use crate::run::scope::change_detector::ScopeChangeDetector;
+use crate::{run::scope::change_detector::ScopeChangeDetector, turbo_json::TurboJson};
 
 pub struct PackageInference {
     package_name: Option<String>,
@@ -112,12 +112,16 @@ impl<'a> FilterResolver<'a, ScopeChangeDetector<'a>> {
         turbo_root: &'a AbsoluteSystemPath,
         inference: Option<PackageInference>,
         scm: &'a SCM,
+        root_turbo_json: &TurboJson,
     ) -> Self {
+        let mut global_deps = opts.global_deps.clone();
+        global_deps.extend_from_slice(&root_turbo_json.global_deps);
+
         let change_detector = ScopeChangeDetector::new(
             turbo_root,
             scm,
             pkg_graph,
-            opts.global_deps.clone(),
+            global_deps,
             opts.ignore_patterns.clone(),
         );
         Self::new_with_change_detector(pkg_graph, turbo_root, inference, scm, change_detector)

--- a/crates/turborepo-lib/src/run/scope/mod.rs
+++ b/crates/turborepo-lib/src/run/scope/mod.rs
@@ -10,8 +10,8 @@ use turbopath::AbsoluteSystemPath;
 use turborepo_repository::package_graph::{PackageGraph, PackageName};
 use turborepo_scm::SCM;
 
-use crate::opts::ScopeOpts;
 pub use crate::run::scope::filter::ResolutionError;
+use crate::{opts::ScopeOpts, turbo_json::TurboJson};
 
 #[tracing::instrument(skip(opts, pkg_graph, scm))]
 pub fn resolve_packages(
@@ -19,11 +19,19 @@ pub fn resolve_packages(
     turbo_root: &AbsoluteSystemPath,
     pkg_graph: &PackageGraph,
     scm: &SCM,
+    root_turbo_json: &TurboJson,
 ) -> Result<(HashSet<PackageName>, bool), ResolutionError> {
     let pkg_inference = opts.pkg_inference_root.as_ref().map(|pkg_inference_path| {
         PackageInference::calculate(turbo_root, pkg_inference_path, pkg_graph)
     });
 
-    FilterResolver::new(opts, pkg_graph, turbo_root, pkg_inference, scm)
-        .resolve(&opts.get_filters())
+    FilterResolver::new(
+        opts,
+        pkg_graph,
+        turbo_root,
+        pkg_inference,
+        scm,
+        root_turbo_json,
+    )
+    .resolve(&opts.get_filters())
 }

--- a/turborepo-tests/integration/tests/filter-run.t
+++ b/turborepo-tests/integration/tests/filter-run.t
@@ -27,3 +27,17 @@ Setup
   Cached:    0 cached, 0 total
     Time:\s*[\.0-9]+m?s  (re)
   
+
+  $ rm bar.txt
+  $ echo "global dependency" >> foo.txt
+  $ git commit -am "global dependency change" --quiet
+  $ ${TURBO} run build --filter="[HEAD^]" --output-logs none
+  \xe2\x80\xa2 Packages in scope: //, another, my-app, util (esc)
+  \xe2\x80\xa2 Running build in 4 packages (esc)
+  \xe2\x80\xa2 Remote caching disabled (esc)
+  
+   Tasks:    2 successful, 2 total
+  Cached:    0 cached, 2 total
+    Time:\s*[\.0-9]+m?s  (re)
+  
+


### PR DESCRIPTION
### Description

We didn't respect the `globalDependencies` field in `turbo.json` when determining changed packages. This meant that you could have a global dependency changed, but turbo wouldn't run.

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->


Closes TURBO-2486