### PR TITLE
feat: add entire screen viewer to vt100

### DIFF
--- a/crates/turborepo-vt100/src/entire_screen.rs
+++ b/crates/turborepo-vt100/src/entire_screen.rs
@@ -1,0 +1,21 @@
+pub struct EntireScreen<'a>(pub(crate) &'a crate::Screen);
+
+impl<'a> EntireScreen<'a> {
+    #[must_use]
+    pub fn cell(&self, row: u16, col: u16) -> Option<&crate::Cell> {
+        self.0.grid().all_row(row).and_then(|r| r.get(col))
+    }
+
+    #[must_use]
+    pub fn contents(&self) -> String {
+        let mut s = String::new();
+        self.0.grid().write_full_contents(&mut s);
+        s
+    }
+
+    /// Size required to render all contents
+    #[must_use]
+    pub fn size(&self) -> (usize, u16) {
+        self.0.grid().size_with_contents()
+    }
+}

--- a/crates/turborepo-vt100/src/lib.rs
+++ b/crates/turborepo-vt100/src/lib.rs
@@ -50,6 +50,7 @@
 mod attrs;
 mod callbacks;
 mod cell;
+mod entire_screen;
 mod grid;
 mod parser;
 mod perform;
@@ -60,5 +61,6 @@ mod term;
 pub use attrs::Color;
 pub use callbacks::Callbacks;
 pub use cell::Cell;
+pub use entire_screen::EntireScreen;
 pub use parser::Parser;
 pub use screen::{MouseProtocolEncoding, MouseProtocolMode, Screen};

--- a/crates/turborepo-vt100/src/parser.rs
+++ b/crates/turborepo-vt100/src/parser.rs
@@ -57,6 +57,13 @@ impl Parser {
     pub fn screen_mut(&mut self) -> &mut crate::Screen {
         &mut self.screen.0
     }
+
+    /// Returns a reference to an `EntireScreen` object containing the
+    /// terminal state where all contents including scrollback and displayed.
+    #[must_use]
+    pub fn entire_screen(&self) -> crate::EntireScreen {
+        crate::EntireScreen(self.screen())
+    }
 }
 
 impl Default for Parser {

--- a/crates/turborepo-vt100/src/row.rs
+++ b/crates/turborepo-vt100/src/row.rs
@@ -29,6 +29,10 @@ impl Row {
         self.wrapped = false;
     }
 
+    pub fn is_blank(&self) -> bool {
+        self.cells().all(|cell| !cell.has_contents())
+    }
+
     fn cells(&self) -> impl Iterator<Item = &crate::Cell> {
         self.cells.iter()
     }

--- a/crates/turborepo-vt100/tests/entire_screen.rs
+++ b/crates/turborepo-vt100/tests/entire_screen.rs
@@ -1,0 +1,33 @@
+use turborepo_vt100 as vt100;
+
+#[test]
+fn test_screen_includes_scrollback() {
+    let mut parser = vt100::Parser::new(2, 20, 100);
+    parser.process(b"foo\r\nbar\r\nbaz\r\n");
+    let screen = parser.entire_screen();
+    assert_eq!(screen.contents(), "foo\nbar\nbaz");
+    assert_eq!(screen.size(), (3, 20));
+}
+
+#[test]
+fn test_screen_trims_trailing_blank_lines() {
+    let mut parser = vt100::Parser::new(8, 20, 0);
+    parser.process(b"foo\r\nbar\r\n");
+    let screen = parser.entire_screen();
+    assert_eq!(screen.contents(), "foo\nbar");
+    assert_eq!(screen.size(), (2, 20));
+}
+
+#[test]
+fn test_wrapped_lines_size() {
+    let mut parser = vt100::Parser::new(8, 8, 10);
+    parser.process(b"one long line\r\nbar\r\n");
+    let screen = parser.entire_screen();
+    assert_eq!(screen.contents(), "one long line\nbar");
+    assert_eq!(screen.size(), (3, 8));
+    assert_eq!(screen.cell(0, 0).unwrap().contents(), "o");
+    assert_eq!(screen.cell(1, 0).unwrap().contents(), " ");
+    // "one long line"
+    //         ^ last char that fits on line, rest will appear on next row
+    assert_eq!(screen.cell(2, 0).unwrap().contents(), "b");
+}


### PR DESCRIPTION
### Description

In order to properly persist a task's output we need to display the full terminal contents including whatever might be in the scrollback buffer. This PR adds an alternative screen where the row index includes the scrollback rows. The `Screen` trait added in https://github.com/a-kenji/tui-term/pull/152 will be implemented for `EntireScreen` allowing for us to use this structure with the `PseudoTerminal` widget.

### Testing Instructions

Added some basic unit tests to verify that scrollback gets printed.


Closes TURBO-2592