### PR TITLE
chore(ci): reorder matrix fields so generated name is easier to read

### DIFF
--- a/.github/workflows/turborepo-library-release.yml
+++ b/.github/workflows/turborepo-library-release.yml
@@ -21,6 +21,7 @@ jobs:
             target: "aarch64-apple-darwin"
           - host: macos-latest
             target: "x86_64-apple-darwin"
+
           - host: ubuntu-latest
             target: "aarch64-unknown-linux-gnu"
             setup: |
@@ -29,6 +30,7 @@ jobs:
               echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
               echo "CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
               echo "CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++" >> $GITHUB_ENV
+
           - host: ubuntu-latest
             target: "x86_64-unknown-linux-gnu"
             container: amazon/aws-lambda-nodejs:18
@@ -38,14 +40,17 @@ jobs:
               npm i -g pnpm@8.9.0
             setup: |
               pnpm install
+
           - host: ubuntu-latest
+            target: "x86_64-unknown-linux-musl"
             container: ghcr.io/napi-rs/napi-rs/nodejs-rust:stable-2023-09-17-alpine
             install: |
               apk add libc6-compat curl
             setup: |
               pnpm install
-            target: "x86_64-unknown-linux-musl"
+
           - host: ubuntu-latest
+            target: "aarch64-unknown-linux-musl"
             container: ghcr.io/napi-rs/napi-rs/nodejs-rust:stable-2023-09-17-alpine
             install: |
               apk add libc6-compat curl
@@ -59,10 +64,11 @@ jobs:
               rustup target add aarch64-unknown-linux-musl
               rustup toolchain install $(cat ./rust-toolchain)
               pnpm install
-            target: "aarch64-unknown-linux-musl"
             rust_env: CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc RUSTFLAGS="-Ctarget-feature=-crt-static"
+
           - host: windows-latest
             target: "aarch64-pc-windows-msvc"
+
           - host: windows-latest
             target: "x86_64-pc-windows-msvc"
 


### PR DESCRIPTION
Can't differentiate the two musl builds because they have a long target. Validated fix in https://github.com/vercel/turbo/actions/runs/8167045370

| before | after |
| --- | --- |
| ![CleanShot 2024-03-05 at 22 41 31@2x](https://github.com/vercel/turbo/assets/490968/4adb9470-727d-4ce7-bbef-f5ec62fd893b) | ![CleanShot 2024-03-05 at 22 42 27@2x](https://github.com/vercel/turbo/assets/490968/4b448929-c037-4c13-9d1e-e7063f21bc21) |

