### PR TITLE
fix(yarn4): properly handle workspace protocol with path

### DIFF
--- a/crates/turborepo-repository/src/package_graph/dep_splitter.rs
+++ b/crates/turborepo-repository/src/package_graph/dep_splitter.rs
@@ -1,6 +1,9 @@
 use std::{collections::HashMap, fmt};
 
-use turbopath::{AbsoluteSystemPath, AnchoredSystemPathBuf, RelativeUnixPath, RelativeUnixPathBuf};
+use turbopath::{
+    AbsoluteSystemPath, AnchoredSystemPath, AnchoredSystemPathBuf, RelativeUnixPath,
+    RelativeUnixPathBuf,
+};
 
 use super::{npmrc::NpmRc, PackageInfo, PackageName};
 
@@ -66,19 +69,28 @@ impl<'a> DependencySplitter<'a> {
                 Some((package_name, info))
             }
             WorkspacePackageSpecifier::Path(path) => {
-                let path = self.workspace_dir.join_unix_path(path);
+                let package_path = self.workspace_dir.join_unix_path(path);
                 // There's a chance that the user provided path could escape the root, in which
                 // case we don't support packages outside of the workspace.
                 // Pnpm also doesn't support this so we defer to them to provide the error
                 // message.
-                let package_path = AnchoredSystemPathBuf::new(self.repo_root, path).ok()?;
-                let (name, info) = self
-                    .workspaces
-                    .iter()
-                    .find(|(_, info)| info.package_path() == &*package_path)?;
+                let package_path = AnchoredSystemPathBuf::new(self.repo_root, package_path).ok()?;
+                let (name, info) = self.workspace(&package_path).or_else(|| {
+                    // Yarn4 allows for workspace root relative paths
+                    let package_path = self.repo_root.join_unix_path(path);
+                    let package_path =
+                        AnchoredSystemPathBuf::new(self.repo_root, package_path).ok()?;
+                    self.workspace(&package_path)
+                })?;
                 Some((name.clone(), info))
             }
         }
+    }
+
+    fn workspace(&self, path: &AnchoredSystemPath) -> Option<(&PackageName, &PackageInfo)> {
+        self.workspaces
+            .iter()
+            .find(|(_, info)| info.package_path() == path)
     }
 }
 
@@ -205,6 +217,7 @@ mod test {
     #[test_case("1.2.3", None, "workspace:1.2.3", Some("@scope/foo"), true ; "handles workspace protocol with version")]
     #[test_case("1.2.3", None, "workspace:*", Some("@scope/foo"), true ; "handles workspace protocol with no version")]
     #[test_case("1.2.3", None, "workspace:../@scope/foo", Some("@scope/foo"), true ; "handles workspace protocol with scoped relative path")]
+    #[test_case("1.2.3", None, "workspace:packages/@scope/foo", Some("@scope/foo"), true ; "handles workspace protocol with root relative path")]
     #[test_case("1.2.3", Some("bar"), "workspace:../baz", Some("baz"), true ; "handles workspace protocol with path to differing package")]
     #[test_case("1.2.3", None, "npm:^1.2.3", Some("@scope/foo"), true ; "handles npm protocol with satisfied semver range")]
     #[test_case("2.3.4", None, "npm:^1.2.3", None, true ; "handles npm protocol with not satisfied semver range")]


### PR DESCRIPTION
### Description

Fixes #7732

It seems that Yarn 4 supports using workspace-root relative paths with the `workspace:` protocol. 

I cannot find [any](https://yarnpkg.com/features/workspaces#cross-references) [reference](https://yarnpkg.com/protocol/workspace) to this behavior in the docs, but confirmed that it's supported by a default `yarn` configuration.

### Testing Instructions
Added unit test for `workspace:` protocol used with a workspace root relative path.

Verify that dependencies declared via a workspace root relative path:
```
[0 olszewski@chriss-mbp] /tmp/yarn4 $ turbo prune web          
Generating pruned monorepo for web in /private/tmp/yarn4/out
 - Added @repo/eslint-config
 - Added @repo/typescript-config
 - Added web
[0 olszewski@chriss-mbp] /tmp/yarn4 $ turbo_dev --skip-infer prune web
Generating pruned monorepo for web in /private/tmp/yarn4/out
 - Added @repo/eslint-config
 - Added @repo/typescript-config
 - Added @repo/ui
 - Added web
[0 olszewski@chriss-mbp] /tmp/yarn4 $ cat apps/web/package.json | jq '.dependencies'
{
  "@repo/ui": "workspace:packages/ui",
  "next": "^14.1.1",
  "react": "^18.2.0",
  "react-dom": "^18.2.0"
}
```

Closes TURBO-2691