### PR TITLE
Turbopack docs: Fix broken webpack loaders link

### DIFF
--- a/docs/pages/pack/docs/migrating-from-webpack.mdx
+++ b/docs/pages/pack/docs/migrating-from-webpack.mdx
@@ -11,7 +11,8 @@ We're planning Turbopack as the successor to webpack. In the future, we plan to 
 
 ## webpack loaders and resolve aliases
 
-For apps running Next.js 13.2 or later, Turbopack supports configuration familiar to webpack users, including support for webpack loaders and customizing resolution rules. Visit the [Turbopack for Next.js](features/customizing-turbopack) for how to configure Turbopack with these options.
+For apps running Next.js 13.2 or later, Turbopack supports configuration familiar to webpack users, including support for webpack loaders and customizing resolution rules.
+Visit the [webpack loaders page in the Next.js docs](https://nextjs.org/docs/app/api-reference/next-config-js/turbo#webpack-loaders) for how to configure Turbopack with these options.
 
 Note that using webpack-based Next.js plugins as-is from `next.config.js` is **not yet supported**.
 


### PR DESCRIPTION
Now that docs have been moved to the Next.js docs site in #7511, this link is broken. Update it to link there instead.

Test Plan: Preview deployment


Closes PACK-2816