### PR TITLE
fix webpack loader incorrectly calling custom_evaluate

### DIFF
--- a/crates/turbopack-node/src/transforms/webpack.rs
+++ b/crates/turbopack-node/src/transforms/webpack.rs
@@ -207,7 +207,7 @@ impl WebpackLoadersProcessedAsset {
             bail!("Resource path need to be on project filesystem");
         };
         let loaders = transform.loaders.await?;
-        let config_value = custom_evaluate(WebpackLoaderContext {
+        let config_value = evaluate_webpack_loader(WebpackLoaderContext {
             module_asset: webpack_loaders_executor,
             cwd: project_path,
             env,


### PR DESCRIPTION
### Description

fixes SCSS HMR for imported files

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->


Closes PACK-2818

fixes PACK-2809