### PR TITLE
feat(ui): add ability to scroll task output

### DIFF
--- a/crates/turborepo-ui/src/tui/app.rs
+++ b/crates/turborepo-ui/src/tui/app.rs
@@ -25,6 +25,11 @@ pub struct App<I> {
     interact: bool,
 }
 
+pub enum Direction {
+    Up,
+    Down,
+}
+
 impl<I> App<I> {
     pub fn new(rows: u16, cols: u16, tasks: Vec<String>) -> Self {
         debug!("tasks: {tasks:?}");
@@ -61,6 +66,15 @@ impl<I> App<I> {
             self.interact = interact;
             self.pane.highlight(interact);
         }
+    }
+
+    pub fn scroll(&mut self, direction: Direction) {
+        let Some(selected_task) = self.table.selected() else {
+            return;
+        };
+        self.pane
+            .scroll(selected_task, direction)
+            .expect("selected task should be in pane");
     }
 }
 
@@ -183,6 +197,12 @@ fn update(
         }
         Event::Down => {
             app.next();
+        }
+        Event::ScrollUp => {
+            app.scroll(Direction::Up);
+        }
+        Event::ScrollDown => {
+            app.scroll(Direction::Down);
         }
         Event::EnterInteractive => {
             app.interact(true);

--- a/crates/turborepo-ui/src/tui/app.rs
+++ b/crates/turborepo-ui/src/tui/app.rs
@@ -149,7 +149,9 @@ fn poll(interact: bool, receiver: &AppReceiver, deadline: Instant) -> Option<Eve
 /// Configures terminal for rendering App
 fn startup() -> io::Result<Terminal<CrosstermBackend<Stdout>>> {
     crossterm::terminal::enable_raw_mode()?;
-    let backend = CrosstermBackend::new(io::stdout());
+    let mut stdout = io::stdout();
+    crossterm::execute!(stdout, crossterm::event::EnableMouseCapture)?;
+    let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::with_options(
         backend,
         ratatui::TerminalOptions {
@@ -162,8 +164,12 @@ fn startup() -> io::Result<Terminal<CrosstermBackend<Stdout>>> {
 }
 
 /// Restores terminal to expected state
-fn cleanup<B: Backend>(mut terminal: Terminal<B>) -> io::Result<()> {
+fn cleanup<B: Backend + io::Write>(mut terminal: Terminal<B>) -> io::Result<()> {
     terminal.clear()?;
+    crossterm::execute!(
+        terminal.backend_mut(),
+        crossterm::event::DisableMouseCapture
+    )?;
     crossterm::terminal::disable_raw_mode()?;
     terminal.show_cursor()?;
     Ok(())

--- a/crates/turborepo-ui/src/tui/event.rs
+++ b/crates/turborepo-ui/src/tui/event.rs
@@ -16,6 +16,8 @@ pub enum Event {
     },
     Up,
     Down,
+    ScrollUp,
+    ScrollDown,
     SetStdin {
         task: String,
         stdin: Box<dyn std::io::Write + Send>,

--- a/crates/turborepo-ui/src/tui/input.rs
+++ b/crates/turborepo-ui/src/tui/input.rs
@@ -9,10 +9,14 @@ pub fn input(interact: bool) -> Result<Option<Event>, Error> {
     // poll with 0 duration will only return true if event::read won't need to wait
     // for input
     if crossterm::event::poll(Duration::from_millis(0))? {
-        if let crossterm::event::Event::Key(k) = crossterm::event::read()? {
-            Ok(translate_key_event(interact, k))
-        } else {
-            Ok(None)
+        match crossterm::event::read()? {
+            crossterm::event::Event::Key(k) => Ok(translate_key_event(interact, k)),
+            crossterm::event::Event::Mouse(m) => match m.kind {
+                crossterm::event::MouseEventKind::ScrollDown => Ok(Some(Event::ScrollDown)),
+                crossterm::event::MouseEventKind::ScrollUp => Ok(Some(Event::ScrollUp)),
+                _ => Ok(None),
+            },
+            _ => Ok(None),
         }
     } else {
         Ok(None)

--- a/crates/turborepo-ui/src/tui/input.rs
+++ b/crates/turborepo-ui/src/tui/input.rs
@@ -36,6 +36,10 @@ fn translate_key_event(interact: bool, key_event: KeyEvent) -> Option<Event> {
             bytes: encode_key(key_event),
         }),
         // Fall through if we aren't in interactive mode
+        KeyCode::Char('p') if key_event.modifiers == KeyModifiers::CONTROL => Some(Event::ScrollUp),
+        KeyCode::Char('n') if key_event.modifiers == KeyModifiers::CONTROL => {
+            Some(Event::ScrollDown)
+        }
         KeyCode::Up => Some(Event::Up),
         KeyCode::Down => Some(Event::Down),
         KeyCode::Enter => Some(Event::EnterInteractive),


### PR DESCRIPTION
### Description

Adds ability to scroll through task output when the task is not interacted with. This is so we retain the ability for users to enter `Ctrl-P`/`Ctrl-N` to the underlying task.

Current keybinds: `Ctrl-P` for scroll up and `Ctrl-N` for scroll down. `Ctrl-Up` and `Ctrl-Down` are more intuitive, but conflict with default macOS keybinds.


### Testing Instructions


https://github.com/vercel/turbo/assets/4131117/3c76c9f4-2e26-4e51-8fde-80d803b708b3




Closes TURBO-2682