### PR TITLE
fix(ui): avoid dupe key events on windows

### DIFF
--- a/crates/turborepo-ui/src/tui/input.rs
+++ b/crates/turborepo-ui/src/tui/input.rs
@@ -21,6 +21,13 @@ pub fn input(interact: bool) -> Result<Option<Event>, Error> {
 
 /// Converts a crostterm key event into a TUI interaction event
 fn translate_key_event(interact: bool, key_event: KeyEvent) -> Option<Event> {
+    // On Windows events for releasing a key are produced
+    // We skip these to avoid emitting 2 events per key press.
+    // There is still a `Repeat` event for when a key is held that will pass through
+    // this guard.
+    if key_event.kind == KeyEventKind::Release {
+        return None;
+    }
     match key_event.code {
         KeyCode::Char('c') if key_event.modifiers == crossterm::event::KeyModifiers::CONTROL => {
             ctrl_c()


### PR DESCRIPTION
### Description

Fixes #7808

Windows console produces an event for a key press as well as an event for when the key is released. This caused a single arrow key press to trigger 2 events. This fix is to ignore release events.

As per `crossterm` [docs](https://docs.rs/crossterm/latest/crossterm/event/struct.KeyEvent.html#structfield.kind)
> kind: [KeyEventKind](https://docs.rs/crossterm/latest/crossterm/event/enum.KeyEventKind.html)
Kind of event.
Only set if:
    Unix: [KeyboardEnhancementFlags::REPORT_EVENT_TYPES](https://docs.rs/crossterm/latest/crossterm/event/struct.KeyboardEnhancementFlags.html#associatedconstant.REPORT_EVENT_TYPES) has been enabled with [PushKeyboardEnhancementFlags](https://docs.rs/crossterm/latest/crossterm/event/struct.PushKeyboardEnhancementFlags.html).
    Windows: always

### Testing Instructions

Use Turbo UI on a run with at least 3 tasks and verify that arrow keys now only move a single task.


Closes TURBO-2683