### PR TITLE
chore: update turbo.json schema for interactive tasks

### DIFF
--- a/packages/turbo-types/src/types/config.ts
+++ b/packages/turbo-types/src/types/config.ts
@@ -111,6 +111,15 @@ export interface RootSchema extends BaseSchema {
    * @defaultValue `{}`
    */
   remoteCache?: RemoteCache;
+
+  /**
+   * Enable use of the new UI for `turbo`.
+   *
+   * Documentation: https://turbo.build/repo/docs/reference/configuration#experimentalui
+   *
+   * @defaultValue `{}`
+   */
+  experimentalUI?: boolean;
 }
 
 export interface Pipeline {
@@ -249,6 +258,15 @@ export interface Pipeline {
    * @defaultValue false
    */
   persistent?: boolean;
+
+  /**
+   * Mark a task as interactive allowing it to receive input from stdin.
+   * Interactive tasks must be marked with "cache": false as the input
+   * they receive from stdin can change the outcome of the task.
+   *
+   * Documentation: https://turbo.build/repo/docs/reference/configuration#interactive
+   */
+  interactive?: boolean;
 }
 
 export interface RemoteCache {


### PR DESCRIPTION
### Description

Update schema with new options added in #7767 and #7755 

Note: this won't update the live schema until we bump the docs site to use a version of `@turbo/types` with the updates. Also anchors in doc links won't be valid until docs PR lands.

### Testing Instructions

👀 
