### PR TITLE
Add MinifyType to BrowserChunkingContext

### DIFF
--- a/crates/turbopack-browser/src/chunking_context.rs
+++ b/crates/turbopack-browser/src/chunking_context.rs
@@ -7,7 +7,7 @@ use turbopack_core::{
         availability_info::AvailabilityInfo,
         chunk_group::{make_chunk_group, MakeChunkGroupResult},
         Chunk, ChunkGroupResult, ChunkItem, ChunkableModule, ChunkingContext, EvaluatableAssets,
-        ModuleId,
+        MinifyType, ModuleId,
     },
     environment::Environment,
     ident::AssetIdent,
@@ -67,6 +67,11 @@ impl BrowserChunkingContextBuilder {
         self
     }
 
+    pub fn minify_type(mut self, minify_type: MinifyType) -> Self {
+        self.chunking_context.minify_type = minify_type;
+        self
+    }
+
     pub fn build(self) -> Vc<BrowserChunkingContext> {
         BrowserChunkingContext::new(Value::new(self.chunking_context))
     }
@@ -107,6 +112,8 @@ pub struct BrowserChunkingContext {
     environment: Vc<Environment>,
     /// The kind of runtime to include in the output.
     runtime_type: RuntimeType,
+    /// Whether to minify resulting chunks
+    minify_type: MinifyType,
     /// Whether to use manifest chunks for lazy compilation
     manifest_chunks: bool,
 }
@@ -134,6 +141,7 @@ impl BrowserChunkingContext {
                 enable_hot_module_replacement: false,
                 environment,
                 runtime_type: Default::default(),
+                minify_type: MinifyType::Minify,
                 manifest_chunks: false,
             },
         }
@@ -152,6 +160,11 @@ impl BrowserChunkingContext {
     /// Returns the asset base path.
     pub fn chunk_base_path(&self) -> Vc<Option<String>> {
         self.chunk_base_path
+    }
+
+    /// Returns the minify type.
+    pub fn minify_type(&self) -> MinifyType {
+        self.minify_type
     }
 }
 

--- a/crates/turbopack-browser/src/chunking_context.rs
+++ b/crates/turbopack-browser/src/chunking_context.rs
@@ -141,7 +141,7 @@ impl BrowserChunkingContext {
                 enable_hot_module_replacement: false,
                 environment,
                 runtime_type: Default::default(),
-                minify_type: MinifyType::Minify,
+                minify_type: MinifyType::NoMinify,
                 manifest_chunks: false,
             },
         }

--- a/crates/turbopack-ecmascript/Cargo.toml
+++ b/crates/turbopack-ecmascript/Cargo.toml
@@ -41,6 +41,7 @@ turbopack-core = { workspace = true }
 turbopack-resolve = { workspace = true }
 turbopack-swc-utils = { workspace = true }
 url = { workspace = true }
+urlencoding = { workspace = true }
 
 swc_core = { workspace = true, features = [
   "ecma_ast",
@@ -50,6 +51,8 @@ swc_core = { workspace = true, features = [
   "common_sourcemap",
   "ecma_codegen",
   "ecma_lints",
+  "ecma_minifier",
+  "ecma_minifier_concurrent",
   "ecma_parser",
   "ecma_preset_env",
   "ecma_transforms",

--- a/crates/turbopack-ecmascript/src/lib.rs
+++ b/crates/turbopack-ecmascript/src/lib.rs
@@ -14,6 +14,7 @@ pub mod code_gen;
 mod errors;
 pub mod magic_identifier;
 pub mod manifest;
+pub mod minify;
 pub mod parse;
 mod path_visitor;
 pub mod references;

--- a/crates/turbopack-ecmascript/src/minify.rs
+++ b/crates/turbopack-ecmascript/src/minify.rs
@@ -25,7 +25,8 @@ use turbopack_core::{
     code_builder::{Code, CodeBuilder},
     source_map::GenerateSourceMap,
 };
-use turbopack_ecmascript::ParseResultSourceMap;
+
+use crate::ParseResultSourceMap;
 
 #[turbo_tasks::function]
 pub async fn minify(path: Vc<FileSystemPath>, code: Vc<Code>) -> Result<Vc<Code>> {

--- a/crates/turbopack-nodejs/Cargo.toml
+++ b/crates/turbopack-nodejs/Cargo.toml
@@ -26,11 +26,6 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_qs = { workspace = true }
 sourcemap = { workspace = true }
-swc_core = { workspace = true, features = [
-  "__parser",
-  "ecma_minifier",
-  "ecma_minifier_concurrent",
-] }
 tracing = { workspace = true }
 urlencoding = { workspace = true }
 

--- a/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/crates/turbopack-nodejs/src/chunking_context.rs
@@ -106,7 +106,7 @@ impl NodeJsChunkingContext {
                 asset_prefix: Default::default(),
                 environment,
                 runtime_type: Default::default(),
-                minify_type: MinifyType::Minify,
+                minify_type: MinifyType::NoMinify,
                 manifest_chunks: false,
             },
         }

--- a/crates/turbopack-nodejs/src/ecmascript/mod.rs
+++ b/crates/turbopack-nodejs/src/ecmascript/mod.rs
@@ -1,2 +1,1 @@
-pub(crate) mod minify;
 pub(crate) mod node;

--- a/crates/turbopack-nodejs/src/ecmascript/node/content.rs
+++ b/crates/turbopack-nodejs/src/ecmascript/node/content.rs
@@ -14,11 +14,12 @@ use turbopack_core::{
 };
 use turbopack_ecmascript::{
     chunk::{EcmascriptChunkContent, EcmascriptChunkItemExt},
+    minify::minify,
     utils::StringifyJs,
 };
 
 use super::{chunk::EcmascriptBuildNodeChunk, version::EcmascriptBuildNodeChunkVersion};
-use crate::{ecmascript::minify::minify, NodeJsChunkingContext};
+use crate::NodeJsChunkingContext;
 
 #[turbo_tasks::value]
 pub(super) struct EcmascriptBuildNodeChunkContent {


### PR DESCRIPTION
### Description

Ensures minifier runs for browser code.

Moves minify.rs to turbopack-ecmascript as it's shared between turbopack-nodejs and turbopack-browser.

<!--
  ✍️ Write a short summary of your work.
  If necessary, include relevant screenshots.
-->

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
