### PR TITLE
Turbopack HMR: reload on any failed HMR update

### DIFF
--- a/crates/turbopack-ecmascript-runtime/js/src/dev/client/hmr-client.ts
+++ b/crates/turbopack-ecmascript-runtime/js/src/dev/client/hmr-client.ts
@@ -40,10 +40,6 @@ export function connect({
           }
           applyAggregatedUpdates();
         } catch (e: unknown) {
-          if (!(e instanceof Error && e.name === "UpdateApplyError")) {
-            throw e;
-          }
-
           console.warn(
             "[Fast Refresh] performing full reload\n\n" +
               "Fast Refresh will perform a full reload when you edit a file that's imported by modules outside of the React rendering tree.\n" +


### PR DESCRIPTION
Whether due to a runtime error or an apply error, it should be reloaded.


Closes PACK-2751