### PR TITLE
fix ASSET_PREFIX

### DIFF
--- a/crates/turbopack-nodejs/src/ecmascript/node/entry/runtime.rs
+++ b/crates/turbopack-nodejs/src/ecmascript/node/entry/runtime.rs
@@ -49,12 +49,8 @@ impl EcmascriptBuildNodeRuntimeChunk {
 
         let mut code = CodeBuilder::default();
         let output_root = output_root.to_string();
-        let asset_prefix = this
-            .chunking_context
-            .asset_prefix()
-            .await?
-            .clone_value()
-            .unwrap_or("".to_string());
+        let asset_prefix = this.chunking_context.asset_prefix().await?;
+        let asset_prefix = asset_prefix.as_deref().unwrap_or("/");
 
         writedoc!(
             code,
@@ -65,7 +61,7 @@ impl EcmascriptBuildNodeRuntimeChunk {
             "#,
             StringifyJs(runtime_public_path),
             StringifyJs(output_root.as_str()),
-            StringifyJs(asset_prefix.as_str()),
+            StringifyJs(asset_prefix),
         )?;
 
         match this.chunking_context.await?.runtime_type() {

--- a/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/output/[turbopack]_runtime.js
+++ b/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/output/[turbopack]_runtime.js
@@ -1,4 +1,4 @@
 const RUNTIME_PUBLIC_PATH = "output/[turbopack]_runtime.js";
 const OUTPUT_ROOT = "crates/turbopack-tests/tests/snapshot/basic/async_chunk_build";
-const ASSET_PREFIX = "";
+const ASSET_PREFIX = "/";
 // Dummy runtime

--- a/crates/turbopack-tests/tests/snapshot/basic/ecmascript_minify/output/[turbopack]_runtime.js
+++ b/crates/turbopack-tests/tests/snapshot/basic/ecmascript_minify/output/[turbopack]_runtime.js
@@ -1,4 +1,4 @@
 const RUNTIME_PUBLIC_PATH = "output/[turbopack]_runtime.js";
 const OUTPUT_ROOT = "crates/turbopack-tests/tests/snapshot/basic/ecmascript_minify";
-const ASSET_PREFIX = "";
+const ASSET_PREFIX = "/";
 // Dummy runtime

--- a/crates/turbopack-tests/tests/snapshot/runtime/default_build_runtime/output/[turbopack]_runtime.js
+++ b/crates/turbopack-tests/tests/snapshot/runtime/default_build_runtime/output/[turbopack]_runtime.js
@@ -1,6 +1,6 @@
 const RUNTIME_PUBLIC_PATH = "output/[turbopack]_runtime.js";
 const OUTPUT_ROOT = "crates/turbopack-tests/tests/snapshot/runtime/default_build_runtime";
-const ASSET_PREFIX = "";
+const ASSET_PREFIX = "/";
 /**
  * This file contains runtime types and functions that are shared between all
  * TurboPack ECMAScript runtimes.


### PR DESCRIPTION
### Description

The default for asset prefix is `"/"` and not `""`

### Testing Instructions

https://github.com/vercel/next.js/pull/62134
