### PR TITLE
fix: login success page redirect

### DIFF
--- a/crates/turborepo-auth/src/auth/login.rs
+++ b/crates/turborepo-auth/src/auth/login.rs
@@ -79,7 +79,15 @@ pub async fn login<T: Client + TokenClient + CacheClient>(
 
     let redirect_url = format!("http://{DEFAULT_HOST_NAME}:{DEFAULT_PORT}");
     let mut login_url = Url::parse(login_url_configuration)?;
+    let mut success_url = login_url.clone();
+    success_url
+        .path_segments_mut()
+        .map_err(|_: ()| Error::LoginUrlCannotBeABase {
+            value: login_url_configuration.to_string(),
+        })?
+        .extend(["turborepo", "success"]);
 
+    // Create the full login URL.
     login_url
         .path_segments_mut()
         .map_err(|_: ()| Error::LoginUrlCannotBeABase {
@@ -105,7 +113,7 @@ pub async fn login<T: Client + TokenClient + CacheClient>(
         .run(
             DEFAULT_PORT,
             crate::LoginType::Basic {
-                login_url_configuration: login_url.to_string(),
+                success_redirect: success_url.to_string(),
             },
             token_cell.clone(),
         )

--- a/crates/turborepo-auth/src/login_server.rs
+++ b/crates/turborepo-auth/src/login_server.rs
@@ -10,7 +10,7 @@ use url::Url;
 use crate::Error;
 
 pub enum LoginType {
-    Basic { login_url_configuration: String },
+    Basic { success_redirect: String },
     SSO,
 }
 
@@ -57,15 +57,13 @@ impl LoginServer for DefaultLoginServer {
         let route_handle = handle.clone();
         let addr = SocketAddr::from(([127, 0, 0, 1], port));
         match login_type {
-            LoginType::Basic {
-                login_url_configuration,
-            } => {
+            LoginType::Basic { success_redirect } => {
                 let app = Router::new().route(
                     "/",
                     get(|login_payload: Query<LoginPayload>| async move {
                         let _ = login_token.set(login_payload.0.token);
                         route_handle.shutdown();
-                        Redirect::to(&format!("{login_url_configuration}/turborepo/success"))
+                        Redirect::to(&success_redirect)
                     }),
                 );
 


### PR DESCRIPTION
### Description
Success page url was wrong and re-prompting with the same authorize page, even though it did nothing.

String formatting is hard sometimes.

### Testing Instructions
1. `turbo logout` -> ensure you have no tokens that'll prompt the "Existing token found!" check
2. `turbo login` -> get the login page
3. Ensure that when you click `Authorize`, and it works, that the second page is the success page.


Closes TURBO-2488