### PR TITLE
chore: rename vendored vt100 crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12049,7 +12049,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "turborepo_vt100"
+name = "turborepo-vt100"
 version = "0.15.2"
 dependencies = [
  "itoa",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12049,6 +12049,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "turborepo_vt100"
+version = "0.15.2"
+dependencies = [
+ "itoa",
+ "log 0.4.20",
+ "quickcheck",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "terminal_size 0.2.6",
+ "unicode-width",
+ "vte 0.11.1",
+]
+
+[[package]]
 name = "twox-hash"
 version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12459,21 +12474,6 @@ name = "vlq"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65dd7eed29412da847b0f78bcec0ac98588165988a8cfe41d4ea1d429f8ccfff"
-
-[[package]]
-name = "vt100"
-version = "0.15.2"
-dependencies = [
- "itoa",
- "log 0.4.20",
- "quickcheck",
- "rand 0.8.5",
- "serde",
- "serde_json",
- "terminal_size 0.2.6",
- "unicode-width",
- "vte 0.11.1",
-]
 
 [[package]]
 name = "vte"

--- a/crates/turborepo-vt100/Cargo.toml
+++ b/crates/turborepo-vt100/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "turborepo_vt100"
+name = "turborepo-vt100"
 version = "0.15.2"
 authors = ["Jesse Luehrs <doy@tozt.net>"]
 edition = "2021"

--- a/crates/turborepo-vt100/Cargo.toml
+++ b/crates/turborepo-vt100/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "vt100"
+name = "turborepo_vt100"
 version = "0.15.2"
 authors = ["Jesse Luehrs <doy@tozt.net>"]
 edition = "2021"

--- a/crates/turborepo-vt100/src/lib.rs
+++ b/crates/turborepo-vt100/src/lib.rs
@@ -12,13 +12,13 @@
 //! # Synopsis
 //!
 //! ```
-//! let mut parser = vt100::Parser::new(24, 80, 0);
+//! let mut parser = turborepo_vt100::Parser::new(24, 80, 0);
 //!
 //! let screen = parser.screen().clone();
 //! parser.process(b"this text is \x1b[31mRED\x1b[m");
 //! assert_eq!(
 //!     parser.screen().cell(0, 13).unwrap().fgcolor(),
-//!     vt100::Color::Idx(1),
+//!     turborepo_vt100::Color::Idx(1),
 //! );
 //!
 //! let screen = parser.screen().clone();

--- a/crates/turborepo-vt100/tests/attr.rs
+++ b/crates/turborepo-vt100/tests/attr.rs
@@ -1,3 +1,5 @@
+use turborepo_vt100 as vt100;
+
 mod helpers;
 
 #[test]
@@ -12,7 +14,7 @@ fn attrs() {
 
 #[test]
 fn attributes_formatted() {
-    let mut parser = vt100::Parser::default();
+    let mut parser = turborepo_vt100::Parser::default();
     assert_eq!(parser.screen().attributes_formatted(), b"\x1b[m");
     parser.process(b"\x1b[32mfoo\x1b[41mbar\x1b[33mbaz");
     assert_eq!(parser.screen().attributes_formatted(), b"\x1b[m\x1b[33;41m");

--- a/crates/turborepo-vt100/tests/basic.rs
+++ b/crates/turborepo-vt100/tests/basic.rs
@@ -1,3 +1,5 @@
+use turborepo_vt100 as vt100;
+
 #[test]
 fn object_creation() {
     let parser = vt100::Parser::default();

--- a/crates/turborepo-vt100/tests/control.rs
+++ b/crates/turborepo-vt100/tests/control.rs
@@ -1,5 +1,7 @@
 mod helpers;
 
+use turborepo_vt100 as vt100;
+
 #[test]
 fn bel() {
     struct State {

--- a/crates/turborepo-vt100/tests/csi.rs
+++ b/crates/turborepo-vt100/tests/csi.rs
@@ -1,3 +1,5 @@
+use turborepo_vt100 as vt100;
+
 mod helpers;
 
 #[test]

--- a/crates/turborepo-vt100/tests/escape.rs
+++ b/crates/turborepo-vt100/tests/escape.rs
@@ -1,3 +1,5 @@
+use turborepo_vt100 as vt100;
+
 mod helpers;
 
 #[test]

--- a/crates/turborepo-vt100/tests/helpers/fixtures.rs
+++ b/crates/turborepo-vt100/tests/helpers/fixtures.rs
@@ -1,3 +1,5 @@
+use turborepo_vt100 as vt100;
+
 use serde::de::Deserialize as _;
 use std::io::Read as _;
 

--- a/crates/turborepo-vt100/tests/helpers/mod.rs
+++ b/crates/turborepo-vt100/tests/helpers/mod.rs
@@ -2,6 +2,8 @@ mod fixtures;
 pub use fixtures::fixture;
 pub use fixtures::FixtureScreen;
 
+use turborepo_vt100 as vt100;
+
 pub static mut QUIET: bool = false;
 
 macro_rules! is {

--- a/crates/turborepo-vt100/tests/init.rs
+++ b/crates/turborepo-vt100/tests/init.rs
@@ -1,3 +1,5 @@
+use turborepo_vt100 as vt100;
+
 #[test]
 fn init() {
     let parser = vt100::Parser::default();

--- a/crates/turborepo-vt100/tests/mode.rs
+++ b/crates/turborepo-vt100/tests/mode.rs
@@ -1,3 +1,5 @@
+use turborepo_vt100 as vt100;
+
 mod helpers;
 
 #[test]

--- a/crates/turborepo-vt100/tests/osc.rs
+++ b/crates/turborepo-vt100/tests/osc.rs
@@ -1,3 +1,5 @@
+use turborepo_vt100 as vt100;
+
 mod helpers;
 
 #[test]

--- a/crates/turborepo-vt100/tests/processing.rs
+++ b/crates/turborepo-vt100/tests/processing.rs
@@ -1,3 +1,5 @@
+use turborepo_vt100 as vt100;
+
 mod helpers;
 
 #[test]

--- a/crates/turborepo-vt100/tests/quickcheck.rs
+++ b/crates/turborepo-vt100/tests/quickcheck.rs
@@ -1,3 +1,5 @@
+use turborepo_vt100 as vt100;
+
 use quickcheck::Arbitrary as _;
 
 mod helpers;

--- a/crates/turborepo-vt100/tests/scroll.rs
+++ b/crates/turborepo-vt100/tests/scroll.rs
@@ -1,3 +1,5 @@
+use turborepo_vt100 as vt100;
+
 mod helpers;
 
 #[test]

--- a/crates/turborepo-vt100/tests/split-escapes.rs
+++ b/crates/turborepo-vt100/tests/split-escapes.rs
@@ -1,3 +1,5 @@
+use turborepo_vt100 as vt100;
+
 use std::io::Read as _;
 
 fn get_file_contents(name: &str) -> Vec<u8> {

--- a/crates/turborepo-vt100/tests/text.rs
+++ b/crates/turborepo-vt100/tests/text.rs
@@ -1,3 +1,5 @@
+use turborepo_vt100 as vt100;
+
 mod helpers;
 
 #[test]

--- a/crates/turborepo-vt100/tests/weird.rs
+++ b/crates/turborepo-vt100/tests/weird.rs
@@ -1,3 +1,5 @@
+use turborepo_vt100 as vt100;
+
 mod helpers;
 
 #[test]

--- a/crates/turborepo-vt100/tests/window_contents.rs
+++ b/crates/turborepo-vt100/tests/window_contents.rs
@@ -1,3 +1,5 @@
+use turborepo_vt100 as vt100;
+
 mod helpers;
 
 use std::io::Read as _;

--- a/crates/turborepo-vt100/tests/write.rs
+++ b/crates/turborepo-vt100/tests/write.rs
@@ -1,3 +1,5 @@
+use turborepo_vt100 as vt100;
+
 use std::io::Write as _;
 
 #[test]


### PR DESCRIPTION
### Description

Renaming our vendored `vt100` crate to avoid confusion since `tui_term` comes with prebuilt `vt100` integration, but won't work with our vendored crate. 

### Testing Instructions

CI

Closes TURBO-2553