### PR TITLE
chore(Turborepo): Switch tests to use filesystem, remove unused generics

### DIFF
--- a/crates/turborepo-lib/src/daemon/server.rs
+++ b/crates/turborepo-lib/src/daemon/server.rs
@@ -689,14 +689,19 @@ mod test {
             paths.clone(),
             Duration::from_secs(60 * 60),
             exit_signal,
-        )
-        .with_package_discovery_backup(MockDiscovery);
+        );
 
         // the package watcher reads data from the package.json file
         // so we need to create it
         repo_root.create_dir_all().unwrap();
         let package_json = repo_root.join_component("package.json");
-        std::fs::write(package_json, r#"{"workspaces": ["packages/*"]}"#).unwrap();
+        package_json
+            .create_with_contents(r#"{"workspaces": ["packages/*"]}"#)
+            .unwrap();
+        repo_root
+            .join_component("package-lock.json")
+            .create_with_contents("")
+            .unwrap();
 
         let handle = tokio::task::spawn(service.serve());
 
@@ -741,14 +746,19 @@ mod test {
             paths.clone(),
             Duration::from_millis(10),
             exit_signal,
-        )
-        .with_package_discovery_backup(MockDiscovery);
+        );
 
         // the package watcher reads data from the package.json file
         // so we need to create it
         repo_root.create_dir_all().unwrap();
         let package_json = repo_root.join_component("package.json");
-        std::fs::write(package_json, r#"{"workspaces": ["packages/*"]}"#).unwrap();
+        package_json
+            .create_with_contents(r#"{"workspaces": ["packages/*"]}"#)
+            .unwrap();
+        repo_root
+            .join_component("package-lock.json")
+            .create_with_contents("")
+            .unwrap();
 
         let close_reason = server.serve().await;
 
@@ -774,6 +784,15 @@ mod test {
             .unwrap();
 
         let repo_root = path.join_component("repo");
+        repo_root.create_dir_all().unwrap();
+        let package_json = repo_root.join_component("package.json");
+        package_json
+            .create_with_contents(r#"{"workspaces": ["packages/*"]}"#)
+            .unwrap();
+        repo_root
+            .join_component("package-lock.json")
+            .create_with_contents("")
+            .unwrap();
         let paths = Paths::from_repo_root(&repo_root);
 
         let (_tx, rx) = oneshot::channel::<CloseReason>();
@@ -784,8 +803,7 @@ mod test {
             paths,
             Duration::from_secs(60 * 60),
             exit_signal,
-        )
-        .with_package_discovery_backup(MockDiscovery);
+        );
 
         let handle = tokio::task::spawn(server.serve());
 

--- a/crates/turborepo-repository/src/discovery.rs
+++ b/crates/turborepo-repository/src/discovery.rs
@@ -9,8 +9,6 @@
 //! these strategies will implement some sort of monad-style composition so that
 //! we can track areas of run that are performing sub-optimally.
 
-use std::sync::Arc;
-
 use tokio::time::error::Elapsed;
 use tokio_stream::{iter, StreamExt};
 use turbopath::AbsoluteSystemPathBuf;
@@ -91,16 +89,6 @@ impl<T: PackageDiscovery + Send + Sync> PackageDiscovery for Option<T> {
                 Err(Error::Unavailable)
             }
         }
-    }
-}
-
-impl<T: PackageDiscovery + Send + Sync> PackageDiscovery for Arc<T> {
-    async fn discover_packages(&self) -> Result<DiscoveryResponse, Error> {
-        self.as_ref().discover_packages().await
-    }
-
-    async fn discover_packages_blocking(&self) -> Result<DiscoveryResponse, Error> {
-        self.as_ref().discover_packages_blocking().await
     }
 }
 

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -84,7 +84,6 @@ impl<'a, P> PackageGraphBuilder<'a, P> {
         self
     }
 
-    #[allow(dead_code)]
     pub fn with_package_jsons(
         mut self,
         package_jsons: Option<HashMap<AbsoluteSystemPathBuf, PackageJson>>,
@@ -93,7 +92,6 @@ impl<'a, P> PackageGraphBuilder<'a, P> {
         self
     }
 
-    #[allow(dead_code)]
     pub fn with_lockfile(mut self, lockfile: Option<Box<dyn Lockfile>>) -> Self {
         self.lockfile = lockfile;
         self


### PR DESCRIPTION
### Description

 - Switch some daemon tests to fully use filesystem, rather than partially using it
 - Remove some generics that are no longer necessary
 - Clean up some no-longer-needed clippy annotations

### Testing Instructions

Modified tests to not use a mock


Closes TURBO-2513