### PR TITLE
docs: Update testing configuration documentation for clarity

### DIFF
--- a/docs/pages/repo/docs/handbook/testing.mdx
+++ b/docs/pages/repo/docs/handbook/testing.mdx
@@ -65,7 +65,10 @@ Because of this difference, we recommend specifying **two separate Turborepo tas
 
 Here's an example:
 
+Inside your individual `package.json` files for each workspace:
+
 <Tabs items={["Jest", "Vitest"]} storageKey="selected-test-runner">
+
   <Tab>
 ```json filename="apps/web/package.json"
 {
@@ -88,6 +91,8 @@ Here's an example:
     </Tab>
 </Tabs>
 
+Inside the root `turbo.json`:
+
 ```json filename="turbo.json"
 {
   "pipeline": {
@@ -98,6 +103,8 @@ Here's an example:
   }
 }
 ```
+
+Inside the root `package.json`:
 
 ```json filename="package.json"
 {


### PR DESCRIPTION
### Description

The Testing section is really helpful, but it would be clearer by specifying exactly where each of these snippets should be placed.

Before: 
<img width="400" alt="Screenshot 2024-03-09 at 8 08 59 AM" src="https://github.com/vercel/turbo/assets/26635607/1e8e8b05-4702-402b-8ea8-df7d9e6f21cf">

After: 
<img width="400" alt="Screenshot 2024-03-09 at 8 14 03 AM" src="https://github.com/vercel/turbo/assets/26635607/e6ab7ce4-0cb7-4f4d-b14d-9b70598ce7c3">


Looking forward to your thoughts and feedback.
Thanks.