### PR TITLE
feat(turbopack-ecmascript): cache external modules with wrapper

### DIFF
--- a/crates/turbopack-core/src/resolve/mod.rs
+++ b/crates/turbopack-core/src/resolve/mod.rs
@@ -11,7 +11,7 @@ use anyhow::{bail, Result};
 use indexmap::{indexmap, IndexMap, IndexSet};
 use serde::{Deserialize, Serialize};
 use tracing::{Instrument, Level};
-use turbo_tasks::{trace::TraceRawVcs, TryJoinIterExt, Value, ValueToString, Vc};
+use turbo_tasks::{trace::TraceRawVcs, TaskInput, TryJoinIterExt, Value, ValueToString, Vc};
 use turbo_tasks_fs::{
     util::{normalize_path, normalize_request},
     FileSystemEntryType, FileSystemPath, RealPathResult,
@@ -379,9 +379,8 @@ impl ModuleResolveResultOption {
     }
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, TraceRawVcs)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, TraceRawVcs, TaskInput)]
 pub enum ExternalType {
-    OriginalReference,
     Url,
     CommonJs,
     EcmaScriptModule,
@@ -390,7 +389,6 @@ pub enum ExternalType {
 impl Display for ExternalType {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            ExternalType::OriginalReference => write!(f, "original reference"),
             ExternalType::CommonJs => write!(f, "commonjs"),
             ExternalType::EcmaScriptModule => write!(f, "esm"),
             ExternalType::Url => write!(f, "url"),

--- a/crates/turbopack-ecmascript/src/chunk/chunk_type.rs
+++ b/crates/turbopack-ecmascript/src/chunk/chunk_type.rs
@@ -11,8 +11,8 @@ use super::{
     EcmascriptChunk, EcmascriptChunkContent, EcmascriptChunkItem, EcmascriptChunkingContext,
 };
 
-#[derive(Default)]
 #[turbo_tasks::value]
+#[derive(Default)]
 pub struct EcmascriptChunkType {}
 
 #[turbo_tasks::value_impl]

--- a/crates/turbopack-ecmascript/src/references/async_module.rs
+++ b/crates/turbopack-ecmascript/src/references/async_module.rs
@@ -15,9 +15,7 @@ use turbopack_core::{
 
 use super::esm::base::ReferencedAsset;
 use crate::{
-    chunk::{EcmascriptChunkPlaceable, EcmascriptChunkingContext},
-    code_gen::CodeGeneration,
-    create_visitor,
+    chunk::EcmascriptChunkingContext, code_gen::CodeGeneration, create_visitor,
     references::esm::base::insert_hoisted_stmt,
 };
 
@@ -47,7 +45,6 @@ impl OptionAsyncModuleOptions {
 /// level await statement or is referencing an external ESM module.
 #[turbo_tasks::value(shared)]
 pub struct AsyncModule {
-    pub placeable: Vc<Box<dyn EcmascriptChunkPlaceable>>,
     pub has_top_level_await: bool,
     pub import_externals: bool,
 }
@@ -116,10 +113,7 @@ impl AsyncModule {
                     return Ok(None);
                 };
                 Ok(match &*referenced_asset {
-                    ReferencedAsset::External(
-                        _,
-                        ExternalType::OriginalReference | ExternalType::EcmaScriptModule,
-                    ) => {
+                    ReferencedAsset::External(_, ExternalType::EcmaScriptModule) => {
                         if self.import_externals {
                             referenced_asset.get_ident().await?
                         } else {
@@ -168,10 +162,7 @@ impl AsyncModule {
                         };
                         Ok(matches!(
                             &*referenced_asset,
-                            ReferencedAsset::External(
-                                _,
-                                ExternalType::OriginalReference | ExternalType::EcmaScriptModule
-                            )
+                            ReferencedAsset::External(_, ExternalType::EcmaScriptModule)
                         ))
                     })
                     .try_join()

--- a/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -239,10 +239,7 @@ impl CodeGenerateable for EsmAssetReference {
                             insert_hoisted_stmt(program, stmt);
                         }));
                     }
-                    ReferencedAsset::External(
-                        request,
-                        ExternalType::OriginalReference | ExternalType::EcmaScriptModule,
-                    ) => {
+                    ReferencedAsset::External(request, ExternalType::EcmaScriptModule) => {
                         if !*chunking_context
                             .environment()
                             .supports_esm_externals()

--- a/crates/turbopack-ecmascript/src/references/esm/url.rs
+++ b/crates/turbopack-ecmascript/src/references/esm/url.rs
@@ -183,10 +183,7 @@ impl CodeGenerateable for UrlAssetReference {
                             }
                         }));
                     }
-                    ReferencedAsset::External(
-                        request,
-                        ExternalType::OriginalReference | ExternalType::Url,
-                    ) => {
+                    ReferencedAsset::External(request, ExternalType::Url) => {
                         let request = request.to_string();
                         visitors.push(create_visitor!(ast_path, visit_mut_expr(new_expr: &mut Expr) {
                             let should_rewrite_to_relative = if let Expr::New(NewExpr { args: Some(args), .. }) = new_expr {
@@ -275,10 +272,7 @@ impl CodeGenerateable for UrlAssetReference {
                             }
                         }));
                     }
-                    ReferencedAsset::External(
-                        request,
-                        ExternalType::OriginalReference | ExternalType::Url,
-                    ) => {
+                    ReferencedAsset::External(request, ExternalType::Url) => {
                         let request = request.to_string();
                         visitors.push(create_visitor!(ast_path, visit_mut_expr(new_expr: &mut Expr) {
                             if let Expr::New(NewExpr { args: Some(args), .. }) = new_expr {

--- a/crates/turbopack-ecmascript/src/references/external_module.rs
+++ b/crates/turbopack-ecmascript/src/references/external_module.rs
@@ -1,0 +1,248 @@
+use std::{fmt::Display, io::Write};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use turbo_tasks::{trace::TraceRawVcs, TaskInput, Vc};
+use turbo_tasks_fs::{glob::Glob, rope::RopeBuilder, FileContent, FileSystem, VirtualFileSystem};
+use turbopack_core::{
+    asset::{Asset, AssetContent},
+    chunk::{AsyncModuleInfo, ChunkItem, ChunkType, ChunkableModule, ChunkingContext},
+    ident::AssetIdent,
+    module::Module,
+    reference::ModuleReferences,
+};
+
+use crate::{
+    chunk::{
+        EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkPlaceable,
+        EcmascriptChunkType, EcmascriptChunkingContext, EcmascriptExports,
+    },
+    references::async_module::{AsyncModule, OptionAsyncModule},
+    utils::StringifyJs,
+    EcmascriptModuleContent,
+};
+
+#[turbo_tasks::function]
+fn layer() -> Vc<String> {
+    Vc::cell("external".to_string())
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, TraceRawVcs, TaskInput)]
+pub enum CachedExternalType {
+    CommonJs,
+    EcmaScriptViaRequire,
+    EcmaScriptViaImport,
+}
+
+impl Display for CachedExternalType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CachedExternalType::CommonJs => write!(f, "cjs"),
+            CachedExternalType::EcmaScriptViaRequire => write!(f, "esm_require"),
+            CachedExternalType::EcmaScriptViaImport => write!(f, "esm_import"),
+        }
+    }
+}
+
+#[turbo_tasks::value]
+pub struct CachedExternalModule {
+    pub request: String,
+    pub external_type: CachedExternalType,
+}
+
+#[turbo_tasks::value_impl]
+impl CachedExternalModule {
+    #[turbo_tasks::function]
+    pub fn new(request: String, external_type: CachedExternalType) -> Vc<Self> {
+        Self::cell(CachedExternalModule {
+            request,
+            external_type,
+        })
+    }
+
+    #[turbo_tasks::function]
+    pub fn content(&self) -> Result<Vc<EcmascriptModuleContent>> {
+        let mut code = RopeBuilder::default();
+
+        if self.external_type == CachedExternalType::EcmaScriptViaImport {
+            writeln!(
+                code,
+                "const mod = await __turbopack_external_import__({});",
+                StringifyJs(&self.request)
+            )?;
+        } else {
+            writeln!(
+                code,
+                "const mod = __turbopack_external_require__({});",
+                StringifyJs(&self.request)
+            )?;
+        }
+
+        writeln!(code)?;
+
+        if self.external_type == CachedExternalType::CommonJs {
+            writeln!(code, "module.exports = mod;")?;
+        } else {
+            writeln!(code, "__turbopack_dynamic__(mod);")?;
+        }
+
+        Ok(EcmascriptModuleContent {
+            inner_code: code.build(),
+            source_map: None,
+            is_esm: true,
+        }
+        .cell())
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl Module for CachedExternalModule {
+    #[turbo_tasks::function]
+    fn ident(&self) -> Vc<AssetIdent> {
+        let fs = VirtualFileSystem::new_with_name("externals".to_string());
+
+        AssetIdent::from_path(fs.root())
+            .with_layer(layer())
+            .with_modifier(Vc::cell(self.request.clone()))
+            .with_modifier(Vc::cell(self.external_type.to_string()))
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl Asset for CachedExternalModule {
+    #[turbo_tasks::function]
+    fn content(&self) -> Vc<AssetContent> {
+        AssetContent::file(FileContent::NotFound.cell())
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl ChunkableModule for CachedExternalModule {
+    #[turbo_tasks::function]
+    async fn as_chunk_item(
+        self: Vc<Self>,
+        chunking_context: Vc<Box<dyn ChunkingContext>>,
+    ) -> Result<Vc<Box<dyn ChunkItem>>> {
+        let chunking_context =
+            Vc::try_resolve_downcast::<Box<dyn EcmascriptChunkingContext>>(chunking_context)
+                .await?
+                .context(
+                    "chunking context must impl EcmascriptChunkingContext to use \
+                     WebAssemblyModuleAsset",
+                )?;
+
+        Ok(Vc::upcast(
+            CachedExternalModuleChunkItem {
+                module: self,
+                chunking_context,
+            }
+            .cell(),
+        ))
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl EcmascriptChunkPlaceable for CachedExternalModule {
+    #[turbo_tasks::function]
+    fn get_exports(&self) -> Vc<EcmascriptExports> {
+        if self.external_type == CachedExternalType::CommonJs {
+            EcmascriptExports::CommonJs.cell()
+        } else {
+            EcmascriptExports::DynamicNamespace.cell()
+        }
+    }
+
+    #[turbo_tasks::function]
+    fn get_async_module(&self) -> Vc<OptionAsyncModule> {
+        Vc::cell(
+            if self.external_type == CachedExternalType::EcmaScriptViaImport {
+                Some(
+                    AsyncModule {
+                        has_top_level_await: true,
+                        import_externals: true,
+                    }
+                    .cell(),
+                )
+            } else {
+                None
+            },
+        )
+    }
+
+    #[turbo_tasks::function]
+    fn is_marked_as_side_effect_free(
+        self: Vc<Self>,
+        _side_effect_free_packages: Vc<Glob>,
+    ) -> Vc<bool> {
+        Vc::cell(false)
+    }
+}
+
+#[turbo_tasks::value]
+pub struct CachedExternalModuleChunkItem {
+    module: Vc<CachedExternalModule>,
+    chunking_context: Vc<Box<dyn EcmascriptChunkingContext>>,
+}
+
+#[turbo_tasks::value_impl]
+impl ChunkItem for CachedExternalModuleChunkItem {
+    #[turbo_tasks::function]
+    fn asset_ident(&self) -> Vc<AssetIdent> {
+        self.module.ident()
+    }
+
+    #[turbo_tasks::function]
+    fn references(&self) -> Vc<ModuleReferences> {
+        self.module.references()
+    }
+
+    #[turbo_tasks::function]
+    fn ty(self: Vc<Self>) -> Vc<Box<dyn ChunkType>> {
+        Vc::upcast(Vc::<EcmascriptChunkType>::default())
+    }
+
+    #[turbo_tasks::function]
+    fn module(&self) -> Vc<Box<dyn Module>> {
+        Vc::upcast(self.module)
+    }
+
+    #[turbo_tasks::function]
+    fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
+        Vc::upcast(self.chunking_context)
+    }
+
+    #[turbo_tasks::function]
+    fn is_self_async(&self) -> Vc<bool> {
+        Vc::cell(true)
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl EcmascriptChunkItem for CachedExternalModuleChunkItem {
+    #[turbo_tasks::function]
+    fn chunking_context(&self) -> Vc<Box<dyn EcmascriptChunkingContext>> {
+        self.chunking_context
+    }
+
+    #[turbo_tasks::function]
+    fn content(self: Vc<Self>) -> Vc<EcmascriptChunkItemContent> {
+        panic!("content() should not be called");
+    }
+
+    #[turbo_tasks::function]
+    async fn content_with_async_module_info(
+        &self,
+        async_module_info: Option<Vc<AsyncModuleInfo>>,
+    ) -> Result<Vc<EcmascriptChunkItemContent>> {
+        let async_module_options = self
+            .module
+            .get_async_module()
+            .module_options(async_module_info);
+
+        Ok(EcmascriptChunkItemContent::new(
+            self.module.content(),
+            self.chunking_context,
+            async_module_options,
+        ))
+    }
+}

--- a/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/crates/turbopack-ecmascript/src/references/mod.rs
@@ -5,6 +5,7 @@ pub mod constant_condition;
 pub mod constant_value;
 pub mod dynamic_expression;
 pub mod esm;
+pub mod external_module;
 pub mod node;
 pub mod pattern_mapping;
 pub mod raw;
@@ -749,7 +750,6 @@ pub(crate) async fn analyse_ecmascript_module_internal(
 
     if eval_context.is_esm() || specified_type == SpecifiedModuleType::EcmaScript {
         let async_module = AsyncModule {
-            placeable: Vc::upcast(module),
             has_top_level_await,
             import_externals,
         }

--- a/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
+++ b/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
@@ -114,17 +114,15 @@ impl SinglePatternMapping {
                 span: DUMMY_SP,
                 type_args: None,
             }),
-            Self::External(request, ExternalType::OriginalReference | ExternalType::CommonJs) => {
-                Expr::Call(CallExpr {
-                    callee: Callee::Expr(quote_expr!("require")),
-                    args: vec![ExprOrSpread {
-                        spread: None,
-                        expr: Box::new(Expr::Lit(Lit::Str(request.as_str().into()))),
-                    }],
-                    span: DUMMY_SP,
-                    type_args: None,
-                })
-            }
+            Self::External(request, ExternalType::CommonJs) => Expr::Call(CallExpr {
+                callee: Callee::Expr(quote_expr!("__turbopack_external_require__")),
+                args: vec![ExprOrSpread {
+                    spread: None,
+                    expr: Box::new(Expr::Lit(Lit::Str(request.as_str().into()))),
+                }],
+                span: DUMMY_SP,
+                type_args: None,
+            }),
             Self::External(request, ty) => throw_module_not_found_error_expr(
                 request,
                 &format!("Unsupported external type {:?} for commonjs reference", ty),
@@ -150,7 +148,7 @@ impl SinglePatternMapping {
                 })
             }
             Self::Unresolveable(_) => self.create_id(key_expr),
-            Self::External(_, ExternalType::EcmaScriptModule | ExternalType::OriginalReference) => {
+            Self::External(_, ExternalType::EcmaScriptModule) => {
                 if import_externals {
                     Expr::Call(CallExpr {
                         callee: Callee::Expr(quote_expr!("__turbopack_external_import__")),
@@ -402,11 +400,7 @@ impl PatternMapping {
                     .iter()
                     .filter_map(|(k, v)| {
                         let request = k.request.as_ref()?;
-                        if set.insert(request) {
-                            Some((request.to_string(), v))
-                        } else {
-                            None
-                        }
+                        set.insert(request).then(|| (request.to_string(), v))
                     })
                     .map(|(k, v)| async move {
                         let single_pattern_mapping =

--- a/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
+++ b/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
@@ -48,7 +48,6 @@ impl EcmascriptModuleFacadeModule {
                 false
             };
         Ok(AsyncModule {
-            placeable: Vc::upcast(self),
             has_top_level_await: false,
             import_externals,
         }

--- a/crates/turbopack-resolve/src/typescript.rs
+++ b/crates/turbopack-resolve/src/typescript.rs
@@ -27,6 +27,7 @@ use turbopack_core::{
 };
 
 use crate::ecmascript::get_condition_maps;
+
 #[turbo_tasks::value(shared)]
 pub struct TsConfigIssue {
     pub severity: Vc<IssueSeverity>,

--- a/crates/turbopack/src/lib.rs
+++ b/crates/turbopack/src/lib.rs
@@ -46,13 +46,14 @@ use turbopack_core::{
         CssReferenceSubType, EcmaScriptModulesReferenceSubType, InnerAssets, ReferenceType,
     },
     resolve::{
-        options::ResolveOptions, origin::PlainResolveOrigin, parse::Request, resolve, ModulePart,
-        ModuleResolveResult, ModuleResolveResultItem, ResolveResult,
+        options::ResolveOptions, origin::PlainResolveOrigin, parse::Request, resolve, ExternalType,
+        ModulePart, ModuleResolveResult, ModuleResolveResultItem, ResolveResult,
     },
     source::Source,
 };
 pub use turbopack_css as css;
 pub use turbopack_ecmascript as ecmascript;
+use turbopack_ecmascript::references::external_module::{CachedExternalModule, CachedExternalType};
 use turbopack_json::JsonModuleAsset;
 use turbopack_mdx::MdxModuleAsset;
 pub use turbopack_resolve::{resolve::resolve_options, resolve_options_context};
@@ -661,7 +662,8 @@ impl AssetContext for ModuleAssetContext {
     ) -> Result<Vc<ModuleResolveResult>> {
         let this = self.await?;
         let transition = this.transition;
-        Ok(result
+
+        let result = result
             .await?
             .map_module(|source| {
                 let reference_type = reference_type.clone();
@@ -677,8 +679,12 @@ impl AssetContext for ModuleAssetContext {
                     })
                 }
             })
-            .await?
-            .into())
+            .await?;
+
+        let result =
+            replace_externals(result, this.module_options_context.await?.import_externals).await?;
+
+        Ok(result.cell())
     }
 
     #[turbo_tasks::function]
@@ -837,6 +843,41 @@ async fn top_references(list: Vc<ReferencesList>) -> Result<Vc<ReferencesList>> 
             .collect(),
     }
     .into())
+}
+
+/// Replaces the externals in the result with `ExternalModuleAsset` instances.
+pub async fn replace_externals(
+    mut result: ModuleResolveResult,
+    import_externals: bool,
+) -> Result<ModuleResolveResult> {
+    for item in result.primary.values_mut() {
+        let ModuleResolveResultItem::External(request, ty) = item else {
+            continue;
+        };
+
+        let external_type = match ty {
+            ExternalType::CommonJs => CachedExternalType::CommonJs,
+            ExternalType::EcmaScriptModule => {
+                if import_externals {
+                    CachedExternalType::EcmaScriptViaImport
+                } else {
+                    CachedExternalType::EcmaScriptViaRequire
+                }
+            }
+            ExternalType::Url => {
+                // we don't want to wrap url externals.
+                continue;
+            }
+        };
+
+        let module = CachedExternalModule::new(request.clone(), external_type)
+            .resolve()
+            .await?;
+
+        *item = ModuleResolveResultItem::Module(Vc::upcast(module));
+    }
+
+    Ok(result)
 }
 
 pub fn register() {


### PR DESCRIPTION
### Description

This should prevent issues when an external module is removed from the require cache leading to 2 version used from the bundle.
