### PR TITLE
feat(pnpm): respect link-workspace-packages npmrc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1704,6 +1704,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed3d0b5ff30645a68f35ece8cea4556ca14ef8a1651455f789a099a0513532a6"
 
 [[package]]
+name = "const-random"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aaf16c9c2c612020bcfd042e170f6e32de9b9d75adb5277cdbbd2e2c8c8299a"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "const-str"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2168,6 +2188,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2568,6 +2594,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac1b7517328c04c2aa68422fc60a41b92208182142ed04a25879c26c8f878794"
 dependencies = [
  "libloading 0.7.4",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
 ]
 
 [[package]]
@@ -5391,6 +5426,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-multimap"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4d6a8c22fc714f0c2373e6091bf6f5e9b37b1bc0b1184874b7e0a4e303d318f"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.3",
+]
+
+[[package]]
 name = "os_info"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6856,6 +6901,16 @@ dependencies = [
  "rand 0.8.5",
  "rustc_version 0.4.0",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e0698206bcb8882bf2a9ecb4c1e7785db57ff052297085a6efd4fe42302068a"
+dependencies = [
+ "cfg-if 1.0.0",
+ "ordered-multimap",
 ]
 
 [[package]]
@@ -9807,6 +9862,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11815,6 +11879,7 @@ dependencies = [
  "petgraph",
  "pretty_assertions",
  "regex",
+ "rust-ini",
  "serde",
  "serde_json",
  "serde_yaml 0.9.27",

--- a/crates/turborepo-repository/Cargo.toml
+++ b/crates/turborepo-repository/Cargo.toml
@@ -16,6 +16,7 @@ lazy-regex = "2.5.0"
 node-semver = "2.1.0"
 petgraph = { workspace = true }
 regex = { workspace = true }
+rust-ini = "0.20.0"
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -12,7 +12,8 @@ use turborepo_graph_utils as graph;
 use turborepo_lockfiles::Lockfile;
 
 use super::{
-    dep_splitter::DependencySplitter, PackageGraph, PackageInfo, PackageName, PackageNode,
+    dep_splitter::DependencySplitter, npmrc::NpmRc, PackageGraph, PackageInfo, PackageName,
+    PackageNode,
 };
 use crate::{
     discovery::{
@@ -20,6 +21,7 @@ use crate::{
         PackageDiscoveryBuilder,
     },
     package_json::PackageJson,
+    package_manager::{self, PackageManager},
 };
 
 pub struct PackageGraphBuilder<'a, T> {
@@ -341,7 +343,20 @@ impl<'a, T: PackageDiscovery> BuildState<'a, ResolvedPackageManager, T> {
 
 impl<'a, T: PackageDiscovery> BuildState<'a, ResolvedWorkspaces, T> {
     #[tracing::instrument(skip(self))]
-    fn connect_internal_dependencies(&mut self) -> Result<(), Error> {
+    fn connect_internal_dependencies(
+        &mut self,
+        package_manager: PackageManager,
+    ) -> Result<(), Error> {
+        let npmrc = match package_manager {
+            PackageManager::Pnpm | PackageManager::Pnpm6 => {
+                let npmrc_path = self.repo_root.join_component(".npmrc");
+                match npmrc_path.read_existing_to_string().ok().flatten() {
+                    Some(contents) => NpmRc::from_reader(contents.as_bytes()).ok(),
+                    None => None,
+                }
+            }
+            _ => None,
+        };
         let split_deps = self
             .workspaces
             .iter()
@@ -353,6 +368,7 @@ impl<'a, T: PackageDiscovery> BuildState<'a, ResolvedWorkspaces, T> {
                         self.repo_root,
                         &entry.package_json_path,
                         &self.workspaces,
+                        npmrc.as_ref(),
                         entry.package_json.all_dependencies(),
                     ),
                 )
@@ -415,7 +431,14 @@ impl<'a, T: PackageDiscovery> BuildState<'a, ResolvedWorkspaces, T> {
 
     #[tracing::instrument(skip(self))]
     async fn resolve_lockfile(mut self) -> Result<BuildState<'a, ResolvedLockfile, T>, Error> {
-        self.connect_internal_dependencies()?;
+        // Since we've already performed package discovery, this should just be a cache
+        // hit
+        let package_manager = self
+            .package_discovery
+            .discover_packages()
+            .await?
+            .package_manager;
+        self.connect_internal_dependencies(package_manager)?;
 
         let lockfile = match self.populate_lockfile().await {
             Ok(lockfile) => Some(lockfile),
@@ -531,6 +554,7 @@ impl Dependencies {
         repo_root: &AbsoluteSystemPath,
         workspace_json_path: &AnchoredSystemPathBuf,
         workspaces: &HashMap<PackageName, PackageInfo>,
+        npmrc: Option<&NpmRc>,
         dependencies: I,
     ) -> Self {
         let resolved_workspace_json_path = repo_root.resolve(workspace_json_path);
@@ -539,7 +563,7 @@ impl Dependencies {
             .expect("package.json path should have parent");
         let mut internal = HashSet::new();
         let mut external = BTreeMap::new();
-        let splitter = DependencySplitter::new(repo_root, workspace_dir, workspaces);
+        let splitter = DependencySplitter::new(repo_root, workspace_dir, workspaces, npmrc);
         for (name, version) in dependencies.into_iter() {
             if let Some(workspace) = splitter.is_internal(name, version) {
                 internal.insert(workspace);

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -16,6 +16,7 @@ use crate::{
 
 pub mod builder;
 mod dep_splitter;
+mod npmrc;
 
 pub use builder::{Error, PackageGraphBuilder};
 

--- a/crates/turborepo-repository/src/package_graph/npmrc.rs
+++ b/crates/turborepo-repository/src/package_graph/npmrc.rs
@@ -1,0 +1,80 @@
+use std::io;
+
+use ini::Ini;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("encountered error parsing .npmrc: {0}")]
+    Ini(#[from] ini::Error),
+}
+
+/// Representation of .npmrc used by both npm and pnpm to configure behavior
+/// The representation is intentionally incomplete and is only intended to
+/// contain settings that affect the package graph.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct NpmRc {
+    /// Used by pnpm to determine whether dependencies
+    /// declared without an explicit workspace protocol
+    /// can target a workspace package.
+    pub link_workspace_packages: Option<bool>,
+}
+
+impl NpmRc {
+    pub fn from_reader(mut reader: impl io::Read) -> Result<Self, Error> {
+        let ini = Ini::read_from(&mut reader)?;
+        Ok(Self::from_ini(ini))
+    }
+
+    // Private to avoid leaking the underlying ini parsing library we use
+    fn from_ini(ini: Ini) -> Self {
+        let link_workspace_packages = ini
+            .get_from::<&str>(None, "link-workspace-packages")
+            .and_then(parse_link_workspace_packages);
+
+        Self {
+            link_workspace_packages,
+        }
+    }
+}
+
+fn parse_link_workspace_packages(value: &str) -> Option<bool> {
+    match value {
+        // "deep" changes the underlying linking strategy used by pnpm, but it still results
+        // in workspace packages being used over npm packages
+        "true" | "deep" => Some(true),
+        "false" => Some(false),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_parse_empty_npmrc() {
+        let empty = NpmRc::from_reader(b"".as_slice()).unwrap();
+        assert_eq!(
+            empty,
+            NpmRc {
+                link_workspace_packages: None
+            }
+        );
+    }
+
+    #[test]
+    fn test_example_pnpm_npmrc() {
+        let contents = b"auto-install-peers=true
+        enable-pre-post-scripts=true
+        link-workspace-packages=false
+        "
+        .as_slice();
+        let example = NpmRc::from_reader(contents).unwrap();
+        assert_eq!(
+            example,
+            NpmRc {
+                link_workspace_packages: Some(false)
+            }
+        );
+    }
+}


### PR DESCRIPTION
### Description

Closes https://github.com/vercel/turbo/issues/7188

Start reading `.npmrc` for `pnpm` projects in order to respect [`link-workspace-packages`](https://pnpm.io/npmrc#link-workspace-packages) which changes when workspace packages will be used.

### Testing Instructions

Added unit tests for verifying that when `link-workspace-packages` is set to false the `workspace` protocol must be used for a workspace package to be considered.

Also tested against repro repo in issue:
<img width="733" alt="Screenshot 2024-03-20 at 2 10 01 PM" src="https://github.com/vercel/turbo/assets/4131117/0fb751f8-3b6e-4e45-9e6d-506625664377">
(See that the service package depends on `is-odd` and there's an `is-odd` in the workspace, but it is only used if `link-workspace-package=true`)


Closes TURBO-2666