### PR TITLE
fix(ui): avoid using prefix for replayed logs

### DIFF
--- a/crates/turborepo-lib/src/run/cache.rs
+++ b/crates/turborepo-lib/src/run/cache.rs
@@ -184,6 +184,7 @@ impl TaskCache {
     pub async fn restore_outputs(
         &mut self,
         mut terminal_output: impl Write,
+        alternative_log_replay: Option<impl Write>,
         telemetry: &PackageTaskEventBuilder,
     ) -> Result<Option<CacheHitMetadata>, Error> {
         if self.caching_disabled || self.run_cache.reads_disabled {
@@ -312,7 +313,11 @@ impl TaskCache {
                         color!(self.ui, GREY, "{}", self.hash)
                     ),
                 );
-                self.replay_log_file(&mut terminal_output)?;
+                if let Some(mut replay_writer) = alternative_log_replay {
+                    self.replay_log_file(&mut replay_writer)?;
+                } else {
+                    self.replay_log_file(&mut terminal_output)?;
+                }
             }
             // Note that if we're restoring from cache, the task succeeded
             // so we know we don't need to print anything for errors

--- a/crates/turborepo-lib/src/task_graph/visitor.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor.rs
@@ -827,9 +827,19 @@ impl ExecContext {
             }
         }
 
+        // When the UI is enabled we don't want to have the prefix appear on the
+        // replayed logs.
+        let alt_log_replay_writer = match output_client {
+            TaskOutput::UI(task) => Some(task.clone()),
+            TaskOutput::Direct(_) => None,
+        };
         match self
             .task_cache
-            .restore_outputs(prefixed_ui.output_prefixed_writer(), telemetry)
+            .restore_outputs(
+                prefixed_ui.output_prefixed_writer(),
+                alt_log_replay_writer,
+                telemetry,
+            )
             .await
         {
             Ok(Some(status)) => {


### PR DESCRIPTION
### Description

Currently on a cache hit the replayed logs in the UI contain the task prefix which is unnecessary in the UI. This brings the cache hit/miss output to be the same in the UI (modulo cache hit/miss lines).

### Testing Instructions

Before:
<img width="760" alt="Screenshot 2024-03-21 at 1 43 03 PM" src="https://github.com/vercel/turbo/assets/4131117/c10d6758-eb68-46f4-a9c2-d2889dba78a5">

After:
<img width="478" alt="Screenshot 2024-03-21 at 1 42 24 PM" src="https://github.com/vercel/turbo/assets/4131117/79a13765-d7bd-4c0b-8cee-2f38f2e28c01">

(Also making sure non-UI behavior is preserved)
<img width="716" alt="Screenshot 2024-03-21 at 1 43 54 PM" src="https://github.com/vercel/turbo/assets/4131117/1aa91267-4cad-4b8e-833c-cc50dabd31b0">


Closes TURBO-2684