### PR TITLE
chore(@turbo/repository): bump to 0.0.1-canary.9

### DIFF
--- a/packages/turbo-repository/js/package.json
+++ b/packages/turbo-repository/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/repository",
-  "version": "0.0.1-canary.8",
+  "version": "0.0.1-canary.9",
   "description": "",
   "bugs": "https://github.com/vercel/turbo/issues",
   "homepage": "https://turbo.build/repo",
@@ -15,13 +15,13 @@
   ],
   "types": "dist/index.d.ts",
   "optionalDependencies": {
-    "@turbo/repository-darwin-x64": "0.0.1-canary.8",
-    "@turbo/repository-darwin-arm64": "0.0.1-canary.8",
-    "@turbo/repository-linux-x64-gnu": "0.0.1-canary.8",
-    "@turbo/repository-linux-arm64-gnu": "0.0.1-canary.8",
-    "@turbo/repository-linux-x64-musl": "0.0.1-canary.8",
-    "@turbo/repository-linux-arm64-musl": "0.0.1-canary.8",
-    "@turbo/repository-win32-x64-msvc": "0.0.1-canary.8",
-    "@turbo/repository-win32-arm64-msvc": "0.0.1-canary.8"
+    "@turbo/repository-darwin-x64": "0.0.1-canary.9",
+    "@turbo/repository-darwin-arm64": "0.0.1-canary.9",
+    "@turbo/repository-linux-x64-gnu": "0.0.1-canary.9",
+    "@turbo/repository-linux-arm64-gnu": "0.0.1-canary.9",
+    "@turbo/repository-linux-x64-musl": "0.0.1-canary.9",
+    "@turbo/repository-linux-arm64-musl": "0.0.1-canary.9",
+    "@turbo/repository-win32-x64-msvc": "0.0.1-canary.9",
+    "@turbo/repository-win32-arm64-msvc": "0.0.1-canary.9"
   }
 }

--- a/packages/turbo-repository/npm/darwin-arm64/package.json
+++ b/packages/turbo-repository/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/repository-darwin-arm64",
-  "version": "0.0.1-canary.8",
+  "version": "0.0.1-canary.9",
   "repository": {
     "type": "git",
     "url": "https://github.com/vercel/turbo",

--- a/packages/turbo-repository/npm/darwin-x64/package.json
+++ b/packages/turbo-repository/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/repository-darwin-x64",
-  "version": "0.0.1-canary.8",
+  "version": "0.0.1-canary.9",
   "repository": {
     "type": "git",
     "url": "https://github.com/vercel/turbo",

--- a/packages/turbo-repository/npm/linux-arm64-gnu/package.json
+++ b/packages/turbo-repository/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/repository-linux-arm64-gnu",
-  "version": "0.0.1-canary.8",
+  "version": "0.0.1-canary.9",
   "repository": {
     "type": "git",
     "url": "https://github.com/vercel/turbo",

--- a/packages/turbo-repository/npm/linux-arm64-musl/package.json
+++ b/packages/turbo-repository/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/repository-linux-arm64-musl",
-  "version": "0.0.1-canary.8",
+  "version": "0.0.1-canary.9",
   "repository": {
     "type": "git",
     "url": "https://github.com/vercel/turbo",

--- a/packages/turbo-repository/npm/linux-x64-gnu/package.json
+++ b/packages/turbo-repository/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/repository-linux-x64-gnu",
-  "version": "0.0.1-canary.8",
+  "version": "0.0.1-canary.9",
   "repository": {
     "type": "git",
     "url": "https://github.com/vercel/turbo",

--- a/packages/turbo-repository/npm/linux-x64-musl/package.json
+++ b/packages/turbo-repository/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/repository-linux-x64-musl",
-  "version": "0.0.1-canary.8",
+  "version": "0.0.1-canary.9",
   "repository": {
     "type": "git",
     "url": "https://github.com/vercel/turbo",

--- a/packages/turbo-repository/npm/win32-arm64-msvc/package.json
+++ b/packages/turbo-repository/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/repository-win32-arm64-msvc",
-  "version": "0.0.1-canary.8",
+  "version": "0.0.1-canary.9",
   "repository": {
     "type": "git",
     "url": "https://github.com/vercel/turbo",

--- a/packages/turbo-repository/npm/win32-x64-msvc/package.json
+++ b/packages/turbo-repository/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/repository-win32-x64-msvc",
-  "version": "0.0.1-canary.8",
+  "version": "0.0.1-canary.9",
   "repository": {
     "type": "git",
     "url": "https://github.com/vercel/turbo",


### PR DESCRIPTION


Closes TURBO-2556