### PR TITLE
feat(turbopack): Support marking packages as side-effect-free

### DIFF
--- a/crates/turbopack-ecmascript/src/chunk/placeable.rs
+++ b/crates/turbopack-ecmascript/src/chunk/placeable.rs
@@ -21,8 +21,11 @@ pub trait EcmascriptChunkPlaceable: ChunkableModule + Module + Asset {
     fn get_async_module(self: Vc<Self>) -> Vc<OptionAsyncModule> {
         Vc::cell(None)
     }
-    fn is_marked_as_side_effect_free(self: Vc<Self>) -> Vc<bool> {
-        is_marked_as_side_effect_free(self.ident().path())
+    fn is_marked_as_side_effect_free(
+        self: Vc<Self>,
+        optimized_packages: Vc<Vec<String>>,
+    ) -> Vc<bool> {
+        is_marked_as_side_effect_free(self.ident().path(), optimized_packages)
     }
 }
 
@@ -147,7 +150,10 @@ impl Issue for SideEffectsInPackageJsonIssue {
 }
 
 #[turbo_tasks::function]
-pub async fn is_marked_as_side_effect_free(path: Vc<FileSystemPath>) -> Result<Vc<bool>> {
+pub async fn is_marked_as_side_effect_free(
+    path: Vc<FileSystemPath>,
+    optimized_packages: Vc<Vec<String>>,
+) -> Result<Vc<bool>> {
     let find_package_json: turbo_tasks::ReadRef<FindContextFileResult> =
         find_context_file(path.parent(), package_json()).await?;
 

--- a/crates/turbopack-ecmascript/src/chunk/placeable.rs
+++ b/crates/turbopack-ecmascript/src/chunk/placeable.rs
@@ -47,7 +47,7 @@ async fn side_effects_from_package_json(
                 .await?
                 .contains(&pacakge_name.to_string())
             {
-                return Ok(SideEffectsValue::Constant(true).cell());
+                return Ok(SideEffectsValue::Constant(false).cell());
             }
         }
 

--- a/crates/turbopack-ecmascript/src/chunk/placeable.rs
+++ b/crates/turbopack-ecmascript/src/chunk/placeable.rs
@@ -154,7 +154,7 @@ pub async fn is_marked_as_side_effect_free(
     path: Vc<FileSystemPath>,
     side_effect_free_packages: Vc<Glob>,
 ) -> Result<Vc<bool>> {
-    if side_effect_free_packages.await?.execute(&*path.await?.path) {
+    if side_effect_free_packages.await?.execute(&path.await?.path) {
         return Ok(Vc::cell(true));
     }
 

--- a/crates/turbopack-ecmascript/src/chunk/placeable.rs
+++ b/crates/turbopack-ecmascript/src/chunk/placeable.rs
@@ -23,9 +23,9 @@ pub trait EcmascriptChunkPlaceable: ChunkableModule + Module + Asset {
     }
     fn is_marked_as_side_effect_free(
         self: Vc<Self>,
-        optimized_packages: Vc<Vec<String>>,
+        side_effect_free_packages: Vc<Vec<String>>,
     ) -> Vc<bool> {
-        is_marked_as_side_effect_free(self.ident().path(), optimized_packages)
+        is_marked_as_side_effect_free(self.ident().path(), side_effect_free_packages)
     }
 }
 
@@ -152,7 +152,7 @@ impl Issue for SideEffectsInPackageJsonIssue {
 #[turbo_tasks::function]
 pub async fn is_marked_as_side_effect_free(
     path: Vc<FileSystemPath>,
-    optimized_packages: Vc<Vec<String>>,
+    side_effect_free_packages: Vc<Vec<String>>,
 ) -> Result<Vc<bool>> {
     let find_package_json: turbo_tasks::ReadRef<FindContextFileResult> =
         find_context_file(path.parent(), package_json()).await?;

--- a/crates/turbopack-ecmascript/src/chunk/placeable.rs
+++ b/crates/turbopack-ecmascript/src/chunk/placeable.rs
@@ -23,7 +23,7 @@ pub trait EcmascriptChunkPlaceable: ChunkableModule + Module + Asset {
     }
     fn is_marked_as_side_effect_free(
         self: Vc<Self>,
-        side_effect_free_packages: Vc<Vec<String>>,
+        side_effect_free_packages: Vc<Glob>,
     ) -> Vc<bool> {
         is_marked_as_side_effect_free(self.ident().path(), side_effect_free_packages)
     }
@@ -39,7 +39,7 @@ enum SideEffectsValue {
 #[turbo_tasks::function]
 async fn side_effects_from_package_json(
     package_json: Vc<FileSystemPath>,
-    side_effect_free_packages: Vc<Vec<String>>,
+    side_effect_free_packages: Vc<Glob>,
 ) -> Result<Vc<SideEffectsValue>> {
     if let FileJsonContent::Content(content) = &*package_json.read_json().await? {
         if let Some(pacakge_name) = content.get("name").and_then(|v| v.as_str()) {
@@ -163,7 +163,7 @@ impl Issue for SideEffectsInPackageJsonIssue {
 #[turbo_tasks::function]
 pub async fn is_marked_as_side_effect_free(
     path: Vc<FileSystemPath>,
-    side_effect_free_packages: Vc<Vec<String>>,
+    side_effect_free_packages: Vc<Glob>,
 ) -> Result<Vc<bool>> {
     let find_package_json: turbo_tasks::ReadRef<FindContextFileResult> =
         find_context_file(path.parent(), package_json()).await?;

--- a/crates/turbopack-ecmascript/src/chunk/placeable.rs
+++ b/crates/turbopack-ecmascript/src/chunk/placeable.rs
@@ -45,7 +45,8 @@ async fn side_effects_from_package_json(
         if let Some(pacakge_name) = content.get("name").and_then(|v| v.as_str()) {
             if side_effect_free_packages
                 .await?
-                .contains(&pacakge_name.to_string())
+                .iter()
+                .any(|v| pacakge_name == v)
             {
                 return Ok(SideEffectsValue::Constant(false).cell());
             }

--- a/crates/turbopack-ecmascript/src/references/esm/export.rs
+++ b/crates/turbopack-ecmascript/src/references/esm/export.rs
@@ -145,7 +145,7 @@ async fn handle_declared_export(
     module: Vc<Box<dyn EcmascriptChunkPlaceable>>,
     export_name: String,
     export: &EsmExport,
-    side_effect_free_packages: Vc<Vec<String>>,
+    side_effect_free_packages: Vc<Glob>,
 ) -> Result<ControlFlow<FollowExportsResult, (Vc<Box<dyn EcmascriptChunkPlaceable>>, String)>> {
     match export {
         EsmExport::ImportedBinding(reference, name) => {

--- a/crates/turbopack-ecmascript/src/references/esm/export.rs
+++ b/crates/turbopack-ecmascript/src/references/esm/export.rs
@@ -62,8 +62,23 @@ pub struct FollowExportsResult {
 pub async fn follow_reexports(
     module: Vc<Box<dyn EcmascriptChunkPlaceable>>,
     export_name: String,
+    optimized_packages: Vc<Vec<String>>,
+) -> Vc<FollowExportsResult> {
+    follow_reexports_internal(module, export_name, true, optimized_packages)
+}
+
+#[turbo_tasks::function]
+pub async fn follow_reexports_internal(
+    mut module: Vc<Box<dyn EcmascriptChunkPlaceable>>,
+    mut export_name: String,
+    stop_on_side_effects: bool,
+    optimized_packages: Vc<Vec<String>>,
 ) -> Result<Vc<FollowExportsResult>> {
-    if !*module.is_marked_as_side_effect_free().await? {
+    if stop_on_side_effects
+        && !*module
+            .is_marked_as_side_effect_free(optimized_packages)
+            .await?
+    {
         return Ok(FollowExportsResult::cell(FollowExportsResult {
             module,
             export_name: Some(export_name),
@@ -83,9 +98,16 @@ pub async fn follow_reexports(
         };
 
         // Try to find the export in the local exports
-        let exports_ref = exports.await?;
-        if let Some(export) = exports_ref.exports.get(&export_name) {
-            match handle_declared_export(module, export_name, export).await? {
+        if let Some(export) = exports.exports.get(&export_name) {
+            match handle_declared_export(
+                module,
+                export_name,
+                export,
+                stop_on_side_effects,
+                optimized_packages,
+            )
+            .await?
+            {
                 ControlFlow::Continue((m, n)) => {
                     module = m;
                     export_name = n;
@@ -98,32 +120,15 @@ pub async fn follow_reexports(
         }
 
         // Try to find the export in the star exports
-        if !exports_ref.star_exports.is_empty() && export_name != "default" {
-            let result = get_all_export_names(module).await?;
-            if let Some(m) = result.esm_exports.get(&export_name) {
-                module = *m;
-                continue;
-            }
-            return match &result.dynamic_exporting_modules[..] {
-                [] => Ok(FollowExportsResult {
-                    module,
-                    export_name: Some(export_name),
-                    ty: FoundExportType::NotFound,
-                }
-                .cell()),
-                [module] => Ok(FollowExportsResult {
-                    module: *module,
-                    export_name: Some(export_name),
-                    ty: FoundExportType::Dynamic,
-                }
-                .cell()),
-                _ => Ok(FollowExportsResult {
-                    module,
-                    export_name: Some(export_name),
-                    ty: FoundExportType::Dynamic,
-                }
-                .cell()),
-            };
+        if export_name != "default" {
+            return handle_star_reexports(
+                module,
+                export_name,
+                &exports.star_exports,
+                stop_on_side_effects,
+                optimized_packages,
+            )
+            .await;
         }
 
         return Ok(FollowExportsResult::cell(FollowExportsResult {
@@ -138,13 +143,19 @@ async fn handle_declared_export(
     module: Vc<Box<dyn EcmascriptChunkPlaceable>>,
     export_name: String,
     export: &EsmExport,
+    stop_on_side_effects: bool,
+    optimized_packages: Vc<Vec<String>>,
 ) -> Result<ControlFlow<FollowExportsResult, (Vc<Box<dyn EcmascriptChunkPlaceable>>, String)>> {
     match export {
         EsmExport::ImportedBinding(reference, name) => {
             if let ReferencedAsset::Some(module) =
                 *ReferencedAsset::from_resolve_result(reference.resolve_reference()).await?
             {
-                if !*module.is_marked_as_side_effect_free().await? {
+                if stop_on_side_effects
+                    && !*module
+                        .is_marked_as_side_effect_free(optimized_packages)
+                        .await?
+                {
                     return Ok(ControlFlow::Break(FollowExportsResult {
                         module,
                         export_name: Some(name.to_string()),
@@ -196,12 +207,48 @@ struct AllExportNamesResult {
 #[turbo_tasks::function]
 async fn get_all_export_names(
     module: Vc<Box<dyn EcmascriptChunkPlaceable>>,
-) -> Result<Vc<AllExportNamesResult>> {
-    let exports = module.get_exports().await?;
-    let EcmascriptExports::EsmExports(exports) = &*exports else {
-        return Ok(AllExportNamesResult {
-            esm_exports: IndexMap::new(),
-            dynamic_exporting_modules: vec![module],
+    export_name: String,
+    star_exports: &[Vc<Box<dyn ModuleReference>>],
+    stop_on_side_effects: bool,
+    optimized_packages: Vc<Vec<String>>,
+) -> Result<Vc<FollowExportsResult>> {
+    let mut potential_modules = Vec::new();
+    for star_export in star_exports {
+        if let ReferencedAsset::Some(m) =
+            *ReferencedAsset::from_resolve_result(star_export.resolve_reference()).await?
+        {
+            let result =
+                follow_reexports_internal(m, export_name.clone(), false, optimized_packages);
+            let result_ref = result.await?;
+            match result_ref.ty {
+                FoundExportType::Found => {
+                    if stop_on_side_effects {
+                        return Ok(follow_reexports(m, export_name.clone(), optimized_packages));
+                    } else {
+                        return Ok(result);
+                    }
+                }
+                FoundExportType::SideEffects => {
+                    unreachable!();
+                }
+                FoundExportType::Dynamic => {
+                    potential_modules.push(result);
+                }
+                FoundExportType::NotFound => {}
+                FoundExportType::Unknown => {
+                    return Ok(FollowExportsResult::cell(FollowExportsResult {
+                        module,
+                        export_name: Some(export_name),
+                        ty: FoundExportType::Unknown,
+                    }));
+                }
+            }
+        } else {
+            return Ok(FollowExportsResult::cell(FollowExportsResult {
+                module,
+                export_name: Some(export_name),
+                ty: FoundExportType::Unknown,
+            }));
         }
         .cell());
     };

--- a/crates/turbopack-ecmascript/src/references/esm/export.rs
+++ b/crates/turbopack-ecmascript/src/references/esm/export.rs
@@ -62,23 +62,8 @@ pub struct FollowExportsResult {
 pub async fn follow_reexports(
     module: Vc<Box<dyn EcmascriptChunkPlaceable>>,
     export_name: String,
-    side_effect_free_packages: Vc<Vec<String>>,
-) -> Vc<FollowExportsResult> {
-    follow_reexports_internal(module, export_name, true, side_effect_free_packages)
-}
-
-#[turbo_tasks::function]
-pub async fn follow_reexports_internal(
-    mut module: Vc<Box<dyn EcmascriptChunkPlaceable>>,
-    mut export_name: String,
-    stop_on_side_effects: bool,
-    side_effect_free_packages: Vc<Vec<String>>,
 ) -> Result<Vc<FollowExportsResult>> {
-    if stop_on_side_effects
-        && !*module
-            .is_marked_as_side_effect_free(side_effect_free_packages)
-            .await?
-    {
+    if !*module.is_marked_as_side_effect_free().await? {
         return Ok(FollowExportsResult::cell(FollowExportsResult {
             module,
             export_name: Some(export_name),
@@ -98,16 +83,9 @@ pub async fn follow_reexports_internal(
         };
 
         // Try to find the export in the local exports
-        if let Some(export) = exports.exports.get(&export_name) {
-            match handle_declared_export(
-                module,
-                export_name,
-                export,
-                stop_on_side_effects,
-                side_effect_free_packages,
-            )
-            .await?
-            {
+        let exports_ref = exports.await?;
+        if let Some(export) = exports_ref.exports.get(&export_name) {
+            match handle_declared_export(module, export_name, export).await? {
                 ControlFlow::Continue((m, n)) => {
                     module = m;
                     export_name = n;
@@ -120,15 +98,32 @@ pub async fn follow_reexports_internal(
         }
 
         // Try to find the export in the star exports
-        if export_name != "default" {
-            return handle_star_reexports(
-                module,
-                export_name,
-                &exports.star_exports,
-                stop_on_side_effects,
-                side_effect_free_packages,
-            )
-            .await;
+        if !exports_ref.star_exports.is_empty() && export_name != "default" {
+            let result = get_all_export_names(module).await?;
+            if let Some(m) = result.esm_exports.get(&export_name) {
+                module = *m;
+                continue;
+            }
+            return match &result.dynamic_exporting_modules[..] {
+                [] => Ok(FollowExportsResult {
+                    module,
+                    export_name: Some(export_name),
+                    ty: FoundExportType::NotFound,
+                }
+                .cell()),
+                [module] => Ok(FollowExportsResult {
+                    module: *module,
+                    export_name: Some(export_name),
+                    ty: FoundExportType::Dynamic,
+                }
+                .cell()),
+                _ => Ok(FollowExportsResult {
+                    module,
+                    export_name: Some(export_name),
+                    ty: FoundExportType::Dynamic,
+                }
+                .cell()),
+            };
         }
 
         return Ok(FollowExportsResult::cell(FollowExportsResult {
@@ -143,19 +138,13 @@ async fn handle_declared_export(
     module: Vc<Box<dyn EcmascriptChunkPlaceable>>,
     export_name: String,
     export: &EsmExport,
-    stop_on_side_effects: bool,
-    side_effect_free_packages: Vc<Vec<String>>,
 ) -> Result<ControlFlow<FollowExportsResult, (Vc<Box<dyn EcmascriptChunkPlaceable>>, String)>> {
     match export {
         EsmExport::ImportedBinding(reference, name) => {
             if let ReferencedAsset::Some(module) =
                 *ReferencedAsset::from_resolve_result(reference.resolve_reference()).await?
             {
-                if stop_on_side_effects
-                    && !*module
-                        .is_marked_as_side_effect_free(side_effect_free_packages)
-                        .await?
-                {
+                if !*module.is_marked_as_side_effect_free().await? {
                     return Ok(ControlFlow::Break(FollowExportsResult {
                         module,
                         export_name: Some(name.to_string()),
@@ -207,52 +196,12 @@ struct AllExportNamesResult {
 #[turbo_tasks::function]
 async fn get_all_export_names(
     module: Vc<Box<dyn EcmascriptChunkPlaceable>>,
-    export_name: String,
-    star_exports: &[Vc<Box<dyn ModuleReference>>],
-    stop_on_side_effects: bool,
-    side_effect_free_packages: Vc<Vec<String>>,
-) -> Result<Vc<FollowExportsResult>> {
-    let mut potential_modules = Vec::new();
-    for star_export in star_exports {
-        if let ReferencedAsset::Some(m) =
-            *ReferencedAsset::from_resolve_result(star_export.resolve_reference()).await?
-        {
-            let result =
-                follow_reexports_internal(m, export_name.clone(), false, side_effect_free_packages);
-            let result_ref = result.await?;
-            match result_ref.ty {
-                FoundExportType::Found => {
-                    if stop_on_side_effects {
-                        return Ok(follow_reexports(
-                            m,
-                            export_name.clone(),
-                            side_effect_free_packages,
-                        ));
-                    } else {
-                        return Ok(result);
-                    }
-                }
-                FoundExportType::SideEffects => {
-                    unreachable!();
-                }
-                FoundExportType::Dynamic => {
-                    potential_modules.push(result);
-                }
-                FoundExportType::NotFound => {}
-                FoundExportType::Unknown => {
-                    return Ok(FollowExportsResult::cell(FollowExportsResult {
-                        module,
-                        export_name: Some(export_name),
-                        ty: FoundExportType::Unknown,
-                    }));
-                }
-            }
-        } else {
-            return Ok(FollowExportsResult::cell(FollowExportsResult {
-                module,
-                export_name: Some(export_name),
-                ty: FoundExportType::Unknown,
-            }));
+) -> Result<Vc<AllExportNamesResult>> {
+    let exports = module.get_exports().await?;
+    let EcmascriptExports::EsmExports(exports) = &*exports else {
+        return Ok(AllExportNamesResult {
+            esm_exports: IndexMap::new(),
+            dynamic_exporting_modules: vec![module],
         }
         .cell());
     };

--- a/crates/turbopack-ecmascript/src/references/esm/export.rs
+++ b/crates/turbopack-ecmascript/src/references/esm/export.rs
@@ -15,6 +15,7 @@ use swc_core::{
     quote, quote_expr,
 };
 use turbo_tasks::{trace::TraceRawVcs, TryFlatJoinIterExt, ValueToString, Vc};
+use turbo_tasks_fs::glob::Glob;
 use turbopack_core::{
     ident::AssetIdent,
     issue::{analyze::AnalyzeIssue, IssueExt, IssueSeverity, StyledString},
@@ -62,7 +63,7 @@ pub struct FollowExportsResult {
 pub async fn follow_reexports(
     module: Vc<Box<dyn EcmascriptChunkPlaceable>>,
     export_name: String,
-    side_effect_free_packages: Vc<Vec<String>>,
+    side_effect_free_packages: Vc<Glob>,
 ) -> Result<Vc<FollowExportsResult>> {
     if !*module
         .is_marked_as_side_effect_free(side_effect_free_packages)

--- a/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
+++ b/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use anyhow::{bail, Context, Result};
 use turbo_tasks::Vc;
-use turbo_tasks_fs::{File, FileContent};
+use turbo_tasks_fs::{glob::Glob, File, FileContent};
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{ChunkableModule, ChunkingContext, EvaluatableAsset},
@@ -247,7 +247,7 @@ impl EcmascriptChunkPlaceable for EcmascriptModuleFacadeModule {
     #[turbo_tasks::function]
     async fn is_marked_as_side_effect_free(
         &self,
-        side_effect_free_packages: Vc<Vec<String>>,
+        side_effect_free_packages: Vc<Glob>,
     ) -> Result<Vc<bool>> {
         Ok(match *self.ty.await? {
             ModulePart::Evaluation | ModulePart::Facade => self

--- a/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
+++ b/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
@@ -245,11 +245,14 @@ impl EcmascriptChunkPlaceable for EcmascriptModuleFacadeModule {
     }
 
     #[turbo_tasks::function]
-    async fn is_marked_as_side_effect_free(&self) -> Result<Vc<bool>> {
+    async fn is_marked_as_side_effect_free(
+        &self,
+        optimized_packages: Vc<Vec<String>>,
+    ) -> Result<Vc<bool>> {
         Ok(match *self.ty.await? {
-            ModulePart::Evaluation | ModulePart::Facade => {
-                self.module.is_marked_as_side_effect_free()
-            }
+            ModulePart::Evaluation | ModulePart::Facade => self
+                .module
+                .is_marked_as_side_effect_free(optimized_packages),
             ModulePart::Exports
             | ModulePart::RenamedExport { .. }
             | ModulePart::RenamedNamespace { .. } => Vc::cell(true),

--- a/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
+++ b/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
@@ -247,12 +247,12 @@ impl EcmascriptChunkPlaceable for EcmascriptModuleFacadeModule {
     #[turbo_tasks::function]
     async fn is_marked_as_side_effect_free(
         &self,
-        optimized_packages: Vc<Vec<String>>,
+        side_effect_free_packages: Vc<Vec<String>>,
     ) -> Result<Vc<bool>> {
         Ok(match *self.ty.await? {
             ModulePart::Evaluation | ModulePart::Facade => self
                 .module
-                .is_marked_as_side_effect_free(optimized_packages),
+                .is_marked_as_side_effect_free(side_effect_free_packages),
             ModulePart::Exports
             | ModulePart::RenamedExport { .. }
             | ModulePart::RenamedNamespace { .. } => Vc::cell(true),

--- a/crates/turbopack-ecmascript/src/side_effect_optimization/locals/module.rs
+++ b/crates/turbopack-ecmascript/src/side_effect_optimization/locals/module.rs
@@ -94,9 +94,12 @@ impl EcmascriptChunkPlaceable for EcmascriptModuleLocalsModule {
     }
 
     #[turbo_tasks::function]
-    fn is_marked_as_side_effect_free(&self, optimized_packages: Vc<Vec<String>>) -> Vc<bool> {
+    fn is_marked_as_side_effect_free(
+        &self,
+        side_effect_free_packages: Vc<Vec<String>>,
+    ) -> Vc<bool> {
         self.module
-            .is_marked_as_side_effect_free(optimized_packages)
+            .is_marked_as_side_effect_free(side_effect_free_packages)
     }
 
     #[turbo_tasks::function]

--- a/crates/turbopack-ecmascript/src/side_effect_optimization/locals/module.rs
+++ b/crates/turbopack-ecmascript/src/side_effect_optimization/locals/module.rs
@@ -94,8 +94,9 @@ impl EcmascriptChunkPlaceable for EcmascriptModuleLocalsModule {
     }
 
     #[turbo_tasks::function]
-    fn is_marked_as_side_effect_free(&self) -> Vc<bool> {
-        self.module.is_marked_as_side_effect_free()
+    fn is_marked_as_side_effect_free(&self, optimized_packages: Vc<Vec<String>>) -> Vc<bool> {
+        self.module
+            .is_marked_as_side_effect_free(optimized_packages)
     }
 
     #[turbo_tasks::function]

--- a/crates/turbopack-ecmascript/src/side_effect_optimization/locals/module.rs
+++ b/crates/turbopack-ecmascript/src/side_effect_optimization/locals/module.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 
 use anyhow::{bail, Context, Result};
 use turbo_tasks::Vc;
+use turbo_tasks_fs::glob::Glob;
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{ChunkableModule, ChunkingContext},
@@ -94,10 +95,7 @@ impl EcmascriptChunkPlaceable for EcmascriptModuleLocalsModule {
     }
 
     #[turbo_tasks::function]
-    fn is_marked_as_side_effect_free(
-        &self,
-        side_effect_free_packages: Vc<Vec<String>>,
-    ) -> Vc<bool> {
+    fn is_marked_as_side_effect_free(&self, side_effect_free_packages: Vc<Glob>) -> Vc<bool> {
         self.module
             .is_marked_as_side_effect_free(side_effect_free_packages)
     }

--- a/crates/turbopack/src/lib.rs
+++ b/crates/turbopack/src/lib.rs
@@ -277,7 +277,7 @@ async fn apply_module_type(
 async fn apply_reexport_tree_shaking(
     module: Vc<Box<dyn EcmascriptChunkPlaceable>>,
     part: Vc<ModulePart>,
-    side_effect_free_packages: Vc<Vec<String>>,
+    side_effect_free_packages: Vc<Glob>,
 ) -> Result<Vc<Box<dyn Module>>> {
     if let ModulePart::Export(export) = *part.await? {
         let export = export.await?;
@@ -416,7 +416,7 @@ impl ModuleAssetContext {
         let mut globs = Vec::with_capacity(pkgs.len());
 
         for pkg in pkgs {
-            globs.push(Glob::parse(&format!("node_modules/{pkg}/**"))?);
+            globs.push(Glob::new(format!("node_modules/{pkg}/**")));
         }
 
         Ok(Glob::alternatives(globs))

--- a/crates/turbopack/src/lib.rs
+++ b/crates/turbopack/src/lib.rs
@@ -416,7 +416,7 @@ impl ModuleAssetContext {
         let mut globs = Vec::with_capacity(pkgs.len());
 
         for pkg in pkgs {
-            globs.push(Glob::new(format!("node_modules/{pkg}/**")));
+            globs.push(Glob::new(format!("**/node_modules/{{{}}}/**", pkg)));
         }
 
         Ok(Glob::alternatives(globs))

--- a/crates/turbopack/src/lib.rs
+++ b/crates/turbopack/src/lib.rs
@@ -171,11 +171,17 @@ async fn apply_module_type(
                         }
                     }
                     Some(TreeShakingMode::ReexportsOnly) => {
+                        let side_effect_free_packages =
+                            module_asset_context.side_effect_free_packages();
+
                         let module = builder.build();
                         if let Some(part) = part {
                             match *part.await? {
                                 ModulePart::Evaluation => {
-                                    if *module.is_marked_as_side_effect_free().await? {
+                                    if *module
+                                        .is_marked_as_side_effect_free(side_effect_free_packages)
+                                        .await?
+                                    {
                                         return Ok(ProcessResult::Ignore.cell());
                                     }
                                     if *module.get_exports().needs_facade().await? {
@@ -195,9 +201,14 @@ async fn apply_module_type(
                                                 ModulePart::exports(),
                                             )),
                                             part,
+                                            side_effect_free_packages,
                                         )
                                     } else {
-                                        apply_reexport_tree_shaking(Vc::upcast(module), part)
+                                        apply_reexport_tree_shaking(
+                                            Vc::upcast(module),
+                                            part,
+                                            side_effect_free_packages,
+                                        )
                                     }
                                 }
                                 _ => bail!(
@@ -266,6 +277,7 @@ async fn apply_module_type(
 async fn apply_reexport_tree_shaking(
     module: Vc<Box<dyn EcmascriptChunkPlaceable>>,
     part: Vc<ModulePart>,
+    side_effect_free_packages: Vc<Vec<String>>,
 ) -> Result<Vc<Box<dyn Module>>> {
     if let ModulePart::Export(export) = *part.await? {
         let export = export.await?;
@@ -273,7 +285,7 @@ async fn apply_reexport_tree_shaking(
             module: final_module,
             export_name: new_export,
             ..
-        } = &*follow_reexports(module, export.clone_value()).await?;
+        } = &*follow_reexports(module, export.clone_value(), side_effect_free_packages).await?;
         let module = if let Some(new_export) = new_export {
             if *new_export == *export {
                 Vc::upcast(*final_module)
@@ -390,6 +402,15 @@ impl ModuleAssetContext {
         reference_type: Value<ReferenceType>,
     ) -> Vc<ProcessResult> {
         process_default(self, source, reference_type, Vec::new())
+    }
+
+    #[turbo_tasks::function]
+    pub async fn side_effect_free_packages(self: Vc<Self>) -> Result<Vc<Vec<String>>> {
+        Ok(self
+            .await?
+            .module_options_context
+            .await?
+            .side_effect_free_packages)
     }
 }
 

--- a/crates/turbopack/src/module_options/module_options_context.rs
+++ b/crates/turbopack/src/module_options/module_options_context.rs
@@ -159,6 +159,8 @@ pub struct ModuleOptionsContext {
     pub ignore_dynamic_requests: bool,
 
     pub use_swc_css: bool,
+
+    pub side_effect_free_packages: Vc<Vec<String>>,
 }
 
 #[turbo_tasks::value_impl]


### PR DESCRIPTION
### Description

This is required to support `experimental.optimizePackageImports` of `next.config.js`.

next.js counterpart: https://github.com/vercel/next.js/pull/63268

Closes PACK-2527

### Testing Instructions

Look at the test case I added to https://github.com/vercel/next.js/pull/63268