### PR TITLE
publish 1.13.0-canary.2 to registry

### DIFF
--- a/packages/create-turbo/package.json
+++ b/packages/create-turbo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-turbo",
-  "version": "1.13.0-canary.1",
+  "version": "1.13.0-canary.2",
   "description": "Create a new Turborepo",
   "homepage": "https://turbo.build/repo",
   "license": "MPL-2.0",

--- a/packages/eslint-config-turbo/package.json
+++ b/packages/eslint-config-turbo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-turbo",
-  "version": "1.13.0-canary.1",
+  "version": "1.13.0-canary.2",
   "description": "ESLint config for Turborepo",
   "repository": {
     "type": "git",

--- a/packages/eslint-plugin-turbo/package.json
+++ b/packages/eslint-plugin-turbo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-turbo",
-  "version": "1.13.0-canary.1",
+  "version": "1.13.0-canary.2",
   "description": "ESLint plugin for Turborepo",
   "keywords": [
     "turbo",

--- a/packages/turbo-codemod/package.json
+++ b/packages/turbo-codemod/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/codemod",
-  "version": "1.13.0-canary.1",
+  "version": "1.13.0-canary.2",
   "description": "Provides Codemod transformations to help upgrade your Turborepo codebase when a feature is deprecated.",
   "homepage": "https://turbo.build/repo",
   "license": "MPL-2.0",

--- a/packages/turbo-gen/package.json
+++ b/packages/turbo-gen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/gen",
-  "version": "1.13.0-canary.1",
+  "version": "1.13.0-canary.2",
   "description": "Extend a Turborepo",
   "homepage": "https://turbo.build/repo",
   "license": "MPL-2.0",

--- a/packages/turbo-ignore/package.json
+++ b/packages/turbo-ignore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbo-ignore",
-  "version": "1.13.0-canary.1",
+  "version": "1.13.0-canary.2",
   "description": "",
   "homepage": "https://turbo.build/repo",
   "keywords": [],

--- a/packages/turbo-types/package.json
+++ b/packages/turbo-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/types",
-  "version": "1.13.0-canary.1",
+  "version": "1.13.0-canary.2",
   "description": "Turborepo types",
   "homepage": "https://turbo.build/repo",
   "license": "MPL-2.0",

--- a/packages/turbo-workspaces/package.json
+++ b/packages/turbo-workspaces/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/workspaces",
-  "version": "1.13.0-canary.1",
+  "version": "1.13.0-canary.2",
   "description": "Tools for working with package managers",
   "homepage": "https://turbo.build/repo",
   "license": "MPL-2.0",

--- a/packages/turbo/package.json
+++ b/packages/turbo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbo",
-  "version": "1.13.0-canary.1",
+  "version": "1.13.0-canary.2",
   "description": "Turborepo is a high-performance build system for JavaScript and TypeScript codebases.",
   "repository": "https://github.com/vercel/turbo",
   "bugs": "https://github.com/vercel/turbo/issues",
@@ -17,11 +17,11 @@
     "bin"
   ],
   "optionalDependencies": {
-    "turbo-darwin-64": "1.13.0-canary.1",
-    "turbo-darwin-arm64": "1.13.0-canary.1",
-    "turbo-linux-64": "1.13.0-canary.1",
-    "turbo-linux-arm64": "1.13.0-canary.1",
-    "turbo-windows-64": "1.13.0-canary.1",
-    "turbo-windows-arm64": "1.13.0-canary.1"
+    "turbo-darwin-64": "1.13.0-canary.2",
+    "turbo-darwin-arm64": "1.13.0-canary.2",
+    "turbo-linux-64": "1.13.0-canary.2",
+    "turbo-linux-arm64": "1.13.0-canary.2",
+    "turbo-windows-64": "1.13.0-canary.2",
+    "turbo-windows-arm64": "1.13.0-canary.2"
   }
 }

--- a/version.txt
+++ b/version.txt
@@ -1,2 +1,2 @@
-1.13.0-canary.1
+1.13.0-canary.2
 canary


### PR DESCRIPTION
### Description

Finish the failed release from https://github.com/vercel/turbo/actions/runs/8364249288/job/22899998283#step:11:1722

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->


Closes TURBO-2663