### PR TITLE
feat(ui): persist logs on failure

### DIFF
--- a/crates/turborepo-lib/src/task_graph/visitor.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor.rs
@@ -803,19 +803,23 @@ impl ExecContext {
         }
     }
 
+    fn prefixed_ui<W: Write>(&self, stdout: W, stderr: W) -> PrefixedUI<W> {
+        Visitor::prefixed_ui(
+            self.ui,
+            self.is_github_actions,
+            stdout,
+            stderr,
+            self.pretty_prefix.clone(),
+        )
+    }
+
     async fn execute_inner(
         &mut self,
         output_client: &TaskOutput<impl std::io::Write>,
         telemetry: &PackageTaskEventBuilder,
     ) -> ExecOutcome {
         let task_start = Instant::now();
-        let mut prefixed_ui = Visitor::prefixed_ui(
-            self.ui,
-            self.is_github_actions,
-            output_client.stdout(),
-            output_client.stderr(),
-            self.pretty_prefix.clone(),
-        );
+        let mut prefixed_ui = self.prefixed_ui(output_client.stdout(), output_client.stderr());
 
         if self.experimental_ui {
             if let TaskOutput::UI(task) = output_client {

--- a/crates/turborepo-lib/src/task_graph/visitor.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor.rs
@@ -974,7 +974,6 @@ impl ExecContext {
                 }
                 if let TaskOutput::UI(task) = output_client {
                     let mut persisted_ui = self.prefixed_ui(task.stdout(), task.stdout());
-                    // If we can't write to stdout we're dead
                     let _ = self
                         .task_cache
                         .replay_log_file(persisted_ui.output_prefixed_writer());

--- a/crates/turborepo-lib/src/task_graph/visitor.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor.rs
@@ -972,6 +972,13 @@ impl ExecContext {
                 if let Err(e) = stdout_writer.flush() {
                     error!("error flushing logs: {e}");
                 }
+                if let TaskOutput::UI(task) = output_client {
+                    let mut persisted_ui = self.prefixed_ui(task.stdout(), task.stdout());
+                    // If we can't write to stdout we're dead
+                    let _ = self
+                        .task_cache
+                        .replay_log_file(persisted_ui.output_prefixed_writer());
+                }
                 if let Err(e) = self
                     .task_cache
                     .on_error(prefixed_ui.output_prefixed_writer())

--- a/crates/turborepo-ui/src/lib.rs
+++ b/crates/turborepo-ui/src/lib.rs
@@ -5,6 +5,7 @@
 #![feature(deadline_api)]
 
 mod color_selector;
+mod line;
 mod logs;
 mod output;
 mod prefixed;
@@ -19,6 +20,7 @@ use thiserror::Error;
 
 pub use crate::{
     color_selector::ColorSelector,
+    line::LineWriter,
     logs::{replay_logs, LogWriter},
     output::{OutputClient, OutputClientBehavior, OutputSink, OutputWriter},
     prefixed::{PrefixedUI, PrefixedWriter},

--- a/crates/turborepo-ui/src/line.rs
+++ b/crates/turborepo-ui/src/line.rs
@@ -1,0 +1,43 @@
+use std::io::Write;
+
+/// Writer that will buffer writes so the underlying writer is only called with
+/// writes that end in a newline
+pub struct LineWriter<W> {
+    writer: W,
+    buffer: Vec<u8>,
+}
+
+impl<W: Write> LineWriter<W> {
+    pub fn new(writer: W) -> Self {
+        Self {
+            writer,
+            buffer: Vec::with_capacity(512),
+        }
+    }
+}
+
+impl<W: Write> Write for LineWriter<W> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        for line in buf.split_inclusive(|c| *c == b'\n') {
+            if line.ends_with(b"\n") {
+                if self.buffer.is_empty() {
+                    self.writer.write_all(line)?;
+                } else {
+                    self.buffer.extend_from_slice(line);
+                    self.writer.write_all(&self.buffer)?;
+                    self.buffer.clear();
+                }
+            } else {
+                // This should only happen on the last chunk?
+                self.buffer.extend_from_slice(line)
+            }
+        }
+
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        // We don't flush our buffer as that would lead to a write without a newline
+        self.writer.flush()
+    }
+}

--- a/crates/turborepo-ui/src/prefixed.rs
+++ b/crates/turborepo-ui/src/prefixed.rs
@@ -1,12 +1,12 @@
 use std::{
-    fmt::{Debug, Display, Formatter},
+    fmt::{Debug, Display},
     io::Write,
 };
 
 use console::{Style, StyledObject};
 use tracing::error;
 
-use crate::UI;
+use crate::{LineWriter, UI};
 
 /// Writes messages with different prefixes, depending on log level. Note that
 /// this does output the prefix when message is empty, unlike the Go
@@ -109,14 +109,6 @@ pub struct PrefixedWriter<W> {
     inner: LineWriter<PrefixedWriterInner<W>>,
 }
 
-impl<W> Debug for PrefixedWriter<W> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("PrefixedWriter")
-            .field("prefix", &self.inner.writer.prefix)
-            .finish()
-    }
-}
-
 impl<W: Write> PrefixedWriter<W> {
     pub fn new(ui: UI, prefix: StyledObject<impl Display>, writer: W) -> Self {
         Self {
@@ -173,48 +165,6 @@ impl<W: Write> Write for PrefixedWriterInner<W> {
     }
 
     fn flush(&mut self) -> std::io::Result<()> {
-        self.writer.flush()
-    }
-}
-
-/// Writer that will buffer writes so the underlying writer is only called with
-/// writes that end in a newline
-struct LineWriter<W> {
-    writer: W,
-    buffer: Vec<u8>,
-}
-
-impl<W: Write> LineWriter<W> {
-    pub fn new(writer: W) -> Self {
-        Self {
-            writer,
-            buffer: Vec::with_capacity(512),
-        }
-    }
-}
-
-impl<W: Write> Write for LineWriter<W> {
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        for line in buf.split_inclusive(|c| *c == b'\n') {
-            if line.ends_with(b"\n") {
-                if self.buffer.is_empty() {
-                    self.writer.write_all(line)?;
-                } else {
-                    self.buffer.extend_from_slice(line);
-                    self.writer.write_all(&self.buffer)?;
-                    self.buffer.clear();
-                }
-            } else {
-                // This should only happen on the last chunk?
-                self.buffer.extend_from_slice(line)
-            }
-        }
-
-        Ok(buf.len())
-    }
-
-    fn flush(&mut self) -> std::io::Result<()> {
-        // We don't flush our buffer as that would lead to a write without a newline
         self.writer.flush()
     }
 }

--- a/crates/turborepo-ui/src/prefixed.rs
+++ b/crates/turborepo-ui/src/prefixed.rs
@@ -240,6 +240,7 @@ mod test {
     }
 
     #[test_case(&["foo"], "" ; "no newline")]
+    #[test_case(&["\n"], "\n" ; "one newline")]
     #[test_case(&["foo\n"], "foo\n" ; "single newline")]
     #[test_case(&["foo ", "bar ", "baz\n"], "foo bar baz\n" ; "building line")]
     #[test_case(&["multiple\nlines\nin\none"], "multiple\nlines\nin\n" ; "multiple lines")]
@@ -267,9 +268,11 @@ mod test {
             .write_all(b", now\nbut \ranother one starts")
             .unwrap();
         writer.write_all(b" done\n").unwrap();
+        writer.write_all(b"\n").unwrap();
         assert_eq!(
             String::from_utf8(buffer).unwrap(),
-            "turbo > not a line yet, now\nturbo > but \rturbo > another one starts done\n"
+            "turbo > not a line yet, now\nturbo > but \rturbo > another one starts done\nturbo > \
+             \n"
         );
     }
 }

--- a/crates/turborepo-ui/src/tui/app.rs
+++ b/crates/turborepo-ui/src/tui/app.rs
@@ -173,6 +173,7 @@ fn update(
             app.table.tick();
         }
         Event::Log { message } => {
+            debug!("received message");
             return Ok(Some(message));
         }
         Event::EndTask { task } => {
@@ -214,6 +215,7 @@ fn persist_bytes(terminal: &mut Terminal<impl Backend>, bytes: &[u8]) -> Result<
     parser.process(bytes);
     let screen = parser.entire_screen();
     let (height, _) = screen.size();
+    debug!("{} bytes rendered as {} lines", bytes.len(), height);
     terminal.insert_before(height as u16, |buf| {
         PseudoTerminal::new(&screen).render(buf.area, buf)
     })?;

--- a/crates/turborepo-ui/src/tui/app.rs
+++ b/crates/turborepo-ui/src/tui/app.rs
@@ -173,7 +173,6 @@ fn update(
             app.table.tick();
         }
         Event::Log { message } => {
-            debug!("received message");
             return Ok(Some(message));
         }
         Event::EndTask { task } => {
@@ -215,7 +214,6 @@ fn persist_bytes(terminal: &mut Terminal<impl Backend>, bytes: &[u8]) -> Result<
     parser.process(bytes);
     let screen = parser.entire_screen();
     let (height, _) = screen.size();
-    debug!("{} bytes rendered as {} lines", bytes.len(), height);
     terminal.insert_before(height as u16, |buf| {
         PseudoTerminal::new(&screen).render(buf.area, buf)
     })?;

--- a/crates/turborepo-ui/src/tui/handle.rs
+++ b/crates/turborepo-ui/src/tui/handle.rs
@@ -183,7 +183,6 @@ impl std::io::Write for PersistedWriter {
 
 impl std::io::Write for PersistedWriterInner {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        debug!("persisted write for {} bytes to ui", buf.len());
         let bytes = buf.to_vec();
         self.handle
             .priority

--- a/crates/turborepo-ui/src/tui/mod.rs
+++ b/crates/turborepo-ui/src/tui/mod.rs
@@ -9,7 +9,7 @@ mod task_duration;
 
 pub use app::run_app;
 use event::Event;
-pub use handle::{AppReceiver, AppSender, PersistedWriter, TuiTask};
+pub use handle::{AppReceiver, AppSender, PersistedWriterInner, TuiTask};
 use input::input;
 pub use pane::TerminalPane;
 pub use table::TaskTable;


### PR DESCRIPTION
### Description

If a task fails when using the UI, it isn't easy to find the reason for the failure.

This PR makes it so that if a task fails, we'll persist the logs to the terminal so they remain after the UI exits.

### Testing Instructions

<img width="1034" alt="Screenshot 2024-03-21 at 9 46 11 AM" src="https://github.com/vercel/turbo/assets/4131117/31a6f29d-22c2-4ad9-a569-a95afb200f54">



Closes TURBO-2681