### PR TITLE
fix(turbopack-ecmascript): use correct reference type in dynamic reference

### DIFF
--- a/crates/turbopack-ecmascript/src/references/esm/dynamic.rs
+++ b/crates/turbopack-ecmascript/src/references/esm/dynamic.rs
@@ -63,7 +63,7 @@ impl ModuleReference for EsmAsyncAssetReference {
         esm_resolve(
             self.origin,
             self.request,
-            Default::default(),
+            Value::new(EcmaScriptModulesReferenceSubType::DynamicImport),
             try_to_severity(self.in_try),
             Some(self.issue_source),
         )


### PR DESCRIPTION
### Description

Async module detection missed this previously leading to a broken bundle.

Fixes https://github.com/vercel/next.js/issues/63164
Closes PACK-2715