### PR TITLE
change port of trace-server

### DIFF
--- a/crates/turbopack-trace-server/src/server.rs
+++ b/crates/turbopack-trace-server/src/server.rs
@@ -108,7 +108,10 @@ struct ConnectionState {
 }
 
 pub fn serve(store: Arc<StoreContainer>) -> Result<()> {
-    let mut server = Server::bind("127.0.0.1:57475")?;
+    let mut server: websocket::server::WsServer<
+        websocket::server::NoTlsAcceptor,
+        std::net::TcpListener,
+    > = Server::bind("127.0.0.1:5747")?;
     loop {
         let Ok(connection) = server.accept() else {
             continue;


### PR DESCRIPTION
### Description

The port number is too high and in the automatically chosen range. This could lead to port being already used.

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->


Closes PACK-2798