### PR TITLE
add FullContextTransition

### DIFF
--- a/crates/turbopack/src/transition/full_context_transition.rs
+++ b/crates/turbopack/src/transition/full_context_transition.rs
@@ -1,0 +1,29 @@
+use anyhow::Result;
+use turbo_tasks::Vc;
+
+use crate::{transition::Transition, ModuleAssetContext};
+
+/// A transition that only affects the asset context.
+#[turbo_tasks::value(shared)]
+pub struct FullContextTransition {
+    module_context: Vc<ModuleAssetContext>,
+}
+
+#[turbo_tasks::value_impl]
+impl FullContextTransition {
+    #[turbo_tasks::function]
+    pub async fn new(module_context: Vc<ModuleAssetContext>) -> Result<Vc<FullContextTransition>> {
+        Ok(FullContextTransition { module_context }.cell())
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl Transition for FullContextTransition {
+    #[turbo_tasks::function]
+    fn process_context(
+        &self,
+        _module_asset_context: Vc<ModuleAssetContext>,
+    ) -> Vc<ModuleAssetContext> {
+        self.module_context
+    }
+}

--- a/crates/turbopack/src/transition/mod.rs
+++ b/crates/turbopack/src/transition/mod.rs
@@ -1,9 +1,11 @@
 pub(crate) mod context_transition;
+pub(crate) mod full_context_transition;
 
 use std::collections::HashMap;
 
 use anyhow::Result;
 pub use context_transition::ContextTransition;
+pub use full_context_transition::FullContextTransition;
 use turbo_tasks::{Value, ValueDefault, Vc};
 use turbopack_core::{
     compile_time_info::CompileTimeInfo, context::ProcessResult, module::Module,
@@ -30,7 +32,9 @@ pub trait Transition {
         compile_time_info
     }
     /// Apply modifications to the layer
-    fn process_layer(self: Vc<Self>, layer: Vc<String>) -> Vc<String>;
+    fn process_layer(self: Vc<Self>, layer: Vc<String>) -> Vc<String> {
+        layer
+    }
     /// Apply modifications/wrapping to the module options context
     fn process_module_options_context(
         self: Vc<Self>,


### PR DESCRIPTION
### Description

Add `FullContextTransition` to transition to a completely different ModuleAssetContext without inheriting the transitions

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->


Closes PACK-2696