### PR TITLE
feat(turbopack): add missing webpack context property

### DIFF
--- a/crates/turbopack-node/js/src/transforms/webpack-loaders.ts
+++ b/crates/turbopack-node/js/src/transforms/webpack-loaders.ts
@@ -185,6 +185,11 @@ const transform = (
       {
         resource,
         context: {
+          _module: {
+            // For debugging purpose, if someone find context is not full compatible to
+            // webpack they can guess this comes from turbopack
+            __reserved: "TurbopackContext",
+          },
           currentTraceSpan: new DummySpan(),
           rootContext: contextDir,
           getOptions() {


### PR DESCRIPTION
### Description

https://vercel.slack.com/archives/C03EWR7LGEN/p1709598188040829?thread_ts=1709595370.496449&cid=C03EWR7LGEN

One of the loader uses context's `_module` property, puts an empty one to avoid runtime exception at least.

Closes PACK-2656