### PR TITLE
fix: sso login duplicate popup

### DIFF
--- a/crates/turborepo-auth/src/auth/sso.rs
+++ b/crates/turborepo-auth/src/auth/sso.rs
@@ -68,11 +68,9 @@ pub async fn sso_login<'a, T: Client + TokenClient + CacheClient>(
             {
                 return Ok(token);
             }
-        }
-
-        // No existing turbo token found. If the user is logging into Vercel, check for
-        // an existing `vc` token with correct scope.
-        if login_url_configuration.contains("vercel.com") {
+        // No existing turbo token found. If the user is logging into Vercel,
+        // check for an existing `vc` token with correct scope.
+        } else if login_url_configuration.contains("vercel.com") {
             if let Ok(Some(token)) = extract_vercel_token() {
                 let token = Token::existing(token);
                 if token


### PR DESCRIPTION
### Description
Forgot to do the conditional check in the sso login.

### Testing Instructions
Do a couple SSO logins for Vercel (no `--api` flag), the page shouldn't pop up twice.


Closes TURBO-2502