### PR TITLE
fix(mdx): allow failsafe analyze for mdxasset

### DIFF
--- a/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/crates/turbopack-ecmascript/src/references/mod.rs
@@ -151,7 +151,7 @@ pub struct AnalyzeEcmascriptModuleResult {
 
 /// A temporary analysis result builder to pass around, to be turned into an
 /// `Vc<AnalyzeEcmascriptModuleResult>` eventually.
-pub(crate) struct AnalyzeEcmascriptModuleResultBuilder {
+pub struct AnalyzeEcmascriptModuleResultBuilder {
     references: IndexSet<Vc<Box<dyn ModuleReference>>>,
     local_references: IndexSet<Vc<Box<dyn ModuleReference>>>,
     reexport_references: IndexSet<Vc<Box<dyn ModuleReference>>>,


### PR DESCRIPTION
### Description

For the `failsafe_analyze`, make it not failable by not bubbling up the error - the error will be propagated by chunk generation anyway.

Closes PACK-2764