### PR TITLE
fix typo in tsconfig

### DIFF
--- a/examples/with-tailwind/tsconfig.json
+++ b/examples/with-tailwind/tsconfig.json
@@ -1,3 +1,0 @@
-{
-  "extends": "@repo/typescript-config/base.json"
-}

--- a/examples/with-tailwind/tsconfig.json
+++ b/examples/with-tailwind/tsconfig.json
@@ -1,3 +1,3 @@
 {
-  "extends": "tsconfig/base.json"
+  "extends": "@repo/typescript-config/base.json"
 }


### PR DESCRIPTION
There is no package named 'tsconfig'. Replaced it with the correct name which is '@repo/typescript-config'

### Description

Replaced `tsconfig/base.json` with `@repo/typescript-config/base.json`

### Testing Instructions

running `pnpm lint` should work now and also ctrl + click on the extended typescript file in the root's tsconfig.json should work too.