### PR TITLE
add getResolve to webpack loader context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11339,6 +11339,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-stream",
+ "async-trait",
  "bytes 1.5.0",
  "const_format",
  "futures 0.3.28",
@@ -11364,6 +11365,7 @@ dependencies = [
  "turbopack-core",
  "turbopack-dev-server",
  "turbopack-ecmascript",
+ "turbopack-resolve",
  "url 2.4.1",
  "urlencoding",
 ]

--- a/crates/turbopack-node/Cargo.toml
+++ b/crates/turbopack-node/Cargo.toml
@@ -19,6 +19,7 @@ workspace = true
 [dependencies]
 anyhow = { workspace = true }
 async-stream = "0.3.4"
+async-trait = { workspace = true }
 bytes = { workspace = true }
 const_format = "0.2.30"
 futures = { workspace = true }
@@ -43,6 +44,7 @@ turbopack-cli-utils = { workspace = true }
 turbopack-core = { workspace = true }
 turbopack-dev-server = { workspace = true }
 turbopack-ecmascript = { workspace = true }
+turbopack-resolve = { workspace = true }
 url = { workspace = true }
 urlencoding = { workspace = true }
 

--- a/crates/turbopack-node/js/src/ipc/evaluate.ts
+++ b/crates/turbopack-node/js/src/ipc/evaluate.ts
@@ -1,64 +1,135 @@
 import { IPC, StructuredError } from "./index";
 import type { Ipc as GenericIpc } from "./index";
 
-type IpcIncomingMessage = {
-  type: "evaluate";
-  args: string[];
-};
+type IpcIncomingMessage =
+  | {
+      type: "evaluate";
+      args: string[];
+    }
+  | {
+      type: "result";
+      id: number;
+      error: string | null;
+      data: any | null;
+    };
 
 type IpcOutgoingMessage =
   | {
-      type: "value";
-      data: string;
-    }
-  | {
       type: "end";
       data: string | undefined;
+      duration: number;
     }
   | {
-      type: "fileDependency";
-      path: string;
+      type: "info";
+      data: any;
     }
   | {
-      type: "buildDependency";
-      path: string;
-    }
-  | {
-      type: "dirDependency";
-      path: string;
-      glob: string;
-    }
-  | {
-      type: "emittedError";
-      severity: "warning" | "error";
-      error: StructuredError;
+      type: "request";
+      id: number;
+      data: any;
     };
 
-export type Ipc = GenericIpc<IpcIncomingMessage, IpcOutgoingMessage>;
-const ipc = IPC as Ipc;
+export type Ipc<IM, RM> = {
+  sendInfo(message: IM): Promise<void>;
+  sendRequest(message: RM): Promise<unknown>;
+  sendError(error: Error): Promise<never>;
+};
+const ipc = IPC as GenericIpc<IpcIncomingMessage, IpcOutgoingMessage>;
+
+const queue: string[][] = [];
 
 export const run = async (
-  getValue: (ipc: Ipc, ...deserializedArgs: any[]) => any
+  moduleFactory: () => Promise<{
+    init?: () => Promise<void>;
+    default: (ipc: Ipc<any, any>, ...deserializedArgs: any[]) => any;
+  }>
 ) => {
+  let nextId = 1;
+  const requests = new Map();
+  const internalIpc = {
+    sendInfo: (message: any) =>
+      ipc.send({
+        type: "info",
+        data: message,
+      }),
+    sendRequest: (message: any) => {
+      const id = nextId++;
+      let resolve, reject;
+      const promise = new Promise((res, rej) => {
+        resolve = res;
+        reject = rej;
+      });
+      requests.set(id, { resolve, reject });
+      return ipc
+        .send({ type: "request", id, data: message })
+        .then(() => promise);
+    },
+    sendError: (error: Error) => {
+      return ipc.sendError(error);
+    },
+  };
+
+  // Initialize module and send ready message
+  let getValue: (ipc: Ipc<any, any>, ...deserializedArgs: any[]) => any;
+  try {
+    const module = await moduleFactory();
+    if (typeof module.init === "function") {
+      await module.init();
+    }
+    getValue = module.default;
+  } catch (err) {
+    await ipc.sendReady();
+    await ipc.sendError(err as Error);
+  }
+  await ipc.sendReady();
+
+  // Queue handling
+  let isRunning = false;
+  const run = async () => {
+    while (queue.length > 0) {
+      const args = queue.shift()!;
+      try {
+        const value = await getValue(internalIpc, ...args);
+        await ipc.send({
+          type: "end",
+          data:
+            value === undefined ? undefined : JSON.stringify(value, null, 2),
+          duration: 0,
+        });
+      } catch (e) {
+        await ipc.sendError(e as Error);
+      }
+    }
+    isRunning = false;
+  };
+
+  // Communication handling
   while (true) {
     const msg = await ipc.recv();
 
     switch (msg.type) {
       case "evaluate": {
-        try {
-          const value = await getValue(ipc, ...msg.args);
-          await ipc.send({
-            type: "end",
-            data:
-              value === undefined ? undefined : JSON.stringify(value, null, 2),
-          });
-        } catch (e) {
-          await ipc.sendError(e as Error);
+        queue.push(msg.args);
+        if (!isRunning) {
+          isRunning = true;
+          run();
+        }
+        break;
+      }
+      case "result": {
+        const request = requests.get(msg.id);
+        if (request) {
+          requests.delete(msg.id);
+          if (msg.error) {
+            request.reject(new Error(msg.error));
+          } else {
+            request.resolve(msg.data);
+          }
         }
         break;
       }
       default: {
-        console.error("unexpected message type", msg.type);
+        console.error("unexpected message type", (msg as any).type);
         process.exit(1);
       }
     }

--- a/crates/turbopack-node/js/src/ipc/evaluate.ts
+++ b/crates/turbopack-node/js/src/ipc/evaluate.ts
@@ -77,11 +77,12 @@ export const run = async (
       await module.init();
     }
     getValue = module.default;
+   await ipc.sendReady();
   } catch (err) {
     await ipc.sendReady();
     await ipc.sendError(err as Error);
   }
-  await ipc.sendReady();
+
 
   // Queue handling
   let isRunning = false;

--- a/crates/turbopack-node/js/src/ipc/index.ts
+++ b/crates/turbopack-node/js/src/ipc/index.ts
@@ -32,6 +32,7 @@ export type Ipc<TIncoming, TOutgoing> = {
   recv(): Promise<TIncoming>;
   send(message: TOutgoing): Promise<void>;
   sendError(error: Error): Promise<never>;
+  sendReady(): Promise<void>;
 };
 
 function createIpc<TIncoming, TOutgoing>(
@@ -109,6 +110,21 @@ function createIpc<TIncoming, TOutgoing>(
     });
   }
 
+  function sendReady(): Promise<void> {
+    const length = Buffer.from([0, 0, 0, 0]);
+    return new Promise((resolve, reject) => {
+      socket.write(length, (err) => {
+        process.stderr.write(`TURBOPACK_OUTPUT_D\n`);
+        process.stdout.write(`TURBOPACK_OUTPUT_D\n`);
+        if (err != null) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
+  }
+
   return {
     async recv() {
       const packet = packetQueue.shift();
@@ -128,6 +144,8 @@ function createIpc<TIncoming, TOutgoing>(
     send(message: TOutgoing) {
       return send(message);
     },
+
+    sendReady,
 
     async sendError(error: Error): Promise<never> {
       try {

--- a/crates/turbopack-node/js/src/transforms/postcss.ts
+++ b/crates/turbopack-node/js/src/transforms/postcss.ts
@@ -6,6 +6,7 @@ import postcss from "@vercel/turbopack/postcss";
 import importedConfig from "CONFIG";
 import { relative, isAbsolute, sep } from "path";
 import type { Ipc } from "../ipc/evaluate";
+import type { IpcInfoMessage, IpcRequestMessage } from "./webpack-loaders";
 
 const contextDir = process.cwd();
 
@@ -19,11 +20,9 @@ function toPath(file: string) {
   return sep !== "/" ? relPath.replaceAll(sep, "/") : relPath;
 }
 
-export default async function transform(
-  ipc: Ipc,
-  cssContent: string,
-  name: string
-) {
+let processor: any;
+
+export const init = async (ipc: Ipc<IpcInfoMessage, IpcRequestMessage>) => {
   let config = importedConfig;
   if (typeof config === "function") {
     config = await config({ env: "development" });
@@ -67,7 +66,14 @@ export default async function transform(
     return plugin;
   });
 
-  const processor = postcss(loadedPlugins);
+  processor = postcss(loadedPlugins);
+};
+
+export default async function transform(
+  ipc: Ipc<IpcInfoMessage, IpcRequestMessage>,
+  cssContent: string,
+  name: string
+) => {
   const { css, map, messages } = await processor.process(cssContent, {
     from: name,
     to: name,
@@ -92,26 +98,26 @@ export default async function transform(
         break;
       case "file-dependency":
       case "missing-dependency":
-        ipc.send({
+        ipc.sendInfo({
           type: "fileDependency",
           path: toPath(msg.file),
         });
         break;
       case "build-dependency":
-        ipc.send({
+        ipc.sendInfo({
           type: "buildDependency",
           path: toPath(msg.file),
         });
         break;
       case "dir-dependency":
-        ipc.send({
+        ipc.sendInfo({
           type: "dirDependency",
           path: toPath(msg.dir),
           glob: msg.glob,
         });
         break;
       case "context-dependency":
-        ipc.send({
+        ipc.sendInfo({
           type: "dirDependency",
           path: toPath(msg.file),
           glob: "**",

--- a/crates/turbopack-node/js/src/transforms/postcss.ts
+++ b/crates/turbopack-node/js/src/transforms/postcss.ts
@@ -73,7 +73,7 @@ export default async function transform(
   ipc: Ipc<IpcInfoMessage, IpcRequestMessage>,
   cssContent: string,
   name: string
-) => {
+) {
   const { css, map, messages } = await processor.process(cssContent, {
     from: name,
     to: name,

--- a/crates/turbopack-node/js/src/transforms/webpack-loaders.ts
+++ b/crates/turbopack-node/js/src/transforms/webpack-loaders.ts
@@ -40,7 +40,7 @@ export type IpcInfoMessage =
 export type IpcRequestMessage = {
   type: "resolve";
   options: any;
-  context: string;
+  lookupPath: string;
   request: string;
 };
 
@@ -290,7 +290,7 @@ const transform = (
               rustOptions.preferRelative = options.preferRelative;
             }
             return (
-              context: string,
+              lookupPath: string,
               request: string,
               callback?: (err?: Error, result?: string) => void
             ) => {
@@ -298,26 +298,19 @@ const transform = (
                 .sendRequest({
                   type: "resolve",
                   options: rustOptions,
-                  context: toPath(context),
+                  lookupPath: toPath(lookupPath),
                   request,
                 })
-                .then(
-                  (unknownResult) => {
-                    let result = unknownResult as { path: string };
-                    if (result && typeof result.path === "string") {
-                      console.log({ context, request, result: result.path });
-                      return fromPath(result.path);
-                    } else {
-                      throw Error(
-                        "Expected { path: string } from resolve request"
-                      );
-                    }
-                  },
-                  (e) => {
-                    console.log({ context, request, error: e });
-                    throw e;
+                .then((unknownResult) => {
+                  let result = unknownResult as { path: string };
+                  if (result && typeof result.path === "string") {
+                    return fromPath(result.path);
+                  } else {
+                    throw Error(
+                      "Expected { path: string } from resolve request"
+                    );
                   }
-                );
+                });
               if (callback) {
                 promise
                   .then(

--- a/crates/turbopack-node/js/src/transforms/webpack-loaders.ts
+++ b/crates/turbopack-node/js/src/transforms/webpack-loaders.ts
@@ -6,6 +6,7 @@ import type { Ipc } from "../ipc/evaluate";
 import {
   relative,
   isAbsolute,
+  join,
   sep,
   dirname,
   resolve as pathResolve,
@@ -14,6 +15,34 @@ import {
   StackFrame,
   parse as parseStackTrace,
 } from "../compiled/stacktrace-parser";
+import { type StructuredError } from "src/ipc";
+
+export type IpcInfoMessage =
+  | {
+      type: "fileDependency";
+      path: string;
+    }
+  | {
+      type: "buildDependency";
+      path: string;
+    }
+  | {
+      type: "dirDependency";
+      path: string;
+      glob: string;
+    }
+  | {
+      type: "emittedError";
+      severity: "warning" | "error";
+      error: StructuredError;
+    };
+
+export type IpcRequestMessage = {
+  type: "resolve";
+  options: any;
+  context: string;
+  request: string;
+};
 
 type LoaderConfig =
   | string
@@ -38,6 +67,9 @@ const toPath = (file: string) => {
     );
   }
   return sep !== "/" ? relPath.replaceAll(sep, "/") : relPath;
+};
+const fromPath = (path: string) => {
+  return join(contextDir, sep !== "/" ? path.replaceAll("/", sep) : path);
 };
 
 const LogType = Object.freeze({
@@ -95,8 +127,48 @@ class DummySpan {
   }
 }
 
+type ResolveOptions = {
+  dependencyType?: string;
+  alias?: Record<string, string[]> | unknown[];
+  aliasFields?: string[];
+  cacheWithContext?: boolean;
+  conditionNames?: string[];
+  descriptionFiles?: string[];
+  enforceExtension?: boolean;
+  extensionAlias: Record<string, string[]>;
+  extensions?: string[];
+  fallback?: Record<string, string[]>;
+  mainFields?: string[];
+  mainFiles?: string[];
+  exportsFields?: string[];
+  modules?: string[];
+  plugins?: unknown[];
+  symlinks?: boolean;
+  unsafeCache?: boolean;
+  useSyncFileSystemCalls?: boolean;
+  preferRelative?: boolean;
+  preferAbsolute?: boolean;
+  restrictions?: unknown[];
+  roots?: string[];
+  importFields?: string[];
+};
+const SUPPORTED_RESOLVE_OPTIONS = new Set([
+  "alias",
+  "aliasFields",
+  "conditionNames",
+  "descriptionFiles",
+  "extensions",
+  "exportsFields",
+  "mainFields",
+  "mainFiles",
+  "modules",
+  "restrictions",
+  "preferRelative",
+  "dependencyType",
+]);
+
 const transform = (
-  ipc: Ipc,
+  ipc: Ipc<IpcInfoMessage, IpcRequestMessage>,
   content: string,
   name: string,
   loaders: LoaderConfig[]
@@ -121,9 +193,145 @@ const transform = (
               ? entry.options
               : {};
           },
-          getResolve: () => ({
-            // [TODO] this is incomplete
-          }),
+          getResolve: (options: ResolveOptions) => {
+            const rustOptions = {
+              noAlias: false,
+              aliasFields: undefined as undefined | string[],
+              conditionNames: undefined as undefined | string[],
+              noPackageJson: false,
+              extensions: undefined as undefined | string[],
+              mainFields: undefined as undefined | string[],
+              noExportsField: false,
+              mainFiles: undefined as undefined | string[],
+              noModules: false,
+              preferRelative: false,
+            };
+            if (options.alias) {
+              if (!Array.isArray(options.alias) || options.alias.length > 0) {
+                throw new Error("alias resolve option is not supported");
+              }
+              rustOptions.noAlias = true;
+            }
+            if (options.aliasFields) {
+              if (!Array.isArray(options.aliasFields)) {
+                throw new Error("aliasFields resolve option must be an array");
+              }
+              rustOptions.aliasFields = options.aliasFields;
+            }
+            if (options.conditionNames) {
+              if (!Array.isArray(options.conditionNames)) {
+                throw new Error(
+                  "conditionNames resolve option must be an array"
+                );
+              }
+              rustOptions.conditionNames = options.conditionNames;
+            }
+            if (options.descriptionFiles) {
+              if (
+                !Array.isArray(options.descriptionFiles) ||
+                options.descriptionFiles.length > 0
+              ) {
+                throw new Error(
+                  "descriptionFiles resolve option is not supported"
+                );
+              }
+              rustOptions.noPackageJson = true;
+            }
+            if (options.extensions) {
+              if (!Array.isArray(options.extensions)) {
+                throw new Error("extensions resolve option must be an array");
+              }
+              rustOptions.extensions = options.extensions;
+            }
+            if (options.mainFields) {
+              if (!Array.isArray(options.mainFields)) {
+                throw new Error("mainFields resolve option must be an array");
+              }
+              rustOptions.mainFields = options.mainFields;
+            }
+            if (options.exportsFields) {
+              if (
+                !Array.isArray(options.exportsFields) ||
+                options.exportsFields.length > 0
+              ) {
+                throw new Error(
+                  "exportsFields resolve option is not supported"
+                );
+              }
+              rustOptions.noExportsField = true;
+            }
+            if (options.mainFiles) {
+              if (!Array.isArray(options.mainFiles)) {
+                throw new Error("mainFiles resolve option must be an array");
+              }
+              rustOptions.mainFiles = options.mainFiles;
+            }
+            if (options.modules) {
+              if (
+                !Array.isArray(options.modules) ||
+                options.modules.length > 0
+              ) {
+                throw new Error("modules resolve option is not supported");
+              }
+              rustOptions.noModules = true;
+            }
+            if (options.restrictions) {
+              // TODO This is ignored for now
+            }
+            if (options.dependencyType) {
+              // TODO This is ignored for now
+            }
+            if (options.preferRelative) {
+              if (typeof options.preferRelative !== "boolean") {
+                throw new Error(
+                  "preferRelative resolve option must be a boolean"
+                );
+              }
+              rustOptions.preferRelative = options.preferRelative;
+            }
+            return (
+              context: string,
+              request: string,
+              callback?: (err?: Error, result?: string) => void
+            ) => {
+              const promise = ipc
+                .sendRequest({
+                  type: "resolve",
+                  options: rustOptions,
+                  context: toPath(context),
+                  request,
+                })
+                .then(
+                  (unknownResult) => {
+                    let result = unknownResult as { path: string };
+                    if (result && typeof result.path === "string") {
+                      console.log({ context, request, result: result.path });
+                      return fromPath(result.path);
+                    } else {
+                      throw Error(
+                        "Expected { path: string } from resolve request"
+                      );
+                    }
+                  },
+                  (e) => {
+                    console.log({ context, request, error: e });
+                    throw e;
+                  }
+                );
+              if (callback) {
+                promise
+                  .then(
+                    (result) => callback(undefined, result),
+                    (err) => callback(err)
+                  )
+                  .catch((err) => {
+                    ipc.sendError(err);
+                  });
+              } else {
+                return promise;
+              }
+            };
+          },
           emitWarning: makeErrorEmitter("warning", ipc),
           emitError: makeErrorEmitter("error", ipc),
           getLogger(name: unknown) {
@@ -164,14 +372,14 @@ const transform = (
       (err, result) => {
         if (err) return reject(err);
         for (const dep of result.contextDependencies) {
-          ipc.send({
+          ipc.sendInfo({
             type: "dirDependency",
             path: toPath(dep),
             glob: "**",
           });
         }
         for (const dep of result.fileDependencies) {
-          ipc.send({
+          ipc.sendInfo({
             type: "fileDependency",
             path: toPath(dep),
           });
@@ -186,9 +394,12 @@ const transform = (
 
 export { transform as default };
 
-function makeErrorEmitter(severity: "warning" | "error", ipc: Ipc) {
+function makeErrorEmitter(
+  severity: "warning" | "error",
+  ipc: Ipc<IpcInfoMessage, IpcRequestMessage>
+) {
   return function (error: Error | string) {
-    ipc.send({
+    ipc.sendInfo({
       type: "emittedError",
       severity: severity,
       error:

--- a/crates/turbopack-node/src/evaluate.rs
+++ b/crates/turbopack-node/src/evaluate.rs
@@ -2,6 +2,7 @@ use std::{borrow::Cow, ops::ControlFlow, thread::available_parallelism, time::Du
 
 use anyhow::{anyhow, bail, Result};
 use async_stream::try_stream as generator;
+use async_trait::async_trait;
 use futures::{
     channel::mpsc::{unbounded, UnboundedSender},
     pin_mut, SinkExt, StreamExt,
@@ -9,23 +10,23 @@ use futures::{
 use futures_retry::{FutureRetry, RetryPolicy};
 use indexmap::indexmap;
 use parking_lot::Mutex;
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use turbo_tasks::{
-    duration_span, mark_finished, util::SharedError, Completion, RawVc, TryJoinIterExt, Value, Vc,
+    duration_span, mark_finished, util::SharedError, Completion, RawVc, TaskInput, TryJoinIterExt,
+    Value, Vc,
 };
 use turbo_tasks_bytes::{Bytes, Stream};
 use turbo_tasks_env::ProcessEnv;
-use turbo_tasks_fs::{
-    glob::Glob, to_sys_path, DirectoryEntry, File, FileSystemPath, ReadGlobResult,
-};
+use turbo_tasks_fs::{to_sys_path, File, FileSystemPath};
 use turbopack_core::{
     asset::AssetContent,
     chunk::{ChunkingContext, EvaluatableAsset, EvaluatableAssets},
     context::AssetContext,
+    error::PrettyPrintError,
     file_source::FileSource,
     ident::AssetIdent,
-    issue::{Issue, IssueExt, IssueSeverity, IssueStage, OptionStyledString, StyledString},
+    issue::{Issue, IssueExt, IssueStage, OptionStyledString, StyledString},
     module::Module,
     reference_type::{InnerAssets, ReferenceType},
     virtual_source::VirtualSource,
@@ -45,33 +46,19 @@ use crate::{
 enum EvalJavaScriptOutgoingMessage<'a> {
     #[serde(rename_all = "camelCase")]
     Evaluate { args: Vec<&'a JsonValue> },
+    Result {
+        id: u64,
+        data: Option<JsonValue>,
+        error: Option<String>,
+    },
 }
 
 #[derive(Deserialize, Debug)]
 #[serde(tag = "type", rename_all = "camelCase")]
 enum EvalJavaScriptIncomingMessage {
-    FileDependency {
-        path: String,
-    },
-    BuildDependency {
-        path: String,
-    },
-    DirDependency {
-        path: String,
-        glob: String,
-    },
-    EmittedError {
-        severity: IssueSeverity,
-        error: StructuredError,
-    },
-    Value {
-        // TODO(WEB-735): There is like 3 levels of JSON string encoding that goes into returning a
-        // value, making it really inefficient.
-        data: String,
-    },
-    End {
-        data: Option<String>,
-    },
+    Info { data: JsonValue },
+    Request { id: u64, data: JsonValue },
+    End { data: Option<String> },
     Error(StructuredError),
 }
 
@@ -81,7 +68,7 @@ type EvaluationItem = Result<Bytes, SharedError>;
 type JavaScriptStream = Stream<EvaluationItem>;
 
 #[turbo_tasks::value(eq = "manual", cell = "new", serialization = "none")]
-struct JavaScriptStreamSender {
+pub struct JavaScriptStreamSender {
     #[turbo_tasks(trace_ignore, debug_ignore)]
     get: Box<dyn Fn() -> UnboundedSender<Result<Bytes, SharedError>> + Send + Sync>,
 }
@@ -127,11 +114,7 @@ pub async fn get_evaluate_pool(
             Vc::upcast(VirtualSource::new(
                 runtime_asset.ident().path().join("evaluate.js".to_string()),
                 AssetContent::file(
-                    File::from(
-                        "import { run } from 'RUNTIME'; run(async (...args) => ((await \
-                         import('INNER')).default(...args)))",
-                    )
-                    .into(),
+                    File::from("import { run } from 'RUNTIME'; run(() => import('INNER'))").into(),
                 ),
             )),
             Value::new(ReferenceType::Internal(Vc::cell(indexmap! {
@@ -229,21 +212,29 @@ impl futures_retry::ErrorHandler<anyhow::Error> for PoolErrorHandler {
     }
 }
 
-/// Pass the file you cared as `runtime_entries` to invalidate and reload the
-/// evaluated result automatically.
-#[turbo_tasks::function]
-pub fn evaluate(
-    module_asset: Vc<Box<dyn Module>>,
-    cwd: Vc<FileSystemPath>,
-    env: Vc<Box<dyn ProcessEnv>>,
-    context_ident_for_issue: Vc<AssetIdent>,
-    asset_context: Vc<Box<dyn AssetContext>>,
-    chunking_context: Vc<Box<dyn ChunkingContext>>,
-    runtime_entries: Option<Vc<EvaluatableAssets>>,
-    args: Vec<Vc<JsonValue>>,
-    additional_invalidation: Vc<Completion>,
-    debug: bool,
-) -> Vc<JavaScriptEvaluation> {
+#[async_trait]
+pub trait EvaluateContext {
+    type InfoMessage: DeserializeOwned;
+    type RequestMessage: DeserializeOwned;
+    type ResponseMessage: Serialize;
+
+    fn compute(self, sender: Vc<JavaScriptStreamSender>);
+    fn pool(&self) -> Vc<NodeJsPool>;
+    fn keep_alive(&self) -> bool {
+        false
+    }
+    fn args(&self) -> &[Vc<JsonValue>];
+    fn cwd(&self) -> Vc<FileSystemPath>;
+    async fn emit_error(&self, error: StructuredError, pool: &NodeJsPool) -> Result<()>;
+    async fn info(&self, data: Self::InfoMessage, pool: &NodeJsPool) -> Result<()>;
+    async fn request(
+        &self,
+        data: Self::RequestMessage,
+        pool: &NodeJsPool,
+    ) -> Result<Self::ResponseMessage>;
+}
+
+pub fn custom_evaluate(context: impl EvaluateContext) -> Vc<JavaScriptEvaluation> {
     // Note the following code uses some hacks to create a child task that produces
     // a stream that is returned by this task.
 
@@ -261,17 +252,7 @@ pub fn evaluate(
     let initial = Mutex::new(Some(sender));
 
     // run the evaluation as side effect
-    let _ = compute_evaluate_stream(
-        module_asset,
-        cwd,
-        env,
-        context_ident_for_issue,
-        asset_context,
-        chunking_context,
-        runtime_entries,
-        args,
-        additional_invalidation,
-        debug,
+    context.compute(
         JavaScriptStreamSender {
             get: Box::new(move || {
                 if let Some(sender) = initial.lock().take() {
@@ -295,8 +276,10 @@ pub fn evaluate(
     raw.into()
 }
 
+/// Pass the file you cared as `runtime_entries` to invalidate and reload the
+/// evaluated result automatically.
 #[turbo_tasks::function]
-async fn compute_evaluate_stream(
+pub fn evaluate(
     module_asset: Vc<Box<dyn Module>>,
     cwd: Vc<FileSystemPath>,
     env: Vc<Box<dyn ProcessEnv>>,
@@ -307,6 +290,23 @@ async fn compute_evaluate_stream(
     args: Vec<Vc<JsonValue>>,
     additional_invalidation: Vc<Completion>,
     debug: bool,
+) -> Vc<JavaScriptEvaluation> {
+    custom_evaluate(BasicEvaluateContext {
+        module_asset,
+        cwd,
+        env,
+        context_ident_for_issue,
+        asset_context,
+        chunking_context,
+        runtime_entries,
+        args,
+        additional_invalidation,
+        debug,
+    })
+}
+
+pub async fn compute(
+    context: impl EvaluateContext,
     sender: Vc<JavaScriptStreamSender>,
 ) -> Result<Vc<()>> {
     mark_finished();
@@ -316,22 +316,13 @@ async fn compute_evaluate_stream(
     };
 
     let stream = generator! {
-        let pool = get_evaluate_pool(
-            module_asset,
-            cwd,
-            env,
-            asset_context,
-            chunking_context,
-            runtime_entries,
-            additional_invalidation,
-            debug,
-        );
+        let pool = context.pool();
 
         // Read this strongly consistent, since we don't want to run inconsistent
         // node.js code.
         let pool = pool.strongly_consistent().await?;
 
-        let args = args.into_iter().try_join().await?;
+        let args = context.args().into_iter().try_join().await?;
         // Assume this is a one-off operation, so we can kill the process
         // TODO use a better way to decide that.
         let kill = args.is_empty();
@@ -360,7 +351,7 @@ async fn compute_evaluate_stream(
         // need to spawn a new thread to continually pull data out of the process,
         // and ferry that along.
         loop {
-            let output = pull_operation(&mut operation, cwd, &pool, context_ident_for_issue, chunking_context).await?;
+            let output = pull_operation(&mut operation, &pool, &context).await?;
 
             match output {
                 LoopResult::Continue(data) => {
@@ -371,7 +362,7 @@ async fn compute_evaluate_stream(
                     break;
                 }
                 LoopResult::Break(Err(e)) => {
-                    let error = e.print(pool.assets_for_source_mapping, pool.assets_root, chunking_context.context_path().root(), FormattingMode::Plain).await?;
+                    let error = print_error(e, &pool, &context).await?;
                     Err(anyhow!("Node.js evaluation failed: {}", error))?;
                     break;
                 }
@@ -404,82 +395,150 @@ async fn compute_evaluate_stream(
 /// value/error/end.
 async fn pull_operation(
     operation: &mut NodeJsOperation,
-    cwd: Vc<FileSystemPath>,
     pool: &NodeJsPool,
-    context_ident_for_issue: Vc<AssetIdent>,
-    chunking_context: Vc<Box<dyn ChunkingContext>>,
+    context: &impl EvaluateContext,
 ) -> Result<LoopResult> {
-    let mut file_dependencies = Vec::new();
-    let mut dir_dependencies = Vec::new();
-
     let guard = duration_span!("Node.js evaluation");
 
     let output = loop {
         match operation.recv().await? {
             EvalJavaScriptIncomingMessage::Error(error) => {
-                EvaluationIssue {
-                    error,
-                    context_ident: context_ident_for_issue,
-                    assets_for_source_mapping: pool.assets_for_source_mapping,
-                    assets_root: pool.assets_root,
-                    project_dir: chunking_context.context_path().root(),
-                }
-                .cell()
-                .emit();
+                context.emit_error(error, pool).await?;
                 // Do not reuse the process in case of error
                 operation.disallow_reuse();
                 // Issue emitted, we want to break but don't want to return an error
                 break ControlFlow::Break(Ok(None));
             }
-            EvalJavaScriptIncomingMessage::Value { data } => break ControlFlow::Continue(data),
             EvalJavaScriptIncomingMessage::End { data } => break ControlFlow::Break(Ok(data)),
-            EvalJavaScriptIncomingMessage::FileDependency { path } => {
-                // TODO We might miss some changes that happened during execution
-                file_dependencies.push(cwd.join(path).read());
+            EvalJavaScriptIncomingMessage::Info { data } => {
+                context.info(serde_json::from_value(data)?, pool).await?;
             }
-            EvalJavaScriptIncomingMessage::BuildDependency { path } => {
-                // TODO We might miss some changes that happened during execution
-                BuildDependencyIssue {
-                    context_ident: context_ident_for_issue,
-                    path: cwd.join(path),
+            EvalJavaScriptIncomingMessage::Request { id, data } => {
+                match context.request(serde_json::from_value(data)?, pool).await {
+                    Ok(response) => {
+                        operation
+                            .send(EvalJavaScriptOutgoingMessage::Result {
+                                id,
+                                error: None,
+                                data: Some(serde_json::to_value(response)?),
+                            })
+                            .await?;
+                    }
+                    Err(e) => {
+                        operation
+                            .send(EvalJavaScriptOutgoingMessage::Result {
+                                id,
+                                error: Some(PrettyPrintError(&e).to_string()),
+                                data: None,
+                            })
+                            .await?;
+                    }
                 }
-                .cell()
-                .emit();
-            }
-            EvalJavaScriptIncomingMessage::DirDependency { path, glob } => {
-                // TODO We might miss some changes that happened during execution
-                dir_dependencies.push(dir_dependency(
-                    cwd.join(path).read_glob(Glob::new(glob), false),
-                ));
-            }
-            EvalJavaScriptIncomingMessage::EmittedError { error, severity } => {
-                EvaluateEmittedErrorIssue {
-                    file_path: context_ident_for_issue.path(),
-                    error,
-                    severity: severity.cell(),
-                    assets_for_source_mapping: pool.assets_for_source_mapping,
-                    assets_root: pool.assets_root,
-                    project_dir: chunking_context.context_path().root(),
-                }
-                .cell()
-                .emit();
             }
         }
     };
     drop(guard);
 
-    // Read dependencies to make them a dependencies of this task. This task will
-    // execute again when they change.
-    for dep in file_dependencies {
-        dep.await?;
-    }
-    for dep in dir_dependencies {
-        dep.await?;
-    }
-
     Ok(output)
 }
 
+#[turbo_tasks::function]
+async fn basic_compute(
+    context: BasicEvaluateContext,
+    sender: Vc<JavaScriptStreamSender>,
+) -> Result<Vc<()>> {
+    compute(context, sender).await
+}
+
+#[derive(Clone, PartialEq, Eq, TaskInput)]
+struct BasicEvaluateContext {
+    module_asset: Vc<Box<dyn Module>>,
+    cwd: Vc<FileSystemPath>,
+    env: Vc<Box<dyn ProcessEnv>>,
+    context_ident_for_issue: Vc<AssetIdent>,
+    asset_context: Vc<Box<dyn AssetContext>>,
+    chunking_context: Vc<Box<dyn ChunkingContext>>,
+    runtime_entries: Option<Vc<EvaluatableAssets>>,
+    args: Vec<Vc<JsonValue>>,
+    additional_invalidation: Vc<Completion>,
+    debug: bool,
+}
+
+#[async_trait]
+impl EvaluateContext for BasicEvaluateContext {
+    type InfoMessage = ();
+    type RequestMessage = ();
+    type ResponseMessage = ();
+
+    fn compute(self, sender: Vc<JavaScriptStreamSender>) {
+        let _ = basic_compute(self, sender);
+    }
+
+    fn pool(&self) -> Vc<crate::pool::NodeJsPool> {
+        get_evaluate_pool(
+            self.module_asset,
+            self.cwd,
+            self.env,
+            self.asset_context,
+            self.chunking_context,
+            self.runtime_entries,
+            self.additional_invalidation,
+            self.debug,
+        )
+    }
+
+    fn args(&self) -> &[Vc<serde_json::Value>] {
+        &self.args
+    }
+
+    fn cwd(&self) -> Vc<turbo_tasks_fs::FileSystemPath> {
+        self.cwd
+    }
+
+    fn keep_alive(&self) -> bool {
+        !self.args.is_empty()
+    }
+
+    async fn emit_error(&self, error: StructuredError, pool: &NodeJsPool) -> Result<()> {
+        EvaluationIssue {
+            error,
+            context_ident: self.context_ident_for_issue,
+            assets_for_source_mapping: pool.assets_for_source_mapping,
+            assets_root: pool.assets_root,
+            project_dir: self.chunking_context.context_path().root(),
+        }
+        .cell()
+        .emit();
+        Ok(())
+    }
+
+    async fn info(&self, _data: Self::InfoMessage, _pool: &NodeJsPool) -> Result<()> {
+        bail!("BasicEvaluateContext does not support info messages")
+    }
+
+    async fn request(
+        &self,
+        _data: Self::RequestMessage,
+        _pool: &NodeJsPool,
+    ) -> Result<Self::ResponseMessage> {
+        bail!("BasicEvaluateContext does not support request messages")
+    }
+}
+
+async fn print_error(
+    error: StructuredError,
+    pool: &NodeJsPool,
+    context: &impl EvaluateContext,
+) -> Result<String> {
+    error
+        .print(
+            pool.assets_for_source_mapping,
+            pool.assets_root,
+            context.cwd(),
+            FormattingMode::Plain,
+        )
+        .await
+}
 /// An issue that occurred while evaluating node code.
 #[turbo_tasks::value(shared)]
 pub struct EvaluationIssue {
@@ -505,135 +564,6 @@ impl Issue for EvaluationIssue {
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
         self.context_ident.path()
-    }
-
-    #[turbo_tasks::function]
-    async fn description(&self) -> Result<Vc<OptionStyledString>> {
-        Ok(Vc::cell(Some(
-            StyledString::Text(
-                self.error
-                    .print(
-                        self.assets_for_source_mapping,
-                        self.assets_root,
-                        self.project_dir,
-                        FormattingMode::Plain,
-                    )
-                    .await?,
-            )
-            .cell(),
-        )))
-    }
-}
-
-/// An issue that occurred while evaluating node code.
-#[turbo_tasks::value(shared)]
-pub struct BuildDependencyIssue {
-    pub context_ident: Vc<AssetIdent>,
-    pub path: Vc<FileSystemPath>,
-}
-
-#[turbo_tasks::value_impl]
-impl Issue for BuildDependencyIssue {
-    #[turbo_tasks::function]
-    fn severity(&self) -> Vc<IssueSeverity> {
-        IssueSeverity::Warning.into()
-    }
-
-    #[turbo_tasks::function]
-    fn title(&self) -> Vc<StyledString> {
-        StyledString::Text("Build dependencies are not yet supported".to_string()).cell()
-    }
-
-    #[turbo_tasks::function]
-    fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::Unsupported.cell()
-    }
-
-    #[turbo_tasks::function]
-    fn file_path(&self) -> Vc<FileSystemPath> {
-        self.context_ident.path()
-    }
-
-    #[turbo_tasks::function]
-    async fn description(&self) -> Result<Vc<OptionStyledString>> {
-        Ok(Vc::cell(Some(StyledString::Line(vec![
-            StyledString::Text("The file at ".to_string()),
-            StyledString::Code(self.path.await?.to_string()),
-            StyledString::Text(" is a build dependency, which is not yet implemented.
-Changing this file or any dependency will not be recognized and might require restarting the server".to_string()),
-        ]).cell())))
-    }
-}
-
-/// A hack to invalidate when any file in a directory changes. Need to be
-/// awaited before files are accessed.
-#[turbo_tasks::function]
-async fn dir_dependency(glob: Vc<ReadGlobResult>) -> Result<Vc<Completion>> {
-    let shallow = dir_dependency_shallow(glob);
-    let glob = glob.await?;
-    glob.inner
-        .values()
-        .map(|&inner| dir_dependency(inner))
-        .try_join()
-        .await?;
-    shallow.await?;
-    Ok(Completion::new())
-}
-
-#[turbo_tasks::function]
-async fn dir_dependency_shallow(glob: Vc<ReadGlobResult>) -> Result<Vc<Completion>> {
-    let glob = glob.await?;
-    for item in glob.results.values() {
-        // Reading all files to add itself as dependency
-        match *item {
-            DirectoryEntry::File(file) => {
-                file.track().await?;
-            }
-            DirectoryEntry::Directory(dir) => {
-                dir_dependency(dir.read_glob(Glob::new("**".to_string()), false)).await?;
-            }
-            DirectoryEntry::Symlink(symlink) => {
-                symlink.read_link().await?;
-            }
-            DirectoryEntry::Other(other) => {
-                other.get_type().await?;
-            }
-            DirectoryEntry::Error => {}
-        }
-    }
-    Ok(Completion::new())
-}
-
-#[turbo_tasks::value(shared)]
-pub struct EvaluateEmittedErrorIssue {
-    pub file_path: Vc<FileSystemPath>,
-    pub severity: Vc<IssueSeverity>,
-    pub error: StructuredError,
-    pub assets_for_source_mapping: Vc<AssetsForSourceMapping>,
-    pub assets_root: Vc<FileSystemPath>,
-    pub project_dir: Vc<FileSystemPath>,
-}
-
-#[turbo_tasks::value_impl]
-impl Issue for EvaluateEmittedErrorIssue {
-    #[turbo_tasks::function]
-    fn file_path(&self) -> Vc<FileSystemPath> {
-        self.file_path
-    }
-
-    #[turbo_tasks::function]
-    fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::Transform.cell()
-    }
-
-    #[turbo_tasks::function]
-    fn severity(&self) -> Vc<IssueSeverity> {
-        self.severity
-    }
-
-    #[turbo_tasks::function]
-    fn title(&self) -> Vc<StyledString> {
-        StyledString::Text("Issue while running loader".to_string()).cell()
     }
 
     #[turbo_tasks::function]

--- a/crates/turbopack-node/src/evaluate.rs
+++ b/crates/turbopack-node/src/evaluate.rs
@@ -322,7 +322,7 @@ pub async fn compute(
         // node.js code.
         let pool = pool.strongly_consistent().await?;
 
-        let args = context.args().into_iter().try_join().await?;
+        let args = context.args().iter().try_join().await?;
         // Assume this is a one-off operation, so we can kill the process
         // TODO use a better way to decide that.
         let kill = args.is_empty();

--- a/crates/turbopack-node/src/lib.rs
+++ b/crates/turbopack-node/src/lib.rs
@@ -2,6 +2,7 @@
 #![feature(min_specialization)]
 #![feature(lint_reasons)]
 #![feature(arbitrary_self_types)]
+#![feature(extract_if)]
 
 use std::{collections::HashMap, iter::once, thread::available_parallelism};
 

--- a/crates/turbopack-node/src/transforms/postcss.rs
+++ b/crates/turbopack-node/src/transforms/postcss.rs
@@ -26,11 +26,11 @@ use turbopack_core::{
     virtual_source::VirtualSource,
 };
 
-use super::util::{emitted_assets_to_virtual_sources, EmittedAsset};
-use crate::{
-    debug::should_debug, embed_js::embed_file, evaluate::evaluate,
-    execution_context::ExecutionContext,
+use super::{
+    util::{emitted_assets_to_virtual_sources, EmittedAsset},
+    webpack::WebpackLoaderContext,
 };
+use crate::{embed_js::embed_file, evaluate::custom_evaluate, execution_context::ExecutionContext};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -370,18 +370,17 @@ impl PostCssTransformedAsset {
         let css_fs_path = this.source.ident().path().await?;
         let css_path = css_fs_path.path.as_str();
 
-        let config_value = evaluate(
-            postcss_executor,
-            project_path,
+        let config_value = custom_evaluate(WebpackLoaderContext {
+            module_asset: postcss_executor,
+            cwd: project_path,
             env,
-            this.source.ident(),
-            evaluate_context,
+            context_ident_for_issue: this.source.ident(),
+            asset_context: evaluate_context,
             chunking_context,
-            None,
-            vec![Vc::cell(content.into()), Vc::cell(css_path.into())],
-            config_changed,
-            should_debug("postcss_transform"),
-        )
+            resolve_options_context: None,
+            args: vec![Vc::cell(content.into()), Vc::cell(css_path.into())],
+            additional_invalidation: config_changed,
+        })
         .await?;
 
         let SingleValue::Single(val) = config_value.try_into_single().await? else {

--- a/crates/turbopack-node/src/transforms/webpack.rs
+++ b/crates/turbopack-node/src/transforms/webpack.rs
@@ -1,24 +1,54 @@
+use std::mem::take;
+
 use anyhow::{bail, Context, Result};
+use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
-use serde_json::json;
-use turbo_tasks::{trace::TraceRawVcs, Completion, Value, Vc};
+use serde_json::{json, Value as JsonValue};
+use turbo_tasks::{
+    trace::TraceRawVcs, Completion, TaskInput, TryJoinIterExt, Value, ValueToString, Vc,
+};
 use turbo_tasks_bytes::stream::SingleValue;
-use turbo_tasks_fs::{json::parse_json_with_source_context, File, FileContent};
+use turbo_tasks_env::ProcessEnv;
+use turbo_tasks_fs::{
+    glob::Glob, json::parse_json_with_source_context, DirectoryEntry, File, FileContent,
+    FileSystemPath, ReadGlobResult,
+};
 use turbopack_core::{
     asset::{Asset, AssetContent},
+    chunk::ChunkingContext,
     context::{AssetContext, ProcessResult},
     file_source::FileSource,
     ident::AssetIdent,
+    issue::{Issue, IssueExt, IssueSeverity, IssueStage, OptionStyledString, StyledString},
+    module::Module,
     reference_type::{InnerAssets, ReferenceType},
+    resolve::{
+        options::{ConditionValue, ResolveInPackage, ResolveIntoPackage, ResolveOptions},
+        parse::Request,
+        pattern::Pattern,
+        resolve,
+    },
     source::Source,
     source_transform::SourceTransform,
     virtual_source::VirtualSource,
 };
+use turbopack_resolve::{
+    ecmascript::get_condition_maps, resolve::resolve_options,
+    resolve_options_context::ResolveOptionsContext,
+};
 
 use super::util::{emitted_assets_to_virtual_sources, EmittedAsset};
 use crate::{
-    debug::should_debug, embed_js::embed_file_path, evaluate::evaluate,
+    debug::should_debug,
+    embed_js::embed_file_path,
+    evaluate::{
+        compute, custom_evaluate, get_evaluate_pool, EvaluateContext, EvaluationIssue,
+        JavaScriptEvaluation, JavaScriptStreamSender,
+    },
     execution_context::ExecutionContext,
+    pool::{FormattingMode, NodeJsPool},
+    source_map::StructuredError,
+    AssetsForSourceMapping,
 };
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -48,6 +78,7 @@ pub struct WebpackLoaders {
     execution_context: Vc<ExecutionContext>,
     loaders: Vc<WebpackLoaderItems>,
     rename_as: Option<String>,
+    resolve_options_context: Vc<ResolveOptionsContext>,
 }
 
 #[turbo_tasks::value_impl]
@@ -58,12 +89,14 @@ impl WebpackLoaders {
         execution_context: Vc<ExecutionContext>,
         loaders: Vc<WebpackLoaderItems>,
         rename_as: Option<String>,
+        resolve_options_context: Vc<ResolveOptionsContext>,
     ) -> Vc<Self> {
         WebpackLoaders {
             evaluate_context,
             execution_context,
             loaders,
             rename_as,
+            resolve_options_context,
         }
         .cell()
     }
@@ -155,24 +188,26 @@ impl WebpackLoadersProcessedAsset {
 
         let webpack_loaders_executor = webpack_loaders_executor(evaluate_context).module();
         let resource_fs_path = this.source.ident().path().await?;
-        let resource_path = resource_fs_path.path.as_str();
+        let Some(resource_path) = project_path.await?.get_relative_path_to(&resource_fs_path)
+        else {
+            bail!("Resource path need to be on project filesystem");
+        };
         let loaders = transform.loaders.await?;
-        let config_value = evaluate(
-            webpack_loaders_executor,
-            project_path,
+        let config_value = custom_evaluate(WebpackLoaderContext {
+            module_asset: webpack_loaders_executor,
+            cwd: project_path,
             env,
-            this.source.ident(),
-            evaluate_context,
+            context_ident_for_issue: this.source.ident(),
+            asset_context: evaluate_context,
             chunking_context,
-            None,
-            vec![
+            resolve_options_context: Some(transform.resolve_options_context),
+            args: vec![
                 Vc::cell(content.into()),
                 Vc::cell(resource_path.into()),
                 Vc::cell(json!(*loaders)),
             ],
-            Completion::immutable(),
-            should_debug("webpack_loader"),
-        )
+            additional_invalidation: Completion::immutable(),
+        })
         .await?;
 
         let SingleValue::Single(val) = config_value.try_into_single().await? else {
@@ -193,5 +228,433 @@ impl WebpackLoadersProcessedAsset {
         let assets = emitted_assets_to_virtual_sources(processed.assets);
         let content = AssetContent::File(FileContent::Content(file).cell()).cell();
         Ok(ProcessWebpackLoadersResult { content, assets }.cell())
+    }
+}
+
+#[turbo_tasks::function]
+fn evaluate_webpack_loader(context: WebpackLoaderContext) -> Vc<JavaScriptEvaluation> {
+    custom_evaluate(context)
+}
+
+#[turbo_tasks::function]
+async fn compute_webpack_loader_evaluation(
+    context: WebpackLoaderContext,
+    sender: Vc<JavaScriptStreamSender>,
+) -> Result<Vc<()>> {
+    compute(context, sender).await
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum InfoMessage {
+    FileDependency {
+        path: String,
+    },
+    BuildDependency {
+        path: String,
+    },
+    DirDependency {
+        path: String,
+        glob: String,
+    },
+    EmittedError {
+        severity: IssueSeverity,
+        error: StructuredError,
+    },
+}
+
+#[derive(Deserialize, Debug, Clone, TaskInput)]
+#[serde(rename_all = "camelCase")]
+
+pub struct WebpackResolveOptions {
+    no_alias: bool,
+    alias_fields: Option<Vec<String>>,
+    condition_names: Option<Vec<String>>,
+    no_package_json: bool,
+    extensions: Option<Vec<String>>,
+    main_fields: Option<Vec<String>>,
+    no_exports_field: bool,
+    main_files: Option<Vec<String>>,
+    no_modules: bool,
+    prefer_relative: bool,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum RequestMessage {
+    Resolve {
+        options: WebpackResolveOptions,
+        context: String,
+        request: String,
+    },
+}
+
+#[derive(Serialize, Debug)]
+#[serde(untagged)]
+pub enum ResponseMessage {
+    Resolve { path: String },
+}
+
+#[derive(Clone, PartialEq, Eq, TaskInput)]
+pub struct WebpackLoaderContext {
+    pub module_asset: Vc<Box<dyn Module>>,
+    pub cwd: Vc<FileSystemPath>,
+    pub env: Vc<Box<dyn ProcessEnv>>,
+    pub context_ident_for_issue: Vc<AssetIdent>,
+    pub asset_context: Vc<Box<dyn AssetContext>>,
+    pub chunking_context: Vc<Box<dyn ChunkingContext>>,
+    pub resolve_options_context: Option<Vc<ResolveOptionsContext>>,
+    pub args: Vec<Vc<JsonValue>>,
+    pub additional_invalidation: Vc<Completion>,
+}
+
+#[async_trait]
+impl EvaluateContext for WebpackLoaderContext {
+    type InfoMessage = InfoMessage;
+    type RequestMessage = RequestMessage;
+    type ResponseMessage = ResponseMessage;
+
+    fn compute(self, sender: Vc<JavaScriptStreamSender>) {
+        let _ = compute_webpack_loader_evaluation(self, sender);
+    }
+
+    fn pool(&self) -> Vc<crate::pool::NodeJsPool> {
+        get_evaluate_pool(
+            self.module_asset,
+            self.cwd,
+            self.env,
+            self.asset_context,
+            self.chunking_context,
+            None,
+            self.additional_invalidation,
+            should_debug("webpack_loader"),
+        )
+    }
+
+    fn args(&self) -> &[Vc<serde_json::Value>] {
+        &self.args
+    }
+
+    fn cwd(&self) -> Vc<turbo_tasks_fs::FileSystemPath> {
+        self.cwd
+    }
+
+    fn keep_alive(&self) -> bool {
+        true
+    }
+
+    async fn emit_error(&self, error: StructuredError, pool: &NodeJsPool) -> Result<()> {
+        EvaluationIssue {
+            error,
+            context_ident: self.context_ident_for_issue,
+            assets_for_source_mapping: pool.assets_for_source_mapping,
+            assets_root: pool.assets_root,
+            project_dir: self.chunking_context.context_path().root(),
+        }
+        .cell()
+        .emit();
+        Ok(())
+    }
+
+    async fn info(&self, data: Self::InfoMessage, pool: &NodeJsPool) -> Result<()> {
+        match data {
+            InfoMessage::FileDependency { path } => {
+                // TODO We might miss some changes that happened during execution
+                // Read dependencies to make them a dependencies of this task. This task will
+                // execute again when they change.
+                self.cwd.join(path).read().await?;
+            }
+            InfoMessage::BuildDependency { path } => {
+                // TODO We might miss some changes that happened during execution
+                BuildDependencyIssue {
+                    context_ident: self.context_ident_for_issue,
+                    path: self.cwd.join(path),
+                }
+                .cell()
+                .emit();
+            }
+            InfoMessage::DirDependency { path, glob } => {
+                // TODO We might miss some changes that happened during execution
+                // Read dependencies to make them a dependencies of this task. This task will
+                // execute again when they change.
+                dir_dependency(self.cwd.join(path).read_glob(Glob::new(glob), false)).await?;
+            }
+            InfoMessage::EmittedError { error, severity } => {
+                EvaluateEmittedErrorIssue {
+                    file_path: self.context_ident_for_issue.path(),
+                    error,
+                    severity: severity.cell(),
+                    assets_for_source_mapping: pool.assets_for_source_mapping,
+                    assets_root: pool.assets_root,
+                    project_dir: self.chunking_context.context_path().root(),
+                }
+                .cell()
+                .emit();
+            }
+        }
+        Ok(())
+    }
+
+    async fn request(
+        &self,
+        data: Self::RequestMessage,
+        _pool: &NodeJsPool,
+    ) -> Result<Self::ResponseMessage> {
+        match data {
+            RequestMessage::Resolve {
+                options: webpack_options,
+                context,
+                request,
+            } => {
+                let Some(resolve_options_context) = self.resolve_options_context else {
+                    bail!("Resolve options are not available in this context");
+                };
+                let context = self.cwd.join(context);
+                let request = Request::parse(Value::new(Pattern::Constant(request)));
+                let options = resolve_options(context, resolve_options_context);
+
+                let options = apply_webpack_resolve_options(options, webpack_options);
+
+                let resolved = resolve(
+                    context,
+                    Value::new(ReferenceType::Undefined),
+                    request,
+                    options,
+                );
+                if let Some(source) = *resolved.first_source().await? {
+                    if let Some(path) = self
+                        .cwd
+                        .await?
+                        .get_relative_path_to(&*source.ident().path().await?)
+                    {
+                        Ok(ResponseMessage::Resolve { path })
+                    } else {
+                        bail!(
+                            "Resolving {} in {} ends up on a different filesystem",
+                            request.to_string().await?,
+                            context.to_string().await?
+                        );
+                    }
+                } else {
+                    bail!(
+                        "Unable to resolve {} in {}",
+                        request.to_string().await?,
+                        context.to_string().await?
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[turbo_tasks::function]
+async fn apply_webpack_resolve_options(
+    resolve_options: Vc<ResolveOptions>,
+    webpack_resolve_options: WebpackResolveOptions,
+) -> Result<Vc<ResolveOptions>> {
+    let mut resolve_options = resolve_options.await?.clone_value();
+    if webpack_resolve_options.no_alias {
+        resolve_options.import_map = None;
+        resolve_options.fallback_import_map = None;
+    }
+    if let Some(alias_fields) = webpack_resolve_options.alias_fields {
+        let mut old = resolve_options
+            .in_package
+            .extract_if(|field| matches!(field, ResolveInPackage::AliasField(..)))
+            .collect::<Vec<_>>();
+        for field in alias_fields {
+            if field == "..." {
+                resolve_options.in_package.extend(take(&mut old));
+            } else {
+                resolve_options
+                    .in_package
+                    .push(ResolveInPackage::AliasField(field));
+            }
+        }
+    }
+    if let Some(condition_names) = webpack_resolve_options.condition_names {
+        for conditions in get_condition_maps(&mut resolve_options) {
+            let mut old = take(conditions);
+            for name in &condition_names {
+                if name == "..." {
+                    conditions.extend(take(&mut old));
+                } else {
+                    conditions.insert(name.clone(), ConditionValue::Set);
+                }
+            }
+        }
+    }
+    if webpack_resolve_options.no_package_json {
+        resolve_options.into_package.retain(|item| {
+            !matches!(
+                item,
+                ResolveIntoPackage::ExportsField { .. } | ResolveIntoPackage::MainField { .. }
+            )
+        });
+    }
+    if let Some(mut extensions) = webpack_resolve_options.extensions {
+        if let Some(pos) = extensions.iter().position(|ext| ext == "...") {
+            extensions.splice(pos..=pos, take(&mut resolve_options.extensions));
+        }
+        resolve_options.extensions = extensions;
+    }
+    if let Some(main_fields) = webpack_resolve_options.main_fields {
+        let mut old = resolve_options
+            .into_package
+            .extract_if(|field| matches!(field, ResolveIntoPackage::MainField { .. }))
+            .collect::<Vec<_>>();
+        for field in main_fields {
+            if field == "..." {
+                resolve_options.into_package.extend(take(&mut old));
+            } else {
+                resolve_options
+                    .into_package
+                    .push(ResolveIntoPackage::MainField { field });
+            }
+        }
+    }
+    if webpack_resolve_options.no_exports_field {
+        resolve_options
+            .into_package
+            .retain(|field| !matches!(field, ResolveIntoPackage::ExportsField { .. }));
+    }
+    if let Some(main_files) = webpack_resolve_options.main_files {
+        resolve_options.default_files = main_files;
+    }
+    if webpack_resolve_options.no_modules {
+        resolve_options.modules.clear();
+    }
+    if webpack_resolve_options.prefer_relative {
+        resolve_options.prefer_relative = true;
+    }
+    Ok(resolve_options.cell())
+}
+
+/// An issue that occurred while evaluating node code.
+#[turbo_tasks::value(shared)]
+pub struct BuildDependencyIssue {
+    pub context_ident: Vc<AssetIdent>,
+    pub path: Vc<FileSystemPath>,
+}
+
+#[turbo_tasks::value_impl]
+impl Issue for BuildDependencyIssue {
+    #[turbo_tasks::function]
+    fn severity(&self) -> Vc<IssueSeverity> {
+        IssueSeverity::Warning.into()
+    }
+
+    #[turbo_tasks::function]
+    fn title(&self) -> Vc<StyledString> {
+        StyledString::Text("Build dependencies are not yet supported".to_string()).cell()
+    }
+
+    #[turbo_tasks::function]
+    fn stage(&self) -> Vc<IssueStage> {
+        IssueStage::Unsupported.cell()
+    }
+
+    #[turbo_tasks::function]
+    fn file_path(&self) -> Vc<FileSystemPath> {
+        self.context_ident.path()
+    }
+
+    #[turbo_tasks::function]
+    async fn description(&self) -> Result<Vc<OptionStyledString>> {
+        Ok(Vc::cell(Some(StyledString::Line(vec![
+            StyledString::Text("The file at ".to_string()),
+            StyledString::Code(self.path.await?.to_string()),
+            StyledString::Text(" is a build dependency, which is not yet implemented.
+Changing this file or any dependency will not be recognized and might require restarting the server".to_string()),
+        ]).cell())))
+    }
+}
+
+/// A hack to invalidate when any file in a directory changes. Need to be
+/// awaited before files are accessed.
+#[turbo_tasks::function]
+async fn dir_dependency(glob: Vc<ReadGlobResult>) -> Result<Vc<Completion>> {
+    let shallow = dir_dependency_shallow(glob);
+    let glob = glob.await?;
+    glob.inner
+        .values()
+        .map(|&inner| dir_dependency(inner))
+        .try_join()
+        .await?;
+    shallow.await?;
+    Ok(Completion::new())
+}
+
+#[turbo_tasks::function]
+async fn dir_dependency_shallow(glob: Vc<ReadGlobResult>) -> Result<Vc<Completion>> {
+    let glob = glob.await?;
+    for item in glob.results.values() {
+        // Reading all files to add itself as dependency
+        match *item {
+            DirectoryEntry::File(file) => {
+                file.track().await?;
+            }
+            DirectoryEntry::Directory(dir) => {
+                dir_dependency(dir.read_glob(Glob::new("**".to_string()), false)).await?;
+            }
+            DirectoryEntry::Symlink(symlink) => {
+                symlink.read_link().await?;
+            }
+            DirectoryEntry::Other(other) => {
+                other.get_type().await?;
+            }
+            DirectoryEntry::Error => {}
+        }
+    }
+    Ok(Completion::new())
+}
+
+#[turbo_tasks::value(shared)]
+pub struct EvaluateEmittedErrorIssue {
+    pub file_path: Vc<FileSystemPath>,
+    pub severity: Vc<IssueSeverity>,
+    pub error: StructuredError,
+    pub assets_for_source_mapping: Vc<AssetsForSourceMapping>,
+    pub assets_root: Vc<FileSystemPath>,
+    pub project_dir: Vc<FileSystemPath>,
+}
+
+#[turbo_tasks::value_impl]
+impl Issue for EvaluateEmittedErrorIssue {
+    #[turbo_tasks::function]
+    fn file_path(&self) -> Vc<FileSystemPath> {
+        self.file_path
+    }
+
+    #[turbo_tasks::function]
+    fn stage(&self) -> Vc<IssueStage> {
+        IssueStage::Transform.cell()
+    }
+
+    #[turbo_tasks::function]
+    fn severity(&self) -> Vc<IssueSeverity> {
+        self.severity
+    }
+
+    #[turbo_tasks::function]
+    fn title(&self) -> Vc<StyledString> {
+        StyledString::Text("Issue while running loader".to_string()).cell()
+    }
+
+    #[turbo_tasks::function]
+    async fn description(&self) -> Result<Vc<OptionStyledString>> {
+        Ok(Vc::cell(Some(
+            StyledString::Text(
+                self.error
+                    .print(
+                        self.assets_for_source_mapping,
+                        self.assets_root,
+                        self.project_dir,
+                        FormattingMode::Plain,
+                    )
+                    .await?,
+            )
+            .cell(),
+        )))
     }
 }

--- a/crates/turbopack/src/lib.rs
+++ b/crates/turbopack/src/lib.rs
@@ -353,6 +353,11 @@ impl ModuleAssetContext {
     }
 
     #[turbo_tasks::function]
+    pub async fn resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
+        Ok(self.await?.resolve_options_context)
+    }
+
+    #[turbo_tasks::function]
     pub async fn is_types_resolving_enabled(self: Vc<Self>) -> Result<Vc<bool>> {
         let resolve_options_context = self.await?.resolve_options_context.await?;
         Ok(Vc::cell(
@@ -424,6 +429,7 @@ async fn process_default_internal(
     let options = ModuleOptions::new(
         ident.path().parent(),
         module_asset_context.module_options_context(),
+        module_asset_context.resolve_options_context(),
     );
 
     let reference_type = reference_type.into_value();

--- a/crates/turbopack/src/module_options/mod.rs
+++ b/crates/turbopack/src/module_options/mod.rs
@@ -20,7 +20,9 @@ use turbopack_mdx::MdxTransformOptions;
 use turbopack_node::transforms::{postcss::PostCssTransform, webpack::WebpackLoaders};
 use turbopack_wasm::source::WebAssemblySourceType;
 
-use crate::evaluate_context::node_evaluate_asset_context;
+use crate::{
+    evaluate_context::node_evaluate_asset_context, resolve_options_context::ResolveOptionsContext,
+};
 
 #[turbo_tasks::function]
 async fn package_import_map_from_import_mapping(
@@ -59,6 +61,7 @@ impl ModuleOptions {
     pub async fn new(
         path: Vc<FileSystemPath>,
         module_options_context: Vc<ModuleOptionsContext>,
+        resolve_options_context: Vc<ResolveOptionsContext>,
     ) -> Result<Vc<ModuleOptions>> {
         let ModuleOptionsContext {
             enable_jsx,
@@ -85,7 +88,11 @@ impl ModuleOptions {
 
             for (condition, new_context) in rules.iter() {
                 if condition.matches(&path_value).await? {
-                    return Ok(ModuleOptions::new(path, *new_context));
+                    return Ok(ModuleOptions::new(
+                        path,
+                        *new_context,
+                        resolve_options_context,
+                    ));
                 }
             }
         }
@@ -548,6 +555,7 @@ impl ModuleOptions {
                                 execution_context,
                                 rule.loaders,
                                 rule.rename_as.clone(),
+                                resolve_options_context,
                             ),
                         )])),
                     ],


### PR DESCRIPTION
### Description

* Increase Node.js execution timeout
* Add ready signal to node.js pool
* add tracing for Node.js bootstrapping
* fixes a tracing bug, where queue time is accounted towards Node.js execution
* refactor evaluation to allow custom message handlers
* add getResolve to webpack loader context

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->


Closes PACK-2633