### PR TITLE
refactor(turborepo): Split up `Run` into `RunBuilder` and `Run`

### DIFF
--- a/crates/turborepo-lib/src/commands/run.rs
+++ b/crates/turborepo-lib/src/commands/run.rs
@@ -1,6 +1,6 @@
 use turborepo_telemetry::events::command::CommandEventBuilder;
 
-use crate::{commands::CommandBase, run, run::Run, signal::SignalHandler};
+use crate::{commands::CommandBase, run, run::builder::RunBuilder, signal::SignalHandler};
 
 pub async fn run(base: CommandBase, telemetry: CommandEventBuilder) -> Result<i32, run::Error> {
     #[cfg(windows)]
@@ -31,8 +31,12 @@ pub async fn run(base: CommandBase, telemetry: CommandEventBuilder) -> Result<i3
 
     let api_auth = base.api_auth()?;
     let api_client = base.api_client()?;
-    let run = Run::new(base, api_auth)?;
-    let run_fut = run.run(&handler, telemetry, api_client);
+    let run_builder = RunBuilder::new(base, api_auth)?;
+    let run_fut = async {
+        let run = run_builder.build(&handler, telemetry, api_client).await?;
+        run.run().await
+    };
+
     let handler_fut = handler.done();
     tokio::select! {
         biased;

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -1,0 +1,443 @@
+use std::{
+    collections::HashSet,
+    io::{ErrorKind, IsTerminal},
+    sync::Arc,
+    time::SystemTime,
+};
+
+use chrono::{DateTime, Local};
+use rayon::iter::ParallelBridge;
+use tracing::debug;
+use turbopath::{AbsoluteSystemPathBuf, AnchoredSystemPath};
+use turborepo_analytics::{start_analytics, AnalyticsHandle, AnalyticsSender};
+use turborepo_api_client::{APIAuth, APIClient};
+use turborepo_cache::{AsyncCache, RemoteCacheOpts};
+use turborepo_env::EnvironmentVariableMap;
+use turborepo_errors::Spanned;
+use turborepo_repository::{
+    package_graph::{PackageGraph, PackageName},
+    package_json,
+    package_json::PackageJson,
+};
+use turborepo_scm::SCM;
+use turborepo_telemetry::events::{
+    command::CommandEventBuilder,
+    generic::{DaemonInitStatus, GenericEventBuilder},
+    repo::{RepoEventBuilder, RepoType},
+    EventBuilder, TrackedErrors,
+};
+use turborepo_ui::{ColorSelector, UI};
+
+use crate::{
+    cli::{DryRunMode, EnvMode},
+    commands::CommandBase,
+    engine::{Engine, EngineBuilder},
+    opts::Opts,
+    process::ProcessManager,
+    run::{scope, task_access::TaskAccess, task_id::TaskName, Error, Run, RunCache},
+    shim::TurboState,
+    signal::{SignalHandler, SignalSubscriber},
+    task_hash::PackageInputsHashes,
+    turbo_json::TurboJson,
+    DaemonConnector,
+};
+
+pub struct RunBuilder {
+    processes: ProcessManager,
+    opts: Opts,
+    api_auth: Option<APIAuth>,
+    repo_root: AbsoluteSystemPathBuf,
+    ui: UI,
+    version: &'static str,
+}
+
+impl RunBuilder {
+    pub fn new(base: CommandBase, api_auth: Option<APIAuth>) -> Result<Self, Error> {
+        let processes = ProcessManager::infer();
+        let mut opts: Opts = base.args().try_into()?;
+        let config = base.config()?;
+        let is_linked = turborepo_api_client::is_linked(&api_auth);
+        if !is_linked {
+            opts.cache_opts.skip_remote = true;
+        } else if let Some(enabled) = config.enabled {
+            // We're linked, but if the user has explicitly enabled or disabled, use that
+            // value
+            opts.cache_opts.skip_remote = !enabled;
+        }
+        // Note that we don't currently use the team_id value here. In the future, we
+        // should probably verify that we only use the signature value when the
+        // configured team_id matches the final resolved team_id.
+        let unused_remote_cache_opts_team_id = config.team_id().map(|team_id| team_id.to_string());
+        let signature = config.signature();
+        opts.cache_opts.remote_cache_opts = Some(RemoteCacheOpts::new(
+            unused_remote_cache_opts_team_id,
+            signature,
+        ));
+        if opts.run_opts.experimental_space_id.is_none() {
+            opts.run_opts.experimental_space_id = config.spaces_id().map(|s| s.to_owned());
+        }
+        let version = base.version();
+        let CommandBase { repo_root, ui, .. } = base;
+        Ok(Self {
+            processes,
+            opts,
+            api_auth,
+            repo_root,
+            ui,
+            version,
+        })
+    }
+
+    fn connect_process_manager(&self, signal_subscriber: SignalSubscriber) {
+        let manager = self.processes.clone();
+        tokio::spawn(async move {
+            let _guard = signal_subscriber.listen().await;
+            manager.stop().await;
+        });
+    }
+
+    fn initialize_analytics(
+        api_auth: Option<APIAuth>,
+        api_client: APIClient,
+    ) -> Option<(AnalyticsSender, AnalyticsHandle)> {
+        // If there's no API auth, we don't want to record analytics
+        let api_auth = api_auth?;
+        api_auth
+            .is_linked()
+            .then(|| start_analytics(api_auth, api_client))
+    }
+
+    #[tracing::instrument(skip(self, signal_handler, api_client))]
+    pub async fn build(
+        self,
+        signal_handler: &SignalHandler,
+        telemetry: CommandEventBuilder,
+        api_client: APIClient,
+    ) -> Result<Run, Error> {
+        tracing::trace!(
+            platform = %TurboState::platform_name(),
+            start_time = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).expect("system time after epoch").as_micros(),
+            turbo_version = %TurboState::version(),
+            numcpus = num_cpus::get(),
+            "performing run on {:?}",
+            TurboState::platform_name(),
+        );
+        let start_at = Local::now();
+        if let Some(subscriber) = signal_handler.subscribe() {
+            self.connect_process_manager(subscriber);
+        }
+
+        let (analytics_sender, analytics_handle) =
+            Self::initialize_analytics(self.api_auth.clone(), api_client.clone()).unzip();
+
+        let result = self
+            .run_with_analytics(
+                start_at,
+                api_client,
+                analytics_sender,
+                signal_handler,
+                telemetry,
+            )
+            .await;
+
+        if let Some(analytics_handle) = analytics_handle {
+            analytics_handle.close_with_timeout().await;
+        }
+
+        result
+    }
+
+    // We split this into a separate function because we need
+    // to close the AnalyticsHandle regardless of whether the run succeeds or not
+    async fn run_with_analytics(
+        mut self,
+        start_at: DateTime<Local>,
+        api_client: APIClient,
+        analytics_sender: Option<AnalyticsSender>,
+        signal_handler: &SignalHandler,
+        telemetry: CommandEventBuilder,
+    ) -> Result<Run, Error> {
+        let scm = {
+            let repo_root = self.repo_root.clone();
+            tokio::task::spawn_blocking(move || SCM::new(&repo_root))
+        };
+        let package_json_path = self.repo_root.join_component("package.json");
+        let root_package_json = PackageJson::load(&package_json_path)?;
+        let run_telemetry = GenericEventBuilder::new().with_parent(&telemetry);
+        let repo_telemetry =
+            RepoEventBuilder::new(&self.repo_root.to_string()).with_parent(&telemetry);
+
+        // Pulled from initAnalyticsClient in run.go
+        let is_linked = turborepo_api_client::is_linked(&self.api_auth);
+        run_telemetry.track_is_linked(is_linked);
+        // we only track the remote cache if we're linked because this defaults to
+        // Vercel
+        if is_linked {
+            run_telemetry.track_remote_cache(api_client.base_url());
+        }
+        let _is_structured_output = self.opts.run_opts.graph.is_some()
+            || matches!(self.opts.run_opts.dry_run, Some(DryRunMode::Json));
+
+        let is_single_package = self.opts.run_opts.single_package;
+        repo_telemetry.track_type(if is_single_package {
+            RepoType::SinglePackage
+        } else {
+            RepoType::Monorepo
+        });
+
+        let is_ci_or_not_tty = turborepo_ci::is_ci() || !std::io::stdout().is_terminal();
+        run_telemetry.track_ci(turborepo_ci::Vendor::get_name());
+
+        // Remove allow when daemon is flagged back on
+        #[allow(unused_mut)]
+        let mut daemon = match (is_ci_or_not_tty, self.opts.run_opts.daemon) {
+            (true, None) => {
+                run_telemetry.track_daemon_init(DaemonInitStatus::Skipped);
+                debug!("skipping turbod since we appear to be in a non-interactive context");
+                None
+            }
+            (_, Some(true)) | (false, None) => {
+                let can_start_server = true;
+                let can_kill_server = true;
+                let connector =
+                    DaemonConnector::new(can_start_server, can_kill_server, &self.repo_root);
+                match (connector.connect().await, self.opts.run_opts.daemon) {
+                    (Ok(client), _) => {
+                        run_telemetry.track_daemon_init(DaemonInitStatus::Started);
+                        debug!("running in daemon mode");
+                        Some(client)
+                    }
+                    (Err(e), Some(true)) => {
+                        run_telemetry.track_daemon_init(DaemonInitStatus::Failed);
+                        debug!("failed to connect to daemon when forced {e}, exiting");
+                        return Err(e.into());
+                    }
+                    (Err(e), None) => {
+                        run_telemetry.track_daemon_init(DaemonInitStatus::Failed);
+                        debug!("failed to connect to daemon {e}");
+                        None
+                    }
+                    (_, Some(false)) => unreachable!(),
+                }
+            }
+            (_, Some(false)) => {
+                run_telemetry.track_daemon_init(DaemonInitStatus::Disabled);
+                debug!("skipping turbod since --no-daemon was passed");
+                None
+            }
+        };
+
+        let mut pkg_dep_graph = {
+            let builder = PackageGraph::builder(&self.repo_root, root_package_json.clone())
+                .with_single_package_mode(self.opts.run_opts.single_package);
+
+            #[cfg(feature = "daemon-package-discovery")]
+            let graph = match (&daemon, self.opts.run_opts.daemon) {
+                (None, Some(true)) => {
+                    // We've asked for the daemon, but it's not available. This is an error
+                    return Err(turborepo_repository::package_graph::Error::Discovery(
+                        DiscoveryError::Unavailable,
+                    )
+                    .into());
+                }
+                (Some(daemon), Some(true)) => {
+                    // We have the daemon, and have explicitly asked to only use that
+                    let daemon_discovery = DaemonPackageDiscovery::new(daemon.clone());
+                    builder
+                        .with_package_discovery(daemon_discovery)
+                        .build()
+                        .await
+                }
+                (_, Some(false)) | (None, _) => {
+                    // We have explicitly requested to not use the daemon, or we don't have it
+                    // No change to default.
+                    builder.build().await
+                }
+                (Some(daemon), None) => {
+                    // We have the daemon, and it's not flagged off. Use the fallback strategy
+                    let daemon_discovery = DaemonPackageDiscovery::new(daemon.clone());
+                    let local_discovery = LocalPackageDiscoveryBuilder::new(
+                        self.repo_root.clone(),
+                        None,
+                        Some(root_package_json.clone()),
+                    )
+                    .build()?;
+                    let fallback_discover = FallbackPackageDiscovery::new(
+                        daemon_discovery,
+                        local_discovery,
+                        Duration::from_millis(10),
+                    );
+                    builder
+                        .with_package_discovery(fallback_discover)
+                        .build()
+                        .await
+                }
+            };
+            #[cfg(not(feature = "daemon-package-discovery"))]
+            let graph = builder.build().await;
+
+            match graph {
+                Ok(graph) => graph,
+                // if we can't find the package.json, it is a bug, and we should report it.
+                // likely cause is that package discovery watching is not up to date.
+                // note: there _is_ a false positive from a race condition that can occur
+                //       from toctou if the package.json is deleted, but we'd like to know
+                Err(turborepo_repository::package_graph::Error::PackageJson(
+                    package_json::Error::Io(io),
+                )) if io.kind() == ErrorKind::NotFound => {
+                    run_telemetry.track_error(TrackedErrors::InvalidPackageDiscovery);
+                    return Err(turborepo_repository::package_graph::Error::PackageJson(
+                        package_json::Error::Io(io),
+                    )
+                    .into());
+                }
+                Err(e) => return Err(e.into()),
+            }
+        };
+
+        repo_telemetry.track_package_manager(pkg_dep_graph.package_manager().to_string());
+        repo_telemetry.track_size(pkg_dep_graph.len());
+        run_telemetry.track_run_type(self.opts.run_opts.dry_run.is_some());
+
+        let scm = scm.await.expect("detecting scm panicked");
+        let async_cache = AsyncCache::new(
+            &self.opts.cache_opts,
+            &self.repo_root,
+            api_client.clone(),
+            self.api_auth.clone(),
+            analytics_sender,
+        )?;
+
+        // restore config from task access trace if it's enabled
+        let task_access = TaskAccess::new(self.repo_root.clone(), async_cache.clone(), &scm);
+        task_access.restore_config().await;
+
+        let root_turbo_json = TurboJson::load(
+            &self.repo_root,
+            AnchoredSystemPath::empty(),
+            &root_package_json,
+            is_single_package,
+        )?;
+
+        pkg_dep_graph.validate()?;
+
+        let filtered_pkgs = {
+            let (mut filtered_pkgs, is_all_packages) = scope::resolve_packages(
+                &self.opts.scope_opts,
+                &self.repo_root,
+                &pkg_dep_graph,
+                &scm,
+                &root_turbo_json,
+            )?;
+
+            if is_all_packages {
+                for target in self.opts.run_opts.tasks.iter() {
+                    let mut task_name = TaskName::from(target.as_str());
+                    // If it's not a package task, we convert to a root task
+                    if !task_name.is_package_task() {
+                        task_name = task_name.into_root_task()
+                    }
+
+                    if root_turbo_json.pipeline.contains_key(&task_name) {
+                        filtered_pkgs.insert(PackageName::Root);
+                        break;
+                    }
+                }
+            };
+
+            filtered_pkgs
+        };
+
+        let env_at_execution_start = EnvironmentVariableMap::infer();
+        let mut engine = self.build_engine(&pkg_dep_graph, &root_turbo_json, &filtered_pkgs)?;
+
+        let workspaces = pkg_dep_graph.packages().collect();
+        let package_inputs_hashes = PackageInputsHashes::calculate_file_hashes(
+            &scm,
+            engine.tasks().par_bridge(),
+            workspaces,
+            engine.task_definitions(),
+            &self.repo_root,
+            &run_telemetry,
+        )?;
+
+        if self.opts.run_opts.parallel {
+            pkg_dep_graph.remove_package_dependencies();
+            engine = self.build_engine(&pkg_dep_graph, &root_turbo_json, &filtered_pkgs)?;
+        }
+
+        let color_selector = ColorSelector::default();
+
+        let run_cache = Arc::new(RunCache::new(
+            async_cache,
+            &self.repo_root,
+            &self.opts.runcache_opts,
+            color_selector,
+            daemon,
+            self.ui,
+            self.opts.run_opts.dry_run.is_some(),
+        ));
+
+        if matches!(self.opts.run_opts.env_mode, EnvMode::Infer)
+            && root_turbo_json.global_pass_through_env.is_some()
+        {
+            self.opts.run_opts.env_mode = EnvMode::Strict;
+        }
+
+        Ok(Run {
+            version: self.version,
+            ui: self.ui,
+            start_at,
+            processes: self.processes,
+            run_telemetry,
+            task_access,
+            repo_root: self.repo_root,
+            opts: self.opts,
+            api_client,
+            api_auth: self.api_auth,
+            env_at_execution_start,
+            filtered_pkgs,
+            pkg_dep_graph: Arc::new(pkg_dep_graph),
+            root_turbo_json,
+            package_inputs_hashes,
+            scm,
+            engine: Arc::new(engine),
+            run_cache,
+            signal_handler: signal_handler.clone(),
+        })
+    }
+
+    fn build_engine(
+        &self,
+        pkg_dep_graph: &PackageGraph,
+        root_turbo_json: &TurboJson,
+        filtered_pkgs: &HashSet<PackageName>,
+    ) -> Result<Engine, Error> {
+        let engine = EngineBuilder::new(
+            &self.repo_root,
+            pkg_dep_graph,
+            self.opts.run_opts.single_package,
+        )
+        .with_root_tasks(root_turbo_json.pipeline.keys().cloned())
+        .with_turbo_jsons(Some(
+            Some((PackageName::Root, root_turbo_json.clone()))
+                .into_iter()
+                .collect(),
+        ))
+        .with_tasks_only(self.opts.run_opts.only)
+        .with_workspaces(filtered_pkgs.clone().into_iter().collect())
+        .with_tasks(self.opts.run_opts.tasks.iter().map(|task| {
+            // TODO: Pull span info from command
+            Spanned::new(TaskName::from(task.as_str()).into_owned())
+        }))
+        .build()?;
+
+        if !self.opts.run_opts.parallel {
+            engine
+                .validate(pkg_dep_graph, self.opts.run_opts.concurrency)
+                .map_err(Error::EngineValidation)?;
+        }
+
+        Ok(engine)
+    }
+}

--- a/crates/turborepo-lib/src/run/global_hash.rs
+++ b/crates/turborepo-lib/src/run/global_hash.rs
@@ -176,25 +176,7 @@ fn collect_global_deps(
 }
 
 impl<'a> GlobalHashableInputs<'a> {
-    pub fn calculate_global_hash_from_inputs(&mut self) -> String {
-        match self.env_mode {
-            // In infer mode, if there is any pass_through config (even if it is an empty array)
-            // we'll hash the whole object, so we can detect changes to that config
-            // Further, resolve the envMode to the concrete value.
-            EnvMode::Infer if self.pass_through_env.is_some() => {
-                self.env_mode = EnvMode::Strict;
-            }
-            EnvMode::Loose => {
-                // Remove the passthroughs from hash consideration if we're explicitly loose.
-                self.pass_through_env = None;
-            }
-            _ => {}
-        }
-
-        self.calculate_global_hash()
-    }
-
-    fn calculate_global_hash(&self) -> String {
+    pub fn calculate_global_hash(&self) -> String {
         let global_hashable = GlobalHashable {
             global_cache_key: self.global_cache_key,
             global_file_hash_map: &self.global_file_hash_map,

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
 
+pub mod builder;
 mod cache;
 mod error;
 pub(crate) mod global_hash;
@@ -10,135 +11,66 @@ pub(crate) mod summary;
 pub mod task_access;
 pub mod task_id;
 
-use std::{
-    collections::HashSet,
-    io::{ErrorKind, IsTerminal, Write},
-    sync::Arc,
-    time::SystemTime,
-};
+use std::{collections::HashSet, io::Write, sync::Arc};
 
 pub use cache::{ConfigCache, RunCache, TaskCache};
 use chrono::{DateTime, Local};
-use rayon::iter::ParallelBridge;
 use tracing::debug;
-use turbopath::{AbsoluteSystemPathBuf, AnchoredSystemPath};
-use turborepo_analytics::{start_analytics, AnalyticsHandle, AnalyticsSender};
+use turbopath::AbsoluteSystemPathBuf;
 use turborepo_api_client::{APIAuth, APIClient};
-use turborepo_cache::{AsyncCache, RemoteCacheOpts};
 use turborepo_ci::Vendor;
 use turborepo_env::EnvironmentVariableMap;
-use turborepo_errors::Spanned;
-use turborepo_repository::{
-    package_graph::{self, PackageGraph, PackageName},
-    package_json::{self, PackageJson},
-};
-use turborepo_scm::SCM;
-use turborepo_telemetry::events::{
-    command::CommandEventBuilder,
-    generic::{DaemonInitStatus, GenericEventBuilder},
-    repo::{RepoEventBuilder, RepoType},
-    EventBuilder, TrackedErrors,
-};
-use turborepo_ui::{cprint, cprintln, ColorSelector, BOLD_GREY, GREY, UI};
 #[cfg(feature = "daemon-package-discovery")]
-use {
-    crate::run::package_discovery::DaemonPackageDiscovery,
-    std::time::Duration,
-    turborepo_repository::discovery::{
-        Error as DiscoveryError, FallbackPackageDiscovery, LocalPackageDiscoveryBuilder,
-        PackageDiscoveryBuilder,
-    },
-};
+use turborepo_repository::discovery::PackageDiscoveryBuilder;
+use turborepo_repository::package_graph::{PackageGraph, PackageName};
+use turborepo_scm::SCM;
+use turborepo_telemetry::events::generic::GenericEventBuilder;
+use turborepo_ui::{cprint, cprintln, BOLD_GREY, GREY, UI};
 
-use self::task_id::TaskName;
 pub use crate::run::error::Error;
 use crate::{
-    cli::{DryRunMode, EnvMode},
-    commands::CommandBase,
-    daemon::DaemonConnector,
-    engine::{Engine, EngineBuilder},
+    cli::EnvMode,
+    engine::Engine,
     opts::Opts,
     process::ProcessManager,
     run::{global_hash::get_global_hash_inputs, summary::RunTracker, task_access::TaskAccess},
-    shim::TurboState,
-    signal::{SignalHandler, SignalSubscriber},
+    signal::SignalHandler,
     task_graph::Visitor,
     task_hash::{get_external_deps_hash, PackageInputsHashes},
     turbo_json::TurboJson,
 };
 
 pub struct Run {
-    processes: ProcessManager,
-    opts: Opts,
-    api_auth: Option<APIAuth>,
-    repo_root: AbsoluteSystemPathBuf,
-    ui: UI,
     version: &'static str,
+    ui: UI,
+    start_at: DateTime<Local>,
+    processes: ProcessManager,
+    run_telemetry: GenericEventBuilder,
+    repo_root: AbsoluteSystemPathBuf,
+    opts: Opts,
+    api_client: APIClient,
+    api_auth: Option<APIAuth>,
+    env_at_execution_start: EnvironmentVariableMap,
+    filtered_pkgs: HashSet<PackageName>,
+    pkg_dep_graph: Arc<PackageGraph>,
+    root_turbo_json: TurboJson,
+    package_inputs_hashes: PackageInputsHashes,
+    scm: SCM,
+    run_cache: Arc<RunCache>,
+    signal_handler: SignalHandler,
+    engine: Arc<Engine>,
+    task_access: TaskAccess,
 }
 
 impl Run {
-    pub fn new(base: CommandBase, api_auth: Option<APIAuth>) -> Result<Self, Error> {
-        let processes = ProcessManager::infer();
-        let mut opts: Opts = base.args().try_into()?;
-        let config = base.config()?;
-        let is_linked = turborepo_api_client::is_linked(&api_auth);
-        if !is_linked {
-            opts.cache_opts.skip_remote = true;
-        } else if let Some(enabled) = config.enabled {
-            // We're linked, but if the user has explicitly enabled or disabled, use that
-            // value
-            opts.cache_opts.skip_remote = !enabled;
-        }
-        // Note that we don't currently use the team_id value here. In the future, we
-        // should probably verify that we only use the signature value when the
-        // configured team_id matches the final resolved team_id.
-        let unused_remote_cache_opts_team_id = config.team_id().map(|team_id| team_id.to_string());
-        let signature = config.signature();
-        opts.cache_opts.remote_cache_opts = Some(RemoteCacheOpts::new(
-            unused_remote_cache_opts_team_id,
-            signature,
-        ));
-        if opts.run_opts.experimental_space_id.is_none() {
-            opts.run_opts.experimental_space_id = config.spaces_id().map(|s| s.to_owned());
-        }
-        let version = base.version();
-        let CommandBase { repo_root, ui, .. } = base;
-        Ok(Self {
-            processes,
-            opts,
-            api_auth,
-            repo_root,
-            ui,
-            version,
-        })
-    }
-
-    fn connect_process_manager(&self, signal_subscriber: SignalSubscriber) {
-        let manager = self.processes.clone();
-        tokio::spawn(async move {
-            let _guard = signal_subscriber.listen().await;
-            manager.stop().await;
-        });
-    }
-
-    fn initialize_analytics(
-        api_auth: Option<APIAuth>,
-        api_client: APIClient,
-    ) -> Option<(AnalyticsSender, AnalyticsHandle)> {
-        // If there's no API auth, we don't want to record analytics
-        let api_auth = api_auth?;
-        api_auth
-            .is_linked()
-            .then(|| start_analytics(api_auth, api_client))
-    }
-
-    fn print_run_prelude(&self, filtered_pkgs: &HashSet<PackageName>) {
+    fn print_run_prelude(&self) {
         let targets_list = self.opts.run_opts.tasks.join(", ");
         if self.opts.run_opts.single_package {
             cprint!(self.ui, GREY, "{}", "• Running");
             cprint!(self.ui, BOLD_GREY, " {}\n", targets_list);
         } else {
-            let mut packages = filtered_pkgs
+            let mut packages = self
+                .filtered_pkgs
                 .iter()
                 .map(|workspace_name| workspace_name.to_string())
                 .collect::<Vec<String>>();
@@ -151,7 +83,7 @@ impl Run {
             );
             cprint!(self.ui, GREY, "{} ", "• Running");
             cprint!(self.ui, BOLD_GREY, "{}", targets_list);
-            cprint!(self.ui, GREY, " in {} packages\n", filtered_pkgs.len());
+            cprint!(self.ui, GREY, " in {} packages\n", self.filtered_pkgs.len());
         }
 
         let use_http_cache = !self.opts.cache_opts.skip_remote;
@@ -162,330 +94,26 @@ impl Run {
         }
     }
 
-    #[tracing::instrument(skip(self, signal_handler, api_client))]
-    pub async fn run(
-        &self,
-        signal_handler: &SignalHandler,
-        telemetry: CommandEventBuilder,
-        api_client: APIClient,
-    ) -> Result<i32, Error> {
-        tracing::trace!(
-            platform = %TurboState::platform_name(),
-            start_time = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).expect("system time after epoch").as_micros(),
-            turbo_version = %TurboState::version(),
-            numcpus = num_cpus::get(),
-            "performing run on {:?}",
-            TurboState::platform_name(),
-        );
-        let start_at = Local::now();
-        if let Some(subscriber) = signal_handler.subscribe() {
-            self.connect_process_manager(subscriber);
-        }
-
-        let (analytics_sender, analytics_handle) =
-            Self::initialize_analytics(self.api_auth.clone(), api_client.clone()).unzip();
-
-        let result = self
-            .run_with_analytics(
-                start_at,
-                api_client,
-                analytics_sender,
-                signal_handler,
-                telemetry,
-            )
-            .await;
-
-        if let Some(analytics_handle) = analytics_handle {
-            analytics_handle.close_with_timeout().await;
-        }
-
-        result
-    }
-
-    // We split this into a separate function because we need
-    // to close the AnalyticsHandle regardless of whether the run succeeds or not
-    async fn run_with_analytics(
-        &self,
-        start_at: DateTime<Local>,
-        api_client: APIClient,
-        analytics_sender: Option<AnalyticsSender>,
-        signal_handler: &SignalHandler,
-        telemetry: CommandEventBuilder,
-    ) -> Result<i32, Error> {
-        let scm = {
-            let repo_root = self.repo_root.clone();
-            tokio::task::spawn_blocking(move || SCM::new(&repo_root))
-        };
-        let package_json_path = self.repo_root.join_component("package.json");
-        let root_package_json = PackageJson::load(&package_json_path)?;
-        let run_telemetry = GenericEventBuilder::new().with_parent(&telemetry);
-        let repo_telemetry =
-            RepoEventBuilder::new(&self.repo_root.to_string()).with_parent(&telemetry);
-
-        // Pulled from initAnalyticsClient in run.go
-        let is_linked = turborepo_api_client::is_linked(&self.api_auth);
-        run_telemetry.track_is_linked(is_linked);
-        // we only track the remote cache if we're linked because this defaults to
-        // Vercel
-        if is_linked {
-            run_telemetry.track_remote_cache(api_client.base_url());
-        }
-        let _is_structured_output = self.opts.run_opts.graph.is_some()
-            || matches!(self.opts.run_opts.dry_run, Some(DryRunMode::Json));
-
-        let is_single_package = self.opts.run_opts.single_package;
-        repo_telemetry.track_type(if is_single_package {
-            RepoType::SinglePackage
-        } else {
-            RepoType::Monorepo
-        });
-
-        let is_ci_or_not_tty = turborepo_ci::is_ci() || !std::io::stdout().is_terminal();
-        run_telemetry.track_ci(turborepo_ci::Vendor::get_name());
-
-        // Remove allow when daemon is flagged back on
-        #[allow(unused_mut)]
-        let mut daemon = match (is_ci_or_not_tty, self.opts.run_opts.daemon) {
-            (true, None) => {
-                run_telemetry.track_daemon_init(DaemonInitStatus::Skipped);
-                debug!("skipping turbod since we appear to be in a non-interactive context");
-                None
-            }
-            (_, Some(true)) | (false, None) => {
-                let can_start_server = true;
-                let can_kill_server = true;
-                let connector =
-                    DaemonConnector::new(can_start_server, can_kill_server, &self.repo_root);
-                match (connector.connect().await, self.opts.run_opts.daemon) {
-                    (Ok(client), _) => {
-                        run_telemetry.track_daemon_init(DaemonInitStatus::Started);
-                        debug!("running in daemon mode");
-                        Some(client)
-                    }
-                    (Err(e), Some(true)) => {
-                        run_telemetry.track_daemon_init(DaemonInitStatus::Failed);
-                        debug!("failed to connect to daemon when forced {e}, exiting");
-                        return Err(e.into());
-                    }
-                    (Err(e), None) => {
-                        run_telemetry.track_daemon_init(DaemonInitStatus::Failed);
-                        debug!("failed to connect to daemon {e}");
-                        None
-                    }
-                    (_, Some(false)) => unreachable!(),
-                }
-            }
-            (_, Some(false)) => {
-                run_telemetry.track_daemon_init(DaemonInitStatus::Disabled);
-                debug!("skipping turbod since --no-daemon was passed");
-                None
-            }
-        };
-
-        let mut pkg_dep_graph = {
-            let builder = PackageGraph::builder(&self.repo_root, root_package_json.clone())
-                .with_single_package_mode(self.opts.run_opts.single_package);
-
-            #[cfg(feature = "daemon-package-discovery")]
-            let graph = match (&daemon, self.opts.run_opts.daemon) {
-                (None, Some(true)) => {
-                    // We've asked for the daemon, but it's not available. This is an error
-                    return Err(package_graph::builder::Error::Discovery(
-                        DiscoveryError::Unavailable,
-                    )
-                    .into());
-                }
-                (Some(daemon), Some(true)) => {
-                    // We have the daemon, and have explicitly asked to only use that
-                    let daemon_discovery = DaemonPackageDiscovery::new(daemon.clone());
-                    builder
-                        .with_package_discovery(daemon_discovery)
-                        .build()
-                        .await
-                }
-                (_, Some(false)) | (None, _) => {
-                    // We have explicitly requested to not use the daemon, or we don't have it
-                    // No change to default.
-                    builder.build().await
-                }
-                (Some(daemon), None) => {
-                    // We have the daemon, and it's not flagged off. Use the fallback strategy
-                    let daemon_discovery = DaemonPackageDiscovery::new(daemon.clone());
-                    let local_discovery = LocalPackageDiscoveryBuilder::new(
-                        self.repo_root.clone(),
-                        None,
-                        Some(root_package_json.clone()),
-                    )
-                    .build()?;
-                    let fallback_discover = FallbackPackageDiscovery::new(
-                        daemon_discovery,
-                        local_discovery,
-                        Duration::from_millis(10),
-                    );
-                    builder
-                        .with_package_discovery(fallback_discover)
-                        .build()
-                        .await
-                }
-            };
-            #[cfg(not(feature = "daemon-package-discovery"))]
-            let graph = builder.build().await;
-
-            match graph {
-                Ok(graph) => graph,
-                // if we can't find the package.json, it is a bug, and we should report it.
-                // likely cause is that package discovery watching is not up to date.
-                // note: there _is_ a false positive from a race condition that can occur
-                //       from toctou if the package.json is deleted, but we'd like to know
-                Err(package_graph::builder::Error::PackageJson(package_json::Error::Io(io)))
-                    if io.kind() == ErrorKind::NotFound =>
-                {
-                    run_telemetry.track_error(TrackedErrors::InvalidPackageDiscovery);
-                    return Err(package_graph::builder::Error::PackageJson(
-                        package_json::Error::Io(io),
-                    )
-                    .into());
-                }
-                Err(e) => return Err(e.into()),
-            }
-        };
-
-        repo_telemetry.track_package_manager(pkg_dep_graph.package_manager().to_string());
-        repo_telemetry.track_size(pkg_dep_graph.len());
-        run_telemetry.track_run_type(self.opts.run_opts.dry_run.is_some());
-
-        let scm = scm.await.expect("detecting scm panicked");
-        let async_cache = AsyncCache::new(
-            &self.opts.cache_opts,
-            &self.repo_root,
-            api_client.clone(),
-            self.api_auth.clone(),
-            analytics_sender,
-        )?;
-
-        // restore config from task access trace if it's enabled
-        let task_access = TaskAccess::new(self.repo_root.clone(), async_cache.clone(), &scm);
-        task_access.restore_config().await;
-
-        let root_turbo_json = TurboJson::load(
-            &self.repo_root,
-            AnchoredSystemPath::empty(),
-            &root_package_json,
-            is_single_package,
-        )?;
-
-        pkg_dep_graph.validate()?;
-
-        let filtered_pkgs = {
-            let (mut filtered_pkgs, is_all_packages) = scope::resolve_packages(
-                &self.opts.scope_opts,
-                &self.repo_root,
-                &pkg_dep_graph,
-                &scm,
-                &root_turbo_json,
-            )?;
-
-            if is_all_packages {
-                for target in self.opts.run_opts.tasks.iter() {
-                    let mut task_name = TaskName::from(target.as_str());
-                    // If it's not a package task, we convert to a root task
-                    if !task_name.is_package_task() {
-                        task_name = task_name.into_root_task()
-                    }
-
-                    if root_turbo_json.pipeline.contains_key(&task_name) {
-                        filtered_pkgs.insert(PackageName::Root);
-                        break;
-                    }
-                }
-            };
-
-            filtered_pkgs
-        };
-
-        let env_at_execution_start = EnvironmentVariableMap::infer();
-        let mut engine = self.build_engine(&pkg_dep_graph, &root_turbo_json, &filtered_pkgs)?;
-
+    pub async fn run(self) -> Result<i32, Error> {
         if self.opts.run_opts.dry_run.is_none() && self.opts.run_opts.graph.is_none() {
-            self.print_run_prelude(&filtered_pkgs);
+            self.print_run_prelude();
         }
 
-        let root_workspace = pkg_dep_graph
-            .package_info(&PackageName::Root)
-            .expect("must have root workspace");
-
-        let is_monorepo = !self.opts.run_opts.single_package;
-
-        let root_external_dependencies_hash =
-            is_monorepo.then(|| get_external_deps_hash(&root_workspace.transitive_dependencies));
-
-        let mut global_hash_inputs = get_global_hash_inputs(
-            root_external_dependencies_hash.as_deref(),
-            &self.repo_root,
-            pkg_dep_graph.package_manager(),
-            pkg_dep_graph.lockfile(),
-            &root_turbo_json.global_deps,
-            &env_at_execution_start,
-            &root_turbo_json.global_env,
-            root_turbo_json.global_pass_through_env.as_deref(),
-            self.opts.run_opts.env_mode,
-            self.opts.run_opts.framework_inference,
-            root_turbo_json.global_dot_env.as_deref(),
-            &scm,
-        )?;
-
-        let global_hash = global_hash_inputs.calculate_global_hash_from_inputs();
-
-        debug!("global hash: {}", global_hash);
-
-        let color_selector = ColorSelector::default();
-
-        let runcache = Arc::new(RunCache::new(
-            async_cache,
-            &self.repo_root,
-            &self.opts.runcache_opts,
-            color_selector,
-            daemon,
-            self.ui,
-            self.opts.run_opts.dry_run.is_some(),
-        ));
-        if let Some(subscriber) = signal_handler.subscribe() {
-            let runcache = runcache.clone();
+        if let Some(subscriber) = self.signal_handler.subscribe() {
+            let run_cache = self.run_cache.clone();
             tokio::spawn(async move {
                 let _guard = subscriber.listen().await;
                 let spinner = turborepo_ui::start_spinner("...Finishing writing to cache...");
-                runcache.shutdown_cache().await;
+                run_cache.shutdown_cache().await;
                 spinner.finish_and_clear();
             });
-        }
-
-        let mut global_env_mode = self.opts.run_opts.env_mode;
-        if matches!(global_env_mode, EnvMode::Infer)
-            && root_turbo_json.global_pass_through_env.is_some()
-        {
-            global_env_mode = EnvMode::Strict;
-        }
-
-        let workspaces = pkg_dep_graph.packages().collect();
-        let package_inputs_hashes = PackageInputsHashes::calculate_file_hashes(
-            &scm,
-            engine.tasks().par_bridge(),
-            workspaces,
-            engine.task_definitions(),
-            &self.repo_root,
-            &run_telemetry,
-        )?;
-
-        if self.opts.run_opts.parallel {
-            pkg_dep_graph.remove_package_dependencies();
-            engine = self.build_engine(&pkg_dep_graph, &root_turbo_json, &filtered_pkgs)?;
         }
 
         if let Some(graph_opts) = &self.opts.run_opts.graph {
             graph_visualizer::write_graph(
                 self.ui,
                 graph_opts,
-                &engine,
+                &self.engine,
                 self.opts.run_opts.single_package,
                 // Note that cwd used to be pulled from CommandBase, which had it set
                 // as the repo root.
@@ -494,11 +122,55 @@ impl Run {
             return Ok(0);
         }
 
-        let pkg_dep_graph = Arc::new(pkg_dep_graph);
-        let engine = Arc::new(engine);
+        let root_workspace = self
+            .pkg_dep_graph
+            .package_info(&PackageName::Root)
+            .expect("must have root workspace");
+
+        let is_monorepo = !self.opts.run_opts.single_package;
+
+        let root_external_dependencies_hash =
+            is_monorepo.then(|| get_external_deps_hash(&root_workspace.transitive_dependencies));
+
+        let global_hash_inputs = {
+            let (env_mode, pass_through_env) = match self.opts.run_opts.env_mode {
+                // In infer mode, if there is any pass_through config (even if it is an empty array)
+                // we'll hash the whole object, so we can detect changes to that config
+                // Further, resolve the envMode to the concrete value.
+                EnvMode::Infer if self.root_turbo_json.global_pass_through_env.is_some() => (
+                    EnvMode::Strict,
+                    self.root_turbo_json.global_pass_through_env.as_deref(),
+                ),
+                EnvMode::Loose => {
+                    // Remove the passthroughs from hash consideration if we're explicitly loose.
+                    (EnvMode::Loose, None)
+                }
+                env_mode => (
+                    env_mode,
+                    self.root_turbo_json.global_pass_through_env.as_deref(),
+                ),
+            };
+
+            get_global_hash_inputs(
+                root_external_dependencies_hash.as_deref(),
+                &self.repo_root,
+                self.pkg_dep_graph.package_manager(),
+                self.pkg_dep_graph.lockfile(),
+                &self.root_turbo_json.global_deps,
+                &self.env_at_execution_start,
+                &self.root_turbo_json.global_env,
+                pass_through_env,
+                env_mode,
+                self.opts.run_opts.framework_inference,
+                self.root_turbo_json.global_dot_env.as_deref(),
+                &self.scm,
+            )?
+        };
+        let global_hash = global_hash_inputs.calculate_global_hash();
 
         let global_env = {
-            let mut env = env_at_execution_start
+            let mut env = self
+                .env_at_execution_start
                 .from_wildcards(global_hash_inputs.pass_through_env.unwrap_or_default())
                 .map_err(Error::Env)?;
             if let Some(resolved_global) = &global_hash_inputs.resolved_env_vars {
@@ -508,29 +180,29 @@ impl Run {
         };
 
         let run_tracker = RunTracker::new(
-            start_at,
+            self.start_at,
             self.opts.synthesize_command(),
             self.opts.scope_opts.pkg_inference_root.as_deref(),
-            &env_at_execution_start,
+            &self.env_at_execution_start,
             &self.repo_root,
             self.version,
             self.opts.run_opts.experimental_space_id.clone(),
-            api_client,
+            self.api_client,
             self.api_auth.clone(),
             Vendor::get_user(),
-            &scm,
+            &self.scm,
         );
 
         let mut visitor = Visitor::new(
-            pkg_dep_graph.clone(),
-            runcache,
+            self.pkg_dep_graph.clone(),
+            self.run_cache,
             run_tracker,
-            task_access,
+            self.task_access,
             &self.opts.run_opts,
-            package_inputs_hashes,
-            &env_at_execution_start,
+            self.package_inputs_hashes,
+            &self.env_at_execution_start,
             &global_hash,
-            global_env_mode,
+            self.opts.run_opts.env_mode,
             self.ui,
             self.processes.clone(),
             &self.repo_root,
@@ -545,7 +217,9 @@ impl Run {
         // in benchmarks, so please don't remove it
         debug!("running visitor");
 
-        let errors = visitor.visit(engine.clone(), &run_telemetry).await?;
+        let errors = visitor
+            .visit(self.engine.clone(), &self.run_telemetry)
+            .await?;
 
         let exit_code = errors
             .iter()
@@ -566,48 +240,14 @@ impl Run {
         visitor
             .finish(
                 exit_code,
-                filtered_pkgs,
+                self.filtered_pkgs,
                 global_hash_inputs,
-                &engine,
-                &env_at_execution_start,
+                &self.engine,
+                &self.env_at_execution_start,
                 self.opts.scope_opts.pkg_inference_root.as_deref(),
             )
             .await?;
 
         Ok(exit_code)
-    }
-
-    fn build_engine(
-        &self,
-        pkg_dep_graph: &PackageGraph,
-        root_turbo_json: &TurboJson,
-        filtered_pkgs: &HashSet<PackageName>,
-    ) -> Result<Engine, Error> {
-        let engine = EngineBuilder::new(
-            &self.repo_root,
-            pkg_dep_graph,
-            self.opts.run_opts.single_package,
-        )
-        .with_root_tasks(root_turbo_json.pipeline.keys().cloned())
-        .with_turbo_jsons(Some(
-            Some((PackageName::Root, root_turbo_json.clone()))
-                .into_iter()
-                .collect(),
-        ))
-        .with_tasks_only(self.opts.run_opts.only)
-        .with_workspaces(filtered_pkgs.clone().into_iter().collect())
-        .with_tasks(self.opts.run_opts.tasks.iter().map(|task| {
-            // TODO: Pull span info from command
-            Spanned::new(TaskName::from(task.as_str()).into_owned())
-        }))
-        .build()?;
-
-        if !self.opts.run_opts.parallel {
-            engine
-                .validate(pkg_dep_graph, self.opts.run_opts.concurrency)
-                .map_err(Error::EngineValidation)?;
-        }
-
-        Ok(engine)
     }
 }


### PR DESCRIPTION
### Description
We're going to need access to the `Run` struct in watch mode, but without the actual execution part. To facilitate this, I'm splitting it up into a `RunBuilder` that builds all of the necessary data structures and a `Run` that executes the build.

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->


Closes TURBO-2583