### PR TITLE
chore(Turborepo): refactor telemetry to use turbopath

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11970,6 +11970,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "turbopath",
  "turborepo-api-client",
  "turborepo-dirs",
  "turborepo-ui",

--- a/crates/turborepo-lib/src/commands/telemetry.rs
+++ b/crates/turborepo-lib/src/commands/telemetry.rs
@@ -38,7 +38,7 @@ pub fn configure(
     base: &mut CommandBase,
     telemetry: CommandEventBuilder,
 ) {
-    let config = TelemetryConfig::new();
+    let config = TelemetryConfig::with_default_config_path();
     let mut config = match config {
         Ok(config) => config,
         Err(e) => {

--- a/crates/turborepo-telemetry/Cargo.toml
+++ b/crates/turborepo-telemetry/Cargo.toml
@@ -30,6 +30,7 @@ sha2 = "0.10.8"
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full", "time"] }
 tracing = { workspace = true }
+turbopath = { workspace = true }
 turborepo-api-client = { workspace = true }
 turborepo-dirs = { path = "../turborepo-dirs" }
 turborepo-ui = { workspace = true }

--- a/crates/turborepo-telemetry/src/config.rs
+++ b/crates/turborepo-telemetry/src/config.rs
@@ -1,4 +1,4 @@
-use std::{env, fs};
+use std::env;
 
 use chrono::{DateTime, Utc};
 pub use config::{Config, ConfigError, File, FileFormat};
@@ -93,7 +93,8 @@ impl TelemetryConfig {
     fn write(&self) -> Result<(), ConfigError> {
         let serialized = serde_json::to_string_pretty(&self.config)
             .map_err(|e| ConfigError::Message(e.to_string()))?;
-        fs::write(&self.config_path, serialized)
+        self.config_path
+            .create_with_contents(serialized)
             .map_err(|e| ConfigError::Message(e.to_string()))?;
         Ok(())
     }

--- a/crates/turborepo-telemetry/src/config.rs
+++ b/crates/turborepo-telemetry/src/config.rs
@@ -54,8 +54,12 @@ pub struct TelemetryConfig {
 }
 
 impl TelemetryConfig {
-    pub fn new() -> Result<TelemetryConfig, ConfigError> {
+    pub fn with_default_config_path() -> Result<TelemetryConfig, ConfigError> {
         let config_path = get_config_path()?;
+        TelemetryConfig::new(config_path)
+    }
+
+    pub fn new(config_path: AbsoluteSystemPathBuf) -> Result<TelemetryConfig, ConfigError> {
         debug!("Telemetry config path: {}", config_path);
         if !config_path.exists() {
             write_new_config(&config_path)?;
@@ -100,7 +104,7 @@ impl TelemetryConfig {
     }
 
     pub fn one_way_hash(input: &str) -> String {
-        match TelemetryConfig::new() {
+        match TelemetryConfig::with_default_config_path() {
             Ok(config) => config.one_way_hash_with_config_salt(input),
             Err(_) => TelemetryConfig::one_way_hash_with_tmp_salt(input),
         }
@@ -252,7 +256,7 @@ fn write_new_config(file_path: &AbsoluteSystemPath) -> Result<(), ConfigError> {
     // Create the directory if it doesn't exist
     file_path
         .ensure_dir()
-        .map_err(|_| ConfigError::Message("Failed to create director".to_string()))?;
+        .map_err(|_| ConfigError::Message("Failed to create directory".to_string()))?;
 
     // Write the file
     file_path

--- a/crates/turborepo-telemetry/src/lib.rs
+++ b/crates/turborepo-telemetry/src/lib.rs
@@ -81,7 +81,7 @@ fn init(
 ) -> Result<(TelemetryHandle, TelemetrySender), Box<dyn std::error::Error>> {
     let (tx, rx) = mpsc::unbounded_channel();
     let (cancel_tx, cancel_rx) = oneshot::channel();
-    let mut config = TelemetryConfig::new()?;
+    let mut config = TelemetryConfig::with_default_config_path()?;
     config.show_alert(ui);
 
     let session_id = Uuid::new_v4();


### PR DESCRIPTION
### Description

 - switch to Turbopath to handle paths, rather than strings / `fs` module
 - create separate constructors that use an explicit config path vs one that uses the default
 - prep for refactor to move test code into test module to better control filesystem during test execution

### Testing Instructions

Existing test suite

Closes TURBO-2495