### PR TITLE
Add version to package in internal packages docs for yarn

### DIFF
--- a/docs/pages/repo/docs/handbook/sharing-code/internal-packages.mdx
+++ b/docs/pages/repo/docs/handbook/sharing-code/internal-packages.mdx
@@ -45,6 +45,7 @@ Create a `package.json`:
 ```json filename="packages/math-helpers/package.json"
 {
   "name": "math-helpers",
+  "version": "0.0.1",
   "dependencies": {
     // Use whatever version of TypeScript you're using
     "typescript": "latest"


### PR DESCRIPTION
### Description

Added the package version to the internal packages docs example. Without version in the shared internal package, Yarn will attempt to fetch from the npm registry leading to rabbitholes like this one: https://github.com/vercel/turbo/issues/6322

### Testing Instructions

Confirm docs load with new text.
