### PR TITLE
feat: enable env var for preflight

### DIFF
--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -2377,4 +2377,15 @@ mod test {
         assert!(Args::try_parse_from(["turbo", "build", "--cache-dir="]).is_err());
         assert!(Args::try_parse_from(["turbo", "build", "--cache-dir", ""]).is_err());
     }
+
+    #[test]
+    fn test_preflight() {
+        assert!(!Args::try_parse_from(["turbo", "build",]).unwrap().preflight);
+        assert!(
+            Args::try_parse_from(["turbo", "build", "--preflight"])
+                .unwrap()
+                .preflight
+        );
+        assert!(Args::try_parse_from(["turbo", "build", "--preflight=true"]).is_err());
+    }
 }

--- a/crates/turborepo-lib/src/commands/mod.rs
+++ b/crates/turborepo-lib/src/commands/mod.rs
@@ -67,6 +67,7 @@ impl CommandBase {
             .with_team_slug(self.args.team.clone())
             .with_token(self.args.token.clone())
             .with_timeout(self.args.remote_cache_timeout)
+            .with_preflight(self.args.preflight.then_some(true))
             .build()
     }
 

--- a/crates/turborepo-lib/src/commands/mod.rs
+++ b/crates/turborepo-lib/src/commands/mod.rs
@@ -118,12 +118,10 @@ impl CommandBase {
 
     pub fn api_client(&self) -> Result<APIClient, ConfigError> {
         let config = self.config()?;
-        let args = self.args();
-
         let api_url = config.api_url();
         let timeout = config.timeout();
 
-        APIClient::new(api_url, timeout, self.version, args.preflight)
+        APIClient::new(api_url, timeout, self.version, config.preflight())
             .map_err(ConfigError::ApiClient)
     }
 

--- a/crates/turborepo-lib/src/config.rs
+++ b/crates/turborepo-lib/src/config.rs
@@ -298,10 +298,10 @@ fn get_env_var_config(
     turbo_mapping.insert(OsString::from("turbo_teamid"), "team_id");
     turbo_mapping.insert(OsString::from("turbo_token"), "token");
     turbo_mapping.insert(OsString::from("turbo_remote_cache_timeout"), "timeout");
+    turbo_mapping.insert(OsString::from("turbo_preflight"), "preflight");
 
     // We do not enable new config sources:
     // turbo_mapping.insert(String::from("turbo_signature"), "signature"); // new
-    // turbo_mapping.insert(String::from("turbo_preflight"), "preflight"); // new
     // turbo_mapping.insert(String::from("turbo_remote_cache_enabled"), "enabled");
 
     let mut output_map = HashMap::new();
@@ -337,8 +337,9 @@ fn get_env_var_config(
     // Process preflight
     let preflight = if let Some(preflight) = output_map.get("preflight") {
         match preflight.as_str() {
-            "0" => Some(false),
-            "1" => Some(true),
+            "0" | "false" => Some(false),
+            "1" | "true" => Some(true),
+            "" => None,
             _ => return Err(Error::InvalidPreflight),
         }
     } else {
@@ -706,8 +707,10 @@ mod test {
             "turbo_remote_cache_timeout".into(),
             turbo_remote_cache_timeout.to_string().into(),
         );
+        env.insert("turbo_preflight".into(), "true".into());
 
         let config = get_env_var_config(&env).unwrap();
+        assert!(config.preflight());
         assert_eq!(turbo_api, config.api_url.unwrap());
         assert_eq!(turbo_login, config.login_url.unwrap());
         assert_eq!(turbo_team, config.team_slug.unwrap());
@@ -724,6 +727,7 @@ mod test {
         env.insert("turbo_team".into(), "".into());
         env.insert("turbo_teamid".into(), "".into());
         env.insert("turbo_token".into(), "".into());
+        env.insert("turbo_preflight".into(), "".into());
 
         let config = get_env_var_config(&env).unwrap();
         assert_eq!(config.api_url(), DEFAULT_API_URL);
@@ -731,6 +735,7 @@ mod test {
         assert_eq!(config.team_slug(), None);
         assert_eq!(config.team_id(), None);
         assert_eq!(config.token(), None);
+        assert!(!config.preflight());
     }
 
     #[test]


### PR DESCRIPTION
### Description

Fixes https://github.com/vercel/turbo/issues/7753

- Enabled `TURBO_PREFLIGHT` env var as a config source with `1` and `true` being considered truthy
- Pipe `--preflight` CLI arg into our config
- Use `config.pipeline()` instead of directly reading value from CLI args 

### Testing Instructions

Expanded unit tests to cover `TURBO_PREFLIGHT`


Closes TURBO-2650