### PR TITLE
Rename `BuildChunkingContext` -> `NodeJsChunkingContext` and `DevChunkingContext` -> `BrowserChunkingContext`

### DIFF
--- a/crates/turbopack-build/src/chunking_context.rs
+++ b/crates/turbopack-build/src/chunking_context.rs
@@ -51,12 +51,12 @@ pub enum MinifyType {
     NoMinify,
 }
 
-/// A builder for [`Vc<BuildChunkingContext>`].
-pub struct BuildChunkingContextBuilder {
-    chunking_context: BuildChunkingContext,
+/// A builder for [`Vc<NodeJsChunkingContext>`].
+pub struct NodeJsChunkingContextBuilder {
+    chunking_context: NodeJsChunkingContext,
 }
 
-impl BuildChunkingContextBuilder {
+impl NodeJsChunkingContextBuilder {
     pub fn asset_prefix(mut self, asset_prefix: Vc<Option<String>>) -> Self {
         self.chunking_context.asset_prefix = asset_prefix;
         self
@@ -78,15 +78,15 @@ impl BuildChunkingContextBuilder {
     }
 
     /// Builds the chunking context.
-    pub fn build(self) -> Vc<BuildChunkingContext> {
-        BuildChunkingContext::new(Value::new(self.chunking_context))
+    pub fn build(self) -> Vc<NodeJsChunkingContext> {
+        NodeJsChunkingContext::new(Value::new(self.chunking_context))
     }
 }
 
 /// A chunking context for build mode.
 #[turbo_tasks::value(serialization = "auto_for_input")]
 #[derive(Debug, Clone, Hash, PartialOrd, Ord)]
-pub struct BuildChunkingContext {
+pub struct NodeJsChunkingContext {
     /// This path get stripped off of chunk paths before generating output asset
     /// paths.
     context_path: Vc<FileSystemPath>,
@@ -110,7 +110,7 @@ pub struct BuildChunkingContext {
     manifest_chunks: bool,
 }
 
-impl BuildChunkingContext {
+impl NodeJsChunkingContext {
     /// Creates a new chunking context builder.
     pub fn builder(
         context_path: Vc<FileSystemPath>,
@@ -119,9 +119,9 @@ impl BuildChunkingContext {
         chunk_root_path: Vc<FileSystemPath>,
         asset_root_path: Vc<FileSystemPath>,
         environment: Vc<Environment>,
-    ) -> BuildChunkingContextBuilder {
-        BuildChunkingContextBuilder {
-            chunking_context: BuildChunkingContext {
+    ) -> NodeJsChunkingContextBuilder {
+        NodeJsChunkingContextBuilder {
+            chunking_context: NodeJsChunkingContext {
                 context_path,
                 output_root,
                 client_root,
@@ -137,10 +137,10 @@ impl BuildChunkingContext {
     }
 }
 
-impl BuildChunkingContext {
+impl NodeJsChunkingContext {
     /// Returns the kind of runtime to include in output chunks.
     ///
-    /// This is defined directly on `BuildChunkingContext` so it is zero-cost
+    /// This is defined directly on `NodeJsChunkingContext` so it is zero-cost
     /// when `RuntimeType` has a single variant.
     pub fn runtime_type(&self) -> RuntimeType {
         self.runtime_type
@@ -158,9 +158,9 @@ pub struct EntryChunkGroupResult {
 }
 
 #[turbo_tasks::value_impl]
-impl BuildChunkingContext {
+impl NodeJsChunkingContext {
     #[turbo_tasks::function]
-    fn new(this: Value<BuildChunkingContext>) -> Vc<Self> {
+    fn new(this: Value<NodeJsChunkingContext>) -> Vc<Self> {
         this.into_value().cell()
     }
 
@@ -240,7 +240,7 @@ impl BuildChunkingContext {
 }
 
 #[turbo_tasks::value_impl]
-impl ChunkingContext for BuildChunkingContext {
+impl ChunkingContext for NodeJsChunkingContext {
     #[turbo_tasks::function]
     fn context_path(&self) -> Vc<FileSystemPath> {
         self.context_path
@@ -414,4 +414,4 @@ impl ChunkingContext for BuildChunkingContext {
 }
 
 #[turbo_tasks::value_impl]
-impl EcmascriptChunkingContext for BuildChunkingContext {}
+impl EcmascriptChunkingContext for NodeJsChunkingContext {}

--- a/crates/turbopack-build/src/ecmascript/node/chunk.rs
+++ b/crates/turbopack-build/src/ecmascript/node/chunk.rs
@@ -13,12 +13,12 @@ use turbopack_core::{
 use turbopack_ecmascript::chunk::EcmascriptChunk;
 
 use super::content::EcmascriptBuildNodeChunkContent;
-use crate::BuildChunkingContext;
+use crate::NodeJsChunkingContext;
 
 /// Production Ecmascript chunk targeting Node.js.
 #[turbo_tasks::value(shared)]
 pub(crate) struct EcmascriptBuildNodeChunk {
-    chunking_context: Vc<BuildChunkingContext>,
+    chunking_context: Vc<NodeJsChunkingContext>,
     chunk: Vc<EcmascriptChunk>,
 }
 
@@ -26,7 +26,10 @@ pub(crate) struct EcmascriptBuildNodeChunk {
 impl EcmascriptBuildNodeChunk {
     /// Creates a new [`Vc<EcmascriptBuildNodeChunk>`].
     #[turbo_tasks::function]
-    pub fn new(chunking_context: Vc<BuildChunkingContext>, chunk: Vc<EcmascriptChunk>) -> Vc<Self> {
+    pub fn new(
+        chunking_context: Vc<NodeJsChunkingContext>,
+        chunk: Vc<EcmascriptChunk>,
+    ) -> Vc<Self> {
         EcmascriptBuildNodeChunk {
             chunking_context,
             chunk,

--- a/crates/turbopack-build/src/ecmascript/node/content.rs
+++ b/crates/turbopack-build/src/ecmascript/node/content.rs
@@ -18,12 +18,12 @@ use turbopack_ecmascript::{
 };
 
 use super::{chunk::EcmascriptBuildNodeChunk, version::EcmascriptBuildNodeChunkVersion};
-use crate::{chunking_context::MinifyType, ecmascript::minify::minify, BuildChunkingContext};
+use crate::{chunking_context::MinifyType, ecmascript::minify::minify, NodeJsChunkingContext};
 
 #[turbo_tasks::value]
 pub(super) struct EcmascriptBuildNodeChunkContent {
     pub(super) content: Vc<EcmascriptChunkContent>,
-    pub(super) chunking_context: Vc<BuildChunkingContext>,
+    pub(super) chunking_context: Vc<NodeJsChunkingContext>,
     pub(super) chunk: Vc<EcmascriptBuildNodeChunk>,
 }
 
@@ -31,7 +31,7 @@ pub(super) struct EcmascriptBuildNodeChunkContent {
 impl EcmascriptBuildNodeChunkContent {
     #[turbo_tasks::function]
     pub(crate) async fn new(
-        chunking_context: Vc<BuildChunkingContext>,
+        chunking_context: Vc<NodeJsChunkingContext>,
         chunk: Vc<EcmascriptBuildNodeChunk>,
         content: Vc<EcmascriptChunkContent>,
     ) -> Result<Vc<Self>> {

--- a/crates/turbopack-build/src/ecmascript/node/entry/chunk.rs
+++ b/crates/turbopack-build/src/ecmascript/node/entry/chunk.rs
@@ -15,14 +15,14 @@ use turbopack_core::{
 use turbopack_ecmascript::{chunk::EcmascriptChunkPlaceable, utils::StringifyJs};
 
 use super::runtime::EcmascriptBuildNodeRuntimeChunk;
-use crate::BuildChunkingContext;
+use crate::NodeJsChunkingContext;
 
 /// An Ecmascript chunk that loads a list of parallel chunks, then instantiates
 /// runtime entries.
 #[turbo_tasks::value(shared)]
 pub(crate) struct EcmascriptBuildNodeEntryChunk {
     path: Vc<FileSystemPath>,
-    chunking_context: Vc<BuildChunkingContext>,
+    chunking_context: Vc<NodeJsChunkingContext>,
     other_chunks: Vc<OutputAssets>,
     evaluatable_assets: Vc<EvaluatableAssets>,
     exported_module: Vc<Box<dyn EcmascriptChunkPlaceable>>,
@@ -34,7 +34,7 @@ impl EcmascriptBuildNodeEntryChunk {
     #[turbo_tasks::function]
     pub fn new(
         path: Vc<FileSystemPath>,
-        chunking_context: Vc<BuildChunkingContext>,
+        chunking_context: Vc<NodeJsChunkingContext>,
         other_chunks: Vc<OutputAssets>,
         evaluatable_assets: Vc<EvaluatableAssets>,
         exported_module: Vc<Box<dyn EcmascriptChunkPlaceable>>,

--- a/crates/turbopack-build/src/ecmascript/node/entry/runtime.rs
+++ b/crates/turbopack-build/src/ecmascript/node/entry/runtime.rs
@@ -15,19 +15,19 @@ use turbopack_core::{
 use turbopack_ecmascript::utils::StringifyJs;
 use turbopack_ecmascript_runtime::RuntimeType;
 
-use crate::BuildChunkingContext;
+use crate::NodeJsChunkingContext;
 
 /// An Ecmascript chunk that contains the Node.js runtime code.
 #[turbo_tasks::value(shared)]
 pub(crate) struct EcmascriptBuildNodeRuntimeChunk {
-    chunking_context: Vc<BuildChunkingContext>,
+    chunking_context: Vc<NodeJsChunkingContext>,
 }
 
 #[turbo_tasks::value_impl]
 impl EcmascriptBuildNodeRuntimeChunk {
     /// Creates a new [`Vc<EcmascriptBuildNodeRuntimeChunk>`].
     #[turbo_tasks::function]
-    pub fn new(chunking_context: Vc<BuildChunkingContext>) -> Vc<Self> {
+    pub fn new(chunking_context: Vc<NodeJsChunkingContext>) -> Vc<Self> {
         EcmascriptBuildNodeRuntimeChunk { chunking_context }.cell()
     }
 

--- a/crates/turbopack-build/src/lib.rs
+++ b/crates/turbopack-build/src/lib.rs
@@ -6,7 +6,7 @@ pub(crate) mod chunking_context;
 pub(crate) mod ecmascript;
 
 pub use chunking_context::{
-    BuildChunkingContext, BuildChunkingContextBuilder, EntryChunkGroupResult, MinifyType,
+    EntryChunkGroupResult, MinifyType, NodeJsChunkingContext, NodeJsChunkingContextBuilder,
 };
 
 pub fn register() {

--- a/crates/turbopack-cli/src/build/mod.rs
+++ b/crates/turbopack-cli/src/build/mod.rs
@@ -10,7 +10,7 @@ use turbo_tasks::{TransientInstance, TryJoinIterExt, TurboTasks, Value, Vc};
 use turbo_tasks_fs::FileSystem;
 use turbo_tasks_memory::MemoryBackend;
 use turbopack::ecmascript::EcmascriptModuleAsset;
-use turbopack_build::{BuildChunkingContext, MinifyType};
+use turbopack_build::{MinifyType, NodeJsChunkingContext};
 use turbopack_cli_utils::issue::{ConsoleUi, LogOptions};
 use turbopack_core::{
     asset::Asset,
@@ -181,7 +181,7 @@ async fn build_internal(
     let build_output_root = output_fs.root().join("dist".to_string());
 
     let chunking_context = Vc::upcast(
-        BuildChunkingContext::builder(
+        NodeJsChunkingContext::builder(
             project_path,
             build_output_root,
             build_output_root,
@@ -248,7 +248,7 @@ async fn build_internal(
                     Vc::try_resolve_downcast_type::<EcmascriptModuleAsset>(entry_module).await?
                 {
                     Vc::cell(vec![
-                        Vc::try_resolve_downcast_type::<BuildChunkingContext>(chunking_context)
+                        Vc::try_resolve_downcast_type::<NodeJsChunkingContext>(chunking_context)
                             .await?
                             .unwrap()
                             .entry_chunk_group(

--- a/crates/turbopack-cli/src/dev/mod.rs
+++ b/crates/turbopack-cli/src/dev/mod.rs
@@ -25,7 +25,7 @@ use turbopack_core::{
     resolve::parse::Request,
     server_fs::ServerFileSystem,
 };
-use turbopack_dev::DevChunkingContext;
+use turbopack_dev::BrowserChunkingContext;
 use turbopack_dev_server::{
     introspect::IntrospectionSource,
     source::{
@@ -248,7 +248,7 @@ async fn source(
     let env = load_env(project_path);
     let build_output_root = output_fs.root().join(".turbopack/build".to_string());
 
-    let build_chunking_context = DevChunkingContext::builder(
+    let build_chunking_context = BrowserChunkingContext::builder(
         project_path,
         build_output_root,
         build_output_root,

--- a/crates/turbopack-cli/src/dev/web_entry_source.rs
+++ b/crates/turbopack-cli/src/dev/web_entry_source.rs
@@ -14,7 +14,7 @@ use turbopack_core::{
         parse::Request,
     },
 };
-use turbopack_dev::{react_refresh::assert_can_resolve_react_refresh, DevChunkingContext};
+use turbopack_dev::{react_refresh::assert_can_resolve_react_refresh, BrowserChunkingContext};
 use turbopack_dev_server::{
     html::DevHtmlAsset,
     source::{asset_graph::AssetGraphContentSource, ContentSource},
@@ -36,7 +36,7 @@ pub fn get_client_chunking_context(
     environment: Vc<Environment>,
 ) -> Vc<Box<dyn ChunkingContext>> {
     Vc::upcast(
-        DevChunkingContext::builder(
+        BrowserChunkingContext::builder(
             project_path,
             server_root,
             server_root,

--- a/crates/turbopack-dev/src/chunking_context.rs
+++ b/crates/turbopack-dev/src/chunking_context.rs
@@ -27,11 +27,11 @@ use crate::ecmascript::{
     list::asset::{EcmascriptDevChunkList, EcmascriptDevChunkListSource},
 };
 
-pub struct DevChunkingContextBuilder {
-    chunking_context: DevChunkingContext,
+pub struct BrowserChunkingContextBuilder {
+    chunking_context: BrowserChunkingContext,
 }
 
-impl DevChunkingContextBuilder {
+impl BrowserChunkingContextBuilder {
     pub fn hot_module_replacement(mut self) -> Self {
         self.chunking_context.enable_hot_module_replacement = true;
         self
@@ -67,8 +67,8 @@ impl DevChunkingContextBuilder {
         self
     }
 
-    pub fn build(self) -> Vc<DevChunkingContext> {
-        DevChunkingContext::new(Value::new(self.chunking_context))
+    pub fn build(self) -> Vc<BrowserChunkingContext> {
+        BrowserChunkingContext::new(Value::new(self.chunking_context))
     }
 }
 
@@ -79,7 +79,7 @@ impl DevChunkingContextBuilder {
 /// during development
 #[turbo_tasks::value(serialization = "auto_for_input")]
 #[derive(Debug, Clone, Hash, PartialOrd, Ord)]
-pub struct DevChunkingContext {
+pub struct BrowserChunkingContext {
     /// This path get stripped off of chunk paths before generating output asset
     /// paths.
     context_path: Vc<FileSystemPath>,
@@ -111,7 +111,7 @@ pub struct DevChunkingContext {
     manifest_chunks: bool,
 }
 
-impl DevChunkingContext {
+impl BrowserChunkingContext {
     pub fn builder(
         context_path: Vc<FileSystemPath>,
         output_root: Vc<FileSystemPath>,
@@ -119,9 +119,9 @@ impl DevChunkingContext {
         chunk_root_path: Vc<FileSystemPath>,
         asset_root_path: Vc<FileSystemPath>,
         environment: Vc<Environment>,
-    ) -> DevChunkingContextBuilder {
-        DevChunkingContextBuilder {
-            chunking_context: DevChunkingContext {
+    ) -> BrowserChunkingContextBuilder {
+        BrowserChunkingContextBuilder {
+            chunking_context: BrowserChunkingContext {
                 context_path,
                 output_root,
                 client_root,
@@ -140,11 +140,11 @@ impl DevChunkingContext {
     }
 }
 
-impl DevChunkingContext {
+impl BrowserChunkingContext {
     /// Returns the kind of runtime to include in output chunks.
     ///
-    /// This is defined directly on `DevChunkingContext` so it is zero-cost when
-    /// `RuntimeType` has a single variant.
+    /// This is defined directly on `BrowserChunkingContext` so it is zero-cost
+    /// when `RuntimeType` has a single variant.
     pub fn runtime_type(&self) -> RuntimeType {
         self.runtime_type
     }
@@ -156,9 +156,9 @@ impl DevChunkingContext {
 }
 
 #[turbo_tasks::value_impl]
-impl DevChunkingContext {
+impl BrowserChunkingContext {
     #[turbo_tasks::function]
-    fn new(this: Value<DevChunkingContext>) -> Vc<Self> {
+    fn new(this: Value<BrowserChunkingContext>) -> Vc<Self> {
         this.into_value().cell()
     }
 
@@ -216,7 +216,7 @@ impl DevChunkingContext {
 }
 
 #[turbo_tasks::value_impl]
-impl ChunkingContext for DevChunkingContext {
+impl ChunkingContext for BrowserChunkingContext {
     #[turbo_tasks::function]
     fn context_path(&self) -> Vc<FileSystemPath> {
         self.context_path
@@ -462,7 +462,7 @@ impl ChunkingContext for DevChunkingContext {
 }
 
 #[turbo_tasks::value_impl]
-impl EcmascriptChunkingContext for DevChunkingContext {
+impl EcmascriptChunkingContext for BrowserChunkingContext {
     #[turbo_tasks::function]
     fn has_react_refresh(&self) -> Vc<bool> {
         Vc::cell(true)

--- a/crates/turbopack-dev/src/ecmascript/chunk.rs
+++ b/crates/turbopack-dev/src/ecmascript/chunk.rs
@@ -12,12 +12,12 @@ use turbopack_core::{
 };
 use turbopack_ecmascript::chunk::EcmascriptChunk;
 
-use crate::{ecmascript::content::EcmascriptDevChunkContent, DevChunkingContext};
+use crate::{ecmascript::content::EcmascriptDevChunkContent, BrowserChunkingContext};
 
 /// Development Ecmascript chunk.
 #[turbo_tasks::value(shared)]
 pub(crate) struct EcmascriptDevChunk {
-    chunking_context: Vc<DevChunkingContext>,
+    chunking_context: Vc<BrowserChunkingContext>,
     chunk: Vc<EcmascriptChunk>,
 }
 
@@ -25,7 +25,10 @@ pub(crate) struct EcmascriptDevChunk {
 impl EcmascriptDevChunk {
     /// Creates a new [`Vc<EcmascriptDevChunk>`].
     #[turbo_tasks::function]
-    pub fn new(chunking_context: Vc<DevChunkingContext>, chunk: Vc<EcmascriptChunk>) -> Vc<Self> {
+    pub fn new(
+        chunking_context: Vc<BrowserChunkingContext>,
+        chunk: Vc<EcmascriptChunk>,
+    ) -> Vc<Self> {
         EcmascriptDevChunk {
             chunking_context,
             chunk,

--- a/crates/turbopack-dev/src/ecmascript/content.rs
+++ b/crates/turbopack-dev/src/ecmascript/content.rs
@@ -18,12 +18,12 @@ use super::{
     chunk::EcmascriptDevChunk, content_entry::EcmascriptDevChunkContentEntries,
     merged::merger::EcmascriptDevChunkContentMerger, version::EcmascriptDevChunkVersion,
 };
-use crate::DevChunkingContext;
+use crate::BrowserChunkingContext;
 
 #[turbo_tasks::value(serialization = "none")]
 pub struct EcmascriptDevChunkContent {
     pub(super) entries: Vc<EcmascriptDevChunkContentEntries>,
-    pub(super) chunking_context: Vc<DevChunkingContext>,
+    pub(super) chunking_context: Vc<BrowserChunkingContext>,
     pub(super) chunk: Vc<EcmascriptDevChunk>,
 }
 
@@ -31,7 +31,7 @@ pub struct EcmascriptDevChunkContent {
 impl EcmascriptDevChunkContent {
     #[turbo_tasks::function]
     pub(crate) async fn new(
-        chunking_context: Vc<DevChunkingContext>,
+        chunking_context: Vc<BrowserChunkingContext>,
         chunk: Vc<EcmascriptDevChunk>,
         content: Vc<EcmascriptChunkContent>,
     ) -> Result<Vc<Self>> {

--- a/crates/turbopack-dev/src/ecmascript/evaluate/chunk.rs
+++ b/crates/turbopack-dev/src/ecmascript/evaluate/chunk.rs
@@ -23,14 +23,14 @@ use turbopack_ecmascript::{
 };
 use turbopack_ecmascript_runtime::RuntimeType;
 
-use crate::DevChunkingContext;
+use crate::BrowserChunkingContext;
 
 /// An Ecmascript chunk that:
 /// * Contains the Turbopack dev runtime code; and
 /// * Evaluates a list of runtime entries.
 #[turbo_tasks::value(shared)]
 pub(crate) struct EcmascriptDevEvaluateChunk {
-    chunking_context: Vc<DevChunkingContext>,
+    chunking_context: Vc<BrowserChunkingContext>,
     ident: Vc<AssetIdent>,
     other_chunks: Vc<OutputAssets>,
     evaluatable_assets: Vc<EvaluatableAssets>,
@@ -41,7 +41,7 @@ impl EcmascriptDevEvaluateChunk {
     /// Creates a new [`Vc<EcmascriptDevEvaluateChunk>`].
     #[turbo_tasks::function]
     pub fn new(
-        chunking_context: Vc<DevChunkingContext>,
+        chunking_context: Vc<BrowserChunkingContext>,
         ident: Vc<AssetIdent>,
         other_chunks: Vc<OutputAssets>,
         evaluatable_assets: Vc<EvaluatableAssets>,

--- a/crates/turbopack-dev/src/ecmascript/list/asset.rs
+++ b/crates/turbopack-dev/src/ecmascript/list/asset.rs
@@ -11,7 +11,7 @@ use turbopack_core::{
 };
 
 use super::content::EcmascriptDevChunkListContent;
-use crate::DevChunkingContext;
+use crate::BrowserChunkingContext;
 
 /// An asset that represents a list of chunks that exist together in a chunk
 /// group, and should be *updated* together.
@@ -26,7 +26,7 @@ use crate::DevChunkingContext;
 /// * changing a chunk's path.
 #[turbo_tasks::value(shared)]
 pub(crate) struct EcmascriptDevChunkList {
-    pub(super) chunking_context: Vc<DevChunkingContext>,
+    pub(super) chunking_context: Vc<BrowserChunkingContext>,
     pub(super) ident: Vc<AssetIdent>,
     pub(super) evaluatable_assets: Vc<EvaluatableAssets>,
     pub(super) chunks: Vc<OutputAssets>,
@@ -38,7 +38,7 @@ impl EcmascriptDevChunkList {
     /// Creates a new [`Vc<EcmascriptDevChunkList>`].
     #[turbo_tasks::function]
     pub fn new(
-        chunking_context: Vc<DevChunkingContext>,
+        chunking_context: Vc<BrowserChunkingContext>,
         ident: Vc<AssetIdent>,
         evaluatable_assets: Vc<EvaluatableAssets>,
         chunks: Vc<OutputAssets>,

--- a/crates/turbopack-dev/src/lib.rs
+++ b/crates/turbopack-dev/src/lib.rs
@@ -7,7 +7,7 @@ pub(crate) mod chunking_context;
 pub mod ecmascript;
 pub mod react_refresh;
 
-pub use chunking_context::{DevChunkingContext, DevChunkingContextBuilder};
+pub use chunking_context::{BrowserChunkingContext, BrowserChunkingContextBuilder};
 
 pub fn register() {
     turbo_tasks::register();

--- a/crates/turbopack-tests/tests/execution.rs
+++ b/crates/turbopack-tests/tests/execution.rs
@@ -33,7 +33,7 @@ use turbopack_core::{
     reference_type::{EntryReferenceSubType, ReferenceType},
     source::Source,
 };
-use turbopack_dev::DevChunkingContext;
+use turbopack_dev::BrowserChunkingContext;
 use turbopack_node::{debug::should_debug, evaluate::evaluate};
 use turbopack_resolve::resolve_options_context::ResolveOptionsContext;
 use turbopack_test_utils::jest::JestRunResult;
@@ -295,7 +295,7 @@ async fn run_test(prepared_test: Vc<PreparedTest>) -> Result<Vc<RunTestResult>> 
         Vc::cell("test".to_string()),
     ));
 
-    let chunking_context = DevChunkingContext::builder(
+    let chunking_context = BrowserChunkingContext::builder(
         project_root,
         chunk_root_path,
         static_root_path,

--- a/crates/turbopack-tests/tests/snapshot.rs
+++ b/crates/turbopack-tests/tests/snapshot.rs
@@ -27,7 +27,7 @@ use turbopack::{
     },
     ModuleAssetContext,
 };
-use turbopack_build::{BuildChunkingContext, MinifyType};
+use turbopack_build::{MinifyType, NodeJsChunkingContext};
 use turbopack_core::{
     asset::Asset,
     chunk::{
@@ -47,7 +47,7 @@ use turbopack_core::{
     reference_type::{EntryReferenceSubType, ReferenceType},
     source::Source,
 };
-use turbopack_dev::DevChunkingContext;
+use turbopack_dev::BrowserChunkingContext;
 use turbopack_ecmascript_plugins::transform::{
     emotion::{EmotionTransformConfig, EmotionTransformer},
     styled_components::{StyledComponentsTransformConfig, StyledComponentsTransformer},
@@ -302,7 +302,7 @@ async fn run_test(resource: String) -> Result<Vc<FileSystemPath>> {
 
     let chunking_context: Vc<Box<dyn ChunkingContext>> = match options.runtime {
         Runtime::Dev => Vc::upcast(
-            DevChunkingContext::builder(
+            BrowserChunkingContext::builder(
                 project_root,
                 path,
                 path,
@@ -314,7 +314,7 @@ async fn run_test(resource: String) -> Result<Vc<FileSystemPath>> {
             .build(),
         ),
         Runtime::Build => Vc::upcast(
-            BuildChunkingContext::builder(
+            NodeJsChunkingContext::builder(
                 project_root,
                 path,
                 path,
@@ -355,7 +355,7 @@ async fn run_test(resource: String) -> Result<Vc<FileSystemPath>> {
             ),
             Runtime::Build => {
                 Vc::cell(vec![
-                    Vc::try_resolve_downcast_type::<BuildChunkingContext>(chunking_context)
+                    Vc::try_resolve_downcast_type::<NodeJsChunkingContext>(chunking_context)
                         .await?
                         .unwrap()
                         .entry_chunk_group(


### PR DESCRIPTION
### Description

As discussed with @sokra, this aligns the names to what they're used for.

Renaming the packages in a follow-up PR.

<!--
  ✍️ Write a short summary of your work.
  If necessary, include relevant screenshots.
-->

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
