### PR TITLE
feat(resolve): skip alias to d.ts

### DIFF
--- a/crates/turbopack-resolve/src/typescript.rs
+++ b/crates/turbopack-resolve/src/typescript.rs
@@ -270,7 +270,13 @@ pub async fn tsconfig_resolve_options(
                         let entries = vec
                             .iter()
                             .filter_map(|entry| {
-                                entry.as_str().map(|s| {
+                                let entry = entry.as_str();
+
+                                if entry.map(|e| e.ends_with(".d.ts")).unwrap_or_default() {
+                                    return None;
+                                }
+
+                                entry.map(|s| {
                                     // tsconfig paths are always relative requests
                                     if s.starts_with("./") || s.starts_with("../") {
                                         s.to_string()


### PR DESCRIPTION
### Description

Simple port to https://github.com/vercel/next.js/pull/11322/files#diff-f80cef26fea96d9530aab29fcaa89b2cc296a54a826a367254997d2885727d33R179.

Maybe we can consider to expose this as sort of configuration predicate for specific filter, but the depth of this call is somewhat deep from resolve context and so far there is only one cases (excluding d.ts), so followed same practices to exising next.js behavior.

Closes PACK-2701