### PR TITLE
refactor(turborepo): Renaming -PackageDetector to -PackageChangeMapper

### DIFF
--- a/crates/turborepo-lib/src/lib.rs
+++ b/crates/turborepo-lib/src/lib.rs
@@ -21,7 +21,7 @@ mod engine;
 
 mod framework;
 mod gitignore;
-mod global_deps_package_detector;
+mod global_deps_package_change_mapper;
 pub(crate) mod globwatcher;
 mod hash;
 mod opts;

--- a/crates/turborepo-lib/src/run/scope/filter.rs
+++ b/crates/turborepo-lib/src/run/scope/filter.rs
@@ -19,7 +19,7 @@ use super::{
     target_selector::{InvalidSelectorError, TargetSelector},
 };
 use crate::{
-    global_deps_package_detector, run::scope::change_detector::ScopeChangeDetector,
+    global_deps_package_change_mapper, run::scope::change_detector::ScopeChangeDetector,
     turbo_json::TurboJson,
 };
 
@@ -599,7 +599,7 @@ pub enum ResolutionError {
         err: Box<wax::BuildError>,
     },
     #[error("failed to construct glob for globalDependencies")]
-    GlobalDependenciesGlob(#[from] global_deps_package_detector::Error),
+    GlobalDependenciesGlob(#[from] global_deps_package_change_mapper::Error),
 }
 
 #[cfg(test)]

--- a/crates/turborepo-repository/src/change_mapper.rs
+++ b/crates/turborepo-repository/src/change_mapper.rs
@@ -32,11 +32,11 @@ const DEFAULT_GLOBAL_DEPS: [&str; 2] = ["package.json", "turbo.json"];
 /// not in any package will automatically invalidate all
 /// packages. This is fine for builds, but less fine
 /// for situations like watch mode.
-pub struct DefaultPackageDetector<'a> {
+pub struct DefaultPackageChangeMapper<'a> {
     pkg_dep_graph: &'a PackageGraph,
 }
 
-impl<'a> DefaultPackageDetector<'a> {
+impl<'a> DefaultPackageChangeMapper<'a> {
     pub fn new(pkg_dep_graph: &'a PackageGraph) -> Self {
         Self { pkg_dep_graph }
     }
@@ -47,7 +47,7 @@ impl<'a> DefaultPackageDetector<'a> {
     }
 }
 
-impl<'a> PackageChangeMapper for DefaultPackageDetector<'a> {
+impl<'a> PackageChangeMapper for DefaultPackageChangeMapper<'a> {
     fn detect_package(&self, file: &AnchoredSystemPath) -> PackageMapping {
         for (name, entry) in self.pkg_dep_graph.packages() {
             if name == &PackageName::Root {
@@ -228,7 +228,7 @@ mod test {
     use test_case::test_case;
 
     use super::ChangeMapper;
-    use crate::change_mapper::DefaultPackageDetector;
+    use crate::change_mapper::DefaultPackageChangeMapper;
 
     #[cfg(unix)]
     #[test_case("/a/b/c", &["package.lock"], "/a/b/c/package.lock", true ; "simple")]
@@ -245,7 +245,7 @@ mod test {
             .iter()
             .map(|s| turbopath::AnchoredSystemPathBuf::from_raw(s).unwrap())
             .collect();
-        let changes = ChangeMapper::<DefaultPackageDetector>::lockfile_changed(
+        let changes = ChangeMapper::<DefaultPackageChangeMapper>::lockfile_changed(
             &turbo_root,
             &changed_files,
             &lockfile_path,
@@ -269,7 +269,7 @@ mod test {
             .iter()
             .map(|s| turbopath::AnchoredSystemPathBuf::from_raw(s).unwrap())
             .collect();
-        let changes = ChangeMapper::<DefaultPackageDetector>::lockfile_changed(
+        let changes = ChangeMapper::<DefaultPackageChangeMapper>::lockfile_changed(
             &turbo_root,
             &changed_files,
             &lockfile_path,

--- a/packages/turbo-repository/rust/src/lib.rs
+++ b/packages/turbo-repository/rust/src/lib.rs
@@ -7,7 +7,7 @@ use napi::Error;
 use napi_derive::napi;
 use turbopath::{AbsoluteSystemPath, AnchoredSystemPathBuf};
 use turborepo_repository::{
-    change_mapper::{ChangeMapper, DefaultPackageDetector, PackageChanges},
+    change_mapper::{ChangeMapper, DefaultPackageChangeMapper, PackageChanges},
     inference::RepoState as WorkspaceState,
     package_graph::{PackageGraph, PackageName, PackageNode, WorkspacePackage, ROOT_PKG_NAME},
 };
@@ -202,7 +202,7 @@ impl Workspace {
             .collect();
 
         // Create a ChangeMapper with no ignore patterns
-        let default_package_detector = DefaultPackageDetector::new(&self.graph);
+        let default_package_detector = DefaultPackageChangeMapper::new(&self.graph);
         let mapper = ChangeMapper::new(&self.graph, vec![], default_package_detector);
         let package_changes = match mapper.changed_packages(hash_set_of_paths, None) {
             Ok(changes) => changes,


### PR DESCRIPTION
### Description

I forgot to do this in #7549, whoops. Renames to PackageChangeMapper according to PR feedback.

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->


Closes TURBO-2559