### PR TITLE
feat(Turborepo): handle package manager changes

### DIFF
--- a/crates/turborepo-filewatch/src/cookies.rs
+++ b/crates/turborepo-filewatch/src/cookies.rs
@@ -193,11 +193,6 @@ impl CookieWriter {
         Self::new(&cookie_root, timeout, recv)
     }
 
-    #[cfg(test)]
-    pub(crate) fn cookie_dir(&self) -> &AbsoluteSystemPath {
-        &self.cookie_root
-    }
-
     pub fn new(
         cookie_root: &AbsoluteSystemPath,
         timeout: Duration,


### PR DESCRIPTION
### Description

 - Always use local discovery inside package discovery process
 - Keep package watching state in a local variable inside the process
 - Handle recovering from package manager changes

### Testing Instructions

 - Added a test for changing package manager
 - Switch tests to blocking calls to avoid reliance on timeout



Closes TURBO-2658