### PR TITLE
chore: Change  to use borrowed path

### DIFF
--- a/crates/turborepo-auth/src/lib.rs
+++ b/crates/turborepo-auth/src/lib.rs
@@ -13,7 +13,7 @@ pub use auth::*;
 pub use error::Error;
 pub use login_server::*;
 use serde::Deserialize;
-use turbopath::AbsoluteSystemPathBuf;
+use turbopath::AbsoluteSystemPath;
 use turborepo_api_client::{CacheClient, Client, TokenClient};
 use turborepo_vercel_api::{token::ResponseTokenMetadata, User};
 
@@ -48,11 +48,11 @@ impl Token {
     /// Reads a token from a file. If the file is a JSON object with a
     /// `token` field, we read that in. If no such field exists, we error out.
     ///
-    /// # Errors
+    /// ## Errors
     /// * `Error::TokenNotFound` - If the file does not exist.
     /// * `Error::InvalidTokenFileFormat` - If the file does not contain a
     ///   properly formatted JSON object with a `token` field.
-    pub fn from_file(path: AbsoluteSystemPathBuf) -> Result<Self, Error> {
+    pub fn from_file(path: &AbsoluteSystemPath) -> Result<Self, Error> {
         #[derive(Deserialize)]
         struct TokenWrapper {
             token: Option<String>,
@@ -259,6 +259,7 @@ fn is_token_active(metadata: &ResponseTokenMetadata, current_time: u128) -> bool
 #[cfg(test)]
 mod tests {
     use tempfile::tempdir;
+    use turbopath::AbsoluteSystemPathBuf;
     use turborepo_vercel_api::token::Scope;
 
     use super::*;
@@ -339,7 +340,7 @@ mod tests {
             .create_with_contents(r#"{"token": "valid_token_here"}"#)
             .unwrap();
 
-        let result = Token::from_file(file_path).expect("Failed to read token from file");
+        let result = Token::from_file(&file_path).expect("Failed to read token from file");
 
         assert!(matches!(result, Token::Existing(ref t) if t == "valid_token_here"));
     }
@@ -352,7 +353,7 @@ mod tests {
             .expect("Failed to create AbsoluteSystemPathBuf");
         file_path.create_with_contents("not a valid json").unwrap();
 
-        let result = Token::from_file(file_path);
+        let result = Token::from_file(&file_path);
         assert!(
             matches!(result, Err(Error::InvalidTokenFileFormat(_))),
             "Expected Err(Error::InvalidTokenFileFormat), got {:?}",
@@ -367,7 +368,7 @@ mod tests {
 
         let file_path = AbsoluteSystemPathBuf::try_from(tmp_path)
             .expect("Failed to create AbsoluteSystemPathBuf");
-        let result = Token::from_file(file_path);
+        let result = Token::from_file(&file_path);
 
         assert!(matches!(result, Err(Error::TokenNotFound)));
     }

--- a/crates/turborepo-lib/src/config.rs
+++ b/crates/turborepo-lib/src/config.rs
@@ -531,7 +531,7 @@ impl TurborepoConfigBuilder {
 
     fn get_global_auth(&self) -> Result<ConfigurationOptions, Error> {
         let global_auth_path = self.global_auth_path()?;
-        let token = match turborepo_auth::Token::from_file(global_auth_path) {
+        let token = match turborepo_auth::Token::from_file(&global_auth_path) {
             Ok(token) => token,
             // Multiple ways this can go wrong. Don't error out if we can't find the token - it
             // just might not be there.


### PR DESCRIPTION
### Description
No need to clone - makes sense to pass in a borrowed path.


Closes TURBO-2498