### PR TITLE
chore(docs): move client token to env var

### DIFF
--- a/docs/lib/useTurborepoMinutesSaved.ts
+++ b/docs/lib/useTurborepoMinutesSaved.ts
@@ -4,8 +4,7 @@ import axios from "axios";
 const fetcher = (url: string) =>
   axios.get(url).then((res) => res.data as QueryResponse);
 
-const path =
-  "https://api.us-east.tinybird.co/v0/pipes/turborepo_time_saved_ticker.json?token=p.eyJ1IjogIjAzYzA0Y2MyLTM1YTAtNDhhNC05ZTZjLThhMWE0NGNhNjhkZiIsICJpZCI6ICJmOWIzMTU5Yi0wOTVjLTQyM2UtOWIwNS04ZDZlNzIyNjEwNzIifQ.A3TOPdm3Lhmn-1x5m6jNvulCQbbgUeQfAIO3IaaAt5k";
+const path = `https://api.us-east.tinybird.co/v0/pipes/turborepo_time_saved_ticker.json?token=${process.env.NEXT_PUBLIC_TINYBIRD_TIME_SAVED_PUBLIC_TOKEN}`;
 
 const REFRESH_INTERVAL_IN_MS = 3500;
 

--- a/docs/turbo/generators/utils.ts
+++ b/docs/turbo/generators/utils.ts
@@ -7,9 +7,13 @@ interface Answers {
 const MINUTES_IN_YEAR = 60 * 24 * 365;
 
 const PUBLIC_TB_TOKEN =
-  "p.eyJ1IjogIjAzYzA0Y2MyLTM1YTAtNDhhNC05ZTZjLThhMWE0NGNhNjhkZiIsICJpZCI6ICJmOWIzMTU5Yi0wOTVjLTQyM2UtOWIwNS04ZDZlNzIyNjEwNzIifQ.A3TOPdm3Lhmn-1x5m6jNvulCQbbgUeQfAIO3IaaAt5k";
+  process.env.NEXT_PUBLIC_TINYBIRD_TIME_SAVED_PUBLIC_TOKEN;
 
 export async function releasePostStats(answers: Answers): Promise<string> {
+  if (!PUBLIC_TB_TOKEN) {
+    throw new Error("Missing NEXT_PUBLIC_TINYBIRD_TIME_SAVED_PUBLIC_TOKEN");
+  }
+
   const [starsResponse, downloadsResponse, timeSavedResponse] =
     await Promise.all([
       fetch("https://api.github.com/repos/vercel/turbo"),


### PR DESCRIPTION
### Description

Move the client token to env var so we can more easily rotate it

