### PR TITLE
chore: remove experimentalGlobalPassThroughEnv from schema

### DIFF
--- a/packages/turbo-types/src/types/config.ts
+++ b/packages/turbo-types/src/types/config.ts
@@ -79,17 +79,6 @@ export interface RootSchema extends BaseSchema {
    * Documentation: https://turbo.build/repo/docs/reference/configuration#globalPassThroughEnv
    *
    * @defaultValue null
-   * @deprecated use `globalPassThroughEnv` instead
-   */
-  experimentalGlobalPassThroughEnv?: null | Array<string>;
-
-  /**
-   * An allowlist of environment variables that should be made to all tasks, but
-   * should not contribute to the task's cache key, e.g. `AWS_SECRET_KEY`.
-   *
-   * Documentation: https://turbo.build/repo/docs/reference/configuration#globalPassThroughEnv
-   *
-   * @defaultValue null
    */
   globalPassThroughEnv?: null | Array<EnvWildcard>;
 


### PR DESCRIPTION
### Description

Remove this from the schema as we currently don't respect it and `globalPassThroughEnv` has been around for some time.

### Testing Instructions

👀 + a quick `rg -F 'experimentalGlobalPassThroughEnv'` to verify we never actually read this.


Closes TURBO-2678