### PR TITLE
accept css files outside of the project as virtual assets

### DIFF
--- a/crates/turbopack-node/src/transforms/postcss.rs
+++ b/crates/turbopack-node/src/transforms/postcss.rs
@@ -3,8 +3,7 @@ use indexmap::indexmap;
 use indoc::formatdoc;
 use serde::{Deserialize, Serialize};
 use turbo_tasks::{
-    trace::TraceRawVcs, Completion, Completions, TaskInput, TryFlatJoinIterExt, Value,
-    ValueToString, Vc,
+    trace::TraceRawVcs, Completion, Completions, TaskInput, TryFlatJoinIterExt, Value, Vc,
 };
 use turbo_tasks_bytes::stream::SingleValue;
 use turbo_tasks_fs::{

--- a/crates/turbopack-node/src/transforms/postcss.rs
+++ b/crates/turbopack-node/src/transforms/postcss.rs
@@ -375,15 +375,14 @@ impl PostCssTransformedAsset {
 
         // We need to get a path relative to the project because the postcss loader
         // runs with the project as the current working directory.
-        let Some(css_path) = project_path
+        let css_path = if let Some(css_path) = project_path
             .await?
             .get_relative_path_to(&*css_fs_path.await?)
-        else {
-            bail!(
-                "CSS path {} is outside of the project {}",
-                css_fs_path.to_string().await?,
-                project_path.to_string().await?
-            );
+        {
+            css_path
+        } else {
+            // This shouldn't be an error since it can happen on virtual assets
+            "".to_string()
         };
 
         let config_value = evaluate_webpack_loader(WebpackLoaderContext {


### PR DESCRIPTION
### Description

This can actually happen e. g. with next/font, which creates virtual css files that are not inside of the project directory

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->


Closes PACK-2732