### PR TITLE
fix(Turborepo): Fix cookie directory

### DIFF
--- a/crates/turborepo-filewatch/src/cookies.rs
+++ b/crates/turborepo-filewatch/src/cookies.rs
@@ -183,6 +183,7 @@ fn serial_for_path(root: &AbsoluteSystemPath, path: &AbsoluteSystemPath) -> Opti
 }
 
 impl CookieWriter {
+    #[cfg(test)]
     pub fn new_with_default_cookie_dir(
         repo_root: &AbsoluteSystemPath,
         timeout: Duration,
@@ -190,6 +191,11 @@ impl CookieWriter {
     ) -> Self {
         let cookie_root = repo_root.join_components(&[".turbo", "cookies"]);
         Self::new(&cookie_root, timeout, recv)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn cookie_dir(&self) -> &AbsoluteSystemPath {
+        &self.cookie_root
     }
 
     pub fn new(

--- a/crates/turborepo-lib/src/daemon/server.rs
+++ b/crates/turborepo-lib/src/daemon/server.rs
@@ -102,19 +102,24 @@ impl FileWatching {
         let watcher = Arc::new(FileSystemWatcher::new_with_default_cookie_dir(&repo_root)?);
         let recv = watcher.watch();
 
-        let cookie_watcher = CookieWriter::new(
+        let cookie_writer = CookieWriter::new(
             watcher.cookie_dir(),
             Duration::from_millis(100),
             recv.clone(),
         );
         let glob_watcher = Arc::new(GlobWatcher::new(
             repo_root.clone(),
-            cookie_watcher,
+            cookie_writer.clone(),
             recv.clone(),
         ));
         let package_watcher = Arc::new(
-            PackageWatcher::new(repo_root.clone(), recv.clone(), backup_discovery)
-                .map_err(|e| WatchError::Setup(format!("{:?}", e)))?,
+            PackageWatcher::new(
+                repo_root.clone(),
+                recv.clone(),
+                backup_discovery,
+                cookie_writer,
+            )
+            .map_err(|e| WatchError::Setup(format!("{:?}", e)))?,
         );
 
         Ok(FileWatching {


### PR DESCRIPTION
### Description

 - Only create a CookieWriter once, use clone from then on to ensure we have the right directory
 - Fixes bug where we passed the wrong directory into a CookieWriter

### Testing Instructions

Manual verification that the cookie directory is now correct


Closes TURBO-2566