### PR TITLE
feat: support apple git in scan diagnostic

### DIFF
--- a/crates/turborepo-lib/src/diagnostics.rs
+++ b/crates/turborepo-lib/src/diagnostics.rs
@@ -189,6 +189,13 @@ impl Diagnostic for GitDaemonDiagnostic {
                         return;
                     };
 
+                    // attempt to split out the apple git suffix
+                    let version = if let Some((version, _)) = version.split_once(" (Apple") {
+                        version
+                    } else {
+                        version
+                    };
+
                     let Ok(version) = semver::Version::parse(version) else {
                         chan.failed("Failed to parse git version".to_string()).await;
                         return;


### PR DESCRIPTION
### Description

macOS can have either Apple git or regular git depending on source.
This PR adds support for the Apple git output format.


Closes TURBO-2646