### PR TITLE
fix(examples): avoid clearing screen when using vite

### DIFF
--- a/examples/with-vite/apps/docs/package.json
+++ b/examples/with-vite/apps/docs/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --clearScreen false",
     "build": "tsc && vite build",
     "preview": "vite preview",
     "lint": "eslint \"src/**/*.ts\""

--- a/examples/with-vite/apps/web/package.json
+++ b/examples/with-vite/apps/web/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --clearScreen false",
     "build": "tsc && vite build",
     "preview": "vite preview",
     "lint": "eslint \"src/**/*.ts\""


### PR DESCRIPTION
### Description

By default [`vite`](https://vitejs.dev/guide/cli) clears the terminal upon starting the server. This is not desirable when being used via `turbo` as it will  erase output from `turbo` or other tasks that have run or are still running.

### Testing Instructions

Invoking the `dev` script should no longer clear the screen.


Closes TURBO-2661