### PR TITLE
chore: add ability to configure TUI via turbo.json

### DIFF
--- a/crates/turborepo-lib/src/config.rs
+++ b/crates/turborepo-lib/src/config.rs
@@ -176,6 +176,8 @@ pub struct ConfigurationOptions {
     pub(crate) timeout: Option<u64>,
     pub(crate) enabled: Option<bool>,
     pub(crate) spaces_id: Option<String>,
+    #[serde(rename = "experimentalUI")]
+    pub(crate) experimental_ui: Option<bool>,
 }
 
 #[derive(Default)]
@@ -232,6 +234,10 @@ impl ConfigurationOptions {
     pub fn spaces_id(&self) -> Option<&str> {
         self.spaces_id.as_deref()
     }
+
+    pub fn experimental_ui(&self) -> bool {
+        self.experimental_ui.unwrap_or_default() && atty::is(atty::Stream::Stdout)
+    }
 }
 
 // Maps Some("") to None to emulate how Go handles empty strings
@@ -271,6 +277,7 @@ impl ResolvedConfigurationOptions for RawTurboJson {
             .experimental_spaces
             .and_then(|spaces| spaces.id)
             .map(|spaces_id| spaces_id.into());
+        opts.experimental_ui = self.experimental_ui;
         Ok(opts)
     }
 }
@@ -298,6 +305,7 @@ fn get_env_var_config(
     turbo_mapping.insert(OsString::from("turbo_teamid"), "team_id");
     turbo_mapping.insert(OsString::from("turbo_token"), "token");
     turbo_mapping.insert(OsString::from("turbo_remote_cache_timeout"), "timeout");
+    turbo_mapping.insert(OsString::from("turbo_experimental_ui"), "experimental_ui");
 
     // We do not enable new config sources:
     // turbo_mapping.insert(String::from("turbo_signature"), "signature"); // new
@@ -367,6 +375,15 @@ fn get_env_var_config(
         None
     };
 
+    // Process experimentalUI
+    let experimental_ui = output_map
+        .get("experimental_ui")
+        .and_then(|val| match val.as_str() {
+            "true" | "1" => Some(true),
+            "false" | "0" => Some(false),
+            _ => None,
+        });
+
     // We currently don't pick up a Spaces ID via env var, we likely won't
     // continue using the Spaces name, we can add an env var when we have the
     // name we want to stick with.
@@ -383,6 +400,7 @@ fn get_env_var_config(
         signature,
         preflight,
         enabled,
+        experimental_ui,
 
         // Processed numbers
         timeout,
@@ -429,6 +447,7 @@ fn get_override_env_var_config(
         signature: None,
         preflight: None,
         enabled: None,
+        experimental_ui: None,
         timeout: None,
         spaces_id: None,
     };
@@ -565,6 +584,7 @@ impl TurborepoConfigBuilder {
     create_builder!(with_enabled, enabled, Option<bool>);
     create_builder!(with_preflight, preflight, Option<bool>);
     create_builder!(with_timeout, timeout, Option<u64>);
+    create_builder!(with_experimental_ui, experimental_ui, Option<bool>);
 
     pub fn build(&self) -> Result<ConfigurationOptions, Error> {
         // Priority, from least significant to most significant:
@@ -651,6 +671,9 @@ impl TurborepoConfigBuilder {
                     if let Some(spaces_id) = current_source_config.spaces_id {
                         acc.spaces_id = Some(spaces_id);
                     }
+                    if let Some(experimental_ui) = current_source_config.experimental_ui {
+                        acc.experimental_ui = Some(experimental_ui);
+                    }
 
                     acc
                 })
@@ -706,6 +729,7 @@ mod test {
             "turbo_remote_cache_timeout".into(),
             turbo_remote_cache_timeout.to_string().into(),
         );
+        env.insert("turbo_experimental_ui".into(), "true".into());
 
         let config = get_env_var_config(&env).unwrap();
         assert_eq!(turbo_api, config.api_url.unwrap());
@@ -714,6 +738,7 @@ mod test {
         assert_eq!(turbo_teamid, config.team_id.unwrap());
         assert_eq!(turbo_token, config.token.unwrap());
         assert_eq!(turbo_remote_cache_timeout, config.timeout.unwrap());
+        assert_eq!(Some(true), config.experimental_ui);
     }
 
     #[test]
@@ -724,6 +749,7 @@ mod test {
         env.insert("turbo_team".into(), "".into());
         env.insert("turbo_teamid".into(), "".into());
         env.insert("turbo_token".into(), "".into());
+        env.insert("turbo_experimental_ui".into(), "".into());
 
         let config = get_env_var_config(&env).unwrap();
         assert_eq!(config.api_url(), DEFAULT_API_URL);
@@ -731,6 +757,7 @@ mod test {
         assert_eq!(config.team_slug(), None);
         assert_eq!(config.team_id(), None);
         assert_eq!(config.token(), None);
+        assert!(!config.experimental_ui());
     }
 
     #[test]

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -58,6 +58,7 @@ pub struct RunBuilder {
     repo_root: AbsoluteSystemPathBuf,
     ui: UI,
     version: &'static str,
+    experimental_ui: bool,
 }
 
 impl RunBuilder {
@@ -86,6 +87,7 @@ impl RunBuilder {
             opts.run_opts.experimental_space_id = config.spaces_id().map(|s| s.to_owned());
         }
         let version = base.version();
+        let experimental_ui = config.experimental_ui();
         let CommandBase { repo_root, ui, .. } = base;
         Ok(Self {
             processes,
@@ -94,6 +96,7 @@ impl RunBuilder {
             repo_root,
             ui,
             version,
+            experimental_ui,
         })
     }
 
@@ -371,6 +374,7 @@ impl RunBuilder {
         Ok(Run {
             version: self.version,
             ui: self.ui,
+            experimental_ui: self.experimental_ui,
             analytics_handle,
             start_at,
             processes: self.processes,

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -42,6 +42,7 @@ use crate::{
 pub struct Run {
     version: &'static str,
     ui: UI,
+    experimental_ui: bool,
     start_at: DateTime<Local>,
     processes: ProcessManager,
     run_telemetry: GenericEventBuilder,
@@ -220,6 +221,7 @@ impl Run {
             self.processes.clone(),
             &self.repo_root,
             global_env,
+            self.experimental_ui,
         );
 
         if self.opts.run_opts.dry_run.is_some() {

--- a/crates/turborepo-lib/src/task_graph/visitor.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor.rs
@@ -105,6 +105,7 @@ impl<'a> Visitor<'a> {
         manager: ProcessManager,
         repo_root: &'a AbsoluteSystemPath,
         global_env: EnvironmentVariableMap,
+        experimental_ui: bool,
     ) -> Self {
         let task_hasher = TaskHasher::new(
             package_inputs_hashes,
@@ -112,12 +113,6 @@ impl<'a> Visitor<'a> {
             env_at_execution_start,
             global_hash,
         );
-
-        let experimental_ui = atty::is(atty::Stream::Stdout)
-            && std::env::var("TURBO_EXPERIMENTAL_UI")
-                .ok()
-                .map(|val| matches!(val.as_str(), "true" | "1"))
-                .unwrap_or_default();
 
         let sink = Self::sink(run_opts);
         let color_cache = ColorSelector::default();

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -128,6 +128,8 @@ pub struct RawTurboJson {
     // Configuration options when interfacing with the remote cache
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) remote_cache: Option<RawRemoteCacheOptions>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "experimentalUI")]
+    pub experimental_ui: Option<bool>,
 }
 
 #[derive(Serialize, Default, Debug, PartialEq, Clone)]
@@ -1089,5 +1091,13 @@ mod tests {
             .and_then(|build| build.value.output_mode.clone())
             .map(|mode| mode.into_inner());
         assert_eq!(actual, expected);
+    }
+
+    #[test_case(r#"{ "experimentalUI": true }"#, Some(true) ; "t")]
+    #[test_case(r#"{ "experimentalUI": false }"#, Some(false) ; "f")]
+    #[test_case(r#"{}"#, None ; "missing")]
+    fn test_experimental_ui(json: &str, expected: Option<bool>) {
+        let json = RawTurboJson::parse(json, AnchoredSystemPath::new("").unwrap()).unwrap();
+        assert_eq!(json.experimental_ui, expected);
     }
 }

--- a/crates/turborepo-lib/src/turbo_json/parser.rs
+++ b/crates/turborepo-lib/src/turbo_json/parser.rs
@@ -399,6 +399,11 @@ impl DeserializationVisitor for RawRemoteCacheOptionsVisitor {
                         result.timeout = Some(timeout);
                     }
                 }
+                "enabled" => {
+                    if let Some(enabled) = bool::deserialize(&value, &key_text, diagnostics) {
+                        result.enabled = Some(enabled);
+                    }
+                }
                 unknown_key => diagnostics.push(create_unknown_key_diagnostic_from_struct(
                     &result,
                     unknown_key,

--- a/crates/turborepo-lib/src/turbo_json/parser.rs
+++ b/crates/turborepo-lib/src/turbo_json/parser.rs
@@ -399,11 +399,6 @@ impl DeserializationVisitor for RawRemoteCacheOptionsVisitor {
                         result.timeout = Some(timeout);
                     }
                 }
-                "enabled" => {
-                    if let Some(enabled) = bool::deserialize(&value, &key_text, diagnostics) {
-                        result.enabled = Some(enabled);
-                    }
-                }
                 unknown_key => diagnostics.push(create_unknown_key_diagnostic_from_struct(
                     &result,
                     unknown_key,
@@ -593,6 +588,12 @@ impl DeserializationVisitor for RawTurboJsonVisitor {
                         RawRemoteCacheOptions::deserialize(&value, &key_text, diagnostics)
                     {
                         result.remote_cache = Some(remote_cache);
+                    }
+                }
+                "experimentalUI" => {
+                    if let Some(experimental_ui) = bool::deserialize(&value, &key_text, diagnostics)
+                    {
+                        result.experimental_ui = Some(experimental_ui);
                     }
                 }
                 // Allow for faux-comments at the top level


### PR DESCRIPTION
### Description

Add `experimentalUI` to `turbo.json` that is equivalent to setting `TURBO_EXPERIMENTAL_UI`

Docs update will be in separate PR to be merged on release.

### Testing Instructions

Verify that TUI is used in following scenarios:
 - `TURBO_EXPERIMENTAL_UI=true turbo build`
 - Add `"experimentalUI": true` to `turbo.json`

Closes TURBO-2652