### PR TITLE
chore: vendor vt100 crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,7 +122,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "220044e6a1bb31ddee4e3db724d29767f352de47445a6cd75e1a173142136c83"
 dependencies = [
  "nom",
- "vte",
+ "vte 0.10.1",
 ]
 
 [[package]]
@@ -6384,6 +6384,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
+name = "quickcheck"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
+dependencies = [
+ "env_logger 0.8.4",
+ "log 0.4.20",
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12446,12 +12457,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65dd7eed29412da847b0f78bcec0ac98588165988a8cfe41d4ea1d429f8ccfff"
 
 [[package]]
+name = "vt100"
+version = "0.15.2"
+dependencies = [
+ "itoa",
+ "log 0.4.20",
+ "nix 0.26.2",
+ "quickcheck",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "terminal_size 0.2.6",
+ "unicode-width",
+ "vte 0.11.1",
+]
+
+[[package]]
 name = "vte"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6cbce692ab4ca2f1f3047fcf732430249c0e971bfdd2b234cf2c47ad93af5983"
 dependencies = [
  "arrayvec 0.5.2",
+ "utf8parse",
+ "vte_generate_state_changes",
+]
+
+[[package]]
+name = "vte"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5022b5fbf9407086c180e9557be968742d839e68346af7792b8592489732197"
+dependencies = [
+ "arrayvec 0.7.4",
  "utf8parse",
  "vte_generate_state_changes",
 ]

--- a/crates/turborepo-vt100/.rustfmt.toml
+++ b/crates/turborepo-vt100/.rustfmt.toml
@@ -1,0 +1,2 @@
+edition = "2018"
+max_width = 78

--- a/crates/turborepo-vt100/CHANGELOG.md
+++ b/crates/turborepo-vt100/CHANGELOG.md
@@ -1,0 +1,364 @@
+# Changelog
+
+## [Unreleased]
+
+### Added
+
+- `Parser::process_cb`, which works the same as `Parser::process` except that
+  it calls callbacks during parsing when it finds a terminal escape which is
+  potentially useful but not something that affects the screen itself.
+- Support for xterm window resize request escape codes, via the new callback
+  mechanism.
+
+### Removed
+
+- `Screen::bells_diff`, `Screen::audible_bell_count`,
+  `Screen::visual_bell_count`, and `Screen::errors` have been removed in favor
+  of the new callback api described above.
+- `Cell` no longer implements `Default`.
+- `Screen` no longer implements `vte::Perform`.
+
+### Changed
+
+- `Parser::set_size` and `Parser::set_scrollback` have been moved to methods
+  on `Screen`, and `Parser::screen_mut` was added to get a mutable reference
+  to the screen.
+
+## [0.15.2] - 2023-02-05
+
+### Changed
+
+- Bumped dependencies
+
+## [0.15.1] - 2021-12-21
+
+### Changed
+
+- Removed a lot of unnecessary test data from the packaged crate, making
+  downloads faster
+
+## [0.15.0] - 2021-12-15
+
+### Added
+
+- `Screen::errors` to track the number of parsing errors seen so far
+
+### Fixed
+
+- No longer generate spurious diffs in some cases where the cursor is past the
+  end of a row
+- Fix restoring the cursor position when scrolled back
+
+### Changed
+
+- Various internal refactorings
+
+## [0.14.0] - 2021-12-06
+
+### Changed
+
+- Unknown UTF-8 characters default to a width of 1, rather than 0 (except for
+  control characters, as mentioned below)
+
+### Fixed
+
+- Ignore C1 control characters rather than adding them to the cell data, since
+  they are non-printable
+
+## [0.13.2] - 2021-12-05
+
+### Changed
+
+- Delay allocation of the alternate screen until it is used (saves a bit of
+  memory in basic cases)
+
+## [0.13.1] - 2021-12-04
+
+### Fixed
+
+- Fixed various line wrapping state issues
+- Fixed cursor positioning after writing zero width characters at the end of
+  the line
+- Fixed `Screen::cursor_state_formatted` to draw the last character in a line
+  with the appropriate drawing attributes if it needs to redraw it
+
+## [0.13.0] - 2021-11-17
+
+### Added
+
+- `Screen::alternate_screen` to determine if the alternate screen is in use
+- `Screen::row_wrapped` to determine whether the row at the given index should
+  wrap its text
+- `Screen::cursor_state_formatted` to set the cursor position and hidden state
+  (including internal state like the one-past-the-end state which isn't visible
+  in the return value of `cursor_position`)
+
+### Fixed
+
+- `Screen::rows_formatted` now outputs correct escape codes in some edge cases
+  at the beginning of a row when the previous row was wrapped
+- VPA escape sequence can no longer position the cursor off the screen
+
+## [0.12.0] - 2021-03-09
+
+### Added
+
+- `Screen::state_formatted` and `Screen::state_diff` convenience wrappers
+
+### Fixed
+
+- `Screen::attributes_formatted` now correctly resets previously set attributes
+  where necessary
+
+### Removed
+
+- Removed `Screen::attributes_diff`, since I can't actually think of any
+  situation where it does a thing that makes sense.
+
+## [0.11.1] - 2021-03-07
+
+### Changed
+
+- Drop dependency on `enumset`
+
+## [0.11.0] - 2021-03-07
+
+### Added
+
+- `Screen::attributes_formatted` and `Screen::attributes_diff` to retrieve the
+  current state of the drawing attributes as escape sequences
+- `Screen::fgcolor`, `Screen::bgcolor`, `Screen::bold`, `Screen::italic`,
+  `Screen::underline`, and `Screen::inverse` to retrieve the current state of
+  the drawing attributes directly
+
+## [0.10.0] - 2021-03-06
+
+### Added
+
+- Implementation of `std::io::Write` for `Parser`
+
+## [0.9.0] - 2021-03-05
+
+### Added
+
+- `Screen::contents_between`, for returning the contents logically between two
+  given cells (for things like clipboard selection)
+- Support SGR subparameters (so `\e[38:2:255:0:0m` behaves the same way as
+  `\e[38;2;255;0;0m`)
+
+### Fixed
+
+- Bump `enumset` to fix a dependency which fails to build
+
+## [0.8.1] - 2020-02-09
+
+### Changed
+
+- Bumped `vte` dep to 0.6.
+
+## [0.8.0] - 2019-12-07
+
+### Removed
+
+- Removed the unicode-normalization feature altogether - it turns out that it
+  still has a couple edge cases where it causes incorrect behavior, and fixing
+  those would be a lot more effort.
+
+### Fixed
+
+- Fix a couple more end-of-line/wrapping bugs, especially around cursor
+  positioning.
+- Fix applying combining characters to wide characters.
+- Ensure cells can't have contents with width zero (to avoid ambiguity). If an
+  empty cell gets a combining character applied to it, default that cell to a
+  (normal-width) space first.
+
+## [0.7.0] - 2019-11-23
+
+### Added
+
+- New (default-on) cargo feature `unicode-normalization` which can be disabled
+  to disable normalizing cell contents to NFC - it's a pretty small edge case,
+  and the data tables required to support it are quite large, which affects
+  size-sensitive targets like wasm
+
+## [0.6.3] - 2019-11-20
+
+### Fixed
+
+- Fix output of `contents_formatted` and `contents_diff` when the cursor
+  position ends at one past the end of a row.
+- If the cursor position is one past the end of a row, any char, even a
+  combining char, needs to cause the cursor position to wrap.
+
+## [0.6.2] - 2019-11-13
+
+### Fixed
+
+- Fix zero-width characters when the cursor is at the end of a row.
+
+## [0.6.1] - 2019-11-13
+
+### Added
+
+- Add more debug logging for unhandled escape sequences.
+
+### Changed
+
+- Unhandled escape sequence warnings are now at the `debug` log level.
+
+## [0.6.0] - 2019-11-13
+
+### Added
+
+- `Screen::input_mode_formatted` and `Screen::input_mode_diff` give escape
+  codes to set the current terminal input modes.
+- `Screen::title_formatted` and `Screen::title_diff` give escape codes to set
+  the terminal window title.
+- `Screen::bells_diff` gives escape codes to trigger any audible or visual
+  bells which have been seen since the previous state.
+
+### Changed
+
+- `Screen::contents_diff` no longer includes audible or visual bells (see
+  `Screen::bells_diff` instead).
+
+## [0.5.1] - 2019-11-12
+
+### Fixed
+
+- `Screen::set_size` now actually resizes when requested (previously the
+  underlying storage was not being resized, leading to panics when writing
+  outside of the original screen).
+
+## [0.5.0] - 2019-11-12
+
+### Added
+
+- Scrollback support.
+- `Default` impl for `Parser` which creates an 80x24 terminal with no
+  scrollback.
+
+### Removed
+
+- `Parser::screen_mut` (and the `pub` `&mut self` methods on `Screen`). The few
+  things you can do to change the screen state directly are now exposed as
+  methods on `Parser` itself.
+
+### Changed
+
+- `Cell::contents` now returns a `String` instead of a `&str`.
+- `Screen::check_audible_bell` and `Screen::check_visual_bell` have been
+  replaced with `Screen::audible_bell_count` and `Screen::visual_bell_count`.
+  You should keep track of the "since the last method call" state yourself
+  instead of having the screen track it for you.
+
+### Fixed
+
+- Lots of performance and output optimizations.
+- Clearing a cell now sets all of that cell's attributes to the current
+  attribute set, since different terminals render different things for an empty
+  cell based on the attributes.
+- `Screen::contents_diff` now includes audible and visual bells when
+  appropriate.
+
+## [0.4.0] - 2019-11-08
+
+### Removed
+
+- `Screen::fgcolor`, `Screen::bgcolor`, `Screen::bold`, `Screen::italic`,
+  `Screen::underline`, `Screen::inverse`, and `Screen::alternate_screen`:
+  these are just implementation details that people shouldn't need to care
+  about.
+
+### Fixed
+
+- Fixed cursor movement when the cursor position is already outside of an
+  active scroll region.
+
+## [0.3.2] - 2019-11-08
+
+### Fixed
+
+- Clearing cells now correctly sets the cell background color.
+- Fixed a couple bugs in wide character handling in `contents_formatted` and
+  `contents_diff`.
+- Fixed RI when the cursor is at the top of the screen (fixes scrolling up in
+  `less`, for instance).
+- Fixed VPA incorrectly being clamped to the scroll region.
+- Stop treating soft hyphen specially (as far as i can tell, no other terminals
+  do this, and i'm not sure why i thought it was necessary to begin with).
+- `contents_formatted` now also resets attributes at the start, like
+  `contents_diff` does.
+
+## [0.3.1] - 2019-11-06
+
+### Fixed
+
+- Make `contents_formatted` explicitly show the cursor when necessary, in case
+  the cursor was previously hidden.
+
+## [0.3.0] - 2019-11-06
+
+### Added
+
+- `Screen::rows` which is like `Screen::contents` except that it returns the
+  data by row instead of all at once, and also allows you to restrict the
+  region returned to a subset of columns.
+- `Screen::rows_formatted` which is like `Screen::rows`, but returns escape
+  sequences sufficient to draw the requested subset of each row.
+- `Screen::contents_diff` and `Screen::rows_diff` which return escape sequences
+  sufficient to turn the visible state of one screen (or a subset of the screen
+  in the case of `rows_diff`) into another.
+
+### Changed
+
+- The screen is now exposed separately from the parser, and is cloneable.
+- `contents_formatted` now returns `Vec<u8>` instead of `String`.
+- `contents` and `contents_formatted` now only allow getting the contents of
+  the entire screen rather than a subset (but see the entry for `rows` and
+  `rows_formatted` above).
+
+### Removed
+
+- `Cell::new`, since there's not really any reason that this is useful for
+  someone to do from outside of the crate.
+
+### Fixed
+
+- `contents_formatted` now preserves the state of empty cells instead of
+  filling them with spaces.
+- We now clear the row wrapping state when the number of columns in the
+  terminal is changed.
+- `contents_formatted` now ensures that the cursor has the correct hidden state
+  and location.
+- `contents_formatted` now clears the screen before starting to draw.
+
+## [0.2.0] - 2019-11-04
+
+### Changed
+
+- Reimplemented in pure safe rust, with a much more accurate parser
+- A bunch of minor API tweaks, some backwards-incompatible
+
+## [0.1.2] - 2016-06-04
+
+### Fixed
+
+- Fix returning uninit memory in get_string_formatted/get_string_plaintext
+- Handle emoji and zero width unicode characters properly
+- Fix cursor positioning with regards to scroll regions and wrapping
+- Fix parsing of (ignored) character set escapes
+- Explicitly suppress status report escapes
+
+## [0.1.1] - 2016-04-28
+
+### Fixed
+
+- Fix builds
+
+## [0.1.0] - 2016-04-28
+
+### Added
+
+- Initial release

--- a/crates/turborepo-vt100/Cargo.toml
+++ b/crates/turborepo-vt100/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "vt100"
+version = "0.15.2"
+authors = ["Jesse Luehrs <doy@tozt.net>"]
+edition = "2021"
+
+description = "Library for parsing terminal data"
+homepage = "https://github.com/doy/vt100-rust"
+repository = "https://github.com/doy/vt100-rust"
+readme = "README.md"
+keywords = ["terminal", "vt100"]
+categories = ["command-line-interface", "encoding"]
+license = "MIT"
+include = ["src/**/*", "LICENSE", "README.md", "CHANGELOG.md"]
+
+[dependencies]
+itoa = "1.0.9"
+log = "0.4.19"
+unicode-width = "0.1.10"
+vte = "0.11.1"
+
+[dev-dependencies]
+nix = "0.26.2"
+quickcheck = "1.0"
+rand = "0.8"
+serde = { version = "1.0.182", features = ["derive"] }
+serde_json = "1.0.104"
+terminal_size = "0.2.6"
+vte = "0.11.1"

--- a/crates/turborepo-vt100/LICENSE
+++ b/crates/turborepo-vt100/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Jesse Luehrs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/crates/turborepo-vt100/README.md
+++ b/crates/turborepo-vt100/README.md
@@ -1,0 +1,49 @@
+# turborepo-vt100
+
+This is a fork of vt100 modified for use by turborepo.
+Most changes made can be upstreamed and hopefully one day we won't need to vendor the crate.
+
+## Changes
+
+This fork is based on commit `1e4014aa72a7552d2f69b81ad89d56e035354041` of `vt100`.
+A few immediate changes made when vendoring:
+
+- Dropped fuzz tests as they require special setup
+- Dropped scripts for helping with fuzz testing
+
+## Original README of vt100
+
+This crate parses a terminal byte stream and provides an in-memory
+representation of the rendered contents.
+
+### Overview
+
+This is essentially the terminal parser component of a graphical terminal
+emulator pulled out into a separate crate. Although you can use this crate
+to build a graphical terminal emulator, it also contains functionality
+necessary for implementing terminal applications that want to run other
+terminal applications - programs like `screen` or `tmux` for example.
+
+### Synopsis
+
+```rust
+let mut parser = vt100::Parser::new(24, 80, 0);
+
+let screen = parser.screen().clone();
+parser.process(b"this text is \x1b[31mRED\x1b[m");
+assert_eq!(
+    parser.screen().cell(0, 13).unwrap().fgcolor(),
+    vt100::Color::Idx(1),
+);
+
+let screen = parser.screen().clone();
+parser.process(b"\x1b[3D\x1b[32mGREEN");
+assert_eq!(
+    parser.screen().contents_formatted(),
+    &b"\x1b[?25h\x1b[m\x1b[H\x1b[Jthis text is \x1b[32mGREEN"[..],
+);
+assert_eq!(
+    parser.screen().contents_diff(&screen),
+    &b"\x1b[1;14H\x1b[32mGREEN"[..],
+);
+```

--- a/crates/turborepo-vt100/examples/fuzz.rs
+++ b/crates/turborepo-vt100/examples/fuzz.rs
@@ -1,0 +1,112 @@
+use std::io::Read as _;
+
+#[path = "../tests/helpers/mod.rs"]
+mod helpers;
+
+fn check_full(vt_base: &vt100::Screen, idx: usize) {
+    let mut input = vec![];
+    input.extend(vt_base.state_formatted());
+    let mut vt_full = vt100::Parser::default();
+    vt_full.process(&input);
+    assert!(
+        helpers::compare_screens(vt_full.screen(), vt_base),
+        "{}: full:\n{}",
+        idx,
+        helpers::format_bytes(&input),
+    );
+}
+
+fn check_diff_empty(
+    vt_base: &vt100::Screen,
+    empty: &vt100::Screen,
+    idx: usize,
+) {
+    let mut input = vec![];
+    input.extend(vt_base.state_diff(empty));
+    let mut vt_diff_empty = vt100::Parser::default();
+    vt_diff_empty.process(&input);
+    assert!(
+        helpers::compare_screens(vt_diff_empty.screen(), vt_base),
+        "{}: diff-empty:\n{}",
+        idx,
+        helpers::format_bytes(&input),
+    );
+}
+
+fn check_diff(
+    vt_base: &vt100::Screen,
+    vt_diff: &mut vt100::Parser,
+    prev: &vt100::Screen,
+    idx: usize,
+) {
+    let mut input = vec![];
+    input.extend(vt_base.state_diff(prev));
+    vt_diff.process(&input);
+    assert!(
+        helpers::compare_screens(vt_diff.screen(), vt_base),
+        "{}: diff:\n{}",
+        idx,
+        helpers::format_bytes(&input),
+    );
+}
+
+fn check_rows(vt_base: &vt100::Screen, idx: usize) {
+    let mut input = vec![];
+    let mut wrapped = false;
+    for (idx, row) in vt_base.rows_formatted(0, 80).enumerate() {
+        input.extend(b"\x1b[m");
+        if !wrapped {
+            input.extend(format!("\x1b[{}H", idx + 1).as_bytes());
+        }
+        input.extend(&row);
+        wrapped = vt_base.row_wrapped(idx.try_into().unwrap());
+    }
+    input.extend(b"\x1b[m");
+    input.extend(&vt_base.cursor_state_formatted());
+    input.extend(&vt_base.attributes_formatted());
+    input.extend(&vt_base.input_mode_formatted());
+    input.extend(&vt_base.title_formatted());
+    let mut vt_rows = vt100::Parser::default();
+    vt_rows.process(&input);
+    assert!(
+        helpers::compare_screens(vt_rows.screen(), vt_base),
+        "{}: rows:\n{}",
+        idx,
+        helpers::format_bytes(&input),
+    );
+}
+
+fn read_byte() -> Option<u8> {
+    let mut byte = [0];
+    match std::io::stdin().read(&mut byte) {
+        Ok(bytes) => {
+            if bytes != 1 {
+                return None;
+            }
+        }
+        Err(e) => {
+            eprintln!("{e}");
+            return None;
+        }
+    }
+    Some(byte[0])
+}
+
+fn main() {
+    let mut vt_base = vt100::Parser::default();
+    let mut vt_diff = vt100::Parser::default();
+    let mut prev_screen = vt_base.screen().clone();
+    let empty_screen = vt100::Parser::default().screen().clone();
+    let mut idx = 0;
+    while let Some(byte) = read_byte() {
+        vt_base.process(&[byte]);
+
+        check_full(vt_base.screen(), idx);
+        check_diff_empty(vt_base.screen(), &empty_screen, idx);
+        check_diff(vt_base.screen(), &mut vt_diff, &prev_screen, idx);
+        check_rows(vt_base.screen(), idx);
+
+        prev_screen = vt_base.screen().clone();
+        idx += 1;
+    }
+}

--- a/crates/turborepo-vt100/examples/generate_fixture.rs
+++ b/crates/turborepo-vt100/examples/generate_fixture.rs
@@ -1,0 +1,42 @@
+use std::io::BufRead as _;
+use std::io::Write as _;
+
+#[path = "../tests/helpers/mod.rs"]
+mod helpers;
+
+fn main() {
+    let name = std::env::args().nth(1).unwrap();
+    let _ = std::fs::remove_dir_all(format!("tests/data/fixtures/{name}"));
+    std::fs::create_dir_all(format!("tests/data/fixtures/{name}")).unwrap();
+
+    let inputs =
+        std::fs::File::open(format!("tests/data/fixtures/{name}.in"))
+            .unwrap();
+    let inputs = std::io::BufReader::new(inputs);
+
+    let mut i = 1;
+    let mut prev_input = vec![];
+    for line in inputs.lines() {
+        let line = line.unwrap();
+
+        let input = helpers::unhex(line.as_bytes());
+        let mut input_file = std::fs::File::create(format!(
+            "tests/data/fixtures/{name}/{i}.typescript"
+        ))
+        .unwrap();
+        input_file.write_all(&input).unwrap();
+
+        prev_input.extend(input);
+        let mut term = vt100::Parser::default();
+        term.process(&prev_input);
+        let screen = helpers::FixtureScreen::from_screen(term.screen());
+
+        let output_file = std::fs::File::create(format!(
+            "tests/data/fixtures/{name}/{i}.json"
+        ))
+        .unwrap();
+        serde_json::to_writer_pretty(output_file, &screen).unwrap();
+
+        i += 1;
+    }
+}

--- a/crates/turborepo-vt100/examples/generate_fuzz.rs
+++ b/crates/turborepo-vt100/examples/generate_fuzz.rs
@@ -1,0 +1,25 @@
+use std::io::BufRead as _;
+use std::io::Write as _;
+
+#[path = "../tests/helpers/mod.rs"]
+mod helpers;
+
+fn main() {
+    let name = std::env::args().nth(1).unwrap();
+    let _ = std::fs::remove_file(format!("fuzz/in/{name}"));
+
+    let inputs =
+        std::fs::File::open(format!("tests/data/fixtures/{name}.in"))
+            .unwrap();
+    let inputs = std::io::BufReader::new(inputs);
+
+    let mut bytes = vec![];
+    for line in inputs.lines() {
+        let line = line.unwrap();
+        let input = helpers::unhex(line.as_bytes());
+        bytes.extend(input.iter());
+    }
+    let mut input_file =
+        std::fs::File::create(format!("fuzz/in/{name}")).unwrap();
+    input_file.write_all(&bytes).unwrap();
+}

--- a/crates/turborepo-vt100/examples/process.rs
+++ b/crates/turborepo-vt100/examples/process.rs
@@ -1,0 +1,33 @@
+use std::io::Read as _;
+
+fn read_frames() -> impl Iterator<Item = Vec<u8>> {
+    (1..=7625).map(|i| {
+        let mut file =
+            std::fs::File::open(format!("tests/data/crawl/crawl{i}"))
+                .unwrap();
+        let mut frame = vec![];
+        file.read_to_end(&mut frame).unwrap();
+        frame
+    })
+}
+
+fn process_frames(frames: &[Vec<u8>]) {
+    let mut parser = vt100::Parser::default();
+    for frame in frames {
+        parser.process(frame);
+    }
+}
+
+fn main() {
+    let frames: Vec<Vec<u8>> = read_frames().collect();
+    let start = std::time::Instant::now();
+    let mut i = 0;
+    loop {
+        i += 1;
+        process_frames(&frames);
+        if (std::time::Instant::now() - start).as_secs() >= 30 {
+            break;
+        }
+    }
+    eprintln!("{i} iterations");
+}

--- a/crates/turborepo-vt100/examples/process_cb.rs
+++ b/crates/turborepo-vt100/examples/process_cb.rs
@@ -1,0 +1,36 @@
+use std::io::Read as _;
+
+struct Callbacks;
+impl vt100::Callbacks for Callbacks {}
+
+fn read_frames() -> impl Iterator<Item = Vec<u8>> {
+    (1..=7625).map(|i| {
+        let mut file =
+            std::fs::File::open(format!("tests/data/crawl/crawl{i}"))
+                .unwrap();
+        let mut frame = vec![];
+        file.read_to_end(&mut frame).unwrap();
+        frame
+    })
+}
+
+fn process_frames(frames: &[Vec<u8>]) {
+    let mut parser = vt100::Parser::default();
+    for frame in frames {
+        parser.process_cb(frame, &mut Callbacks);
+    }
+}
+
+fn main() {
+    let frames: Vec<Vec<u8>> = read_frames().collect();
+    let start = std::time::Instant::now();
+    let mut i = 0;
+    loop {
+        i += 1;
+        process_frames(&frames);
+        if (std::time::Instant::now() - start).as_secs() >= 30 {
+            break;
+        }
+    }
+    eprintln!("{i} iterations");
+}

--- a/crates/turborepo-vt100/examples/process_cb_bb.rs
+++ b/crates/turborepo-vt100/examples/process_cb_bb.rs
@@ -1,0 +1,52 @@
+use std::io::Read as _;
+
+struct Callbacks;
+impl vt100::Callbacks for Callbacks {
+    fn audible_bell(&mut self, screen: &mut vt100::Screen) {
+        std::hint::black_box(screen);
+    }
+
+    fn visual_bell(&mut self, screen: &mut vt100::Screen) {
+        std::hint::black_box(screen);
+    }
+
+    fn resize(&mut self, screen: &mut vt100::Screen, request: (u16, u16)) {
+        std::hint::black_box((screen, request));
+    }
+
+    fn error(&mut self, screen: &mut vt100::Screen) {
+        std::hint::black_box(screen);
+    }
+}
+
+fn read_frames() -> impl Iterator<Item = Vec<u8>> {
+    (1..=7625).map(|i| {
+        let mut file =
+            std::fs::File::open(format!("tests/data/crawl/crawl{i}"))
+                .unwrap();
+        let mut frame = vec![];
+        file.read_to_end(&mut frame).unwrap();
+        frame
+    })
+}
+
+fn process_frames(frames: &[Vec<u8>]) {
+    let mut parser = vt100::Parser::default();
+    for frame in frames {
+        parser.process_cb(frame, &mut Callbacks);
+    }
+}
+
+fn main() {
+    let frames: Vec<Vec<u8>> = read_frames().collect();
+    let start = std::time::Instant::now();
+    let mut i = 0;
+    loop {
+        i += 1;
+        process_frames(&frames);
+        if (std::time::Instant::now() - start).as_secs() >= 30 {
+            break;
+        }
+    }
+    eprintln!("{i} iterations");
+}

--- a/crates/turborepo-vt100/examples/process_diff.rs
+++ b/crates/turborepo-vt100/examples/process_diff.rs
@@ -1,0 +1,39 @@
+use std::io::{Read as _, Write as _};
+
+fn read_frames() -> impl Iterator<Item = Vec<u8>> {
+    (1..=7625).map(|i| {
+        let mut file =
+            std::fs::File::open(format!("tests/data/crawl/crawl{i}"))
+                .unwrap();
+        let mut frame = vec![];
+        file.read_to_end(&mut frame).unwrap();
+        frame
+    })
+}
+
+fn draw_frames(frames: &[Vec<u8>]) {
+    let mut stdout = std::io::stdout();
+    let mut parser = vt100::Parser::default();
+    let mut screen = parser.screen().clone();
+    for frame in frames {
+        parser.process(frame);
+        let new_screen = parser.screen().clone();
+        let diff = new_screen.contents_diff(&screen);
+        stdout.write_all(&diff).unwrap();
+        screen = new_screen;
+    }
+}
+
+fn main() {
+    let frames: Vec<Vec<u8>> = read_frames().collect();
+    let start = std::time::Instant::now();
+    let mut i = 0;
+    loop {
+        i += 1;
+        draw_frames(&frames);
+        if (std::time::Instant::now() - start).as_secs() >= 30 {
+            break;
+        }
+    }
+    eprintln!("{i} iterations");
+}

--- a/crates/turborepo-vt100/examples/process_full.rs
+++ b/crates/turborepo-vt100/examples/process_full.rs
@@ -1,0 +1,36 @@
+use std::io::{Read as _, Write as _};
+
+fn read_frames() -> impl Iterator<Item = Vec<u8>> {
+    (1..=7625).map(|i| {
+        let mut file =
+            std::fs::File::open(format!("tests/data/crawl/crawl{i}"))
+                .unwrap();
+        let mut frame = vec![];
+        file.read_to_end(&mut frame).unwrap();
+        frame
+    })
+}
+
+fn draw_frames(frames: &[Vec<u8>]) {
+    let mut stdout = std::io::stdout();
+    let mut parser = vt100::Parser::default();
+    for frame in frames {
+        parser.process(frame);
+        let contents = parser.screen().contents_formatted();
+        stdout.write_all(&contents).unwrap();
+    }
+}
+
+fn main() {
+    let frames: Vec<Vec<u8>> = read_frames().collect();
+    let start = std::time::Instant::now();
+    let mut i = 0;
+    loop {
+        i += 1;
+        draw_frames(&frames);
+        if (std::time::Instant::now() - start).as_secs() >= 30 {
+            break;
+        }
+    }
+    eprintln!("{i} iterations");
+}

--- a/crates/turborepo-vt100/examples/real_terminal_compare.rs
+++ b/crates/turborepo-vt100/examples/real_terminal_compare.rs
@@ -1,0 +1,134 @@
+use std::io::{Read as _, Write as _};
+use std::os::unix::io::AsRawFd as _;
+
+#[path = "../tests/helpers/mod.rs"]
+mod helpers;
+
+fn main() {
+    unsafe { helpers::QUIET = true }
+
+    let mut stdin = std::io::stdin();
+    let mut stdout = std::io::stdout();
+
+    let stdin_fd = std::io::stdin().as_raw_fd();
+    let mut termios = nix::sys::termios::tcgetattr(stdin_fd).unwrap();
+    nix::sys::termios::cfmakeraw(&mut termios);
+    nix::sys::termios::tcsetattr(
+        stdin_fd,
+        nix::sys::termios::SetArg::TCSANOW,
+        &termios,
+    )
+    .unwrap();
+
+    let size = terminal_size::terminal_size().map_or(
+        (24, 80),
+        |(terminal_size::Width(w), terminal_size::Height(h))| (h, w),
+    );
+
+    let file = std::env::args_os().nth(1).unwrap();
+    let mut fh = std::fs::File::open(file).unwrap();
+
+    let mut log = std::fs::File::create("compare.log").unwrap();
+    macro_rules! log {
+        ($out:expr) => {
+            log.write_all($out).unwrap();
+            log.flush().unwrap();
+        };
+    }
+
+    stdout.write_all(b"\x1b[H\x1b[J").unwrap();
+    stdout.flush().unwrap();
+
+    let mut parser = vt100::Parser::new(size.0, size.1, 0);
+    let mut buf = [0u8; 4096];
+    let mut screen = parser.screen().clone();
+    let mut idx = 0;
+    loop {
+        match fh.read(&mut buf) {
+            Ok(0) => break,
+            Ok(bytes) => {
+                for byte in &buf[..bytes] {
+                    parser.process(&[*byte]);
+                    let mut pos = parser.screen().cursor_position();
+                    if pos.1 == size.1 {
+                        pos.1 -= 1;
+                    }
+                    if helpers::compare_screens(parser.screen(), &screen) {
+                        log!(format!(
+                            "{}: {}: ({}, {})\n",
+                            idx, byte, pos.0, pos.1,
+                        )
+                        .as_bytes());
+                    } else {
+                        let diff = parser.screen().state_diff(&screen);
+                        stdout.write_all(&diff).unwrap();
+                        stdout.write_all(b"\x1b[6n").unwrap();
+                        stdout.flush().unwrap();
+
+                        let mut buf = [0u8; 1];
+                        let mut n = 0;
+                        let mut row: Option<u16> = None;
+                        let col: Option<u16>;
+                        loop {
+                            match stdin.read(&mut buf) {
+                                Ok(0) => panic!("stdin closed"),
+                                Ok(1) => match buf[0] {
+                                    b'\x1b' | b'[' => {}
+                                    b'0'..=b'9' => {
+                                        let digit = (buf[0] - b'0') as u16;
+                                        n = n * 10 + digit;
+                                    }
+                                    b';' => {
+                                        row = Some(n - 1);
+                                        n = 0;
+                                    }
+                                    b'R' => {
+                                        col = Some(n - 1);
+                                        break;
+                                    }
+                                    _ => panic!("unexpected char {}", buf[0]),
+                                },
+                                Ok(_) => unreachable!(),
+                                Err(e) => panic!("{}", e),
+                            }
+                        }
+
+                        let row = row.unwrap();
+                        let mut col = col.unwrap();
+                        if col == size.1 {
+                            col -= 1;
+                        }
+
+                        log!(format!(
+                            "{}: {}: ({}, {}): wrote '{}', got ({}, {})\n",
+                            idx,
+                            byte,
+                            pos.0,
+                            pos.1,
+                            helpers::format_bytes(&diff),
+                            row,
+                            col,
+                        )
+                        .as_bytes());
+
+                        if row != pos.0 || col != pos.1 {
+                            panic!(
+                                "unexpected cursor position at idx {} ({}): \
+                                vt100 was at ({}, {}) but the real terminal \
+                                was at ({}, {})",
+                                idx, byte, pos.0, pos.1, row, col,
+                            );
+                        }
+
+                        screen = parser.screen().clone();
+                    }
+                    idx += 1;
+                }
+            }
+            Err(e) => {
+                eprintln!("{e}");
+                std::process::exit(1);
+            }
+        }
+    }
+}

--- a/crates/turborepo-vt100/examples/vte.rs
+++ b/crates/turborepo-vt100/examples/vte.rs
@@ -1,0 +1,83 @@
+use std::io::Read as _;
+
+/// A type implementing Perform that just logs actions
+struct Log;
+
+impl vte::Perform for Log {
+    fn print(&mut self, c: char) {
+        println!("[print] U+{:04x}", c as u32);
+    }
+
+    fn execute(&mut self, byte: u8) {
+        println!("[execute] {byte:02x}");
+    }
+
+    fn hook(
+        &mut self,
+        params: &vte::Params,
+        intermediates: &[u8],
+        ignore: bool,
+        c: char,
+    ) {
+        println!(
+            "[hook] params={:?}, intermediates={:?}, ignore={:?}, c=U+{:04x}",
+            params, intermediates, ignore, c as u32
+        );
+    }
+
+    fn put(&mut self, byte: u8) {
+        println!("[put] {byte:02x}");
+    }
+
+    fn unhook(&mut self) {
+        println!("[unhook]");
+    }
+
+    fn osc_dispatch(&mut self, params: &[&[u8]], bell_terminated: bool) {
+        println!(
+            "[osc_dispatch] params={params:?} bell_terminated={bell_terminated}"
+        );
+    }
+
+    fn csi_dispatch(
+        &mut self,
+        params: &vte::Params,
+        intermediates: &[u8],
+        ignore: bool,
+        c: char,
+    ) {
+        println!(
+            "[csi_dispatch] \
+            params={:#?}, intermediates={:?}, ignore={:?}, c=U+{:04x}",
+            params, intermediates, ignore, c as u32
+        );
+    }
+
+    fn esc_dispatch(&mut self, intermediates: &[u8], ignore: bool, byte: u8) {
+        println!(
+            "[esc_dispatch] intermediates={intermediates:?}, ignore={ignore:?}, byte={byte:02x}"
+        );
+    }
+}
+
+fn main() {
+    let mut stdin = std::io::stdin();
+    let mut parser = vte::Parser::new();
+    let mut performer = Log;
+
+    let mut buf = [0; 4096];
+    loop {
+        match stdin.read(&mut buf) {
+            Ok(0) => break,
+            Ok(n) => {
+                for byte in &buf[..n] {
+                    parser.advance(&mut performer, *byte);
+                }
+            }
+            Err(err) => {
+                eprintln!("err: {err}");
+                std::process::exit(1);
+            }
+        }
+    }
+}

--- a/crates/turborepo-vt100/src/attrs.rs
+++ b/crates/turborepo-vt100/src/attrs.rs
@@ -1,0 +1,128 @@
+use crate::term::BufWrite as _;
+
+/// Represents a foreground or background color for cells.
+#[derive(Eq, PartialEq, Debug, Copy, Clone)]
+pub enum Color {
+    /// The default terminal color.
+    Default,
+
+    /// An indexed terminal color.
+    Idx(u8),
+
+    /// An RGB terminal color. The parameters are (red, green, blue).
+    Rgb(u8, u8, u8),
+}
+
+impl Default for Color {
+    fn default() -> Self {
+        Self::Default
+    }
+}
+
+const TEXT_MODE_BOLD: u8 = 0b0000_0001;
+const TEXT_MODE_ITALIC: u8 = 0b0000_0010;
+const TEXT_MODE_UNDERLINE: u8 = 0b0000_0100;
+const TEXT_MODE_INVERSE: u8 = 0b0000_1000;
+
+#[derive(Default, Clone, Copy, PartialEq, Eq, Debug)]
+pub struct Attrs {
+    pub fgcolor: Color,
+    pub bgcolor: Color,
+    pub mode: u8,
+}
+
+impl Attrs {
+    pub fn bold(&self) -> bool {
+        self.mode & TEXT_MODE_BOLD != 0
+    }
+
+    pub fn set_bold(&mut self, bold: bool) {
+        if bold {
+            self.mode |= TEXT_MODE_BOLD;
+        } else {
+            self.mode &= !TEXT_MODE_BOLD;
+        }
+    }
+
+    pub fn italic(&self) -> bool {
+        self.mode & TEXT_MODE_ITALIC != 0
+    }
+
+    pub fn set_italic(&mut self, italic: bool) {
+        if italic {
+            self.mode |= TEXT_MODE_ITALIC;
+        } else {
+            self.mode &= !TEXT_MODE_ITALIC;
+        }
+    }
+
+    pub fn underline(&self) -> bool {
+        self.mode & TEXT_MODE_UNDERLINE != 0
+    }
+
+    pub fn set_underline(&mut self, underline: bool) {
+        if underline {
+            self.mode |= TEXT_MODE_UNDERLINE;
+        } else {
+            self.mode &= !TEXT_MODE_UNDERLINE;
+        }
+    }
+
+    pub fn inverse(&self) -> bool {
+        self.mode & TEXT_MODE_INVERSE != 0
+    }
+
+    pub fn set_inverse(&mut self, inverse: bool) {
+        if inverse {
+            self.mode |= TEXT_MODE_INVERSE;
+        } else {
+            self.mode &= !TEXT_MODE_INVERSE;
+        }
+    }
+
+    pub fn write_escape_code_diff(
+        &self,
+        contents: &mut Vec<u8>,
+        other: &Self,
+    ) {
+        if self != other && self == &Self::default() {
+            crate::term::ClearAttrs.write_buf(contents);
+            return;
+        }
+
+        let attrs = crate::term::Attrs::default();
+
+        let attrs = if self.fgcolor == other.fgcolor {
+            attrs
+        } else {
+            attrs.fgcolor(self.fgcolor)
+        };
+        let attrs = if self.bgcolor == other.bgcolor {
+            attrs
+        } else {
+            attrs.bgcolor(self.bgcolor)
+        };
+        let attrs = if self.bold() == other.bold() {
+            attrs
+        } else {
+            attrs.bold(self.bold())
+        };
+        let attrs = if self.italic() == other.italic() {
+            attrs
+        } else {
+            attrs.italic(self.italic())
+        };
+        let attrs = if self.underline() == other.underline() {
+            attrs
+        } else {
+            attrs.underline(self.underline())
+        };
+        let attrs = if self.inverse() == other.inverse() {
+            attrs
+        } else {
+            attrs.inverse(self.inverse())
+        };
+
+        attrs.write_buf(contents);
+    }
+}

--- a/crates/turborepo-vt100/src/callbacks.rs
+++ b/crates/turborepo-vt100/src/callbacks.rs
@@ -1,0 +1,16 @@
+/// This trait is used with `Parser::process_cb` to handle extra escape
+/// sequences that don't have an impact on the terminal screen directly.
+pub trait Callbacks {
+    /// This callback is called when the terminal requests an audible bell
+    /// (typically with `^G`).
+    fn audible_bell(&mut self, _: &mut crate::Screen) {}
+    /// This callback is called when the terminal requests an visual bell
+    /// (typically with `\eg`).
+    fn visual_bell(&mut self, _: &mut crate::Screen) {}
+    /// This callback is called when the terminal requests a resize
+    /// (typically with `\e[8;<rows>;<cols>t`).
+    fn resize(&mut self, _: &mut crate::Screen, _request: (u16, u16)) {}
+    /// This callback is called when the terminal receives invalid input
+    /// (such as an invalid UTF-8 character or an unused control character).
+    fn error(&mut self, _: &mut crate::Screen) {}
+}

--- a/crates/turborepo-vt100/src/cell.rs
+++ b/crates/turborepo-vt100/src/cell.rs
@@ -1,0 +1,166 @@
+use unicode_width::UnicodeWidthChar as _;
+
+const CODEPOINTS_IN_CELL: usize = 6;
+
+/// Represents a single terminal cell.
+#[derive(Clone, Debug, Eq)]
+pub struct Cell {
+    contents: [char; CODEPOINTS_IN_CELL],
+    len: u8,
+    attrs: crate::attrs::Attrs,
+}
+
+impl PartialEq<Self> for Cell {
+    fn eq(&self, other: &Self) -> bool {
+        if self.len != other.len {
+            return false;
+        }
+        if self.attrs != other.attrs {
+            return false;
+        }
+        let len = self.len();
+        // self.len() always returns a valid value
+        self.contents[..len] == other.contents[..len]
+    }
+}
+
+impl Cell {
+    pub(crate) fn new() -> Self {
+        Self {
+            contents: Default::default(),
+            len: 0,
+            attrs: crate::attrs::Attrs::default(),
+        }
+    }
+
+    #[inline]
+    fn len(&self) -> usize {
+        usize::from(self.len & 0x0f)
+    }
+
+    pub(crate) fn set(&mut self, c: char, a: crate::attrs::Attrs) {
+        self.contents[0] = c;
+        self.len = 1;
+        // strings in this context should always be an arbitrary character
+        // followed by zero or more zero-width characters, so we should only
+        // have to look at the first character
+        self.set_wide(c.width().unwrap_or(1) > 1);
+        self.attrs = a;
+    }
+
+    pub(crate) fn append(&mut self, c: char) {
+        let len = self.len();
+        if len >= CODEPOINTS_IN_CELL {
+            return;
+        }
+        if len == 0 {
+            // 0 is always less than 6
+            self.contents[0] = ' ';
+            self.len += 1;
+        }
+
+        let len = self.len();
+        // we already checked that len < CODEPOINTS_IN_CELL
+        self.contents[len] = c;
+        self.len += 1;
+    }
+
+    pub(crate) fn clear(&mut self, attrs: crate::attrs::Attrs) {
+        self.len = 0;
+        self.attrs = attrs;
+    }
+
+    /// Returns the text contents of the cell.
+    ///
+    /// Can include multiple unicode characters if combining characters are
+    /// used, but will contain at most one character with a non-zero character
+    /// width.
+    #[must_use]
+    pub fn contents(&self) -> String {
+        let mut s = String::with_capacity(CODEPOINTS_IN_CELL * 4);
+        for c in self.contents.iter().take(self.len()) {
+            s.push(*c);
+        }
+        s
+    }
+
+    /// Returns whether the cell contains any text data.
+    #[must_use]
+    pub fn has_contents(&self) -> bool {
+        self.len > 0
+    }
+
+    /// Returns whether the text data in the cell represents a wide character.
+    #[must_use]
+    pub fn is_wide(&self) -> bool {
+        self.len & 0x80 == 0x80
+    }
+
+    /// Returns whether the cell contains the second half of a wide character
+    /// (in other words, whether the previous cell in the row contains a wide
+    /// character)
+    #[must_use]
+    pub fn is_wide_continuation(&self) -> bool {
+        self.len & 0x40 == 0x40
+    }
+
+    fn set_wide(&mut self, wide: bool) {
+        if wide {
+            self.len |= 0x80;
+        } else {
+            self.len &= 0x7f;
+        }
+    }
+
+    pub(crate) fn set_wide_continuation(&mut self, wide: bool) {
+        if wide {
+            self.len |= 0x40;
+        } else {
+            self.len &= 0xbf;
+        }
+    }
+
+    pub(crate) fn attrs(&self) -> &crate::attrs::Attrs {
+        &self.attrs
+    }
+
+    /// Returns the foreground color of the cell.
+    #[must_use]
+    pub fn fgcolor(&self) -> crate::Color {
+        self.attrs.fgcolor
+    }
+
+    /// Returns the background color of the cell.
+    #[must_use]
+    pub fn bgcolor(&self) -> crate::Color {
+        self.attrs.bgcolor
+    }
+
+    /// Returns whether the cell should be rendered with the bold text
+    /// attribute.
+    #[must_use]
+    pub fn bold(&self) -> bool {
+        self.attrs.bold()
+    }
+
+    /// Returns whether the cell should be rendered with the italic text
+    /// attribute.
+    #[must_use]
+    pub fn italic(&self) -> bool {
+        self.attrs.italic()
+    }
+
+    /// Returns whether the cell should be rendered with the underlined text
+    /// attribute.
+    #[must_use]
+    pub fn underline(&self) -> bool {
+        self.attrs.underline()
+    }
+
+    /// Returns whether the cell should be rendered with the inverse text
+    /// attribute.
+    #[must_use]
+    pub fn inverse(&self) -> bool {
+        self.attrs.inverse()
+    }
+}

--- a/crates/turborepo-vt100/src/grid.rs
+++ b/crates/turborepo-vt100/src/grid.rs
@@ -1,0 +1,728 @@
+use crate::term::BufWrite as _;
+
+#[derive(Clone, Debug)]
+pub struct Grid {
+    size: Size,
+    pos: Pos,
+    saved_pos: Pos,
+    rows: Vec<crate::row::Row>,
+    scroll_top: u16,
+    scroll_bottom: u16,
+    origin_mode: bool,
+    saved_origin_mode: bool,
+    scrollback: std::collections::VecDeque<crate::row::Row>,
+    scrollback_len: usize,
+    scrollback_offset: usize,
+}
+
+impl Grid {
+    pub fn new(size: Size, scrollback_len: usize) -> Self {
+        Self {
+            size,
+            pos: Pos::default(),
+            saved_pos: Pos::default(),
+            rows: vec![],
+            scroll_top: 0,
+            scroll_bottom: size.rows - 1,
+            origin_mode: false,
+            saved_origin_mode: false,
+            scrollback: std::collections::VecDeque::new(),
+            scrollback_len,
+            scrollback_offset: 0,
+        }
+    }
+
+    pub fn allocate_rows(&mut self) {
+        if self.rows.is_empty() {
+            self.rows.extend(
+                std::iter::repeat_with(|| {
+                    crate::row::Row::new(self.size.cols)
+                })
+                .take(usize::from(self.size.rows)),
+            );
+        }
+    }
+
+    fn new_row(&self) -> crate::row::Row {
+        crate::row::Row::new(self.size.cols)
+    }
+
+    pub fn clear(&mut self) {
+        self.pos = Pos::default();
+        self.saved_pos = Pos::default();
+        for row in self.drawing_rows_mut() {
+            row.clear(crate::attrs::Attrs::default());
+        }
+        self.scroll_top = 0;
+        self.scroll_bottom = self.size.rows - 1;
+        self.origin_mode = false;
+        self.saved_origin_mode = false;
+    }
+
+    pub fn size(&self) -> Size {
+        self.size
+    }
+
+    pub fn set_size(&mut self, size: Size) {
+        if size.cols != self.size.cols {
+            for row in &mut self.rows {
+                row.wrap(false);
+            }
+        }
+
+        if self.scroll_bottom == self.size.rows - 1 {
+            self.scroll_bottom = size.rows - 1;
+        }
+
+        self.size = size;
+        for row in &mut self.rows {
+            row.resize(size.cols, crate::Cell::new());
+        }
+        self.rows.resize(usize::from(size.rows), self.new_row());
+
+        if self.scroll_bottom >= size.rows {
+            self.scroll_bottom = size.rows - 1;
+        }
+        if self.scroll_bottom < self.scroll_top {
+            self.scroll_top = 0;
+        }
+
+        self.row_clamp_top(false);
+        self.row_clamp_bottom(false);
+        self.col_clamp();
+    }
+
+    pub fn pos(&self) -> Pos {
+        self.pos
+    }
+
+    pub fn set_pos(&mut self, mut pos: Pos) {
+        if self.origin_mode {
+            pos.row = pos.row.saturating_add(self.scroll_top);
+        }
+        self.pos = pos;
+        self.row_clamp_top(self.origin_mode);
+        self.row_clamp_bottom(self.origin_mode);
+        self.col_clamp();
+    }
+
+    pub fn save_cursor(&mut self) {
+        self.saved_pos = self.pos;
+        self.saved_origin_mode = self.origin_mode;
+    }
+
+    pub fn restore_cursor(&mut self) {
+        self.pos = self.saved_pos;
+        self.origin_mode = self.saved_origin_mode;
+    }
+
+    pub fn visible_rows(&self) -> impl Iterator<Item = &crate::row::Row> {
+        let scrollback_len = self.scrollback.len();
+        let rows_len = self.rows.len();
+        self.scrollback
+            .iter()
+            .skip(scrollback_len - self.scrollback_offset)
+            .chain(self.rows.iter().take(rows_len - self.scrollback_offset))
+    }
+
+    pub fn drawing_rows(&self) -> impl Iterator<Item = &crate::row::Row> {
+        self.rows.iter()
+    }
+
+    pub fn drawing_rows_mut(
+        &mut self,
+    ) -> impl Iterator<Item = &mut crate::row::Row> {
+        self.rows.iter_mut()
+    }
+
+    pub fn visible_row(&self, row: u16) -> Option<&crate::row::Row> {
+        self.visible_rows().nth(usize::from(row))
+    }
+
+    pub fn drawing_row(&self, row: u16) -> Option<&crate::row::Row> {
+        self.drawing_rows().nth(usize::from(row))
+    }
+
+    pub fn drawing_row_mut(
+        &mut self,
+        row: u16,
+    ) -> Option<&mut crate::row::Row> {
+        self.drawing_rows_mut().nth(usize::from(row))
+    }
+
+    pub fn current_row_mut(&mut self) -> &mut crate::row::Row {
+        self.drawing_row_mut(self.pos.row)
+            // we assume self.pos.row is always valid
+            .unwrap()
+    }
+
+    pub fn visible_cell(&self, pos: Pos) -> Option<&crate::Cell> {
+        self.visible_row(pos.row).and_then(|r| r.get(pos.col))
+    }
+
+    pub fn drawing_cell(&self, pos: Pos) -> Option<&crate::Cell> {
+        self.drawing_row(pos.row).and_then(|r| r.get(pos.col))
+    }
+
+    pub fn drawing_cell_mut(&mut self, pos: Pos) -> Option<&mut crate::Cell> {
+        self.drawing_row_mut(pos.row)
+            .and_then(|r| r.get_mut(pos.col))
+    }
+
+    pub fn scrollback_len(&self) -> usize {
+        self.scrollback_len
+    }
+
+    pub fn scrollback(&self) -> usize {
+        self.scrollback_offset
+    }
+
+    pub fn set_scrollback(&mut self, rows: usize) {
+        self.scrollback_offset = rows.min(self.scrollback.len());
+    }
+
+    pub fn write_contents(&self, contents: &mut String) {
+        let mut wrapping = false;
+        for row in self.visible_rows() {
+            row.write_contents(contents, 0, self.size.cols, wrapping);
+            if !row.wrapped() {
+                contents.push('\n');
+            }
+            wrapping = row.wrapped();
+        }
+
+        while contents.ends_with('\n') {
+            contents.truncate(contents.len() - 1);
+        }
+    }
+
+    pub fn write_contents_formatted(
+        &self,
+        contents: &mut Vec<u8>,
+    ) -> crate::attrs::Attrs {
+        crate::term::ClearAttrs.write_buf(contents);
+        crate::term::ClearScreen.write_buf(contents);
+
+        let mut prev_attrs = crate::attrs::Attrs::default();
+        let mut prev_pos = Pos::default();
+        let mut wrapping = false;
+        for (i, row) in self.visible_rows().enumerate() {
+            // we limit the number of cols to a u16 (see Size), so
+            // visible_rows() can never return more rows than will fit
+            let i = i.try_into().unwrap();
+            let (new_pos, new_attrs) = row.write_contents_formatted(
+                contents,
+                0,
+                self.size.cols,
+                i,
+                wrapping,
+                Some(prev_pos),
+                Some(prev_attrs),
+            );
+            prev_pos = new_pos;
+            prev_attrs = new_attrs;
+            wrapping = row.wrapped();
+        }
+
+        self.write_cursor_position_formatted(
+            contents,
+            Some(prev_pos),
+            Some(prev_attrs),
+        );
+
+        prev_attrs
+    }
+
+    pub fn write_contents_diff(
+        &self,
+        contents: &mut Vec<u8>,
+        prev: &Self,
+        mut prev_attrs: crate::attrs::Attrs,
+    ) -> crate::attrs::Attrs {
+        let mut prev_pos = prev.pos;
+        let mut wrapping = false;
+        let mut prev_wrapping = false;
+        for (i, (row, prev_row)) in
+            self.visible_rows().zip(prev.visible_rows()).enumerate()
+        {
+            // we limit the number of cols to a u16 (see Size), so
+            // visible_rows() can never return more rows than will fit
+            let i = i.try_into().unwrap();
+            let (new_pos, new_attrs) = row.write_contents_diff(
+                contents,
+                prev_row,
+                0,
+                self.size.cols,
+                i,
+                wrapping,
+                prev_wrapping,
+                prev_pos,
+                prev_attrs,
+            );
+            prev_pos = new_pos;
+            prev_attrs = new_attrs;
+            wrapping = row.wrapped();
+            prev_wrapping = prev_row.wrapped();
+        }
+
+        self.write_cursor_position_formatted(
+            contents,
+            Some(prev_pos),
+            Some(prev_attrs),
+        );
+
+        prev_attrs
+    }
+
+    pub fn write_cursor_position_formatted(
+        &self,
+        contents: &mut Vec<u8>,
+        prev_pos: Option<Pos>,
+        prev_attrs: Option<crate::attrs::Attrs>,
+    ) {
+        let prev_attrs = prev_attrs.unwrap_or_default();
+        // writing a character to the last column of a row doesn't wrap the
+        // cursor immediately - it waits until the next character is actually
+        // drawn. it is only possible for the cursor to have this kind of
+        // position after drawing a character though, so if we end in this
+        // position, we need to redraw the character at the end of the row.
+        if prev_pos != Some(self.pos) && self.pos.col >= self.size.cols {
+            let mut pos = Pos {
+                row: self.pos.row,
+                col: self.size.cols - 1,
+            };
+            if self
+                .drawing_cell(pos)
+                // we assume self.pos.row is always valid, and self.size.cols
+                // - 1 is always a valid column
+                .unwrap()
+                .is_wide_continuation()
+            {
+                pos.col = self.size.cols - 2;
+            }
+            let cell =
+                // we assume self.pos.row is always valid, and self.size.cols
+                // - 2 must be a valid column because self.size.cols - 1 is
+                // always valid and we just checked that the cell at
+                // self.size.cols - 1 is a wide continuation character, which
+                // means that the first half of the wide character must be
+                // before it
+                self.drawing_cell(pos).unwrap();
+            if cell.has_contents() {
+                if let Some(prev_pos) = prev_pos {
+                    crate::term::MoveFromTo::new(prev_pos, pos)
+                        .write_buf(contents);
+                } else {
+                    crate::term::MoveTo::new(pos).write_buf(contents);
+                }
+                cell.attrs().write_escape_code_diff(contents, &prev_attrs);
+                contents.extend(cell.contents().as_bytes());
+                prev_attrs.write_escape_code_diff(contents, cell.attrs());
+            } else {
+                // if the cell doesn't have contents, we can't have gotten
+                // here by drawing a character in the last column. this means
+                // that as far as i'm aware, we have to have reached here from
+                // a newline when we were already after the end of an earlier
+                // row. in the case where we are already after the end of an
+                // earlier row, we can just write a few newlines, otherwise we
+                // also need to do the same as above to get ourselves to after
+                // the end of a row.
+                let mut found = false;
+                for i in (0..self.pos.row).rev() {
+                    pos.row = i;
+                    pos.col = self.size.cols - 1;
+                    if self
+                        .drawing_cell(pos)
+                        // i is always less than self.pos.row, which we assume
+                        // to be always valid, so it must also be valid.
+                        // self.size.cols - 1 is always a valid col.
+                        .unwrap()
+                        .is_wide_continuation()
+                    {
+                        pos.col = self.size.cols - 2;
+                    }
+                    let cell = self
+                        .drawing_cell(pos)
+                        // i is always less than self.pos.row, which we assume
+                        // to be always valid, so it must also be valid.
+                        // self.size.cols - 2 is valid because self.size.cols
+                        // - 1 is always valid, and col gets set to
+                        // self.size.cols - 2 when the cell at self.size.cols
+                        // - 1 is a wide continuation character, meaning that
+                        // the first half of the wide character must be before
+                        // it
+                        .unwrap();
+                    if cell.has_contents() {
+                        if let Some(prev_pos) = prev_pos {
+                            if prev_pos.row != i
+                                || prev_pos.col < self.size.cols
+                            {
+                                crate::term::MoveFromTo::new(prev_pos, pos)
+                                    .write_buf(contents);
+                                cell.attrs().write_escape_code_diff(
+                                    contents,
+                                    &prev_attrs,
+                                );
+                                contents.extend(cell.contents().as_bytes());
+                                prev_attrs.write_escape_code_diff(
+                                    contents,
+                                    cell.attrs(),
+                                );
+                            }
+                        } else {
+                            crate::term::MoveTo::new(pos).write_buf(contents);
+                            cell.attrs().write_escape_code_diff(
+                                contents,
+                                &prev_attrs,
+                            );
+                            contents.extend(cell.contents().as_bytes());
+                            prev_attrs.write_escape_code_diff(
+                                contents,
+                                cell.attrs(),
+                            );
+                        }
+                        contents.extend(
+                            "\n".repeat(usize::from(self.pos.row - i))
+                                .as_bytes(),
+                        );
+                        found = true;
+                        break;
+                    }
+                }
+
+                // this can happen if you get the cursor off the end of a row,
+                // and then do something to clear the end of the current row
+                // without moving the cursor (IL, DL, ED, EL, etc). we know
+                // there can't be something in the last column because we
+                // would have caught that above, so it should be safe to
+                // overwrite it.
+                if !found {
+                    pos = Pos {
+                        row: self.pos.row,
+                        col: self.size.cols - 1,
+                    };
+                    if let Some(prev_pos) = prev_pos {
+                        crate::term::MoveFromTo::new(prev_pos, pos)
+                            .write_buf(contents);
+                    } else {
+                        crate::term::MoveTo::new(pos).write_buf(contents);
+                    }
+                    contents.push(b' ');
+                    // we know that the cell has no contents, but it still may
+                    // have drawing attributes (background color, etc)
+                    let end_cell = self
+                        .drawing_cell(pos)
+                        // we assume self.pos.row is always valid, and
+                        // self.size.cols - 1 is always a valid column
+                        .unwrap();
+                    end_cell
+                        .attrs()
+                        .write_escape_code_diff(contents, &prev_attrs);
+                    crate::term::SaveCursor.write_buf(contents);
+                    crate::term::Backspace.write_buf(contents);
+                    crate::term::EraseChar::new(1).write_buf(contents);
+                    crate::term::RestoreCursor.write_buf(contents);
+                    prev_attrs
+                        .write_escape_code_diff(contents, end_cell.attrs());
+                }
+            }
+        } else if let Some(prev_pos) = prev_pos {
+            crate::term::MoveFromTo::new(prev_pos, self.pos)
+                .write_buf(contents);
+        } else {
+            crate::term::MoveTo::new(self.pos).write_buf(contents);
+        }
+    }
+
+    pub fn erase_all(&mut self, attrs: crate::attrs::Attrs) {
+        for row in self.drawing_rows_mut() {
+            row.clear(attrs);
+        }
+    }
+
+    pub fn erase_all_forward(&mut self, attrs: crate::attrs::Attrs) {
+        let pos = self.pos;
+        for row in self.drawing_rows_mut().skip(usize::from(pos.row) + 1) {
+            row.clear(attrs);
+        }
+
+        self.erase_row_forward(attrs);
+    }
+
+    pub fn erase_all_backward(&mut self, attrs: crate::attrs::Attrs) {
+        let pos = self.pos;
+        for row in self.drawing_rows_mut().take(usize::from(pos.row)) {
+            row.clear(attrs);
+        }
+
+        self.erase_row_backward(attrs);
+    }
+
+    pub fn erase_row(&mut self, attrs: crate::attrs::Attrs) {
+        self.current_row_mut().clear(attrs);
+    }
+
+    pub fn erase_row_forward(&mut self, attrs: crate::attrs::Attrs) {
+        let size = self.size;
+        let pos = self.pos;
+        let row = self.current_row_mut();
+        for col in pos.col..size.cols {
+            row.erase(col, attrs);
+        }
+    }
+
+    pub fn erase_row_backward(&mut self, attrs: crate::attrs::Attrs) {
+        let size = self.size;
+        let pos = self.pos;
+        let row = self.current_row_mut();
+        for col in 0..=pos.col.min(size.cols - 1) {
+            row.erase(col, attrs);
+        }
+    }
+
+    pub fn insert_cells(&mut self, count: u16) {
+        let size = self.size;
+        let pos = self.pos;
+        let wide = pos.col < size.cols
+            && self
+                .drawing_cell(pos)
+                // we assume self.pos.row is always valid, and we know we are
+                // not off the end of a row because we just checked pos.col <
+                // size.cols
+                .unwrap()
+                .is_wide_continuation();
+        let row = self.current_row_mut();
+        for _ in 0..count {
+            if wide {
+                row.get_mut(pos.col).unwrap().set_wide_continuation(false);
+            }
+            row.insert(pos.col, crate::Cell::new());
+            if wide {
+                row.get_mut(pos.col).unwrap().set_wide_continuation(true);
+            }
+        }
+        row.truncate(size.cols);
+    }
+
+    pub fn delete_cells(&mut self, count: u16) {
+        let size = self.size;
+        let pos = self.pos;
+        let row = self.current_row_mut();
+        for _ in 0..(count.min(size.cols - pos.col)) {
+            row.remove(pos.col);
+        }
+        row.resize(size.cols, crate::Cell::new());
+    }
+
+    pub fn erase_cells(&mut self, count: u16, attrs: crate::attrs::Attrs) {
+        let size = self.size;
+        let pos = self.pos;
+        let row = self.current_row_mut();
+        for col in pos.col..((pos.col.saturating_add(count)).min(size.cols)) {
+            row.erase(col, attrs);
+        }
+    }
+
+    pub fn insert_lines(&mut self, count: u16) {
+        for _ in 0..count {
+            self.rows.remove(usize::from(self.scroll_bottom));
+            self.rows.insert(usize::from(self.pos.row), self.new_row());
+            // self.scroll_bottom is maintained to always be a valid row
+            self.rows[usize::from(self.scroll_bottom)].wrap(false);
+        }
+    }
+
+    pub fn delete_lines(&mut self, count: u16) {
+        for _ in 0..(count.min(self.size.rows - self.pos.row)) {
+            self.rows
+                .insert(usize::from(self.scroll_bottom) + 1, self.new_row());
+            self.rows.remove(usize::from(self.pos.row));
+        }
+    }
+
+    pub fn scroll_up(&mut self, count: u16) {
+        for _ in 0..(count.min(self.size.rows - self.scroll_top)) {
+            self.rows
+                .insert(usize::from(self.scroll_bottom) + 1, self.new_row());
+            let removed = self.rows.remove(usize::from(self.scroll_top));
+            if self.scrollback_len > 0 && !self.scroll_region_active() {
+                self.scrollback.push_back(removed);
+                while self.scrollback.len() > self.scrollback_len {
+                    self.scrollback.pop_front();
+                }
+                if self.scrollback_offset > 0 {
+                    self.scrollback_offset =
+                        self.scrollback.len().min(self.scrollback_offset + 1);
+                }
+            }
+        }
+    }
+
+    pub fn scroll_down(&mut self, count: u16) {
+        for _ in 0..count {
+            self.rows.remove(usize::from(self.scroll_bottom));
+            self.rows
+                .insert(usize::from(self.scroll_top), self.new_row());
+            // self.scroll_bottom is maintained to always be a valid row
+            self.rows[usize::from(self.scroll_bottom)].wrap(false);
+        }
+    }
+
+    pub fn set_scroll_region(&mut self, top: u16, bottom: u16) {
+        let bottom = bottom.min(self.size().rows - 1);
+        if top < bottom {
+            self.scroll_top = top;
+            self.scroll_bottom = bottom;
+        } else {
+            self.scroll_top = 0;
+            self.scroll_bottom = self.size().rows - 1;
+        }
+        self.pos.row = self.scroll_top;
+        self.pos.col = 0;
+    }
+
+    fn in_scroll_region(&self) -> bool {
+        self.pos.row >= self.scroll_top && self.pos.row <= self.scroll_bottom
+    }
+
+    fn scroll_region_active(&self) -> bool {
+        self.scroll_top != 0 || self.scroll_bottom != self.size.rows - 1
+    }
+
+    pub fn set_origin_mode(&mut self, mode: bool) {
+        self.origin_mode = mode;
+        self.set_pos(Pos { row: 0, col: 0 });
+    }
+
+    pub fn row_inc_clamp(&mut self, count: u16) {
+        let in_scroll_region = self.in_scroll_region();
+        self.pos.row = self.pos.row.saturating_add(count);
+        self.row_clamp_bottom(in_scroll_region);
+    }
+
+    pub fn row_inc_scroll(&mut self, count: u16) -> u16 {
+        let in_scroll_region = self.in_scroll_region();
+        self.pos.row = self.pos.row.saturating_add(count);
+        let lines = self.row_clamp_bottom(in_scroll_region);
+        if in_scroll_region {
+            self.scroll_up(lines);
+            lines
+        } else {
+            0
+        }
+    }
+
+    pub fn row_dec_clamp(&mut self, count: u16) {
+        let in_scroll_region = self.in_scroll_region();
+        self.pos.row = self.pos.row.saturating_sub(count);
+        self.row_clamp_top(in_scroll_region);
+    }
+
+    pub fn row_dec_scroll(&mut self, count: u16) {
+        let in_scroll_region = self.in_scroll_region();
+        // need to account for clamping by both row_clamp_top and by
+        // saturating_sub
+        let extra_lines = if count > self.pos.row {
+            count - self.pos.row
+        } else {
+            0
+        };
+        self.pos.row = self.pos.row.saturating_sub(count);
+        let lines = self.row_clamp_top(in_scroll_region);
+        self.scroll_down(lines + extra_lines);
+    }
+
+    pub fn row_set(&mut self, i: u16) {
+        self.pos.row = i;
+        self.row_clamp();
+    }
+
+    pub fn col_inc(&mut self, count: u16) {
+        self.pos.col = self.pos.col.saturating_add(count);
+    }
+
+    pub fn col_inc_clamp(&mut self, count: u16) {
+        self.pos.col = self.pos.col.saturating_add(count);
+        self.col_clamp();
+    }
+
+    pub fn col_dec(&mut self, count: u16) {
+        self.pos.col = self.pos.col.saturating_sub(count);
+    }
+
+    pub fn col_tab(&mut self) {
+        self.pos.col -= self.pos.col % 8;
+        self.pos.col += 8;
+        self.col_clamp();
+    }
+
+    pub fn col_set(&mut self, i: u16) {
+        self.pos.col = i;
+        self.col_clamp();
+    }
+
+    pub fn col_wrap(&mut self, width: u16, wrap: bool) {
+        if self.pos.col > self.size.cols - width {
+            let mut prev_pos = self.pos;
+            self.pos.col = 0;
+            let scrolled = self.row_inc_scroll(1);
+            prev_pos.row -= scrolled;
+            let new_pos = self.pos;
+            self.drawing_row_mut(prev_pos.row)
+                // we assume self.pos.row is always valid, and so prev_pos.row
+                // must be valid because it is always less than or equal to
+                // self.pos.row
+                .unwrap()
+                .wrap(wrap && prev_pos.row + 1 == new_pos.row);
+        }
+    }
+
+    fn row_clamp_top(&mut self, limit_to_scroll_region: bool) -> u16 {
+        if limit_to_scroll_region && self.pos.row < self.scroll_top {
+            let rows = self.scroll_top - self.pos.row;
+            self.pos.row = self.scroll_top;
+            rows
+        } else {
+            0
+        }
+    }
+
+    fn row_clamp_bottom(&mut self, limit_to_scroll_region: bool) -> u16 {
+        let bottom = if limit_to_scroll_region {
+            self.scroll_bottom
+        } else {
+            self.size.rows - 1
+        };
+        if self.pos.row > bottom {
+            let rows = self.pos.row - bottom;
+            self.pos.row = bottom;
+            rows
+        } else {
+            0
+        }
+    }
+
+    fn row_clamp(&mut self) {
+        if self.pos.row > self.size.rows - 1 {
+            self.pos.row = self.size.rows - 1;
+        }
+    }
+
+    fn col_clamp(&mut self) {
+        if self.pos.col > self.size.cols - 1 {
+            self.pos.col = self.size.cols - 1;
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
+pub struct Size {
+    pub rows: u16,
+    pub cols: u16,
+}
+
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
+pub struct Pos {
+    pub row: u16,
+    pub col: u16,
+}

--- a/crates/turborepo-vt100/src/lib.rs
+++ b/crates/turborepo-vt100/src/lib.rs
@@ -1,0 +1,63 @@
+//! This crate parses a terminal byte stream and provides an in-memory
+//! representation of the rendered contents.
+//!
+//! # Overview
+//!
+//! This is essentially the terminal parser component of a graphical terminal
+//! emulator pulled out into a separate crate. Although you can use this crate
+//! to build a graphical terminal emulator, it also contains functionality
+//! necessary for implementing terminal applications that want to run other
+//! terminal applications - programs like `screen` or `tmux` for example.
+//!
+//! # Synopsis
+//!
+//! ```
+//! let mut parser = vt100::Parser::new(24, 80, 0);
+//!
+//! let screen = parser.screen().clone();
+//! parser.process(b"this text is \x1b[31mRED\x1b[m");
+//! assert_eq!(
+//!     parser.screen().cell(0, 13).unwrap().fgcolor(),
+//!     vt100::Color::Idx(1),
+//! );
+//!
+//! let screen = parser.screen().clone();
+//! parser.process(b"\x1b[3D\x1b[32mGREEN");
+//! assert_eq!(
+//!     parser.screen().contents_formatted(),
+//!     &b"\x1b[?25h\x1b[m\x1b[H\x1b[Jthis text is \x1b[32mGREEN"[..],
+//! );
+//! assert_eq!(
+//!     parser.screen().contents_diff(&screen),
+//!     &b"\x1b[1;14H\x1b[32mGREEN"[..],
+//! );
+//! ```
+
+#![warn(clippy::cargo)]
+#![warn(clippy::pedantic)]
+#![warn(clippy::nursery)]
+#![warn(clippy::as_conversions)]
+#![warn(clippy::get_unwrap)]
+#![allow(clippy::cognitive_complexity)]
+#![allow(clippy::missing_const_for_fn)]
+#![allow(clippy::similar_names)]
+#![allow(clippy::struct_excessive_bools)]
+#![allow(clippy::too_many_arguments)]
+#![allow(clippy::too_many_lines)]
+#![allow(clippy::type_complexity)]
+
+mod attrs;
+mod callbacks;
+mod cell;
+mod grid;
+mod parser;
+mod perform;
+mod row;
+mod screen;
+mod term;
+
+pub use attrs::Color;
+pub use callbacks::Callbacks;
+pub use cell::Cell;
+pub use parser::Parser;
+pub use screen::{MouseProtocolEncoding, MouseProtocolMode, Screen};

--- a/crates/turborepo-vt100/src/parser.rs
+++ b/crates/turborepo-vt100/src/parser.rs
@@ -1,0 +1,78 @@
+/// A parser for terminal output which produces an in-memory representation of
+/// the terminal contents.
+pub struct Parser {
+    parser: vte::Parser,
+    screen: crate::perform::WrappedScreen,
+}
+
+impl Parser {
+    /// Creates a new terminal parser of the given size and with the given
+    /// amount of scrollback.
+    #[must_use]
+    pub fn new(rows: u16, cols: u16, scrollback_len: usize) -> Self {
+        Self {
+            parser: vte::Parser::new(),
+            screen: crate::perform::WrappedScreen(crate::Screen::new(
+                crate::grid::Size { rows, cols },
+                scrollback_len,
+            )),
+        }
+    }
+
+    /// Processes the contents of the given byte string, and updates the
+    /// in-memory terminal state.
+    pub fn process(&mut self, bytes: &[u8]) {
+        for byte in bytes {
+            self.parser.advance(&mut self.screen, *byte);
+        }
+    }
+
+    /// Processes the contents of the given byte string, and updates the
+    /// in-memory terminal state. Calls methods on the given `Callbacks`
+    /// object when relevant escape sequences are seen.
+    pub fn process_cb(
+        &mut self,
+        bytes: &[u8],
+        callbacks: &mut impl crate::callbacks::Callbacks,
+    ) {
+        let mut screen = crate::perform::WrappedScreenWithCallbacks::new(
+            &mut self.screen,
+            callbacks,
+        );
+        for byte in bytes {
+            self.parser.advance(&mut screen, *byte);
+        }
+    }
+
+    /// Returns a reference to a `Screen` object containing the terminal
+    /// state.
+    #[must_use]
+    pub fn screen(&self) -> &crate::Screen {
+        &self.screen.0
+    }
+
+    /// Returns a mutable reference to a `Screen` object containing the
+    /// terminal state.
+    #[must_use]
+    pub fn screen_mut(&mut self) -> &mut crate::Screen {
+        &mut self.screen.0
+    }
+}
+
+impl Default for Parser {
+    /// Returns a parser with dimensions 80x24 and no scrollback.
+    fn default() -> Self {
+        Self::new(24, 80, 0)
+    }
+}
+
+impl std::io::Write for Parser {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.process(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}

--- a/crates/turborepo-vt100/src/perform.rs
+++ b/crates/turborepo-vt100/src/perform.rs
@@ -1,0 +1,305 @@
+pub struct WrappedScreen(pub crate::Screen);
+
+impl vte::Perform for WrappedScreen {
+    fn print(&mut self, c: char) {
+        if c == '\u{fffd}' || ('\u{80}'..'\u{a0}').contains(&c) {
+            log::debug!("unhandled text character: {c}");
+        }
+        self.0.text(c);
+    }
+
+    fn execute(&mut self, b: u8) {
+        match b {
+            8 => self.0.bs(),
+            9 => self.0.tab(),
+            10 => self.0.lf(),
+            11 => self.0.vt(),
+            12 => self.0.ff(),
+            13 => self.0.cr(),
+            // we don't implement shift in/out alternate character sets, but
+            // it shouldn't count as an "error"
+            7 | 14 | 15 => {}
+            _ => {
+                log::debug!("unhandled control character: {b}");
+            }
+        }
+    }
+
+    fn esc_dispatch(&mut self, intermediates: &[u8], _ignore: bool, b: u8) {
+        intermediates.first().map_or_else(
+            || match b {
+                b'7' => self.0.decsc(),
+                b'8' => self.0.decrc(),
+                b'=' => self.0.deckpam(),
+                b'>' => self.0.deckpnm(),
+                b'M' => self.0.ri(),
+                b'c' => self.0.ris(),
+                b'g' => {}
+                _ => {
+                    log::debug!("unhandled escape code: ESC {b}");
+                }
+            },
+            |i| {
+                log::debug!("unhandled escape code: ESC {i} {b}");
+            },
+        );
+    }
+
+    fn csi_dispatch(
+        &mut self,
+        params: &vte::Params,
+        intermediates: &[u8],
+        _ignore: bool,
+        c: char,
+    ) {
+        match intermediates.first() {
+            None => match c {
+                '@' => self.0.ich(canonicalize_params_1(params, 1)),
+                'A' => self.0.cuu(canonicalize_params_1(params, 1)),
+                'B' => self.0.cud(canonicalize_params_1(params, 1)),
+                'C' => self.0.cuf(canonicalize_params_1(params, 1)),
+                'D' => self.0.cub(canonicalize_params_1(params, 1)),
+                'E' => self.0.cnl(canonicalize_params_1(params, 1)),
+                'F' => self.0.cpl(canonicalize_params_1(params, 1)),
+                'G' => self.0.cha(canonicalize_params_1(params, 1)),
+                'H' => self.0.cup(canonicalize_params_2(params, 1, 1)),
+                'J' => self.0.ed(canonicalize_params_1(params, 0)),
+                'K' => self.0.el(canonicalize_params_1(params, 0)),
+                'L' => self.0.il(canonicalize_params_1(params, 1)),
+                'M' => self.0.dl(canonicalize_params_1(params, 1)),
+                'P' => self.0.dch(canonicalize_params_1(params, 1)),
+                'S' => self.0.su(canonicalize_params_1(params, 1)),
+                'T' => self.0.sd(canonicalize_params_1(params, 1)),
+                'X' => self.0.ech(canonicalize_params_1(params, 1)),
+                'd' => self.0.vpa(canonicalize_params_1(params, 1)),
+                'h' => self.0.sm(params),
+                'l' => self.0.rm(params),
+                'm' => self.0.sgr(params),
+                'r' => self.0.decstbm(canonicalize_params_decstbm(
+                    params,
+                    self.0.grid().size(),
+                )),
+                't' => self.0.xtwinops(params),
+                _ => {
+                    if log::log_enabled!(log::Level::Debug) {
+                        log::debug!(
+                            "unhandled csi sequence: CSI {} {}",
+                            param_str(params),
+                            c
+                        );
+                    }
+                }
+            },
+            Some(b'?') => match c {
+                'J' => self.0.decsed(canonicalize_params_1(params, 0)),
+                'K' => self.0.decsel(canonicalize_params_1(params, 0)),
+                'h' => self.0.decset(params),
+                'l' => self.0.decrst(params),
+                _ => {
+                    if log::log_enabled!(log::Level::Debug) {
+                        log::debug!(
+                            "unhandled csi sequence: CSI ? {} {}",
+                            param_str(params),
+                            c
+                        );
+                    }
+                }
+            },
+            Some(i) => {
+                if log::log_enabled!(log::Level::Debug) {
+                    log::debug!(
+                        "unhandled csi sequence: CSI {} {} {}",
+                        i,
+                        param_str(params),
+                        c
+                    );
+                }
+            }
+        }
+    }
+
+    fn osc_dispatch(&mut self, params: &[&[u8]], _bel_terminated: bool) {
+        match (params.get(0), params.get(1)) {
+            (Some(&b"0"), Some(s)) => self.0.osc0(s),
+            (Some(&b"1"), Some(s)) => self.0.osc1(s),
+            (Some(&b"2"), Some(s)) => self.0.osc2(s),
+            _ => {
+                if log::log_enabled!(log::Level::Debug) {
+                    log::debug!(
+                        "unhandled osc sequence: OSC {}",
+                        osc_param_str(params),
+                    );
+                }
+            }
+        }
+    }
+
+    fn hook(
+        &mut self,
+        params: &vte::Params,
+        intermediates: &[u8],
+        _ignore: bool,
+        action: char,
+    ) {
+        if log::log_enabled!(log::Level::Debug) {
+            intermediates.first().map_or_else(
+                || {
+                    log::debug!(
+                        "unhandled dcs sequence: DCS {} {}",
+                        param_str(params),
+                        action,
+                    );
+                },
+                |i| {
+                    log::debug!(
+                        "unhandled dcs sequence: DCS {} {} {}",
+                        i,
+                        param_str(params),
+                        action,
+                    );
+                },
+            );
+        }
+    }
+}
+
+fn canonicalize_params_1(params: &vte::Params, default: u16) -> u16 {
+    let first = params.iter().next().map_or(0, |x| *x.first().unwrap_or(&0));
+    if first == 0 {
+        default
+    } else {
+        first
+    }
+}
+
+fn canonicalize_params_2(
+    params: &vte::Params,
+    default1: u16,
+    default2: u16,
+) -> (u16, u16) {
+    let mut iter = params.iter();
+    let first = iter.next().map_or(0, |x| *x.first().unwrap_or(&0));
+    let first = if first == 0 { default1 } else { first };
+
+    let second = iter.next().map_or(0, |x| *x.first().unwrap_or(&0));
+    let second = if second == 0 { default2 } else { second };
+
+    (first, second)
+}
+
+fn canonicalize_params_decstbm(
+    params: &vte::Params,
+    size: crate::grid::Size,
+) -> (u16, u16) {
+    let mut iter = params.iter();
+    let top = iter.next().map_or(0, |x| *x.first().unwrap_or(&0));
+    let top = if top == 0 { 1 } else { top };
+
+    let bottom = iter.next().map_or(0, |x| *x.first().unwrap_or(&0));
+    let bottom = if bottom == 0 { size.rows } else { bottom };
+
+    (top, bottom)
+}
+
+pub fn param_str(params: &vte::Params) -> String {
+    let strs: Vec<_> = params
+        .iter()
+        .map(|subparams| {
+            let subparam_strs: Vec<_> = subparams
+                .iter()
+                .map(std::string::ToString::to_string)
+                .collect();
+            subparam_strs.join(" : ")
+        })
+        .collect();
+    strs.join(" ; ")
+}
+
+fn osc_param_str(params: &[&[u8]]) -> String {
+    let strs: Vec<_> = params
+        .iter()
+        .map(|b| format!("\"{}\"", std::string::String::from_utf8_lossy(b)))
+        .collect();
+    strs.join(" ; ")
+}
+
+pub struct WrappedScreenWithCallbacks<'a, T: crate::callbacks::Callbacks> {
+    screen: &'a mut crate::perform::WrappedScreen,
+    callbacks: &'a mut T,
+}
+
+impl<'a, T: crate::callbacks::Callbacks> WrappedScreenWithCallbacks<'a, T> {
+    pub fn new(
+        screen: &'a mut crate::perform::WrappedScreen,
+        callbacks: &'a mut T,
+    ) -> Self {
+        Self { screen, callbacks }
+    }
+}
+
+impl<'a, T: crate::callbacks::Callbacks> vte::Perform
+    for WrappedScreenWithCallbacks<'a, T>
+{
+    fn print(&mut self, c: char) {
+        if c == '\u{fffd}' || ('\u{80}'..'\u{a0}').contains(&c) {
+            self.callbacks.error(&mut self.screen.0);
+        }
+        self.screen.print(c);
+    }
+
+    fn execute(&mut self, b: u8) {
+        match b {
+            7 => self.callbacks.audible_bell(&mut self.screen.0),
+            8..=15 => {}
+            _ => {
+                self.callbacks.error(&mut self.screen.0);
+            }
+        }
+        self.screen.execute(b);
+    }
+
+    fn esc_dispatch(&mut self, intermediates: &[u8], ignore: bool, b: u8) {
+        if intermediates.is_empty() && b == b'g' {
+            self.callbacks.visual_bell(&mut self.screen.0);
+        }
+        self.screen.esc_dispatch(intermediates, ignore, b);
+    }
+
+    fn csi_dispatch(
+        &mut self,
+        params: &vte::Params,
+        intermediates: &[u8],
+        ignore: bool,
+        c: char,
+    ) {
+        if intermediates.first().is_none() && c == 't' {
+            let mut iter = params.iter();
+            let op = iter.next().and_then(|x| x.first().copied());
+            if op == Some(8) {
+                let (screen_rows, screen_cols) = self.screen.0.size();
+                let rows = iter.next().map_or(screen_rows, |x| {
+                    *x.first().unwrap_or(&screen_rows)
+                });
+                let cols = iter.next().map_or(screen_cols, |x| {
+                    *x.first().unwrap_or(&screen_cols)
+                });
+                self.callbacks.resize(&mut self.screen.0, (rows, cols));
+            }
+        }
+        self.screen.csi_dispatch(params, intermediates, ignore, c);
+    }
+
+    fn osc_dispatch(&mut self, params: &[&[u8]], bel_terminated: bool) {
+        self.screen.osc_dispatch(params, bel_terminated);
+    }
+
+    fn hook(
+        &mut self,
+        params: &vte::Params,
+        intermediates: &[u8],
+        ignore: bool,
+        action: char,
+    ) {
+        self.screen.hook(params, intermediates, ignore, action);
+    }
+}

--- a/crates/turborepo-vt100/src/row.rs
+++ b/crates/turborepo-vt100/src/row.rs
@@ -1,0 +1,474 @@
+use crate::term::BufWrite as _;
+
+#[derive(Clone, Debug)]
+pub struct Row {
+    cells: Vec<crate::Cell>,
+    wrapped: bool,
+}
+
+impl Row {
+    pub fn new(cols: u16) -> Self {
+        Self {
+            cells: vec![crate::Cell::new(); usize::from(cols)],
+            wrapped: false,
+        }
+    }
+
+    fn cols(&self) -> u16 {
+        self.cells
+            .len()
+            .try_into()
+            // we limit the number of cols to a u16 (see Size)
+            .unwrap()
+    }
+
+    pub fn clear(&mut self, attrs: crate::attrs::Attrs) {
+        for cell in &mut self.cells {
+            cell.clear(attrs);
+        }
+        self.wrapped = false;
+    }
+
+    fn cells(&self) -> impl Iterator<Item = &crate::Cell> {
+        self.cells.iter()
+    }
+
+    pub fn get(&self, col: u16) -> Option<&crate::Cell> {
+        self.cells.get(usize::from(col))
+    }
+
+    pub fn get_mut(&mut self, col: u16) -> Option<&mut crate::Cell> {
+        self.cells.get_mut(usize::from(col))
+    }
+
+    pub fn insert(&mut self, i: u16, cell: crate::Cell) {
+        self.cells.insert(usize::from(i), cell);
+        self.wrapped = false;
+    }
+
+    pub fn remove(&mut self, i: u16) {
+        self.clear_wide(i);
+        self.cells.remove(usize::from(i));
+        self.wrapped = false;
+    }
+
+    pub fn erase(&mut self, i: u16, attrs: crate::attrs::Attrs) {
+        let wide = self.cells[usize::from(i)].is_wide();
+        self.clear_wide(i);
+        self.cells[usize::from(i)].clear(attrs);
+        if i == self.cols() - if wide { 2 } else { 1 } {
+            self.wrapped = false;
+        }
+    }
+
+    pub fn truncate(&mut self, len: u16) {
+        self.cells.truncate(usize::from(len));
+        self.wrapped = false;
+        let last_cell = &mut self.cells[usize::from(len) - 1];
+        if last_cell.is_wide() {
+            last_cell.clear(*last_cell.attrs());
+        }
+    }
+
+    pub fn resize(&mut self, len: u16, cell: crate::Cell) {
+        self.cells.resize(usize::from(len), cell);
+        self.wrapped = false;
+    }
+
+    pub fn wrap(&mut self, wrap: bool) {
+        self.wrapped = wrap;
+    }
+
+    pub fn wrapped(&self) -> bool {
+        self.wrapped
+    }
+
+    pub fn clear_wide(&mut self, col: u16) {
+        let cell = &self.cells[usize::from(col)];
+        let other = if cell.is_wide() {
+            &mut self.cells[usize::from(col + 1)]
+        } else if cell.is_wide_continuation() {
+            &mut self.cells[usize::from(col - 1)]
+        } else {
+            return;
+        };
+        other.clear(*other.attrs());
+    }
+
+    pub fn write_contents(
+        &self,
+        contents: &mut String,
+        start: u16,
+        width: u16,
+        wrapping: bool,
+    ) {
+        let mut prev_was_wide = false;
+
+        let mut prev_col = start;
+        for (col, cell) in self
+            .cells()
+            .enumerate()
+            .skip(usize::from(start))
+            .take(usize::from(width))
+        {
+            if prev_was_wide {
+                prev_was_wide = false;
+                continue;
+            }
+            prev_was_wide = cell.is_wide();
+
+            // we limit the number of cols to a u16 (see Size)
+            let col: u16 = col.try_into().unwrap();
+            if cell.has_contents() {
+                for _ in 0..(col - prev_col) {
+                    contents.push(' ');
+                }
+                prev_col += col - prev_col;
+
+                contents.push_str(&cell.contents());
+                prev_col += if cell.is_wide() { 2 } else { 1 };
+            }
+        }
+        if prev_col == start && wrapping {
+            contents.push('\n');
+        }
+    }
+
+    pub fn write_contents_formatted(
+        &self,
+        contents: &mut Vec<u8>,
+        start: u16,
+        width: u16,
+        row: u16,
+        wrapping: bool,
+        prev_pos: Option<crate::grid::Pos>,
+        prev_attrs: Option<crate::attrs::Attrs>,
+    ) -> (crate::grid::Pos, crate::attrs::Attrs) {
+        let mut prev_was_wide = false;
+        let default_cell = crate::Cell::new();
+
+        let mut prev_pos = prev_pos.unwrap_or_else(|| {
+            if wrapping {
+                crate::grid::Pos {
+                    row: row - 1,
+                    col: self.cols(),
+                }
+            } else {
+                crate::grid::Pos { row, col: start }
+            }
+        });
+        let mut prev_attrs = prev_attrs.unwrap_or_default();
+
+        let first_cell = &self.cells[usize::from(start)];
+        if wrapping && first_cell == &default_cell {
+            let default_attrs = default_cell.attrs();
+            if &prev_attrs != default_attrs {
+                default_attrs.write_escape_code_diff(contents, &prev_attrs);
+                prev_attrs = *default_attrs;
+            }
+            contents.push(b' ');
+            crate::term::Backspace.write_buf(contents);
+            crate::term::EraseChar::new(1).write_buf(contents);
+            prev_pos = crate::grid::Pos { row, col: 0 };
+        }
+
+        let mut erase: Option<(u16, &crate::attrs::Attrs)> = None;
+        for (col, cell) in self
+            .cells()
+            .enumerate()
+            .skip(usize::from(start))
+            .take(usize::from(width))
+        {
+            if prev_was_wide {
+                prev_was_wide = false;
+                continue;
+            }
+            prev_was_wide = cell.is_wide();
+
+            // we limit the number of cols to a u16 (see Size)
+            let col: u16 = col.try_into().unwrap();
+            let pos = crate::grid::Pos { row, col };
+
+            if let Some((prev_col, attrs)) = erase {
+                if cell.has_contents() || cell.attrs() != attrs {
+                    let new_pos = crate::grid::Pos { row, col: prev_col };
+                    if wrapping
+                        && prev_pos.row + 1 == new_pos.row
+                        && prev_pos.col >= self.cols()
+                    {
+                        if new_pos.col > 0 {
+                            contents.extend(
+                                " ".repeat(usize::from(new_pos.col))
+                                    .as_bytes(),
+                            );
+                        } else {
+                            contents.extend(b" ");
+                            crate::term::Backspace.write_buf(contents);
+                        }
+                    } else {
+                        crate::term::MoveFromTo::new(prev_pos, new_pos)
+                            .write_buf(contents);
+                    }
+                    prev_pos = new_pos;
+                    if &prev_attrs != attrs {
+                        attrs.write_escape_code_diff(contents, &prev_attrs);
+                        prev_attrs = *attrs;
+                    }
+                    crate::term::EraseChar::new(pos.col - prev_col)
+                        .write_buf(contents);
+                    erase = None;
+                }
+            }
+
+            if cell != &default_cell {
+                let attrs = cell.attrs();
+                if cell.has_contents() {
+                    if pos != prev_pos {
+                        if !wrapping
+                            || prev_pos.row + 1 != pos.row
+                            || prev_pos.col
+                                < self.cols() - u16::from(cell.is_wide())
+                            || pos.col != 0
+                        {
+                            crate::term::MoveFromTo::new(prev_pos, pos)
+                                .write_buf(contents);
+                        }
+                        prev_pos = pos;
+                    }
+
+                    if &prev_attrs != attrs {
+                        attrs.write_escape_code_diff(contents, &prev_attrs);
+                        prev_attrs = *attrs;
+                    }
+
+                    prev_pos.col += if cell.is_wide() { 2 } else { 1 };
+                    let cell_contents = cell.contents();
+                    contents.extend(cell_contents.as_bytes());
+                } else if erase.is_none() {
+                    erase = Some((pos.col, attrs));
+                }
+            }
+        }
+        if let Some((prev_col, attrs)) = erase {
+            let new_pos = crate::grid::Pos { row, col: prev_col };
+            if wrapping
+                && prev_pos.row + 1 == new_pos.row
+                && prev_pos.col >= self.cols()
+            {
+                if new_pos.col > 0 {
+                    contents.extend(
+                        " ".repeat(usize::from(new_pos.col)).as_bytes(),
+                    );
+                } else {
+                    contents.extend(b" ");
+                    crate::term::Backspace.write_buf(contents);
+                }
+            } else {
+                crate::term::MoveFromTo::new(prev_pos, new_pos)
+                    .write_buf(contents);
+            }
+            prev_pos = new_pos;
+            if &prev_attrs != attrs {
+                attrs.write_escape_code_diff(contents, &prev_attrs);
+                prev_attrs = *attrs;
+            }
+            crate::term::ClearRowForward.write_buf(contents);
+        }
+
+        (prev_pos, prev_attrs)
+    }
+
+    // while it's true that most of the logic in this is identical to
+    // write_contents_formatted, i can't figure out how to break out the
+    // common parts without making things noticeably slower.
+    pub fn write_contents_diff(
+        &self,
+        contents: &mut Vec<u8>,
+        prev: &Self,
+        start: u16,
+        width: u16,
+        row: u16,
+        wrapping: bool,
+        prev_wrapping: bool,
+        mut prev_pos: crate::grid::Pos,
+        mut prev_attrs: crate::attrs::Attrs,
+    ) -> (crate::grid::Pos, crate::attrs::Attrs) {
+        let mut prev_was_wide = false;
+
+        let first_cell = &self.cells[usize::from(start)];
+        let prev_first_cell = &prev.cells[usize::from(start)];
+        if wrapping
+            && !prev_wrapping
+            && first_cell == prev_first_cell
+            && prev_pos.row + 1 == row
+            && prev_pos.col
+                >= self.cols() - u16::from(prev_first_cell.is_wide())
+        {
+            let first_cell_attrs = first_cell.attrs();
+            if &prev_attrs != first_cell_attrs {
+                first_cell_attrs
+                    .write_escape_code_diff(contents, &prev_attrs);
+                prev_attrs = *first_cell_attrs;
+            }
+            let mut cell_contents = prev_first_cell.contents();
+            let need_erase = if cell_contents.is_empty() {
+                cell_contents = " ".to_string();
+                true
+            } else {
+                false
+            };
+            contents.extend(cell_contents.as_bytes());
+            crate::term::Backspace.write_buf(contents);
+            if prev_first_cell.is_wide() {
+                crate::term::Backspace.write_buf(contents);
+            }
+            if need_erase {
+                crate::term::EraseChar::new(1).write_buf(contents);
+            }
+            prev_pos = crate::grid::Pos { row, col: 0 };
+        }
+
+        let mut erase: Option<(u16, &crate::attrs::Attrs)> = None;
+        for (col, (cell, prev_cell)) in self
+            .cells()
+            .zip(prev.cells())
+            .enumerate()
+            .skip(usize::from(start))
+            .take(usize::from(width))
+        {
+            if prev_was_wide {
+                prev_was_wide = false;
+                continue;
+            }
+            prev_was_wide = cell.is_wide();
+
+            // we limit the number of cols to a u16 (see Size)
+            let col: u16 = col.try_into().unwrap();
+            let pos = crate::grid::Pos { row, col };
+
+            if let Some((prev_col, attrs)) = erase {
+                if cell.has_contents() || cell.attrs() != attrs {
+                    let new_pos = crate::grid::Pos { row, col: prev_col };
+                    if wrapping
+                        && prev_pos.row + 1 == new_pos.row
+                        && prev_pos.col >= self.cols()
+                    {
+                        if new_pos.col > 0 {
+                            contents.extend(
+                                " ".repeat(usize::from(new_pos.col))
+                                    .as_bytes(),
+                            );
+                        } else {
+                            contents.extend(b" ");
+                            crate::term::Backspace.write_buf(contents);
+                        }
+                    } else {
+                        crate::term::MoveFromTo::new(prev_pos, new_pos)
+                            .write_buf(contents);
+                    }
+                    prev_pos = new_pos;
+                    if &prev_attrs != attrs {
+                        attrs.write_escape_code_diff(contents, &prev_attrs);
+                        prev_attrs = *attrs;
+                    }
+                    crate::term::EraseChar::new(pos.col - prev_col)
+                        .write_buf(contents);
+                    erase = None;
+                }
+            }
+
+            if cell != prev_cell {
+                let attrs = cell.attrs();
+                if cell.has_contents() {
+                    if pos != prev_pos {
+                        if !wrapping
+                            || prev_pos.row + 1 != pos.row
+                            || prev_pos.col
+                                < self.cols() - u16::from(cell.is_wide())
+                            || pos.col != 0
+                        {
+                            crate::term::MoveFromTo::new(prev_pos, pos)
+                                .write_buf(contents);
+                        }
+                        prev_pos = pos;
+                    }
+
+                    if &prev_attrs != attrs {
+                        attrs.write_escape_code_diff(contents, &prev_attrs);
+                        prev_attrs = *attrs;
+                    }
+
+                    prev_pos.col += if cell.is_wide() { 2 } else { 1 };
+                    contents.extend(cell.contents().as_bytes());
+                } else if erase.is_none() {
+                    erase = Some((pos.col, attrs));
+                }
+            }
+        }
+        if let Some((prev_col, attrs)) = erase {
+            let new_pos = crate::grid::Pos { row, col: prev_col };
+            if wrapping
+                && prev_pos.row + 1 == new_pos.row
+                && prev_pos.col >= self.cols()
+            {
+                if new_pos.col > 0 {
+                    contents.extend(
+                        " ".repeat(usize::from(new_pos.col)).as_bytes(),
+                    );
+                } else {
+                    contents.extend(b" ");
+                    crate::term::Backspace.write_buf(contents);
+                }
+            } else {
+                crate::term::MoveFromTo::new(prev_pos, new_pos)
+                    .write_buf(contents);
+            }
+            prev_pos = new_pos;
+            if &prev_attrs != attrs {
+                attrs.write_escape_code_diff(contents, &prev_attrs);
+                prev_attrs = *attrs;
+            }
+            crate::term::ClearRowForward.write_buf(contents);
+        }
+
+        // if this row is going from wrapped to not wrapped, we need to erase
+        // and redraw the last character to break wrapping. if this row is
+        // wrapped, we need to redraw the last character without erasing it to
+        // position the cursor after the end of the line correctly so that
+        // drawing the next line can just start writing and be wrapped.
+        if (!self.wrapped && prev.wrapped) || (!prev.wrapped && self.wrapped)
+        {
+            let end_pos = if self.cells[usize::from(self.cols() - 1)]
+                .is_wide_continuation()
+            {
+                crate::grid::Pos {
+                    row,
+                    col: self.cols() - 2,
+                }
+            } else {
+                crate::grid::Pos {
+                    row,
+                    col: self.cols() - 1,
+                }
+            };
+            crate::term::MoveFromTo::new(prev_pos, end_pos)
+                .write_buf(contents);
+            prev_pos = end_pos;
+            if !self.wrapped {
+                crate::term::EraseChar::new(1).write_buf(contents);
+            }
+            let end_cell = &self.cells[usize::from(end_pos.col)];
+            if end_cell.has_contents() {
+                let attrs = end_cell.attrs();
+                if &prev_attrs != attrs {
+                    attrs.write_escape_code_diff(contents, &prev_attrs);
+                    prev_attrs = *attrs;
+                }
+                contents.extend(end_cell.contents().as_bytes());
+                prev_pos.col += if end_cell.is_wide() { 2 } else { 1 };
+            }
+        }
+
+        (prev_pos, prev_attrs)
+    }
+}

--- a/crates/turborepo-vt100/src/screen.rs
+++ b/crates/turborepo-vt100/src/screen.rs
@@ -1,0 +1,1511 @@
+use crate::term::BufWrite as _;
+use unicode_width::UnicodeWidthChar as _;
+
+const MODE_APPLICATION_KEYPAD: u8 = 0b0000_0001;
+const MODE_APPLICATION_CURSOR: u8 = 0b0000_0010;
+const MODE_HIDE_CURSOR: u8 = 0b0000_0100;
+const MODE_ALTERNATE_SCREEN: u8 = 0b0000_1000;
+const MODE_BRACKETED_PASTE: u8 = 0b0001_0000;
+
+/// The xterm mouse handling mode currently in use.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum MouseProtocolMode {
+    /// Mouse handling is disabled.
+    None,
+
+    /// Mouse button events should be reported on button press. Also known as
+    /// X10 mouse mode.
+    Press,
+
+    /// Mouse button events should be reported on button press and release.
+    /// Also known as VT200 mouse mode.
+    PressRelease,
+
+    // Highlight,
+    /// Mouse button events should be reported on button press and release, as
+    /// well as when the mouse moves between cells while a button is held
+    /// down.
+    ButtonMotion,
+
+    /// Mouse button events should be reported on button press and release,
+    /// and mouse motion events should be reported when the mouse moves
+    /// between cells regardless of whether a button is held down or not.
+    AnyMotion,
+    // DecLocator,
+}
+
+impl Default for MouseProtocolMode {
+    fn default() -> Self {
+        Self::None
+    }
+}
+
+/// The encoding to use for the enabled `MouseProtocolMode`.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum MouseProtocolEncoding {
+    /// Default single-printable-byte encoding.
+    Default,
+
+    /// UTF-8-based encoding.
+    Utf8,
+
+    /// SGR-like encoding.
+    Sgr,
+    // Urxvt,
+}
+
+impl Default for MouseProtocolEncoding {
+    fn default() -> Self {
+        Self::Default
+    }
+}
+
+/// Represents the overall terminal state.
+#[derive(Clone, Debug)]
+pub struct Screen {
+    grid: crate::grid::Grid,
+    alternate_grid: crate::grid::Grid,
+
+    attrs: crate::attrs::Attrs,
+    saved_attrs: crate::attrs::Attrs,
+
+    title: String,
+    icon_name: String,
+
+    modes: u8,
+    mouse_protocol_mode: MouseProtocolMode,
+    mouse_protocol_encoding: MouseProtocolEncoding,
+}
+
+impl Screen {
+    pub(crate) fn new(
+        size: crate::grid::Size,
+        scrollback_len: usize,
+    ) -> Self {
+        let mut grid = crate::grid::Grid::new(size, scrollback_len);
+        grid.allocate_rows();
+        Self {
+            grid,
+            alternate_grid: crate::grid::Grid::new(size, 0),
+
+            attrs: crate::attrs::Attrs::default(),
+            saved_attrs: crate::attrs::Attrs::default(),
+
+            title: String::default(),
+            icon_name: String::default(),
+
+            modes: 0,
+            mouse_protocol_mode: MouseProtocolMode::default(),
+            mouse_protocol_encoding: MouseProtocolEncoding::default(),
+        }
+    }
+
+    /// Resizes the terminal.
+    pub fn set_size(&mut self, rows: u16, cols: u16) {
+        self.grid.set_size(crate::grid::Size { rows, cols });
+        self.alternate_grid
+            .set_size(crate::grid::Size { rows, cols });
+    }
+
+    /// Returns the current size of the terminal.
+    ///
+    /// The return value will be (rows, cols).
+    #[must_use]
+    pub fn size(&self) -> (u16, u16) {
+        let size = self.grid().size();
+        (size.rows, size.cols)
+    }
+
+    /// Scrolls to the given position in the scrollback.
+    ///
+    /// This position indicates the offset from the top of the screen, and
+    /// should be `0` to put the normal screen in view.
+    ///
+    /// This affects the return values of methods called on the screen: for
+    /// instance, `screen.cell(0, 0)` will return the top left corner of the
+    /// screen after taking the scrollback offset into account.
+    ///
+    /// The value given will be clamped to the actual size of the scrollback.
+    pub fn set_scrollback(&mut self, rows: usize) {
+        self.grid_mut().set_scrollback(rows);
+    }
+
+    /// Returns the current position in the scrollback.
+    ///
+    /// This position indicates the offset from the top of the screen, and is
+    /// `0` when the normal screen is in view.
+    #[must_use]
+    pub fn scrollback(&self) -> usize {
+        self.grid().scrollback()
+    }
+
+    /// Returns the text contents of the terminal.
+    ///
+    /// This will not include any formatting information, and will be in plain
+    /// text format.
+    #[must_use]
+    pub fn contents(&self) -> String {
+        let mut contents = String::new();
+        self.write_contents(&mut contents);
+        contents
+    }
+
+    fn write_contents(&self, contents: &mut String) {
+        self.grid().write_contents(contents);
+    }
+
+    /// Returns the text contents of the terminal by row, restricted to the
+    /// given subset of columns.
+    ///
+    /// This will not include any formatting information, and will be in plain
+    /// text format.
+    ///
+    /// Newlines will not be included.
+    pub fn rows(
+        &self,
+        start: u16,
+        width: u16,
+    ) -> impl Iterator<Item = String> + '_ {
+        self.grid().visible_rows().map(move |row| {
+            let mut contents = String::new();
+            row.write_contents(&mut contents, start, width, false);
+            contents
+        })
+    }
+
+    /// Returns the text contents of the terminal logically between two cells.
+    /// This will include the remainder of the starting row after `start_col`,
+    /// followed by the entire contents of the rows between `start_row` and
+    /// `end_row`, followed by the beginning of the `end_row` up until
+    /// `end_col`. This is useful for things like determining the contents of
+    /// a clipboard selection.
+    #[must_use]
+    pub fn contents_between(
+        &self,
+        start_row: u16,
+        start_col: u16,
+        end_row: u16,
+        end_col: u16,
+    ) -> String {
+        match start_row.cmp(&end_row) {
+            std::cmp::Ordering::Less => {
+                let (_, cols) = self.size();
+                let mut contents = String::new();
+                for (i, row) in self
+                    .grid()
+                    .visible_rows()
+                    .enumerate()
+                    .skip(usize::from(start_row))
+                    .take(usize::from(end_row) - usize::from(start_row) + 1)
+                {
+                    if i == usize::from(start_row) {
+                        row.write_contents(
+                            &mut contents,
+                            start_col,
+                            cols - start_col,
+                            false,
+                        );
+                        if !row.wrapped() {
+                            contents.push('\n');
+                        }
+                    } else if i == usize::from(end_row) {
+                        row.write_contents(&mut contents, 0, end_col, false);
+                    } else {
+                        row.write_contents(&mut contents, 0, cols, false);
+                        if !row.wrapped() {
+                            contents.push('\n');
+                        }
+                    }
+                }
+                contents
+            }
+            std::cmp::Ordering::Equal => {
+                if start_col < end_col {
+                    self.rows(start_col, end_col - start_col)
+                        .nth(usize::from(start_row))
+                        .unwrap_or_default()
+                } else {
+                    String::new()
+                }
+            }
+            std::cmp::Ordering::Greater => String::new(),
+        }
+    }
+
+    /// Return escape codes sufficient to reproduce the entire contents of the
+    /// current terminal state. This is a convenience wrapper around
+    /// `contents_formatted`, `input_mode_formatted`, and `title_formatted`.
+    #[must_use]
+    pub fn state_formatted(&self) -> Vec<u8> {
+        let mut contents = vec![];
+        self.write_contents_formatted(&mut contents);
+        self.write_input_mode_formatted(&mut contents);
+        self.write_title_formatted(&mut contents);
+        contents
+    }
+
+    /// Return escape codes sufficient to turn the terminal state of the
+    /// screen `prev` into the current terminal state. This is a convenience
+    /// wrapper around `contents_diff`, `input_mode_diff`, and `title_diff`
+    #[must_use]
+    pub fn state_diff(&self, prev: &Self) -> Vec<u8> {
+        let mut contents = vec![];
+        self.write_contents_diff(&mut contents, prev);
+        self.write_input_mode_diff(&mut contents, prev);
+        self.write_title_diff(&mut contents, prev);
+        contents
+    }
+
+    /// Returns the formatted visible contents of the terminal.
+    ///
+    /// Formatting information will be included inline as terminal escape
+    /// codes. The result will be suitable for feeding directly to a raw
+    /// terminal parser, and will result in the same visual output.
+    #[must_use]
+    pub fn contents_formatted(&self) -> Vec<u8> {
+        let mut contents = vec![];
+        self.write_contents_formatted(&mut contents);
+        contents
+    }
+
+    fn write_contents_formatted(&self, contents: &mut Vec<u8>) {
+        crate::term::HideCursor::new(self.hide_cursor()).write_buf(contents);
+        let prev_attrs = self.grid().write_contents_formatted(contents);
+        self.attrs.write_escape_code_diff(contents, &prev_attrs);
+    }
+
+    /// Returns the formatted visible contents of the terminal by row,
+    /// restricted to the given subset of columns.
+    ///
+    /// Formatting information will be included inline as terminal escape
+    /// codes. The result will be suitable for feeding directly to a raw
+    /// terminal parser, and will result in the same visual output.
+    ///
+    /// You are responsible for positioning the cursor before printing each
+    /// row, and the final cursor position after displaying each row is
+    /// unspecified.
+    // the unwraps in this method shouldn't be reachable
+    #[allow(clippy::missing_panics_doc)]
+    pub fn rows_formatted(
+        &self,
+        start: u16,
+        width: u16,
+    ) -> impl Iterator<Item = Vec<u8>> + '_ {
+        let mut wrapping = false;
+        self.grid().visible_rows().enumerate().map(move |(i, row)| {
+            // number of rows in a grid is stored in a u16 (see Size), so
+            // visible_rows can never return enough rows to overflow here
+            let i = i.try_into().unwrap();
+            let mut contents = vec![];
+            row.write_contents_formatted(
+                &mut contents,
+                start,
+                width,
+                i,
+                wrapping,
+                None,
+                None,
+            );
+            if start == 0 && width == self.grid.size().cols {
+                wrapping = row.wrapped();
+            }
+            contents
+        })
+    }
+
+    /// Returns a terminal byte stream sufficient to turn the visible contents
+    /// of the screen described by `prev` into the visible contents of the
+    /// screen described by `self`.
+    ///
+    /// The result of rendering `prev.contents_formatted()` followed by
+    /// `self.contents_diff(prev)` should be equivalent to the result of
+    /// rendering `self.contents_formatted()`. This is primarily useful when
+    /// you already have a terminal parser whose state is described by `prev`,
+    /// since the diff will likely require less memory and cause less
+    /// flickering than redrawing the entire screen contents.
+    #[must_use]
+    pub fn contents_diff(&self, prev: &Self) -> Vec<u8> {
+        let mut contents = vec![];
+        self.write_contents_diff(&mut contents, prev);
+        contents
+    }
+
+    fn write_contents_diff(&self, contents: &mut Vec<u8>, prev: &Self) {
+        if self.hide_cursor() != prev.hide_cursor() {
+            crate::term::HideCursor::new(self.hide_cursor())
+                .write_buf(contents);
+        }
+        let prev_attrs = self.grid().write_contents_diff(
+            contents,
+            prev.grid(),
+            prev.attrs,
+        );
+        self.attrs.write_escape_code_diff(contents, &prev_attrs);
+    }
+
+    /// Returns a sequence of terminal byte streams sufficient to turn the
+    /// visible contents of the subset of each row from `prev` (as described
+    /// by `start` and `width`) into the visible contents of the corresponding
+    /// row subset in `self`.
+    ///
+    /// You are responsible for positioning the cursor before printing each
+    /// row, and the final cursor position after displaying each row is
+    /// unspecified.
+    // the unwraps in this method shouldn't be reachable
+    #[allow(clippy::missing_panics_doc)]
+    pub fn rows_diff<'a>(
+        &'a self,
+        prev: &'a Self,
+        start: u16,
+        width: u16,
+    ) -> impl Iterator<Item = Vec<u8>> + 'a {
+        self.grid()
+            .visible_rows()
+            .zip(prev.grid().visible_rows())
+            .enumerate()
+            .map(move |(i, (row, prev_row))| {
+                // number of rows in a grid is stored in a u16 (see Size), so
+                // visible_rows can never return enough rows to overflow here
+                let i = i.try_into().unwrap();
+                let mut contents = vec![];
+                row.write_contents_diff(
+                    &mut contents,
+                    prev_row,
+                    start,
+                    width,
+                    i,
+                    false,
+                    false,
+                    crate::grid::Pos { row: i, col: start },
+                    crate::attrs::Attrs::default(),
+                );
+                contents
+            })
+    }
+
+    /// Returns terminal escape sequences sufficient to set the current
+    /// terminal's input modes.
+    ///
+    /// Supported modes are:
+    /// * application keypad
+    /// * application cursor
+    /// * bracketed paste
+    /// * xterm mouse support
+    #[must_use]
+    pub fn input_mode_formatted(&self) -> Vec<u8> {
+        let mut contents = vec![];
+        self.write_input_mode_formatted(&mut contents);
+        contents
+    }
+
+    fn write_input_mode_formatted(&self, contents: &mut Vec<u8>) {
+        crate::term::ApplicationKeypad::new(
+            self.mode(MODE_APPLICATION_KEYPAD),
+        )
+        .write_buf(contents);
+        crate::term::ApplicationCursor::new(
+            self.mode(MODE_APPLICATION_CURSOR),
+        )
+        .write_buf(contents);
+        crate::term::BracketedPaste::new(self.mode(MODE_BRACKETED_PASTE))
+            .write_buf(contents);
+        crate::term::MouseProtocolMode::new(
+            self.mouse_protocol_mode,
+            MouseProtocolMode::None,
+        )
+        .write_buf(contents);
+        crate::term::MouseProtocolEncoding::new(
+            self.mouse_protocol_encoding,
+            MouseProtocolEncoding::Default,
+        )
+        .write_buf(contents);
+    }
+
+    /// Returns terminal escape sequences sufficient to change the previous
+    /// terminal's input modes to the input modes enabled in the current
+    /// terminal.
+    #[must_use]
+    pub fn input_mode_diff(&self, prev: &Self) -> Vec<u8> {
+        let mut contents = vec![];
+        self.write_input_mode_diff(&mut contents, prev);
+        contents
+    }
+
+    fn write_input_mode_diff(&self, contents: &mut Vec<u8>, prev: &Self) {
+        if self.mode(MODE_APPLICATION_KEYPAD)
+            != prev.mode(MODE_APPLICATION_KEYPAD)
+        {
+            crate::term::ApplicationKeypad::new(
+                self.mode(MODE_APPLICATION_KEYPAD),
+            )
+            .write_buf(contents);
+        }
+        if self.mode(MODE_APPLICATION_CURSOR)
+            != prev.mode(MODE_APPLICATION_CURSOR)
+        {
+            crate::term::ApplicationCursor::new(
+                self.mode(MODE_APPLICATION_CURSOR),
+            )
+            .write_buf(contents);
+        }
+        if self.mode(MODE_BRACKETED_PASTE) != prev.mode(MODE_BRACKETED_PASTE)
+        {
+            crate::term::BracketedPaste::new(self.mode(MODE_BRACKETED_PASTE))
+                .write_buf(contents);
+        }
+        crate::term::MouseProtocolMode::new(
+            self.mouse_protocol_mode,
+            prev.mouse_protocol_mode,
+        )
+        .write_buf(contents);
+        crate::term::MouseProtocolEncoding::new(
+            self.mouse_protocol_encoding,
+            prev.mouse_protocol_encoding,
+        )
+        .write_buf(contents);
+    }
+
+    /// Returns terminal escape sequences sufficient to set the current
+    /// terminal's window title.
+    #[must_use]
+    pub fn title_formatted(&self) -> Vec<u8> {
+        let mut contents = vec![];
+        self.write_title_formatted(&mut contents);
+        contents
+    }
+
+    fn write_title_formatted(&self, contents: &mut Vec<u8>) {
+        crate::term::ChangeTitle::new(&self.icon_name, &self.title, "", "")
+            .write_buf(contents);
+    }
+
+    /// Returns terminal escape sequences sufficient to change the previous
+    /// terminal's window title to the window title set in the current
+    /// terminal.
+    #[must_use]
+    pub fn title_diff(&self, prev: &Self) -> Vec<u8> {
+        let mut contents = vec![];
+        self.write_title_diff(&mut contents, prev);
+        contents
+    }
+
+    fn write_title_diff(&self, contents: &mut Vec<u8>, prev: &Self) {
+        crate::term::ChangeTitle::new(
+            &self.icon_name,
+            &self.title,
+            &prev.icon_name,
+            &prev.title,
+        )
+        .write_buf(contents);
+    }
+
+    /// Returns terminal escape sequences sufficient to set the current
+    /// terminal's drawing attributes.
+    ///
+    /// Supported drawing attributes are:
+    /// * fgcolor
+    /// * bgcolor
+    /// * bold
+    /// * italic
+    /// * underline
+    /// * inverse
+    ///
+    /// This is not typically necessary, since `contents_formatted` will leave
+    /// the current active drawing attributes in the correct state, but this
+    /// can be useful in the case of drawing additional things on top of a
+    /// terminal output, since you will need to restore the terminal state
+    /// without the terminal contents necessarily being the same.
+    #[must_use]
+    pub fn attributes_formatted(&self) -> Vec<u8> {
+        let mut contents = vec![];
+        self.write_attributes_formatted(&mut contents);
+        contents
+    }
+
+    fn write_attributes_formatted(&self, contents: &mut Vec<u8>) {
+        crate::term::ClearAttrs.write_buf(contents);
+        self.attrs.write_escape_code_diff(
+            contents,
+            &crate::attrs::Attrs::default(),
+        );
+    }
+
+    /// Returns the current cursor position of the terminal.
+    ///
+    /// The return value will be (row, col).
+    #[must_use]
+    pub fn cursor_position(&self) -> (u16, u16) {
+        let pos = self.grid().pos();
+        (pos.row, pos.col)
+    }
+
+    /// Returns terminal escape sequences sufficient to set the current
+    /// cursor state of the terminal.
+    ///
+    /// This is not typically necessary, since `contents_formatted` will leave
+    /// the cursor in the correct state, but this can be useful in the case of
+    /// drawing additional things on top of a terminal output, since you will
+    /// need to restore the terminal state without the terminal contents
+    /// necessarily being the same.
+    ///
+    /// Note that the bytes returned by this function may alter the active
+    /// drawing attributes, because it may require redrawing existing cells in
+    /// order to position the cursor correctly (for instance, in the case
+    /// where the cursor is past the end of a row). Therefore, you should
+    /// ensure to reset the active drawing attributes if necessary after
+    /// processing this data, for instance by using `attributes_formatted`.
+    #[must_use]
+    pub fn cursor_state_formatted(&self) -> Vec<u8> {
+        let mut contents = vec![];
+        self.write_cursor_state_formatted(&mut contents);
+        contents
+    }
+
+    fn write_cursor_state_formatted(&self, contents: &mut Vec<u8>) {
+        crate::term::HideCursor::new(self.hide_cursor()).write_buf(contents);
+        self.grid()
+            .write_cursor_position_formatted(contents, None, None);
+
+        // we don't just call write_attributes_formatted here, because that
+        // would still be confusing - consider the case where the user sets
+        // their own unrelated drawing attributes (on a different parser
+        // instance) and then calls cursor_state_formatted. just documenting
+        // it and letting the user handle it on their own is more
+        // straightforward.
+    }
+
+    /// Returns the `Cell` object at the given location in the terminal, if it
+    /// exists.
+    #[must_use]
+    pub fn cell(&self, row: u16, col: u16) -> Option<&crate::Cell> {
+        self.grid().visible_cell(crate::grid::Pos { row, col })
+    }
+
+    /// Returns whether the text in row `row` should wrap to the next line.
+    #[must_use]
+    pub fn row_wrapped(&self, row: u16) -> bool {
+        self.grid()
+            .visible_row(row)
+            .map_or(false, crate::row::Row::wrapped)
+    }
+
+    /// Returns the terminal's window title.
+    #[must_use]
+    pub fn title(&self) -> &str {
+        &self.title
+    }
+
+    /// Returns the terminal's icon name.
+    #[must_use]
+    pub fn icon_name(&self) -> &str {
+        &self.icon_name
+    }
+
+    /// Returns whether the alternate screen is currently in use.
+    #[must_use]
+    pub fn alternate_screen(&self) -> bool {
+        self.mode(MODE_ALTERNATE_SCREEN)
+    }
+
+    /// Returns whether the terminal should be in application keypad mode.
+    #[must_use]
+    pub fn application_keypad(&self) -> bool {
+        self.mode(MODE_APPLICATION_KEYPAD)
+    }
+
+    /// Returns whether the terminal should be in application cursor mode.
+    #[must_use]
+    pub fn application_cursor(&self) -> bool {
+        self.mode(MODE_APPLICATION_CURSOR)
+    }
+
+    /// Returns whether the terminal should be in hide cursor mode.
+    #[must_use]
+    pub fn hide_cursor(&self) -> bool {
+        self.mode(MODE_HIDE_CURSOR)
+    }
+
+    /// Returns whether the terminal should be in bracketed paste mode.
+    #[must_use]
+    pub fn bracketed_paste(&self) -> bool {
+        self.mode(MODE_BRACKETED_PASTE)
+    }
+
+    /// Returns the currently active `MouseProtocolMode`
+    #[must_use]
+    pub fn mouse_protocol_mode(&self) -> MouseProtocolMode {
+        self.mouse_protocol_mode
+    }
+
+    /// Returns the currently active `MouseProtocolEncoding`
+    #[must_use]
+    pub fn mouse_protocol_encoding(&self) -> MouseProtocolEncoding {
+        self.mouse_protocol_encoding
+    }
+
+    /// Returns the currently active foreground color.
+    #[must_use]
+    pub fn fgcolor(&self) -> crate::Color {
+        self.attrs.fgcolor
+    }
+
+    /// Returns the currently active background color.
+    #[must_use]
+    pub fn bgcolor(&self) -> crate::Color {
+        self.attrs.bgcolor
+    }
+
+    /// Returns whether newly drawn text should be rendered with the bold text
+    /// attribute.
+    #[must_use]
+    pub fn bold(&self) -> bool {
+        self.attrs.bold()
+    }
+
+    /// Returns whether newly drawn text should be rendered with the italic
+    /// text attribute.
+    #[must_use]
+    pub fn italic(&self) -> bool {
+        self.attrs.italic()
+    }
+
+    /// Returns whether newly drawn text should be rendered with the
+    /// underlined text attribute.
+    #[must_use]
+    pub fn underline(&self) -> bool {
+        self.attrs.underline()
+    }
+
+    /// Returns whether newly drawn text should be rendered with the inverse
+    /// text attribute.
+    #[must_use]
+    pub fn inverse(&self) -> bool {
+        self.attrs.inverse()
+    }
+
+    pub(crate) fn grid(&self) -> &crate::grid::Grid {
+        if self.mode(MODE_ALTERNATE_SCREEN) {
+            &self.alternate_grid
+        } else {
+            &self.grid
+        }
+    }
+
+    fn grid_mut(&mut self) -> &mut crate::grid::Grid {
+        if self.mode(MODE_ALTERNATE_SCREEN) {
+            &mut self.alternate_grid
+        } else {
+            &mut self.grid
+        }
+    }
+
+    fn enter_alternate_grid(&mut self) {
+        self.grid_mut().set_scrollback(0);
+        self.set_mode(MODE_ALTERNATE_SCREEN);
+        self.alternate_grid.allocate_rows();
+    }
+
+    fn exit_alternate_grid(&mut self) {
+        self.clear_mode(MODE_ALTERNATE_SCREEN);
+    }
+
+    fn save_cursor(&mut self) {
+        self.grid_mut().save_cursor();
+        self.saved_attrs = self.attrs;
+    }
+
+    fn restore_cursor(&mut self) {
+        self.grid_mut().restore_cursor();
+        self.attrs = self.saved_attrs;
+    }
+
+    fn set_mode(&mut self, mode: u8) {
+        self.modes |= mode;
+    }
+
+    fn clear_mode(&mut self, mode: u8) {
+        self.modes &= !mode;
+    }
+
+    fn mode(&self, mode: u8) -> bool {
+        self.modes & mode != 0
+    }
+
+    fn set_mouse_mode(&mut self, mode: MouseProtocolMode) {
+        self.mouse_protocol_mode = mode;
+    }
+
+    fn clear_mouse_mode(&mut self, mode: MouseProtocolMode) {
+        if self.mouse_protocol_mode == mode {
+            self.mouse_protocol_mode = MouseProtocolMode::default();
+        }
+    }
+
+    fn set_mouse_encoding(&mut self, encoding: MouseProtocolEncoding) {
+        self.mouse_protocol_encoding = encoding;
+    }
+
+    fn clear_mouse_encoding(&mut self, encoding: MouseProtocolEncoding) {
+        if self.mouse_protocol_encoding == encoding {
+            self.mouse_protocol_encoding = MouseProtocolEncoding::default();
+        }
+    }
+}
+
+impl Screen {
+    pub(crate) fn text(&mut self, c: char) {
+        let pos = self.grid().pos();
+        let size = self.grid().size();
+        let attrs = self.attrs;
+
+        let width = c.width();
+        if width.is_none() && (u32::from(c)) < 256 {
+            // don't even try to draw control characters
+            return;
+        }
+        let width = width
+            .unwrap_or(1)
+            .try_into()
+            // width() can only return 0, 1, or 2
+            .unwrap();
+
+        // it doesn't make any sense to wrap if the last column in a row
+        // didn't already have contents. don't try to handle the case where a
+        // character wraps because there was only one column left in the
+        // previous row - literally everything handles this case differently,
+        // and this is tmux behavior (and also the simplest). i'm open to
+        // reconsidering this behavior, but only with a really good reason
+        // (xterm handles this by introducing the concept of triple width
+        // cells, which i really don't want to do).
+        let mut wrap = false;
+        if pos.col > size.cols - width {
+            let last_cell = self
+                .grid()
+                .drawing_cell(crate::grid::Pos {
+                    row: pos.row,
+                    col: size.cols - 1,
+                })
+                // pos.row is valid, since it comes directly from
+                // self.grid().pos() which we assume to always have a valid
+                // row value. size.cols - 1 is also always a valid column.
+                .unwrap();
+            if last_cell.has_contents() || last_cell.is_wide_continuation() {
+                wrap = true;
+            }
+        }
+        self.grid_mut().col_wrap(width, wrap);
+        let pos = self.grid().pos();
+
+        if width == 0 {
+            if pos.col > 0 {
+                let mut prev_cell = self
+                    .grid_mut()
+                    .drawing_cell_mut(crate::grid::Pos {
+                        row: pos.row,
+                        col: pos.col - 1,
+                    })
+                    // pos.row is valid, since it comes directly from
+                    // self.grid().pos() which we assume to always have a
+                    // valid row value. pos.col - 1 is valid because we just
+                    // checked for pos.col > 0.
+                    .unwrap();
+                if prev_cell.is_wide_continuation() {
+                    prev_cell = self
+                        .grid_mut()
+                        .drawing_cell_mut(crate::grid::Pos {
+                            row: pos.row,
+                            col: pos.col - 2,
+                        })
+                        // pos.row is valid, since it comes directly from
+                        // self.grid().pos() which we assume to always have a
+                        // valid row value. we know pos.col - 2 is valid
+                        // because the cell at pos.col - 1 is a wide
+                        // continuation character, which means there must be
+                        // the first half of the wide character before it.
+                        .unwrap();
+                }
+                prev_cell.append(c);
+            } else if pos.row > 0 {
+                let prev_row = self
+                    .grid()
+                    .drawing_row(pos.row - 1)
+                    // pos.row is valid, since it comes directly from
+                    // self.grid().pos() which we assume to always have a
+                    // valid row value. pos.row - 1 is valid because we just
+                    // checked for pos.row > 0.
+                    .unwrap();
+                if prev_row.wrapped() {
+                    let mut prev_cell = self
+                        .grid_mut()
+                        .drawing_cell_mut(crate::grid::Pos {
+                            row: pos.row - 1,
+                            col: size.cols - 1,
+                        })
+                        // pos.row is valid, since it comes directly from
+                        // self.grid().pos() which we assume to always have a
+                        // valid row value. pos.row - 1 is valid because we
+                        // just checked for pos.row > 0. col of size.cols - 1
+                        // is always valid.
+                        .unwrap();
+                    if prev_cell.is_wide_continuation() {
+                        prev_cell = self
+                            .grid_mut()
+                            .drawing_cell_mut(crate::grid::Pos {
+                                row: pos.row - 1,
+                                col: size.cols - 2,
+                            })
+                            // pos.row is valid, since it comes directly from
+                            // self.grid().pos() which we assume to always
+                            // have a valid row value. pos.row - 1 is valid
+                            // because we just checked for pos.row > 0. col of
+                            // size.cols - 2 is valid because the cell at
+                            // size.cols - 1 is a wide continuation character,
+                            // so it must have the first half of the wide
+                            // character before it.
+                            .unwrap();
+                    }
+                    prev_cell.append(c);
+                }
+            }
+        } else {
+            if self
+                .grid()
+                .drawing_cell(pos)
+                // pos.row is valid because we assume self.grid().pos() to
+                // always have a valid row value. pos.col is valid because we
+                // called col_wrap() immediately before this, which ensures
+                // that self.grid().pos().col has a valid value.
+                .unwrap()
+                .is_wide_continuation()
+            {
+                let prev_cell = self
+                    .grid_mut()
+                    .drawing_cell_mut(crate::grid::Pos {
+                        row: pos.row,
+                        col: pos.col - 1,
+                    })
+                    // pos.row is valid because we assume self.grid().pos() to
+                    // always have a valid row value. pos.col is valid because
+                    // we called col_wrap() immediately before this, which
+                    // ensures that self.grid().pos().col has a valid value.
+                    // pos.col - 1 is valid because the cell at pos.col is a
+                    // wide continuation character, so it must have the first
+                    // half of the wide character before it.
+                    .unwrap();
+                prev_cell.clear(attrs);
+            }
+
+            if self
+                .grid()
+                .drawing_cell(pos)
+                // pos.row is valid because we assume self.grid().pos() to
+                // always have a valid row value. pos.col is valid because we
+                // called col_wrap() immediately before this, which ensures
+                // that self.grid().pos().col has a valid value.
+                .unwrap()
+                .is_wide()
+            {
+                let next_cell = self
+                    .grid_mut()
+                    .drawing_cell_mut(crate::grid::Pos {
+                        row: pos.row,
+                        col: pos.col + 1,
+                    })
+                    // pos.row is valid because we assume self.grid().pos() to
+                    // always have a valid row value. pos.col is valid because
+                    // we called col_wrap() immediately before this, which
+                    // ensures that self.grid().pos().col has a valid value.
+                    // pos.col + 1 is valid because the cell at pos.col is a
+                    // wide character, so it must have the second half of the
+                    // wide character after it.
+                    .unwrap();
+                next_cell.set(' ', attrs);
+            }
+
+            let cell = self
+                .grid_mut()
+                .drawing_cell_mut(pos)
+                // pos.row is valid because we assume self.grid().pos() to
+                // always have a valid row value. pos.col is valid because we
+                // called col_wrap() immediately before this, which ensures
+                // that self.grid().pos().col has a valid value.
+                .unwrap();
+            cell.set(c, attrs);
+            self.grid_mut().col_inc(1);
+            if width > 1 {
+                let pos = self.grid().pos();
+                if self
+                    .grid()
+                    .drawing_cell(pos)
+                    // pos.row is valid because we assume self.grid().pos() to
+                    // always have a valid row value. pos.col is valid because
+                    // we called col_wrap() earlier, which ensures that
+                    // self.grid().pos().col has a valid value. this is true
+                    // even though we just called col_inc, because this branch
+                    // only happens if width > 1, and col_wrap takes width
+                    // into account.
+                    .unwrap()
+                    .is_wide()
+                {
+                    let next_next_pos = crate::grid::Pos {
+                        row: pos.row,
+                        col: pos.col + 1,
+                    };
+                    let next_next_cell = self
+                        .grid_mut()
+                        .drawing_cell_mut(next_next_pos)
+                        // pos.row is valid because we assume
+                        // self.grid().pos() to always have a valid row value.
+                        // pos.col is valid because we called col_wrap()
+                        // earlier, which ensures that self.grid().pos().col
+                        // has a valid value. this is true even though we just
+                        // called col_inc, because this branch only happens if
+                        // width > 1, and col_wrap takes width into account.
+                        // pos.col + 1 is valid because the cell at pos.col is
+                        // wide, and so it must have the second half of the
+                        // wide character after it.
+                        .unwrap();
+                    next_next_cell.clear(attrs);
+                    if next_next_pos.col == size.cols - 1 {
+                        self.grid_mut()
+                            .drawing_row_mut(pos.row)
+                            // we assume self.grid().pos().row is always valid
+                            .unwrap()
+                            .wrap(false);
+                    }
+                }
+                let next_cell = self
+                    .grid_mut()
+                    .drawing_cell_mut(pos)
+                    // pos.row is valid because we assume self.grid().pos() to
+                    // always have a valid row value. pos.col is valid because
+                    // we called col_wrap() earlier, which ensures that
+                    // self.grid().pos().col has a valid value. this is true
+                    // even though we just called col_inc, because this branch
+                    // only happens if width > 1, and col_wrap takes width
+                    // into account.
+                    .unwrap();
+                next_cell.clear(crate::attrs::Attrs::default());
+                next_cell.set_wide_continuation(true);
+                self.grid_mut().col_inc(1);
+            }
+        }
+    }
+
+    // control codes
+
+    pub(crate) fn bs(&mut self) {
+        self.grid_mut().col_dec(1);
+    }
+
+    pub(crate) fn tab(&mut self) {
+        self.grid_mut().col_tab();
+    }
+
+    pub(crate) fn lf(&mut self) {
+        self.grid_mut().row_inc_scroll(1);
+    }
+
+    pub(crate) fn vt(&mut self) {
+        self.lf();
+    }
+
+    pub(crate) fn ff(&mut self) {
+        self.lf();
+    }
+
+    pub(crate) fn cr(&mut self) {
+        self.grid_mut().col_set(0);
+    }
+
+    // escape codes
+
+    // ESC 7
+    pub(crate) fn decsc(&mut self) {
+        self.save_cursor();
+    }
+
+    // ESC 8
+    pub(crate) fn decrc(&mut self) {
+        self.restore_cursor();
+    }
+
+    // ESC =
+    pub(crate) fn deckpam(&mut self) {
+        self.set_mode(MODE_APPLICATION_KEYPAD);
+    }
+
+    // ESC >
+    pub(crate) fn deckpnm(&mut self) {
+        self.clear_mode(MODE_APPLICATION_KEYPAD);
+    }
+
+    // ESC M
+    pub(crate) fn ri(&mut self) {
+        self.grid_mut().row_dec_scroll(1);
+    }
+
+    // ESC c
+    pub(crate) fn ris(&mut self) {
+        let title = self.title.clone();
+        let icon_name = self.icon_name.clone();
+
+        *self = Self::new(self.grid.size(), self.grid.scrollback_len());
+
+        self.title = title;
+        self.icon_name = icon_name;
+    }
+
+    // csi codes
+
+    // CSI @
+    pub(crate) fn ich(&mut self, count: u16) {
+        self.grid_mut().insert_cells(count);
+    }
+
+    // CSI A
+    pub(crate) fn cuu(&mut self, offset: u16) {
+        self.grid_mut().row_dec_clamp(offset);
+    }
+
+    // CSI B
+    pub(crate) fn cud(&mut self, offset: u16) {
+        self.grid_mut().row_inc_clamp(offset);
+    }
+
+    // CSI C
+    pub(crate) fn cuf(&mut self, offset: u16) {
+        self.grid_mut().col_inc_clamp(offset);
+    }
+
+    // CSI D
+    pub(crate) fn cub(&mut self, offset: u16) {
+        self.grid_mut().col_dec(offset);
+    }
+
+    // CSI E
+    pub(crate) fn cnl(&mut self, offset: u16) {
+        self.grid_mut().col_set(0);
+        self.grid_mut().row_inc_clamp(offset);
+    }
+
+    // CSI F
+    pub(crate) fn cpl(&mut self, offset: u16) {
+        self.grid_mut().col_set(0);
+        self.grid_mut().row_dec_clamp(offset);
+    }
+
+    // CSI G
+    pub(crate) fn cha(&mut self, col: u16) {
+        self.grid_mut().col_set(col - 1);
+    }
+
+    // CSI H
+    pub(crate) fn cup(&mut self, (row, col): (u16, u16)) {
+        self.grid_mut().set_pos(crate::grid::Pos {
+            row: row - 1,
+            col: col - 1,
+        });
+    }
+
+    // CSI J
+    pub(crate) fn ed(&mut self, mode: u16) {
+        let attrs = self.attrs;
+        match mode {
+            0 => self.grid_mut().erase_all_forward(attrs),
+            1 => self.grid_mut().erase_all_backward(attrs),
+            2 => self.grid_mut().erase_all(attrs),
+            n => {
+                log::debug!("unhandled ED mode: {n}");
+            }
+        }
+    }
+
+    // CSI ? J
+    pub(crate) fn decsed(&mut self, mode: u16) {
+        self.ed(mode);
+    }
+
+    // CSI K
+    pub(crate) fn el(&mut self, mode: u16) {
+        let attrs = self.attrs;
+        match mode {
+            0 => self.grid_mut().erase_row_forward(attrs),
+            1 => self.grid_mut().erase_row_backward(attrs),
+            2 => self.grid_mut().erase_row(attrs),
+            n => {
+                log::debug!("unhandled EL mode: {n}");
+            }
+        }
+    }
+
+    // CSI ? K
+    pub(crate) fn decsel(&mut self, mode: u16) {
+        self.el(mode);
+    }
+
+    // CSI L
+    pub(crate) fn il(&mut self, count: u16) {
+        self.grid_mut().insert_lines(count);
+    }
+
+    // CSI M
+    pub(crate) fn dl(&mut self, count: u16) {
+        self.grid_mut().delete_lines(count);
+    }
+
+    // CSI P
+    pub(crate) fn dch(&mut self, count: u16) {
+        self.grid_mut().delete_cells(count);
+    }
+
+    // CSI S
+    pub(crate) fn su(&mut self, count: u16) {
+        self.grid_mut().scroll_up(count);
+    }
+
+    // CSI T
+    pub(crate) fn sd(&mut self, count: u16) {
+        self.grid_mut().scroll_down(count);
+    }
+
+    // CSI X
+    pub(crate) fn ech(&mut self, count: u16) {
+        let attrs = self.attrs;
+        self.grid_mut().erase_cells(count, attrs);
+    }
+
+    // CSI d
+    pub(crate) fn vpa(&mut self, row: u16) {
+        self.grid_mut().row_set(row - 1);
+    }
+
+    // CSI h
+    #[allow(clippy::unused_self)]
+    pub(crate) fn sm(&mut self, params: &vte::Params) {
+        // nothing, i think?
+        if log::log_enabled!(log::Level::Debug) {
+            log::debug!(
+                "unhandled SM mode: {}",
+                crate::perform::param_str(params)
+            );
+        }
+    }
+
+    // CSI ? h
+    pub(crate) fn decset(&mut self, params: &vte::Params) {
+        for param in params {
+            match param {
+                &[1] => self.set_mode(MODE_APPLICATION_CURSOR),
+                &[6] => self.grid_mut().set_origin_mode(true),
+                &[9] => self.set_mouse_mode(MouseProtocolMode::Press),
+                &[25] => self.clear_mode(MODE_HIDE_CURSOR),
+                &[47] => self.enter_alternate_grid(),
+                &[1000] => {
+                    self.set_mouse_mode(MouseProtocolMode::PressRelease);
+                }
+                &[1002] => {
+                    self.set_mouse_mode(MouseProtocolMode::ButtonMotion);
+                }
+                &[1003] => self.set_mouse_mode(MouseProtocolMode::AnyMotion),
+                &[1005] => {
+                    self.set_mouse_encoding(MouseProtocolEncoding::Utf8);
+                }
+                &[1006] => {
+                    self.set_mouse_encoding(MouseProtocolEncoding::Sgr);
+                }
+                &[1049] => {
+                    self.decsc();
+                    self.alternate_grid.clear();
+                    self.enter_alternate_grid();
+                }
+                &[2004] => self.set_mode(MODE_BRACKETED_PASTE),
+                ns => {
+                    if log::log_enabled!(log::Level::Debug) {
+                        let n = if ns.len() == 1 {
+                            format!(
+                                "{}",
+                                // we just checked that ns.len() == 1, so 0
+                                // must be valid
+                                ns[0]
+                            )
+                        } else {
+                            format!("{ns:?}")
+                        };
+                        log::debug!("unhandled DECSET mode: {n}");
+                    }
+                }
+            }
+        }
+    }
+
+    // CSI l
+    #[allow(clippy::unused_self)]
+    pub(crate) fn rm(&mut self, params: &vte::Params) {
+        // nothing, i think?
+        if log::log_enabled!(log::Level::Debug) {
+            log::debug!(
+                "unhandled RM mode: {}",
+                crate::perform::param_str(params)
+            );
+        }
+    }
+
+    // CSI ? l
+    pub(crate) fn decrst(&mut self, params: &vte::Params) {
+        for param in params {
+            match param {
+                &[1] => self.clear_mode(MODE_APPLICATION_CURSOR),
+                &[6] => self.grid_mut().set_origin_mode(false),
+                &[9] => self.clear_mouse_mode(MouseProtocolMode::Press),
+                &[25] => self.set_mode(MODE_HIDE_CURSOR),
+                &[47] => {
+                    self.exit_alternate_grid();
+                }
+                &[1000] => {
+                    self.clear_mouse_mode(MouseProtocolMode::PressRelease);
+                }
+                &[1002] => {
+                    self.clear_mouse_mode(MouseProtocolMode::ButtonMotion);
+                }
+                &[1003] => {
+                    self.clear_mouse_mode(MouseProtocolMode::AnyMotion);
+                }
+                &[1005] => {
+                    self.clear_mouse_encoding(MouseProtocolEncoding::Utf8);
+                }
+                &[1006] => {
+                    self.clear_mouse_encoding(MouseProtocolEncoding::Sgr);
+                }
+                &[1049] => {
+                    self.exit_alternate_grid();
+                    self.decrc();
+                }
+                &[2004] => self.clear_mode(MODE_BRACKETED_PASTE),
+                ns => {
+                    if log::log_enabled!(log::Level::Debug) {
+                        let n = if ns.len() == 1 {
+                            format!(
+                                "{}",
+                                // we just checked that ns.len() == 1, so 0
+                                // must be valid
+                                ns[0]
+                            )
+                        } else {
+                            format!("{ns:?}")
+                        };
+                        log::debug!("unhandled DECRST mode: {n}");
+                    }
+                }
+            }
+        }
+    }
+
+    // CSI m
+    pub(crate) fn sgr(&mut self, params: &vte::Params) {
+        // XXX really i want to just be able to pass in a default Params
+        // instance with a 0 in it, but vte doesn't allow creating new Params
+        // instances
+        if params.is_empty() {
+            self.attrs = crate::attrs::Attrs::default();
+            return;
+        }
+
+        let mut iter = params.iter();
+
+        macro_rules! next_param {
+            () => {
+                match iter.next() {
+                    Some(n) => n,
+                    _ => return,
+                }
+            };
+        }
+
+        macro_rules! to_u8 {
+            ($n:expr) => {
+                if let Some(n) = u16_to_u8($n) {
+                    n
+                } else {
+                    return;
+                }
+            };
+        }
+
+        macro_rules! next_param_u8 {
+            () => {
+                if let &[n] = next_param!() {
+                    to_u8!(n)
+                } else {
+                    return;
+                }
+            };
+        }
+
+        loop {
+            match next_param!() {
+                &[0] => self.attrs = crate::attrs::Attrs::default(),
+                &[1] => self.attrs.set_bold(true),
+                &[3] => self.attrs.set_italic(true),
+                &[4] => self.attrs.set_underline(true),
+                &[7] => self.attrs.set_inverse(true),
+                &[22] => self.attrs.set_bold(false),
+                &[23] => self.attrs.set_italic(false),
+                &[24] => self.attrs.set_underline(false),
+                &[27] => self.attrs.set_inverse(false),
+                &[n] if (30..=37).contains(&n) => {
+                    self.attrs.fgcolor = crate::Color::Idx(to_u8!(n) - 30);
+                }
+                &[38, 2, r, g, b] => {
+                    self.attrs.fgcolor =
+                        crate::Color::Rgb(to_u8!(r), to_u8!(g), to_u8!(b));
+                }
+                &[38, 5, i] => {
+                    self.attrs.fgcolor = crate::Color::Idx(to_u8!(i));
+                }
+                &[38] => match next_param!() {
+                    &[2] => {
+                        let r = next_param_u8!();
+                        let g = next_param_u8!();
+                        let b = next_param_u8!();
+                        self.attrs.fgcolor = crate::Color::Rgb(r, g, b);
+                    }
+                    &[5] => {
+                        self.attrs.fgcolor =
+                            crate::Color::Idx(next_param_u8!());
+                    }
+                    ns => {
+                        if log::log_enabled!(log::Level::Debug) {
+                            let n = if ns.len() == 1 {
+                                format!(
+                                    "{}",
+                                    // we just checked that ns.len() == 1, so
+                                    // 0 must be valid
+                                    ns[0]
+                                )
+                            } else {
+                                format!("{ns:?}")
+                            };
+                            log::debug!("unhandled SGR mode: 38 {n}");
+                        }
+                        return;
+                    }
+                },
+                &[39] => {
+                    self.attrs.fgcolor = crate::Color::Default;
+                }
+                &[n] if (40..=47).contains(&n) => {
+                    self.attrs.bgcolor = crate::Color::Idx(to_u8!(n) - 40);
+                }
+                &[48, 2, r, g, b] => {
+                    self.attrs.bgcolor =
+                        crate::Color::Rgb(to_u8!(r), to_u8!(g), to_u8!(b));
+                }
+                &[48, 5, i] => {
+                    self.attrs.bgcolor = crate::Color::Idx(to_u8!(i));
+                }
+                &[48] => match next_param!() {
+                    &[2] => {
+                        let r = next_param_u8!();
+                        let g = next_param_u8!();
+                        let b = next_param_u8!();
+                        self.attrs.bgcolor = crate::Color::Rgb(r, g, b);
+                    }
+                    &[5] => {
+                        self.attrs.bgcolor =
+                            crate::Color::Idx(next_param_u8!());
+                    }
+                    ns => {
+                        if log::log_enabled!(log::Level::Debug) {
+                            let n = if ns.len() == 1 {
+                                format!(
+                                    "{}",
+                                    // we just checked that ns.len() == 1, so
+                                    // 0 must be valid
+                                    ns[0]
+                                )
+                            } else {
+                                format!("{ns:?}")
+                            };
+                            log::debug!("unhandled SGR mode: 48 {n}");
+                        }
+                        return;
+                    }
+                },
+                &[49] => {
+                    self.attrs.bgcolor = crate::Color::Default;
+                }
+                &[n] if (90..=97).contains(&n) => {
+                    self.attrs.fgcolor = crate::Color::Idx(to_u8!(n) - 82);
+                }
+                &[n] if (100..=107).contains(&n) => {
+                    self.attrs.bgcolor = crate::Color::Idx(to_u8!(n) - 92);
+                }
+                ns => {
+                    if log::log_enabled!(log::Level::Debug) {
+                        let n = if ns.len() == 1 {
+                            format!(
+                                "{}",
+                                // we just checked that ns.len() == 1, so 0
+                                // must be valid
+                                ns[0]
+                            )
+                        } else {
+                            format!("{ns:?}")
+                        };
+                        log::debug!("unhandled SGR mode: {n}");
+                    }
+                }
+            }
+        }
+    }
+
+    // CSI r
+    pub(crate) fn decstbm(&mut self, (top, bottom): (u16, u16)) {
+        self.grid_mut().set_scroll_region(top - 1, bottom - 1);
+    }
+
+    // CSI t
+    #[allow(clippy::unused_self)]
+    pub(crate) fn xtwinops(&self, params: &vte::Params) {
+        let mut iter = params.iter();
+        let op = iter.next().and_then(|x| x.first().copied());
+        match op {
+            Some(8) => {}
+            _ => {
+                log::debug!(
+                    "unhandled XTWINOPS: {}",
+                    crate::perform::param_str(params)
+                );
+            }
+        }
+    }
+
+    // osc codes
+
+    pub(crate) fn osc0(&mut self, s: &[u8]) {
+        self.osc1(s);
+        self.osc2(s);
+    }
+
+    pub(crate) fn osc1(&mut self, s: &[u8]) {
+        if let Ok(s) = std::str::from_utf8(s) {
+            self.icon_name = s.to_string();
+        }
+    }
+
+    pub(crate) fn osc2(&mut self, s: &[u8]) {
+        if let Ok(s) = std::str::from_utf8(s) {
+            self.title = s.to_string();
+        }
+    }
+}
+
+fn u16_to_u8(i: u16) -> Option<u8> {
+    if i > u16::from(u8::max_value()) {
+        None
+    } else {
+        // safe because we just ensured that the value fits in a u8
+        Some(i.try_into().unwrap())
+    }
+}

--- a/crates/turborepo-vt100/src/term.rs
+++ b/crates/turborepo-vt100/src/term.rs
@@ -1,0 +1,592 @@
+// TODO: read all of this from terminfo
+
+pub trait BufWrite {
+    fn write_buf(&self, buf: &mut Vec<u8>);
+}
+
+#[derive(Default, Debug)]
+#[must_use = "this struct does nothing unless you call write_buf"]
+pub struct ClearScreen;
+
+impl BufWrite for ClearScreen {
+    fn write_buf(&self, buf: &mut Vec<u8>) {
+        buf.extend_from_slice(b"\x1b[H\x1b[J");
+    }
+}
+
+#[derive(Default, Debug)]
+#[must_use = "this struct does nothing unless you call write_buf"]
+pub struct ClearRowForward;
+
+impl BufWrite for ClearRowForward {
+    fn write_buf(&self, buf: &mut Vec<u8>) {
+        buf.extend_from_slice(b"\x1b[K");
+    }
+}
+
+#[derive(Default, Debug)]
+#[must_use = "this struct does nothing unless you call write_buf"]
+pub struct Crlf;
+
+impl BufWrite for Crlf {
+    fn write_buf(&self, buf: &mut Vec<u8>) {
+        buf.extend_from_slice(b"\r\n");
+    }
+}
+
+#[derive(Default, Debug)]
+#[must_use = "this struct does nothing unless you call write_buf"]
+pub struct Backspace;
+
+impl BufWrite for Backspace {
+    fn write_buf(&self, buf: &mut Vec<u8>) {
+        buf.extend_from_slice(b"\x08");
+    }
+}
+
+#[derive(Default, Debug)]
+#[must_use = "this struct does nothing unless you call write_buf"]
+pub struct SaveCursor;
+
+impl BufWrite for SaveCursor {
+    fn write_buf(&self, buf: &mut Vec<u8>) {
+        buf.extend_from_slice(b"\x1b7");
+    }
+}
+
+#[derive(Default, Debug)]
+#[must_use = "this struct does nothing unless you call write_buf"]
+pub struct RestoreCursor;
+
+impl BufWrite for RestoreCursor {
+    fn write_buf(&self, buf: &mut Vec<u8>) {
+        buf.extend_from_slice(b"\x1b8");
+    }
+}
+
+#[derive(Default, Debug)]
+#[must_use = "this struct does nothing unless you call write_buf"]
+pub struct MoveTo {
+    row: u16,
+    col: u16,
+}
+
+impl MoveTo {
+    pub fn new(pos: crate::grid::Pos) -> Self {
+        Self {
+            row: pos.row,
+            col: pos.col,
+        }
+    }
+}
+
+impl BufWrite for MoveTo {
+    fn write_buf(&self, buf: &mut Vec<u8>) {
+        if self.row == 0 && self.col == 0 {
+            buf.extend_from_slice(b"\x1b[H");
+        } else {
+            buf.extend_from_slice(b"\x1b[");
+            extend_itoa(buf, self.row + 1);
+            buf.push(b';');
+            extend_itoa(buf, self.col + 1);
+            buf.push(b'H');
+        }
+    }
+}
+
+#[derive(Default, Debug)]
+#[must_use = "this struct does nothing unless you call write_buf"]
+pub struct ClearAttrs;
+
+impl BufWrite for ClearAttrs {
+    fn write_buf(&self, buf: &mut Vec<u8>) {
+        buf.extend_from_slice(b"\x1b[m");
+    }
+}
+
+#[derive(Default, Debug)]
+#[must_use = "this struct does nothing unless you call write_buf"]
+pub struct Attrs {
+    fgcolor: Option<crate::Color>,
+    bgcolor: Option<crate::Color>,
+    bold: Option<bool>,
+    italic: Option<bool>,
+    underline: Option<bool>,
+    inverse: Option<bool>,
+}
+
+impl Attrs {
+    pub fn fgcolor(mut self, fgcolor: crate::Color) -> Self {
+        self.fgcolor = Some(fgcolor);
+        self
+    }
+
+    pub fn bgcolor(mut self, bgcolor: crate::Color) -> Self {
+        self.bgcolor = Some(bgcolor);
+        self
+    }
+
+    pub fn bold(mut self, bold: bool) -> Self {
+        self.bold = Some(bold);
+        self
+    }
+
+    pub fn italic(mut self, italic: bool) -> Self {
+        self.italic = Some(italic);
+        self
+    }
+
+    pub fn underline(mut self, underline: bool) -> Self {
+        self.underline = Some(underline);
+        self
+    }
+
+    pub fn inverse(mut self, inverse: bool) -> Self {
+        self.inverse = Some(inverse);
+        self
+    }
+}
+
+impl BufWrite for Attrs {
+    #[allow(unused_assignments)]
+    #[allow(clippy::branches_sharing_code)]
+    fn write_buf(&self, buf: &mut Vec<u8>) {
+        if self.fgcolor.is_none()
+            && self.bgcolor.is_none()
+            && self.bold.is_none()
+            && self.italic.is_none()
+            && self.underline.is_none()
+            && self.inverse.is_none()
+        {
+            return;
+        }
+
+        buf.extend_from_slice(b"\x1b[");
+        let mut first = true;
+
+        macro_rules! write_param {
+            ($i:expr) => {
+                if first {
+                    first = false;
+                } else {
+                    buf.push(b';');
+                }
+                extend_itoa(buf, $i);
+            };
+        }
+
+        if let Some(fgcolor) = self.fgcolor {
+            match fgcolor {
+                crate::Color::Default => {
+                    write_param!(39);
+                }
+                crate::Color::Idx(i) => {
+                    if i < 8 {
+                        write_param!(i + 30);
+                    } else if i < 16 {
+                        write_param!(i + 82);
+                    } else {
+                        write_param!(38);
+                        write_param!(5);
+                        write_param!(i);
+                    }
+                }
+                crate::Color::Rgb(r, g, b) => {
+                    write_param!(38);
+                    write_param!(2);
+                    write_param!(r);
+                    write_param!(g);
+                    write_param!(b);
+                }
+            }
+        }
+
+        if let Some(bgcolor) = self.bgcolor {
+            match bgcolor {
+                crate::Color::Default => {
+                    write_param!(49);
+                }
+                crate::Color::Idx(i) => {
+                    if i < 8 {
+                        write_param!(i + 40);
+                    } else if i < 16 {
+                        write_param!(i + 92);
+                    } else {
+                        write_param!(48);
+                        write_param!(5);
+                        write_param!(i);
+                    }
+                }
+                crate::Color::Rgb(r, g, b) => {
+                    write_param!(48);
+                    write_param!(2);
+                    write_param!(r);
+                    write_param!(g);
+                    write_param!(b);
+                }
+            }
+        }
+
+        if let Some(bold) = self.bold {
+            if bold {
+                write_param!(1);
+            } else {
+                write_param!(22);
+            }
+        }
+
+        if let Some(italic) = self.italic {
+            if italic {
+                write_param!(3);
+            } else {
+                write_param!(23);
+            }
+        }
+
+        if let Some(underline) = self.underline {
+            if underline {
+                write_param!(4);
+            } else {
+                write_param!(24);
+            }
+        }
+
+        if let Some(inverse) = self.inverse {
+            if inverse {
+                write_param!(7);
+            } else {
+                write_param!(27);
+            }
+        }
+
+        buf.push(b'm');
+    }
+}
+
+#[derive(Debug)]
+#[must_use = "this struct does nothing unless you call write_buf"]
+pub struct MoveRight {
+    count: u16,
+}
+
+impl MoveRight {
+    pub fn new(count: u16) -> Self {
+        Self { count }
+    }
+}
+
+impl Default for MoveRight {
+    fn default() -> Self {
+        Self { count: 1 }
+    }
+}
+
+impl BufWrite for MoveRight {
+    fn write_buf(&self, buf: &mut Vec<u8>) {
+        match self.count {
+            0 => {}
+            1 => buf.extend_from_slice(b"\x1b[C"),
+            n => {
+                buf.extend_from_slice(b"\x1b[");
+                extend_itoa(buf, n);
+                buf.push(b'C');
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+#[must_use = "this struct does nothing unless you call write_buf"]
+pub struct EraseChar {
+    count: u16,
+}
+
+impl EraseChar {
+    pub fn new(count: u16) -> Self {
+        Self { count }
+    }
+}
+
+impl Default for EraseChar {
+    fn default() -> Self {
+        Self { count: 1 }
+    }
+}
+
+impl BufWrite for EraseChar {
+    fn write_buf(&self, buf: &mut Vec<u8>) {
+        match self.count {
+            0 => {}
+            1 => buf.extend_from_slice(b"\x1b[X"),
+            n => {
+                buf.extend_from_slice(b"\x1b[");
+                extend_itoa(buf, n);
+                buf.push(b'X');
+            }
+        }
+    }
+}
+
+#[derive(Default, Debug)]
+#[must_use = "this struct does nothing unless you call write_buf"]
+pub struct HideCursor {
+    state: bool,
+}
+
+impl HideCursor {
+    pub fn new(state: bool) -> Self {
+        Self { state }
+    }
+}
+
+impl BufWrite for HideCursor {
+    fn write_buf(&self, buf: &mut Vec<u8>) {
+        if self.state {
+            buf.extend_from_slice(b"\x1b[?25l");
+        } else {
+            buf.extend_from_slice(b"\x1b[?25h");
+        }
+    }
+}
+
+#[derive(Debug)]
+#[must_use = "this struct does nothing unless you call write_buf"]
+pub struct MoveFromTo {
+    from: crate::grid::Pos,
+    to: crate::grid::Pos,
+}
+
+impl MoveFromTo {
+    pub fn new(from: crate::grid::Pos, to: crate::grid::Pos) -> Self {
+        Self { from, to }
+    }
+}
+
+impl BufWrite for MoveFromTo {
+    fn write_buf(&self, buf: &mut Vec<u8>) {
+        if self.to.row == self.from.row + 1 && self.to.col == 0 {
+            crate::term::Crlf.write_buf(buf);
+        } else if self.from.row == self.to.row && self.from.col < self.to.col
+        {
+            crate::term::MoveRight::new(self.to.col - self.from.col)
+                .write_buf(buf);
+        } else if self.to != self.from {
+            crate::term::MoveTo::new(self.to).write_buf(buf);
+        }
+    }
+}
+
+#[must_use = "this struct does nothing unless you call write_buf"]
+pub struct ChangeTitle<'a> {
+    icon_name: &'a str,
+    title: &'a str,
+    prev_icon_name: &'a str,
+    prev_title: &'a str,
+}
+
+impl<'a> ChangeTitle<'a> {
+    pub fn new(
+        icon_name: &'a str,
+        title: &'a str,
+        prev_icon_name: &'a str,
+        prev_title: &'a str,
+    ) -> Self {
+        Self {
+            icon_name,
+            title,
+            prev_icon_name,
+            prev_title,
+        }
+    }
+}
+
+impl<'a> BufWrite for ChangeTitle<'a> {
+    fn write_buf(&self, buf: &mut Vec<u8>) {
+        if self.icon_name == self.title
+            && (self.icon_name != self.prev_icon_name
+                || self.title != self.prev_title)
+        {
+            buf.extend_from_slice(b"\x1b]0;");
+            buf.extend_from_slice(self.icon_name.as_bytes());
+            buf.push(b'\x07');
+        } else {
+            if self.icon_name != self.prev_icon_name {
+                buf.extend_from_slice(b"\x1b]1;");
+                buf.extend_from_slice(self.icon_name.as_bytes());
+                buf.push(b'\x07');
+            }
+            if self.title != self.prev_title {
+                buf.extend_from_slice(b"\x1b]2;");
+                buf.extend_from_slice(self.title.as_bytes());
+                buf.push(b'\x07');
+            }
+        }
+    }
+}
+
+#[derive(Default, Debug)]
+#[must_use = "this struct does nothing unless you call write_buf"]
+pub struct ApplicationKeypad {
+    state: bool,
+}
+
+impl ApplicationKeypad {
+    pub fn new(state: bool) -> Self {
+        Self { state }
+    }
+}
+
+impl BufWrite for ApplicationKeypad {
+    fn write_buf(&self, buf: &mut Vec<u8>) {
+        if self.state {
+            buf.extend_from_slice(b"\x1b=");
+        } else {
+            buf.extend_from_slice(b"\x1b>");
+        }
+    }
+}
+
+#[derive(Default, Debug)]
+#[must_use = "this struct does nothing unless you call write_buf"]
+pub struct ApplicationCursor {
+    state: bool,
+}
+
+impl ApplicationCursor {
+    pub fn new(state: bool) -> Self {
+        Self { state }
+    }
+}
+
+impl BufWrite for ApplicationCursor {
+    fn write_buf(&self, buf: &mut Vec<u8>) {
+        if self.state {
+            buf.extend_from_slice(b"\x1b[?1h");
+        } else {
+            buf.extend_from_slice(b"\x1b[?1l");
+        }
+    }
+}
+
+#[derive(Default, Debug)]
+#[must_use = "this struct does nothing unless you call write_buf"]
+pub struct BracketedPaste {
+    state: bool,
+}
+
+impl BracketedPaste {
+    pub fn new(state: bool) -> Self {
+        Self { state }
+    }
+}
+
+impl BufWrite for BracketedPaste {
+    fn write_buf(&self, buf: &mut Vec<u8>) {
+        if self.state {
+            buf.extend_from_slice(b"\x1b[?2004h");
+        } else {
+            buf.extend_from_slice(b"\x1b[?2004l");
+        }
+    }
+}
+
+#[derive(Default, Debug)]
+#[must_use = "this struct does nothing unless you call write_buf"]
+pub struct MouseProtocolMode {
+    mode: crate::MouseProtocolMode,
+    prev: crate::MouseProtocolMode,
+}
+
+impl MouseProtocolMode {
+    pub fn new(
+        mode: crate::MouseProtocolMode,
+        prev: crate::MouseProtocolMode,
+    ) -> Self {
+        Self { mode, prev }
+    }
+}
+
+impl BufWrite for MouseProtocolMode {
+    fn write_buf(&self, buf: &mut Vec<u8>) {
+        if self.mode == self.prev {
+            return;
+        }
+
+        match self.mode {
+            crate::MouseProtocolMode::None => match self.prev {
+                crate::MouseProtocolMode::None => {}
+                crate::MouseProtocolMode::Press => {
+                    buf.extend_from_slice(b"\x1b[?9l");
+                }
+                crate::MouseProtocolMode::PressRelease => {
+                    buf.extend_from_slice(b"\x1b[?1000l");
+                }
+                crate::MouseProtocolMode::ButtonMotion => {
+                    buf.extend_from_slice(b"\x1b[?1002l");
+                }
+                crate::MouseProtocolMode::AnyMotion => {
+                    buf.extend_from_slice(b"\x1b[?1003l");
+                }
+            },
+            crate::MouseProtocolMode::Press => {
+                buf.extend_from_slice(b"\x1b[?9h");
+            }
+            crate::MouseProtocolMode::PressRelease => {
+                buf.extend_from_slice(b"\x1b[?1000h");
+            }
+            crate::MouseProtocolMode::ButtonMotion => {
+                buf.extend_from_slice(b"\x1b[?1002h");
+            }
+            crate::MouseProtocolMode::AnyMotion => {
+                buf.extend_from_slice(b"\x1b[?1003h");
+            }
+        }
+    }
+}
+
+#[derive(Default, Debug)]
+#[must_use = "this struct does nothing unless you call write_buf"]
+pub struct MouseProtocolEncoding {
+    encoding: crate::MouseProtocolEncoding,
+    prev: crate::MouseProtocolEncoding,
+}
+
+impl MouseProtocolEncoding {
+    pub fn new(
+        encoding: crate::MouseProtocolEncoding,
+        prev: crate::MouseProtocolEncoding,
+    ) -> Self {
+        Self { encoding, prev }
+    }
+}
+
+impl BufWrite for MouseProtocolEncoding {
+    fn write_buf(&self, buf: &mut Vec<u8>) {
+        if self.encoding == self.prev {
+            return;
+        }
+
+        match self.encoding {
+            crate::MouseProtocolEncoding::Default => match self.prev {
+                crate::MouseProtocolEncoding::Default => {}
+                crate::MouseProtocolEncoding::Utf8 => {
+                    buf.extend_from_slice(b"\x1b[?1005l");
+                }
+                crate::MouseProtocolEncoding::Sgr => {
+                    buf.extend_from_slice(b"\x1b[?1006l");
+                }
+            },
+            crate::MouseProtocolEncoding::Utf8 => {
+                buf.extend_from_slice(b"\x1b[?1005h");
+            }
+            crate::MouseProtocolEncoding::Sgr => {
+                buf.extend_from_slice(b"\x1b[?1006h");
+            }
+        }
+    }
+}
+
+fn extend_itoa<I: itoa::Integer>(buf: &mut Vec<u8>, i: I) {
+    let mut itoa_buf = itoa::Buffer::new();
+    buf.extend_from_slice(itoa_buf.format(i).as_bytes());
+}

--- a/crates/turborepo-vt100/tests/attr.rs
+++ b/crates/turborepo-vt100/tests/attr.rs
@@ -1,0 +1,23 @@
+mod helpers;
+
+#[test]
+fn colors() {
+    helpers::fixture("colors");
+}
+
+#[test]
+fn attrs() {
+    helpers::fixture("attrs");
+}
+
+#[test]
+fn attributes_formatted() {
+    let mut parser = vt100::Parser::default();
+    assert_eq!(parser.screen().attributes_formatted(), b"\x1b[m");
+    parser.process(b"\x1b[32mfoo\x1b[41mbar\x1b[33mbaz");
+    assert_eq!(parser.screen().attributes_formatted(), b"\x1b[m\x1b[33;41m");
+    parser.process(b"\x1b[1m\x1b[39m");
+    assert_eq!(parser.screen().attributes_formatted(), b"\x1b[m\x1b[41;1m");
+    parser.process(b"\x1b[m");
+    assert_eq!(parser.screen().attributes_formatted(), b"\x1b[m");
+}

--- a/crates/turborepo-vt100/tests/basic.rs
+++ b/crates/turborepo-vt100/tests/basic.rs
@@ -1,0 +1,118 @@
+#[test]
+fn object_creation() {
+    let parser = vt100::Parser::default();
+    assert_eq!(parser.screen().size(), (24, 80));
+}
+
+#[test]
+fn process_text() {
+    let mut parser = vt100::Parser::default();
+    let input = b"foo\x1b[31m\x1b[32mb\x1b[3;7;42ma\x1b[23mr";
+    parser.process(input);
+    assert_eq!(parser.screen().contents(), "foobar");
+}
+
+#[test]
+fn set_size() {
+    let mut parser = vt100::Parser::default();
+    assert_eq!(parser.screen().size(), (24, 80));
+    assert_eq!(parser.screen().cursor_position(), (0, 0));
+
+    parser.screen_mut().set_size(34, 8);
+    assert_eq!(parser.screen().size(), (34, 8));
+    assert_eq!(parser.screen().cursor_position(), (0, 0));
+
+    parser.process(b"\x1b[30;5H");
+    assert_eq!(parser.screen().cursor_position(), (29, 4));
+
+    parser.screen_mut().set_size(24, 80);
+    assert_eq!(parser.screen().size(), (24, 80));
+    assert_eq!(parser.screen().cursor_position(), (23, 4));
+
+    parser.screen_mut().set_size(34, 8);
+    assert_eq!(parser.screen().size(), (34, 8));
+    assert_eq!(parser.screen().cursor_position(), (23, 4));
+
+    parser.process(b"\x1b[?1049h");
+    assert_eq!(parser.screen().size(), (34, 8));
+    assert_eq!(parser.screen().cursor_position(), (0, 0));
+
+    parser.screen_mut().set_size(24, 80);
+    assert_eq!(parser.screen().size(), (24, 80));
+    assert_eq!(parser.screen().cursor_position(), (0, 0));
+
+    parser.process(b"\x1b[?1049l");
+    assert_eq!(parser.screen().size(), (24, 80));
+    assert_eq!(parser.screen().cursor_position(), (23, 4));
+
+    parser.screen_mut().set_size(34, 8);
+    parser.process(b"\x1bc01234567890123456789");
+    assert_eq!(parser.screen().contents(), "01234567890123456789");
+
+    parser.screen_mut().set_size(24, 80);
+    assert_eq!(parser.screen().contents(), "01234567\n89012345\n6789");
+
+    parser.screen_mut().set_size(34, 8);
+    assert_eq!(parser.screen().contents(), "01234567\n89012345\n6789");
+
+    let mut parser = vt100::Parser::default();
+    assert_eq!(parser.screen().size(), (24, 80));
+    parser.screen_mut().set_size(30, 100);
+    assert_eq!(parser.screen().size(), (30, 100));
+    parser.process(b"\x1b[75Cfoobar");
+    assert_eq!(parser.screen().contents(), "                                                                           foobar");
+
+    let mut parser = vt100::Parser::default();
+    assert_eq!(parser.screen().size(), (24, 80));
+    parser.screen_mut().set_size(30, 100);
+    assert_eq!(parser.screen().size(), (30, 100));
+    parser.process(b"1\r\n2\r\n3\r\n4\r\n5\r\n6\r\n7\r\n8\r\n9\r\n10\r\n11\r\n12\r\n13\r\n14\r\n15\r\n16\r\n17\r\n18\r\n19\r\n20\r\n21\r\n22\r\n23\r\n24\x1b[24;99Hfoobar");
+    assert_eq!(parser.screen().contents(), "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n20\n21\n22\n23\n24                                                                                                foobar");
+}
+
+#[test]
+fn cell_contents() {
+    let mut parser = vt100::Parser::default();
+    let input = b"foo\x1b[31m\x1b[32mb\x1b[3;7;42ma\x1b[23mr";
+    parser.process(input);
+    assert_eq!(parser.screen().cell(0, 0).unwrap().contents(), "f");
+    assert_eq!(parser.screen().cell(0, 1).unwrap().contents(), "o");
+    assert_eq!(parser.screen().cell(0, 2).unwrap().contents(), "o");
+    assert_eq!(parser.screen().cell(0, 3).unwrap().contents(), "b");
+    assert_eq!(parser.screen().cell(0, 4).unwrap().contents(), "a");
+    assert_eq!(parser.screen().cell(0, 5).unwrap().contents(), "r");
+    assert_eq!(parser.screen().cell(0, 6).unwrap().contents(), "");
+}
+
+#[test]
+fn cell_colors() {
+    let mut parser = vt100::Parser::default();
+    let input = b"foo\x1b[31m\x1b[32mb\x1b[3;7;42ma\x1b[23mr";
+    parser.process(input);
+
+    assert_eq!(
+        parser.screen().cell(0, 0).unwrap().fgcolor(),
+        vt100::Color::Default
+    );
+    assert_eq!(
+        parser.screen().cell(0, 3).unwrap().fgcolor(),
+        vt100::Color::Idx(2)
+    );
+    assert_eq!(
+        parser.screen().cell(0, 4).unwrap().fgcolor(),
+        vt100::Color::Idx(2)
+    );
+    assert_eq!(
+        parser.screen().cell(0, 4).unwrap().bgcolor(),
+        vt100::Color::Idx(2)
+    );
+}
+
+#[test]
+fn cell_attrs() {
+    let mut parser = vt100::Parser::default();
+    let input = b"foo\x1b[31m\x1b[32mb\x1b[3;7;42ma\x1b[23mr";
+    parser.process(input);
+
+    assert!(parser.screen().cell(0, 4).unwrap().italic());
+}

--- a/crates/turborepo-vt100/tests/control.rs
+++ b/crates/turborepo-vt100/tests/control.rs
@@ -1,0 +1,73 @@
+mod helpers;
+
+#[test]
+fn bel() {
+    struct State {
+        bel: usize,
+    }
+
+    impl vt100::Callbacks for State {
+        fn audible_bell(&mut self, _: &mut vt100::Screen) {
+            self.bel += 1;
+        }
+    }
+
+    let mut parser = vt100::Parser::default();
+    let mut state = State { bel: 0 };
+    assert_eq!(state.bel, 0);
+
+    let screen = parser.screen().clone();
+    parser.process_cb(b"\x07", &mut state);
+    assert_eq!(state.bel, 1);
+    assert_eq!(parser.screen().contents_diff(&screen), b"");
+
+    let screen = parser.screen().clone();
+    parser.process_cb(b"\x07", &mut state);
+    assert_eq!(state.bel, 2);
+    assert_eq!(parser.screen().contents_diff(&screen), b"");
+
+    let screen = parser.screen().clone();
+    parser.process_cb(b"\x07\x07\x07", &mut state);
+    assert_eq!(state.bel, 5);
+    assert_eq!(parser.screen().contents_diff(&screen), b"");
+
+    let screen = parser.screen().clone();
+    parser.process_cb(b"foo", &mut state);
+    assert_eq!(state.bel, 5);
+    assert_eq!(parser.screen().contents_diff(&screen), b"foo");
+
+    let screen = parser.screen().clone();
+    parser.process_cb(b"ba\x07r", &mut state);
+    assert_eq!(state.bel, 6);
+    assert_eq!(parser.screen().contents_diff(&screen), b"bar");
+}
+
+#[test]
+fn bs() {
+    helpers::fixture("bs");
+}
+
+#[test]
+fn tab() {
+    helpers::fixture("tab");
+}
+
+#[test]
+fn lf() {
+    helpers::fixture("lf");
+}
+
+#[test]
+fn vt() {
+    helpers::fixture("vt");
+}
+
+#[test]
+fn ff() {
+    helpers::fixture("ff");
+}
+
+#[test]
+fn cr() {
+    helpers::fixture("cr");
+}

--- a/crates/turborepo-vt100/tests/csi.rs
+++ b/crates/turborepo-vt100/tests/csi.rs
@@ -1,0 +1,86 @@
+mod helpers;
+
+#[test]
+fn absolute_movement() {
+    helpers::fixture("absolute_movement");
+}
+
+#[test]
+fn row_clamp() {
+    let mut vt = vt100::Parser::default();
+    assert_eq!(vt.screen().cursor_position(), (0, 0));
+    vt.process(b"\x1b[15d");
+    assert_eq!(vt.screen().cursor_position(), (14, 0));
+    vt.process(b"\x1b[150d");
+    assert_eq!(vt.screen().cursor_position(), (23, 0));
+}
+
+#[test]
+fn relative_movement() {
+    helpers::fixture("relative_movement");
+}
+
+#[test]
+fn ed() {
+    helpers::fixture("ed");
+}
+
+#[test]
+fn el() {
+    helpers::fixture("el");
+}
+
+#[test]
+fn ich_dch_ech() {
+    helpers::fixture("ich_dch_ech");
+}
+
+#[test]
+fn il_dl() {
+    helpers::fixture("il_dl");
+}
+
+#[test]
+fn scroll() {
+    helpers::fixture("scroll");
+}
+
+#[test]
+fn xtwinops() {
+    struct Callbacks;
+    impl vt100::Callbacks for Callbacks {
+        fn resize(
+            &mut self,
+            screen: &mut vt100::Screen,
+            (rows, cols): (u16, u16),
+        ) {
+            screen.set_size(rows, cols);
+        }
+    }
+
+    let mut vt = vt100::Parser::default();
+    assert_eq!(vt.screen().size(), (24, 80));
+    vt.process_cb(b"\x1b[8;24;80t", &mut Callbacks);
+    assert_eq!(vt.screen().size(), (24, 80));
+    vt.process_cb(b"\x1b[8t", &mut Callbacks);
+    assert_eq!(vt.screen().size(), (24, 80));
+    vt.process_cb(b"\x1b[8;80;24t", &mut Callbacks);
+    assert_eq!(vt.screen().size(), (80, 24));
+    vt.process_cb(b"\x1b[8;24t", &mut Callbacks);
+    assert_eq!(vt.screen().size(), (24, 24));
+
+    let mut vt = vt100::Parser::default();
+    assert_eq!(vt.screen().size(), (24, 80));
+    vt.process_cb(b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", &mut Callbacks);
+    assert_eq!(vt.screen().rows(0, 80).next().unwrap(), "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    assert_eq!(vt.screen().rows(0, 80).nth(1).unwrap(), "aaaaaaaaaa");
+    vt.process_cb(
+        b"\x1b[H\x1b[8;24;15tbbbbbbbbbbbbbbbbbbbb\x1b[8;24;80tcccccccccccccccccccc",
+        &mut Callbacks,
+    );
+    assert_eq!(vt.screen().rows(0, 80).next().unwrap(), "bbbbbbbbbbbbbbb");
+    assert_eq!(
+        vt.screen().rows(0, 80).nth(1).unwrap(),
+        "bbbbbcccccccccccccccccccc"
+    );
+}

--- a/crates/turborepo-vt100/tests/escape.rs
+++ b/crates/turborepo-vt100/tests/escape.rs
@@ -1,0 +1,63 @@
+mod helpers;
+
+#[test]
+fn deckpam() {
+    helpers::fixture("deckpam");
+}
+
+#[test]
+fn ri() {
+    helpers::fixture("ri");
+}
+
+#[test]
+fn ris() {
+    helpers::fixture("ris");
+}
+
+#[test]
+fn vb() {
+    struct State {
+        vb: usize,
+    }
+
+    impl vt100::Callbacks for State {
+        fn visual_bell(&mut self, _: &mut vt100::Screen) {
+            self.vb += 1;
+        }
+    }
+
+    let mut parser = vt100::Parser::default();
+    let mut state = State { vb: 0 };
+    assert_eq!(state.vb, 0);
+
+    let screen = parser.screen().clone();
+    parser.process_cb(b"\x1bg", &mut state);
+    assert_eq!(state.vb, 1);
+    assert_eq!(parser.screen().contents_diff(&screen), b"");
+
+    let screen = parser.screen().clone();
+    parser.process_cb(b"\x1bg", &mut state);
+    assert_eq!(state.vb, 2);
+    assert_eq!(parser.screen().contents_diff(&screen), b"");
+
+    let screen = parser.screen().clone();
+    parser.process_cb(b"\x1bg\x1bg\x1bg", &mut state);
+    assert_eq!(state.vb, 5);
+    assert_eq!(parser.screen().contents_diff(&screen), b"");
+
+    let screen = parser.screen().clone();
+    parser.process_cb(b"foo", &mut state);
+    assert_eq!(state.vb, 5);
+    assert_eq!(parser.screen().contents_diff(&screen), b"foo");
+
+    let screen = parser.screen().clone();
+    parser.process_cb(b"ba\x1bgr", &mut state);
+    assert_eq!(state.vb, 6);
+    assert_eq!(parser.screen().contents_diff(&screen), b"bar");
+}
+
+#[test]
+fn decsc() {
+    helpers::fixture("decsc");
+}

--- a/crates/turborepo-vt100/tests/helpers/fixtures.rs
+++ b/crates/turborepo-vt100/tests/helpers/fixtures.rs
@@ -1,0 +1,317 @@
+use serde::de::Deserialize as _;
+use std::io::Read as _;
+
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
+pub struct FixtureCell {
+    contents: String,
+    #[serde(default, skip_serializing_if = "is_default")]
+    is_wide: bool,
+    #[serde(default, skip_serializing_if = "is_default")]
+    is_wide_continuation: bool,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_color",
+        serialize_with = "serialize_color",
+        skip_serializing_if = "is_default"
+    )]
+    fgcolor: vt100::Color,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_color",
+        serialize_with = "serialize_color",
+        skip_serializing_if = "is_default"
+    )]
+    bgcolor: vt100::Color,
+    #[serde(default, skip_serializing_if = "is_default")]
+    bold: bool,
+    #[serde(default, skip_serializing_if = "is_default")]
+    italic: bool,
+    #[serde(default, skip_serializing_if = "is_default")]
+    underline: bool,
+    #[serde(default, skip_serializing_if = "is_default")]
+    inverse: bool,
+}
+
+impl FixtureCell {
+    #[allow(dead_code)]
+    pub fn from_cell(cell: &vt100::Cell) -> Self {
+        Self {
+            contents: cell.contents(),
+            is_wide: cell.is_wide(),
+            is_wide_continuation: cell.is_wide_continuation(),
+            fgcolor: cell.fgcolor(),
+            bgcolor: cell.bgcolor(),
+            bold: cell.bold(),
+            italic: cell.italic(),
+            underline: cell.underline(),
+            inverse: cell.inverse(),
+        }
+    }
+}
+
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+pub struct FixtureScreen {
+    contents: String,
+    cells: std::collections::BTreeMap<String, FixtureCell>,
+    cursor_position: (u16, u16),
+    #[serde(default, skip_serializing_if = "is_default")]
+    title: String,
+    #[serde(default, skip_serializing_if = "is_default")]
+    icon_name: String,
+    #[serde(default, skip_serializing_if = "is_default")]
+    application_keypad: bool,
+    #[serde(default, skip_serializing_if = "is_default")]
+    application_cursor: bool,
+    #[serde(default, skip_serializing_if = "is_default")]
+    hide_cursor: bool,
+    #[serde(default, skip_serializing_if = "is_default")]
+    bracketed_paste: bool,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_mouse_protocol_mode",
+        serialize_with = "serialize_mouse_protocol_mode",
+        skip_serializing_if = "is_default"
+    )]
+    mouse_protocol_mode: vt100::MouseProtocolMode,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_mouse_protocol_encoding",
+        serialize_with = "serialize_mouse_protocol_encoding",
+        skip_serializing_if = "is_default"
+    )]
+    mouse_protocol_encoding: vt100::MouseProtocolEncoding,
+}
+
+impl FixtureScreen {
+    fn load<R: std::io::Read>(r: R) -> Self {
+        serde_json::from_reader(r).unwrap()
+    }
+
+    #[allow(dead_code)]
+    pub fn from_screen(screen: &vt100::Screen) -> Self {
+        let empty_screen = vt100::Parser::default().screen().clone();
+        let empty_cell = empty_screen.cell(0, 0).unwrap();
+        let mut cells = std::collections::BTreeMap::new();
+        let (rows, cols) = screen.size();
+        for row in 0..rows {
+            for col in 0..cols {
+                let cell = screen.cell(row, col).unwrap();
+                if cell != empty_cell {
+                    cells.insert(
+                        format!("{row},{col}"),
+                        FixtureCell::from_cell(cell),
+                    );
+                }
+            }
+        }
+        Self {
+            contents: screen.contents(),
+            cells,
+            cursor_position: screen.cursor_position(),
+            title: screen.title().to_string(),
+            icon_name: screen.icon_name().to_string(),
+            application_keypad: screen.application_keypad(),
+            application_cursor: screen.application_cursor(),
+            hide_cursor: screen.hide_cursor(),
+            bracketed_paste: screen.bracketed_paste(),
+            mouse_protocol_mode: screen.mouse_protocol_mode(),
+            mouse_protocol_encoding: screen.mouse_protocol_encoding(),
+        }
+    }
+}
+
+fn is_default<T: Default + PartialEq>(t: &T) -> bool {
+    t == &T::default()
+}
+
+fn deserialize_color<'a, D>(
+    deserializer: D,
+) -> std::result::Result<vt100::Color, D::Error>
+where
+    D: serde::de::Deserializer<'a>,
+{
+    let val = <Option<String>>::deserialize(deserializer)?;
+    match val {
+        None => Ok(vt100::Color::Default),
+        Some(x) if x.starts_with('#') => {
+            let x = x.as_bytes();
+            if x.len() != 7 {
+                return Err(serde::de::Error::custom("invalid rgb color"));
+            }
+            let r =
+                super::hex(x[1], x[2]).map_err(serde::de::Error::custom)?;
+            let g =
+                super::hex(x[3], x[4]).map_err(serde::de::Error::custom)?;
+            let b =
+                super::hex(x[5], x[6]).map_err(serde::de::Error::custom)?;
+            Ok(vt100::Color::Rgb(r, g, b))
+        }
+        Some(x) => Ok(vt100::Color::Idx(
+            x.parse().map_err(serde::de::Error::custom)?,
+        )),
+    }
+}
+
+fn serialize_color<S>(
+    color: &vt100::Color,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    let s = match color {
+        vt100::Color::Default => unreachable!(),
+        vt100::Color::Idx(n) => format!("{n}"),
+        vt100::Color::Rgb(r, g, b) => format!("#{r:02x}{g:02x}{b:02x}"),
+    };
+    serializer.serialize_str(&s)
+}
+
+fn deserialize_mouse_protocol_mode<'a, D>(
+    deserializer: D,
+) -> std::result::Result<vt100::MouseProtocolMode, D::Error>
+where
+    D: serde::de::Deserializer<'a>,
+{
+    let name = <String>::deserialize(deserializer)?;
+    match name.as_ref() {
+        "none" => Ok(vt100::MouseProtocolMode::None),
+        "press" => Ok(vt100::MouseProtocolMode::Press),
+        "press_release" => Ok(vt100::MouseProtocolMode::PressRelease),
+        "button_motion" => Ok(vt100::MouseProtocolMode::ButtonMotion),
+        "any_motion" => Ok(vt100::MouseProtocolMode::AnyMotion),
+        _ => unimplemented!(),
+    }
+}
+
+fn serialize_mouse_protocol_mode<S>(
+    mode: &vt100::MouseProtocolMode,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    let s = match mode {
+        vt100::MouseProtocolMode::None => "none",
+        vt100::MouseProtocolMode::Press => "press",
+        vt100::MouseProtocolMode::PressRelease => "press_release",
+        vt100::MouseProtocolMode::ButtonMotion => "button_motion",
+        vt100::MouseProtocolMode::AnyMotion => "any_motion",
+    };
+    serializer.serialize_str(s)
+}
+
+fn deserialize_mouse_protocol_encoding<'a, D>(
+    deserializer: D,
+) -> std::result::Result<vt100::MouseProtocolEncoding, D::Error>
+where
+    D: serde::de::Deserializer<'a>,
+{
+    let name = <String>::deserialize(deserializer)?;
+    match name.as_ref() {
+        "default" => Ok(vt100::MouseProtocolEncoding::Default),
+        "utf8" => Ok(vt100::MouseProtocolEncoding::Utf8),
+        "sgr" => Ok(vt100::MouseProtocolEncoding::Sgr),
+        _ => unimplemented!(),
+    }
+}
+
+fn serialize_mouse_protocol_encoding<S>(
+    encoding: &vt100::MouseProtocolEncoding,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    let s = match encoding {
+        vt100::MouseProtocolEncoding::Default => "default",
+        vt100::MouseProtocolEncoding::Utf8 => "utf8",
+        vt100::MouseProtocolEncoding::Sgr => "sgr",
+    };
+    serializer.serialize_str(s)
+}
+
+fn load_input(name: &str, i: usize) -> Option<Vec<u8>> {
+    let mut file = std::fs::File::open(format!(
+        "tests/data/fixtures/{name}/{i}.typescript"
+    ))
+    .ok()?;
+    let mut input = vec![];
+    file.read_to_end(&mut input).unwrap();
+    Some(input)
+}
+
+fn load_screen(name: &str, i: usize) -> Option<FixtureScreen> {
+    let mut file =
+        std::fs::File::open(format!("tests/data/fixtures/{name}/{i}.json"))
+            .ok()?;
+    Some(FixtureScreen::load(&mut file))
+}
+
+fn assert_produces(input: &[u8], expected: &FixtureScreen) {
+    let mut parser = vt100::Parser::default();
+    parser.process(input);
+
+    assert_eq!(parser.screen().contents(), expected.contents);
+    assert_eq!(parser.screen().cursor_position(), expected.cursor_position);
+    assert_eq!(parser.screen().title(), expected.title);
+    assert_eq!(parser.screen().icon_name(), expected.icon_name);
+    assert_eq!(
+        parser.screen().application_keypad(),
+        expected.application_keypad
+    );
+    assert_eq!(
+        parser.screen().application_cursor(),
+        expected.application_cursor
+    );
+    assert_eq!(parser.screen().hide_cursor(), expected.hide_cursor);
+    assert_eq!(parser.screen().bracketed_paste(), expected.bracketed_paste);
+    assert_eq!(
+        parser.screen().mouse_protocol_mode(),
+        expected.mouse_protocol_mode
+    );
+    assert_eq!(
+        parser.screen().mouse_protocol_encoding(),
+        expected.mouse_protocol_encoding
+    );
+
+    let (rows, cols) = parser.screen().size();
+    for row in 0..rows {
+        for col in 0..cols {
+            let expected_cell = expected
+                .cells
+                .get(&format!("{row},{col}"))
+                .cloned()
+                .unwrap_or_default();
+            let got_cell = parser.screen().cell(row, col).unwrap();
+            assert_eq!(got_cell.contents(), expected_cell.contents);
+            assert_eq!(got_cell.is_wide(), expected_cell.is_wide);
+            assert_eq!(
+                got_cell.is_wide_continuation(),
+                expected_cell.is_wide_continuation
+            );
+            assert_eq!(got_cell.fgcolor(), expected_cell.fgcolor);
+            assert_eq!(got_cell.bgcolor(), expected_cell.bgcolor);
+            assert_eq!(got_cell.bold(), expected_cell.bold);
+            assert_eq!(got_cell.italic(), expected_cell.italic);
+            assert_eq!(got_cell.underline(), expected_cell.underline);
+            assert_eq!(got_cell.inverse(), expected_cell.inverse);
+        }
+    }
+}
+
+#[allow(dead_code)]
+pub fn fixture(name: &str) {
+    let mut i = 1;
+    let mut prev_input = vec![];
+    while let Some(input) = load_input(name, i) {
+        super::assert_reproduces_state_from(&input, &prev_input);
+        prev_input.extend(input);
+
+        let expected = load_screen(name, i).unwrap();
+        assert_produces(&prev_input, &expected);
+
+        i += 1;
+    }
+    assert!(i > 1, "couldn't find fixtures to test");
+}

--- a/crates/turborepo-vt100/tests/helpers/mod.rs
+++ b/crates/turborepo-vt100/tests/helpers/mod.rs
@@ -1,0 +1,349 @@
+mod fixtures;
+pub use fixtures::fixture;
+pub use fixtures::FixtureScreen;
+
+pub static mut QUIET: bool = false;
+
+macro_rules! is {
+    ($got:expr, $expected:expr) => {
+        if ($got) != ($expected) {
+            if !unsafe { QUIET } {
+                eprintln!(
+                    "{} != {}:",
+                    stringify!($got),
+                    stringify!($expected)
+                );
+                eprintln!("     got: {:?}", $got);
+                eprintln!("expected: {:?}", $expected);
+            }
+            return false;
+        }
+    };
+}
+macro_rules! ok {
+    ($e:expr) => {
+        if !($e) {
+            if !unsafe { QUIET } {
+                eprintln!("!{}", stringify!($e));
+            }
+            return false;
+        }
+    };
+}
+
+#[derive(Eq, PartialEq)]
+struct Bytes<'a>(&'a [u8]);
+
+impl<'a> std::fmt::Debug for Bytes<'a> {
+    fn fmt(
+        &self,
+        f: &mut std::fmt::Formatter<'_>,
+    ) -> Result<(), std::fmt::Error> {
+        f.write_str("b\"")?;
+        for c in self.0 {
+            match c {
+                10 => f.write_str("\\n")?,
+                13 => f.write_str("\\r")?,
+                92 => f.write_str("\\\\")?,
+                32..=126 => f.write_str(&char::from(*c).to_string())?,
+                _ => f.write_fmt(format_args!("\\x{c:02x}"))?,
+            }
+        }
+        f.write_str("\"")?;
+        Ok(())
+    }
+}
+
+pub fn compare_screens(
+    got: &vt100::Screen,
+    expected: &vt100::Screen,
+) -> bool {
+    let (rows, cols) = got.size();
+
+    is!(got.contents(), expected.contents());
+    is!(
+        Bytes(&got.contents_formatted()),
+        Bytes(&expected.contents_formatted())
+    );
+    for (got_row, expected_row) in
+        got.rows(0, cols).zip(expected.rows(0, cols))
+    {
+        is!(got_row, expected_row);
+    }
+    for (got_row, expected_row) in got
+        .rows_formatted(0, cols)
+        .zip(expected.rows_formatted(0, cols))
+    {
+        is!(Bytes(&got_row), Bytes(&expected_row));
+    }
+    for i in 0..rows {
+        is!(got.row_wrapped(i), expected.row_wrapped(i));
+    }
+    is!(
+        Bytes(&got.contents_diff(vt100::Parser::default().screen())),
+        Bytes(&expected.contents_diff(vt100::Parser::default().screen()))
+    );
+
+    is!(Bytes(&got.contents_diff(got)), Bytes(b""));
+
+    for row in 0..rows {
+        for col in 0..cols {
+            let expected_cell = expected.cell(row, col);
+            let got_cell = got.cell(row, col);
+            is!(got_cell, expected_cell);
+        }
+    }
+
+    is!(got.cursor_position(), expected.cursor_position());
+    ok!(got.cursor_position().0 <= rows);
+    ok!(expected.cursor_position().0 <= rows);
+    ok!(got.cursor_position().1 <= cols);
+    ok!(expected.cursor_position().1 <= cols);
+
+    is!(got.title(), expected.title());
+    is!(got.icon_name(), expected.icon_name());
+
+    is!(got.application_keypad(), expected.application_keypad());
+    is!(got.application_cursor(), expected.application_cursor());
+    is!(got.hide_cursor(), expected.hide_cursor());
+    is!(got.bracketed_paste(), expected.bracketed_paste());
+    is!(got.mouse_protocol_mode(), expected.mouse_protocol_mode());
+    is!(
+        got.mouse_protocol_encoding(),
+        expected.mouse_protocol_encoding()
+    );
+
+    true
+}
+
+pub fn contents_formatted_reproduces_state(input: &[u8]) -> bool {
+    let mut parser = vt100::Parser::default();
+    parser.process(input);
+    contents_formatted_reproduces_screen(parser.screen())
+}
+
+pub fn rows_formatted_reproduces_state(input: &[u8]) -> bool {
+    let mut parser = vt100::Parser::default();
+    parser.process(input);
+    rows_formatted_reproduces_screen(parser.screen())
+}
+
+pub fn contents_formatted_reproduces_screen(screen: &vt100::Screen) -> bool {
+    let mut new_input = screen.contents_formatted();
+    new_input.extend(screen.input_mode_formatted());
+    new_input.extend(screen.title_formatted());
+    assert_eq!(new_input, screen.state_formatted());
+    let mut new_parser = vt100::Parser::default();
+    new_parser.process(&new_input);
+    let got_screen = new_parser.screen().clone();
+
+    compare_screens(&got_screen, screen)
+}
+
+pub fn rows_formatted_reproduces_screen(screen: &vt100::Screen) -> bool {
+    let mut new_input = vec![];
+    let mut wrapped = false;
+    for (idx, row) in screen.rows_formatted(0, 80).enumerate() {
+        new_input.extend(b"\x1b[m");
+        if !wrapped {
+            new_input.extend(format!("\x1b[{}H", idx + 1).as_bytes());
+        }
+        new_input.extend(row);
+        wrapped = screen.row_wrapped(idx.try_into().unwrap());
+    }
+    new_input.extend(b"\x1b[m");
+    new_input.extend(screen.cursor_state_formatted());
+    new_input.extend(screen.attributes_formatted());
+    new_input.extend(screen.input_mode_formatted());
+    new_input.extend(screen.title_formatted());
+    let mut new_parser = vt100::Parser::default();
+    new_parser.process(&new_input);
+    let got_screen = new_parser.screen().clone();
+
+    compare_screens(&got_screen, screen)
+}
+
+fn assert_contents_formatted_reproduces_state(input: &[u8]) {
+    assert!(contents_formatted_reproduces_state(input));
+}
+
+fn assert_rows_formatted_reproduces_state(input: &[u8]) {
+    assert!(rows_formatted_reproduces_state(input));
+}
+
+#[allow(dead_code)]
+pub fn contents_diff_reproduces_state(input: &[u8]) -> bool {
+    contents_diff_reproduces_state_from(input, &[])
+}
+
+pub fn contents_diff_reproduces_state_from(
+    input: &[u8],
+    prev_input: &[u8],
+) -> bool {
+    let mut parser = vt100::Parser::default();
+    parser.process(prev_input);
+    let prev_screen = parser.screen().clone();
+    parser.process(input);
+
+    contents_diff_reproduces_state_from_screens(&prev_screen, parser.screen())
+}
+
+pub fn contents_diff_reproduces_state_from_screens(
+    prev_screen: &vt100::Screen,
+    screen: &vt100::Screen,
+) -> bool {
+    let mut diff_input = screen.contents_diff(prev_screen);
+    diff_input.extend(screen.input_mode_diff(prev_screen));
+    diff_input.extend(screen.title_diff(prev_screen));
+    assert_eq!(diff_input, screen.state_diff(prev_screen));
+
+    let mut diff_prev_input = prev_screen.contents_formatted();
+    diff_prev_input.extend(screen.input_mode_formatted());
+    diff_prev_input.extend(screen.title_formatted());
+
+    let mut new_parser = vt100::Parser::default();
+    new_parser.process(&diff_prev_input);
+    new_parser.process(&diff_input);
+    let got_screen = new_parser.screen().clone();
+
+    compare_screens(&got_screen, screen)
+}
+
+#[allow(dead_code)]
+pub fn assert_contents_diff_reproduces_state_from_screens(
+    prev_screen: &vt100::Screen,
+    screen: &vt100::Screen,
+) {
+    assert!(contents_diff_reproduces_state_from_screens(
+        prev_screen,
+        screen,
+    ));
+}
+
+fn assert_contents_diff_reproduces_state_from(
+    input: &[u8],
+    prev_input: &[u8],
+) {
+    assert!(contents_diff_reproduces_state_from(input, prev_input));
+}
+
+#[allow(dead_code)]
+pub fn assert_reproduces_state(input: &[u8]) {
+    assert_reproduces_state_from(input, &[]);
+}
+
+pub fn assert_reproduces_state_from(input: &[u8], prev_input: &[u8]) {
+    let full_input: Vec<_> =
+        prev_input.iter().chain(input.iter()).copied().collect();
+    assert_contents_formatted_reproduces_state(&full_input);
+    assert_rows_formatted_reproduces_state(&full_input);
+    assert_contents_diff_reproduces_state_from(input, prev_input);
+}
+
+#[allow(dead_code)]
+pub fn format_bytes(bytes: &[u8]) -> String {
+    let mut v = vec![];
+    for b in bytes {
+        match *b {
+            10 => v.extend(b"\\n"),
+            13 => v.extend(b"\\r"),
+            27 => v.extend(b"\\e"),
+            c if c < 32 || c == 127 => {
+                v.extend(format!("\\x{c:02x}").as_bytes())
+            }
+            b => v.push(b),
+        }
+    }
+    String::from_utf8_lossy(&v).to_string()
+}
+
+fn hex_char(c: u8) -> Result<u8, String> {
+    match c {
+        b'0' => Ok(0),
+        b'1' => Ok(1),
+        b'2' => Ok(2),
+        b'3' => Ok(3),
+        b'4' => Ok(4),
+        b'5' => Ok(5),
+        b'6' => Ok(6),
+        b'7' => Ok(7),
+        b'8' => Ok(8),
+        b'9' => Ok(9),
+        b'a' => Ok(10),
+        b'b' => Ok(11),
+        b'c' => Ok(12),
+        b'd' => Ok(13),
+        b'e' => Ok(14),
+        b'f' => Ok(15),
+        b'A' => Ok(10),
+        b'B' => Ok(11),
+        b'C' => Ok(12),
+        b'D' => Ok(13),
+        b'E' => Ok(14),
+        b'F' => Ok(15),
+        _ => Err("invalid hex char".to_string()),
+    }
+}
+
+pub fn hex(upper: u8, lower: u8) -> Result<u8, String> {
+    Ok(hex_char(upper)? * 16 + hex_char(lower)?)
+}
+
+#[allow(dead_code)]
+pub fn unhex(s: &[u8]) -> Vec<u8> {
+    let mut ret = vec![];
+    let mut i = 0;
+    while i < s.len() {
+        if s[i] == b'\\' {
+            match s[i + 1] {
+                b'\\' => {
+                    ret.push(b'\\');
+                    i += 2;
+                }
+                b'x' => {
+                    let upper = s[i + 2];
+                    let lower = s[i + 3];
+                    ret.push(hex(upper, lower).unwrap());
+                    i += 4;
+                }
+                b'u' => {
+                    assert_eq!(s[i + 2], b'{');
+                    let mut digits = vec![];
+                    let mut j = i + 3;
+                    while s[j] != b'}' {
+                        digits.push(s[j]);
+                        j += 1;
+                    }
+                    let digits: Vec<_> = digits
+                        .iter()
+                        .copied()
+                        .skip_while(|x| x == &b'0')
+                        .collect();
+                    let digits = String::from_utf8(digits).unwrap();
+                    let codepoint = u32::from_str_radix(&digits, 16).unwrap();
+                    let c = char::try_from(codepoint).unwrap();
+                    let mut bytes = [0; 4];
+                    ret.extend(c.encode_utf8(&mut bytes).bytes());
+                    i = j + 1;
+                }
+                b'r' => {
+                    ret.push(0x0d);
+                    i += 2;
+                }
+                b'n' => {
+                    ret.push(0x0a);
+                    i += 2;
+                }
+                b't' => {
+                    ret.push(0x09);
+                    i += 2;
+                }
+                _ => panic!("invalid escape"),
+            }
+        } else {
+            ret.push(s[i]);
+            i += 1;
+        }
+    }
+    ret
+}

--- a/crates/turborepo-vt100/tests/init.rs
+++ b/crates/turborepo-vt100/tests/init.rs
@@ -1,0 +1,37 @@
+#[test]
+fn init() {
+    let parser = vt100::Parser::default();
+    assert_eq!(parser.screen().size(), (24, 80));
+    assert_eq!(parser.screen().cursor_position(), (0, 0));
+
+    let cell = parser.screen().cell(0, 0);
+    assert_eq!(cell.unwrap().contents(), "");
+    let cell = parser.screen().cell(23, 79);
+    assert_eq!(cell.unwrap().contents(), "");
+    let cell = parser.screen().cell(24, 0);
+    assert!(cell.is_none());
+    let cell = parser.screen().cell(0, 80);
+    assert!(cell.is_none());
+
+    assert_eq!(parser.screen().contents(), "");
+    assert_eq!(
+        parser.screen().contents_formatted(),
+        b"\x1b[?25h\x1b[m\x1b[H\x1b[J"
+    );
+
+    assert_eq!(parser.screen().title(), "");
+    assert_eq!(parser.screen().icon_name(), "");
+
+    assert!(!parser.screen().application_keypad());
+    assert!(!parser.screen().application_cursor());
+    assert!(!parser.screen().hide_cursor());
+    assert!(!parser.screen().bracketed_paste());
+    assert_eq!(
+        parser.screen().mouse_protocol_mode(),
+        vt100::MouseProtocolMode::None
+    );
+    assert_eq!(
+        parser.screen().mouse_protocol_encoding(),
+        vt100::MouseProtocolEncoding::Default
+    );
+}

--- a/crates/turborepo-vt100/tests/mode.rs
+++ b/crates/turborepo-vt100/tests/mode.rs
@@ -1,0 +1,11 @@
+mod helpers;
+
+#[test]
+fn modes() {
+    helpers::fixture("modes");
+}
+
+#[test]
+fn alternate_buffer() {
+    helpers::fixture("alternate_buffer");
+}

--- a/crates/turborepo-vt100/tests/osc.rs
+++ b/crates/turborepo-vt100/tests/osc.rs
@@ -1,0 +1,21 @@
+mod helpers;
+
+#[test]
+fn title() {
+    helpers::fixture("title");
+}
+
+#[test]
+fn icon_name() {
+    helpers::fixture("icon_name");
+}
+
+#[test]
+fn title_icon_name() {
+    helpers::fixture("title_icon_name");
+}
+
+#[test]
+fn unknown_osc() {
+    helpers::fixture("unknown_osc");
+}

--- a/crates/turborepo-vt100/tests/processing.rs
+++ b/crates/turborepo-vt100/tests/processing.rs
@@ -1,0 +1,11 @@
+mod helpers;
+
+#[test]
+fn split_escape_sequences() {
+    helpers::fixture("split_escape_sequences");
+}
+
+#[test]
+fn split_utf8() {
+    helpers::fixture("split_utf8");
+}

--- a/crates/turborepo-vt100/tests/quickcheck.rs
+++ b/crates/turborepo-vt100/tests/quickcheck.rs
@@ -1,0 +1,153 @@
+use quickcheck::Arbitrary as _;
+
+mod helpers;
+
+#[derive(Clone, Debug)]
+struct TerminalInput(Vec<u8>);
+
+fn gen_range<T>(gen: &mut quickcheck::Gen, range: std::ops::Range<T>) -> T
+where
+    T: Copy,
+    T: quickcheck::Arbitrary,
+    T: std::ops::Add<Output = T>
+        + std::ops::Rem<Output = T>
+        + std::ops::Sub<Output = T>,
+{
+    T::arbitrary(gen) % (range.end - range.start) + range.start
+}
+
+impl quickcheck::Arbitrary for TerminalInput {
+    fn arbitrary(g: &mut quickcheck::Gen) -> Self {
+        let size = {
+            let s = g.size();
+            gen_range(g, 0..s)
+        };
+        TerminalInput(
+            (0..size)
+                .flat_map(|_| choose_terminal_input_fragment(g))
+                .collect(),
+        )
+    }
+
+    fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {
+        Box::new(self.0.shrink().map(TerminalInput))
+    }
+}
+
+fn choose_terminal_input_fragment(g: &mut quickcheck::Gen) -> Vec<u8> {
+    #[derive(Clone)]
+    enum Fragment {
+        Text,
+        Control,
+        Escape,
+        Csi,
+        #[allow(dead_code)]
+        Osc,
+        #[allow(dead_code)]
+        Dcs,
+    }
+
+    impl quickcheck::Arbitrary for Fragment {
+        fn arbitrary(g: &mut quickcheck::Gen) -> Self {
+            match u8::arbitrary(g) {
+                0u8..=231 => Fragment::Text,
+                232..=239 => Fragment::Control,
+                240..=247 => Fragment::Escape,
+                248..=255 => Fragment::Csi,
+            }
+        }
+    }
+
+    match Fragment::arbitrary(g) {
+        Fragment::Text => {
+            let mut u: u32 = gen_range(g, 32..(2u32.pow(20) - 2048));
+            // surrogates aren't valid codepoints on their own
+            if u >= 0xD800 {
+                u += 2048;
+            }
+            let c: Result<char, _> = std::convert::TryFrom::try_from(u);
+            let c = match c {
+                Ok(c) => c,
+                Err(e) => panic!("failed to create char from {u}: {e}"),
+            };
+            let mut b = [0; 4];
+            let s = c.encode_utf8(&mut b);
+            (*s).to_string().into_bytes()
+        }
+        Fragment::Control => vec![gen_range(g, 7..14)],
+        Fragment::Escape => {
+            let mut v = vec![0x1b];
+            let c = gen_range(g, b'0'..b'~');
+            v.push(c);
+            v
+        }
+        Fragment::Csi => {
+            let mut v = vec![0x1b, b'['];
+            // TODO: params
+            let c = gen_range(g, b'@'..b'~');
+            v.push(c);
+            v
+        }
+        Fragment::Osc => {
+            // TODO
+            unimplemented!()
+        }
+        Fragment::Dcs => {
+            // TODO
+            unimplemented!()
+        }
+    }
+    // TODO: sometimes add garbage in random places
+}
+
+fn contents_formatted_reproduces_state_random(input: Vec<u8>) -> bool {
+    helpers::contents_formatted_reproduces_state(&input)
+}
+
+fn contents_formatted_reproduces_state_structured(
+    input: TerminalInput,
+) -> bool {
+    helpers::contents_formatted_reproduces_state(&input.0)
+}
+
+#[test]
+#[ignore]
+fn qc_structured_long() {
+    let mut qc = quickcheck::QuickCheck::new()
+        .tests(1_000_000)
+        .max_tests(1_000_000);
+    qc.quickcheck(
+        contents_formatted_reproduces_state_structured
+            as fn(TerminalInput) -> bool,
+    );
+}
+
+#[test]
+fn qc_structured_short() {
+    let mut qc = quickcheck::QuickCheck::new().tests(1_000).max_tests(1_000);
+    qc.quickcheck(
+        contents_formatted_reproduces_state_structured
+            as fn(TerminalInput) -> bool,
+    );
+}
+
+#[test]
+#[ignore]
+fn qc_random_long() {
+    let mut qc = quickcheck::QuickCheck::new()
+        .tests(10_000_000)
+        .max_tests(10_000_000);
+    qc.quickcheck(
+        contents_formatted_reproduces_state_random as fn(Vec<u8>) -> bool,
+    );
+}
+
+#[test]
+fn qc_random_short() {
+    let mut qc = quickcheck::QuickCheck::new()
+        .tests(10_000)
+        .max_tests(10_000);
+    qc.quickcheck(
+        contents_formatted_reproduces_state_random as fn(Vec<u8>) -> bool,
+    );
+}

--- a/crates/turborepo-vt100/tests/scroll.rs
+++ b/crates/turborepo-vt100/tests/scroll.rs
@@ -1,0 +1,112 @@
+mod helpers;
+
+#[test]
+fn scroll_regions() {
+    helpers::fixture("decstbm");
+}
+
+#[test]
+fn origin_mode() {
+    helpers::fixture("origin_mode");
+}
+
+#[test]
+fn scrollback() {
+    let mut parser = vt100::Parser::new(24, 80, 10);
+
+    parser.process(b"1\r\n2\r\n3\r\n4\r\n5\r\n6\r\n7\r\n8\r\n9\r\n10\r\n11\r\n12\r\n13\r\n14\r\n15\r\n16\r\n17\r\n18\r\n19\r\n20\r\n21\r\n22\r\n23\r\n24");
+    assert_eq!(parser.screen().contents(), "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n20\n21\n22\n23\n24");
+
+    parser.process(b"\r\n25\r\n26\r\n27\r\n28\r\n29\r\n30");
+    assert_eq!(parser.screen().contents(), "7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n20\n21\n22\n23\n24\n25\n26\n27\n28\n29\n30");
+
+    parser.screen_mut().set_scrollback(0);
+    assert_eq!(parser.screen().scrollback(), 0);
+    assert_eq!(parser.screen().contents(), "7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n20\n21\n22\n23\n24\n25\n26\n27\n28\n29\n30");
+
+    parser.screen_mut().set_scrollback(1);
+    assert_eq!(parser.screen().scrollback(), 1);
+    assert_eq!(parser.screen().contents(), "6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n20\n21\n22\n23\n24\n25\n26\n27\n28\n29");
+
+    parser.screen_mut().set_scrollback(3);
+    assert_eq!(parser.screen().scrollback(), 3);
+    assert_eq!(parser.screen().contents(), "4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n20\n21\n22\n23\n24\n25\n26\n27");
+
+    parser.screen_mut().set_scrollback(6);
+    assert_eq!(parser.screen().scrollback(), 6);
+    assert_eq!(parser.screen().contents(), "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n20\n21\n22\n23\n24");
+
+    parser.screen_mut().set_scrollback(7);
+    assert_eq!(parser.screen().scrollback(), 6);
+    assert_eq!(parser.screen().contents(), "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n20\n21\n22\n23\n24");
+
+    parser.screen_mut().set_scrollback(0);
+    assert_eq!(parser.screen().scrollback(), 0);
+    assert_eq!(parser.screen().contents(), "7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n20\n21\n22\n23\n24\n25\n26\n27\n28\n29\n30");
+
+    parser.screen_mut().set_scrollback(7);
+    assert_eq!(parser.screen().scrollback(), 6);
+    assert_eq!(parser.screen().contents(), "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n20\n21\n22\n23\n24");
+
+    parser.process(b"\r\n31");
+    assert_eq!(parser.screen().scrollback(), 7);
+    assert_eq!(parser.screen().contents(), "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n20\n21\n22\n23\n24");
+
+    parser.process(b"\r\n32");
+    assert_eq!(parser.screen().scrollback(), 8);
+    assert_eq!(parser.screen().contents(), "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n20\n21\n22\n23\n24");
+
+    parser.process(b"\r\n33");
+    assert_eq!(parser.screen().scrollback(), 9);
+    assert_eq!(parser.screen().contents(), "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n20\n21\n22\n23\n24");
+
+    parser.process(b"\r\n34");
+    assert_eq!(parser.screen().scrollback(), 10);
+    assert_eq!(parser.screen().contents(), "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n20\n21\n22\n23\n24");
+
+    parser.process(b"\r\n35");
+    assert_eq!(parser.screen().scrollback(), 10);
+    assert_eq!(parser.screen().contents(), "2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n20\n21\n22\n23\n24\n25");
+
+    parser.process(b"\r\n36");
+    assert_eq!(parser.screen().scrollback(), 10);
+    assert_eq!(parser.screen().contents(), "3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n20\n21\n22\n23\n24\n25\n26");
+
+    parser.screen_mut().set_scrollback(12);
+    assert_eq!(parser.screen().scrollback(), 10);
+    assert_eq!(parser.screen().contents(), "3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n20\n21\n22\n23\n24\n25\n26");
+
+    parser.screen_mut().set_scrollback(0);
+    assert_eq!(parser.screen().scrollback(), 0);
+    assert_eq!(parser.screen().contents(), "13\n14\n15\n16\n17\n18\n19\n20\n21\n22\n23\n24\n25\n26\n27\n28\n29\n30\n31\n32\n33\n34\n35\n36");
+
+    parser.process(b"\r\n37\r\n38");
+    assert_eq!(parser.screen().scrollback(), 0);
+    assert_eq!(parser.screen().contents(), "15\n16\n17\n18\n19\n20\n21\n22\n23\n24\n25\n26\n27\n28\n29\n30\n31\n32\n33\n34\n35\n36\n37\n38");
+
+    parser.screen_mut().set_scrollback(5);
+    assert_eq!(parser.screen().scrollback(), 5);
+    assert_eq!(parser.screen().contents(), "10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n20\n21\n22\n23\n24\n25\n26\n27\n28\n29\n30\n31\n32\n33");
+
+    parser.process(b"\r\n39\r\n40");
+    assert_eq!(parser.screen().scrollback(), 7);
+    assert_eq!(parser.screen().contents(), "10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n20\n21\n22\n23\n24\n25\n26\n27\n28\n29\n30\n31\n32\n33");
+}
+
+#[test]
+fn edge_of_screen() {
+    let mut parser = vt100::Parser::default();
+    let screen = parser.screen().clone();
+
+    parser.process(b"\x1b[31m\x1b[24;75Hfooba\x08r\x08\x1b[1@a");
+    assert_eq!(parser.screen().cursor_position(), (23, 79));
+    assert_eq!(parser.screen().contents(), "\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n                                                                          foobar");
+    assert_eq!(
+        parser.screen().contents_formatted(),
+        &b"\x1b[?25h\x1b[m\x1b[H\x1b[J\x1b[24;75H\x1b[31mfoobar\x1b[24;80H"[..]
+    );
+    assert_eq!(
+        parser.screen().contents_diff(&screen),
+        b"\x1b[24;75H\x1b[31mfoobar\x1b[24;80H"
+    );
+}

--- a/crates/turborepo-vt100/tests/split-escapes.rs
+++ b/crates/turborepo-vt100/tests/split-escapes.rs
@@ -1,0 +1,51 @@
+use std::io::Read as _;
+
+fn get_file_contents(name: &str) -> Vec<u8> {
+    let mut file = std::fs::File::open(name).unwrap();
+    let mut buf = vec![];
+    file.read_to_end(&mut buf).unwrap();
+    buf
+}
+
+fn write_to_parser(chunks: &mut [Vec<u8>]) -> (String, Vec<u8>) {
+    let mut parser = vt100::Parser::new(37, 193, 0);
+    for chunk in chunks.iter_mut() {
+        parser.process(chunk);
+    }
+    (
+        parser.screen().contents(),
+        parser.screen().contents_formatted(),
+    )
+}
+
+fn test_splits(filename: &str, limit: Option<usize>) {
+    let bytes = get_file_contents(filename);
+    let len = bytes.len();
+    let expected = write_to_parser(&mut [bytes.clone()]);
+    for i in 0..(len - 1) {
+        if let Some(limit) = limit {
+            if i > limit {
+                break;
+            }
+        }
+        let bytes_copy = bytes.clone();
+        let (start, end) = bytes_copy.split_at(i);
+        let mut chunks = vec![start.to_vec(), end.to_vec()];
+        let got = write_to_parser(&mut chunks);
+        assert!(
+            got == expected,
+            "failed to render {filename} when split at byte {i}"
+        );
+    }
+}
+
+#[test]
+fn split_escapes_weechat() {
+    test_splits("tests/data/weechat.typescript", Some(500));
+}
+
+#[test]
+#[ignore]
+fn split_escapes_weechat_full() {
+    test_splits("tests/data/weechat.typescript", None);
+}

--- a/crates/turborepo-vt100/tests/text.rs
+++ b/crates/turborepo-vt100/tests/text.rs
@@ -1,0 +1,36 @@
+mod helpers;
+
+#[test]
+fn ascii() {
+    helpers::fixture("ascii");
+}
+
+#[test]
+fn utf8() {
+    helpers::fixture("utf8");
+}
+
+#[test]
+fn newlines() {
+    helpers::fixture("newlines");
+}
+
+#[test]
+fn wide() {
+    helpers::fixture("wide");
+}
+
+#[test]
+fn combining() {
+    helpers::fixture("combining");
+}
+
+#[test]
+fn wrap() {
+    helpers::fixture("wrap");
+}
+
+#[test]
+fn wrap_weird() {
+    helpers::fixture("wrap_weird");
+}

--- a/crates/turborepo-vt100/tests/weird.rs
+++ b/crates/turborepo-vt100/tests/weird.rs
@@ -1,0 +1,15 @@
+mod helpers;
+
+#[test]
+fn intermediate_control() {
+    helpers::fixture("intermediate_control");
+}
+
+#[test]
+fn params() {
+    let mut parser = vt100::Parser::default();
+    parser.process(b"\x1b[::::::::::::::::::::::::::::::::@");
+    parser.process(b"\x1b[::::::::::::::::::::::::::::::::H");
+    parser.process(b"\x1b[::::::::::::::::::::::::::::::::r");
+    parser.process(b"a\x1b[8888888X");
+}

--- a/crates/turborepo-vt100/tests/window_contents.rs
+++ b/crates/turborepo-vt100/tests/window_contents.rs
@@ -1,0 +1,579 @@
+mod helpers;
+
+use std::io::Read as _;
+
+#[test]
+fn formatted() {
+    let mut parser = vt100::Parser::default();
+    helpers::contents_formatted_reproduces_screen(parser.screen());
+    assert_eq!(
+        parser.screen().contents_formatted(),
+        b"\x1b[?25h\x1b[m\x1b[H\x1b[J"
+    );
+
+    parser.process(b"foobar");
+    helpers::contents_formatted_reproduces_screen(parser.screen());
+    assert!(!parser.screen().cell(0, 2).unwrap().bold());
+    assert!(!parser.screen().cell(0, 3).unwrap().bold());
+    assert!(!parser.screen().cell(0, 4).unwrap().bold());
+    assert!(!parser.screen().cell(0, 5).unwrap().bold());
+    assert_eq!(
+        parser.screen().contents_formatted(),
+        b"\x1b[?25h\x1b[m\x1b[H\x1b[Jfoobar"
+    );
+
+    parser.process(b"\x1b[1;4H\x1b[1;7m\x1b[33mb");
+    helpers::contents_formatted_reproduces_screen(parser.screen());
+    assert!(!parser.screen().cell(0, 2).unwrap().bold());
+    assert!(parser.screen().cell(0, 3).unwrap().bold());
+    assert!(!parser.screen().cell(0, 4).unwrap().bold());
+    assert!(!parser.screen().cell(0, 5).unwrap().bold());
+    assert_eq!(
+        parser.screen().contents_formatted(),
+        &b"\x1b[?25h\x1b[m\x1b[H\x1b[Jfoo\x1b[33;1;7mb\x1b[mar\x1b[1;5H\x1b[33;1;7m"[..]
+    );
+
+    parser.process(b"\x1b[1;5H\x1b[22;42ma");
+    helpers::contents_formatted_reproduces_screen(parser.screen());
+    assert!(!parser.screen().cell(0, 2).unwrap().bold());
+    assert!(parser.screen().cell(0, 3).unwrap().bold());
+    assert!(!parser.screen().cell(0, 4).unwrap().bold());
+    assert!(!parser.screen().cell(0, 5).unwrap().bold());
+    assert_eq!(
+        parser.screen().contents_formatted(),
+        &b"\x1b[?25h\x1b[m\x1b[H\x1b[Jfoo\x1b[33;1;7mb\x1b[42;22ma\x1b[mr\x1b[1;6H\x1b[33;42;7m"
+            [..]
+    );
+
+    parser.process(b"\x1b[1;6H\x1b[35mr\r\nquux");
+    helpers::contents_formatted_reproduces_screen(parser.screen());
+    assert_eq!(
+        parser.screen().contents_formatted(),
+        &b"\x1b[?25h\x1b[m\x1b[H\x1b[Jfoo\x1b[33;1;7mb\x1b[42;22ma\x1b[35mr\r\nquux"[..]
+    );
+
+    parser.process(b"\x1b[2;1H\x1b[45mquux");
+    helpers::contents_formatted_reproduces_screen(parser.screen());
+    assert_eq!(
+        parser.screen().contents_formatted(),
+        &b"\x1b[?25h\x1b[m\x1b[H\x1b[Jfoo\x1b[33;1;7mb\x1b[42;22ma\x1b[35mr\r\n\x1b[45mquux"[..]
+    );
+
+    parser
+        .process(b"\x1b[2;2H\x1b[38;2;123;213;231mu\x1b[38;5;254mu\x1b[39mx");
+    helpers::contents_formatted_reproduces_screen(parser.screen());
+    assert_eq!(parser.screen().contents_formatted(), &b"\x1b[?25h\x1b[m\x1b[H\x1b[Jfoo\x1b[33;1;7mb\x1b[42;22ma\x1b[35mr\r\n\x1b[45mq\x1b[38;2;123;213;231mu\x1b[38;5;254mu\x1b[39mx"[..]);
+}
+
+#[test]
+fn empty_cells() {
+    let mut parser = vt100::Parser::default();
+    parser.process(b"\x1b[5C\x1b[32m bar\x1b[H\x1b[31mfoo");
+    helpers::contents_formatted_reproduces_screen(parser.screen());
+    assert_eq!(parser.screen().contents(), "foo   bar");
+    assert_eq!(
+        parser.screen().contents_formatted(),
+        &b"\x1b[?25h\x1b[m\x1b[H\x1b[J\x1b[31mfoo\x1b[2C\x1b[32m bar\x1b[1;4H\x1b[31m"[..]
+    );
+}
+
+#[test]
+fn cursor_positioning() {
+    let mut parser = vt100::Parser::default();
+
+    let screen = parser.screen().clone();
+    parser.process(b":\x1b[K");
+    assert_eq!(parser.screen().cursor_position(), (0, 1));
+    assert_eq!(
+        parser.screen().contents_formatted(),
+        b"\x1b[?25h\x1b[m\x1b[H\x1b[J:"
+    );
+    assert_eq!(parser.screen().contents_diff(&screen), b":");
+
+    let screen = parser.screen().clone();
+    parser.process(b"a");
+    assert_eq!(parser.screen().cursor_position(), (0, 2));
+    assert_eq!(
+        parser.screen().contents_formatted(),
+        b"\x1b[?25h\x1b[m\x1b[H\x1b[J:a"
+    );
+    assert_eq!(parser.screen().contents_diff(&screen), b"a");
+
+    let screen = parser.screen().clone();
+    parser.process(b"\x1b[1;2H\x1b[K");
+    assert_eq!(parser.screen().cursor_position(), (0, 1));
+    assert_eq!(
+        parser.screen().contents_formatted(),
+        b"\x1b[?25h\x1b[m\x1b[H\x1b[J:"
+    );
+    assert_eq!(parser.screen().contents_diff(&screen), b"\x1b[1;2H\x1b[K");
+
+    let screen = parser.screen().clone();
+    parser.process(b"\x1b[H\x1b[J\x1b[4;80H");
+    assert_eq!(parser.screen().cursor_position(), (3, 79));
+    assert_eq!(
+        parser.screen().contents_formatted(),
+        b"\x1b[?25h\x1b[m\x1b[H\x1b[J\x1b[4;80H"
+    );
+    assert_eq!(
+        parser.screen().contents_diff(&screen),
+        b"\x1b[H\x1b[K\x1b[4;80H"
+    );
+
+    let screen = parser.screen().clone();
+    parser.process(b"a");
+    assert_eq!(parser.screen().cursor_position(), (3, 80));
+    assert_eq!(
+        parser.screen().contents_formatted(),
+        b"\x1b[?25h\x1b[m\x1b[H\x1b[J\x1b[4;80Ha"
+    );
+    assert_eq!(parser.screen().contents_diff(&screen), b"a");
+
+    let screen = parser.screen().clone();
+    parser.process(b"\n");
+    assert_eq!(parser.screen().cursor_position(), (4, 80));
+    assert_eq!(
+        parser.screen().contents_formatted(),
+        b"\x1b[?25h\x1b[m\x1b[H\x1b[J\x1b[4;80Ha\n"
+    );
+    assert_eq!(parser.screen().contents_diff(&screen), b"\n");
+
+    let screen = parser.screen().clone();
+    parser.process(b"b");
+    assert_eq!(parser.screen().cursor_position(), (5, 1));
+    assert_eq!(
+        parser.screen().contents_formatted(),
+        b"\x1b[?25h\x1b[m\x1b[H\x1b[J\x1b[4;80Ha\x1b[6;1Hb"
+    );
+    assert_eq!(parser.screen().contents_diff(&screen), b"\r\nb");
+}
+
+#[test]
+fn rows() {
+    let mut parser = vt100::Parser::default();
+    let screen1 = parser.screen().clone();
+    assert_eq!(
+        screen1.rows(0, 80).collect::<Vec<String>>(),
+        vec![
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+        ]
+    );
+    assert_eq!(screen1.rows_formatted(0, 80).collect::<Vec<Vec<u8>>>(), {
+        let x: Vec<Vec<u8>> = vec![
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+        ];
+        x
+    });
+    assert_eq!(
+        screen1.rows(5, 15).collect::<Vec<String>>(),
+        vec![
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+        ]
+    );
+    assert_eq!(screen1.rows_formatted(5, 15).collect::<Vec<Vec<u8>>>(), {
+        let x: Vec<Vec<u8>> = vec![
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+        ];
+        x
+    });
+
+    parser
+        .process(b"\x1b[31mfoo\x1b[10;10H\x1b[32mbar\x1b[20;20H\x1b[33mbaz");
+    let screen2 = parser.screen().clone();
+    assert_eq!(
+        screen2.rows(0, 80).collect::<Vec<String>>(),
+        vec![
+            "foo".to_string(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            "         bar".to_string(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            "                   baz".to_string(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+        ]
+    );
+    assert_eq!(
+        screen2.rows_formatted(0, 80).collect::<Vec<Vec<u8>>>(),
+        vec![
+            b"\x1b[31mfoo".to_vec(),
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            b"\x1b[9C\x1b[32mbar".to_vec(),
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            b"\x1b[19C\x1b[33mbaz".to_vec(),
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+        ]
+    );
+    assert_eq!(
+        screen2.rows(5, 15).collect::<Vec<String>>(),
+        vec![
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            "    bar".to_string(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            "              b".to_string(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+        ]
+    );
+    assert_eq!(
+        screen2.rows_formatted(5, 15).collect::<Vec<Vec<u8>>>(),
+        vec![
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            b"\x1b[4C\x1b[32mbar".to_vec(),
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            b"\x1b[14C\x1b[33mb".to_vec(),
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+        ]
+    );
+
+    assert_eq!(
+        screen2.rows_diff(&screen1, 0, 80).collect::<Vec<Vec<u8>>>(),
+        vec![
+            b"\x1b[31mfoo".to_vec(),
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            b"\x1b[9C\x1b[32mbar".to_vec(),
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            b"\x1b[19C\x1b[33mbaz".to_vec(),
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+        ]
+    );
+
+    parser.process(b"\x1b[10;11Ho");
+    let screen3 = parser.screen().clone();
+    assert_eq!(
+        screen3.rows_diff(&screen2, 0, 80).collect::<Vec<Vec<u8>>>(),
+        vec![
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            b"\x1b[10C\x1b[33mo".to_vec(),
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+        ]
+    );
+}
+
+#[test]
+fn contents_between() {
+    let mut parser = vt100::Parser::default();
+    assert_eq!(parser.screen().contents_between(0, 0, 0, 0), "");
+    assert_eq!(parser.screen().contents_between(0, 0, 5, 0), "\n\n\n\n\n");
+    assert_eq!(parser.screen().contents_between(5, 0, 0, 0), "");
+
+    parser.process(
+        b"Lorem ipsum dolor sit amet, consectetur adipiscing elit, \
+        sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.\n\n\
+        Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris \
+        nisi ut aliquip ex ea commodo consequat.\n\n\
+        Duis aute irure dolor in reprehenderit in voluptate velit esse cillum \
+        dolore eu fugiat nulla pariatur.\n\n\
+        Excepteur sint occaecat cupidatat non proident, sunt in culpa qui \
+        officia deserunt mollit anim id est laborum.",
+    );
+    assert_eq!(parser.screen().contents_between(0, 0, 0, 0), "");
+    assert_eq!(
+        parser.screen().contents_between(0, 0, 0, 26),
+        "Lorem ipsum dolor sit amet"
+    );
+    assert_eq!(parser.screen().contents_between(0, 26, 0, 0), "");
+    assert_eq!(
+        parser.screen().contents_between(0, 57, 1, 43),
+        "sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+    );
+    assert_eq!(
+        parser.screen().contents_between(0, 57, 2, 0),
+        "sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.\n"
+    );
+    assert_eq!(parser.screen().contents_between(2, 0, 0, 57), "");
+}
+
+#[test]
+fn diff_basic() {
+    let mut parser = vt100::Parser::default();
+    let screen1 = parser.screen().clone();
+    parser.process(b"\x1b[5C\x1b[32m bar");
+    let screen2 = parser.screen().clone();
+    assert_eq!(screen2.contents_diff(&screen1), b"\x1b[5C\x1b[32m bar");
+    helpers::assert_contents_diff_reproduces_state_from_screens(
+        &screen1, &screen2,
+    );
+
+    parser.process(b"\x1b[H\x1b[31mfoo");
+    let screen3 = parser.screen().clone();
+    assert_eq!(screen3.contents_diff(&screen2), b"\x1b[H\x1b[31mfoo");
+    helpers::assert_contents_diff_reproduces_state_from_screens(
+        &screen2, &screen3,
+    );
+
+    parser.process(b"\x1b[1;7H\x1b[32mbaz");
+    let screen4 = parser.screen().clone();
+    assert_eq!(screen4.contents_diff(&screen3), b"\x1b[5C\x1b[32mz");
+    helpers::assert_contents_diff_reproduces_state_from_screens(
+        &screen3, &screen4,
+    );
+
+    parser.process(b"\x1b[1;8H\x1b[X");
+    let screen5 = parser.screen().clone();
+    assert_eq!(screen5.contents_diff(&screen4), b"\x1b[1;8H\x1b[X");
+    helpers::assert_contents_diff_reproduces_state_from_screens(
+        &screen4, &screen5,
+    );
+}
+
+#[test]
+fn diff_erase() {
+    let mut parser = vt100::Parser::default();
+
+    let screen = parser.screen().clone();
+    parser.process(b"foo\x1b[5;5Hbar");
+    assert_eq!(parser.screen().contents_diff(&screen), b"foo\x1b[5;5Hbar");
+
+    let screen = parser.screen().clone();
+    parser.process(b"\x1b[3D\x1b[2X");
+    assert_eq!(parser.screen().contents_diff(&screen), b"\x1b[5;5H\x1b[2X");
+
+    let screen = parser.screen().clone();
+    parser.process(b"\x1bcfoo\x1b[5;5Hbar");
+    assert_eq!(parser.screen().contents_diff(&screen), b"ba\x1b[C");
+
+    let screen = parser.screen().clone();
+    parser.process(b"\x1b[3D\x1b[3X");
+    assert_eq!(parser.screen().contents_diff(&screen), b"\x1b[5;5H\x1b[K");
+}
+
+#[test]
+fn diff_crawl_short() {
+    diff_crawl(500);
+}
+
+#[test]
+#[ignore]
+fn diff_crawl_full() {
+    diff_crawl(7625);
+}
+
+fn diff_crawl(i: usize) {
+    let mut parser = vt100::Parser::default();
+    let screens: Vec<_> = (1..=i)
+        .map(|i| {
+            let mut file =
+                std::fs::File::open(format!("tests/data/crawl/crawl{i}"))
+                    .unwrap();
+            let mut frame = vec![];
+            file.read_to_end(&mut frame).unwrap();
+            parser.process(&frame);
+            parser.screen().clone()
+        })
+        .collect();
+
+    for two_screens in screens.windows(2) {
+        match two_screens {
+            [prev_screen, screen] => {
+                helpers::assert_contents_diff_reproduces_state_from_screens(
+                    prev_screen,
+                    screen,
+                );
+            }
+            _ => unreachable!(),
+        }
+    }
+}

--- a/crates/turborepo-vt100/tests/write.rs
+++ b/crates/turborepo-vt100/tests/write.rs
@@ -1,0 +1,60 @@
+use std::io::Write as _;
+
+#[test]
+fn write_text() {
+    let mut parser = vt100::Parser::default();
+    let input = b"foo\x1b[31m\x1b[32mb\x1b[3;7;42ma\x1b[23mr";
+    let bytes = parser.write(input).unwrap();
+    assert_eq!(bytes, input.len());
+    assert_eq!(parser.screen().contents(), "foobar");
+}
+
+#[test]
+fn cell_contents() {
+    let mut parser = vt100::Parser::default();
+    let input = b"foo\x1b[31m\x1b[32mb\x1b[3;7;42ma\x1b[23mr";
+    let bytes = parser.write(input).unwrap();
+    assert_eq!(bytes, input.len());
+    assert_eq!(parser.screen().cell(0, 0).unwrap().contents(), "f");
+    assert_eq!(parser.screen().cell(0, 1).unwrap().contents(), "o");
+    assert_eq!(parser.screen().cell(0, 2).unwrap().contents(), "o");
+    assert_eq!(parser.screen().cell(0, 3).unwrap().contents(), "b");
+    assert_eq!(parser.screen().cell(0, 4).unwrap().contents(), "a");
+    assert_eq!(parser.screen().cell(0, 5).unwrap().contents(), "r");
+    assert_eq!(parser.screen().cell(0, 6).unwrap().contents(), "");
+}
+
+#[test]
+fn cell_colors() {
+    let mut parser = vt100::Parser::default();
+    let input = b"foo\x1b[31m\x1b[32mb\x1b[3;7;42ma\x1b[23mr";
+    let bytes = parser.write(input).unwrap();
+    assert_eq!(bytes, input.len());
+
+    assert_eq!(
+        parser.screen().cell(0, 0).unwrap().fgcolor(),
+        vt100::Color::Default
+    );
+    assert_eq!(
+        parser.screen().cell(0, 3).unwrap().fgcolor(),
+        vt100::Color::Idx(2)
+    );
+    assert_eq!(
+        parser.screen().cell(0, 4).unwrap().fgcolor(),
+        vt100::Color::Idx(2)
+    );
+    assert_eq!(
+        parser.screen().cell(0, 4).unwrap().bgcolor(),
+        vt100::Color::Idx(2)
+    );
+}
+
+#[test]
+fn cell_attrs() {
+    let mut parser = vt100::Parser::default();
+    let input = b"foo\x1b[31m\x1b[32mb\x1b[3;7;42ma\x1b[23mr";
+    let bytes = parser.write(input).unwrap();
+    assert_eq!(bytes, input.len());
+
+    assert!(parser.screen().cell(0, 4).unwrap().italic());
+}


### PR DESCRIPTION
### Description

Due to our use case we need to extend `vt100` with some functionality. The functionality can be added upstream, but based on the age of PRs on the project, we cannot wait for this to happen.

General plans of changes:
 - Cherry pick [underflow fix](https://github.com/doy/vt100-rust/pull/11)
 - [Support dimmed formatting](https://github.com/doy/vt100-rust/pull/9)
 - Add a version of `Screen` that displays *all* content including lines that are now in the scrollback
 - Some [perf fixes](https://github.com/doy/vt100-rust/pull/14)

### Testing Instructions

Verified existing test suite passes on my machine. Verify test suite passes on CI
