### PR TITLE
Guarantee typescript-eslint parser resolving.

### DIFF
--- a/examples/basic/packages/ui/.eslintrc.js
+++ b/examples/basic/packages/ui/.eslintrc.js
@@ -5,5 +5,6 @@ module.exports = {
   parser: "@typescript-eslint/parser",
   parserOptions: {
     project: "./tsconfig.lint.json",
+    tsconfigRootDir: __dirname,
   },
 };

--- a/examples/with-yarn/packages/ui/.eslintrc.js
+++ b/examples/with-yarn/packages/ui/.eslintrc.js
@@ -5,5 +5,6 @@ module.exports = {
   parser: "@typescript-eslint/parser",
   parserOptions: {
     project: "./tsconfig.lint.json",
+    tsconfigRootDir: __dirname,
   },
 };


### PR DESCRIPTION
### Description

As it turns out, where the parser resolves to depends on package manager, project setup, configuration, etc. Let's set  set the `tsconfigRootDir` to be __dirname to make sure it uses exactly where we want.


Closes TURBO-2540