### PR TITLE
Add distinction between Development and Production runtime_type for Turbopack

### DIFF
--- a/crates/turbopack-browser/src/chunking_context.rs
+++ b/crates/turbopack-browser/src/chunking_context.rs
@@ -126,6 +126,7 @@ impl BrowserChunkingContext {
         chunk_root_path: Vc<FileSystemPath>,
         asset_root_path: Vc<FileSystemPath>,
         environment: Vc<Environment>,
+        runtime_type: RuntimeType,
     ) -> BrowserChunkingContextBuilder {
         BrowserChunkingContextBuilder {
             chunking_context: BrowserChunkingContext {
@@ -140,7 +141,7 @@ impl BrowserChunkingContext {
                 asset_base_path: Default::default(),
                 enable_hot_module_replacement: false,
                 environment,
-                runtime_type: Default::default(),
+                runtime_type,
                 minify_type: MinifyType::NoMinify,
                 manifest_chunks: false,
             },

--- a/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
+++ b/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
@@ -143,7 +143,15 @@ impl EcmascriptDevEvaluateChunk {
         )?;
 
         match chunking_context.runtime_type() {
-            RuntimeType::Default => {
+            RuntimeType::Development => {
+                let runtime_code = turbopack_ecmascript_runtime::get_dev_runtime_code(
+                    environment,
+                    chunking_context.chunk_base_path(),
+                    Vc::cell(output_root.to_string()),
+                );
+                code.push_code(&*runtime_code.await?);
+            }
+            RuntimeType::Production => {
                 let runtime_code = turbopack_ecmascript_runtime::get_dev_runtime_code(
                     environment,
                     chunking_context.chunk_base_path(),

--- a/crates/turbopack-cli/src/dev/mod.rs
+++ b/crates/turbopack-cli/src/dev/mod.rs
@@ -34,6 +34,7 @@ use turbopack_dev_server::{
     },
     DevServer, DevServerBuilder,
 };
+use turbopack_ecmascript_runtime::RuntimeType;
 use turbopack_env::dotenv::load_env;
 use turbopack_node::execution_context::ExecutionContext;
 
@@ -255,6 +256,7 @@ async fn source(
         build_output_root.join("chunks".to_string()),
         build_output_root.join("assets".to_string()),
         node_build_environment(),
+        RuntimeType::Development,
     )
     .build();
 

--- a/crates/turbopack-cli/src/dev/web_entry_source.rs
+++ b/crates/turbopack-cli/src/dev/web_entry_source.rs
@@ -19,6 +19,7 @@ use turbopack_dev_server::{
     html::DevHtmlAsset,
     source::{asset_graph::AssetGraphContentSource, ContentSource},
 };
+use turbopack_ecmascript_runtime::RuntimeType;
 use turbopack_node::execution_context::ExecutionContext;
 
 use crate::{
@@ -43,6 +44,7 @@ pub fn get_client_chunking_context(
             server_root.join("/_chunks".to_string()),
             server_root.join("/_assets".to_string()),
             environment,
+            RuntimeType::Development,
         )
         .hot_module_replacement()
         .build(),

--- a/crates/turbopack-ecmascript-runtime/src/runtime_type.rs
+++ b/crates/turbopack-ecmascript-runtime/src/runtime_type.rs
@@ -2,23 +2,11 @@ use serde::{Deserialize, Serialize};
 use turbo_tasks::trace::TraceRawVcs;
 
 #[derive(
-    Serialize,
-    Deserialize,
-    Debug,
-    Clone,
-    Copy,
-    Hash,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    TraceRawVcs,
-    Default,
+    Serialize, Deserialize, Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, TraceRawVcs,
 )]
 pub enum RuntimeType {
-    #[default]
-    /// Default, full-featured runtime.
-    Default,
+    Development,
+    Production,
     #[cfg(feature = "test")]
     /// Dummy runtime for snapshot tests.
     Dummy,

--- a/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/crates/turbopack-nodejs/src/chunking_context.rs
@@ -95,6 +95,7 @@ impl NodeJsChunkingContext {
         chunk_root_path: Vc<FileSystemPath>,
         asset_root_path: Vc<FileSystemPath>,
         environment: Vc<Environment>,
+        runtime_type: RuntimeType,
     ) -> NodeJsChunkingContextBuilder {
         NodeJsChunkingContextBuilder {
             chunking_context: NodeJsChunkingContext {
@@ -105,7 +106,7 @@ impl NodeJsChunkingContext {
                 asset_root_path,
                 asset_prefix: Default::default(),
                 environment,
-                runtime_type: Default::default(),
+                runtime_type,
                 minify_type: MinifyType::NoMinify,
                 manifest_chunks: false,
             },

--- a/crates/turbopack-nodejs/src/ecmascript/node/entry/runtime.rs
+++ b/crates/turbopack-nodejs/src/ecmascript/node/entry/runtime.rs
@@ -69,7 +69,13 @@ impl EcmascriptBuildNodeRuntimeChunk {
         )?;
 
         match this.chunking_context.await?.runtime_type() {
-            RuntimeType::Default => {
+            RuntimeType::Development => {
+                let runtime_code = turbopack_ecmascript_runtime::get_build_runtime_code(
+                    this.chunking_context.environment(),
+                );
+                code.push_code(&*runtime_code.await?);
+            }
+            RuntimeType::Production => {
                 let runtime_code = turbopack_ecmascript_runtime::get_build_runtime_code(
                     this.chunking_context.environment(),
                 );

--- a/crates/turbopack-tests/tests/execution.rs
+++ b/crates/turbopack-tests/tests/execution.rs
@@ -34,6 +34,7 @@ use turbopack_core::{
     reference_type::{EntryReferenceSubType, ReferenceType},
     source::Source,
 };
+use turbopack_ecmascript_runtime::RuntimeType;
 use turbopack_node::{debug::should_debug, evaluate::evaluate};
 use turbopack_resolve::resolve_options_context::ResolveOptionsContext;
 use turbopack_test_utils::jest::JestRunResult;
@@ -302,6 +303,7 @@ async fn run_test(prepared_test: Vc<PreparedTest>) -> Result<Vc<RunTestResult>> 
         chunk_root_path,
         static_root_path,
         env,
+        RuntimeType::Development,
     )
     .build();
 

--- a/crates/turbopack-tests/tests/snapshot.rs
+++ b/crates/turbopack-tests/tests/snapshot.rs
@@ -309,6 +309,7 @@ async fn run_test(resource: String) -> Result<Vc<FileSystemPath>> {
                 chunk_root_path,
                 static_root_path,
                 env,
+                RuntimeType::Development,
             )
             .runtime_type(options.runtime_type)
             .build(),
@@ -321,6 +322,7 @@ async fn run_test(resource: String) -> Result<Vc<FileSystemPath>> {
                 chunk_root_path,
                 static_root_path,
                 env,
+                RuntimeType::Production,
             )
             .minify_type(options.minify_type)
             .runtime_type(options.runtime_type)

--- a/crates/turbopack-tests/tests/snapshot/runtime/default_build_runtime/options.json
+++ b/crates/turbopack-tests/tests/snapshot/runtime/default_build_runtime/options.json
@@ -1,5 +1,5 @@
 {
   "minifyType": "NoMinify",
   "runtime": "Build",
-  "runtimeType": "Default"
+  "runtimeType": "Production"
 }

--- a/crates/turbopack-tests/tests/snapshot/runtime/default_dev_runtime/options.json
+++ b/crates/turbopack-tests/tests/snapshot/runtime/default_dev_runtime/options.json
@@ -1,3 +1,3 @@
 {
-    "runtimeType": "Default"
+    "runtimeType": "Development"
 }


### PR DESCRIPTION
### Description

Currently the development Turbopack runtime is always used as production builds are not fully implemented yet. This is the first step to having a production-specific runtime by adding a distinction between Development and Production for the runtime. This PR does not implement the production runtime, it only adds the plumbing for adding the production specific runtime. The runtime implementation will follow in a later PR.

