### PR TITLE
feat: add ability to control UI via cli arg

### DIFF
--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -199,6 +199,9 @@ pub struct Args {
     pub check_for_update: bool,
     #[clap(long = "__test-run", global = true, hide = true)]
     pub test_run: bool,
+    /// Enable the experimental UI
+    #[clap(long, hide = true, global = true)]
+    pub experimental_ui: bool,
     #[clap(flatten, next_help_heading = "Run Arguments")]
     // We don't serialize this because by the time we're calling
     // Go, we've moved it to the command field as a Command::Run

--- a/crates/turborepo-lib/src/commands/mod.rs
+++ b/crates/turborepo-lib/src/commands/mod.rs
@@ -68,6 +68,7 @@ impl CommandBase {
             .with_token(self.args.token.clone())
             .with_timeout(self.args.remote_cache_timeout)
             .with_preflight(self.args.preflight.then_some(true))
+            .with_experimental_ui(self.args.experimental_ui.then_some(true))
             .build()
     }
 


### PR DESCRIPTION
### Description

Add a command line flag for enabling the experimental UI and hook it up to the config.

### Testing Instructions

<img width="1124" alt="Screenshot 2024-03-20 at 6 37 16 PM" src="https://github.com/vercel/turbo/assets/4131117/9aeff24f-99a0-4b71-a61f-fee444cfac72">



Closes TURBO-2668