### PR TITLE
feat(tui) proper ctrl c

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11898,6 +11898,7 @@ dependencies = [
  "indicatif",
  "indoc",
  "lazy_static",
+ "nix 0.26.2",
  "ratatui",
  "tempfile",
  "test-case",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11907,6 +11907,7 @@ dependencies = [
  "tui-term",
  "turbopath",
  "turborepo-ci",
+ "winapi 0.3.9",
 ]
 
 [[package]]

--- a/crates/turborepo-ui/Cargo.toml
+++ b/crates/turborepo-ui/Cargo.toml
@@ -21,6 +21,7 @@ crossterm = "0.26.1"
 dialoguer.workspace = true
 indicatif = { workspace = true }
 lazy_static = { workspace = true }
+nix = { version = "0.26.2", features = ["signal"] }
 ratatui = "0.26.1"
 thiserror = { workspace = true }
 tracing = { workspace = true }

--- a/crates/turborepo-ui/Cargo.toml
+++ b/crates/turborepo-ui/Cargo.toml
@@ -28,3 +28,4 @@ tracing = { workspace = true }
 tui-term = "0.1.8"
 turbopath = { workspace = true }
 turborepo-ci = { workspace = true }
+winapi = "0.3.9"

--- a/crates/turborepo-ui/src/tui/input.rs
+++ b/crates/turborepo-ui/src/tui/input.rs
@@ -28,8 +28,24 @@ fn translate_key_event(key_event: KeyEvent) -> Option<Event> {
         crossterm::event::KeyCode::Char('c')
             if key_event.modifiers == crossterm::event::KeyModifiers::CONTROL =>
         {
-            Some(Event::Stop)
+            ctrl_c()
         }
         _ => None,
     }
+}
+
+#[cfg(unix)]
+fn ctrl_c() -> Option<Event> {
+    use nix::sys::signal;
+    match signal::raise(signal::SIGINT) {
+        Ok(_) => None,
+        // We're unable to send the signal, stop rendering to force shutdown
+        Err(_) => Some(Event::Stop),
+    }
+}
+
+#[cfg(windows)]
+fn ctrl_c() -> Option<Event> {
+    // TODO: properly send Ctrl-C event to console
+    Some(Event::Stop)
 }


### PR DESCRIPTION
### Description

Proper handling of a user hitting `Ctrl-C`

Since we have [ISIG](https://man7.org/linux/man-pages/man3/termios.3.html) flagged off we are in charge of generating a SIGINT when Ctrl-C is pressed.
 - On unix we use [raise](https://man7.org/linux/man-pages/man3/raise.3.html) to send `SIGINT` to `turbo`
 - On Windows we use [GenerateConsoleCtrlEvent](https://learn.microsoft.com/en-us/windows/console/generateconsolectrlevent) to trigger the CtrlC handler [we set here](https://github.com/vercel/turbo/blob/main/crates/turborepo-lib/src/commands/run.rs#L8)

### Testing Instructions

Start up a run of turbo with `TURBO_EXPERIMENTAL_UI=true` and verify that `Ctrl-C` stops execution. It should display the same as if a `SIGINT` was sent to `turbo` via `kill`


Closes TURBO-2640