### PR TITLE
Ignore circular aliasing with alias field

### DIFF
--- a/crates/turbopack-tests/tests/execution/turbopack/resolving/alias-field/input/index.js
+++ b/crates/turbopack-tests/tests/execution/turbopack/resolving/alias-field/input/index.js
@@ -19,3 +19,9 @@ it("should follow the alias field for a module request", () => {
 it("should follow the alias field for a module request with subpath", () => {
   expect(file5).toBe("file5");
 });
+
+import { otherPackage, otherPackageSubPath } from "package/dir";
+it("should not cycle when following the alias field", () => {
+  expect(otherPackage).toBe("other-package/index");
+  expect(otherPackageSubPath).toBe("other-package/sub-path");
+});

--- a/crates/turbopack-tests/tests/execution/turbopack/resolving/alias-field/input/node_modules/other-package/index.js
+++ b/crates/turbopack-tests/tests/execution/turbopack/resolving/alias-field/input/node_modules/other-package/index.js
@@ -1,0 +1,1 @@
+export default "other-package/index"

--- a/crates/turbopack-tests/tests/execution/turbopack/resolving/alias-field/input/node_modules/other-package/sub-path.js
+++ b/crates/turbopack-tests/tests/execution/turbopack/resolving/alias-field/input/node_modules/other-package/sub-path.js
@@ -1,0 +1,1 @@
+export default "other-package/sub-path"

--- a/crates/turbopack-tests/tests/execution/turbopack/resolving/alias-field/input/node_modules/package/dir/index.js
+++ b/crates/turbopack-tests/tests/execution/turbopack/resolving/alias-field/input/node_modules/package/dir/index.js
@@ -3,3 +3,5 @@ export { default as file2 } from "./file2";
 export { default as file3 } from "./file3";
 export { default as file4 } from "file4";
 export { default as file5 } from "file4/file5";
+export { default as otherPackage } from "other-package";
+export { default as otherPackageSubPath } from "other-package/sub-path";

--- a/crates/turbopack-tests/tests/execution/turbopack/resolving/alias-field/input/node_modules/package/package.json
+++ b/crates/turbopack-tests/tests/execution/turbopack/resolving/alias-field/input/node_modules/package/package.json
@@ -4,6 +4,7 @@
     "./dir/file2": "./replaced/file2",
     "dir/file3.js": "./replaced/file3.js",
     "file4": "./replaced/file4",
-    "file4/file5": "./replaced/file5"
+    "file4/file5": "./replaced/file5",
+    "other-package": "other-package"
   }
 }


### PR DESCRIPTION
### Description

Handles the case where alias field is circular:

```
  "browser": {
    "@smithy/chunked-blob-reader": "@smithy/chunked-blob-reader"
  },
```

### Testing Instructions

added test case

Closes PACK-2637