### PR TITLE
fix(cache): fix restoration issues of directories with very long paths

### DIFF
--- a/crates/turborepo-cache/src/cache_archive/create.rs
+++ b/crates/turborepo-cache/src/cache_archive/create.rs
@@ -395,7 +395,10 @@ mod tests {
 
         let tar_path = tar_dir_path.join_component("test.tar");
         let mut archive = CacheWriter::create(&tar_path)?;
-        let really_long_file = AnchoredSystemPath::new("this-is-a-really-really-really-long-path-like-so-very-long-that-i-can-list-all-of-my-favorite-directors-like-edward-yang-claire-denis-lucrecia-martel-wong-kar-wai-even-kurosawa").unwrap();
+        let base = "this-is-a-really-really-really-long-path-like-so-very-long-that-i-can-list-all-of-my-favorite-directors-like-edward-yang-claire-denis-lucrecia-martel-wong-kar-wai-even-kurosawa";
+        let file_name = format!("{base}.txt");
+        let really_long_file = AnchoredSystemPath::new(&file_name).unwrap();
+        let really_long_dir = AnchoredSystemPath::new(base).unwrap();
         let really_long_symlink = AnchoredSystemPath::new("this-is-a-really-really-really-long-symlink-like-so-very-long-that-i-can-list-all-of-my-other-favorite-directors-like-jim-jarmusch-michelangelo-antonioni-and-terrence-malick-symlink").unwrap();
 
         let really_long_path = archive_dir_path.resolve(really_long_file);
@@ -404,7 +407,11 @@ mod tests {
         let really_long_symlink_path = archive_dir_path.resolve(really_long_symlink);
         really_long_symlink_path.symlink_to_file(really_long_file.as_str())?;
 
+        let really_long_dir_path = archive_dir_path.resolve(really_long_dir);
+        really_long_dir_path.create_dir_all()?;
+
         archive.add_file(archive_dir_path, really_long_file)?;
+        archive.add_file(archive_dir_path, really_long_dir)?;
         archive.add_file(archive_dir_path, really_long_symlink)?;
 
         archive.finish()?;
@@ -414,9 +421,10 @@ mod tests {
 
         let mut restore = CacheReader::open(&tar_path)?;
         let files = restore.restore(restore_dir_path)?;
-        assert_eq!(files.len(), 2);
+        assert_eq!(files.len(), 3);
         assert_eq!(files[0].as_str(), really_long_file.as_str());
-        assert_eq!(files[1].as_str(), really_long_symlink.as_str());
+        assert_eq!(files[1].as_str(), really_long_dir.as_str());
+        assert_eq!(files[2].as_str(), really_long_symlink.as_str());
         Ok(())
     }
 

--- a/crates/turborepo-cache/src/cache_archive/restore.rs
+++ b/crates/turborepo-cache/src/cache_archive/restore.rs
@@ -172,7 +172,7 @@ fn restore_entry<T: Read>(
     let header = entry.header();
 
     match header.entry_type() {
-        tar::EntryType::Directory => restore_directory(dir_cache, anchor, entry.header()),
+        tar::EntryType::Directory => restore_directory(dir_cache, anchor, entry),
         tar::EntryType::Regular => restore_regular(dir_cache, anchor, entry),
         tar::EntryType::Symlink => restore_symlink(dir_cache, anchor, entry),
         ty => Err(CacheError::RestoreUnsupportedFileType(

--- a/crates/turborepo-cache/src/cache_archive/restore_directory.rs
+++ b/crates/turborepo-cache/src/cache_archive/restore_directory.rs
@@ -1,7 +1,7 @@
-use std::{backtrace::Backtrace, ffi::OsString};
+use std::{backtrace::Backtrace, ffi::OsString, io};
 
 use camino::Utf8Component;
-use tar::Header;
+use tar::Entry;
 use tracing::debug;
 use turbopath::{
     AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPath, AnchoredSystemPathBuf,
@@ -12,11 +12,11 @@ use crate::CacheError;
 pub fn restore_directory(
     dir_cache: &mut CachedDirTree,
     anchor: &AbsoluteSystemPath,
-    header: &Header,
+    entry: &Entry<impl io::Read>,
 ) -> Result<AnchoredSystemPathBuf, CacheError> {
-    let processed_name = AnchoredSystemPathBuf::from_system_path(&header.path()?)?;
+    let processed_name = AnchoredSystemPathBuf::from_system_path(&entry.path()?)?;
 
-    dir_cache.safe_mkdir_all(anchor, &processed_name, header.mode()?)?;
+    dir_cache.safe_mkdir_all(anchor, &processed_name, entry.header().mode()?)?;
 
     Ok(processed_name)
 }


### PR DESCRIPTION
### Description

Fixes #7410 

This is just #6662, but applied to directories. See [Entry::path](https://docs.rs/tar/latest/tar/struct.Entry.html#method.path) for explanation as to why one should never rely on a header's path.

### Testing Instructions

In the first commit added a failing unit test, test passes after fix.

Also tested against reproduction: https://github.com/trappar/turbo-cache-missing-output-files

Just need to update `reproduce-issue.sh` to use the `turbo` in this branch:
```
...
Diffing the original force-build's .next directory with the cache-hit-build's .next directory
[0 olszewski@chriss-mbp] /tmp/turbo-cache-missing-output-files $ 
```




Closes TURBO-2532