### PR TITLE
chore(Turborepo): refactor client side of daemon-backed package discovery

### DIFF
--- a/crates/turborepo-lib/src/daemon/client.rs
+++ b/crates/turborepo-lib/src/daemon/client.rs
@@ -1,8 +1,8 @@
-use std::io;
+use std::{io, time::Duration};
 
 use globwalk::ValidatedGlob;
 use thiserror::Error;
-use tonic::{Code, Status};
+use tonic::{Code, IntoRequest, Status};
 use tracing::info;
 use turbopath::AbsoluteSystemPathBuf;
 
@@ -125,11 +125,10 @@ impl<T> DaemonClient<T> {
     }
 
     pub async fn discover_packages(&mut self) -> Result<DiscoverPackagesResponse, DaemonError> {
-        let response = self
-            .client
-            .discover_packages(proto::DiscoverPackagesRequest {})
-            .await?
-            .into_inner();
+        let req = proto::DiscoverPackagesRequest {};
+        let mut req = req.into_request();
+        req.set_timeout(Duration::from_millis(10));
+        let response = self.client.discover_packages(req).await?.into_inner();
 
         Ok(response)
     }

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -45,7 +45,8 @@ use {
     crate::run::package_discovery::DaemonPackageDiscovery,
     std::time::Duration,
     turborepo_repository::discovery::{
-        FallbackPackageDiscovery, LocalPackageDiscoveryBuilder, PackageDiscoveryBuilder,
+        Error as DiscoveryError, FallbackPackageDiscovery, LocalPackageDiscoveryBuilder,
+        PackageDiscoveryBuilder,
     },
 };
 
@@ -286,32 +287,51 @@ impl Run {
                 .with_single_package_mode(self.opts.run_opts.single_package);
 
             #[cfg(feature = "daemon-package-discovery")]
-            let builder = {
-                // if we are forcing the daemon, we don't want to fallback to local discovery
-                let (fallback, duration) = if let Some(true) = self.opts.run_opts.daemon {
-                    (None, Duration::MAX)
-                } else {
-                    (
-                        Some(
-                            LocalPackageDiscoveryBuilder::new(
-                                self.repo_root.clone(),
-                                None,
-                                Some(root_package_json.clone()),
-                            )
-                            .build()?,
-                        ),
-                        Duration::from_millis(10),
+            let graph = match (&daemon, self.opts.run_opts.daemon) {
+                (None, Some(true)) => {
+                    // We've asked for the daemon, but it's not available. This is an error
+                    return Err(package_graph::builder::Error::Discovery(
+                        DiscoveryError::Unavailable,
                     )
-                };
-                let fallback_discovery = FallbackPackageDiscovery::new(
-                    daemon.clone().map(DaemonPackageDiscovery::new),
-                    fallback,
-                    duration,
-                );
-                builder.with_package_discovery(fallback_discovery)
+                    .into());
+                }
+                (Some(daemon), Some(true)) => {
+                    // We have the daemon, and have explicitly asked to only use that
+                    let daemon_discovery = DaemonPackageDiscovery::new(daemon.clone());
+                    builder
+                        .with_package_discovery(daemon_discovery)
+                        .build()
+                        .await
+                }
+                (_, Some(false)) | (None, _) => {
+                    // We have explicitly requested to not use the daemon, or we don't have it
+                    // No change to default.
+                    builder.build().await
+                }
+                (Some(daemon), None) => {
+                    // We have the daemon, and it's not flagged off. Use the fallback strategy
+                    let daemon_discovery = DaemonPackageDiscovery::new(daemon.clone());
+                    let local_discovery = LocalPackageDiscoveryBuilder::new(
+                        self.repo_root.clone(),
+                        None,
+                        Some(root_package_json.clone()),
+                    )
+                    .build()?;
+                    let fallback_discover = FallbackPackageDiscovery::new(
+                        daemon_discovery,
+                        local_discovery,
+                        Duration::from_millis(10),
+                    );
+                    builder
+                        .with_package_discovery(fallback_discover)
+                        .build()
+                        .await
+                }
             };
+            #[cfg(not(feature = "daemon-package-discovery"))]
+            let graph = builder.build().await;
 
-            match builder.build().await {
+            match graph {
                 Ok(graph) => graph,
                 // if we can't find the package.json, it is a bug, and we should report it.
                 // likely cause is that package discovery watching is not up to date.


### PR DESCRIPTION
### Description

 - Set a clientside timeout at the GRPC level for package discovery
 - Refactor FallbackDiscovery to not use Option, as well as drop the impl for Option
 - Only use FallbackDiscovery when we actually want to have a fallback
 - Throw an error in the case where we've requested only daemon usage, but the daemon is unavailable

### Testing Instructions

Existing test suite


Closes TURBO-2549