### PR TITLE
chore: generalize log writer

### DIFF
--- a/crates/turborepo-lib/src/run/cache.rs
+++ b/crates/turborepo-lib/src/run/cache.rs
@@ -160,12 +160,12 @@ impl TaskCache {
         &self,
         prefix: StyledObject<String>,
         writer: W,
-    ) -> Result<LogWriter<W>, Error> {
+    ) -> Result<LogWriter<PrefixedWriter<W>>, Error> {
         let mut log_writer = LogWriter::default();
         let prefixed_writer = PrefixedWriter::new(self.run_cache.ui, prefix, writer);
 
         if self.caching_disabled || self.run_cache.writes_disabled {
-            log_writer.with_prefixed_writer(prefixed_writer);
+            log_writer.with_writer(prefixed_writer);
             return Ok(log_writer);
         }
 
@@ -175,7 +175,7 @@ impl TaskCache {
             self.task_output_mode,
             OutputLogsMode::None | OutputLogsMode::HashOnly | OutputLogsMode::ErrorsOnly
         ) {
-            log_writer.with_prefixed_writer(prefixed_writer);
+            log_writer.with_writer(prefixed_writer);
         }
 
         Ok(log_writer)

--- a/crates/turborepo-ui/src/logs.rs
+++ b/crates/turborepo-ui/src/logs.rs
@@ -6,13 +6,13 @@ use std::{
 use tracing::{debug, warn};
 use turbopath::AbsoluteSystemPath;
 
-use crate::{prefixed::PrefixedUI, Error, PrefixedWriter};
+use crate::{prefixed::PrefixedUI, Error};
 
 /// Receives logs and multiplexes them to a log file and/or a prefixed
 /// writer
 pub struct LogWriter<W> {
     log_file: Option<BufWriter<File>>,
-    prefixed_writer: Option<PrefixedWriter<W>>,
+    writer: Option<W>,
 }
 
 /// Derive didn't work here.
@@ -21,7 +21,7 @@ impl<W> Default for LogWriter<W> {
     fn default() -> Self {
         Self {
             log_file: None,
-            prefixed_writer: None,
+            writer: None,
         }
     }
 }
@@ -43,14 +43,14 @@ impl<W: Write> LogWriter<W> {
         Ok(())
     }
 
-    pub fn with_prefixed_writer(&mut self, prefixed_writer: PrefixedWriter<W>) {
-        self.prefixed_writer = Some(prefixed_writer);
+    pub fn with_writer(&mut self, writer: W) {
+        self.writer = Some(writer);
     }
 }
 
 impl<W: Write> Write for LogWriter<W> {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        match (&mut self.log_file, &mut self.prefixed_writer) {
+        match (&mut self.log_file, &mut self.writer) {
             (Some(log_file), Some(prefixed_writer)) => {
                 let _ = prefixed_writer.write(buf)?;
                 log_file.write(buf)
@@ -69,7 +69,7 @@ impl<W: Write> Write for LogWriter<W> {
         if let Some(log_file) = &mut self.log_file {
             log_file.flush()?;
         }
-        if let Some(prefixed_writer) = &mut self.prefixed_writer {
+        if let Some(prefixed_writer) = &mut self.writer {
             prefixed_writer.flush()?;
         }
 
@@ -141,7 +141,7 @@ mod tests {
         let ui = UI::new(false);
 
         log_writer.with_log_file(&log_file_path)?;
-        log_writer.with_prefixed_writer(PrefixedWriter::new(
+        log_writer.with_writer(PrefixedWriter::new(
             ui,
             CYAN.apply_to(">".to_string()),
             &mut prefixed_writer_output,

--- a/crates/turborepo-ui/tests/threads.rs
+++ b/crates/turborepo-ui/tests/threads.rs
@@ -82,7 +82,7 @@ fn echo_task(
     // log file
     let mut task_logger = LogWriter::default();
     task_logger.with_log_file(log_file).unwrap();
-    task_logger.with_prefixed_writer(PrefixedWriter::new(ui, output_prefix, client.stdout()));
+    task_logger.with_writer(PrefixedWriter::new(ui, output_prefix, client.stdout()));
 
     let mut cmd = Command::new("echo");
     cmd.args(["hello", "from", task_name]);


### PR DESCRIPTION
### Description

We don't need to restrict the "stdout" writer to be a `PrefixedWriter` as there are cases where we don't want the prefix added to a task's output when rendered.

### Testing Instructions

👀 


Closes TURBO-2578