### PR TITLE
chore: silence lint warnings from vt100 crate

### DIFF
--- a/crates/turborepo-vt100/src/lib.rs
+++ b/crates/turborepo-vt100/src/lib.rs
@@ -45,6 +45,7 @@
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::type_complexity)]
+#![allow(unused_imports)]
 
 mod attrs;
 mod callbacks;

--- a/crates/turborepo-vt100/tests/helpers/mod.rs
+++ b/crates/turborepo-vt100/tests/helpers/mod.rs
@@ -1,3 +1,4 @@
+#![allow(unused_imports)]
 mod fixtures;
 pub use fixtures::fixture;
 pub use fixtures::FixtureScreen;

--- a/crates/turborepo-vt100/tests/window_contents.rs
+++ b/crates/turborepo-vt100/tests/window_contents.rs
@@ -1,3 +1,4 @@
+#![allow(unused_imports)]
 mod helpers;
 
 use std::io::Read as _;


### PR DESCRIPTION
### Description

Silence these warnings to reduce noise on builds.

I chose to silence instead of fix in order to avoid a possible future headache when trying to either un-vendor the crate or cherry pick upstream commits. 

### Testing Instructions

No lints on `cargo build -p vt100` or `cargo build -p vt100 --tests`

Closes TURBO-2551