### PR TITLE
feat: add ability to configure tasks as interactive

### DIFF
--- a/crates/turborepo-lib/src/config.rs
+++ b/crates/turborepo-lib/src/config.rs
@@ -118,6 +118,13 @@ pub enum Error {
         #[source_code]
         text: NamedSource,
     },
+    #[error("Tasks cannot be marked as interactive and cacheable")]
+    InteractiveNoCacheable {
+        #[label("marked interactive here")]
+        span: Option<SourceSpan>,
+        #[source_code]
+        text: NamedSource,
+    },
     #[error("Failed to create APIClient: {0}")]
     ApiClient(#[source] turborepo_api_client::Error),
     #[error("{0} is not UTF8.")]

--- a/crates/turborepo-lib/src/engine/mod.rs
+++ b/crates/turborepo-lib/src/engine/mod.rs
@@ -181,6 +181,7 @@ impl Engine<Built> {
         &self,
         package_graph: &PackageGraph,
         concurrency: u32,
+        experimental_ui: bool,
     ) -> Result<(), Vec<ValidateError>> {
         // TODO(olszewski) once this is hooked up to a real run, we should
         // see if using rayon to parallelize would provide a speedup
@@ -277,10 +278,33 @@ impl Engine<Built> {
             })
         }
 
+        validation_errors.extend(self.validate_interactive(experimental_ui));
+
         match validation_errors.is_empty() {
             true => Ok(()),
             false => Err(validation_errors),
         }
+    }
+
+    // Validates that UI is setup if any interactive tasks will be executed
+    fn validate_interactive(&self, experimental_ui: bool) -> Vec<ValidateError> {
+        // If experimental_ui is being used, then we don't need check for interactive
+        // tasks
+        if experimental_ui {
+            return Vec::new();
+        }
+        self.task_definitions
+            .iter()
+            .filter_map(|(task, definition)| {
+                if definition.interactive {
+                    Some(ValidateError::InteractiveNeedsUI {
+                        task: task.to_string(),
+                    })
+                } else {
+                    None
+                }
+            })
+            .collect()
     }
 }
 
@@ -310,6 +334,11 @@ pub enum ValidateError {
         persistent_count: u32,
         concurrency: u32,
     },
+    #[error(
+        "Cannot run interactive task \"{task}\" without experimental UI. Set `\"experimentalUI\": \
+         true` in `turbo.json` or `TURBO_EXPERIMENTAL_UI=true` as an environment variable"
+    )]
+    InteractiveNeedsUI { task: String },
 }
 
 impl fmt::Display for TaskNode {
@@ -427,16 +456,16 @@ mod test {
         let graph = graph_builder.build().await.unwrap();
 
         // if our limit is less than, it should fail
-        engine.validate(&graph, 1).expect_err("not enough");
+        engine.validate(&graph, 1, false).expect_err("not enough");
 
         // if our limit is less than, it should fail
-        engine.validate(&graph, 2).expect_err("not enough");
+        engine.validate(&graph, 2, false).expect_err("not enough");
 
         // we have two persistent tasks, and a slot for all other tasks, so this should
         // pass
-        engine.validate(&graph, 3).expect("ok");
+        engine.validate(&graph, 3, false).expect("ok");
 
         // if our limit is greater, then it should pass
-        engine.validate(&graph, 4).expect("ok");
+        engine.validate(&graph, 4, false).expect("ok");
     }
 }

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -423,7 +423,11 @@ impl RunBuilder {
 
         if !self.opts.run_opts.parallel {
             engine
-                .validate(pkg_dep_graph, self.opts.run_opts.concurrency)
+                .validate(
+                    pkg_dep_graph,
+                    self.opts.run_opts.concurrency,
+                    self.experimental_ui,
+                )
                 .map_err(Error::EngineValidation)?;
         }
 

--- a/crates/turborepo-lib/src/run/error.rs
+++ b/crates/turborepo-lib/src/run/error.rs
@@ -13,7 +13,7 @@ use crate::{
 
 #[derive(Debug, Error, Diagnostic)]
 pub enum Error {
-    #[error("invalid persistent task configuration")]
+    #[error("invalid task configuration")]
     EngineValidation(#[related] Vec<ValidateError>),
     #[error(transparent)]
     Graph(#[from] graph_visualizer::Error),

--- a/crates/turborepo-lib/src/run/summary/task.rs
+++ b/crates/turborepo-lib/src/run/summary/task.rs
@@ -105,6 +105,7 @@ pub struct TaskSummaryTaskDefinition {
     env: Vec<String>,
     pass_through_env: Option<Vec<String>>,
     dot_env: Option<Vec<RelativeUnixPathBuf>>,
+    interactive: bool,
 }
 
 #[derive(Debug, Serialize, Clone)]
@@ -282,6 +283,7 @@ impl From<TaskDefinition> for TaskSummaryTaskDefinition {
             mut inputs,
             output_mode,
             persistent,
+            interactive,
         } = value;
 
         let mut outputs = inclusions;
@@ -313,6 +315,7 @@ impl From<TaskDefinition> for TaskSummaryTaskDefinition {
             inputs,
             output_mode,
             persistent,
+            interactive,
             env,
             pass_through_env,
             // This should _not_ be sorted.
@@ -372,6 +375,7 @@ mod test {
             "inputs": [],
             "outputMode": "full",
             "persistent": false,
+            "interactive": false,
             "env": [],
             "passThroughEnv": null,
             "dotEnv": null,

--- a/crates/turborepo-lib/src/task_graph/mod.rs
+++ b/crates/turborepo-lib/src/task_graph/mod.rs
@@ -74,9 +74,9 @@ pub struct TaskDefinition {
     // Tasks marked Persistent do not exit (e.g. --watch mode or dev servers)
     pub persistent: bool,
 
-    // Interactive marks that a task can be interacted with
-    // Tasks that can be interacted with cannot be cached as their outputs may depend on the
-    // interaction.
+    // Interactive marks that a task can have it's stdin written to.
+    // Tasks that take stdin input cannot be cached as their outputs may depend on the
+    // input.
     pub interactive: bool,
 }
 

--- a/crates/turborepo-lib/src/task_graph/mod.rs
+++ b/crates/turborepo-lib/src/task_graph/mod.rs
@@ -73,6 +73,11 @@ pub struct TaskDefinition {
     // Persistent indicates whether the Task is expected to exit or not
     // Tasks marked Persistent do not exit (e.g. --watch mode or dev servers)
     pub persistent: bool,
+
+    // Interactive marks that a task can be interacted with
+    // Tasks that can be interacted with cannot be cached as their outputs may depend on the
+    // interaction.
+    pub interactive: bool,
 }
 
 impl Default for TaskDefinition {
@@ -88,6 +93,7 @@ impl Default for TaskDefinition {
             output_mode: Default::default(),
             persistent: Default::default(),
             dot_env: Default::default(),
+            interactive: Default::default(),
         }
     }
 }

--- a/crates/turborepo-lib/src/task_graph/visitor.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor.rs
@@ -268,14 +268,14 @@ impl<'a> Visitor<'a> {
 
                     let workspace_directory = self.repo_root.resolve(workspace_info.package_path());
 
-                    let persistent = task_definition.persistent;
+                    let interactive = task_definition.interactive || task_definition.persistent;
                     let mut exec_context = factory.exec_context(
                         info.clone(),
                         task_hash,
                         task_cache,
                         workspace_directory,
                         execution_env,
-                        persistent,
+                        interactive,
                         self.task_access.clone(),
                     );
 
@@ -629,7 +629,7 @@ impl<'a> ExecContextFactory<'a> {
         task_cache: TaskCache,
         workspace_directory: AbsoluteSystemPathBuf,
         execution_env: EnvironmentVariableMap,
-        persistent: bool,
+        interactive: bool,
         task_access: TaskAccess,
     ) -> ExecContext {
         let task_id_for_display = self.visitor.display_task_id(&task_id);
@@ -655,7 +655,7 @@ impl<'a> ExecContextFactory<'a> {
             continue_on_error: self.visitor.run_opts.continue_on_error,
             pass_through_args,
             errors: self.errors.clone(),
-            persistent,
+            interactive,
             task_access,
         }
     }
@@ -691,7 +691,7 @@ struct ExecContext {
     continue_on_error: bool,
     pass_through_args: Option<Vec<String>>,
     errors: Arc<Mutex<Vec<TaskError>>>,
-    persistent: bool,
+    interactive: bool,
     task_access: TaskAccess,
 }
 
@@ -876,25 +876,7 @@ impl ExecContext {
             cmd.env(task_access_trace_key, trace_file.to_string());
         }
 
-        // Many persistent tasks if started hooked up to a pseudoterminal
-        // will shut down if stdin is closed, so we open it even if we don't pass
-        // anything to it.
-        if self.persistent {
-            cmd.open_stdin();
-        }
-
-        let mut stdout_writer = match self.task_cache.output_writer(if self.experimental_ui {
-            Either::Left(output_client.stdout())
-        } else {
-            Either::Right(prefixed_ui.output_prefixed_writer())
-        }) {
-            Ok(w) => w,
-            Err(e) => {
-                telemetry.track_error(TrackedErrors::FailedToCaptureOutputs);
-                error!("failed to capture outputs for \"{}\": {e}", self.task_id);
-                return ExecOutcome::Internal;
-            }
-        };
+        cmd.open_stdin();
 
         let mut process = match self.manager.spawn(cmd, Duration::from_millis(500)) {
             Some(Ok(child)) => child,
@@ -918,13 +900,26 @@ impl ExecContext {
             }
         };
 
-        if self.experimental_ui {
+        if self.experimental_ui && self.interactive {
             if let TaskOutput::UI(task) = output_client {
                 if let Some(stdin) = process.stdin() {
                     task.set_stdin(stdin);
                 }
             }
         }
+
+        let mut stdout_writer = match self.task_cache.output_writer(if self.experimental_ui {
+            Either::Left(output_client.stdout())
+        } else {
+            Either::Right(prefixed_ui.output_prefixed_writer())
+        }) {
+            Ok(w) => w,
+            Err(e) => {
+                telemetry.track_error(TrackedErrors::FailedToCaptureOutputs);
+                error!("failed to capture outputs for \"{}\": {e}", self.task_id);
+                return ExecOutcome::Internal;
+            }
+        };
 
         let exit_status = match process.wait_with_piped_outputs(&mut stdout_writer).await {
             Ok(Some(exit_status)) => exit_status,

--- a/crates/turborepo-lib/src/task_graph/visitor.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor.rs
@@ -268,14 +268,14 @@ impl<'a> Visitor<'a> {
 
                     let workspace_directory = self.repo_root.resolve(workspace_info.package_path());
 
-                    let interactive = task_definition.interactive || task_definition.persistent;
+                    let takes_input = task_definition.interactive || task_definition.persistent;
                     let mut exec_context = factory.exec_context(
                         info.clone(),
                         task_hash,
                         task_cache,
                         workspace_directory,
                         execution_env,
-                        interactive,
+                        takes_input,
                         self.task_access.clone(),
                     );
 
@@ -629,7 +629,7 @@ impl<'a> ExecContextFactory<'a> {
         task_cache: TaskCache,
         workspace_directory: AbsoluteSystemPathBuf,
         execution_env: EnvironmentVariableMap,
-        interactive: bool,
+        takes_input: bool,
         task_access: TaskAccess,
     ) -> ExecContext {
         let task_id_for_display = self.visitor.display_task_id(&task_id);
@@ -655,7 +655,7 @@ impl<'a> ExecContextFactory<'a> {
             continue_on_error: self.visitor.run_opts.continue_on_error,
             pass_through_args,
             errors: self.errors.clone(),
-            interactive,
+            takes_input,
             task_access,
         }
     }
@@ -691,7 +691,7 @@ struct ExecContext {
     continue_on_error: bool,
     pass_through_args: Option<Vec<String>>,
     errors: Arc<Mutex<Vec<TaskError>>>,
-    interactive: bool,
+    takes_input: bool,
     task_access: TaskAccess,
 }
 
@@ -900,7 +900,7 @@ impl ExecContext {
             }
         };
 
-        if self.experimental_ui && self.interactive {
+        if self.experimental_ui && self.takes_input {
             if let TaskOutput::UI(task) = output_client {
                 if let Some(stdin) = process.stdin() {
                     task.set_stdin(stdin);

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -181,6 +181,8 @@ pub struct RawTaskDefinition {
     outputs: Option<Vec<Spanned<UnescapedString>>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     output_mode: Option<Spanned<OutputLogsMode>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    interactive: Option<Spanned<bool>>,
 }
 
 macro_rules! set_field {
@@ -197,7 +199,10 @@ impl RawTaskDefinition {
     pub fn merge(&mut self, other: RawTaskDefinition) {
         set_field!(self, other, outputs);
 
-        if other.cache.value.is_some() {
+        if other.cache.value.is_some()
+            // If other has range info and we're missing it, carry it over
+            || (other.cache.range.is_some() && self.cache.range.is_none())
+        {
             self.cache = other.cache;
         }
         set_field!(self, other, depends_on);
@@ -207,6 +212,7 @@ impl RawTaskDefinition {
         set_field!(self, other, env);
         set_field!(self, other, pass_through_env);
         set_field!(self, other, dot_env);
+        set_field!(self, other, interactive);
     }
 }
 
@@ -262,7 +268,19 @@ impl TryFrom<RawTaskDefinition> for TaskDefinition {
     fn try_from(raw_task: RawTaskDefinition) -> Result<Self, Error> {
         let outputs = raw_task.outputs.unwrap_or_default().try_into()?;
 
-        let cache = raw_task.cache;
+        let cache = raw_task.cache.into_inner().unwrap_or(true);
+        let interactive = raw_task
+            .interactive
+            .as_ref()
+            .map(|value| value.value)
+            .unwrap_or_default();
+
+        if let Some(interactive) = raw_task.interactive {
+            let (span, text) = interactive.span_and_text("turbo.json");
+            if cache && interactive.value {
+                return Err(Error::InteractiveNoCacheable { span, text });
+            }
+        }
 
         let mut env_var_dependencies = HashSet::new();
         let mut topological_dependencies: Vec<Spanned<TaskName>> = Vec::new();
@@ -350,7 +368,7 @@ impl TryFrom<RawTaskDefinition> for TaskDefinition {
 
         Ok(TaskDefinition {
             outputs,
-            cache: cache.into_inner().unwrap_or(true),
+            cache,
             topological_dependencies,
             task_dependencies,
             env,
@@ -359,6 +377,7 @@ impl TryFrom<RawTaskDefinition> for TaskDefinition {
             dot_env,
             output_mode: *raw_task.output_mode.unwrap_or_default(),
             persistent: *raw_task.persistent.unwrap_or_default(),
+            interactive,
         })
     }
 }
@@ -910,7 +929,8 @@ mod tests {
           "cache": false,
           "inputs": ["package/a/src/**"],
           "outputMode": "full",
-          "persistent": true
+          "persistent": true,
+          "interactive": true
         }"#,
         RawTaskDefinition {
             depends_on: Some(Spanned::new(vec![Spanned::<UnescapedString>::new("cli#build".into()).with_range(26..37)]).with_range(25..38)),
@@ -922,6 +942,7 @@ mod tests {
             inputs: Some(vec![Spanned::<UnescapedString>::new("package/a/src/**".into()).with_range(241..259)]),
             output_mode: Some(Spanned::new(OutputLogsMode::Full).with_range(286..292)),
             persistent: Some(Spanned::new(true).with_range(318..322)),
+            interactive: Some(Spanned::new(true).with_range(349..353)),
         },
         TaskDefinition {
           dot_env: Some(vec![RelativeUnixPathBuf::new("package/a/.env").unwrap()]),
@@ -937,6 +958,7 @@ mod tests {
           task_dependencies: vec![Spanned::<TaskName<'_>>::new("cli#build".into()).with_range(26..37)],
           topological_dependencies: vec![],
           persistent: true,
+          interactive: true,
         }
       ; "full"
     )]
@@ -962,6 +984,7 @@ mod tests {
             inputs: Some(vec![Spanned::<UnescapedString>::new("package\\a\\src\\**".into()).with_range(273..294)]),
             output_mode: Some(Spanned::new(OutputLogsMode::Full).with_range(325..331)),
             persistent: Some(Spanned::new(true).with_range(361..365)),
+            interactive: None,
         },
         TaskDefinition {
             dot_env: Some(vec![RelativeUnixPathBuf::new("package\\a\\.env").unwrap()]),
@@ -977,6 +1000,7 @@ mod tests {
             task_dependencies: vec![Spanned::<TaskName<'_>>::new("cli#build".into()).with_range(30..41)],
             topological_dependencies: vec![],
             persistent: true,
+            interactive: false,
         }
       ; "full (windows)"
     )]

--- a/crates/turborepo-lib/src/turbo_json/parser.rs
+++ b/crates/turborepo-lib/src/turbo_json/parser.rs
@@ -256,6 +256,11 @@ impl DeserializationVisitor for RawTaskDefinitionVisitor {
                         result.output_mode = Some(Spanned::new(output_mode).with_range(range));
                     }
                 }
+                "interactive" => {
+                    if let Some(interactive) = bool::deserialize(&value, &key_text, diagnostics) {
+                        result.interactive = Some(Spanned::new(interactive).with_range(range));
+                    }
+                }
                 unknown_key => {
                     diagnostics.push(create_unknown_key_diagnostic_from_struct(
                         &result,
@@ -664,7 +669,8 @@ impl WithMetadata for RawTaskDefinition {
         self.pass_through_env.add_text(text.clone());
         self.persistent.add_text(text.clone());
         self.outputs.add_text(text.clone());
-        self.output_mode.add_text(text);
+        self.output_mode.add_text(text.clone());
+        self.interactive.add_text(text);
     }
 
     fn add_path(&mut self, path: Arc<str>) {
@@ -678,7 +684,8 @@ impl WithMetadata for RawTaskDefinition {
         self.pass_through_env.add_path(path.clone());
         self.persistent.add_path(path.clone());
         self.outputs.add_path(path.clone());
-        self.output_mode.add_path(path);
+        self.output_mode.add_path(path.clone());
+        self.interactive.add_path(path);
     }
 }
 

--- a/crates/turborepo-ui/src/tui/app.rs
+++ b/crates/turborepo-ui/src/tui/app.rs
@@ -54,8 +54,13 @@ impl<I> App<I> {
     }
 
     pub fn interact(&mut self, interact: bool) {
-        self.interact = interact;
-        self.pane.highlight(interact);
+        let Some(selected_task) = self.table.selected() else {
+            return;
+        };
+        if self.pane.has_stdin(selected_task) {
+            self.interact = interact;
+            self.pane.highlight(interact);
+        }
     }
 }
 

--- a/crates/turborepo-ui/src/tui/pane.rs
+++ b/crates/turborepo-ui/src/tui/pane.rs
@@ -53,6 +53,13 @@ impl<W> TerminalPane<W> {
         Ok(())
     }
 
+    pub fn has_stdin(&self, task: &str) -> bool {
+        self.tasks
+            .get(task)
+            .map(|task| task.stdin.is_some())
+            .unwrap_or_default()
+    }
+
     pub fn resize(&mut self, rows: u16, cols: u16) -> Result<(), Error> {
         let changed = self.rows != rows || self.cols != cols;
         self.rows = rows;

--- a/turborepo-tests/integration/fixtures/turbo-configs/interactive.json
+++ b/turborepo-tests/integration/fixtures/turbo-configs/interactive.json
@@ -4,18 +4,7 @@
   "globalEnv": ["SOME_ENV_VAR"],
   "pipeline": {
     "build": {
-      "env": ["NODE_ENV"],
-      "interactive": true,
-      "outputs": []
-    },
-    "my-app#build": {
-      "outputs": ["banana.txt", "apple.json"],
-      "dotEnv": [".env.local"]
-    },
-
-    "something": {},
-    "//#something": {},
-
-    "maybefails": {}
+      "interactive": true
+    }
   }
 }

--- a/turborepo-tests/integration/fixtures/turbo-configs/interactive.json
+++ b/turborepo-tests/integration/fixtures/turbo-configs/interactive.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "globalDependencies": ["foo.txt"],
+  "globalEnv": ["SOME_ENV_VAR"],
+  "pipeline": {
+    "build": {
+      "env": ["NODE_ENV"],
+      "interactive": true,
+      "outputs": []
+    },
+    "my-app#build": {
+      "outputs": ["banana.txt", "apple.json"],
+      "dotEnv": [".env.local"]
+    },
+
+    "something": {},
+    "//#something": {},
+
+    "maybefails": {}
+  }
+}

--- a/turborepo-tests/integration/tests/dry-json/monorepo.t
+++ b/turborepo-tests/integration/tests/dry-json/monorepo.t
@@ -87,7 +87,8 @@ Setup
       "passThroughEnv": null,
       "dotEnv": [
         ".env.local"
-      ]
+      ],
+      "interactive": false
     },
     "expandedOutputs": [],
     "framework": "",
@@ -142,7 +143,8 @@ Setup
         "NODE_ENV"
       ],
       "passThroughEnv": null,
-      "dotEnv": null
+      "dotEnv": null,
+      "interactive": false
     },
     "expandedOutputs": [],
     "framework": "",

--- a/turborepo-tests/integration/tests/dry-json/single-package-no-config.t
+++ b/turborepo-tests/integration/tests/dry-json/single-package-no-config.t
@@ -63,7 +63,8 @@ Setup
           "persistent": false,
           "env": [],
           "passThroughEnv": null,
-          "dotEnv": null
+          "dotEnv": null,
+          "interactive": false
         },
         "expandedOutputs": [],
         "framework": "",

--- a/turborepo-tests/integration/tests/dry-json/single-package-with-deps.t
+++ b/turborepo-tests/integration/tests/dry-json/single-package-with-deps.t
@@ -69,7 +69,8 @@ Setup
           "persistent": false,
           "env": [],
           "passThroughEnv": null,
-          "dotEnv": null
+          "dotEnv": null,
+          "interactive": false
         },
         "expandedOutputs": [],
         "framework": "",
@@ -123,7 +124,8 @@ Setup
           "persistent": false,
           "env": [],
           "passThroughEnv": null,
-          "dotEnv": null
+          "dotEnv": null,
+          "interactive": false
         },
         "expandedOutputs": [],
         "framework": "",

--- a/turborepo-tests/integration/tests/dry-json/single-package.t
+++ b/turborepo-tests/integration/tests/dry-json/single-package.t
@@ -67,7 +67,8 @@ Setup
           "persistent": false,
           "env": [],
           "passThroughEnv": null,
-          "dotEnv": null
+          "dotEnv": null,
+          "interactive": false
         },
         "expandedOutputs": [],
         "framework": "",

--- a/turborepo-tests/integration/tests/interactive.t
+++ b/turborepo-tests/integration/tests/interactive.t
@@ -1,0 +1,15 @@
+Setup
+  $ . ${TESTDIR}/../../helpers/setup_integration_test.sh
+  $ . ${TESTDIR}/../../helpers/replace_turbo_json.sh $(pwd) "interactive.json"
+Verify we error on interactive task that hasn't been marked as cache: false
+  $ ${TURBO} build
+    x Tasks cannot be marked as interactive and cacheable
+     ,-[turbo.json:7:1]
+   7 |       "env": ["NODE_ENV"],
+   8 |       "interactive": true,
+     :                      ^^|^
+     :                        `-- marked interactive here
+   9 |       "outputs": []
+     `----
+  
+  [1]

--- a/turborepo-tests/integration/tests/interactive.t
+++ b/turborepo-tests/integration/tests/interactive.t
@@ -4,12 +4,12 @@ Setup
 Verify we error on interactive task that hasn't been marked as cache: false
   $ ${TURBO} build
     x Tasks cannot be marked as interactive and cacheable
-     ,-[turbo.json:7:1]
-   7 |       "env": ["NODE_ENV"],
-   8 |       "interactive": true,
+     ,-[turbo.json:6:1]
+   6 |     "build": {
+   7 |       "interactive": true
      :                      ^^|^
      :                        `-- marked interactive here
-   9 |       "outputs": []
+   8 |     }
      `----
   
   [1]

--- a/turborepo-tests/integration/tests/persistent-dependencies/1-topological.t
+++ b/turborepo-tests/integration/tests/persistent-dependencies/1-topological.t
@@ -13,7 +13,7 @@
 // app-a#dev
 // └── pkg-a#dev
   $ ${TURBO} run dev
-    x invalid persistent task configuration
+    x invalid task configuration
   
   Error:   x "pkg-a#dev" is a persistent task, "app-a#dev" cannot depend on it
      ,-[turbo.json:4:1]

--- a/turborepo-tests/integration/tests/persistent-dependencies/10-too-many.t
+++ b/turborepo-tests/integration/tests/persistent-dependencies/10-too-many.t
@@ -2,7 +2,7 @@
   $ . ${TESTDIR}/../../../helpers/setup_integration_test.sh persistent_dependencies/10-too-many
 
   $ ${TURBO} run build --concurrency=1
-    x invalid persistent task configuration
+    x invalid task configuration
   
   Error:   x You have 2 persistent tasks but `turbo` is configured for concurrency of
     | 1. Set --concurrency to at least 3
@@ -10,7 +10,7 @@
   [1]
 
   $ ${TURBO} run build --concurrency=2
-    x invalid persistent task configuration
+    x invalid task configuration
   
   Error:   x You have 2 persistent tasks but `turbo` is configured for concurrency of
     | 2. Set --concurrency to at least 3

--- a/turborepo-tests/integration/tests/persistent-dependencies/2-same-workspace.t
+++ b/turborepo-tests/integration/tests/persistent-dependencies/2-same-workspace.t
@@ -13,7 +13,7 @@
 // └── app-a#dev
 //
   $ ${TURBO} run build
-    x invalid persistent task configuration
+    x invalid task configuration
   
   Error:   x "app-a#dev" is a persistent task, "app-a#build" cannot depend on it
      ,-[turbo.json:4:1]

--- a/turborepo-tests/integration/tests/persistent-dependencies/3-workspace-specific.t
+++ b/turborepo-tests/integration/tests/persistent-dependencies/3-workspace-specific.t
@@ -17,7 +17,7 @@
 #
 # The regex match is liberal, because the build task from either workspace can throw the error
   $ ${TURBO} run build
-    x invalid persistent task configuration
+    x invalid task configuration
   
   Error:   x "pkg-a#dev" is a persistent task, "((pkg-a)|(app-a))#build" cannot depend on it (re)
      ,-[turbo.json:4:1]

--- a/turborepo-tests/integration/tests/persistent-dependencies/4-cross-workspace.t
+++ b/turborepo-tests/integration/tests/persistent-dependencies/4-cross-workspace.t
@@ -7,7 +7,7 @@
 # app-a#dev
 # └── pkg-a#dev
   $ ${TURBO} run dev
-    x invalid persistent task configuration
+    x invalid task configuration
   
   Error:   x "pkg-a#dev" is a persistent task, "app-a#dev" cannot depend on it
      ,-[turbo.json:4:1]

--- a/turborepo-tests/integration/tests/persistent-dependencies/5-root-workspace.t
+++ b/turborepo-tests/integration/tests/persistent-dependencies/5-root-workspace.t
@@ -13,7 +13,7 @@
 # └── //#dev
 #
   $ ${TURBO} run build
-    x invalid persistent task configuration
+    x invalid task configuration
   
   Error:   x "//#dev" is a persistent task, "app-a#build" cannot depend on it
      ,-[turbo.json:4:1]

--- a/turborepo-tests/integration/tests/persistent-dependencies/7-topological-nested.t
+++ b/turborepo-tests/integration/tests/persistent-dependencies/7-topological-nested.t
@@ -20,7 +20,7 @@
 # error message should say. Leaving as-is so we don't have to implement special casing logic to handle
 # this case.
   $ ${TURBO} run dev
-    x invalid persistent task configuration
+    x invalid task configuration
   
   Error:   x "pkg-b#dev" is a persistent task, "pkg-a#dev" cannot depend on it
      ,-[turbo.json:4:1]

--- a/turborepo-tests/integration/tests/persistent-dependencies/8-topological-with-extra.t
+++ b/turborepo-tests/integration/tests/persistent-dependencies/8-topological-with-extra.t
@@ -19,7 +19,7 @@
 // 		 └── workspace-c#build
 // 		 		 └── workspace-z#dev	// this one is persistent
   $ ${TURBO} run build
-    x invalid persistent task configuration
+    x invalid task configuration
   
   Error:   x "pkg-z#dev" is a persistent task, "pkg-b#build" cannot depend on it
      ,-[turbo.json:7:1]

--- a/turborepo-tests/integration/tests/persistent-dependencies/9-cross-workspace-nested.t
+++ b/turborepo-tests/integration/tests/persistent-dependencies/9-cross-workspace-nested.t
@@ -12,7 +12,7 @@
 // 		 		 └── workspace-z#dev // this one is persistent
 //
   $ ${TURBO} run build
-    x invalid persistent task configuration
+    x invalid task configuration
   
   Error:   x "app-z#dev" is a persistent task, "app-c#build" cannot depend on it
       ,-[turbo.json:12:1]

--- a/turborepo-tests/integration/tests/run-summary/error.t
+++ b/turborepo-tests/integration/tests/run-summary/error.t
@@ -61,7 +61,8 @@ Validate that we got a full task summary for the failed task with an error in .e
       "persistent": false,
       "env": [],
       "passThroughEnv": null,
-      "dotEnv": null
+      "dotEnv": null,
+      "interactive": false
     },
     "expandedOutputs": [],
     "framework": "",

--- a/turborepo-tests/integration/tests/run/single-package/dry-run.t
+++ b/turborepo-tests/integration/tests/run/single-package/dry-run.t
@@ -33,5 +33,5 @@ Check
     Inferred Env Vars Values       =\s* (re)
     Passed Through Env Vars        =\s* (re)
     Passed Through Env Vars Values =\s* (re)
-    Resolved Task Definition       = {"outputs":\["foo.txt"],"cache":true,"dependsOn":\[],"inputs":\[],"outputMode":"full","persistent":false,"env":\[],"passThroughEnv":null,"dotEnv":null}\s* (re)
+    Resolved Task Definition       = {"outputs":["foo.txt"],"cache":true,"dependsOn":[],"inputs":[],"outputMode":"full","persistent":false,"env":[],"passThroughEnv":null,"dotEnv":null,"interactive":false}
     Framework                      =\s* (re)

--- a/turborepo-tests/integration/tests/run/single-package/no-config.t
+++ b/turborepo-tests/integration/tests/run/single-package/no-config.t
@@ -35,7 +35,7 @@ Check
     Inferred Env Vars Values       =\s* (re)
     Passed Through Env Vars        =\s* (re)
     Passed Through Env Vars Values =\s* (re)
-    Resolved Task Definition       = {"outputs":\[],"cache":false,"dependsOn":\[],"inputs":\[],"outputMode":"full","persistent":false,"env":\[],"passThroughEnv":null,"dotEnv":null}\s* (re)
+    Resolved Task Definition       = {"outputs":[],"cache":false,"dependsOn":[],"inputs":[],"outputMode":"full","persistent":false,"env":[],"passThroughEnv":null,"dotEnv":null,"interactive":false}
     Framework                      =\s* (re)
 
   $ ${TURBO} run build --graph

--- a/turborepo-tests/integration/tests/run/single-package/with-deps-dry-run.t
+++ b/turborepo-tests/integration/tests/run/single-package/with-deps-dry-run.t
@@ -33,7 +33,7 @@ Check
     Inferred Env Vars Values       =\s* (re)
     Passed Through Env Vars        =\s* (re)
     Passed Through Env Vars Values =\s* (re)
-    Resolved Task Definition       = {"outputs":\["foo.txt"],"cache":true,"dependsOn":\[],"inputs":\[],"outputMode":"full","persistent":false,"env":\[],"passThroughEnv":null,"dotEnv":null}\s* (re)
+    Resolved Task Definition       = {"outputs":["foo.txt"],"cache":true,"dependsOn":[],"inputs":[],"outputMode":"full","persistent":false,"env":[],"passThroughEnv":null,"dotEnv":null,"interactive":false}
     Framework                      =\s* (re)
   test
     Task                           = test\s* (re)
@@ -52,5 +52,5 @@ Check
     Inferred Env Vars Values       =\s* (re)
     Passed Through Env Vars        =\s* (re)
     Passed Through Env Vars Values =\s* (re)
-    Resolved Task Definition       = {"outputs":\[],"cache":true,"dependsOn":\["build"],"inputs":\[],"outputMode":"full","persistent":false,"env":\[],"passThroughEnv":null,"dotEnv":null}\s* (re)
+    Resolved Task Definition       = {"outputs":[],"cache":true,"dependsOn":["build"],"inputs":[],"outputMode":"full","persistent":false,"env":[],"passThroughEnv":null,"dotEnv":null,"interactive":false}
     Framework                      =\s* (re)

--- a/turborepo-tests/integration/tests/workspace-configs/override-values-deps.t
+++ b/turborepo-tests/integration/tests/workspace-configs/override-values-deps.t
@@ -34,7 +34,8 @@ Setup
     "persistent": false,
     "env": [],
     "passThroughEnv": null,
-    "dotEnv": null
+    "dotEnv": null,
+    "interactive": false
   }
 
 # This task is similar, but `dependsOn` in the root turbo.json _only_ has a topological dependency
@@ -49,5 +50,6 @@ Setup
     "persistent": false,
     "env": [],
     "passThroughEnv": null,
-    "dotEnv": null
+    "dotEnv": null,
+    "interactive": false
   }

--- a/turborepo-tests/integration/tests/workspace-configs/persistent.t
+++ b/turborepo-tests/integration/tests/workspace-configs/persistent.t
@@ -10,7 +10,7 @@ This test covers:
 # persistent-task-1-parent dependsOn persistent-task-1
 # persistent-task-1 is persistent:true in the root workspace, and does NOT get overriden in the workspace
   $ ${TURBO} run persistent-task-1-parent --filter=persistent
-    x invalid persistent task configuration
+    x invalid task configuration
   
   Error:   x "persistent#persistent-task-1" is a persistent task,
     | "persistent#persistent-task-1-parent" cannot depend on it
@@ -51,7 +51,7 @@ This test covers:
 # persistent-task-3 is persistent:true in the root workspace
 # persistent-task-3 is defined in workspace, but does NOT have the persistent flag
   $ ${TURBO} run persistent-task-3-parent --filter=persistent
-    x invalid persistent task configuration
+    x invalid task configuration
   
   Error:   x "persistent#persistent-task-3" is a persistent task,
     | "persistent#persistent-task-3-parent" cannot depend on it
@@ -68,7 +68,7 @@ This test covers:
 # persistent-task-4-parent dependsOn persistent-task-4
 # persistent-task-4 has no config in the root workspace, and is set to true in the workspace
   $ ${TURBO} run persistent-task-4-parent --filter=persistent
-    x invalid persistent task configuration
+    x invalid task configuration
   
   Error:   x "persistent#persistent-task-4" is a persistent task,
     | "persistent#persistent-task-4-parent" cannot depend on it


### PR DESCRIPTION
### Description

This adds a new `"interactive"` field to task definitions which allows users to interact with tasks when it is set to true.

A few notes on the feature:
 - All persistent tasks automatically are interactive
 - Interactive tasks cannot be cached since the interaction can (and probably will) alter the task's execution. This could be done automatically, but I chose to require that the task be explicitly marked as `"cache": false` to reduce perceived magic.
 - `turbo` will not attempt to run if any tasks in the graph are marked as interactive and the experimental UI isn't being used

### Testing Instructions

Snapshot test for various validation errors.

Manual testing: no longer able to select tasks and interact with them e.g. `turbo_dev build --filter=docs --force`


Closes TURBO-2656