### PR TITLE
chore: enable new UI for the repo

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -218,5 +218,6 @@
   },
   "experimentalSpaces": {
     "id": "space_WTrAuWxqVUapGgZDX7KiZV1v"
-  }
+  },
+  "experimentalUI": true
 }


### PR DESCRIPTION
### Description

Enable new UI by default for the repo. Can be opted out of by setting `TURBO_EXPERIMENTAL_UI=false`

### Testing Instructions

Pull this down and give `turbo_dev build --filter=docs` a shot.
