### PR TITLE
make follow reexports more efficient

### DIFF
--- a/crates/turbopack-tests/tests/execution/turbopack/tree-shaking/side-effects/input/node_modules/package-star/index.js
+++ b/crates/turbopack-tests/tests/execution/turbopack/tree-shaking/side-effects/input/node_modules/package-star/index.js
@@ -4,7 +4,5 @@ export { notExecuted } from "./not-executed.js";
 export * from "./not-executed.js";
 export * from "./a.js";
 export * from "./b.js";
-export * from "./not-compiled.js";
-export * from "./not-existing.js";
 export const local = "local";
 


### PR DESCRIPTION
### Description

When accessing many exports of a barrel file with many `export *` it was a bit inefficient before since it was walking all star exports for every accessed export.

After this change it only creates a map of the star exports once and accessing every export only looks up the result in the map. This makes it 4 times more efficient for a file with 140 `export *`. Probably even more for bigger barrel files.

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->


Closes PACK-2747