### PR TITLE
feat: add ability to forward input to tasks

### DIFF
--- a/crates/turborepo-lib/src/process/child.rs
+++ b/crates/turborepo-lib/src/process/child.rs
@@ -881,6 +881,7 @@ mod test {
         let script = find_script_dir().join_component("hello_world.js");
         let mut cmd = Command::new("node");
         cmd.args([script.as_std_path()]);
+        cmd.open_stdin();
         let mut child = Child::spawn(cmd, ShutdownStyle::Kill, use_pty).unwrap();
 
         tokio::time::sleep(STARTUP_DELAY).await;
@@ -1085,6 +1086,7 @@ mod test {
         let script = find_script_dir().join_component("hello_world.js");
         let mut cmd = Command::new("node");
         cmd.args([script.as_std_path()]);
+        cmd.open_stdin();
         let mut child = Child::spawn(cmd, ShutdownStyle::Kill, use_pty).unwrap();
 
         let mut out = Vec::new();
@@ -1106,6 +1108,7 @@ mod test {
         let script = find_script_dir().join_component("hello_world_hello_moon.js");
         let mut cmd = Command::new("node");
         cmd.args([script.as_std_path()]);
+        cmd.open_stdin();
         let mut child = Child::spawn(cmd, ShutdownStyle::Kill, use_pty).unwrap();
 
         let mut buffer = Vec::new();
@@ -1129,6 +1132,7 @@ mod test {
         let script = find_script_dir().join_component("hello_non_utf8.js");
         let mut cmd = Command::new("node");
         cmd.args([script.as_std_path()]);
+        cmd.open_stdin();
         let mut child = Child::spawn(cmd, ShutdownStyle::Kill, use_pty).unwrap();
 
         let mut out = Vec::new();
@@ -1149,6 +1153,7 @@ mod test {
         let script = find_script_dir().join_component("hello_no_line.js");
         let mut cmd = Command::new("node");
         cmd.args([script.as_std_path()]);
+        cmd.open_stdin();
         let mut child = Child::spawn(cmd, ShutdownStyle::Kill, use_pty).unwrap();
 
         let mut out = Vec::new();

--- a/crates/turborepo-lib/src/process/child.rs
+++ b/crates/turborepo-lib/src/process/child.rs
@@ -161,26 +161,6 @@ impl ChildHandle {
         let controller = pair.master;
         let receiver = pair.slave;
 
-        #[cfg(unix)]
-        {
-            use nix::sys::termios;
-            if let Some((file_desc, mut termios)) = controller
-                .as_raw_fd()
-                .and_then(|fd| Some(fd).zip(termios::tcgetattr(fd).ok()))
-            {
-                // We unset ECHOCTL to disable rendering of the closing of stdin
-                // as ^D
-                termios.local_flags &= !nix::sys::termios::LocalFlags::ECHOCTL;
-                if let Err(e) = nix::sys::termios::tcsetattr(
-                    file_desc,
-                    nix::sys::termios::SetArg::TCSANOW,
-                    &termios,
-                ) {
-                    debug!("unable to unset ECHOCTL: {e}");
-                }
-            }
-        }
-
         let child = receiver
             .spawn_command(command)
             .map_err(|err| match err.downcast() {

--- a/crates/turborepo-lib/src/task_graph/visitor.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor.rs
@@ -918,6 +918,9 @@ impl ExecContext {
         if self.experimental_ui {
             if let TaskOutput::UI(task) = output_client {
                 task.start();
+                if let Some(stdin) = process.stdin() {
+                    task.set_stdin(stdin);
+                }
             }
         }
 

--- a/crates/turborepo-ui/src/tui/event.rs
+++ b/crates/turborepo-ui/src/tui/event.rs
@@ -1,13 +1,30 @@
-#[derive(Debug, Clone)]
 pub enum Event {
-    StartTask { task: String },
-    TaskOutput { task: String, output: Vec<u8> },
-    EndTask { task: String },
+    StartTask {
+        task: String,
+    },
+    TaskOutput {
+        task: String,
+        output: Vec<u8>,
+    },
+    EndTask {
+        task: String,
+    },
     Stop,
     Tick,
-    Log { message: Vec<u8> },
+    Log {
+        message: Vec<u8>,
+    },
     Up,
     Down,
+    SetStdin {
+        task: String,
+        stdin: Box<dyn std::io::Write + Send>,
+    },
+    EnterInteractive,
+    ExitInteractive,
+    Input {
+        bytes: Vec<u8>,
+    },
 }
 
 #[cfg(test)]
@@ -15,8 +32,8 @@ mod test {
     use super::*;
 
     #[test]
-    fn assert_event_sync_send() {
-        fn send_sync<T: Send + Sync>() {}
+    fn assert_event_send() {
+        fn send_sync<T: Send>() {}
         send_sync::<Event>();
     }
 }

--- a/crates/turborepo-ui/src/tui/handle.rs
+++ b/crates/turborepo-ui/src/tui/handle.rs
@@ -114,6 +114,16 @@ impl TuiTask {
         self.logs.lock().expect("logs lock poisoned").clone()
     }
 
+    pub fn set_stdin(&self, stdin: Box<dyn std::io::Write + Send>) {
+        self.handle
+            .primary
+            .send(Event::SetStdin {
+                task: self.name.clone(),
+                stdin,
+            })
+            .ok();
+    }
+
     /// Return a `PersistedWriter` which will properly write provided bytes to
     /// a persisted section of the terminal.
     ///

--- a/crates/turborepo-ui/src/tui/input.rs
+++ b/crates/turborepo-ui/src/tui/input.rs
@@ -133,9 +133,6 @@ fn encode_key(key: KeyEvent) -> Vec<u8> {
                 buf.push(0x1b as char);
             }
             buf.push(c);
-            if code == Enter {
-                buf.push('\n');
-            }
         }
 
         Tab => {
@@ -181,7 +178,7 @@ fn encode_key(key: KeyEvent) -> Vec<u8> {
                 buf.push_str(&(1 + encode_modifiers(mods)).to_string());
                 buf.push(c);
             } else {
-                buf.push_str("\x1b[1;");
+                buf.push_str("\x1b[");
                 buf.push(c);
             }
         }

--- a/crates/turborepo-ui/src/tui/input.rs
+++ b/crates/turborepo-ui/src/tui/input.rs
@@ -1,16 +1,16 @@
 use std::time::Duration;
 
-use crossterm::event::KeyEvent;
+use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 
 use super::{event::Event, Error};
 
 /// Return any immediately available event
-pub fn input() -> Result<Option<Event>, Error> {
+pub fn input(interact: bool) -> Result<Option<Event>, Error> {
     // poll with 0 duration will only return true if event::read won't need to wait
     // for input
     if crossterm::event::poll(Duration::from_millis(0))? {
         if let crossterm::event::Event::Key(k) = crossterm::event::read()? {
-            Ok(translate_key_event(k))
+            Ok(translate_key_event(interact, k))
         } else {
             Ok(None)
         }
@@ -20,16 +20,23 @@ pub fn input() -> Result<Option<Event>, Error> {
 }
 
 /// Converts a crostterm key event into a TUI interaction event
-fn translate_key_event(key_event: KeyEvent) -> Option<Event> {
+fn translate_key_event(interact: bool, key_event: KeyEvent) -> Option<Event> {
     match key_event.code {
-        crossterm::event::KeyCode::Up => Some(Event::Up),
-        crossterm::event::KeyCode::Down => Some(Event::Down),
-        // TODO: we should send a ourselves a SIGINT/CtrlC event
-        crossterm::event::KeyCode::Char('c')
-            if key_event.modifiers == crossterm::event::KeyModifiers::CONTROL =>
-        {
+        KeyCode::Char('c') if key_event.modifiers == crossterm::event::KeyModifiers::CONTROL => {
             ctrl_c()
         }
+        // Interactive branches
+        KeyCode::Char('z') if key_event.modifiers == crossterm::event::KeyModifiers::CONTROL => {
+            Some(Event::ExitInteractive)
+        }
+        // If we're in interactive mode, convert the key event to bytes to send to stdin
+        _ if interact => Some(Event::Input {
+            bytes: encode_key(key_event),
+        }),
+        // Fall through if we aren't in interactive mode
+        KeyCode::Up => Some(Event::Up),
+        KeyCode::Down => Some(Event::Down),
+        KeyCode::Enter => Some(Event::EnterInteractive),
         _ => None,
     }
 }
@@ -66,4 +73,271 @@ fn ctrl_c() -> Option<Event> {
         // We're unable to send the Ctrl-C event, stop rendering to force shutdown
         Some(Event::Stop)
     }
+}
+
+// Inspired by mprocs encode_term module
+// https://github.com/pvolok/mprocs/blob/08d17adebd110501106f86124ef1955fb2beb881/src/encode_term.rs
+fn encode_key(key: KeyEvent) -> Vec<u8> {
+    use crossterm::event::KeyCode::*;
+
+    if key.kind == KeyEventKind::Release {
+        return Vec::new();
+    }
+
+    let code = key.code;
+    let mods = key.modifiers;
+
+    let mut buf = String::new();
+
+    let code = normalize_shift_to_upper_case(code, &mods);
+
+    // Normalize Backspace and Delete
+    let code = match code {
+        Char('\x7f') => KeyCode::Backspace,
+        Char('\x08') => KeyCode::Delete,
+        c => c,
+    };
+
+    match code {
+        Char(c) if mods.contains(KeyModifiers::CONTROL) && ctrl_mapping(c).is_some() => {
+            let c = ctrl_mapping(c).unwrap();
+            if mods.contains(KeyModifiers::ALT) {
+                buf.push(0x1b as char);
+            }
+            buf.push(c);
+        }
+
+        // When alt is pressed, send escape first to indicate to the peer that
+        // ALT is pressed.  We do this only for ascii alnum characters because
+        // eg: on macOS generates altgr style glyphs and keeps the ALT key
+        // in the modifier set.  This confuses eg: zsh which then just displays
+        // <fffffffff> as the input, so we want to avoid that.
+        Char(c)
+            if (c.is_ascii_alphanumeric() || c.is_ascii_punctuation())
+                && mods.contains(KeyModifiers::ALT) =>
+        {
+            buf.push(0x1b as char);
+            buf.push(c);
+        }
+
+        Enter | Esc | Backspace => {
+            let c = match code {
+                Enter => '\r',
+                Esc => '\x1b',
+                // Backspace sends the default VERASE which is confusingly
+                // the DEL ascii codepoint
+                Backspace => '\x7f',
+                _ => unreachable!(),
+            };
+            if mods.contains(KeyModifiers::ALT) {
+                buf.push(0x1b as char);
+            }
+            buf.push(c);
+            if code == Enter {
+                buf.push('\n');
+            }
+        }
+
+        Tab => {
+            if mods.contains(KeyModifiers::ALT) {
+                buf.push(0x1b as char);
+            }
+            let mods = mods & !KeyModifiers::ALT;
+            if mods == KeyModifiers::CONTROL {
+                buf.push_str("\x1b[9;5u");
+            } else if mods == KeyModifiers::CONTROL | KeyModifiers::SHIFT {
+                buf.push_str("\x1b[1;5Z");
+            } else if mods == KeyModifiers::SHIFT {
+                buf.push_str("\x1b[Z");
+            } else {
+                buf.push('\t');
+            }
+        }
+
+        BackTab => {
+            buf.push_str("\x1b[Z");
+        }
+
+        Char(c) => {
+            buf.push(c);
+        }
+
+        Home | End | Up | Down | Right | Left => {
+            let c = match code {
+                Up => 'A',
+                Down => 'B',
+                Right => 'C',
+                Left => 'D',
+                Home => 'H',
+                End => 'F',
+                _ => unreachable!(),
+            };
+
+            if mods.contains(KeyModifiers::ALT)
+                || mods.contains(KeyModifiers::SHIFT)
+                || mods.contains(KeyModifiers::CONTROL)
+            {
+                buf.push_str("\x1b[1;");
+                buf.push_str(&(1 + encode_modifiers(mods)).to_string());
+                buf.push(c);
+            } else {
+                buf.push_str("\x1b[1;");
+                buf.push(c);
+            }
+        }
+
+        PageUp | PageDown | Insert | Delete => {
+            let c = match code {
+                Insert => '2',
+                Delete => '3',
+                PageUp => '5',
+                PageDown => '6',
+                _ => unreachable!(),
+            };
+
+            if mods.contains(KeyModifiers::ALT)
+                || mods.contains(KeyModifiers::SHIFT)
+                || mods.contains(KeyModifiers::CONTROL)
+            {
+                buf.push_str("\x1b[");
+                buf.push(c);
+                buf.push_str(&(1 + encode_modifiers(mods)).to_string());
+            } else {
+                buf.push_str("\x1b[");
+                buf.push(c);
+                buf.push('~');
+            }
+        }
+
+        F(n) => {
+            if mods.is_empty() && n < 5 {
+                // F1-F4 are encoded using SS3 if there are no modifiers
+                let s = match n {
+                    1 => "\x1bOP",
+                    2 => "\x1bOQ",
+                    3 => "\x1bOR",
+                    4 => "\x1bOS",
+                    _ => unreachable!("wat?"),
+                };
+                buf.push_str(s);
+            } else {
+                // Higher numbered F-keys plus modified F-keys are encoded
+                // using CSI instead of SS3.
+                let intro = match n {
+                    1 => "\x1b[11",
+                    2 => "\x1b[12",
+                    3 => "\x1b[13",
+                    4 => "\x1b[14",
+                    5 => "\x1b[15",
+                    6 => "\x1b[17",
+                    7 => "\x1b[18",
+                    8 => "\x1b[19",
+                    9 => "\x1b[20",
+                    10 => "\x1b[21",
+                    11 => "\x1b[23",
+                    12 => "\x1b[24",
+                    _ => panic!("unhandled fkey number {}", n),
+                };
+                let encoded_mods = encode_modifiers(mods);
+                if encoded_mods == 0 {
+                    // If no modifiers are held, don't send the modifier
+                    // sequence, as the modifier encoding is a CSI-u extension.
+                    buf.push_str(intro);
+                    buf.push('~');
+                } else {
+                    buf.push_str(intro);
+                    buf.push(';');
+                    buf.push_str(&(1 + encoded_mods).to_string());
+                    buf.push('~');
+                }
+            }
+        }
+
+        Null => (),
+        CapsLock => (),
+        ScrollLock => (),
+        NumLock => (),
+        PrintScreen => (),
+        Pause => (),
+        Menu => (),
+        KeypadBegin => (),
+        Media(_) => (),
+        Modifier(_) => (),
+    };
+
+    buf.into_bytes()
+}
+
+/// Map c to its Ctrl equivalent.
+/// In theory, this mapping is simply translating alpha characters
+/// to upper case and then masking them by 0x1f, but xterm inherits
+/// some built-in translation from legacy X11 so that are some
+/// aliased mappings and a couple that might be technically tied
+/// to US keyboard layout (particularly the punctuation characters
+/// produced in combination with SHIFT) that may not be 100%
+/// the right thing to do here for users with non-US layouts.
+fn ctrl_mapping(c: char) -> Option<char> {
+    Some(match c {
+        '@' | '`' | ' ' | '2' => '\x00',
+        'A' | 'a' => '\x01',
+        'B' | 'b' => '\x02',
+        'C' | 'c' => '\x03',
+        'D' | 'd' => '\x04',
+        'E' | 'e' => '\x05',
+        'F' | 'f' => '\x06',
+        'G' | 'g' => '\x07',
+        'H' | 'h' => '\x08',
+        'I' | 'i' => '\x09',
+        'J' | 'j' => '\x0a',
+        'K' | 'k' => '\x0b',
+        'L' | 'l' => '\x0c',
+        'M' | 'm' => '\x0d',
+        'N' | 'n' => '\x0e',
+        'O' | 'o' => '\x0f',
+        'P' | 'p' => '\x10',
+        'Q' | 'q' => '\x11',
+        'R' | 'r' => '\x12',
+        'S' | 's' => '\x13',
+        'T' | 't' => '\x14',
+        'U' | 'u' => '\x15',
+        'V' | 'v' => '\x16',
+        'W' | 'w' => '\x17',
+        'X' | 'x' => '\x18',
+        'Y' | 'y' => '\x19',
+        'Z' | 'z' => '\x1a',
+        '[' | '3' | '{' => '\x1b',
+        '\\' | '4' | '|' => '\x1c',
+        ']' | '5' | '}' => '\x1d',
+        '^' | '6' | '~' => '\x1e',
+        '_' | '7' | '/' => '\x1f',
+        '8' | '?' => '\x7f', // `Delete`
+        _ => return None,
+    })
+}
+
+/// if SHIFT is held and we have KeyCode::Char('c') we want to normalize
+/// that keycode to KeyCode::Char('C'); that is what this function does.
+pub fn normalize_shift_to_upper_case(code: KeyCode, modifiers: &KeyModifiers) -> KeyCode {
+    if modifiers.contains(KeyModifiers::SHIFT) {
+        match code {
+            KeyCode::Char(c) if c.is_ascii_lowercase() => KeyCode::Char(c.to_ascii_uppercase()),
+            _ => code,
+        }
+    } else {
+        code
+    }
+}
+
+fn encode_modifiers(mods: KeyModifiers) -> u8 {
+    let mut number = 0;
+    if mods.contains(KeyModifiers::SHIFT) {
+        number |= 1;
+    }
+    if mods.contains(KeyModifiers::ALT) {
+        number |= 2;
+    }
+    if mods.contains(KeyModifiers::CONTROL) {
+        number |= 4;
+    }
+    number
 }

--- a/crates/turborepo-ui/src/tui/input.rs
+++ b/crates/turborepo-ui/src/tui/input.rs
@@ -26,7 +26,9 @@ fn translate_key_event(interact: bool, key_event: KeyEvent) -> Option<Event> {
             ctrl_c()
         }
         // Interactive branches
-        KeyCode::Char('z') if key_event.modifiers == crossterm::event::KeyModifiers::CONTROL => {
+        KeyCode::Char('z')
+            if interact && key_event.modifiers == crossterm::event::KeyModifiers::CONTROL =>
+        {
             Some(Event::ExitInteractive)
         }
         // If we're in interactive mode, convert the key event to bytes to send to stdin


### PR DESCRIPTION
### Description

Add ability to forward input to tasks: `Enter` will start forwarding input and `Ctrl-Z` will stop forwarding input to the selected task.

There are definitely gaps in our input forwarding, but for basic text and standard keys such as arrow keys we should do the right thing. Hopefully users do not require handling `Ctrl-Alt-Home` being correctly forwarded to the underlying tasks.

This PR does not add the ability to configure non-persistent tasks to take input

### Testing Instructions

Test it out with persistent tasks e.g. `with-vite` example

https://github.com/vercel/turbo/assets/4131117/abf2263b-cbf2-44d7-9440-1c11c0e28808




Closes TURBO-2639