### PR TITLE
Update `swc_core` to `v0.90.24`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7988,9 +7988,9 @@ dependencies = [
 
 [[package]]
 name = "styled_jsx"
-version = "0.73.9"
+version = "0.73.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243182797daf80d4ebed2f8ea46c787ac0df5609d10bff5d634dace5375c49b0"
+checksum = "fb7b2381ed0b1ba760b75671388d45be3196ab8514a6429b4fca05ab9dcfc86c"
 dependencies = [
  "anyhow",
  "lightningcss",
@@ -8000,6 +8000,7 @@ dependencies = [
  "swc_common",
  "swc_css_ast",
  "swc_css_codegen",
+ "swc_css_compat",
  "swc_css_minifier",
  "swc_css_parser",
  "swc_css_prefixer",
@@ -8400,9 +8401,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_minifier"
-version = "0.116.28"
+version = "0.116.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74888e8f156a087c2aa81e8542d30b5301ea025a1a99e1706e1a8b7f68b9282f"
+checksum = "dc7000b4de2dfbd04d8f2a1cc99046b8594fd9cd67fc9593f07df5425a508f75"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -8443,9 +8444,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_prefixer"
-version = "0.153.31"
+version = "0.153.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc040a489255446c6cfbb506677f0ceee0b8241a6c2a6f0eaf6b460c8d19b8d"
+checksum = "25c08c9394e9d314f4d7995653e7ef7bc9563aff1cb736457ed9009e278d72b9"
 dependencies = [
  "once_cell",
  "preset_env_base",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -765,9 +765,9 @@ dependencies = [
 
 [[package]]
 name = "binding_macros"
-version = "0.64.21"
+version = "0.64.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eafb79d33c5a86e79be2a61e4e61b964ba7f088cc71ccc1cf592bdd1e4ce8f6f"
+checksum = "bfd8f34cab921542b9dcddd34d65e5ee3953d16d07a643509494ad2d7946cb1a"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -8090,9 +8090,9 @@ dependencies = [
 
 [[package]]
 name = "swc"
-version = "0.273.21"
+version = "0.273.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271c22c41d6232166f69dd16264f44ab7217a5b3ee6c6c428991dae86e577c11"
+checksum = "48a68d147a2270bbe2164ee4060d0176590a1035f54d82f7252d16a15e4154a9"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -8168,9 +8168,9 @@ dependencies = [
 
 [[package]]
 name = "swc_bundler"
-version = "0.225.16"
+version = "0.225.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64c48267139ec36f4250360c80a400c4efe3a9d82e69c74406a4760bb0f94297"
+checksum = "f145a1a7293edce9efa80fe4f92a2cbd821c31d5c3123d04182fc1928613d978"
 dependencies = [
  "anyhow",
  "crc",
@@ -8214,9 +8214,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.33.19"
+version = "0.33.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc30ce6695b841f0a9ae01a9ca10ac3922cff559a6253c756a203c4332c62945"
+checksum = "317d2fcdbb1bc9ecfd0bfc67468d675a5159a6fd1863abf41c8c5b7b7adcab03"
 dependencies = [
  "ahash 0.8.9",
  "anyhow",
@@ -8247,9 +8247,9 @@ dependencies = [
 
 [[package]]
 name = "swc_compiler_base"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da889eaa8f6d019f3b391eebfb395990a0b58b4f4e86f76689f2a14fd8de2239"
+checksum = "e14edecfac835e77c88017d016c48dba60e82632ee94eb9565f516ebc7072e6a"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -8299,9 +8299,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "0.90.22"
+version = "0.90.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd79fcc3d20ab7b74794d4155ac12639760e8ec96fed7413624db61f3185e62"
+checksum = "354892a17af24956c9ae5479c2bd0a2f9c344aab79e6f2fbd01b7b8eb4e46c2e"
 dependencies = [
  "binding_macros",
  "swc",
@@ -8342,9 +8342,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_ast"
-version = "0.140.20"
+version = "0.140.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f84c34fffb1b9dde1024ad6fa473ff4e1616cf8efc69600bbb83df0bcac2708"
+checksum = "a930397de06e2d10d5042d927993af9e09e7824ff84b7d4d7b4a663e7c63e55d"
 dependencies = [
  "is-macro",
  "string_enum",
@@ -8354,9 +8354,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_codegen"
-version = "0.151.30"
+version = "0.151.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f59063897824aac5509c94f26f991b64f91c4cda3679aa6cb3acb421ca634c"
+checksum = "9dfdbd0d5eeb7b4cb4193d49aad0c1f1d8561b0533607992505a7c4a11dce4e8"
 dependencies = [
  "auto_impl",
  "bitflags 2.4.0",
@@ -8383,9 +8383,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_compat"
-version = "0.27.31"
+version = "0.27.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9633219ea6d10276555460909afb4d0f8110245a2686a4919d7b721d71255ed9"
+checksum = "8c8c4ffbda70abf13435778820470a804619bd1f33e6d11412a7de595ebcfbbb"
 dependencies = [
  "bitflags 2.4.0",
  "once_cell",
@@ -8414,9 +8414,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_modules"
-version = "0.29.33"
+version = "0.29.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4665118c8f595da12f102229e07244d14e0c2e75138b0232d739497c87f36cb2"
+checksum = "209966e658fb11773a8d14c004554fdc667f6d44128942c47f3d0195cf483613"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -8430,9 +8430,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_parser"
-version = "0.150.29"
+version = "0.150.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab1cb5c7711f052322b47a26a04d064a7dc2fba56839a9249f895618120970d"
+checksum = "ecf8cfbef4c0b847829ca1399d762e7e29da3c9fe6593670145fd222252eab6f"
 dependencies = [
  "lexical",
  "serde",
@@ -8460,9 +8460,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_utils"
-version = "0.137.20"
+version = "0.137.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "516874bfd2cc1ddc9025d4049d1214127e5b2dcff7d02dcc80f54e359e34b675"
+checksum = "3ac61660cd182bbb0fc53ee86f470e8bba6f5b0f1d85e44bf4ff9dfa2c862a12"
 dependencies = [
  "once_cell",
  "serde",
@@ -8475,9 +8475,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_visit"
-version = "0.139.20"
+version = "0.139.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5930573480f409ee39ded5d109781ee68f084c92d1d3c90dc19e04f8988bdb9"
+checksum = "d2bc4deb5540e3869f74e09997b2dd9e1d7b3f750ba2c910f88041f8027868c5"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -8488,9 +8488,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.112.5"
+version = "0.112.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "032f528398358da8ff2fe795755602b4a81ffc93430b9830c0e1d5f198d8f48d"
+checksum = "70656acd47c91918635f1e8589963428cb3170975b71d786c79fb7a25605f687"
 dependencies = [
  "bitflags 2.4.0",
  "bytecheck",
@@ -8508,9 +8508,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.148.11"
+version = "0.148.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d469ef5ec86a90fb2fa3bff474847fc4d16fd98e34254b834aaf2484bfe472"
+checksum = "2afcce205914b8451880fc5ef63dae9bac3dc7b71917921ede64f8e7fd8447a1"
 dependencies = [
  "memchr",
  "num-bigint",
@@ -8539,9 +8539,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_bugfixes"
-version = "0.4.16"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1a491b350c33afc7b043f065f060dcfbfe112e40765b3253e03c33d86149fcc"
+checksum = "8731bec087336f7ed1cd4d4c082a6f7b7b9072ac5fc6f6379b6f98520a0e8303"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -8556,9 +8556,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_common"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30fd7f4e35d1a8e9edc495fdd843993103cf7b230bbd2ee960d402c5ca8e3c7"
+checksum = "1b06844b66a86b8f3bad66888500fd8fe1e4ac09612c5ae0946ca3f77b81f6b0"
 dependencies = [
  "swc_common",
  "swc_ecma_ast",
@@ -8569,9 +8569,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2015"
-version = "0.4.16"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34bd915d417c1dd95811ae7a16588969ccb598e65721f235781396aac158fb33"
+checksum = "7646243203205d2409a891b998d4d30b7a4563a57429da1cbeabd03f18e506b2"
 dependencies = [
  "arrayvec 0.7.4",
  "indexmap 2.2.3",
@@ -8595,9 +8595,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2016"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63ca0be7e941e2c6cfcc66e1821d05511c7fa5bed01da2037ab65c0aa3a508bf"
+checksum = "c75e868ae64fe2625c8aae1f929bae734500ae336d37731f6d4bdf66b8e3b8d3"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -8612,9 +8612,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2017"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a85af431e6b334fbd5d83bebb3fdaaf9f94882c8a3fdb91bb4e5100319109a3"
+checksum = "d9335b27e554e21db7cd541bcee1b5a58b5994439d1a2cb1c9188a3a557548d3"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -8630,9 +8630,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2018"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829e6bf821dbe4381d41b51b062b31f0a97c8d80c98b41060e4c80245d260cb5"
+checksum = "66be32a60872762335524766f0afca4900699e1fc7ab14d87567e0e9b3d95cc2"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -8649,9 +8649,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2019"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa7a7fd53ffa313ed1d03fa913ddb3db42e2e36609a4d062a2c4cfbfae68d9ac"
+checksum = "6a984708b06d662df1c10c2fc06bf98562c6ea3bb93c0e4d5491ee8e61c08e00"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -8665,9 +8665,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2020"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b56f42e0fbeabe54dd963a5f2ae861c5375e50084e0b9bd18520e9ee9308b13"
+checksum = "c8b310227bbafd12dbe717c1969bf5095e9b6aff563cea3e9ff6e46371971293"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -8683,9 +8683,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2021"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44df74b9fe6604faa8ae7b95fadfa1a783ee0e782caa35992f841a87b3943ee1"
+checksum = "ab566642dff583a16b7b188cf9effc6ae603ea2172769f7a3e7fc1aaf41b67b3"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -8699,9 +8699,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2022"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12e9090383b12124af70f1f4853e6b1108bfc70b7199282e8577d85a058bd23c"
+checksum = "62fcfa41b83014ee338c219c446e4ac7f66620706d871b1234d68f990a26225b"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -8718,9 +8718,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es3"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34f8eb567e43cd7d5f0816281eac57c505b5da2afe9e73b7e460fe074b924c32"
+checksum = "3678f2454374d8aefe0997fa32089dd2c3f06d20ecaa0d1fa30c0d3e9871c79b"
 dependencies = [
  "swc_common",
  "swc_ecma_ast",
@@ -8733,9 +8733,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ext_transforms"
-version = "0.113.12"
+version = "0.113.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78c06ae715d8b8137b9c9b2abc6728d699a7b252ed290bfa8a9a14b5af009f1"
+checksum = "71d02e315207f4c6fd0a1a475039b2874392e46a04d1a297c9c66ef0082d9fce"
 dependencies = [
  "phf 0.11.2",
  "swc_atoms",
@@ -8747,9 +8747,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_lints"
-version = "0.92.17"
+version = "0.92.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a41f1bda71bedf2b63f44d0ac3d9830d717491a4d826e70493778efd0fba0af1"
+checksum = "12d3615603b9719f33180080ccada04d0cb6a077d90c958a71d746c7b015c040"
 dependencies = [
  "auto_impl",
  "dashmap",
@@ -8767,9 +8767,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_loader"
-version = "0.45.22"
+version = "0.45.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5a8e2dfe2062f4c33413639ea1f5c2bd331ce30142b1405cbe025037008b95a"
+checksum = "6732100aba9bec438fcff857ab8db5e5d3b64b42a522aec7c388d8c98a36d22a"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -8789,9 +8789,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "0.192.17"
+version = "0.192.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e390390abcdb1800f6106f7da5b462f5b84db6b4dbf8e46ea3c79cc74947709f"
+checksum = "624b38cf23679ab41ca0e47c37f49617275cb15ad7bbaa66a307c42e67ebc1d5"
 dependencies = [
  "arrayvec 0.7.4",
  "indexmap 2.2.3",
@@ -8823,9 +8823,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.143.9"
+version = "0.143.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5166745785657b26ff7722fc32fafd77a79b655602f8628da9c79cede921da74"
+checksum = "4b919bb9ae5e1c8c54fb109f7e94b4a00185bd255c1238ba823e8102601e2133"
 dependencies = [
  "either",
  "new_debug_unreachable",
@@ -8845,9 +8845,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "0.206.16"
+version = "0.206.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7f79092196efdf7c1a714976a39b684ef2d32d9c4e782d0ddc7a35f5785518"
+checksum = "3e30d4cf2d63c2094d22a2778537353ea817f91c42c2e3bafc88cbe064b1f681"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -8870,9 +8870,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_quote_macros"
-version = "0.54.12"
+version = "0.54.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6279141a1514e802863022d5b421a6bebe23f37ee01b426fff4958793028bd03"
+checksum = "49a0e789f5cced50904847f0fefef0f416156c12f0e0cf8b054f6fba6233023a"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -8887,9 +8887,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_testing"
-version = "0.22.21"
+version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5053453e9d7571e80eed154a0567392bc4e8a9021a5336890c301bb17fc6706c"
+checksum = "7c5704ef494b1805bc4566ff566b964bc1e9d3fb0f0e046ad6392b09a54de844"
 dependencies = [
  "anyhow",
  "hex",
@@ -8900,9 +8900,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.229.16"
+version = "0.229.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adf8082fa0c3fea4dd28caf11aff67ac778a299a596ecdd5950f24902594e7bc"
+checksum = "52b22e7877d623332da5f2a93c204e808091ab2da1c060f794eaea66506fb530"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -8920,9 +8920,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.137.15"
+version = "0.137.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4867f24a241877838b03304ce42006f8347aec8ed5a0a3e794aa9350fc1a5362"
+checksum = "69e9a23d6af398b6efd17bbdad2cfa580102f6c560611f85c63b48f76ffe8f0c"
 dependencies = [
  "better_scoped_tls",
  "bitflags 2.4.0",
@@ -8944,9 +8944,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "0.126.15"
+version = "0.126.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1a07bf4a67a816277896fa5841812ff9f74c26f5640d93e70e471a41d168194"
+checksum = "47af84e64f0216f110839f5552a615d07ed74b45757927f29482700966ab4e97"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -8958,9 +8958,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "0.163.16"
+version = "0.163.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1bc9b8f21a57c5ff07a98c02f152d5888efbac616126bc7d977dfd23cad2d30"
+checksum = "895101f18b39009b8d27f231222e6459a0e71151ba0b3ddf934373bf657602b2"
 dependencies = [
  "arrayvec 0.7.4",
  "indexmap 2.2.3",
@@ -9007,9 +9007,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "0.180.16"
+version = "0.180.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6437d14baad04975867acf2f6aabc3e628c4c3122403287e2ca2659f0d4e92e8"
+checksum = "82c53f9d5e7384e840f78d096f0ed2e8cfd38486adafb282ef8550420cd44890"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -9034,9 +9034,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.198.16"
+version = "0.198.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a8eb51e53c81afd3563b763fae5ed9e5aaf7fbfaf113ba4fe8bf0b152a71b8a"
+checksum = "86789174146707d78c086cee25868624bdfef924bb535ea3fc42f53fa426d4c0"
 dependencies = [
  "dashmap",
  "indexmap 2.2.3",
@@ -9059,9 +9059,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "0.171.16"
+version = "0.171.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd56ca4bd886a0b53a77697220780e9f83468885de6b86175558165c3233717"
+checksum = "278fec72878ab88f63cf797b33091045d29789dfe13c4051ab7ea6731c4b7ffd"
 dependencies = [
  "either",
  "rustc-hash",
@@ -9079,9 +9079,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.183.16"
+version = "0.183.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f9649010c5a8d2648c82d8ec1aef90869eb40429d3c107df09b10452be762b3"
+checksum = "762dad12edcdca424213354518ce60bc3f03a026f8e1990b11459311cef04c91"
 dependencies = [
  "base64 0.21.4",
  "dashmap",
@@ -9104,9 +9104,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_testing"
-version = "0.140.15"
+version = "0.140.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2618344ef828120aa9e42f4441849f5c4c66cb171c79ed15daa400469a9f744"
+checksum = "e9a51288aebf6894f8643c44ad08ed1d9c81b8bfce47195c13f9ff994b77a946"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -9130,9 +9130,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.188.16"
+version = "0.188.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64b474891d125eca576e741735acbf54751292c6384efe1e0f32e1e996d9541"
+checksum = "6d6824fcd8d32ab2e90745a408f71548bd081bf4522d32617745ac1ea243de9c"
 dependencies = [
  "ryu-js",
  "serde",
@@ -9147,9 +9147,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_usage_analyzer"
-version = "0.23.12"
+version = "0.23.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f913be2dca4c6f3536dc7645359507692cd66158f25b46b475a3ea76e6e4a9ae"
+checksum = "21ccc0ff427471b70e48f265854a2e0843ef8429c729009898bea993f300fa77"
 dependencies = [
  "indexmap 2.2.3",
  "rustc-hash",
@@ -9164,9 +9164,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.127.12"
+version = "0.127.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20e64596696563ec040297fa5bed9e7b041138664f8c61ad48cfd88d2fd79c3b"
+checksum = "fc9c6ad70038b770d844fdfc20fd970d66ccebb1edc91804c8a9adaa689d4e39"
 dependencies = [
  "indexmap 2.2.3",
  "num_cpus",
@@ -9183,9 +9183,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.98.6"
+version = "0.98.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "889fc0ec3a9b55377e53e3d4ce06678247b635d7136c1e5d3a2c26578e16cd22"
+checksum = "93692bdcdbb63db8f5e10fea5d202b5487cb27eb443aec424f4335c88f9864af"
 dependencies = [
  "num-bigint",
  "serde",
@@ -9233,9 +9233,9 @@ dependencies = [
 
 [[package]]
 name = "swc_error_reporters"
-version = "0.17.18"
+version = "0.17.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df568fdbcfab1bfc9f9df62113da46cf82626ad2e67e1812bf3b76ca3d800f92"
+checksum = "3329e73f159a3d38d4cd5f606a0918eeff39f5bbdbdafd9b6fecb290d2e9a32d"
 dependencies = [
  "anyhow",
  "miette 4.7.1",
@@ -9246,9 +9246,9 @@ dependencies = [
 
 [[package]]
 name = "swc_fast_graph"
-version = "0.21.19"
+version = "0.21.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "740f846d9450f3dd20b5fbea1db70e4c774493dd10d8bde54c2d2d5fc8ac824d"
+checksum = "aa43c68166a88e233f241976dc3291c30471385fd1019d1fa5660ac503520110"
 dependencies = [
  "indexmap 2.2.3",
  "petgraph",
@@ -9258,9 +9258,9 @@ dependencies = [
 
 [[package]]
 name = "swc_graph_analyzer"
-version = "0.22.21"
+version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be3df7f9506c34242a9802ce1406126bbd21a232a99b8782b50ec8e9270352cd"
+checksum = "02b66d0e18899b3a69eca103e5b4af2f0c837427aa07a60be1c4ceb4346ea245"
 dependencies = [
  "auto_impl",
  "petgraph",
@@ -9292,9 +9292,9 @@ dependencies = [
 
 [[package]]
 name = "swc_node_comments"
-version = "0.20.18"
+version = "0.20.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2dcee90f0a9702a4a0c4b11aa811d8e8fa09fbaeb5d5431d5736d20b3f7688b"
+checksum = "fd75c635e4b54961c1c8dc693bb16eb70497eb8a2564f303089a9a66e81ed7ae"
 dependencies = [
  "dashmap",
  "swc_atoms",
@@ -9328,9 +9328,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_proxy"
-version = "0.41.5"
+version = "0.41.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5488302a4e79ae658b6bacd691385e88836276c81dc7abde31d67f0f2ae7425"
+checksum = "012e5996e3fe64805342b6e31a79d826402bbe4eed35be6a9366e54e41f5d75d"
 dependencies = [
  "better_scoped_tls",
  "rkyv",
@@ -9342,9 +9342,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_runner"
-version = "0.106.12"
+version = "0.106.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc260043f8a6aca969b390f612c047f09e670603a0e23a0ca21757e95aa9d73"
+checksum = "e3fe0f8743615139eed21376c94d8201be331040c8999e9a7c86a43d0ca2ff8b"
 dependencies = [
  "anyhow",
  "enumset",
@@ -9384,9 +9384,9 @@ dependencies = [
 
 [[package]]
 name = "swc_timer"
-version = "0.21.20"
+version = "0.21.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b589033a4387ea540b2e9c3e84e45b1e831e7b16dc301f27d4c9cd492099cdee"
+checksum = "e75ce0373fd1b75a021073d796201d5af15106857fc0a801e31379e9e04891e9"
 dependencies = [
  "tracing",
 ]
@@ -9704,9 +9704,9 @@ dependencies = [
 
 [[package]]
 name = "testing"
-version = "0.35.20"
+version = "0.35.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fff8bc163dd91547a6cb0ad5e32c8b19e0f1bc607031c81726d57c56d21609e0"
+checksum = "761d1719907168f43b49b438bdb58c41608f4af5eac0995e2a8bb16c522656c5"
 dependencies = [
  "ansi_term",
  "cargo_metadata",
@@ -12024,7 +12024,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "rand 0.8.5",
  "static_assertions",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,13 +101,13 @@ mdxjs = "0.1.23"
 modularize_imports = { version = "0.68.7" }
 styled_components = { version = "0.96.6" }
 styled_jsx = { version = "0.73.9" }
-swc_core = { version = "0.90.22", features = [
+swc_core = { version = "0.90.24", features = [
   "ecma_loader_lru",
   "ecma_loader_parking_lot",
 ] }
 swc_emotion = { version = "0.72.6" }
 swc_relay = { version = "0.44.5" }
-testing = { version = "0.35.20" }
+testing = { version = "0.35.21" }
 
 auto-hash-map = { path = "crates/turbo-tasks-auto-hash-map" }
 node-file-trace = { path = "crates/node-file-trace", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ miette = { version = "5.10.0", features = ["fancy"] }
 mdxjs = "0.1.23"
 modularize_imports = { version = "0.68.7" }
 styled_components = { version = "0.96.6" }
-styled_jsx = { version = "0.73.9" }
+styled_jsx = { version = "0.73.10" }
 swc_core = { version = "0.90.24", features = [
   "ecma_loader_lru",
   "ecma_loader_parking_lot",

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/1/graph-effects.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/1/graph-effects.snapshot
@@ -54,15 +54,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                54,
-            ),
-            hi: BytePos(
-                61,
-            ),
-            ctxt: #1,
-        },
+        span: 54..61#1,
         in_try: false,
     },
     Call {
@@ -121,15 +113,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                54,
-            ),
-            hi: BytePos(
-                64,
-            ),
-            ctxt: #0,
-        },
+        span: 54..64#0,
         in_try: false,
     },
 ]

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/array-map/graph-effects.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/array-map/graph-effects.snapshot
@@ -63,15 +63,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                53,
-            ),
-            hi: BytePos(
-                87,
-            ),
-            ctxt: #0,
-        },
+        span: 53..87#0,
         in_try: false,
     },
     MemberCall {
@@ -186,15 +178,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                53,
-            ),
-            hi: BytePos(
-                123,
-            ),
-            ctxt: #0,
-        },
+        span: 53..123#0,
         in_try: false,
     },
     Member {
@@ -261,15 +245,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                135,
-            ),
-            hi: BytePos(
-                169,
-            ),
-            ctxt: #0,
-        },
+        span: 135..169#0,
         in_try: false,
     },
     MemberCall {
@@ -384,15 +360,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                135,
-            ),
-            hi: BytePos(
-                207,
-            ),
-            ctxt: #0,
-        },
+        span: 135..207#0,
         in_try: false,
     },
     Member {
@@ -459,15 +427,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                219,
-            ),
-            hi: BytePos(
-                253,
-            ),
-            ctxt: #0,
-        },
+        span: 219..253#0,
         in_try: false,
     },
     MemberCall {
@@ -586,15 +546,7 @@
                                     Member,
                                 ),
                             ],
-                            span: Span {
-                                lo: BytePos(
-                                    281,
-                                ),
-                                hi: BytePos(
-                                    296,
-                                ),
-                                ctxt: #0,
-                            },
+                            span: 281..296#0,
                             in_try: false,
                         },
                         FreeVar {
@@ -674,15 +626,7 @@
                                     Ident,
                                 ),
                             ],
-                            span: Span {
-                                lo: BytePos(
-                                    281,
-                                ),
-                                hi: BytePos(
-                                    288,
-                                ),
-                                ctxt: #1,
-                            },
+                            span: 281..288#1,
                             in_try: false,
                         },
                         MemberCall {
@@ -764,15 +708,7 @@
                                     Call,
                                 ),
                             ],
-                            span: Span {
-                                lo: BytePos(
-                                    281,
-                                ),
-                                hi: BytePos(
-                                    302,
-                                ),
-                                ctxt: #0,
-                            },
+                            span: 281..302#0,
                             in_try: false,
                         },
                     ],
@@ -850,15 +786,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                219,
-            ),
-            hi: BytePos(
-                306,
-            ),
-            ctxt: #0,
-        },
+        span: 219..306#0,
         in_try: false,
     },
     Member {
@@ -917,15 +845,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                339,
-            ),
-            hi: BytePos(
-                354,
-            ),
-            ctxt: #0,
-        },
+        span: 339..354#0,
         in_try: false,
     },
     FreeVar {
@@ -983,15 +903,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                339,
-            ),
-            hi: BytePos(
-                346,
-            ),
-            ctxt: #1,
-        },
+        span: 339..346#1,
         in_try: false,
     },
     MemberCall {
@@ -1051,15 +963,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                339,
-            ),
-            hi: BytePos(
-                360,
-            ),
-            ctxt: #0,
-        },
+        span: 339..360#0,
         in_try: false,
     },
 ]

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/array/graph-effects.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/array/graph-effects.snapshot
@@ -60,15 +60,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                39,
-            ),
-            hi: BytePos(
-                63,
-            ),
-            ctxt: #0,
-        },
+        span: 39..63#0,
         in_try: false,
     },
     Member {
@@ -121,15 +113,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                50,
-            ),
-            hi: BytePos(
-                62,
-            ),
-            ctxt: #0,
-        },
+        span: 50..62#0,
         in_try: false,
     },
     FreeVar {
@@ -181,15 +165,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                50,
-            ),
-            hi: BytePos(
-                56,
-            ),
-            ctxt: #1,
-        },
+        span: 50..56#1,
         in_try: false,
     },
     Member {
@@ -239,15 +215,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                100,
-            ),
-            hi: BytePos(
-                116,
-            ),
-            ctxt: #0,
-        },
+        span: 100..116#0,
         in_try: false,
     },
     Member {
@@ -300,15 +268,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                103,
-            ),
-            hi: BytePos(
-                115,
-            ),
-            ctxt: #0,
-        },
+        span: 103..115#0,
         in_try: false,
     },
     FreeVar {
@@ -360,15 +320,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                103,
-            ),
-            hi: BytePos(
-                109,
-            ),
-            ctxt: #1,
-        },
+        span: 103..109#1,
         in_try: false,
     },
     Member {
@@ -412,15 +364,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                129,
-            ),
-            hi: BytePos(
-                134,
-            ),
-            ctxt: #0,
-        },
+        span: 129..134#0,
         in_try: false,
     },
     Member {
@@ -464,15 +408,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                147,
-            ),
-            hi: BytePos(
-                152,
-            ),
-            ctxt: #0,
-        },
+        span: 147..152#0,
         in_try: false,
     },
 ]

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/class_super/graph-effects.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/class_super/graph-effects.snapshot
@@ -113,15 +113,7 @@
                                     Ident,
                                 ),
                             ],
-                            span: Span {
-                                lo: BytePos(
-                                    152,
-                                ),
-                                hi: BytePos(
-                                    157,
-                                ),
-                                ctxt: #2,
-                            },
+                            span: 152..157#2,
                             in_try: false,
                         },
                         Call {
@@ -222,15 +214,7 @@
                                     Call,
                                 ),
                             ],
-                            span: Span {
-                                lo: BytePos(
-                                    152,
-                                ),
-                                hi: BytePos(
-                                    159,
-                                ),
-                                ctxt: #0,
-                            },
+                            span: 152..159#0,
                             in_try: false,
                         },
                     ],
@@ -348,15 +332,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                132,
-            ),
-            hi: BytePos(
-                167,
-            ),
-            ctxt: #0,
-        },
+        span: 132..167#0,
         in_try: false,
     },
 ]

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/conditional-import/graph-effects.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/conditional-import/graph-effects.snapshot
@@ -134,15 +134,7 @@
                 Test,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                18,
-            ),
-            hi: BytePos(
-                34,
-            ),
-            ctxt: #0,
-        },
+        span: 18..34#0,
         in_try: false,
     },
     Call {
@@ -187,15 +179,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                11,
-            ),
-            hi: BytePos(
-                35,
-            ),
-            ctxt: #0,
-        },
+        span: 11..35#0,
         in_try: false,
     },
     Member {
@@ -269,15 +253,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                53,
-            ),
-            hi: BytePos(
-                77,
-            ),
-            ctxt: #0,
-        },
+        span: 53..77#0,
         in_try: false,
     },
     Member {
@@ -347,15 +323,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                53,
-            ),
-            hi: BytePos(
-                64,
-            ),
-            ctxt: #0,
-        },
+        span: 53..64#0,
         in_try: false,
     },
     FreeVar {
@@ -424,15 +392,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                53,
-            ),
-            hi: BytePos(
-                60,
-            ),
-            ctxt: #1,
-        },
+        span: 53..60#1,
         in_try: false,
     },
     Conditional {
@@ -601,15 +561,7 @@
                 Test,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                53,
-            ),
-            hi: BytePos(
-                188,
-            ),
-            ctxt: #0,
-        },
+        span: 53..188#0,
         in_try: false,
     },
     Call {
@@ -698,15 +650,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                46,
-            ),
-            hi: BytePos(
-                189,
-            ),
-            ctxt: #0,
-        },
+        span: 46..189#0,
         in_try: false,
     },
     Conditional {
@@ -770,15 +714,7 @@
                                 Call,
                             ),
                         ],
-                        span: Span {
-                            lo: BytePos(
-                                216,
-                            ),
-                            hi: BytePos(
-                                227,
-                            ),
-                            ctxt: #0,
-                        },
+                        span: 216..227#0,
                         in_try: false,
                     },
                 ],
@@ -855,15 +791,7 @@
                                 Call,
                             ),
                         ],
-                        span: Span {
-                            lo: BytePos(
-                                243,
-                            ),
-                            hi: BytePos(
-                                254,
-                            ),
-                            ctxt: #0,
-                        },
+                        span: 243..254#0,
                         in_try: false,
                     },
                 ],
@@ -901,15 +829,7 @@
                 Test,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                198,
-            ),
-            hi: BytePos(
-                256,
-            ),
-            ctxt: #0,
-        },
+        span: 198..256#0,
         in_try: false,
     },
 ]

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/declarations/graph-effects.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/declarations/graph-effects.snapshot
@@ -30,15 +30,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                166,
-            ),
-            hi: BytePos(
-                167,
-            ),
-            ctxt: #1,
-        },
+        span: 166..167#1,
         in_try: false,
     },
 ]

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/default-args/graph-effects.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/default-args/graph-effects.snapshot
@@ -51,15 +51,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                62,
-            ),
-            hi: BytePos(
-                67,
-            ),
-            ctxt: #2,
-        },
+        span: 62..67#2,
         in_try: false,
     },
     ImportedBinding {
@@ -119,15 +111,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                117,
-            ),
-            hi: BytePos(
-                122,
-            ),
-            ctxt: #2,
-        },
+        span: 117..122#2,
         in_try: false,
     },
 ]

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/esbuild-reduced/graph-effects.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/esbuild-reduced/graph-effects.snapshot
@@ -39,15 +39,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                12,
-            ),
-            hi: BytePos(
-                19,
-            ),
-            ctxt: #1,
-        },
+        span: 12..19#1,
         in_try: false,
     },
     Call {
@@ -92,15 +84,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                12,
-            ),
-            hi: BytePos(
-                27,
-            ),
-            ctxt: #0,
-        },
+        span: 12..27#0,
         in_try: false,
     },
     FreeVar {
@@ -143,15 +127,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                41,
-            ),
-            hi: BytePos(
-                48,
-            ),
-            ctxt: #1,
-        },
+        span: 41..48#1,
         in_try: false,
     },
     Call {
@@ -196,15 +172,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                41,
-            ),
-            hi: BytePos(
-                56,
-            ),
-            ctxt: #0,
-        },
+        span: 41..56#0,
         in_try: false,
     },
     Member {
@@ -259,15 +227,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                296,
-            ),
-            hi: BytePos(
-                329,
-            ),
-            ctxt: #0,
-        },
+        span: 296..329#0,
         in_try: false,
     },
     FreeVar {
@@ -328,15 +288,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                317,
-            ),
-            hi: BytePos(
-                328,
-            ),
-            ctxt: #1,
-        },
+        span: 317..328#1,
         in_try: false,
     },
     Call {
@@ -391,15 +343,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                443,
-            ),
-            hi: BytePos(
-                476,
-            ),
-            ctxt: #0,
-        },
+        span: 443..476#0,
         in_try: false,
     },
     Member {
@@ -475,15 +419,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                515,
-            ),
-            hi: BytePos(
-                530,
-            ),
-            ctxt: #0,
-        },
+        span: 515..530#0,
         in_try: true,
     },
     FreeVar {
@@ -558,15 +494,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                515,
-            ),
-            hi: BytePos(
-                522,
-            ),
-            ctxt: #1,
-        },
+        span: 515..522#1,
         in_try: true,
     },
     MemberCall {
@@ -661,15 +589,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                515,
-            ),
-            hi: BytePos(
-                551,
-            ),
-            ctxt: #0,
-        },
+        span: 515..551#0,
         in_try: true,
     },
     Call {
@@ -707,15 +627,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                598,
-            ),
-            hi: BytePos(
-                615,
-            ),
-            ctxt: #0,
-        },
+        span: 598..615#0,
         in_try: false,
     },
 ]

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/esbuild/graph-effects.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/esbuild/graph-effects.snapshot
@@ -39,15 +39,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                12,
-            ),
-            hi: BytePos(
-                19,
-            ),
-            ctxt: #1,
-        },
+        span: 12..19#1,
         in_try: false,
     },
     Call {
@@ -92,15 +84,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                12,
-            ),
-            hi: BytePos(
-                27,
-            ),
-            ctxt: #0,
-        },
+        span: 12..27#0,
         in_try: false,
     },
     FreeVar {
@@ -143,15 +127,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                41,
-            ),
-            hi: BytePos(
-                48,
-            ),
-            ctxt: #1,
-        },
+        span: 41..48#1,
         in_try: false,
     },
     Call {
@@ -196,15 +172,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                41,
-            ),
-            hi: BytePos(
-                56,
-            ),
-            ctxt: #0,
-        },
+        span: 41..56#0,
         in_try: false,
     },
     FreeVar {
@@ -247,15 +215,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                67,
-            ),
-            hi: BytePos(
-                74,
-            ),
-            ctxt: #1,
-        },
+        span: 67..74#1,
         in_try: false,
     },
     Call {
@@ -300,15 +260,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                67,
-            ),
-            hi: BytePos(
-                80,
-            ),
-            ctxt: #0,
-        },
+        span: 67..80#0,
         in_try: false,
     },
     Member {
@@ -374,15 +326,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1005,
-            ),
-            hi: BytePos(
-                1021,
-            ),
-            ctxt: #0,
-        },
+        span: 1005..1021#0,
         in_try: false,
     },
     FreeVar {
@@ -447,15 +391,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1005,
-            ),
-            hi: BytePos(
-                1012,
-            ),
-            ctxt: #1,
-        },
+        span: 1005..1012#1,
         in_try: false,
     },
     Member {
@@ -533,15 +469,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1025,
-            ),
-            hi: BytePos(
-                1032,
-            ),
-            ctxt: #0,
-        },
+        span: 1025..1032#0,
         in_try: false,
     },
     MemberCall {
@@ -611,15 +539,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1025,
-            ),
-            hi: BytePos(
-                1034,
-            ),
-            ctxt: #0,
-        },
+        span: 1025..1034#0,
         in_try: false,
     },
     Member {
@@ -697,15 +617,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1038,
-            ),
-            hi: BytePos(
-                1051,
-            ),
-            ctxt: #0,
-        },
+        span: 1038..1051#0,
         in_try: false,
     },
     MemberCall {
@@ -775,15 +687,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1038,
-            ),
-            hi: BytePos(
-                1053,
-            ),
-            ctxt: #0,
-        },
+        span: 1038..1053#0,
         in_try: false,
     },
     Member {
@@ -855,15 +759,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1112,
-            ),
-            hi: BytePos(
-                1145,
-            ),
-            ctxt: #0,
-        },
+        span: 1112..1145#0,
         in_try: false,
     },
     Member {
@@ -941,15 +837,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1239,
-            ),
-            hi: BytePos(
-                1273,
-            ),
-            ctxt: #0,
-        },
+        span: 1239..1273#0,
         in_try: false,
     },
     FreeVar {
@@ -1018,15 +906,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1329,
-            ),
-            hi: BytePos(
-                1334,
-            ),
-            ctxt: #1,
-        },
+        span: 1329..1334#1,
         in_try: false,
     },
     FreeVar {
@@ -1069,15 +949,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1444,
-            ),
-            hi: BytePos(
-                1463,
-            ),
-            ctxt: #1,
-        },
+        span: 1444..1463#1,
         in_try: false,
     },
     Conditional {
@@ -1141,15 +1013,7 @@
                                 Ident,
                             ),
                         ],
-                        span: Span {
-                            lo: BytePos(
-                                1478,
-                            ),
-                            hi: BytePos(
-                                1497,
-                            ),
-                            ctxt: #1,
-                        },
+                        span: 1478..1497#1,
                         in_try: false,
                     },
                 ],
@@ -1221,15 +1085,7 @@
                 Test,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1440,
-            ),
-            hi: BytePos(
-                1502,
-            ),
-            ctxt: #0,
-        },
+        span: 1440..1502#0,
         in_try: false,
     },
     Call {
@@ -1284,15 +1140,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1530,
-            ),
-            hi: BytePos(
-                1563,
-            ),
-            ctxt: #0,
-        },
+        span: 1530..1563#0,
         in_try: false,
     },
     Member {
@@ -1368,15 +1216,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1602,
-            ),
-            hi: BytePos(
-                1617,
-            ),
-            ctxt: #0,
-        },
+        span: 1602..1617#0,
         in_try: true,
     },
     FreeVar {
@@ -1451,15 +1291,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1602,
-            ),
-            hi: BytePos(
-                1609,
-            ),
-            ctxt: #1,
-        },
+        span: 1602..1609#1,
         in_try: true,
     },
     MemberCall {
@@ -1554,15 +1386,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1602,
-            ),
-            hi: BytePos(
-                1638,
-            ),
-            ctxt: #0,
-        },
+        span: 1602..1638#0,
         in_try: true,
     },
     FreeVar {
@@ -1634,15 +1458,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1670,
-            ),
-            hi: BytePos(
-                1687,
-            ),
-            ctxt: #1,
-        },
+        span: 1670..1687#1,
         in_try: false,
     },
     Call {
@@ -1723,15 +1539,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1670,
-            ),
-            hi: BytePos(
-                1701,
-            ),
-            ctxt: #0,
-        },
+        span: 1670..1701#0,
         in_try: false,
     },
     Member {
@@ -1810,15 +1618,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1712,
-            ),
-            hi: BytePos(
-                1725,
-            ),
-            ctxt: #0,
-        },
+        span: 1712..1725#0,
         in_try: false,
     },
     FreeVar {
@@ -1896,15 +1696,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1712,
-            ),
-            hi: BytePos(
-                1714,
-            ),
-            ctxt: #1,
-        },
+        span: 1712..1714#1,
         in_try: false,
     },
     MemberCall {
@@ -1984,15 +1776,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1712,
-            ),
-            hi: BytePos(
-                1734,
-            ),
-            ctxt: #0,
-        },
+        span: 1712..1734#0,
         in_try: false,
     },
     Conditional {
@@ -2118,15 +1902,7 @@
                                 Member,
                             ),
                         ],
-                        span: Span {
-                            lo: BytePos(
-                                1758,
-                            ),
-                            hi: BytePos(
-                                1773,
-                            ),
-                            ctxt: #0,
-                        },
+                        span: 1758..1773#0,
                         in_try: true,
                     },
                     FreeVar {
@@ -2223,15 +1999,7 @@
                                 Ident,
                             ),
                         ],
-                        span: Span {
-                            lo: BytePos(
-                                1758,
-                            ),
-                            hi: BytePos(
-                                1765,
-                            ),
-                            ctxt: #1,
-                        },
+                        span: 1758..1765#1,
                         in_try: true,
                     },
                     MemberCall {
@@ -2330,15 +2098,7 @@
                                 Call,
                             ),
                         ],
-                        span: Span {
-                            lo: BytePos(
-                                1758,
-                            ),
-                            hi: BytePos(
-                                1778,
-                            ),
-                            ctxt: #0,
-                        },
+                        span: 1758..1778#0,
                         in_try: true,
                     },
                     FreeVar {
@@ -2429,15 +2189,7 @@
                                 Ident,
                             ),
                         ],
-                        span: Span {
-                            lo: BytePos(
-                                1814,
-                            ),
-                            hi: BytePos(
-                                1819,
-                            ),
-                            ctxt: #1,
-                        },
+                        span: 1814..1819#1,
                         in_try: false,
                     },
                 ],
@@ -2537,15 +2289,7 @@
                 Test,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1707,
-            ),
-            hi: BytePos(
-                2154,
-            ),
-            ctxt: #0,
-        },
+        span: 1707..2154#0,
         in_try: false,
     },
     FreeVar {
@@ -2608,15 +2352,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                2196,
-            ),
-            hi: BytePos(
-                2203,
-            ),
-            ctxt: #1,
-        },
+        span: 2196..2203#1,
         in_try: true,
     },
     Call {
@@ -2681,15 +2417,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                2196,
-            ),
-            hi: BytePos(
-                2213,
-            ),
-            ctxt: #0,
-        },
+        span: 2196..2213#0,
         in_try: true,
     },
     Conditional {
@@ -2783,15 +2511,7 @@
                                 Member,
                             ),
                         ],
-                        span: Span {
-                            lo: BytePos(
-                                2299,
-                            ),
-                            hi: BytePos(
-                                2311,
-                            ),
-                            ctxt: #0,
-                        },
+                        span: 2299..2311#0,
                         in_try: false,
                     },
                     Member {
@@ -2883,15 +2603,7 @@
                                 Member,
                             ),
                         ],
-                        span: Span {
-                            lo: BytePos(
-                                2312,
-                            ),
-                            hi: BytePos(
-                                2327,
-                            ),
-                            ctxt: #0,
-                        },
+                        span: 2312..2327#0,
                         in_try: false,
                     },
                     FreeVar {
@@ -2982,15 +2694,7 @@
                                 Ident,
                             ),
                         ],
-                        span: Span {
-                            lo: BytePos(
-                                2312,
-                            ),
-                            hi: BytePos(
-                                2319,
-                            ),
-                            ctxt: #1,
-                        },
+                        span: 2312..2319#1,
                         in_try: false,
                     },
                     MemberCall {
@@ -3084,15 +2788,7 @@
                                 Call,
                             ),
                         ],
-                        span: Span {
-                            lo: BytePos(
-                                2312,
-                            ),
-                            hi: BytePos(
-                                2338,
-                            ),
-                            ctxt: #0,
-                        },
+                        span: 2312..2338#0,
                         in_try: false,
                     },
                     MemberCall {
@@ -3193,15 +2889,7 @@
                                 Call,
                             ),
                         ],
-                        span: Span {
-                            lo: BytePos(
-                                2299,
-                            ),
-                            hi: BytePos(
-                                2339,
-                            ),
-                            ctxt: #0,
-                        },
+                        span: 2299..2339#0,
                         in_try: false,
                     },
                     Member {
@@ -3285,15 +2973,7 @@
                                 Member,
                             ),
                         ],
-                        span: Span {
-                            lo: BytePos(
-                                2367,
-                            ),
-                            hi: BytePos(
-                                2376,
-                            ),
-                            ctxt: #0,
-                        },
+                        span: 2367..2376#0,
                         in_try: false,
                     },
                     Member {
@@ -3396,15 +3076,7 @@
                                 Member,
                             ),
                         ],
-                        span: Span {
-                            lo: BytePos(
-                                2422,
-                            ),
-                            hi: BytePos(
-                                2435,
-                            ),
-                            ctxt: #0,
-                        },
+                        span: 2422..2435#0,
                         in_try: false,
                     },
                     MemberCall {
@@ -3508,15 +3180,7 @@
                                 Call,
                             ),
                         ],
-                        span: Span {
-                            lo: BytePos(
-                                2422,
-                            ),
-                            hi: BytePos(
-                                2444,
-                            ),
-                            ctxt: #0,
-                        },
+                        span: 2422..2444#0,
                         in_try: false,
                     },
                     MemberCall {
@@ -3652,15 +3316,7 @@
                                 Call,
                             ),
                         ],
-                        span: Span {
-                            lo: BytePos(
-                                2367,
-                            ),
-                            hi: BytePos(
-                                2452,
-                            ),
-                            ctxt: #0,
-                        },
+                        span: 2367..2452#0,
                         in_try: false,
                     },
                     Member {
@@ -3739,15 +3395,7 @@
                                 Member,
                             ),
                         ],
-                        span: Span {
-                            lo: BytePos(
-                                2463,
-                            ),
-                            hi: BytePos(
-                                2476,
-                            ),
-                            ctxt: #0,
-                        },
+                        span: 2463..2476#0,
                         in_try: false,
                     },
                     FreeVar {
@@ -3825,15 +3473,7 @@
                                 Ident,
                             ),
                         ],
-                        span: Span {
-                            lo: BytePos(
-                                2463,
-                            ),
-                            hi: BytePos(
-                                2465,
-                            ),
-                            ctxt: #1,
-                        },
+                        span: 2463..2465#1,
                         in_try: false,
                     },
                     MemberCall {
@@ -3913,15 +3553,7 @@
                                 Call,
                             ),
                         ],
-                        span: Span {
-                            lo: BytePos(
-                                2463,
-                            ),
-                            hi: BytePos(
-                                2491,
-                            ),
-                            ctxt: #0,
-                        },
+                        span: 2463..2491#0,
                         in_try: false,
                     },
                     Conditional {
@@ -4036,15 +3668,7 @@
                                                 Member,
                                             ),
                                         ],
-                                        span: Span {
-                                            lo: BytePos(
-                                                2501,
-                                            ),
-                                            hi: BytePos(
-                                                2516,
-                                            ),
-                                            ctxt: #0,
-                                        },
+                                        span: 2501..2516#0,
                                         in_try: false,
                                     },
                                     FreeVar {
@@ -4130,15 +3754,7 @@
                                                 Ident,
                                             ),
                                         ],
-                                        span: Span {
-                                            lo: BytePos(
-                                                2501,
-                                            ),
-                                            hi: BytePos(
-                                                2503,
-                                            ),
-                                            ctxt: #1,
-                                        },
+                                        span: 2501..2503#1,
                                         in_try: false,
                                     },
                                     MemberCall {
@@ -4234,15 +3850,7 @@
                                                 Call,
                                             ),
                                         ],
-                                        span: Span {
-                                            lo: BytePos(
-                                                2501,
-                                            ),
-                                            hi: BytePos(
-                                                2540,
-                                            ),
-                                            ctxt: #0,
-                                        },
+                                        span: 2501..2540#0,
                                         in_try: false,
                                     },
                                     Member {
@@ -4329,15 +3937,7 @@
                                                 Member,
                                             ),
                                         ],
-                                        span: Span {
-                                            lo: BytePos(
-                                                2548,
-                                            ),
-                                            hi: BytePos(
-                                                2560,
-                                            ),
-                                            ctxt: #0,
-                                        },
+                                        span: 2548..2560#0,
                                         in_try: false,
                                     },
                                     FreeVar {
@@ -4423,15 +4023,7 @@
                                                 Ident,
                                             ),
                                         ],
-                                        span: Span {
-                                            lo: BytePos(
-                                                2548,
-                                            ),
-                                            hi: BytePos(
-                                                2550,
-                                            ),
-                                            ctxt: #1,
-                                        },
+                                        span: 2548..2550#1,
                                         in_try: false,
                                     },
                                     MemberCall {
@@ -4528,15 +4120,7 @@
                                                 Call,
                                             ),
                                         ],
-                                        span: Span {
-                                            lo: BytePos(
-                                                2548,
-                                            ),
-                                            hi: BytePos(
-                                                2580,
-                                            ),
-                                            ctxt: #0,
-                                        },
+                                        span: 2548..2580#0,
                                         in_try: false,
                                     },
                                 ],
@@ -4636,15 +4220,7 @@
                                 Test,
                             ),
                         ],
-                        span: Span {
-                            lo: BytePos(
-                                2458,
-                            ),
-                            hi: BytePos(
-                                2587,
-                            ),
-                            ctxt: #0,
-                        },
+                        span: 2458..2587#0,
                         in_try: false,
                     },
                 ],
@@ -4716,15 +4292,7 @@
                 Test,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                2256,
-            ),
-            hi: BytePos(
-                2617,
-            ),
-            ctxt: #0,
-        },
+        span: 2256..2617#0,
         in_try: false,
     },
     FreeVar {
@@ -4802,15 +4370,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                2687,
-            ),
-            hi: BytePos(
-                2706,
-            ),
-            ctxt: #1,
-        },
+        span: 2687..2706#1,
         in_try: false,
     },
     Member {
@@ -4907,15 +4467,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                2725,
-            ),
-            hi: BytePos(
-                2739,
-            ),
-            ctxt: #0,
-        },
+        span: 2725..2739#0,
         in_try: false,
     },
     FreeVar {
@@ -5004,15 +4556,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                2740,
-            ),
-            hi: BytePos(
-                2750,
-            ),
-            ctxt: #1,
-        },
+        span: 2740..2750#1,
         in_try: false,
     },
     MemberCall {
@@ -5107,15 +4651,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                2725,
-            ),
-            hi: BytePos(
-                2751,
-            ),
-            ctxt: #0,
-        },
+        span: 2725..2751#0,
         in_try: false,
     },
     Member {
@@ -5212,15 +4748,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                2775,
-            ),
-            hi: BytePos(
-                2789,
-            ),
-            ctxt: #0,
-        },
+        span: 2775..2789#0,
         in_try: false,
     },
     FreeVar {
@@ -5309,15 +4837,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                2790,
-            ),
-            hi: BytePos(
-                2799,
-            ),
-            ctxt: #1,
-        },
+        span: 2790..2799#1,
         in_try: false,
     },
     MemberCall {
@@ -5412,15 +4932,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                2775,
-            ),
-            hi: BytePos(
-                2800,
-            ),
-            ctxt: #0,
-        },
+        span: 2775..2800#0,
         in_try: false,
     },
     Conditional {
@@ -5589,15 +5101,7 @@
                                 Ident,
                             ),
                         ],
-                        span: Span {
-                            lo: BytePos(
-                                2832,
-                            ),
-                            hi: BytePos(
-                                2837,
-                            ),
-                            ctxt: #1,
-                        },
+                        span: 2832..2837#1,
                         in_try: false,
                     },
                     FreeVar {
@@ -5684,15 +5188,7 @@
                                 Ident,
                             ),
                         ],
-                        span: Span {
-                            lo: BytePos(
-                                3047,
-                            ),
-                            hi: BytePos(
-                                3057,
-                            ),
-                            ctxt: #1,
-                        },
+                        span: 3047..3057#1,
                         in_try: false,
                     },
                 ],
@@ -5786,15 +5282,7 @@
                 Test,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                2676,
-            ),
-            hi: BytePos(
-                3489,
-            ),
-            ctxt: #0,
-        },
+        span: 2676..3489#0,
         in_try: false,
     },
     Conditional {
@@ -5910,15 +5398,7 @@
                                 Member,
                             ),
                         ],
-                        span: Span {
-                            lo: BytePos(
-                                3526,
-                            ),
-                            hi: BytePos(
-                                3536,
-                            ),
-                            ctxt: #0,
-                        },
+                        span: 3526..3536#0,
                         in_try: false,
                     },
                     FreeVar {
@@ -6019,15 +5499,7 @@
                                 Ident,
                             ),
                         ],
-                        span: Span {
-                            lo: BytePos(
-                                3537,
-                            ),
-                            hi: BytePos(
-                                3546,
-                            ),
-                            ctxt: #1,
-                        },
+                        span: 3537..3546#1,
                         in_try: false,
                     },
                     MemberCall {
@@ -6161,15 +5633,7 @@
                                 Call,
                             ),
                         ],
-                        span: Span {
-                            lo: BytePos(
-                                3526,
-                            ),
-                            hi: BytePos(
-                                3571,
-                            ),
-                            ctxt: #0,
-                        },
+                        span: 3526..3571#0,
                         in_try: false,
                     },
                 ],
@@ -6263,15 +5727,7 @@
                 Test,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                3492,
-            ),
-            hi: BytePos(
-                3578,
-            ),
-            ctxt: #0,
-        },
+        span: 3492..3578#0,
         in_try: false,
     },
     Call {
@@ -6340,15 +5796,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                3589,
-            ),
-            hi: BytePos(
-                3606,
-            ),
-            ctxt: #0,
-        },
+        span: 3589..3606#0,
         in_try: false,
     },
     Call {
@@ -6386,15 +5834,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                3638,
-            ),
-            hi: BytePos(
-                3661,
-            ),
-            ctxt: #0,
-        },
+        span: 3638..3661#0,
         in_try: false,
     },
     Member {
@@ -6447,15 +5887,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                3671,
-            ),
-            hi: BytePos(
-                3682,
-            ),
-            ctxt: #0,
-        },
+        span: 3671..3682#0,
         in_try: false,
     },
     MemberCall {
@@ -6519,15 +5951,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                3671,
-            ),
-            hi: BytePos(
-                3718,
-            ),
-            ctxt: #0,
-        },
+        span: 3671..3718#0,
         in_try: false,
     },
 ]

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/fn-array-2/graph-effects.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/fn-array-2/graph-effects.snapshot
@@ -53,15 +53,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                72,
-            ),
-            hi: BytePos(
-                83,
-            ),
-            ctxt: #0,
-        },
+        span: 72..83#0,
         in_try: false,
     },
 ]

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/fn-array/graph-effects.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/fn-array/graph-effects.snapshot
@@ -53,15 +53,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                59,
-            ),
-            hi: BytePos(
-                70,
-            ),
-            ctxt: #0,
-        },
+        span: 59..70#0,
         in_try: false,
     },
 ]

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/free-vars/graph-effects.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/free-vars/graph-effects.snapshot
@@ -46,15 +46,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                13,
-            ),
-            hi: BytePos(
-                24,
-            ),
-            ctxt: #0,
-        },
+        span: 13..24#0,
         in_try: false,
     },
     FreeVar {
@@ -103,15 +95,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                13,
-            ),
-            hi: BytePos(
-                19,
-            ),
-            ctxt: #1,
-        },
+        span: 13..19#1,
         in_try: false,
     },
     MemberCall {
@@ -163,15 +147,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                13,
-            ),
-            hi: BytePos(
-                39,
-            ),
-            ctxt: #0,
-        },
+        span: 13..39#0,
         in_try: false,
     },
 ]

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/iife/graph-effects.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/iife/graph-effects.snapshot
@@ -30,15 +30,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                9,
-            ),
-            hi: BytePos(
-                16,
-            ),
-            ctxt: #1,
-        },
+        span: 9..16#1,
         in_try: false,
     },
     Conditional {
@@ -134,15 +126,7 @@
                                 Call,
                             ),
                         ],
-                        span: Span {
-                            lo: BytePos(
-                                153,
-                            ),
-                            hi: BytePos(
-                                162,
-                            ),
-                            ctxt: #0,
-                        },
+                        span: 153..162#0,
                         in_try: false,
                     },
                 ],
@@ -250,15 +234,7 @@
                 Test,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                137,
-            ),
-            hi: BytePos(
-                167,
-            ),
-            ctxt: #0,
-        },
+        span: 137..167#0,
         in_try: false,
     },
 ]

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/imports/graph-effects.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/imports/graph-effects.snapshot
@@ -34,15 +34,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                158,
-            ),
-            hi: BytePos(
-                159,
-            ),
-            ctxt: #2,
-        },
+        span: 158..159#2,
         in_try: false,
     },
     ImportedBinding {
@@ -80,15 +72,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                170,
-            ),
-            hi: BytePos(
-                171,
-            ),
-            ctxt: #2,
-        },
+        span: 170..171#2,
         in_try: false,
     },
     ImportedBinding {
@@ -124,15 +108,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                182,
-            ),
-            hi: BytePos(
-                183,
-            ),
-            ctxt: #2,
-        },
+        span: 182..183#2,
         in_try: false,
     },
 ]

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/logical/graph-effects.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/logical/graph-effects.snapshot
@@ -36,15 +36,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                132,
-            ),
-            hi: BytePos(
-                138,
-            ),
-            ctxt: #1,
-        },
+        span: 132..138#1,
         in_try: false,
     },
     FreeVar {
@@ -102,15 +94,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                164,
-            ),
-            hi: BytePos(
-                170,
-            ),
-            ctxt: #1,
-        },
+        span: 164..170#1,
         in_try: false,
     },
     FreeVar {
@@ -162,15 +146,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                208,
-            ),
-            hi: BytePos(
-                214,
-            ),
-            ctxt: #1,
-        },
+        span: 208..214#1,
         in_try: false,
     },
     FreeVar {
@@ -216,15 +192,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                256,
-            ),
-            hi: BytePos(
-                262,
-            ),
-            ctxt: #1,
-        },
+        span: 256..262#1,
         in_try: false,
     },
     FreeVar {
@@ -264,15 +232,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                284,
-            ),
-            hi: BytePos(
-                290,
-            ),
-            ctxt: #1,
-        },
+        span: 284..290#1,
         in_try: false,
     },
     FreeVar {
@@ -312,15 +272,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                323,
-            ),
-            hi: BytePos(
-                329,
-            ),
-            ctxt: #1,
-        },
+        span: 323..329#1,
         in_try: false,
     },
 ]

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/md5-reduced/graph-effects.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/md5-reduced/graph-effects.snapshot
@@ -56,15 +56,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                138,
-            ),
-            hi: BytePos(
-                149,
-            ),
-            ctxt: #0,
-        },
+        span: 138..149#0,
         in_try: false,
     },
     Member {
@@ -136,15 +128,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                173,
-            ),
-            hi: BytePos(
-                206,
-            ),
-            ctxt: #0,
-        },
+        span: 173..206#0,
         in_try: false,
     },
     Member {
@@ -203,15 +187,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                380,
-            ),
-            hi: BytePos(
-                388,
-            ),
-            ctxt: #0,
-        },
+        span: 380..388#0,
         in_try: false,
     },
     Member {
@@ -294,15 +270,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                484,
-            ),
-            hi: BytePos(
-                488,
-            ),
-            ctxt: #0,
-        },
+        span: 484..488#0,
         in_try: false,
     },
     Call {
@@ -435,15 +403,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                466,
-            ),
-            hi: BytePos(
-                504,
-            ),
-            ctxt: #0,
-        },
+        span: 466..504#0,
         in_try: false,
     },
     Member {
@@ -538,15 +498,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                532,
-            ),
-            hi: BytePos(
-                540,
-            ),
-            ctxt: #0,
-        },
+        span: 532..540#0,
         in_try: false,
     },
     Call {
@@ -691,15 +643,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                514,
-            ),
-            hi: BytePos(
-                557,
-            ),
-            ctxt: #0,
-        },
+        span: 514..557#0,
         in_try: false,
     },
     Member {
@@ -794,15 +738,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                585,
-            ),
-            hi: BytePos(
-                593,
-            ),
-            ctxt: #0,
-        },
+        span: 585..593#0,
         in_try: false,
     },
     Call {
@@ -949,15 +885,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                567,
-            ),
-            hi: BytePos(
-                609,
-            ),
-            ctxt: #0,
-        },
+        span: 567..609#0,
         in_try: false,
     },
     Member {
@@ -1052,15 +980,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                637,
-            ),
-            hi: BytePos(
-                645,
-            ),
-            ctxt: #0,
-        },
+        span: 637..645#0,
         in_try: false,
     },
     Call {
@@ -1205,15 +1125,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                619,
-            ),
-            hi: BytePos(
-                663,
-            ),
-            ctxt: #0,
-        },
+        span: 619..663#0,
         in_try: false,
     },
     Member {
@@ -1308,15 +1220,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                691,
-            ),
-            hi: BytePos(
-                699,
-            ),
-            ctxt: #0,
-        },
+        span: 691..699#0,
         in_try: false,
     },
     Call {
@@ -1461,15 +1365,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                673,
-            ),
-            hi: BytePos(
-                715,
-            ),
-            ctxt: #0,
-        },
+        span: 673..715#0,
         in_try: false,
     },
     Member {
@@ -1564,15 +1460,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                743,
-            ),
-            hi: BytePos(
-                751,
-            ),
-            ctxt: #0,
-        },
+        span: 743..751#0,
         in_try: false,
     },
     Call {
@@ -1719,15 +1607,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                725,
-            ),
-            hi: BytePos(
-                768,
-            ),
-            ctxt: #0,
-        },
+        span: 725..768#0,
         in_try: false,
     },
     Member {
@@ -1822,15 +1702,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                796,
-            ),
-            hi: BytePos(
-                804,
-            ),
-            ctxt: #0,
-        },
+        span: 796..804#0,
         in_try: false,
     },
     Call {
@@ -1975,15 +1847,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                778,
-            ),
-            hi: BytePos(
-                822,
-            ),
-            ctxt: #0,
-        },
+        span: 778..822#0,
         in_try: false,
     },
     Member {
@@ -2078,15 +1942,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                850,
-            ),
-            hi: BytePos(
-                858,
-            ),
-            ctxt: #0,
-        },
+        span: 850..858#0,
         in_try: false,
     },
     Call {
@@ -2231,15 +2087,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                832,
-            ),
-            hi: BytePos(
-                874,
-            ),
-            ctxt: #0,
-        },
+        span: 832..874#0,
         in_try: false,
     },
     Member {
@@ -2334,15 +2182,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                902,
-            ),
-            hi: BytePos(
-                910,
-            ),
-            ctxt: #0,
-        },
+        span: 902..910#0,
         in_try: false,
     },
     Call {
@@ -2489,15 +2329,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                884,
-            ),
-            hi: BytePos(
-                926,
-            ),
-            ctxt: #0,
-        },
+        span: 884..926#0,
         in_try: false,
     },
     Member {
@@ -2592,15 +2424,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                954,
-            ),
-            hi: BytePos(
-                962,
-            ),
-            ctxt: #0,
-        },
+        span: 954..962#0,
         in_try: false,
     },
     Call {
@@ -2745,15 +2569,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                936,
-            ),
-            hi: BytePos(
-                980,
-            ),
-            ctxt: #0,
-        },
+        span: 936..980#0,
         in_try: false,
     },
     Member {
@@ -2848,15 +2664,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1008,
-            ),
-            hi: BytePos(
-                1017,
-            ),
-            ctxt: #0,
-        },
+        span: 1008..1017#0,
         in_try: false,
     },
     Call {
@@ -3001,15 +2809,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                990,
-            ),
-            hi: BytePos(
-                1030,
-            ),
-            ctxt: #0,
-        },
+        span: 990..1030#0,
         in_try: false,
     },
     Member {
@@ -3104,15 +2904,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1058,
-            ),
-            hi: BytePos(
-                1067,
-            ),
-            ctxt: #0,
-        },
+        span: 1058..1067#0,
         in_try: false,
     },
     Call {
@@ -3257,15 +3049,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1040,
-            ),
-            hi: BytePos(
-                1085,
-            ),
-            ctxt: #0,
-        },
+        span: 1040..1085#0,
         in_try: false,
     },
     Member {
@@ -3360,15 +3144,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1113,
-            ),
-            hi: BytePos(
-                1122,
-            ),
-            ctxt: #0,
-        },
+        span: 1113..1122#0,
         in_try: false,
     },
     Call {
@@ -3515,15 +3291,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1095,
-            ),
-            hi: BytePos(
-                1138,
-            ),
-            ctxt: #0,
-        },
+        span: 1095..1138#0,
         in_try: false,
     },
     Member {
@@ -3618,15 +3386,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1166,
-            ),
-            hi: BytePos(
-                1175,
-            ),
-            ctxt: #0,
-        },
+        span: 1166..1175#0,
         in_try: false,
     },
     Call {
@@ -3771,15 +3531,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1148,
-            ),
-            hi: BytePos(
-                1191,
-            ),
-            ctxt: #0,
-        },
+        span: 1148..1191#0,
         in_try: false,
     },
     Member {
@@ -3874,15 +3626,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1219,
-            ),
-            hi: BytePos(
-                1228,
-            ),
-            ctxt: #0,
-        },
+        span: 1219..1228#0,
         in_try: false,
     },
     Call {
@@ -4027,15 +3771,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1201,
-            ),
-            hi: BytePos(
-                1246,
-            ),
-            ctxt: #0,
-        },
+        span: 1201..1246#0,
         in_try: false,
     },
     Member {
@@ -4130,15 +3866,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1274,
-            ),
-            hi: BytePos(
-                1283,
-            ),
-            ctxt: #0,
-        },
+        span: 1274..1283#0,
         in_try: false,
     },
     Call {
@@ -4285,15 +4013,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1256,
-            ),
-            hi: BytePos(
-                1300,
-            ),
-            ctxt: #0,
-        },
+        span: 1256..1300#0,
         in_try: false,
     },
     FreeVar {
@@ -4345,15 +4065,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1459,
-            ),
-            hi: BytePos(
-                1466,
-            ),
-            ctxt: #1,
-        },
+        span: 1459..1466#1,
         in_try: false,
     },
     FreeVar {
@@ -4416,15 +4128,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1467,
-            ),
-            hi: BytePos(
-                1480,
-            ),
-            ctxt: #1,
-        },
+        span: 1467..1480#1,
         in_try: false,
     },
     FreeVar {
@@ -4498,15 +4202,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1481,
-            ),
-            hi: BytePos(
-                1488,
-            ),
-            ctxt: #1,
-        },
+        span: 1481..1488#1,
         in_try: false,
     },
     FreeVar {
@@ -4591,15 +4287,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1489,
-            ),
-            hi: BytePos(
-                1496,
-            ),
-            ctxt: #1,
-        },
+        span: 1489..1496#1,
         in_try: false,
     },
     Call {
@@ -4693,15 +4381,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1489,
-            ),
-            hi: BytePos(
-                1502,
-            ),
-            ctxt: #0,
-        },
+        span: 1489..1502#0,
         in_try: false,
     },
     FreeVar {
@@ -4786,15 +4466,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1504,
-            ),
-            hi: BytePos(
-                1511,
-            ),
-            ctxt: #1,
-        },
+        span: 1504..1511#1,
         in_try: false,
     },
     Call {
@@ -4888,15 +4560,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1504,
-            ),
-            hi: BytePos(
-                1517,
-            ),
-            ctxt: #0,
-        },
+        span: 1504..1517#0,
         in_try: false,
     },
     Call {
@@ -5007,15 +4671,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1481,
-            ),
-            hi: BytePos(
-                1518,
-            ),
-            ctxt: #0,
-        },
+        span: 1481..1518#0,
         in_try: false,
     },
     Call {
@@ -5129,15 +4785,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1467,
-            ),
-            hi: BytePos(
-                1522,
-            ),
-            ctxt: #0,
-        },
+        span: 1467..1522#0,
         in_try: false,
     },
     Call {
@@ -5254,15 +4902,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1459,
-            ),
-            hi: BytePos(
-                1526,
-            ),
-            ctxt: #0,
-        },
+        span: 1459..1526#0,
         in_try: false,
     },
     Call {
@@ -5357,15 +4997,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1577,
-            ),
-            hi: BytePos(
-                1618,
-            ),
-            ctxt: #0,
-        },
+        span: 1577..1618#0,
         in_try: false,
     },
     Member {
@@ -5407,15 +5039,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1622,
-            ),
-            hi: BytePos(
-                1636,
-            ),
-            ctxt: #0,
-        },
+        span: 1622..1636#0,
         in_try: false,
     },
     FreeVar {
@@ -5456,15 +5080,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1622,
-            ),
-            hi: BytePos(
-                1628,
-            ),
-            ctxt: #1,
-        },
+        span: 1622..1628#1,
         in_try: false,
     },
     FreeVar {
@@ -5496,15 +5112,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1639,
-            ),
-            hi: BytePos(
-                1642,
-            ),
-            ctxt: #1,
-        },
+        span: 1639..1642#1,
         in_try: false,
     },
 ]

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/md5_2/graph-effects.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/md5_2/graph-effects.snapshot
@@ -74,15 +74,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                30,
-            ),
-            hi: BytePos(
-                37,
-            ),
-            ctxt: #1,
-        },
+        span: 30..37#1,
         in_try: false,
     },
     Call {
@@ -162,15 +154,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                30,
-            ),
-            hi: BytePos(
-                46,
-            ),
-            ctxt: #0,
-        },
+        span: 30..46#0,
         in_try: false,
     },
     Member {
@@ -258,15 +242,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                59,
-            ),
-            hi: BytePos(
-                82,
-            ),
-            ctxt: #0,
-        },
+        span: 59..82#0,
         in_try: false,
     },
     FreeVar {
@@ -350,15 +326,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                59,
-            ),
-            hi: BytePos(
-                66,
-            ),
-            ctxt: #1,
-        },
+        span: 59..66#1,
         in_try: false,
     },
     Call {
@@ -444,15 +412,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                59,
-            ),
-            hi: BytePos(
-                77,
-            ),
-            ctxt: #0,
-        },
+        span: 59..77#0,
         in_try: false,
     },
     FreeVar {
@@ -530,15 +490,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                99,
-            ),
-            hi: BytePos(
-                106,
-            ),
-            ctxt: #1,
-        },
+        span: 99..106#1,
         in_try: false,
     },
     Call {
@@ -618,15 +570,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                99,
-            ),
-            hi: BytePos(
-                119,
-            ),
-            ctxt: #0,
-        },
+        span: 99..119#0,
         in_try: false,
     },
     Member {
@@ -714,15 +658,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                131,
-            ),
-            hi: BytePos(
-                153,
-            ),
-            ctxt: #0,
-        },
+        span: 131..153#0,
         in_try: false,
     },
     FreeVar {
@@ -806,15 +742,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                131,
-            ),
-            hi: BytePos(
-                138,
-            ),
-            ctxt: #1,
-        },
+        span: 131..138#1,
         in_try: false,
     },
     Call {
@@ -900,15 +828,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                131,
-            ),
-            hi: BytePos(
-                149,
-            ),
-            ctxt: #0,
-        },
+        span: 131..149#0,
         in_try: false,
     },
     Member {
@@ -1013,15 +933,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                252,
-            ),
-            hi: BytePos(
-                271,
-            ),
-            ctxt: #0,
-        },
+        span: 252..271#0,
         in_try: false,
     },
     FreeVar {
@@ -1116,15 +1028,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                275,
-            ),
-            hi: BytePos(
-                281,
-            ),
-            ctxt: #1,
-        },
+        span: 275..281#1,
         in_try: false,
     },
     Conditional {
@@ -1268,15 +1172,7 @@
                                 Member,
                             ),
                         ],
-                        span: Span {
-                            lo: BytePos(
-                                306,
-                            ),
-                            hi: BytePos(
-                                322,
-                            ),
-                            ctxt: #0,
-                        },
+                        span: 306..322#0,
                         in_try: false,
                     },
                     Conditional {
@@ -1445,15 +1341,7 @@
                                                 Member,
                                             ),
                                         ],
-                                        span: Span {
-                                            lo: BytePos(
-                                                357,
-                                            ),
-                                            hi: BytePos(
-                                                374,
-                                            ),
-                                            ctxt: #0,
-                                        },
+                                        span: 357..374#0,
                                         in_try: false,
                                     },
                                     MemberCall {
@@ -1580,15 +1468,7 @@
                                                 Call,
                                             ),
                                         ],
-                                        span: Span {
-                                            lo: BytePos(
-                                                357,
-                                            ),
-                                            hi: BytePos(
-                                                383,
-                                            ),
-                                            ctxt: #0,
-                                        },
+                                        span: 357..383#0,
                                         in_try: false,
                                     },
                                 ],
@@ -1803,15 +1683,7 @@
                                                 Member,
                                             ),
                                         ],
-                                        span: Span {
-                                            lo: BytePos(
-                                                408,
-                                            ),
-                                            hi: BytePos(
-                                                426,
-                                            ),
-                                            ctxt: #0,
-                                        },
+                                        span: 408..426#0,
                                         in_try: false,
                                     },
                                     MemberCall {
@@ -1938,15 +1810,7 @@
                                                 Call,
                                             ),
                                         ],
-                                        span: Span {
-                                            lo: BytePos(
-                                                408,
-                                            ),
-                                            hi: BytePos(
-                                                435,
-                                            ),
-                                            ctxt: #0,
-                                        },
+                                        span: 408..435#0,
                                         in_try: false,
                                     },
                                 ],
@@ -2122,15 +1986,7 @@
                                 Test,
                             ),
                         ],
-                        span: Span {
-                            lo: BytePos(
-                                291,
-                            ),
-                            hi: BytePos(
-                                436,
-                            ),
-                            ctxt: #0,
-                        },
+                        span: 291..436#0,
                         in_try: false,
                     },
                 ],
@@ -2321,15 +2177,7 @@
                                 Call,
                             ),
                         ],
-                        span: Span {
-                            lo: BytePos(
-                                452,
-                            ),
-                            hi: BytePos(
-                                469,
-                            ),
-                            ctxt: #0,
-                        },
+                        span: 452..469#0,
                         in_try: false,
                     },
                     Conditional {
@@ -2493,15 +2341,7 @@
                                                 Member,
                                             ),
                                         ],
-                                        span: Span {
-                                            lo: BytePos(
-                                                489,
-                                            ),
-                                            hi: BytePos(
-                                                515,
-                                            ),
-                                            ctxt: #0,
-                                        },
+                                        span: 489..515#0,
                                         in_try: false,
                                     },
                                     Member {
@@ -2640,15 +2480,7 @@
                                                 Member,
                                             ),
                                         ],
-                                        span: Span {
-                                            lo: BytePos(
-                                                489,
-                                            ),
-                                            hi: BytePos(
-                                                510,
-                                            ),
-                                            ctxt: #0,
-                                        },
+                                        span: 489..510#0,
                                         in_try: false,
                                     },
                                     Member {
@@ -2783,15 +2615,7 @@
                                                 Member,
                                             ),
                                         ],
-                                        span: Span {
-                                            lo: BytePos(
-                                                489,
-                                            ),
-                                            hi: BytePos(
-                                                504,
-                                            ),
-                                            ctxt: #0,
-                                        },
+                                        span: 489..504#0,
                                         in_try: false,
                                     },
                                     FreeVar {
@@ -2925,15 +2749,7 @@
                                                 Ident,
                                             ),
                                         ],
-                                        span: Span {
-                                            lo: BytePos(
-                                                489,
-                                            ),
-                                            hi: BytePos(
-                                                494,
-                                            ),
-                                            ctxt: #1,
-                                        },
+                                        span: 489..494#1,
                                         in_try: false,
                                     },
                                     MemberCall {
@@ -3086,15 +2902,7 @@
                                                 Call,
                                             ),
                                         ],
-                                        span: Span {
-                                            lo: BytePos(
-                                                489,
-                                            ),
-                                            hi: BytePos(
-                                                527,
-                                            ),
-                                            ctxt: #0,
-                                        },
+                                        span: 489..527#0,
                                         in_try: false,
                                     },
                                 ],
@@ -3306,15 +3114,7 @@
                                                 Member,
                                             ),
                                         ],
-                                        span: Span {
-                                            lo: BytePos(
-                                                545,
-                                            ),
-                                            hi: BytePos(
-                                                558,
-                                            ),
-                                            ctxt: #0,
-                                        },
+                                        span: 545..558#0,
                                         in_try: false,
                                     },
                                     FreeVar {
@@ -3436,15 +3236,7 @@
                                                 Ident,
                                             ),
                                         ],
-                                        span: Span {
-                                            lo: BytePos(
-                                                545,
-                                            ),
-                                            hi: BytePos(
-                                                550,
-                                            ),
-                                            ctxt: #1,
-                                        },
+                                        span: 545..550#1,
                                         in_try: false,
                                     },
                                     MemberCall {
@@ -3568,15 +3360,7 @@
                                                 Call,
                                             ),
                                         ],
-                                        span: Span {
-                                            lo: BytePos(
-                                                545,
-                                            ),
-                                            hi: BytePos(
-                                                567,
-                                            ),
-                                            ctxt: #0,
-                                        },
+                                        span: 545..567#0,
                                         in_try: false,
                                     },
                                     Conditional {
@@ -3736,15 +3520,7 @@
                                                                 Member,
                                                             ),
                                                         ],
-                                                        span: Span {
-                                                            lo: BytePos(
-                                                                579,
-                                                            ),
-                                                            hi: BytePos(
-                                                                595,
-                                                            ),
-                                                            ctxt: #0,
-                                                        },
+                                                        span: 579..595#0,
                                                         in_try: false,
                                                     },
                                                     MemberCall {
@@ -3868,15 +3644,7 @@
                                                                 Call,
                                                             ),
                                                         ],
-                                                        span: Span {
-                                                            lo: BytePos(
-                                                                579,
-                                                            ),
-                                                            hi: BytePos(
-                                                                597,
-                                                            ),
-                                                            ctxt: #0,
-                                                        },
+                                                        span: 579..597#0,
                                                         in_try: false,
                                                     },
                                                 ],
@@ -4064,15 +3832,7 @@
                                                 Test,
                                             ),
                                         ],
-                                        span: Span {
-                                            lo: BytePos(
-                                                540,
-                                            ),
-                                            hi: BytePos(
-                                                598,
-                                            ),
-                                            ctxt: #0,
-                                        },
+                                        span: 540..598#0,
                                         in_try: false,
                                     },
                                 ],
@@ -4248,15 +4008,7 @@
                                 Test,
                             ),
                         ],
-                        span: Span {
-                            lo: BytePos(
-                                448,
-                            ),
-                            hi: BytePos(
-                                598,
-                            ),
-                            ctxt: #0,
-                        },
+                        span: 448..598#0,
                         in_try: false,
                     },
                 ],
@@ -4420,15 +4172,7 @@
                 Test,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                248,
-            ),
-            hi: BytePos(
-                598,
-            ),
-            ctxt: #0,
-        },
+        span: 248..598#0,
         in_try: false,
     },
     Member {
@@ -4544,15 +4288,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                655,
-            ),
-            hi: BytePos(
-                673,
-            ),
-            ctxt: #0,
-        },
+        span: 655..673#0,
         in_try: false,
     },
     MemberCall {
@@ -4669,15 +4405,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                655,
-            ),
-            hi: BytePos(
-                682,
-            ),
-            ctxt: #0,
-        },
+        span: 655..682#0,
         in_try: false,
     },
     Member {
@@ -4790,15 +4518,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                696,
-            ),
-            hi: BytePos(
-                710,
-            ),
-            ctxt: #0,
-        },
+        span: 696..710#0,
         in_try: false,
     },
     Member {
@@ -4903,15 +4623,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                860,
-            ),
-            hi: BytePos(
-                868,
-            ),
-            ctxt: #0,
-        },
+        span: 860..868#0,
         in_try: false,
     },
     Member {
@@ -5032,15 +4744,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                885,
-            ),
-            hi: BytePos(
-                889,
-            ),
-            ctxt: #0,
-        },
+        span: 885..889#0,
         in_try: false,
     },
     Member {
@@ -5200,15 +4904,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                905,
-            ),
-            hi: BytePos(
-                909,
-            ),
-            ctxt: #0,
-        },
+        span: 905..909#0,
         in_try: false,
     },
     Member {
@@ -5368,15 +5064,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                919,
-            ),
-            hi: BytePos(
-                923,
-            ),
-            ctxt: #0,
-        },
+        span: 919..923#0,
         in_try: false,
     },
     Member {
@@ -5536,15 +5224,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                962,
-            ),
-            hi: BytePos(
-                966,
-            ),
-            ctxt: #0,
-        },
+        span: 962..966#0,
         in_try: false,
     },
     Member {
@@ -5704,15 +5384,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                977,
-            ),
-            hi: BytePos(
-                981,
-            ),
-            ctxt: #0,
-        },
+        span: 977..981#0,
         in_try: false,
     },
     Member {
@@ -5818,15 +5490,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1037,
-            ),
-            hi: BytePos(
-                1047,
-            ),
-            ctxt: #0,
-        },
+        span: 1037..1047#0,
         in_try: false,
     },
     Member {
@@ -5944,15 +5608,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1073,
-            ),
-            hi: BytePos(
-                1104,
-            ),
-            ctxt: #0,
-        },
+        span: 1073..1104#0,
         in_try: false,
     },
     Member {
@@ -6059,15 +5715,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1152,
-            ),
-            hi: BytePos(
-                1159,
-            ),
-            ctxt: #0,
-        },
+        span: 1152..1159#0,
         in_try: false,
     },
     Member {
@@ -6174,15 +5822,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1174,
-            ),
-            hi: BytePos(
-                1181,
-            ),
-            ctxt: #0,
-        },
+        span: 1174..1181#0,
         in_try: false,
     },
     Member {
@@ -6289,15 +5929,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1196,
-            ),
-            hi: BytePos(
-                1203,
-            ),
-            ctxt: #0,
-        },
+        span: 1196..1203#0,
         in_try: false,
     },
     Member {
@@ -6404,15 +6036,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1218,
-            ),
-            hi: BytePos(
-                1225,
-            ),
-            ctxt: #0,
-        },
+        span: 1218..1225#0,
         in_try: false,
     },
     Member {
@@ -6517,15 +6141,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1254,
-            ),
-            hi: BytePos(
-                1262,
-            ),
-            ctxt: #0,
-        },
+        span: 1254..1262#0,
         in_try: false,
     },
     Member {
@@ -6666,15 +6282,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1377,
-            ),
-            hi: BytePos(
-                1385,
-            ),
-            ctxt: #0,
-        },
+        span: 1377..1385#0,
         in_try: false,
     },
     Call {
@@ -6865,15 +6473,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1362,
-            ),
-            hi: BytePos(
-                1401,
-            ),
-            ctxt: #0,
-        },
+        span: 1362..1401#0,
         in_try: false,
     },
     Member {
@@ -7014,15 +6614,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1430,
-            ),
-            hi: BytePos(
-                1438,
-            ),
-            ctxt: #0,
-        },
+        span: 1430..1438#0,
         in_try: false,
     },
     Call {
@@ -7213,15 +6805,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1415,
-            ),
-            hi: BytePos(
-                1455,
-            ),
-            ctxt: #0,
-        },
+        span: 1415..1455#0,
         in_try: false,
     },
     Member {
@@ -7362,15 +6946,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1484,
-            ),
-            hi: BytePos(
-                1492,
-            ),
-            ctxt: #0,
-        },
+        span: 1484..1492#0,
         in_try: false,
     },
     Call {
@@ -7563,15 +7139,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1469,
-            ),
-            hi: BytePos(
-                1508,
-            ),
-            ctxt: #0,
-        },
+        span: 1469..1508#0,
         in_try: false,
     },
     Member {
@@ -7712,15 +7280,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1537,
-            ),
-            hi: BytePos(
-                1545,
-            ),
-            ctxt: #0,
-        },
+        span: 1537..1545#0,
         in_try: false,
     },
     Call {
@@ -7911,15 +7471,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1522,
-            ),
-            hi: BytePos(
-                1563,
-            ),
-            ctxt: #0,
-        },
+        span: 1522..1563#0,
         in_try: false,
     },
     Member {
@@ -8060,15 +7612,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1592,
-            ),
-            hi: BytePos(
-                1600,
-            ),
-            ctxt: #0,
-        },
+        span: 1592..1600#0,
         in_try: false,
     },
     Call {
@@ -8259,15 +7803,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1577,
-            ),
-            hi: BytePos(
-                1616,
-            ),
-            ctxt: #0,
-        },
+        span: 1577..1616#0,
         in_try: false,
     },
     Member {
@@ -8408,15 +7944,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1645,
-            ),
-            hi: BytePos(
-                1653,
-            ),
-            ctxt: #0,
-        },
+        span: 1645..1653#0,
         in_try: false,
     },
     Call {
@@ -8609,15 +8137,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1630,
-            ),
-            hi: BytePos(
-                1670,
-            ),
-            ctxt: #0,
-        },
+        span: 1630..1670#0,
         in_try: false,
     },
     Member {
@@ -8758,15 +8278,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1699,
-            ),
-            hi: BytePos(
-                1707,
-            ),
-            ctxt: #0,
-        },
+        span: 1699..1707#0,
         in_try: false,
     },
     Call {
@@ -8957,15 +8469,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1684,
-            ),
-            hi: BytePos(
-                1725,
-            ),
-            ctxt: #0,
-        },
+        span: 1684..1725#0,
         in_try: false,
     },
     Member {
@@ -9106,15 +8610,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1754,
-            ),
-            hi: BytePos(
-                1762,
-            ),
-            ctxt: #0,
-        },
+        span: 1754..1762#0,
         in_try: false,
     },
     Call {
@@ -9305,15 +8801,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1739,
-            ),
-            hi: BytePos(
-                1778,
-            ),
-            ctxt: #0,
-        },
+        span: 1739..1778#0,
         in_try: false,
     },
     Member {
@@ -9454,15 +8942,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1807,
-            ),
-            hi: BytePos(
-                1815,
-            ),
-            ctxt: #0,
-        },
+        span: 1807..1815#0,
         in_try: false,
     },
     Call {
@@ -9655,15 +9135,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1792,
-            ),
-            hi: BytePos(
-                1831,
-            ),
-            ctxt: #0,
-        },
+        span: 1792..1831#0,
         in_try: false,
     },
     Member {
@@ -9804,15 +9276,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1860,
-            ),
-            hi: BytePos(
-                1868,
-            ),
-            ctxt: #0,
-        },
+        span: 1860..1868#0,
         in_try: false,
     },
     Call {
@@ -10003,15 +9467,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1845,
-            ),
-            hi: BytePos(
-                1886,
-            ),
-            ctxt: #0,
-        },
+        span: 1845..1886#0,
         in_try: false,
     },
     Member {
@@ -10152,15 +9608,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1915,
-            ),
-            hi: BytePos(
-                1924,
-            ),
-            ctxt: #0,
-        },
+        span: 1915..1924#0,
         in_try: false,
     },
     Call {
@@ -10351,15 +9799,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1900,
-            ),
-            hi: BytePos(
-                1937,
-            ),
-            ctxt: #0,
-        },
+        span: 1900..1937#0,
         in_try: false,
     },
     Member {
@@ -10500,15 +9940,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1966,
-            ),
-            hi: BytePos(
-                1975,
-            ),
-            ctxt: #0,
-        },
+        span: 1966..1975#0,
         in_try: false,
     },
     Call {
@@ -10699,15 +10131,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1951,
-            ),
-            hi: BytePos(
-                1993,
-            ),
-            ctxt: #0,
-        },
+        span: 1951..1993#0,
         in_try: false,
     },
     Member {
@@ -10848,15 +10272,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                2022,
-            ),
-            hi: BytePos(
-                2031,
-            ),
-            ctxt: #0,
-        },
+        span: 2022..2031#0,
         in_try: false,
     },
     Call {
@@ -11049,15 +10465,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                2007,
-            ),
-            hi: BytePos(
-                2047,
-            ),
-            ctxt: #0,
-        },
+        span: 2007..2047#0,
         in_try: false,
     },
     Member {
@@ -11198,15 +10606,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                2076,
-            ),
-            hi: BytePos(
-                2085,
-            ),
-            ctxt: #0,
-        },
+        span: 2076..2085#0,
         in_try: false,
     },
     Call {
@@ -11397,15 +10797,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                2061,
-            ),
-            hi: BytePos(
-                2101,
-            ),
-            ctxt: #0,
-        },
+        span: 2061..2101#0,
         in_try: false,
     },
     Member {
@@ -11546,15 +10938,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                2130,
-            ),
-            hi: BytePos(
-                2139,
-            ),
-            ctxt: #0,
-        },
+        span: 2130..2139#0,
         in_try: false,
     },
     Call {
@@ -11745,15 +11129,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                2115,
-            ),
-            hi: BytePos(
-                2157,
-            ),
-            ctxt: #0,
-        },
+        span: 2115..2157#0,
         in_try: false,
     },
     Member {
@@ -11894,15 +11270,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                2186,
-            ),
-            hi: BytePos(
-                2195,
-            ),
-            ctxt: #0,
-        },
+        span: 2186..2195#0,
         in_try: false,
     },
     Call {
@@ -12095,15 +11463,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                2171,
-            ),
-            hi: BytePos(
-                2212,
-            ),
-            ctxt: #0,
-        },
+        span: 2171..2212#0,
         in_try: false,
     },
     Member {
@@ -12244,15 +11604,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                2242,
-            ),
-            hi: BytePos(
-                2250,
-            ),
-            ctxt: #0,
-        },
+        span: 2242..2250#0,
         in_try: false,
     },
     Call {
@@ -12443,15 +11795,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                2227,
-            ),
-            hi: BytePos(
-                2266,
-            ),
-            ctxt: #0,
-        },
+        span: 2227..2266#0,
         in_try: false,
     },
     Member {
@@ -12592,15 +11936,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                2295,
-            ),
-            hi: BytePos(
-                2303,
-            ),
-            ctxt: #0,
-        },
+        span: 2295..2303#0,
         in_try: false,
     },
     Call {
@@ -12791,15 +12127,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                2280,
-            ),
-            hi: BytePos(
-                2320,
-            ),
-            ctxt: #0,
-        },
+        span: 2280..2320#0,
         in_try: false,
     },
     Member {
@@ -12940,15 +12268,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                2349,
-            ),
-            hi: BytePos(
-                2358,
-            ),
-            ctxt: #0,
-        },
+        span: 2349..2358#0,
         in_try: false,
     },
     Call {
@@ -13141,15 +12461,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                2334,
-            ),
-            hi: BytePos(
-                2374,
-            ),
-            ctxt: #0,
-        },
+        span: 2334..2374#0,
         in_try: false,
     },
     Member {
@@ -13290,15 +12602,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                2403,
-            ),
-            hi: BytePos(
-                2411,
-            ),
-            ctxt: #0,
-        },
+        span: 2403..2411#0,
         in_try: false,
     },
     Call {
@@ -13489,15 +12793,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                2388,
-            ),
-            hi: BytePos(
-                2428,
-            ),
-            ctxt: #0,
-        },
+        span: 2388..2428#0,
         in_try: false,
     },
     Member {
@@ -13638,15 +12934,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                2457,
-            ),
-            hi: BytePos(
-                2465,
-            ),
-            ctxt: #0,
-        },
+        span: 2457..2465#0,
         in_try: false,
     },
     Call {
@@ -13837,15 +13125,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                2442,
-            ),
-            hi: BytePos(
-                2481,
-            ),
-            ctxt: #0,
-        },
+        span: 2442..2481#0,
         in_try: false,
     },
     Member {
@@ -13986,15 +13266,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                2510,
-            ),
-            hi: BytePos(
-                2519,
-            ),
-            ctxt: #0,
-        },
+        span: 2510..2519#0,
         in_try: false,
     },
     Call {
@@ -14187,15 +13459,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                2495,
-            ),
-            hi: BytePos(
-                2533,
-            ),
-            ctxt: #0,
-        },
+        span: 2495..2533#0,
         in_try: false,
     },
     Member {
@@ -14336,15 +13600,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                2562,
-            ),
-            hi: BytePos(
-                2571,
-            ),
-            ctxt: #0,
-        },
+        span: 2562..2571#0,
         in_try: false,
     },
     Call {
@@ -14535,15 +13791,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                2547,
-            ),
-            hi: BytePos(
-                2588,
-            ),
-            ctxt: #0,
-        },
+        span: 2547..2588#0,
         in_try: false,
     },
     Member {
@@ -14684,15 +13932,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                2617,
-            ),
-            hi: BytePos(
-                2625,
-            ),
-            ctxt: #0,
-        },
+        span: 2617..2625#0,
         in_try: false,
     },
     Call {
@@ -14883,15 +14123,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                2602,
-            ),
-            hi: BytePos(
-                2642,
-            ),
-            ctxt: #0,
-        },
+        span: 2602..2642#0,
         in_try: false,
     },
     Member {
@@ -15032,15 +14264,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                2671,
-            ),
-            hi: BytePos(
-                2679,
-            ),
-            ctxt: #0,
-        },
+        span: 2671..2679#0,
         in_try: false,
     },
     Call {
@@ -15233,15 +14457,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                2656,
-            ),
-            hi: BytePos(
-                2694,
-            ),
-            ctxt: #0,
-        },
+        span: 2656..2694#0,
         in_try: false,
     },
     Member {
@@ -15382,15 +14598,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                2723,
-            ),
-            hi: BytePos(
-                2732,
-            ),
-            ctxt: #0,
-        },
+        span: 2723..2732#0,
         in_try: false,
     },
     Call {
@@ -15581,15 +14789,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                2708,
-            ),
-            hi: BytePos(
-                2749,
-            ),
-            ctxt: #0,
-        },
+        span: 2708..2749#0,
         in_try: false,
     },
     Member {
@@ -15730,15 +14930,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                2778,
-            ),
-            hi: BytePos(
-                2786,
-            ),
-            ctxt: #0,
-        },
+        span: 2778..2786#0,
         in_try: false,
     },
     Call {
@@ -15929,15 +15121,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                2763,
-            ),
-            hi: BytePos(
-                2803,
-            ),
-            ctxt: #0,
-        },
+        span: 2763..2803#0,
         in_try: false,
     },
     Member {
@@ -16078,15 +15262,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                2832,
-            ),
-            hi: BytePos(
-                2840,
-            ),
-            ctxt: #0,
-        },
+        span: 2832..2840#0,
         in_try: false,
     },
     Call {
@@ -16279,15 +15455,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                2817,
-            ),
-            hi: BytePos(
-                2857,
-            ),
-            ctxt: #0,
-        },
+        span: 2817..2857#0,
         in_try: false,
     },
     Member {
@@ -16428,15 +15596,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                2886,
-            ),
-            hi: BytePos(
-                2895,
-            ),
-            ctxt: #0,
-        },
+        span: 2886..2895#0,
         in_try: false,
     },
     Call {
@@ -16627,15 +15787,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                2871,
-            ),
-            hi: BytePos(
-                2912,
-            ),
-            ctxt: #0,
-        },
+        span: 2871..2912#0,
         in_try: false,
     },
     Member {
@@ -16776,15 +15928,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                2941,
-            ),
-            hi: BytePos(
-                2949,
-            ),
-            ctxt: #0,
-        },
+        span: 2941..2949#0,
         in_try: false,
     },
     Call {
@@ -16975,15 +16119,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                2926,
-            ),
-            hi: BytePos(
-                2964,
-            ),
-            ctxt: #0,
-        },
+        span: 2926..2964#0,
         in_try: false,
     },
     Member {
@@ -17124,15 +16260,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                2993,
-            ),
-            hi: BytePos(
-                3001,
-            ),
-            ctxt: #0,
-        },
+        span: 2993..3001#0,
         in_try: false,
     },
     Call {
@@ -17325,15 +16453,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                2978,
-            ),
-            hi: BytePos(
-                3018,
-            ),
-            ctxt: #0,
-        },
+        span: 2978..3018#0,
         in_try: false,
     },
     Member {
@@ -17474,15 +16594,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                3047,
-            ),
-            hi: BytePos(
-                3056,
-            ),
-            ctxt: #0,
-        },
+        span: 3047..3056#0,
         in_try: false,
     },
     Call {
@@ -17673,15 +16785,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                3032,
-            ),
-            hi: BytePos(
-                3074,
-            ),
-            ctxt: #0,
-        },
+        span: 3032..3074#0,
         in_try: false,
     },
     Member {
@@ -17822,15 +16926,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                3104,
-            ),
-            hi: BytePos(
-                3112,
-            ),
-            ctxt: #0,
-        },
+        span: 3104..3112#0,
         in_try: false,
     },
     Call {
@@ -18021,15 +17117,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                3089,
-            ),
-            hi: BytePos(
-                3125,
-            ),
-            ctxt: #0,
-        },
+        span: 3089..3125#0,
         in_try: false,
     },
     Member {
@@ -18170,15 +17258,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                3154,
-            ),
-            hi: BytePos(
-                3162,
-            ),
-            ctxt: #0,
-        },
+        span: 3154..3162#0,
         in_try: false,
     },
     Call {
@@ -18369,15 +17449,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                3139,
-            ),
-            hi: BytePos(
-                3180,
-            ),
-            ctxt: #0,
-        },
+        span: 3139..3180#0,
         in_try: false,
     },
     Member {
@@ -18518,15 +17590,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                3209,
-            ),
-            hi: BytePos(
-                3218,
-            ),
-            ctxt: #0,
-        },
+        span: 3209..3218#0,
         in_try: false,
     },
     Call {
@@ -18719,15 +17783,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                3194,
-            ),
-            hi: BytePos(
-                3235,
-            ),
-            ctxt: #0,
-        },
+        span: 3194..3235#0,
         in_try: false,
     },
     Member {
@@ -18868,15 +17924,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                3264,
-            ),
-            hi: BytePos(
-                3273,
-            ),
-            ctxt: #0,
-        },
+        span: 3264..3273#0,
         in_try: false,
     },
     Call {
@@ -19067,15 +18115,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                3249,
-            ),
-            hi: BytePos(
-                3289,
-            ),
-            ctxt: #0,
-        },
+        span: 3249..3289#0,
         in_try: false,
     },
     Member {
@@ -19216,15 +18256,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                3318,
-            ),
-            hi: BytePos(
-                3326,
-            ),
-            ctxt: #0,
-        },
+        span: 3318..3326#0,
         in_try: false,
     },
     Call {
@@ -19415,15 +18447,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                3303,
-            ),
-            hi: BytePos(
-                3343,
-            ),
-            ctxt: #0,
-        },
+        span: 3303..3343#0,
         in_try: false,
     },
     Member {
@@ -19564,15 +18588,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                3372,
-            ),
-            hi: BytePos(
-                3380,
-            ),
-            ctxt: #0,
-        },
+        span: 3372..3380#0,
         in_try: false,
     },
     Call {
@@ -19765,15 +18781,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                3357,
-            ),
-            hi: BytePos(
-                3397,
-            ),
-            ctxt: #0,
-        },
+        span: 3357..3397#0,
         in_try: false,
     },
     Member {
@@ -19914,15 +18922,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                3426,
-            ),
-            hi: BytePos(
-                3434,
-            ),
-            ctxt: #0,
-        },
+        span: 3426..3434#0,
         in_try: false,
     },
     Call {
@@ -20113,15 +19113,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                3411,
-            ),
-            hi: BytePos(
-                3451,
-            ),
-            ctxt: #0,
-        },
+        span: 3411..3451#0,
         in_try: false,
     },
     Member {
@@ -20262,15 +19254,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                3480,
-            ),
-            hi: BytePos(
-                3489,
-            ),
-            ctxt: #0,
-        },
+        span: 3480..3489#0,
         in_try: false,
     },
     Call {
@@ -20461,15 +19445,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                3465,
-            ),
-            hi: BytePos(
-                3507,
-            ),
-            ctxt: #0,
-        },
+        span: 3465..3507#0,
         in_try: false,
     },
     Member {
@@ -20610,15 +19586,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                3536,
-            ),
-            hi: BytePos(
-                3545,
-            ),
-            ctxt: #0,
-        },
+        span: 3536..3545#0,
         in_try: false,
     },
     Call {
@@ -20811,15 +19779,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                3521,
-            ),
-            hi: BytePos(
-                3560,
-            ),
-            ctxt: #0,
-        },
+        span: 3521..3560#0,
         in_try: false,
     },
     Member {
@@ -20960,15 +19920,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                3589,
-            ),
-            hi: BytePos(
-                3597,
-            ),
-            ctxt: #0,
-        },
+        span: 3589..3597#0,
         in_try: false,
     },
     Call {
@@ -21159,15 +20111,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                3574,
-            ),
-            hi: BytePos(
-                3614,
-            ),
-            ctxt: #0,
-        },
+        span: 3574..3614#0,
         in_try: false,
     },
     Member {
@@ -21308,15 +20252,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                3643,
-            ),
-            hi: BytePos(
-                3651,
-            ),
-            ctxt: #0,
-        },
+        span: 3643..3651#0,
         in_try: false,
     },
     Call {
@@ -21507,15 +20443,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                3628,
-            ),
-            hi: BytePos(
-                3668,
-            ),
-            ctxt: #0,
-        },
+        span: 3628..3668#0,
         in_try: false,
     },
     Member {
@@ -21656,15 +20584,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                3697,
-            ),
-            hi: BytePos(
-                3705,
-            ),
-            ctxt: #0,
-        },
+        span: 3697..3705#0,
         in_try: false,
     },
     Call {
@@ -21857,15 +20777,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                3682,
-            ),
-            hi: BytePos(
-                3720,
-            ),
-            ctxt: #0,
-        },
+        span: 3682..3720#0,
         in_try: false,
     },
     Member {
@@ -22006,15 +20918,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                3749,
-            ),
-            hi: BytePos(
-                3757,
-            ),
-            ctxt: #0,
-        },
+        span: 3749..3757#0,
         in_try: false,
     },
     Call {
@@ -22205,15 +21109,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                3734,
-            ),
-            hi: BytePos(
-                3773,
-            ),
-            ctxt: #0,
-        },
+        span: 3734..3773#0,
         in_try: false,
     },
     Member {
@@ -22354,15 +21250,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                3802,
-            ),
-            hi: BytePos(
-                3811,
-            ),
-            ctxt: #0,
-        },
+        span: 3802..3811#0,
         in_try: false,
     },
     Call {
@@ -22553,15 +21441,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                3787,
-            ),
-            hi: BytePos(
-                3828,
-            ),
-            ctxt: #0,
-        },
+        span: 3787..3828#0,
         in_try: false,
     },
     Member {
@@ -22702,15 +21582,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                3857,
-            ),
-            hi: BytePos(
-                3866,
-            ),
-            ctxt: #0,
-        },
+        span: 3857..3866#0,
         in_try: false,
     },
     Call {
@@ -22903,15 +21775,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                3842,
-            ),
-            hi: BytePos(
-                3882,
-            ),
-            ctxt: #0,
-        },
+        span: 3842..3882#0,
         in_try: false,
     },
     Member {
@@ -23052,15 +21916,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                3911,
-            ),
-            hi: BytePos(
-                3919,
-            ),
-            ctxt: #0,
-        },
+        span: 3911..3919#0,
         in_try: false,
     },
     Call {
@@ -23251,15 +22107,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                3896,
-            ),
-            hi: BytePos(
-                3936,
-            ),
-            ctxt: #0,
-        },
+        span: 3896..3936#0,
         in_try: false,
     },
     Member {
@@ -23400,15 +22248,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                3966,
-            ),
-            hi: BytePos(
-                3974,
-            ),
-            ctxt: #0,
-        },
+        span: 3966..3974#0,
         in_try: false,
     },
     Call {
@@ -23599,15 +22439,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                3951,
-            ),
-            hi: BytePos(
-                3990,
-            ),
-            ctxt: #0,
-        },
+        span: 3951..3990#0,
         in_try: false,
     },
     Member {
@@ -23748,15 +22580,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                4019,
-            ),
-            hi: BytePos(
-                4027,
-            ),
-            ctxt: #0,
-        },
+        span: 4019..4027#0,
         in_try: false,
     },
     Call {
@@ -23949,15 +22773,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                4004,
-            ),
-            hi: BytePos(
-                4044,
-            ),
-            ctxt: #0,
-        },
+        span: 4004..4044#0,
         in_try: false,
     },
     Member {
@@ -24098,15 +22914,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                4073,
-            ),
-            hi: BytePos(
-                4082,
-            ),
-            ctxt: #0,
-        },
+        span: 4073..4082#0,
         in_try: false,
     },
     Call {
@@ -24297,15 +23105,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                4058,
-            ),
-            hi: BytePos(
-                4100,
-            ),
-            ctxt: #0,
-        },
+        span: 4058..4100#0,
         in_try: false,
     },
     Member {
@@ -24446,15 +23246,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                4129,
-            ),
-            hi: BytePos(
-                4137,
-            ),
-            ctxt: #0,
-        },
+        span: 4129..4137#0,
         in_try: false,
     },
     Call {
@@ -24645,15 +23437,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                4114,
-            ),
-            hi: BytePos(
-                4153,
-            ),
-            ctxt: #0,
-        },
+        span: 4114..4153#0,
         in_try: false,
     },
     Member {
@@ -24794,15 +23578,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                4182,
-            ),
-            hi: BytePos(
-                4191,
-            ),
-            ctxt: #0,
-        },
+        span: 4182..4191#0,
         in_try: false,
     },
     Call {
@@ -24995,15 +23771,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                4167,
-            ),
-            hi: BytePos(
-                4207,
-            ),
-            ctxt: #0,
-        },
+        span: 4167..4207#0,
         in_try: false,
     },
     Member {
@@ -25144,15 +23912,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                4236,
-            ),
-            hi: BytePos(
-                4244,
-            ),
-            ctxt: #0,
-        },
+        span: 4236..4244#0,
         in_try: false,
     },
     Call {
@@ -25343,15 +24103,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                4221,
-            ),
-            hi: BytePos(
-                4262,
-            ),
-            ctxt: #0,
-        },
+        span: 4221..4262#0,
         in_try: false,
     },
     Member {
@@ -25492,15 +24244,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                4291,
-            ),
-            hi: BytePos(
-                4300,
-            ),
-            ctxt: #0,
-        },
+        span: 4291..4300#0,
         in_try: false,
     },
     Call {
@@ -25691,15 +24435,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                4276,
-            ),
-            hi: BytePos(
-                4315,
-            ),
-            ctxt: #0,
-        },
+        span: 4276..4315#0,
         in_try: false,
     },
     Member {
@@ -25840,15 +24576,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                4344,
-            ),
-            hi: BytePos(
-                4352,
-            ),
-            ctxt: #0,
-        },
+        span: 4344..4352#0,
         in_try: false,
     },
     Call {
@@ -26039,15 +24767,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                4329,
-            ),
-            hi: BytePos(
-                4370,
-            ),
-            ctxt: #0,
-        },
+        span: 4329..4370#0,
         in_try: false,
     },
     Member {
@@ -26188,15 +24908,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                4399,
-            ),
-            hi: BytePos(
-                4407,
-            ),
-            ctxt: #0,
-        },
+        span: 4399..4407#0,
         in_try: false,
     },
     Call {
@@ -26389,15 +25101,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                4384,
-            ),
-            hi: BytePos(
-                4423,
-            ),
-            ctxt: #0,
-        },
+        span: 4384..4423#0,
         in_try: false,
     },
     Member {
@@ -26538,15 +25242,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                4452,
-            ),
-            hi: BytePos(
-                4461,
-            ),
-            ctxt: #0,
-        },
+        span: 4452..4461#0,
         in_try: false,
     },
     Call {
@@ -26737,15 +25433,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                4437,
-            ),
-            hi: BytePos(
-                4477,
-            ),
-            ctxt: #0,
-        },
+        span: 4437..4477#0,
         in_try: false,
     },
     Member {
@@ -26886,15 +25574,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                4506,
-            ),
-            hi: BytePos(
-                4514,
-            ),
-            ctxt: #0,
-        },
+        span: 4506..4514#0,
         in_try: false,
     },
     Call {
@@ -27085,15 +25765,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                4491,
-            ),
-            hi: BytePos(
-                4532,
-            ),
-            ctxt: #0,
-        },
+        span: 4491..4532#0,
         in_try: false,
     },
     Member {
@@ -27234,15 +25906,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                4561,
-            ),
-            hi: BytePos(
-                4570,
-            ),
-            ctxt: #0,
-        },
+        span: 4561..4570#0,
         in_try: false,
     },
     Call {
@@ -27435,15 +26099,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                4546,
-            ),
-            hi: BytePos(
-                4587,
-            ),
-            ctxt: #0,
-        },
+        span: 4546..4587#0,
         in_try: false,
     },
     Member {
@@ -27584,15 +26240,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                4616,
-            ),
-            hi: BytePos(
-                4624,
-            ),
-            ctxt: #0,
-        },
+        span: 4616..4624#0,
         in_try: false,
     },
     Call {
@@ -27783,15 +26431,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                4601,
-            ),
-            hi: BytePos(
-                4640,
-            ),
-            ctxt: #0,
-        },
+        span: 4601..4640#0,
         in_try: false,
     },
     Member {
@@ -27932,15 +26572,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                4669,
-            ),
-            hi: BytePos(
-                4678,
-            ),
-            ctxt: #0,
-        },
+        span: 4669..4678#0,
         in_try: false,
     },
     Call {
@@ -28131,15 +26763,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                4654,
-            ),
-            hi: BytePos(
-                4696,
-            ),
-            ctxt: #0,
-        },
+        span: 4654..4696#0,
         in_try: false,
     },
     Member {
@@ -28280,15 +26904,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                4725,
-            ),
-            hi: BytePos(
-                4733,
-            ),
-            ctxt: #0,
-        },
+        span: 4725..4733#0,
         in_try: false,
     },
     Call {
@@ -28481,15 +27097,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                4710,
-            ),
-            hi: BytePos(
-                4749,
-            ),
-            ctxt: #0,
-        },
+        span: 4710..4749#0,
         in_try: false,
     },
     Member {
@@ -28630,15 +27238,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                4778,
-            ),
-            hi: BytePos(
-                4786,
-            ),
-            ctxt: #0,
-        },
+        span: 4778..4786#0,
         in_try: false,
     },
     Call {
@@ -28829,15 +27429,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                4763,
-            ),
-            hi: BytePos(
-                4803,
-            ),
-            ctxt: #0,
-        },
+        span: 4763..4803#0,
         in_try: false,
     },
     Member {
@@ -28945,15 +27537,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                4940,
-            ),
-            hi: BytePos(
-                4952,
-            ),
-            ctxt: #0,
-        },
+        span: 4940..4952#0,
         in_try: false,
     },
     MemberCall {
@@ -29086,15 +27670,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                4940,
-            ),
-            hi: BytePos(
-                4966,
-            ),
-            ctxt: #0,
-        },
+        span: 4940..4966#0,
         in_try: false,
     },
     Member {
@@ -29174,15 +27750,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                5003,
-            ),
-            hi: BytePos(
-                5010,
-            ),
-            ctxt: #0,
-        },
+        span: 5003..5010#0,
         in_try: false,
     },
     Member {
@@ -29262,15 +27830,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                5153,
-            ),
-            hi: BytePos(
-                5160,
-            ),
-            ctxt: #0,
-        },
+        span: 5153..5160#0,
         in_try: false,
     },
     Member {
@@ -29350,15 +27910,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                5303,
-            ),
-            hi: BytePos(
-                5310,
-            ),
-            ctxt: #0,
-        },
+        span: 5303..5310#0,
         in_try: false,
     },
     Member {
@@ -29438,15 +27990,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                5444,
-            ),
-            hi: BytePos(
-                5451,
-            ),
-            ctxt: #0,
-        },
+        span: 5444..5451#0,
         in_try: false,
     },
     Member {
@@ -29526,15 +28070,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                5620,
-            ),
-            hi: BytePos(
-                5634,
-            ),
-            ctxt: #0,
-        },
+        span: 5620..5634#0,
         in_try: false,
     },
     Member {
@@ -29614,15 +28150,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                5643,
-            ),
-            hi: BytePos(
-                5658,
-            ),
-            ctxt: #0,
-        },
+        span: 5643..5658#0,
         in_try: false,
     },
     Member {
@@ -29699,15 +28227,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                5668,
-            ),
-            hi: BytePos(
-                5682,
-            ),
-            ctxt: #0,
-        },
+        span: 5668..5682#0,
         in_try: false,
     },
     FreeVar {
@@ -29783,15 +28303,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                5668,
-            ),
-            hi: BytePos(
-                5674,
-            ),
-            ctxt: #1,
-        },
+        span: 5668..5674#1,
         in_try: false,
     },
     FreeVar {
@@ -29890,15 +28402,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                5735,
-            ),
-            hi: BytePos(
-                5744,
-            ),
-            ctxt: #1,
-        },
+        span: 5735..5744#1,
         in_try: false,
     },
     Conditional {
@@ -30033,15 +28537,7 @@
                                 Ident,
                             ),
                         ],
-                        span: Span {
-                            lo: BytePos(
-                                5782,
-                            ),
-                            hi: BytePos(
-                                5787,
-                            ),
-                            ctxt: #1,
-                        },
+                        span: 5782..5787#1,
                         in_try: false,
                     },
                 ],
@@ -30201,15 +28697,7 @@
                 Test,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                5719,
-            ),
-            hi: BytePos(
-                5819,
-            ),
-            ctxt: #0,
-        },
+        span: 5719..5819#0,
         in_try: false,
     },
     Member {
@@ -30323,15 +28811,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                5843,
-            ),
-            hi: BytePos(
-                5861,
-            ),
-            ctxt: #0,
-        },
+        span: 5843..5861#0,
         in_try: false,
     },
     Call {
@@ -30458,15 +28938,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                5862,
-            ),
-            hi: BytePos(
-                5883,
-            ),
-            ctxt: #0,
-        },
+        span: 5862..5883#0,
         in_try: false,
     },
     MemberCall {
@@ -30598,15 +29070,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                5843,
-            ),
-            hi: BytePos(
-                5884,
-            ),
-            ctxt: #0,
-        },
+        span: 5843..5884#0,
         in_try: false,
     },
     Member {
@@ -30715,15 +29179,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                5908,
-            ),
-            hi: BytePos(
-                5923,
-            ),
-            ctxt: #0,
-        },
+        span: 5908..5923#0,
         in_try: false,
     },
     Conditional {
@@ -30956,15 +29412,7 @@
                                 Member,
                             ),
                         ],
-                        span: Span {
-                            lo: BytePos(
-                                5963,
-                            ),
-                            hi: BytePos(
-                                5979,
-                            ),
-                            ctxt: #0,
-                        },
+                        span: 5963..5979#0,
                         in_try: false,
                     },
                     Conditional {
@@ -31114,15 +29562,7 @@
                                                 Member,
                                             ),
                                         ],
-                                        span: Span {
-                                            lo: BytePos(
-                                                5988,
-                                            ),
-                                            hi: BytePos(
-                                                6005,
-                                            ),
-                                            ctxt: #0,
-                                        },
+                                        span: 5988..6005#0,
                                         in_try: false,
                                     },
                                     MemberCall {
@@ -31241,15 +29681,7 @@
                                                 Call,
                                             ),
                                         ],
-                                        span: Span {
-                                            lo: BytePos(
-                                                5988,
-                                            ),
-                                            hi: BytePos(
-                                                6018,
-                                            ),
-                                            ctxt: #0,
-                                        },
+                                        span: 5988..6018#0,
                                         in_try: false,
                                     },
                                 ],
@@ -31460,15 +29892,7 @@
                                                 Member,
                                             ),
                                         ],
-                                        span: Span {
-                                            lo: BytePos(
-                                                6027,
-                                            ),
-                                            hi: BytePos(
-                                                6043,
-                                            ),
-                                            ctxt: #0,
-                                        },
+                                        span: 6027..6043#0,
                                         in_try: false,
                                     },
                                     MemberCall {
@@ -31587,15 +30011,7 @@
                                                 Call,
                                             ),
                                         ],
-                                        span: Span {
-                                            lo: BytePos(
-                                                6027,
-                                            ),
-                                            hi: BytePos(
-                                                6056,
-                                            ),
-                                            ctxt: #0,
-                                        },
+                                        span: 6027..6056#0,
                                         in_try: false,
                                     },
                                 ],
@@ -31779,15 +30195,7 @@
                                 Test,
                             ),
                         ],
-                        span: Span {
-                            lo: BytePos(
-                                5952,
-                            ),
-                            hi: BytePos(
-                                6056,
-                            ),
-                            ctxt: #0,
-                        },
+                        span: 5952..6056#0,
                         in_try: false,
                     },
                 ],
@@ -31959,15 +30367,7 @@
                 Test,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                5897,
-            ),
-            hi: BytePos(
-                6056,
-            ),
-            ctxt: #0,
-        },
+        span: 5897..6056#0,
         in_try: false,
     },
 ]

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/member-call/graph-effects.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/member-call/graph-effects.snapshot
@@ -40,15 +40,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                35,
-            ),
-            hi: BytePos(
-                43,
-            ),
-            ctxt: #0,
-        },
+        span: 35..43#0,
         in_try: false,
     },
     Member {
@@ -101,15 +93,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                70,
-            ),
-            hi: BytePos(
-                82,
-            ),
-            ctxt: #0,
-        },
+        span: 70..82#0,
         in_try: false,
     },
     MemberCall {
@@ -231,15 +215,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                70,
-            ),
-            hi: BytePos(
-                119,
-            ),
-            ctxt: #0,
-        },
+        span: 70..119#0,
         in_try: false,
     },
     Member {
@@ -329,15 +305,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                139,
-            ),
-            hi: BytePos(
-                160,
-            ),
-            ctxt: #0,
-        },
+        span: 139..160#0,
         in_try: false,
     },
     Member {
@@ -423,15 +391,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                139,
-            ),
-            hi: BytePos(
-                153,
-            ),
-            ctxt: #0,
-        },
+        span: 139..153#0,
         in_try: false,
     },
     FreeVar {
@@ -487,15 +447,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                171,
-            ),
-            hi: BytePos(
-                178,
-            ),
-            ctxt: #1,
-        },
+        span: 171..178#1,
         in_try: false,
     },
     MemberCall {
@@ -610,15 +562,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                139,
-            ),
-            hi: BytePos(
-                180,
-            ),
-            ctxt: #0,
-        },
+        span: 139..180#0,
         in_try: false,
     },
     Member {
@@ -708,15 +652,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                200,
-            ),
-            hi: BytePos(
-                221,
-            ),
-            ctxt: #0,
-        },
+        span: 200..221#0,
         in_try: false,
     },
     Member {
@@ -802,15 +738,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                200,
-            ),
-            hi: BytePos(
-                214,
-            ),
-            ctxt: #0,
-        },
+        span: 200..214#0,
         in_try: false,
     },
     FreeVar {
@@ -855,15 +783,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                231,
-            ),
-            hi: BytePos(
-                238,
-            ),
-            ctxt: #1,
-        },
+        span: 231..238#1,
         in_try: false,
     },
     MemberCall {
@@ -978,15 +898,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                200,
-            ),
-            hi: BytePos(
-                239,
-            ),
-            ctxt: #0,
-        },
+        span: 200..239#0,
         in_try: false,
     },
     Member {
@@ -1030,15 +942,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                304,
-            ),
-            hi: BytePos(
-                313,
-            ),
-            ctxt: #0,
-        },
+        span: 304..313#0,
         in_try: false,
     },
     Member {
@@ -1091,15 +995,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                348,
-            ),
-            hi: BytePos(
-                360,
-            ),
-            ctxt: #0,
-        },
+        span: 348..360#0,
         in_try: false,
     },
     MemberCall {
@@ -1174,15 +1070,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                348,
-            ),
-            hi: BytePos(
-                371,
-            ),
-            ctxt: #0,
-        },
+        span: 348..371#0,
         in_try: false,
     },
 ]

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/member-prop/graph-effects.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/member-prop/graph-effects.snapshot
@@ -29,15 +29,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1,
-            ),
-            hi: BytePos(
-                4,
-            ),
-            ctxt: #0,
-        },
+        span: 1..4#0,
         in_try: false,
     },
     FreeVar {
@@ -69,15 +61,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1,
-            ),
-            hi: BytePos(
-                2,
-            ),
-            ctxt: #1,
-        },
+        span: 1..2#1,
         in_try: false,
     },
 ]

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/mongoose-reduced/graph-effects.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/mongoose-reduced/graph-effects.snapshot
@@ -43,15 +43,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                16,
-            ),
-            hi: BytePos(
-                43,
-            ),
-            ctxt: #0,
-        },
+        span: 16..43#0,
         in_try: false,
     },
     FreeVar {
@@ -97,15 +89,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                16,
-            ),
-            hi: BytePos(
-                22,
-            ),
-            ctxt: #1,
-        },
+        span: 16..22#1,
         in_try: false,
     },
     FreeVar {
@@ -148,15 +132,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                123,
-            ),
-            hi: BytePos(
-                130,
-            ),
-            ctxt: #1,
-        },
+        span: 123..130#1,
         in_try: false,
     },
     Call {
@@ -212,15 +188,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                123,
-            ),
-            hi: BytePos(
-                154,
-            ),
-            ctxt: #0,
-        },
+        span: 123..154#0,
         in_try: false,
     },
     FreeVar {
@@ -263,15 +231,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                199,
-            ),
-            hi: BytePos(
-                206,
-            ),
-            ctxt: #1,
-        },
+        span: 199..206#1,
         in_try: false,
     },
     Call {
@@ -327,15 +287,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                199,
-            ),
-            hi: BytePos(
-                230,
-            ),
-            ctxt: #0,
-        },
+        span: 199..230#0,
         in_try: false,
     },
 ]

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/nested-args/graph-effects.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/nested-args/graph-effects.snapshot
@@ -53,15 +53,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                77,
-            ),
-            hi: BytePos(
-                81,
-            ),
-            ctxt: #0,
-        },
+        span: 77..81#0,
         in_try: false,
     },
     Call {
@@ -121,15 +113,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                77,
-            ),
-            hi: BytePos(
-                84,
-            ),
-            ctxt: #0,
-        },
+        span: 77..84#0,
         in_try: false,
     },
     Conditional {
@@ -273,15 +257,7 @@
                                 Call,
                             ),
                         ],
-                        span: Span {
-                            lo: BytePos(
-                                159,
-                            ),
-                            hi: BytePos(
-                                167,
-                            ),
-                            ctxt: #0,
-                        },
+                        span: 159..167#0,
                         in_try: false,
                     },
                 ],
@@ -353,15 +329,7 @@
                 Test,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                105,
-            ),
-            hi: BytePos(
-                176,
-            ),
-            ctxt: #0,
-        },
+        span: 105..176#0,
         in_try: false,
     },
     Call {
@@ -409,15 +377,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                190,
-            ),
-            hi: BytePos(
-                194,
-            ),
-            ctxt: #0,
-        },
+        span: 190..194#0,
         in_try: false,
     },
     Call {
@@ -474,15 +434,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                271,
-            ),
-            hi: BytePos(
-                281,
-            ),
-            ctxt: #0,
-        },
+        span: 271..281#0,
         in_try: false,
     },
     Call {
@@ -530,15 +482,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                295,
-            ),
-            hi: BytePos(
-                305,
-            ),
-            ctxt: #0,
-        },
+        span: 295..305#0,
         in_try: false,
     },
 ]

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/object/graph-effects.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/object/graph-effects.snapshot
@@ -40,15 +40,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                75,
-            ),
-            hi: BytePos(
-                83,
-            ),
-            ctxt: #0,
-        },
+        span: 75..83#0,
         in_try: false,
     },
     Member {
@@ -92,15 +84,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                96,
-            ),
-            hi: BytePos(
-                107,
-            ),
-            ctxt: #0,
-        },
+        span: 96..107#0,
         in_try: false,
     },
     Member {
@@ -144,15 +128,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                120,
-            ),
-            hi: BytePos(
-                128,
-            ),
-            ctxt: #0,
-        },
+        span: 120..128#0,
         in_try: false,
     },
     Member {
@@ -196,15 +172,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                141,
-            ),
-            hi: BytePos(
-                152,
-            ),
-            ctxt: #0,
-        },
+        span: 141..152#0,
         in_try: false,
     },
     Member {
@@ -248,15 +216,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                165,
-            ),
-            hi: BytePos(
-                173,
-            ),
-            ctxt: #0,
-        },
+        span: 165..173#0,
         in_try: false,
     },
     Member {
@@ -300,15 +260,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                186,
-            ),
-            hi: BytePos(
-                197,
-            ),
-            ctxt: #0,
-        },
+        span: 186..197#0,
         in_try: false,
     },
     Member {
@@ -352,15 +304,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                210,
-            ),
-            hi: BytePos(
-                218,
-            ),
-            ctxt: #0,
-        },
+        span: 210..218#0,
         in_try: false,
     },
     Member {
@@ -404,15 +348,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                231,
-            ),
-            hi: BytePos(
-                242,
-            ),
-            ctxt: #0,
-        },
+        span: 231..242#0,
         in_try: false,
     },
     Member {
@@ -456,15 +392,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                308,
-            ),
-            hi: BytePos(
-                323,
-            ),
-            ctxt: #0,
-        },
+        span: 308..323#0,
         in_try: false,
     },
     Member {
@@ -508,15 +436,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                336,
-            ),
-            hi: BytePos(
-                351,
-            ),
-            ctxt: #0,
-        },
+        span: 336..351#0,
         in_try: false,
     },
     Member {
@@ -560,15 +480,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                364,
-            ),
-            hi: BytePos(
-                379,
-            ),
-            ctxt: #0,
-        },
+        span: 364..379#0,
         in_try: false,
     },
     Member {
@@ -612,15 +524,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                392,
-            ),
-            hi: BytePos(
-                407,
-            ),
-            ctxt: #0,
-        },
+        span: 392..407#0,
         in_try: false,
     },
     FreeVar {
@@ -668,15 +572,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                548,
-            ),
-            hi: BytePos(
-                554,
-            ),
-            ctxt: #1,
-        },
+        span: 548..554#1,
         in_try: false,
     },
     Member {
@@ -720,15 +616,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                576,
-            ),
-            hi: BytePos(
-                592,
-            ),
-            ctxt: #0,
-        },
+        span: 576..592#0,
         in_try: false,
     },
     Member {
@@ -772,15 +660,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                605,
-            ),
-            hi: BytePos(
-                621,
-            ),
-            ctxt: #0,
-        },
+        span: 605..621#0,
         in_try: false,
     },
     Member {
@@ -824,15 +704,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                634,
-            ),
-            hi: BytePos(
-                650,
-            ),
-            ctxt: #0,
-        },
+        span: 634..650#0,
         in_try: false,
     },
     FreeVar {
@@ -889,15 +761,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                678,
-            ),
-            hi: BytePos(
-                684,
-            ),
-            ctxt: #1,
-        },
+        span: 678..684#1,
         in_try: false,
     },
     FreeVar {
@@ -954,15 +818,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                697,
-            ),
-            hi: BytePos(
-                703,
-            ),
-            ctxt: #1,
-        },
+        span: 697..703#1,
         in_try: false,
     },
     Member {
@@ -1006,15 +862,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                728,
-            ),
-            hi: BytePos(
-                737,
-            ),
-            ctxt: #0,
-        },
+        span: 728..737#0,
         in_try: false,
     },
     Member {
@@ -1058,15 +906,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                750,
-            ),
-            hi: BytePos(
-                759,
-            ),
-            ctxt: #0,
-        },
+        span: 750..759#0,
         in_try: false,
     },
     Member {
@@ -1110,15 +950,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                772,
-            ),
-            hi: BytePos(
-                781,
-            ),
-            ctxt: #0,
-        },
+        span: 772..781#0,
         in_try: false,
     },
     Member {
@@ -1162,15 +994,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                794,
-            ),
-            hi: BytePos(
-                803,
-            ),
-            ctxt: #0,
-        },
+        span: 794..803#0,
         in_try: false,
     },
     Member {
@@ -1214,15 +1038,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                816,
-            ),
-            hi: BytePos(
-                825,
-            ),
-            ctxt: #0,
-        },
+        span: 816..825#0,
         in_try: false,
     },
 ]

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/other-free-vars/graph-effects.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/other-free-vars/graph-effects.snapshot
@@ -30,15 +30,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                11,
-            ),
-            hi: BytePos(
-                17,
-            ),
-            ctxt: #1,
-        },
+        span: 11..17#1,
         in_try: false,
     },
     Member {
@@ -88,15 +80,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                30,
-            ),
-            hi: BytePos(
-                41,
-            ),
-            ctxt: #0,
-        },
+        span: 30..41#0,
         in_try: false,
     },
     FreeVar {
@@ -145,15 +129,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                30,
-            ),
-            hi: BytePos(
-                36,
-            ),
-            ctxt: #1,
-        },
+        span: 30..36#1,
         in_try: false,
     },
     MemberCall {
@@ -204,15 +180,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                30,
-            ),
-            hi: BytePos(
-                44,
-            ),
-            ctxt: #0,
-        },
+        span: 30..44#0,
         in_try: false,
     },
     Member {
@@ -265,15 +233,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                56,
-            ),
-            hi: BytePos(
-                62,
-            ),
-            ctxt: #0,
-        },
+        span: 56..62#0,
         in_try: false,
     },
     FreeVar {
@@ -318,15 +278,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                63,
-            ),
-            hi: BytePos(
-                69,
-            ),
-            ctxt: #1,
-        },
+        span: 63..69#1,
         in_try: false,
     },
     MemberCall {
@@ -377,15 +329,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                56,
-            ),
-            hi: BytePos(
-                70,
-            ),
-            ctxt: #0,
-        },
+        span: 56..70#0,
         in_try: false,
     },
 ]

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/pack-2236/graph-effects.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/pack-2236/graph-effects.snapshot
@@ -51,15 +51,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                102,
-            ),
-            hi: BytePos(
-                113,
-            ),
-            ctxt: #1,
-        },
+        span: 102..113#1,
         in_try: false,
     },
     Conditional {
@@ -132,15 +124,7 @@
                                 Ident,
                             ),
                         ],
-                        span: Span {
-                            lo: BytePos(
-                                132,
-                            ),
-                            hi: BytePos(
-                                139,
-                            ),
-                            ctxt: #1,
-                        },
+                        span: 132..139#1,
                         in_try: false,
                     },
                     Call {
@@ -194,15 +178,7 @@
                                 Call,
                             ),
                         ],
-                        span: Span {
-                            lo: BytePos(
-                                132,
-                            ),
-                            hi: BytePos(
-                                150,
-                            ),
-                            ctxt: #0,
-                        },
+                        span: 132..150#0,
                         in_try: false,
                     },
                 ],
@@ -283,15 +259,7 @@
                                 Ident,
                             ),
                         ],
-                        span: Span {
-                            lo: BytePos(
-                                153,
-                            ),
-                            hi: BytePos(
-                                165,
-                            ),
-                            ctxt: #2,
-                        },
+                        span: 153..165#2,
                         in_try: false,
                     },
                 ],
@@ -363,15 +331,7 @@
                 Test,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                95,
-            ),
-            hi: BytePos(
-                165,
-            ),
-            ctxt: #0,
-        },
+        span: 95..165#0,
         in_try: false,
     },
 ]

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/pack-2521/graph-effects.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/pack-2521/graph-effects.snapshot
@@ -39,15 +39,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                33,
-            ),
-            hi: BytePos(
-                40,
-            ),
-            ctxt: #1,
-        },
+        span: 33..40#1,
         in_try: false,
     },
     Call {
@@ -92,15 +84,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                33,
-            ),
-            hi: BytePos(
-                53,
-            ),
-            ctxt: #0,
-        },
+        span: 33..53#0,
         in_try: false,
     },
     Call {
@@ -138,15 +122,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                79,
-            ),
-            hi: BytePos(
-                100,
-            ),
-            ctxt: #0,
-        },
+        span: 79..100#0,
         in_try: false,
     },
     Member {
@@ -188,15 +164,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                102,
-            ),
-            hi: BytePos(
-                113,
-            ),
-            ctxt: #0,
-        },
+        span: 102..113#0,
         in_try: false,
     },
     FreeVar {
@@ -237,15 +205,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                102,
-            ),
-            hi: BytePos(
-                109,
-            ),
-            ctxt: #1,
-        },
+        span: 102..109#1,
         in_try: false,
     },
     MemberCall {
@@ -297,15 +257,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                102,
-            ),
-            hi: BytePos(
-                150,
-            ),
-            ctxt: #0,
-        },
+        span: 102..150#0,
         in_try: false,
     },
     FreeVar {
@@ -371,15 +323,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                429,
-            ),
-            hi: BytePos(
-                436,
-            ),
-            ctxt: #1,
-        },
+        span: 429..436#1,
         in_try: true,
     },
     Call {
@@ -446,15 +390,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                429,
-            ),
-            hi: BytePos(
-                442,
-            ),
-            ctxt: #0,
-        },
+        span: 429..442#0,
         in_try: true,
     },
     Member {
@@ -527,15 +463,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                508,
-            ),
-            hi: BytePos(
-                519,
-            ),
-            ctxt: #0,
-        },
+        span: 508..519#0,
         in_try: false,
     },
     MemberCall {
@@ -609,15 +537,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                508,
-            ),
-            hi: BytePos(
-                524,
-            ),
-            ctxt: #0,
-        },
+        span: 508..524#0,
         in_try: false,
     },
 ]

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/pack-2682/graph-effects.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/pack-2682/graph-effects.snapshot
@@ -72,15 +72,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                50,
-            ),
-            hi: BytePos(
-                61,
-            ),
-            ctxt: #0,
-        },
+        span: 50..61#0,
         in_try: false,
     },
     FreeVar {
@@ -155,15 +147,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                50,
-            ),
-            hi: BytePos(
-                54,
-            ),
-            ctxt: #1,
-        },
+        span: 50..54#1,
         in_try: false,
     },
     MemberCall {
@@ -231,15 +215,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                50,
-            ),
-            hi: BytePos(
-                63,
-            ),
-            ctxt: #0,
-        },
+        span: 50..63#0,
         in_try: false,
     },
     Member {
@@ -309,15 +285,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                273,
-            ),
-            hi: BytePos(
-                287,
-            ),
-            ctxt: #0,
-        },
+        span: 273..287#0,
         in_try: false,
     },
     FreeVar {
@@ -386,15 +354,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                273,
-            ),
-            hi: BytePos(
-                277,
-            ),
-            ctxt: #1,
-        },
+        span: 273..277#1,
         in_try: false,
     },
     Conditional {
@@ -657,15 +617,7 @@
                 Test,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                354,
-            ),
-            hi: BytePos(
-                392,
-            ),
-            ctxt: #0,
-        },
+        span: 354..392#0,
         in_try: false,
     },
     MemberCall {
@@ -805,15 +757,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                273,
-            ),
-            hi: BytePos(
-                398,
-            ),
-            ctxt: #0,
-        },
+        span: 273..398#0,
         in_try: false,
     },
     Call {
@@ -876,15 +820,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                416,
-            ),
-            hi: BytePos(
-                453,
-            ),
-            ctxt: #0,
-        },
+        span: 416..453#0,
         in_try: false,
     },
 ]

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/path-join/graph-effects.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/path-join/graph-effects.snapshot
@@ -39,15 +39,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                11,
-            ),
-            hi: BytePos(
-                18,
-            ),
-            ctxt: #1,
-        },
+        span: 11..18#1,
         in_try: false,
     },
     Call {
@@ -92,15 +84,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                11,
-            ),
-            hi: BytePos(
-                25,
-            ),
-            ctxt: #0,
-        },
+        span: 11..25#0,
         in_try: false,
     },
     FreeVar {
@@ -143,15 +127,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                79,
-            ),
-            hi: BytePos(
-                86,
-            ),
-            ctxt: #1,
-        },
+        span: 79..86#1,
         in_try: false,
     },
     Call {
@@ -196,15 +172,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                79,
-            ),
-            hi: BytePos(
-                94,
-            ),
-            ctxt: #0,
-        },
+        span: 79..94#0,
         in_try: false,
     },
     Member {
@@ -257,15 +225,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                115,
-            ),
-            hi: BytePos(
-                124,
-            ),
-            ctxt: #0,
-        },
+        span: 115..124#0,
         in_try: false,
     },
     MemberCall {
@@ -329,15 +289,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                115,
-            ),
-            hi: BytePos(
-                138,
-            ),
-            ctxt: #0,
-        },
+        span: 115..138#0,
         in_try: false,
     },
     Member {
@@ -390,15 +342,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                158,
-            ),
-            hi: BytePos(
-                167,
-            ),
-            ctxt: #0,
-        },
+        span: 158..167#0,
         in_try: false,
     },
     MemberCall {
@@ -462,15 +406,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                158,
-            ),
-            hi: BytePos(
-                182,
-            ),
-            ctxt: #0,
-        },
+        span: 158..182#0,
         in_try: false,
     },
     Member {
@@ -523,15 +459,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                202,
-            ),
-            hi: BytePos(
-                211,
-            ),
-            ctxt: #0,
-        },
+        span: 202..211#0,
         in_try: false,
     },
     MemberCall {
@@ -595,15 +523,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                202,
-            ),
-            hi: BytePos(
-                226,
-            ),
-            ctxt: #0,
-        },
+        span: 202..226#0,
         in_try: false,
     },
     Member {
@@ -656,15 +576,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                246,
-            ),
-            hi: BytePos(
-                255,
-            ),
-            ctxt: #0,
-        },
+        span: 246..255#0,
         in_try: false,
     },
     MemberCall {
@@ -728,15 +640,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                246,
-            ),
-            hi: BytePos(
-                271,
-            ),
-            ctxt: #0,
-        },
+        span: 246..271#0,
         in_try: false,
     },
     Member {
@@ -789,15 +693,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                291,
-            ),
-            hi: BytePos(
-                300,
-            ),
-            ctxt: #0,
-        },
+        span: 291..300#0,
         in_try: false,
     },
     FreeVar {
@@ -842,15 +738,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                328,
-            ),
-            hi: BytePos(
-                334,
-            ),
-            ctxt: #1,
-        },
+        span: 328..334#1,
         in_try: false,
     },
     MemberCall {
@@ -955,15 +843,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                291,
-            ),
-            hi: BytePos(
-                348,
-            ),
-            ctxt: #0,
-        },
+        span: 291..348#0,
         in_try: false,
     },
 ]

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/process-and-os/graph-effects.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/process-and-os/graph-effects.snapshot
@@ -39,15 +39,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                40,
-            ),
-            hi: BytePos(
-                47,
-            ),
-            ctxt: #1,
-        },
+        span: 40..47#1,
         in_try: false,
     },
     Call {
@@ -92,15 +84,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                40,
-            ),
-            hi: BytePos(
-                53,
-            ),
-            ctxt: #0,
-        },
+        span: 40..53#0,
         in_try: false,
     },
     FreeVar {
@@ -143,15 +127,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                93,
-            ),
-            hi: BytePos(
-                100,
-            ),
-            ctxt: #1,
-        },
+        span: 93..100#1,
         in_try: false,
     },
     Call {
@@ -196,15 +172,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                93,
-            ),
-            hi: BytePos(
-                111,
-            ),
-            ctxt: #0,
-        },
+        span: 93..111#0,
         in_try: false,
     },
     FreeVar {
@@ -238,15 +206,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                122,
-            ),
-            hi: BytePos(
-                129,
-            ),
-            ctxt: #1,
-        },
+        span: 122..129#1,
         in_try: false,
     },
     FreeVar {
@@ -289,15 +249,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                149,
-            ),
-            hi: BytePos(
-                156,
-            ),
-            ctxt: #1,
-        },
+        span: 149..156#1,
         in_try: false,
     },
     Member {
@@ -357,15 +309,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                171,
-            ),
-            hi: BytePos(
-                183,
-            ),
-            ctxt: #0,
-        },
+        span: 171..183#0,
         in_try: false,
     },
     FreeVar {
@@ -424,15 +368,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                171,
-            ),
-            hi: BytePos(
-                178,
-            ),
-            ctxt: #1,
-        },
+        span: 171..178#1,
         in_try: false,
     },
     Call {
@@ -489,15 +425,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                188,
-            ),
-            hi: BytePos(
-                198,
-            ),
-            ctxt: #0,
-        },
+        span: 188..198#0,
         in_try: false,
     },
     Call {
@@ -554,15 +482,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                202,
-            ),
-            hi: BytePos(
-                214,
-            ),
-            ctxt: #0,
-        },
+        span: 202..214#0,
         in_try: false,
     },
     Call {
@@ -659,15 +579,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                149,
-            ),
-            hi: BytePos(
-                217,
-            ),
-            ctxt: #0,
-        },
+        span: 149..217#0,
         in_try: false,
     },
     FreeVar {
@@ -710,15 +622,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                236,
-            ),
-            hi: BytePos(
-                243,
-            ),
-            ctxt: #1,
-        },
+        span: 236..243#1,
         in_try: false,
     },
     Call {
@@ -775,15 +679,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                255,
-            ),
-            hi: BytePos(
-                261,
-            ),
-            ctxt: #0,
-        },
+        span: 255..261#0,
         in_try: false,
     },
     Call {
@@ -840,15 +736,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                265,
-            ),
-            hi: BytePos(
-                275,
-            ),
-            ctxt: #0,
-        },
+        span: 265..275#0,
         in_try: false,
     },
     Call {
@@ -905,15 +793,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                279,
-            ),
-            hi: BytePos(
-                291,
-            ),
-            ctxt: #0,
-        },
+        span: 279..291#0,
         in_try: false,
     },
     Call {
@@ -1007,15 +887,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                236,
-            ),
-            hi: BytePos(
-                294,
-            ),
-            ctxt: #0,
-        },
+        span: 236..294#0,
         in_try: false,
     },
     FreeVar {
@@ -1058,15 +930,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                313,
-            ),
-            hi: BytePos(
-                320,
-            ),
-            ctxt: #1,
-        },
+        span: 313..320#1,
         in_try: false,
     },
     Call {
@@ -1123,15 +987,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                332,
-            ),
-            hi: BytePos(
-                338,
-            ),
-            ctxt: #0,
-        },
+        span: 332..338#0,
         in_try: false,
     },
     Member {
@@ -1191,15 +1047,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                345,
-            ),
-            hi: BytePos(
-                361,
-            ),
-            ctxt: #0,
-        },
+        span: 345..361#0,
         in_try: false,
     },
     FreeVar {
@@ -1258,15 +1106,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                345,
-            ),
-            hi: BytePos(
-                352,
-            ),
-            ctxt: #1,
-        },
+        span: 345..352#1,
         in_try: false,
     },
     Call {
@@ -1323,15 +1163,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                366,
-            ),
-            hi: BytePos(
-                378,
-            ),
-            ctxt: #0,
-        },
+        span: 366..378#0,
         in_try: false,
     },
     Call {
@@ -1428,15 +1260,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                313,
-            ),
-            hi: BytePos(
-                381,
-            ),
-            ctxt: #0,
-        },
+        span: 313..381#0,
         in_try: false,
     },
     FreeVar {
@@ -1479,15 +1303,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                400,
-            ),
-            hi: BytePos(
-                407,
-            ),
-            ctxt: #1,
-        },
+        span: 400..407#1,
         in_try: false,
     },
     Member {
@@ -1547,15 +1363,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                419,
-            ),
-            hi: BytePos(
-                431,
-            ),
-            ctxt: #0,
-        },
+        span: 419..431#0,
         in_try: false,
     },
     FreeVar {
@@ -1614,15 +1422,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                419,
-            ),
-            hi: BytePos(
-                426,
-            ),
-            ctxt: #1,
-        },
+        span: 419..426#1,
         in_try: false,
     },
     Member {
@@ -1682,15 +1482,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                438,
-            ),
-            hi: BytePos(
-                454,
-            ),
-            ctxt: #0,
-        },
+        span: 438..454#0,
         in_try: false,
     },
     FreeVar {
@@ -1749,15 +1541,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                438,
-            ),
-            hi: BytePos(
-                445,
-            ),
-            ctxt: #1,
-        },
+        span: 438..445#1,
         in_try: false,
     },
     Call {
@@ -1814,15 +1598,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                459,
-            ),
-            hi: BytePos(
-                471,
-            ),
-            ctxt: #0,
-        },
+        span: 459..471#0,
         in_try: false,
     },
     Call {
@@ -1922,15 +1698,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                400,
-            ),
-            hi: BytePos(
-                474,
-            ),
-            ctxt: #0,
-        },
+        span: 400..474#0,
         in_try: false,
     },
     FreeVar {
@@ -1973,15 +1741,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                493,
-            ),
-            hi: BytePos(
-                500,
-            ),
-            ctxt: #1,
-        },
+        span: 493..500#1,
         in_try: false,
     },
     Member {
@@ -2044,15 +1804,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                512,
-            ),
-            hi: BytePos(
-                518,
-            ),
-            ctxt: #0,
-        },
+        span: 512..518#0,
         in_try: false,
     },
     Member {
@@ -2115,15 +1867,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                522,
-            ),
-            hi: BytePos(
-                532,
-            ),
-            ctxt: #0,
-        },
+        span: 522..532#0,
         in_try: false,
     },
     Call {
@@ -2180,15 +1924,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                536,
-            ),
-            hi: BytePos(
-                548,
-            ),
-            ctxt: #0,
-        },
+        span: 536..548#0,
         in_try: false,
     },
     Call {
@@ -2294,15 +2030,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                493,
-            ),
-            hi: BytePos(
-                551,
-            ),
-            ctxt: #0,
-        },
+        span: 493..551#0,
         in_try: false,
     },
     FreeVar {
@@ -2345,15 +2073,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                570,
-            ),
-            hi: BytePos(
-                577,
-            ),
-            ctxt: #1,
-        },
+        span: 570..577#1,
         in_try: false,
     },
     Member {
@@ -2416,15 +2136,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                592,
-            ),
-            hi: BytePos(
-                598,
-            ),
-            ctxt: #0,
-        },
+        span: 592..598#0,
         in_try: false,
     },
     Call {
@@ -2481,15 +2193,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                622,
-            ),
-            hi: BytePos(
-                634,
-            ),
-            ctxt: #0,
-        },
+        span: 622..634#0,
         in_try: false,
     },
     Call {
@@ -2585,15 +2289,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                570,
-            ),
-            hi: BytePos(
-                637,
-            ),
-            ctxt: #0,
-        },
+        span: 570..637#0,
         in_try: false,
     },
 ]

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/require-context/graph-effects.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/require-context/graph-effects.snapshot
@@ -69,15 +69,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                34,
-            ),
-            hi: BytePos(
-                46,
-            ),
-            ctxt: #0,
-        },
+        span: 34..46#0,
         in_try: false,
     },
     Member {
@@ -154,15 +146,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                34,
-            ),
-            hi: BytePos(
-                40,
-            ),
-            ctxt: #0,
-        },
+        span: 34..40#0,
         in_try: false,
     },
     MemberCall {
@@ -231,15 +215,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                34,
-            ),
-            hi: BytePos(
-                42,
-            ),
-            ctxt: #0,
-        },
+        span: 34..42#0,
         in_try: false,
     },
     MemberCall {
@@ -313,15 +289,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                34,
-            ),
-            hi: BytePos(
-                49,
-            ),
-            ctxt: #0,
-        },
+        span: 34..49#0,
         in_try: false,
     },
     Member {
@@ -371,15 +339,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                70,
-            ),
-            hi: BytePos(
-                85,
-            ),
-            ctxt: #0,
-        },
+        span: 70..85#0,
         in_try: false,
     },
     FreeVar {
@@ -428,15 +388,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                70,
-            ),
-            hi: BytePos(
-                77,
-            ),
-            ctxt: #1,
-        },
+        span: 70..77#1,
         in_try: false,
     },
     MemberCall {
@@ -501,15 +453,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                70,
-            ),
-            hi: BytePos(
-                117,
-            ),
-            ctxt: #0,
-        },
+        span: 70..117#0,
         in_try: false,
     },
     Call {
@@ -556,15 +500,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                133,
-            ),
-            hi: BytePos(
-                151,
-            ),
-            ctxt: #0,
-        },
+        span: 133..151#0,
         in_try: false,
     },
     Member {
@@ -617,15 +553,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                164,
-            ),
-            hi: BytePos(
-                179,
-            ),
-            ctxt: #0,
-        },
+        span: 164..179#0,
         in_try: false,
     },
     MemberCall {
@@ -680,15 +608,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                164,
-            ),
-            hi: BytePos(
-                186,
-            ),
-            ctxt: #0,
-        },
+        span: 164..186#0,
         in_try: false,
     },
 ]

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/try/graph-effects.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/try/graph-effects.snapshot
@@ -48,15 +48,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                25,
-            ),
-            hi: BytePos(
-                32,
-            ),
-            ctxt: #1,
-        },
+        span: 25..32#1,
         in_try: true,
     },
     Call {
@@ -110,15 +102,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                25,
-            ),
-            hi: BytePos(
-                54,
-            ),
-            ctxt: #0,
-        },
+        span: 25..54#0,
         in_try: true,
     },
     FreeVar {
@@ -173,15 +157,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                78,
-            ),
-            hi: BytePos(
-                85,
-            ),
-            ctxt: #1,
-        },
+        span: 78..85#1,
         in_try: false,
     },
     Call {
@@ -238,15 +214,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                78,
-            ),
-            hi: BytePos(
-                103,
-            ),
-            ctxt: #0,
-        },
+        span: 78..103#0,
         in_try: false,
     },
     Member {
@@ -291,15 +259,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                108,
-            ),
-            hi: BytePos(
-                114,
-            ),
-            ctxt: #0,
-        },
+        span: 108..114#0,
         in_try: false,
     },
     MemberCall {
@@ -336,15 +296,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                108,
-            ),
-            hi: BytePos(
-                116,
-            ),
-            ctxt: #0,
-        },
+        span: 108..116#0,
         in_try: false,
     },
 ]

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/webpack-target-node/graph-effects.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/webpack-target-node/graph-effects.snapshot
@@ -76,15 +76,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                46,
-            ),
-            hi: BytePos(
-                56,
-            ),
-            ctxt: #0,
-        },
+        span: 46..56#0,
         in_try: false,
     },
     Member {
@@ -164,15 +156,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                66,
-            ),
-            hi: BytePos(
-                77,
-            ),
-            ctxt: #0,
-        },
+        span: 66..77#0,
         in_try: false,
     },
     Member {
@@ -252,15 +236,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                89,
-            ),
-            hi: BytePos(
-                104,
-            ),
-            ctxt: #0,
-        },
+        span: 89..104#0,
         in_try: false,
     },
     Member {
@@ -383,15 +359,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                259,
-            ),
-            hi: BytePos(
-                280,
-            ),
-            ctxt: #0,
-        },
+        span: 259..280#0,
         in_try: false,
     },
     MemberCall {
@@ -515,15 +483,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                259,
-            ),
-            hi: BytePos(
-                301,
-            ),
-            ctxt: #0,
-        },
+        span: 259..301#0,
         in_try: false,
     },
     Member {
@@ -646,15 +606,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                327,
-            ),
-            hi: BytePos(
-                348,
-            ),
-            ctxt: #0,
-        },
+        span: 327..348#0,
         in_try: false,
     },
     MemberCall {
@@ -801,15 +753,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                327,
-            ),
-            hi: BytePos(
-                426,
-            ),
-            ctxt: #0,
-        },
+        span: 327..426#0,
         in_try: false,
     },
     FreeVar {
@@ -930,15 +874,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                515,
-            ),
-            hi: BytePos(
-                522,
-            ),
-            ctxt: #1,
-        },
+        span: 515..522#1,
         in_try: false,
     },
     Call {
@@ -1061,15 +997,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                515,
-            ),
-            hi: BytePos(
-                537,
-            ),
-            ctxt: #0,
-        },
+        span: 515..537#0,
         in_try: false,
     },
     Member {
@@ -1237,15 +1165,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                828,
-            ),
-            hi: BytePos(
-                861,
-            ),
-            ctxt: #0,
-        },
+        span: 828..861#0,
         in_try: false,
     },
     MemberCall {
@@ -1410,15 +1330,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                824,
-            ),
-            hi: BytePos(
-                916,
-            ),
-            ctxt: #0,
-        },
+        span: 824..916#0,
         in_try: false,
     },
     Member {
@@ -1577,15 +1489,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                965,
-            ),
-            hi: BytePos(
-                985,
-            ),
-            ctxt: #0,
-        },
+        span: 965..985#0,
         in_try: false,
     },
     Member {
@@ -1740,15 +1644,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                965,
-            ),
-            hi: BytePos(
-                975,
-            ),
-            ctxt: #0,
-        },
+        span: 965..975#0,
         in_try: false,
     },
     MemberCall {
@@ -1905,15 +1801,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                965,
-            ),
-            hi: BytePos(
-                980,
-            ),
-            ctxt: #0,
-        },
+        span: 965..980#0,
         in_try: false,
     },
     MemberCall {
@@ -2103,15 +1991,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                965,
-            ),
-            hi: BytePos(
-                1032,
-            ),
-            ctxt: #0,
-        },
+        span: 965..1032#0,
         in_try: false,
     },
     FreeVar {
@@ -2189,15 +2069,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1113,
-            ),
-            hi: BytePos(
-                1120,
-            ),
-            ctxt: #1,
-        },
+        span: 1113..1120#1,
         in_try: false,
     },
     Call {
@@ -2277,15 +2149,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1113,
-            ),
-            hi: BytePos(
-                1152,
-            ),
-            ctxt: #0,
-        },
+        span: 1113..1152#0,
         in_try: false,
     },
     Member {
@@ -2365,15 +2229,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1156,
-            ),
-            hi: BytePos(
-                1177,
-            ),
-            ctxt: #0,
-        },
+        span: 1156..1177#0,
         in_try: false,
     },
     MemberCall {
@@ -2454,15 +2310,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1156,
-            ),
-            hi: BytePos(
-                1186,
-            ),
-            ctxt: #0,
-        },
+        span: 1156..1186#0,
         in_try: false,
     },
     Member {
@@ -2576,15 +2424,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1252,
-            ),
-            hi: BytePos(
-                1273,
-            ),
-            ctxt: #0,
-        },
+        span: 1252..1273#0,
         in_try: false,
     },
     Call {
@@ -2674,15 +2514,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1231,
-            ),
-            hi: BytePos(
-                1286,
-            ),
-            ctxt: #0,
-        },
+        span: 1231..1286#0,
         in_try: false,
     },
     Call {
@@ -2765,15 +2597,7 @@
                 Call,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1316,
-            ),
-            hi: BytePos(
-                1338,
-            ),
-            ctxt: #0,
-        },
+        span: 1316..1338#0,
         in_try: false,
     },
     Member {
@@ -2850,15 +2674,7 @@
                 Member,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1342,
-            ),
-            hi: BytePos(
-                1356,
-            ),
-            ctxt: #0,
-        },
+        span: 1342..1356#0,
         in_try: false,
     },
     FreeVar {
@@ -2934,15 +2750,7 @@
                 Ident,
             ),
         ],
-        span: Span {
-            lo: BytePos(
-                1342,
-            ),
-            hi: BytePos(
-                1348,
-            ),
-            ctxt: #1,
-        },
+        span: 1342..1348#1,
         in_try: false,
     },
 ]


### PR DESCRIPTION
### Description

Update SWC crates to https://github.com/swc-project/swc/commit/ad932f0921411364b801b32f60eaf98f8629e812, to keep in sync.


 - Closes PACK-2807
 - Closes PACK-2819

### Testing Instructions

See next.js counterpart: https://github.com/vercel/next.js/pull/63541