### PR TITLE
chore: generalize cache terminal output

### DIFF
--- a/crates/turborepo-lib/src/run/cache.rs
+++ b/crates/turborepo-lib/src/run/cache.rs
@@ -136,9 +136,10 @@ pub struct TaskCache {
 }
 
 impl TaskCache {
-    pub fn replay_log_file(&self, prefixed_ui: &mut PrefixedUI<impl Write>) -> Result<(), Error> {
+    /// Will read log file and write to output a line at a time
+    pub fn replay_log_file(&self, output: impl Write) -> Result<(), Error> {
         if self.log_file_path.exists() {
-            replay_logs(prefixed_ui, &self.log_file_path)?;
+            replay_logs(output, &self.log_file_path)?;
         }
 
         Ok(())
@@ -150,7 +151,7 @@ impl TaskCache {
                 "cache miss, executing {}",
                 color!(self.ui, GREY, "{}", self.hash)
             ));
-            self.replay_log_file(prefixed_ui)?;
+            self.replay_log_file(prefixed_ui.output_prefixed_writer())?;
         }
 
         Ok(())
@@ -304,7 +305,7 @@ impl TaskCache {
                     more_context,
                     color!(self.ui, GREY, "{}", self.hash)
                 ));
-                self.replay_log_file(prefixed_ui)?;
+                self.replay_log_file(prefixed_ui.output_prefixed_writer())?;
             }
             // Note that if we're restoring from cache, the task succeeded
             // so we know we don't need to print anything for errors

--- a/crates/turborepo-lib/src/run/cache.rs
+++ b/crates/turborepo-lib/src/run/cache.rs
@@ -144,7 +144,7 @@ impl TaskCache {
 
     pub fn on_error(&self, mut terminal_output: impl Write) -> Result<(), Error> {
         if self.task_output_mode == OutputLogsMode::ErrorsOnly {
-            failable_write(
+            fallible_write(
                 &mut terminal_output,
                 &format!(
                     "cache miss, executing {}\n",
@@ -191,7 +191,7 @@ impl TaskCache {
                 self.task_output_mode,
                 OutputLogsMode::None | OutputLogsMode::ErrorsOnly
             ) {
-                failable_write(
+                fallible_write(
                     &mut terminal_output,
                     &format!(
                         "cache bypass, force executing {}\n",
@@ -242,7 +242,7 @@ impl TaskCache {
                     self.task_output_mode,
                     OutputLogsMode::None | OutputLogsMode::ErrorsOnly
                 ) {
-                    failable_write(
+                    fallible_write(
                         &mut terminal_output,
                         &format!(
                             "cache miss, executing {}\n",
@@ -293,7 +293,7 @@ impl TaskCache {
 
         match self.task_output_mode {
             OutputLogsMode::HashOnly | OutputLogsMode::NewOnly => {
-                failable_write(
+                fallible_write(
                     &mut terminal_output,
                     &format!(
                         "cache hit{}, suppressing logs {}\n",
@@ -304,7 +304,7 @@ impl TaskCache {
             }
             OutputLogsMode::Full => {
                 debug!("log file path: {}", self.log_file_path);
-                failable_write(
+                fallible_write(
                     &mut terminal_output,
                     &format!(
                         "cache hit{}, replaying logs {}\n",
@@ -473,7 +473,7 @@ impl ConfigCache {
 }
 
 // attempt to write message to writer, swallowing any errors encountered
-fn failable_write(mut writer: impl Write, message: &str) {
+fn fallible_write(mut writer: impl Write, message: &str) {
     if let Err(err) = writer.write_all(message.as_bytes()) {
         error!("cannot write to logs: {:?}", err);
     }

--- a/crates/turborepo-lib/src/run/cache.rs
+++ b/crates/turborepo-lib/src/run/cache.rs
@@ -147,7 +147,7 @@ impl TaskCache {
             failable_write(
                 &mut terminal_output,
                 &format!(
-                    "cache miss, executing {}",
+                    "cache miss, executing {}\n",
                     color!(self.ui, GREY, "{}", self.hash)
                 ),
             );

--- a/crates/turborepo-lib/src/run/cache.rs
+++ b/crates/turborepo-lib/src/run/cache.rs
@@ -9,9 +9,7 @@ use turborepo_cache::{AsyncCache, CacheError, CacheHitMetadata, CacheSource};
 use turborepo_repository::package_graph::PackageInfo;
 use turborepo_scm::SCM;
 use turborepo_telemetry::events::{task::PackageTaskEventBuilder, TrackedErrors};
-use turborepo_ui::{
-    color, replay_logs, ColorSelector, LogWriter, PrefixedUI, PrefixedWriter, GREY, UI,
-};
+use turborepo_ui::{color, replay_logs, ColorSelector, LogWriter, PrefixedWriter, GREY, UI};
 
 use crate::{
     cli::OutputLogsMode,
@@ -145,13 +143,16 @@ impl TaskCache {
         Ok(())
     }
 
-    pub fn on_error(&self, prefixed_ui: &mut PrefixedUI<impl Write>) -> Result<(), Error> {
+    pub fn on_error(&self, mut terminal_output: impl Write) -> Result<(), Error> {
         if self.task_output_mode == OutputLogsMode::ErrorsOnly {
-            prefixed_ui.output(format!(
-                "cache miss, executing {}",
-                color!(self.ui, GREY, "{}", self.hash)
-            ));
-            self.replay_log_file(prefixed_ui.output_prefixed_writer())?;
+            failable_write(
+                &mut terminal_output,
+                &format!(
+                    "cache miss, executing {}",
+                    color!(self.ui, GREY, "{}", self.hash)
+                ),
+            );
+            self.replay_log_file(terminal_output)?;
         }
 
         Ok(())

--- a/crates/turborepo-lib/src/task_graph/visitor.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor.rs
@@ -833,7 +833,7 @@ impl ExecContext {
 
         let mut stdout_writer = match self
             .task_cache
-            .output_writer(self.pretty_prefix.clone(), output_client.stdout())
+            .output_writer(prefixed_ui.output_prefixed_writer())
         {
             Ok(w) => w,
             Err(e) => {

--- a/crates/turborepo-lib/src/task_graph/visitor.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor.rs
@@ -912,7 +912,10 @@ impl ExecContext {
                 if let Err(e) = stdout_writer.flush() {
                     error!("error flushing logs: {e}");
                 }
-                if let Err(e) = self.task_cache.on_error(&mut prefixed_ui) {
+                if let Err(e) = self
+                    .task_cache
+                    .on_error(prefixed_ui.output_prefixed_writer())
+                {
                     error!("error reading logs: {e}");
                 }
                 let error = TaskErrorCause::from_execution(process.label().to_string(), code);

--- a/crates/turborepo-lib/src/task_graph/visitor.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor.rs
@@ -773,7 +773,7 @@ impl ExecContext {
 
         match self
             .task_cache
-            .restore_outputs(&mut prefixed_ui, telemetry)
+            .restore_outputs(prefixed_ui.output_prefixed_writer(), telemetry)
             .await
         {
             Ok(Some(status)) => {

--- a/crates/turborepo-ui/src/prefixed.rs
+++ b/crates/turborepo-ui/src/prefixed.rs
@@ -85,7 +85,7 @@ impl<W: Write> PrefixedUI<W> {
 
     /// Construct a PrefixedWriter which will behave the same as `output`, but
     /// without the requirement that messages be valid UTF-8
-    pub(crate) fn output_prefixed_writer(&mut self) -> PrefixedWriter<&mut W> {
+    pub fn output_prefixed_writer(&mut self) -> PrefixedWriter<&mut W> {
         PrefixedWriter {
             prefix: self
                 .output_prefix


### PR DESCRIPTION
### Description

This PR removes the cache from using concrete implementations for terminal output and instead have it take a generic writer. 

This prefactor is needed for the TUI as we cannot just write to terminal as the cursor could be in an unexpected position.

### Testing Instructions

Our existing integration tests capture this behavior pretty well. Ran some tasks to double check that things appeared identical.


Closes TURBO-2596