### PR TITLE
feat(telemetry): add JS package

### DIFF
--- a/crates/turborepo-telemetry/README.md
+++ b/crates/turborepo-telemetry/README.md
@@ -1,5 +1,9 @@
 # turborepo-telemetry
 
+**NOTE**:
+This crate has been ported to the [turbo-telemetry](https://github.com/vercel/turbo/blob/main/crates/turborepo-telemetry) node package.
+Any changes made here should also be made to that package as well.
+
 ## Overview
 
 This crate provides a way to optionally record anonymous usage data.

--- a/crates/turborepo-telemetry/src/config.rs
+++ b/crates/turborepo-telemetry/src/config.rs
@@ -1,3 +1,12 @@
+/// Configuration for telemetry.
+///
+/// This module is responsible for reading and writing the telemetry
+/// configuration file.
+///
+/// NOTE: There is a port of this crate that is used to instrument node
+/// projects. Any changes made here should be reflected there as well.
+///
+/// https://github.com/vercel/turbo/blob/main/packages/turbo-telemetry/src/config.ts
 use std::env;
 
 use chrono::{DateTime, Utc};

--- a/packages/eslint-config/library.js
+++ b/packages/eslint-config/library.js
@@ -22,5 +22,9 @@ module.exports = {
     "unicorn/filename-case": ["off"],
     "@typescript-eslint/explicit-function-return-type": ["off"],
     "@typescript-eslint/array-type": ["error", { default: "generic" }],
+    "import/no-extraneous-dependencies": [
+      "error",
+      { peerDependencies: true, includeTypes: true },
+    ],
   },
 };

--- a/packages/turbo-telemetry/.eslintrc.js
+++ b/packages/turbo-telemetry/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ["@turbo/eslint-config/library"],
+};

--- a/packages/turbo-telemetry/LICENSE
+++ b/packages/turbo-telemetry/LICENSE
@@ -1,0 +1,373 @@
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/packages/turbo-telemetry/README.md
+++ b/packages/turbo-telemetry/README.md
@@ -11,4 +11,32 @@ This information is used to shape the Turborepo roadmap and prioritize features.
 
 ## Events
 
-All recorded events can be found by browsing the [event methods on the client class](./src/client.ts).
+Each event must have its own method on the client class. All recorded events can be found by browsing the [event methods on the client class](./src/client.ts).
+
+## Usage
+
+1. Init the client with your package name and version:
+
+```ts
+import { initTelemetry } from "@turbo/telemetry";
+import pkgJson from "../package.json";
+
+const { telemetry } = await initTelemetry({
+  name: pkgJson.name,
+  version: pkgJson.version,
+});
+```
+
+2. Send events
+
+```ts
+telemetry.myCustomEventName({
+  // event properties
+});
+```
+
+3. Close the client before exiting
+
+```ts
+await telemetry.close();
+```

--- a/packages/turbo-telemetry/README.md
+++ b/packages/turbo-telemetry/README.md
@@ -1,0 +1,14 @@
+# `@turbo/telemetry`
+
+**NOTE**:
+This package is a direct port of the [turbo-telemetry](https://github.com/vercel/turbo/blob/main/crates/turborepo-telemetry) crate.
+Any changes made here should also be made to that crate as well.
+
+## Overview
+
+This package provides a way to optionally record anonymous usage data that originates from the turborepo node packages.
+This information is used to shape the Turborepo roadmap and prioritize features. You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the [documentation](https://turbo.build/repo/docs/telemetry):
+
+## Events
+
+All recorded events can be found by browsing the [event methods on the client class](./src/client.ts).

--- a/packages/turbo-telemetry/jest.config.js
+++ b/packages/turbo-telemetry/jest.config.js
@@ -1,0 +1,9 @@
+/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
+module.exports = {
+  preset: "ts-jest/presets/js-with-ts",
+  testEnvironment: "node",
+  modulePathIgnorePatterns: ["<rootDir>/node_modules", "<rootDir>/dist"],
+  transformIgnorePatterns: ["/node_modules/(?!(ansi-regex)/)"],
+  verbose: process.env.RUNNER_DEBUG === "1",
+  silent: process.env.RUNNER_DEBUG !== "1",
+};

--- a/packages/turbo-telemetry/package.json
+++ b/packages/turbo-telemetry/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@turbo/telemetry",
+  "version": "0.0.0",
+  "private": true,
+  "description": "",
+  "homepage": "https://turbo.build/repo",
+  "keywords": [],
+  "author": "Vercel",
+  "license": "MPL-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel/turbo",
+    "directory": "packages/turbo-telemetry"
+  },
+  "bugs": {
+    "url": "https://github.com/vercel/turbo/issues"
+  },
+  "module": "src/index.ts",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "test": "jest",
+    "lint": "eslint src/",
+    "check-types": "tsc --noEmit",
+    "lint:prettier": "prettier -c . --cache --ignore-path=../../.prettierignore"
+  },
+  "dependencies": {
+    "chalk": "^4.1.2",
+    "got": "^11.8.6",
+    "uuid": "^9.0.0"
+  },
+  "devDependencies": {
+    "@turbo/eslint-config": "workspace:*",
+    "@turbo/test-utils": "workspace:*",
+    "@turbo/utils": "workspace:*",
+    "@turbo/tsconfig": "workspace:*",
+    "@turbo/types": "workspace:*",
+    "@types/jest": "^27.4.0",
+    "@types/node": "^20.11.30",
+    "@types/uuid": "^9.0.0",
+    "dirs-next": "0.0.1-canary.1",
+    "jest": "^27.4.3",
+    "ts-jest": "^27.1.1",
+    "typescript": "5.3.3"
+  },
+  "peerDependencies": {
+    "commander": "^10.0.0"
+  }
+}

--- a/packages/turbo-telemetry/src/cli.ts
+++ b/packages/turbo-telemetry/src/cli.ts
@@ -1,0 +1,67 @@
+import chalk from "chalk";
+import { logger } from "@turbo/utils";
+import { type Command, Argument } from "commander";
+import { type TelemetryClient } from "./client";
+
+const DEFAULT_CHOICE = "status" as const;
+const CHOICES = ["enable", "disable", DEFAULT_CHOICE] as const;
+type TelemetryCLIAction = (typeof CHOICES)[number];
+
+interface TelemetryCLIOptions {
+  telemetry?: TelemetryClient;
+}
+
+function status(options: TelemetryCLIOptions) {
+  const isEnabled = options.telemetry?.config.isEnabled();
+  logger.log(
+    `Status: ${
+      isEnabled
+        ? chalk.bold(chalk.green("Enabled"))
+        : chalk.bold(chalk.red("Disabled"))
+    }`
+  );
+  logger.log();
+  if (isEnabled) {
+    logger.log(
+      "Turborepo telemetry is completely anonymous. Thank you for participating!"
+    );
+  } else {
+    logger.log(
+      "You have opted-out of Turborepo anonymous telemetry. No data will be collected from your machine."
+    );
+  }
+  logger.log("Learn more: https://turbo.build/repo/docs/telemetry");
+}
+
+function telemetry(action: TelemetryCLIAction, options: TelemetryCLIOptions) {
+  if (!options.telemetry) {
+    logger.error("Telemetry client not found");
+    return;
+  }
+
+  if (action === "enable") {
+    options.telemetry.config.enable();
+    logger.bold("Success!");
+  } else if (action === "disable") {
+    options.telemetry.config.disable();
+    logger.bold("Success!");
+  }
+
+  logger.log();
+  status(options);
+}
+
+/**
+ * Adds a fully functional telemetry command to a CLI
+ */
+export function withTelemetryCommand(command: Command) {
+  command
+    .command("telemetry")
+    .description("Manage telemetry settings")
+    .addArgument(
+      new Argument("[action]", "Action to perform")
+        .choices(CHOICES)
+        .default(DEFAULT_CHOICE)
+    )
+    .action(telemetry);
+}

--- a/packages/turbo-telemetry/src/client.test.ts
+++ b/packages/turbo-telemetry/src/client.test.ts
@@ -1,0 +1,176 @@
+import got from "got";
+import { TelemetryClient } from "./client";
+import { TelemetryConfig } from "./config";
+
+jest.mock("got", () => ({
+  post: jest.fn(),
+}));
+
+describe("TelemetryClient", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("sends request when batch size is reached", () => {
+    const config = new TelemetryConfig({
+      configPath: "test-config-path",
+      config: {
+        telemetry_enabled: true,
+        telemetry_id: "telemetry-test-id",
+        telemetry_salt: "telemetry-salt",
+      },
+    });
+
+    const client = new TelemetryClient(
+      "https://example.com",
+      {
+        name: "test-package",
+        version: "1.0.0",
+      },
+      config,
+      {
+        batchSize: 2,
+      }
+    );
+
+    // add two events to trigger the batch flush
+    client.trackPackageManager("yarn");
+    client.trackPackageManager("pnpm");
+
+    expect(got.post).toHaveBeenCalled();
+    expect(got.post).toHaveBeenCalledWith(
+      "https://example.com/api/turborepo/v1/events",
+      expect.objectContaining({
+        json: [
+          {
+            package: {
+              id: expect.any(String) as string,
+              key: "package_manager",
+              value: "yarn",
+              package_name: "test-package",
+              package_version: "1.0.0",
+            },
+          },
+          {
+            package: {
+              id: expect.any(String) as string,
+              key: "package_manager",
+              value: "pnpm",
+              package_name: "test-package",
+              package_version: "1.0.0",
+            },
+          },
+        ],
+        headers: {
+          "User-Agent": expect.stringContaining("test-package 1.0.0") as string,
+          "x-turbo-session-id": expect.any(String) as string,
+          "x-turbo-telemetry-id": "telemetry-test-id",
+        },
+      })
+    );
+
+    expect(client.hasPendingEvents()).toBe(false);
+  });
+
+  it("does not send request before batch size is reached", () => {
+    const config = new TelemetryConfig({
+      configPath: "test-config-path",
+      config: {
+        telemetry_enabled: true,
+        telemetry_id: "telemetry-test-id",
+        telemetry_salt: "telemetry-salt",
+      },
+    });
+
+    const client = new TelemetryClient(
+      "https://example.com",
+      {
+        name: "test-package",
+        version: "1.0.0",
+      },
+      config
+    );
+
+    client.trackPackageManager("yarn");
+    expect(got.post).not.toHaveBeenCalled();
+    expect(client.hasPendingEvents()).toBe(true);
+  });
+
+  it("does not send request if telemetry is disabled", () => {
+    const config = new TelemetryConfig({
+      configPath: "test-config-path",
+      config: {
+        telemetry_enabled: false,
+        telemetry_id: "telemetry-test-id",
+        telemetry_salt: "telemetry-salt",
+      },
+    });
+
+    const client = new TelemetryClient(
+      "https://example.com",
+      {
+        name: "test-package",
+        version: "1.0.0",
+      },
+      config
+    );
+
+    client.trackPackageManager("yarn");
+    expect(got.post).not.toHaveBeenCalled();
+    expect(client.hasPendingEvents()).toBe(false);
+  });
+
+  it("flushes events when closed even if batch size is not reached", async () => {
+    const config = new TelemetryConfig({
+      configPath: "test-config-path",
+      config: {
+        telemetry_enabled: true,
+        telemetry_id: "telemetry-test-id",
+        telemetry_salt: "telemetry-salt",
+      },
+    });
+
+    const client = new TelemetryClient(
+      "https://example.com",
+      {
+        name: "test-package",
+        version: "1.0.0",
+      },
+      config,
+      {
+        batchSize: 2,
+      }
+    );
+
+    // add one event
+    client.trackPackageManager("pnpm");
+    expect(got.post).not.toHaveBeenCalled();
+
+    await client.close();
+
+    expect(got.post).toHaveBeenCalled();
+    expect(got.post).toHaveBeenCalledWith(
+      "https://example.com/api/turborepo/v1/events",
+      expect.objectContaining({
+        json: [
+          {
+            package: {
+              id: expect.any(String) as string,
+              key: "package_manager",
+              value: "pnpm",
+              package_name: "test-package",
+              package_version: "1.0.0",
+            },
+          },
+        ],
+        headers: {
+          "User-Agent": expect.stringContaining("test-package 1.0.0") as string,
+          "x-turbo-session-id": expect.any(String) as string,
+          "x-turbo-telemetry-id": "telemetry-test-id",
+        },
+      })
+    );
+
+    expect(client.hasPendingEvents()).toBe(false);
+  });
+});

--- a/packages/turbo-telemetry/src/client.ts
+++ b/packages/turbo-telemetry/src/client.ts
@@ -1,0 +1,146 @@
+import got, { type Response } from "got";
+import { logger } from "@turbo/utils";
+import { v4 as uuid } from "uuid";
+import { buildUserAgent } from "./utils";
+import { TelemetryConfig } from "./config";
+
+const DEFAULT_BATCH_SIZE = 20;
+const ENDPOINT = "/api/turborepo/v1/events";
+
+export interface PackageInfo {
+  name: string;
+  version: string;
+}
+
+interface Options {
+  timeout?: number;
+  batchSize?: number;
+}
+
+interface Event {
+  id: string;
+  key: string;
+  value: string;
+  package_name: string;
+  package_version: string;
+  parent_id: string | undefined;
+}
+
+export class TelemetryClient {
+  private api: string;
+  private packageInfo: PackageInfo;
+  private batchSize = DEFAULT_BATCH_SIZE;
+  private timeout = 250;
+  private sessionId = uuid();
+  config: TelemetryConfig;
+  private eventBatches: Array<Promise<Response<string> | undefined>> = [];
+
+  private events: Array<Record<"package", Event>> = [];
+
+  constructor(
+    api: string,
+    packageInfo: PackageInfo,
+    config: TelemetryConfig,
+    opts?: Options
+  ) {
+    // build the telemetry api url with the given base
+    const telemetryApi = new URL(ENDPOINT, api);
+    this.api = telemetryApi.toString();
+    this.packageInfo = packageInfo;
+    this.config = config;
+
+    if (opts?.timeout) {
+      this.timeout = opts.timeout;
+    }
+    if (opts?.batchSize) {
+      this.batchSize = opts.batchSize;
+    }
+  }
+
+  hasPendingEvents(): boolean {
+    return this.events.length !== 0;
+  }
+
+  /**
+   * Flushes the telemetry events by sending them to the server.
+   */
+  private flushEvents() {
+    const batch = this.events.splice(0, this.batchSize);
+    if (TelemetryConfig.isDebug()) {
+      for (const event of batch) {
+        logger.log();
+        logger.bold("[telemetry event]");
+        logger.dimmed(JSON.stringify(event, null, 2));
+        logger.log();
+      }
+    }
+
+    if (this.config.isEnabled()) {
+      // track the promises on the class
+      this.eventBatches.push(
+        got.post(this.api, {
+          timeout: this.timeout,
+          json: batch,
+          headers: {
+            "x-turbo-telemetry-id": this.config.id,
+            "x-turbo-session-id": this.sessionId,
+            "User-Agent": buildUserAgent(this.packageInfo),
+          },
+        })
+      );
+    }
+  }
+
+  /**
+   * Private method that tracks the given key value pair
+   */
+  private track({
+    key,
+    value,
+    parentId,
+  }: {
+    key: string;
+    value: string;
+    parentId?: string;
+  }): Event {
+    const event = {
+      id: uuid(),
+      key,
+      value,
+      package_name: this.packageInfo.name,
+      package_version: this.packageInfo.version,
+      parent_id: parentId,
+    };
+
+    this.events.push({ package: event });
+
+    // flush if we have enough events
+    if (this.events.length >= this.batchSize) {
+      this.flushEvents();
+    }
+
+    return event;
+  }
+
+  /**
+   * Closes the client and flushes any pending requests.
+   */
+  async close(): Promise<void> {
+    while (this.hasPendingEvents()) {
+      this.flushEvents();
+    }
+    try {
+      await Promise.all(this.eventBatches);
+    } catch (err) {
+      // fail silently if we can't send telemetry
+    }
+  }
+
+  // events
+  trackPackageManager(packageManager: string): Event {
+    return this.track({
+      key: "package_manager",
+      value: packageManager,
+    });
+  }
+}

--- a/packages/turbo-telemetry/src/client.ts
+++ b/packages/turbo-telemetry/src/client.ts
@@ -88,21 +88,27 @@ export class TelemetryClient {
   }
 
   /**
-   * Private method that tracks the given key value pair
+   * Method that tracks the given key value pair.
+   *
+   * NOTE: This is intentionally private to prevent misuse.
+   * All tracking should be done through the public methods.
+   * If a new event is needed, a new public method should be created.
    */
   private track({
     key,
     value,
     parentId,
+    isSensitive,
   }: {
     key: string;
     value: string;
     parentId?: string;
+    isSensitive?: boolean;
   }): Event {
     const event = {
       id: uuid(),
       key,
-      value,
+      value: isSensitive ? this.config.oneWayHash(value) : value,
       package_name: this.packageInfo.name,
       package_version: this.packageInfo.version,
       parent_id: parentId,
@@ -141,7 +147,13 @@ export class TelemetryClient {
     }
   }
 
-  // events
+  ////////////
+  // EVENTS //
+  ////////////
+
+  /**
+   * Track selected package manager
+   */
   trackPackageManager(packageManager: string): Event {
     return this.track({
       key: "package_manager",

--- a/packages/turbo-telemetry/src/config.test.ts
+++ b/packages/turbo-telemetry/src/config.test.ts
@@ -1,0 +1,290 @@
+import * as fs from "node:fs";
+import { TelemetryConfig } from "./config";
+import * as utils from "./utils";
+
+jest.mock("node:fs");
+
+describe("TelemetryConfig", () => {
+  let telemetryConfig: TelemetryConfig;
+
+  beforeEach(() => {
+    telemetryConfig = new TelemetryConfig({
+      configPath: "/path/to/config.json",
+      config: {
+        telemetry_enabled: true,
+        telemetry_id: "123456",
+        telemetry_salt: "private-salt",
+      },
+    });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+
+    delete process.env.DO_NOT_TRACK;
+    delete process.env.TURBO_TELEMETRY_DISABLED;
+    delete process.env.TURBO_TELEMETRY_MESSAGE_DISABLED;
+    delete process.env.TURBO_TELEMETRY_DEBUG;
+  });
+
+  describe("fromDefaultConfig", () => {
+    test("should create TelemetryConfig instance from default config", async () => {
+      const mockConfigPath = "/path/to/defaultConfig.json";
+      const mockFileContent = JSON.stringify({
+        telemetry_enabled: true,
+        telemetry_id: "654321",
+        telemetry_salt: "default-salt",
+      });
+
+      const mockDefaultConfigPath = jest.fn().mockResolvedValue(mockConfigPath);
+      const mockReadFileSync = jest.fn().mockReturnValue(mockFileContent);
+
+      jest
+        .spyOn(utils, "defaultConfigPath")
+        .mockImplementation(mockDefaultConfigPath);
+      jest.spyOn(fs, "readFileSync").mockImplementation(mockReadFileSync);
+
+      const result = await TelemetryConfig.fromDefaultConfig();
+
+      expect(mockDefaultConfigPath).toHaveBeenCalled();
+      expect(mockReadFileSync).toHaveBeenCalledWith(mockConfigPath, "utf-8");
+      expect(result).toBeInstanceOf(TelemetryConfig);
+      expect(result.id).toEqual("654321");
+    });
+  });
+
+  describe("write", () => {
+    test("should write the config to the file", () => {
+      const mockWriteFileSync = jest.fn();
+      jest.spyOn(fs, "writeFileSync").mockImplementation(mockWriteFileSync);
+
+      const mockJson = JSON.stringify(telemetryConfig.config, null, 2);
+      telemetryConfig.write();
+
+      expect(mockWriteFileSync).toHaveBeenCalledWith(
+        "/path/to/config.json",
+        mockJson
+      );
+    });
+  });
+
+  describe("hasSeenAlert", () => {
+    test("should return true if telemetry_alerted is defined", () => {
+      telemetryConfig = new TelemetryConfig({
+        configPath: "/path/to/config.json",
+        config: {
+          telemetry_enabled: true,
+          telemetry_id: "123456",
+          telemetry_salt: "private-salt",
+          telemetry_alerted: new Date(),
+        },
+      });
+
+      const result = telemetryConfig.hasSeenAlert();
+
+      expect(result).toBe(true);
+    });
+
+    test("should return false if telemetry_alerted key exists but is undefined", () => {
+      telemetryConfig = new TelemetryConfig({
+        configPath: "/path/to/config.json",
+        config: {
+          telemetry_enabled: true,
+          telemetry_id: "123456",
+          telemetry_salt: "private-salt",
+          telemetry_alerted: undefined,
+        },
+      });
+      const result = telemetryConfig.hasSeenAlert();
+
+      expect(result).toBe(false);
+    });
+
+    test("should return false if telemetry_alerted is undefined", () => {
+      const result = telemetryConfig.hasSeenAlert();
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("isEnabled", () => {
+    test.each([
+      { envVar: "DO_NOT_TRACK", value: "1", expectedResult: false },
+      { envVar: "DO_NOT_TRACK", value: "true", expectedResult: false },
+      { envVar: "TURBO_TELEMETRY_DISABLED", value: "1", expectedResult: false },
+      {
+        envVar: "TURBO_TELEMETRY_DISABLED",
+        value: "true",
+        expectedResult: false,
+      },
+      { envVar: null, value: null, expectedResult: true },
+    ])(
+      "should return $expectedResult when $envVar is set to '$value'",
+      ({ envVar, value, expectedResult }) => {
+        if (envVar) {
+          process.env[envVar] = value;
+        }
+
+        const result = telemetryConfig.isEnabled();
+        expect(result).toBe(expectedResult);
+      }
+    );
+  });
+
+  describe("isTelemetryWarningEnabled", () => {
+    test("should return false if TURBO_TELEMETRY_MESSAGE_DISABLED is set to '1'", () => {
+      process.env.TURBO_TELEMETRY_MESSAGE_DISABLED = "1";
+
+      const result = telemetryConfig.isTelemetryWarningEnabled();
+
+      expect(result).toBe(false);
+    });
+
+    test("should return false if TURBO_TELEMETRY_MESSAGE_DISABLED is set to 'true'", () => {
+      process.env.TURBO_TELEMETRY_MESSAGE_DISABLED = "true";
+
+      const result = telemetryConfig.isTelemetryWarningEnabled();
+
+      expect(result).toBe(false);
+    });
+
+    test("should return true if TURBO_TELEMETRY_MESSAGE_DISABLED is not set", () => {
+      const result = telemetryConfig.isTelemetryWarningEnabled();
+
+      expect(result).toBe(true);
+    });
+  });
+
+  describe("showAlert", () => {
+    test("should log the telemetry alert if conditions are met", () => {
+      const mockLog = jest.spyOn(console, "log").mockImplementation();
+      telemetryConfig.showAlert();
+      expect(mockLog).toHaveBeenCalledTimes(6);
+    });
+
+    test("should not log the telemetry alert if conditions are not met", () => {
+      const mockLog = jest.spyOn(console, "log").mockImplementation();
+
+      telemetryConfig = new TelemetryConfig({
+        configPath: "/path/to/config.json",
+        config: {
+          telemetry_enabled: false,
+          telemetry_id: "123456",
+          telemetry_salt: "private-salt",
+        },
+      });
+
+      telemetryConfig.showAlert();
+
+      expect(mockLog).not.toHaveBeenCalled();
+      expect(mockLog).not.toHaveBeenCalled();
+      expect(mockLog).not.toHaveBeenCalled();
+      expect(mockLog).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("enable", () => {
+    test("should set telemetry_enabled to true and write the config", () => {
+      const mockWriteFileSync = jest.fn();
+      jest.spyOn(fs, "writeFileSync").mockImplementation(mockWriteFileSync);
+
+      telemetryConfig.enable();
+      expect(telemetryConfig.isEnabled()).toBe(true);
+      expect(mockWriteFileSync).toHaveBeenCalled();
+      expect(mockWriteFileSync).toHaveBeenCalledWith(
+        "/path/to/config.json",
+        JSON.stringify(telemetryConfig.config, null, 2)
+      );
+    });
+  });
+
+  describe("disable", () => {
+    test("should set telemetry_enabled to false and write the config", () => {
+      const mockWriteFileSync = jest.fn();
+      jest.spyOn(fs, "writeFileSync").mockImplementation(mockWriteFileSync);
+      telemetryConfig.disable();
+
+      expect(telemetryConfig.isEnabled()).toBe(false);
+      expect(mockWriteFileSync).toHaveBeenCalled();
+      expect(mockWriteFileSync).toHaveBeenCalledWith(
+        "/path/to/config.json",
+        JSON.stringify(telemetryConfig.config, null, 2)
+      );
+    });
+  });
+
+  describe("alertShown", () => {
+    test("should return true if telemetry_alerted is defined", () => {
+      telemetryConfig = new TelemetryConfig({
+        configPath: "/path/to/config.json",
+        config: {
+          telemetry_enabled: true,
+          telemetry_id: "123456",
+          telemetry_salt: "private-salt",
+          telemetry_alerted: new Date(),
+        },
+      });
+
+      const result = telemetryConfig.alertShown();
+
+      expect(result).toBe(true);
+    });
+
+    test("should set telemetry_alerted to current date and write the config if telemetry_alerted is undefined", () => {
+      const mockWriteFileSync = jest.fn();
+      const mockDate = jest.fn().mockReturnValue("2021-01-01T00:00:00.000Z");
+      jest.spyOn(fs, "writeFileSync").mockImplementation(mockWriteFileSync);
+      jest.spyOn(global, "Date").mockImplementation(mockDate);
+
+      const result = telemetryConfig.alertShown();
+
+      expect(result).toBe(true);
+      expect(telemetryConfig.hasSeenAlert()).toBe(true);
+      expect(mockWriteFileSync).toHaveBeenCalled();
+      expect(mockWriteFileSync).toHaveBeenCalledWith(
+        "/path/to/config.json",
+        JSON.stringify(telemetryConfig.config, null, 2)
+      );
+    });
+  });
+
+  describe("oneWayHash", () => {
+    test("should call oneWayHashWithSalt with the input and telemetry_salt from the config", () => {
+      const mockOneWayHashWithSalt = jest.fn().mockReturnValue("hashed-value");
+      jest
+        .spyOn(utils, "oneWayHashWithSalt")
+        .mockImplementation(mockOneWayHashWithSalt);
+
+      const result = telemetryConfig.oneWayHash("input-value");
+      expect(mockOneWayHashWithSalt).toHaveBeenCalledWith({
+        input: "input-value",
+        salt: "private-salt",
+      });
+      expect(result).toBe("hashed-value");
+    });
+  });
+
+  describe("isDebug", () => {
+    test("should return true if TURBO_TELEMETRY_DEBUG is set to '1'", () => {
+      process.env.TURBO_TELEMETRY_DEBUG = "1";
+
+      const result = TelemetryConfig.isDebug();
+
+      expect(result).toBe(true);
+    });
+
+    test("should return true if TURBO_TELEMETRY_DEBUG is set to 'true'", () => {
+      process.env.TURBO_TELEMETRY_DEBUG = "true";
+
+      const result = TelemetryConfig.isDebug();
+
+      expect(result).toBe(true);
+    });
+
+    test("should return false if TURBO_TELEMETRY_DEBUG is not set", () => {
+      const result = TelemetryConfig.isDebug();
+
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/packages/turbo-telemetry/src/config.ts
+++ b/packages/turbo-telemetry/src/config.ts
@@ -1,7 +1,7 @@
 import { readFileSync, writeFileSync } from "node:fs";
 import { logger } from "@turbo/utils";
 import chalk from "chalk";
-import { defaultConfigPath } from "./utils";
+import { defaultConfigPath, oneWayHashWithSalt } from "./utils";
 
 const DEBUG_ENV_VAR = "TURBO_TELEMETRY_DEBUG";
 const DISABLED_ENV_VAR = "TURBO_TELEMETRY_DISABLED";
@@ -22,7 +22,7 @@ interface Config {
  * https://github.com/vercel/turbo/blob/main/crates/turborepo-telemetry/src/config.rs
  */
 export class TelemetryConfig {
-  private config: Config;
+  config: Config;
   private configPath: string;
 
   constructor({ configPath, config }: { configPath: string; config: Config }) {
@@ -118,6 +118,13 @@ export class TelemetryConfig {
     this.config.telemetry_alerted = new Date();
     this.write();
     return true;
+  }
+
+  oneWayHash(input: string) {
+    return oneWayHashWithSalt({
+      input,
+      salt: this.config.telemetry_salt,
+    });
   }
 
   static isDebug() {

--- a/packages/turbo-telemetry/src/config.ts
+++ b/packages/turbo-telemetry/src/config.ts
@@ -1,0 +1,127 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { logger } from "@turbo/utils";
+import chalk from "chalk";
+import { defaultConfigPath } from "./utils";
+
+const DEBUG_ENV_VAR = "TURBO_TELEMETRY_DEBUG";
+const DISABLED_ENV_VAR = "TURBO_TELEMETRY_DISABLED";
+const DISABLED_MESSAGE_ENV_VAR = "TURBO_TELEMETRY_MESSAGE_DISABLED";
+const DO_NOT_TRACK_ENV_VAR = "DO_NOT_TRACK";
+
+interface Config {
+  telemetry_enabled: boolean;
+  telemetry_id: string;
+  telemetry_salt: string;
+  telemetry_alerted?: Date;
+}
+
+/**
+ * NOTE: This package is a direct port of the telemetry config struct from the turbo-telemetry crate. Any changes
+ * made here should be reflected in the turbo-telemetry crate as well.
+ *
+ * https://github.com/vercel/turbo/blob/main/crates/turborepo-telemetry/src/config.rs
+ */
+export class TelemetryConfig {
+  private config: Config;
+  private configPath: string;
+
+  constructor({ configPath, config }: { configPath: string; config: Config }) {
+    this.config = config;
+    this.configPath = configPath;
+  }
+
+  static async fromDefaultConfig() {
+    const configPath = await defaultConfigPath();
+    const file = readFileSync(configPath, "utf-8");
+    const config = JSON.parse(file) as Config;
+    return new TelemetryConfig({ configPath, config });
+  }
+
+  write() {
+    const json = JSON.stringify(this.config, null, 2);
+    writeFileSync(this.configPath, json);
+  }
+
+  hasSeenAlert(): boolean {
+    return this.config.telemetry_alerted !== undefined;
+  }
+
+  isEnabled(): boolean {
+    const doNotTrack = process.env[DO_NOT_TRACK_ENV_VAR] || "0";
+    const turboTelemetryDisabled = process.env[DISABLED_ENV_VAR] || "0";
+
+    if (
+      doNotTrack === "1" ||
+      doNotTrack.toLowerCase() === "true" ||
+      turboTelemetryDisabled === "1" ||
+      turboTelemetryDisabled.toLowerCase() === "true"
+    ) {
+      return false;
+    }
+
+    return this.config.telemetry_enabled;
+  }
+
+  isTelemetryWarningEnabled(): boolean {
+    const turboTelemetryMsgDisabled =
+      process.env[DISABLED_MESSAGE_ENV_VAR] || "0";
+
+    const isDisabled =
+      turboTelemetryMsgDisabled === "1" ||
+      turboTelemetryMsgDisabled.toLowerCase() === "true";
+
+    return !isDisabled;
+  }
+
+  get id() {
+    return this.config.telemetry_id;
+  }
+
+  showAlert() {
+    if (
+      !this.hasSeenAlert() &&
+      this.isEnabled() &&
+      this.isTelemetryWarningEnabled()
+    ) {
+      logger.log();
+      logger.bold("Attention:");
+      logger.grey(
+        "Turborepo now collects completely anonymous telemetry regarding usage."
+      );
+      logger.grey(
+        "This information is used to shape the Turborepo roadmap and prioritize features."
+      );
+      logger.grey(
+        "You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:"
+      );
+      logger.underline(chalk.grey("https://turbo.build/repo/docs/telemetry"));
+    }
+
+    this.alertShown();
+  }
+
+  enable() {
+    this.config.telemetry_enabled = true;
+    this.write();
+  }
+
+  disable() {
+    this.config.telemetry_enabled = false;
+    this.write();
+  }
+
+  alertShown() {
+    if (this.hasSeenAlert()) {
+      return true;
+    }
+
+    this.config.telemetry_alerted = new Date();
+    this.write();
+    return true;
+  }
+
+  static isDebug() {
+    const debug = process.env[DEBUG_ENV_VAR] || "0";
+    return debug === "1" || debug.toLowerCase() === "true";
+  }
+}

--- a/packages/turbo-telemetry/src/index.ts
+++ b/packages/turbo-telemetry/src/index.ts
@@ -1,0 +1,4 @@
+export { initTelemetry } from "./init";
+export { TelemetryClient } from "./client";
+export { TelemetryConfig } from "./config";
+export { withTelemetryCommand } from "./cli";

--- a/packages/turbo-telemetry/src/init.ts
+++ b/packages/turbo-telemetry/src/init.ts
@@ -1,0 +1,14 @@
+import { TelemetryConfig } from "./config";
+import { TelemetryClient, type PackageInfo } from "./client";
+
+const TELEMETRY_API = "https://telemetry.vercel.com";
+
+export async function initTelemetry(packageInfo: PackageInfo) {
+  // read the config
+  const config = await TelemetryConfig.fromDefaultConfig();
+  config.showAlert();
+  // initialize the client
+  const telemetry = new TelemetryClient(TELEMETRY_API, packageInfo, config);
+
+  return { telemetry };
+}

--- a/packages/turbo-telemetry/src/utils.test.ts
+++ b/packages/turbo-telemetry/src/utils.test.ts
@@ -1,0 +1,33 @@
+import { oneWayHashWithSalt, defaultConfigPath } from "./utils";
+
+describe("utils", () => {
+  describe("oneWayHashWithSalt", () => {
+    test("should return the hashed value with salt", () => {
+      const input = "a-sensitive-value";
+      const salt = "private-salt";
+
+      const result = oneWayHashWithSalt({ input, salt });
+      expect(result).toMatchInlineSnapshot(
+        `"568d39ba8435f9c37e80e01c6bb6e27d7b65b4edf837e44dee662ffc99206eec"`
+      );
+    });
+
+    test("should return consistent length", () => {
+      const input = "a-sensitive-value";
+      const salt = "private-salt";
+
+      const result1 = oneWayHashWithSalt({ input, salt });
+      const result2 = oneWayHashWithSalt({ input: `${input}-${input}`, salt });
+
+      expect(result1.length).toEqual(result2.length);
+    });
+  });
+
+  describe("defaultConfigPath", () => {
+    test("supports overriding by env var", async () => {
+      process.env.TURBO_CONFIG_DIR_PATH = "/tmp";
+      const result = await defaultConfigPath();
+      expect(result).toEqual("/tmp/turborepo/telemetry.json");
+    });
+  });
+});

--- a/packages/turbo-telemetry/src/utils.ts
+++ b/packages/turbo-telemetry/src/utils.ts
@@ -1,4 +1,5 @@
 import os from "node:os";
+import crypto from "node:crypto";
 import path from "node:path";
 import { configDir } from "dirs-next";
 import type { PackageInfo } from "./client";
@@ -12,10 +13,23 @@ export function buildUserAgent(packageInfo: PackageInfo): string {
 }
 
 export async function defaultConfigPath() {
-  const dir = await configDir();
+  const dir = process.env.TURBO_CONFIG_DIR_PATH
+    ? process.env.TURBO_CONFIG_DIR_PATH
+    : await configDir();
+
   if (!dir) {
     throw new Error("Could not find telemetry config directory");
   }
 
   return path.join(dir, "turborepo", "telemetry.json");
+}
+
+export function oneWayHashWithSalt({
+  input,
+  salt,
+}: {
+  input: string;
+  salt: string;
+}) {
+  return crypto.createHash("sha256").update(`${salt}${input}`).digest("hex");
 }

--- a/packages/turbo-telemetry/src/utils.ts
+++ b/packages/turbo-telemetry/src/utils.ts
@@ -1,0 +1,21 @@
+import os from "node:os";
+import path from "node:path";
+import { configDir } from "dirs-next";
+import type { PackageInfo } from "./client";
+
+export function buildUserAgent(packageInfo: PackageInfo): string {
+  const nodeVersion = process.version;
+  const operatingSystem = os.type();
+  const architecture = os.arch();
+
+  return `${packageInfo.name} ${packageInfo.version} ${nodeVersion} ${operatingSystem} ${architecture}`;
+}
+
+export async function defaultConfigPath() {
+  const dir = await configDir();
+  if (!dir) {
+    throw new Error("Could not find telemetry config directory");
+  }
+
+  return path.join(dir, "turborepo", "telemetry.json");
+}

--- a/packages/turbo-telemetry/tsconfig.json
+++ b/packages/turbo-telemetry/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "@turbo/tsconfig/library.json",
+  "compilerOptions": {
+    "rootDir": "."
+  }
+}

--- a/packages/turbo-utils/src/logger.ts
+++ b/packages/turbo-utils/src/logger.ts
@@ -27,8 +27,16 @@ export const bold = (...args: Array<string>) => {
   log(chalk.bold(...args));
 };
 
+export const underline = (...args: Array<string>) => {
+  log(chalk.underline(...args));
+};
+
 export const dimmed = (...args: Array<string>) => {
   log(chalk.dim(...args));
+};
+
+export const grey = (...args: Array<string>) => {
+  log(chalk.grey(...args));
 };
 
 export const item = (...args: Array<unknown>) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -674,6 +674,58 @@ importers:
         specifier: ^27.1.1
         version: 27.1.5(@babel/core@7.23.6)(jest@27.5.1)(typescript@4.9.5)
 
+  packages/turbo-telemetry:
+    dependencies:
+      chalk:
+        specifier: ^4.1.2
+        version: 4.1.2
+      commander:
+        specifier: ^10.0.0
+        version: 10.0.0
+      got:
+        specifier: ^11.8.6
+        version: 11.8.6
+      uuid:
+        specifier: ^9.0.0
+        version: 9.0.0
+    devDependencies:
+      '@turbo/eslint-config':
+        specifier: workspace:*
+        version: link:../eslint-config
+      '@turbo/test-utils':
+        specifier: workspace:*
+        version: link:../turbo-test-utils
+      '@turbo/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      '@turbo/types':
+        specifier: workspace:*
+        version: link:../turbo-types
+      '@turbo/utils':
+        specifier: workspace:*
+        version: link:../turbo-utils
+      '@types/jest':
+        specifier: ^27.4.0
+        version: 27.5.2
+      '@types/node':
+        specifier: ^20.11.30
+        version: 20.11.30
+      '@types/uuid':
+        specifier: ^9.0.0
+        version: 9.0.0
+      dirs-next:
+        specifier: 0.0.1-canary.1
+        version: 0.0.1-canary.1
+      jest:
+        specifier: ^27.4.3
+        version: 27.5.1(ts-node@10.9.1)
+      ts-jest:
+        specifier: ^27.1.1
+        version: 27.1.5(@babel/core@7.23.6)(@types/jest@27.5.2)(esbuild@0.14.49)(jest@27.5.1)(typescript@5.3.3)
+      typescript:
+        specifier: 5.3.3
+        version: 5.3.3
+
   packages/turbo-test-utils:
     dependencies:
       fs-extra:
@@ -1196,6 +1248,7 @@ packages:
     dependencies:
       '@babel/highlight': 7.22.13
       chalk: 2.4.2
+    dev: false
 
   /@babel/code-frame@7.23.5:
     resolution: {integrity: sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==}
@@ -1262,6 +1315,7 @@ packages:
       '@jridgewell/gen-mapping': 0.3.2
       '@jridgewell/trace-mapping': 0.3.17
       jsesc: 2.5.2
+    dev: false
 
   /@babel/generator@7.23.6:
     resolution: {integrity: sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==}
@@ -1291,11 +1345,6 @@ packages:
     resolution: {integrity: sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==}
     engines: {node: '>=6.9.0'}
 
-  /@babel/helper-environment-visitor@7.22.5:
-    resolution: {integrity: sha512-XGmhECfVA/5sAt+H+xpSg0mfrHq6FzNr9Oxh7PSEBBRUb/mL7Kz3NICXb194rCqAEdxkhPT1a88teizAFyvk8Q==}
-    engines: {node: '>=6.9.0'}
-    dev: true
-
   /@babel/helper-function-name@7.21.0:
     resolution: {integrity: sha512-HfK1aMRanKHpxemaY2gqBmL04iAPOPRj7DxtNbiDOrJK+gdwkiNRVpCpUJYbUT+aZyemKN8brqTOxzCaG6ExRg==}
     engines: {node: '>=6.9.0'}
@@ -1303,14 +1352,6 @@ packages:
       '@babel/template': 7.22.5
       '@babel/types': 7.22.11
     dev: false
-
-  /@babel/helper-function-name@7.22.5:
-    resolution: {integrity: sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/template': 7.22.5
-      '@babel/types': 7.22.11
-    dev: true
 
   /@babel/helper-function-name@7.23.0:
     resolution: {integrity: sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==}
@@ -1430,6 +1471,7 @@ packages:
       '@babel/helper-validator-identifier': 7.22.5
       chalk: 2.4.2
       js-tokens: 4.0.0
+    dev: false
 
   /@babel/highlight@7.23.4:
     resolution: {integrity: sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==}
@@ -1444,7 +1486,8 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
-      '@babel/types': 7.22.11
+      '@babel/types': 7.23.6
+    dev: false
 
   /@babel/parser@7.23.6:
     resolution: {integrity: sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==}
@@ -1577,13 +1620,6 @@ packages:
       regenerator-runtime: 0.13.11
     dev: false
 
-  /@babel/runtime@7.20.6:
-    resolution: {integrity: sha512-Q+8MqP7TiHMWzSfwiJwXCjyf4GYA4Dgw3emg/7xmwsdLJOZUp+nMqcOwOzzYheuM1rhDu8FSj2l0aoMygEuXuA==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      regenerator-runtime: 0.13.11
-    dev: true
-
   /@babel/runtime@7.22.11:
     resolution: {integrity: sha512-ee7jVNlWN09+KftVOu9n7S8gQzD/Z6hN/I8VBRXW4P1+Xe7kJGXMwu8vds4aGIMHZnNbdpSWCfZZtinytpcAvA==}
     engines: {node: '>=6.9.0'}
@@ -1603,9 +1639,10 @@ packages:
     resolution: {integrity: sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.22.13
-      '@babel/parser': 7.22.13
-      '@babel/types': 7.22.11
+      '@babel/code-frame': 7.23.5
+      '@babel/parser': 7.23.6
+      '@babel/types': 7.23.6
+    dev: false
 
   /@babel/traverse@7.21.2:
     resolution: {integrity: sha512-ts5FFU/dSUPS13tv8XiEObDu9K+iagEKME9kAbaP7r0Y9KtZJZ+NGndDvWoRAYNpeWafbpFeki3q9QoMD6gxyw==}
@@ -1624,24 +1661,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: false
-
-  /@babel/traverse@7.22.11:
-    resolution: {integrity: sha512-mzAenteTfomcB7mfPtyi+4oe5BZ6MXxWcn4CX+h4IRJ+OOGXBrWU6jDQavkQI9Vuc5P+donFabBfFCcmWka9lQ==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/code-frame': 7.22.13
-      '@babel/generator': 7.22.10
-      '@babel/helper-environment-visitor': 7.22.5
-      '@babel/helper-function-name': 7.22.5
-      '@babel/helper-hoist-variables': 7.22.5
-      '@babel/helper-split-export-declaration': 7.22.6
-      '@babel/parser': 7.22.13
-      '@babel/types': 7.22.11
-      debug: 4.3.4
-      globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
 
   /@babel/traverse@7.23.7:
     resolution: {integrity: sha512-tY3mM8rH9jM0YHFGyfC0/xf+SB5eKUu7HPj7/k3fpi9dAlsMc5YbQvDi0Sh2QTPXqMhyaAtzAr807TIyfQrmyg==}
@@ -2260,7 +2279,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 20.10.8
+      '@types/node': 18.17.4
       chalk: 4.1.2
       jest-message-util: 27.5.1
       jest-util: 27.5.1
@@ -2272,7 +2291,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.5.0
-      '@types/node': 20.10.8
+      '@types/node': 18.17.4
       chalk: 4.1.2
       jest-message-util: 29.5.0
       jest-util: 29.5.0
@@ -2379,7 +2398,7 @@ packages:
     dependencies:
       '@jest/types': 29.5.0
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 20.10.8
+      '@types/node': 18.17.4
       jest-message-util: 29.5.0
       jest-mock: 29.5.0
       jest-util: 29.5.0
@@ -2420,7 +2439,7 @@ packages:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 20.10.8
+      '@types/node': 18.17.4
       chalk: 4.1.2
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
@@ -2553,7 +2572,7 @@ packages:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 20.10.8
+      '@types/node': 18.17.4
       '@types/yargs': 16.0.5
       chalk: 4.1.2
     dev: true
@@ -2618,7 +2637,7 @@ packages:
   /@manypkg/find-root@1.1.0:
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.22.11
       '@types/node': 12.20.55
       find-up: 4.1.0
       fs-extra: 8.1.0
@@ -2967,7 +2986,6 @@ packages:
   /@sindresorhus/is@4.6.0:
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
-    dev: true
 
   /@sinonjs/commons@1.8.6:
     resolution: {integrity: sha512-Ky+XkAkqPZSm3NLBeUng77EBQl3cmeJhITaGHdYH8kjVB+aun3S4XBRti2zt17mtt0mIUDiNxYeoJm6drVvBJQ==}
@@ -3010,7 +3028,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       defer-to-connect: 2.0.1
-    dev: true
 
   /@taplo/cli@0.5.2:
     resolution: {integrity: sha512-6Sg10lt0fV9aHHWPycz4gzIsUodZihu68zAFZGWq0UDq+Gif2KMrAvNwjMbe+ZUKbnTJjvqJZcPvE4+UEyanAQ==}
@@ -3043,8 +3060,8 @@ packages:
   /@types/babel__core@7.1.19:
     resolution: {integrity: sha512-WEOTgRsbYkvA/KCsDwVEGkd7WAr1e3g31VHQ8zy5gul/V1qKullU/BU5I68X5v7V3GnB9eotmom4v5a5gjxorw==}
     dependencies:
-      '@babel/parser': 7.22.13
-      '@babel/types': 7.22.11
+      '@babel/parser': 7.23.6
+      '@babel/types': 7.23.6
       '@types/babel__generator': 7.6.4
       '@types/babel__template': 7.4.1
       '@types/babel__traverse': 7.18.3
@@ -3053,14 +3070,14 @@ packages:
   /@types/babel__generator@7.6.4:
     resolution: {integrity: sha512-tFkciB9j2K755yrTALxD44McOrk+gfpIpvC3sxHjRawj6PfnQxrse4Clq5y/Rq+G3mrBurMax/lG8Qn2t9mSsg==}
     dependencies:
-      '@babel/types': 7.22.11
+      '@babel/types': 7.23.6
     dev: true
 
   /@types/babel__template@7.4.1:
     resolution: {integrity: sha512-azBFKemX6kMg5Io+/rdGT0dkGreboUVR0Cdm3fz9QJWpaQGJRQXl7C+6hOTCZcMll7KFyEQpgbYI2lHdsS4U7g==}
     dependencies:
-      '@babel/parser': 7.22.13
-      '@babel/types': 7.22.11
+      '@babel/parser': 7.23.6
+      '@babel/types': 7.23.6
     dev: true
 
   /@types/babel__traverse@7.18.3:
@@ -3079,9 +3096,8 @@ packages:
     dependencies:
       '@types/http-cache-semantics': 4.0.1
       '@types/keyv': 3.1.4
-      '@types/node': 20.10.8
+      '@types/node': 18.17.4
       '@types/responselike': 1.0.0
-    dev: true
 
   /@types/chalk-animation@1.6.1:
     resolution: {integrity: sha512-MSuZqFkBeKcik4oMzd/BjaTRYkLpNftRSYkI/oszmckHAZOTSKslWR1CRdURwsxXBgYHPRlb5JM6Cx+tkyXUAg==}
@@ -3134,7 +3150,7 @@ packages:
     requiresBuild: true
     dependencies:
       '@types/jsonfile': 6.1.4
-      '@types/node': 20.10.8
+      '@types/node': 18.17.4
     dev: false
     optional: true
 
@@ -3167,7 +3183,6 @@ packages:
 
   /@types/http-cache-semantics@4.0.1:
     resolution: {integrity: sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ==}
-    dev: true
 
   /@types/inquirer@6.5.0:
     resolution: {integrity: sha512-rjaYQ9b9y/VFGOpqBEXRavc3jh0a+e6evAbI31tMda8VlPaSy0AZJfXsvmIe3wklc7W6C3zCSfleuMXR7NOyXw==}
@@ -3235,7 +3250,7 @@ packages:
     resolution: {integrity: sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==}
     requiresBuild: true
     dependencies:
-      '@types/node': 20.10.8
+      '@types/node': 18.17.4
     dev: false
     optional: true
 
@@ -3243,13 +3258,12 @@ packages:
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
     dependencies:
       '@types/node': 18.17.4
-    dev: true
 
   /@types/liftoff@4.0.0:
     resolution: {integrity: sha512-Ny/PJkO6nxWAQnaet8q/oWz15lrfwvdvBpuY4treB0CSsBO1CG0fVuNLngR3m3bepQLd+E4c3Y3DlC2okpUvPw==}
     dependencies:
       '@types/fined': 1.1.3
-      '@types/node': 20.10.8
+      '@types/node': 18.17.4
     dev: true
 
   /@types/loader-runner@2.2.4:
@@ -3293,6 +3307,13 @@ packages:
     resolution: {integrity: sha512-f8nQs3cLxbAFc00vEU59yf9UyGUftkPaLGfvbVOIDdx2i1b8epBqj2aNGyP19fiyXWvlmZ7qC1XLjAzw/OKIeA==}
     dependencies:
       undici-types: 5.26.5
+    dev: true
+
+  /@types/node@20.11.30:
+    resolution: {integrity: sha512-dHM6ZxwlmuZaRmUPfv1p+KrdD1Dci04FbdEm/9wEMouFqxYoFl5aMkt0VMAUtYRQDyYvD41WJLukhq/ha3YuTw==}
+    dependencies:
+      undici-types: 5.26.5
+    dev: true
 
   /@types/node@20.3.0:
     resolution: {integrity: sha512-cumHmIAf6On83X7yP+LrsEyUOf/YlociZelmpRYaGFydoaPdxdt80MAbu6vWerQT2COCp2nPvHdsbD7tHn/YlQ==}
@@ -3334,8 +3355,7 @@ packages:
   /@types/responselike@1.0.0:
     resolution: {integrity: sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==}
     dependencies:
-      '@types/node': 20.10.8
-    dev: true
+      '@types/node': 18.17.4
 
   /@types/retry@0.12.2:
     resolution: {integrity: sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==}
@@ -3379,7 +3399,7 @@ packages:
   /@types/through@0.0.30:
     resolution: {integrity: sha512-FvnCJljyxhPM3gkRgWmxmDZyAQSiBQQWLI0A0VFL0K7W1oRUrPJSqNO0NvTnLkBcotdlp3lKvaT0JrnyRDkzOg==}
     dependencies:
-      '@types/node': 20.10.8
+      '@types/node': 18.17.4
 
   /@types/tinycolor2@1.4.3:
     resolution: {integrity: sha512-Kf1w9NE5HEgGxCRyIcRXR/ZYtDv0V8FVPtYHwLxl0O+maGX0erE77pQlD0gpP+/KByMZ87mOA79SjifhSB3PjQ==}
@@ -3416,7 +3436,7 @@ packages:
   /@types/whatwg-url@8.2.2:
     resolution: {integrity: sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==}
     dependencies:
-      '@types/node': 20.10.8
+      '@types/node': 18.17.4
       '@types/webidl-conversions': 7.0.0
     dev: false
 
@@ -4221,8 +4241,8 @@ packages:
     resolution: {integrity: sha512-50wCwD5EMNW4aRpOwtqzyZHIewTYNxLA4nhB+09d8BIssfNfzBRhkBIHiaPv1Si226TQSvp8gxAJm2iY2qs2hQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
-      '@babel/template': 7.22.5
-      '@babel/types': 7.22.11
+      '@babel/template': 7.22.15
+      '@babel/types': 7.23.6
       '@types/babel__core': 7.1.19
       '@types/babel__traverse': 7.18.3
     dev: true
@@ -4497,7 +4517,6 @@ packages:
   /cacheable-lookup@5.0.4:
     resolution: {integrity: sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==}
     engines: {node: '>=10.6.0'}
-    dev: true
 
   /cacheable-request@7.0.2:
     resolution: {integrity: sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==}
@@ -4510,7 +4529,6 @@ packages:
       lowercase-keys: 2.0.0
       normalize-url: 6.1.0
       responselike: 2.0.1
-    dev: true
 
   /call-bind@1.0.2:
     resolution: {integrity: sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==}
@@ -4582,8 +4600,8 @@ packages:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
-  /chalk@5.2.0:
-    resolution: {integrity: sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==}
+  /chalk@5.3.0:
+    resolution: {integrity: sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
   /change-case@3.1.0:
@@ -4743,7 +4761,6 @@ packages:
     resolution: {integrity: sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==}
     dependencies:
       mimic-response: 1.0.1
-    dev: true
 
   /clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
@@ -5169,7 +5186,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       mimic-response: 3.1.0
-    dev: true
 
   /dedent@0.7.0:
     resolution: {integrity: sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==}
@@ -5214,7 +5230,6 @@ packages:
   /defer-to-connect@2.0.1:
     resolution: {integrity: sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==}
     engines: {node: '>=10'}
-    dev: true
 
   /define-lazy-prop@3.0.0:
     resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
@@ -5370,6 +5385,10 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       path-type: 4.0.0
+
+  /dirs-next@0.0.1-canary.1:
+    resolution: {integrity: sha512-spFwZ8c2SfgzJjc8ZtS61xUYz6iTzxh8sCM+tnLRH9KgKzu6GDanEOpV7V3iy+BJZlTJeo76+ueNM+BRodZXLg==}
+    dev: true
 
   /doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
@@ -7000,7 +7019,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       pump: 3.0.0
-    dev: true
 
   /get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
@@ -7171,7 +7189,7 @@ packages:
     dependencies:
       array-union: 2.1.0
       dir-glob: 3.0.1
-      fast-glob: 3.2.12
+      fast-glob: 3.3.1
       ignore: 5.2.1
       merge2: 1.4.1
       slash: 3.0.0
@@ -7222,7 +7240,6 @@ packages:
       lowercase-keys: 2.0.0
       p-cancelable: 2.1.1
       responselike: 2.0.1
-    dev: true
 
   /graceful-fs@4.2.10:
     resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
@@ -7363,7 +7380,6 @@ packages:
 
   /http-cache-semantics@4.1.1:
     resolution: {integrity: sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==}
-    dev: true
 
   /http-proxy-agent@4.0.1:
     resolution: {integrity: sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==}
@@ -7392,7 +7408,6 @@ packages:
     dependencies:
       quick-lru: 5.1.1
       resolve-alpn: 1.2.1
-    dev: true
 
   /https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
@@ -7558,7 +7573,7 @@ packages:
     engines: {node: '>=14.18.0'}
     dependencies:
       ansi-escapes: 4.3.2
-      chalk: 5.2.0
+      chalk: 5.3.0
       cli-cursor: 3.1.0
       cli-width: 4.0.0
       external-editor: 3.1.0
@@ -8056,7 +8071,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       '@babel/core': 7.23.6
-      '@babel/parser': 7.22.13
+      '@babel/parser': 7.23.6
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.0
       semver: 6.3.1
@@ -8340,7 +8355,7 @@ packages:
     dependencies:
       '@jest/types': 27.5.1
       '@types/graceful-fs': 4.1.6
-      '@types/node': 20.10.8
+      '@types/node': 18.17.4
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -8360,7 +8375,7 @@ packages:
     dependencies:
       '@jest/types': 29.5.0
       '@types/graceful-fs': 4.1.6
-      '@types/node': 20.10.8
+      '@types/node': 18.17.4
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -8430,7 +8445,7 @@ packages:
     resolution: {integrity: sha512-rMyFe1+jnyAAf+NHwTclDz0eAaLkVDdKVHHBFWsBWHnnh5YeJMNWWsv7AbFYXfK3oTqvL7VTWkhNLu1jX24D+g==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
-      '@babel/code-frame': 7.22.13
+      '@babel/code-frame': 7.23.5
       '@jest/types': 27.5.1
       '@types/stack-utils': 2.0.1
       chalk: 4.1.2
@@ -8469,7 +8484,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.5.0
-      '@types/node': 20.10.8
+      '@types/node': 18.17.4
       jest-util: 29.5.0
     dev: false
 
@@ -8558,7 +8573,7 @@ packages:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 20.10.8
+      '@types/node': 18.17.4
       chalk: 4.1.2
       emittery: 0.8.1
       graceful-fs: 4.2.11
@@ -8654,10 +8669,10 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@babel/core': 7.23.6
-      '@babel/generator': 7.22.10
+      '@babel/generator': 7.23.6
       '@babel/plugin-syntax-typescript': 7.20.0(@babel/core@7.23.6)
-      '@babel/traverse': 7.22.11
-      '@babel/types': 7.22.11
+      '@babel/traverse': 7.23.7
+      '@babel/types': 7.23.6
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
       '@types/babel__traverse': 7.18.3
@@ -8764,7 +8779,7 @@ packages:
     dependencies:
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 20.10.8
+      '@types/node': 18.17.4
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       jest-util: 27.5.1
@@ -8896,7 +8911,6 @@ packages:
 
   /json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
-    dev: true
 
   /json-parse-better-errors@1.0.2:
     resolution: {integrity: sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==}
@@ -8960,7 +8974,6 @@ packages:
     resolution: {integrity: sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==}
     dependencies:
       json-buffer: 3.0.1
-    dev: true
 
   /kind-of@3.2.2:
     resolution: {integrity: sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==}
@@ -9148,7 +9161,7 @@ packages:
     resolution: {integrity: sha512-l0x2DvrW294C9uDCoQe1VSU4gf529FkSZ6leBl4TiqZH/e+0R7hSfHQBNut2mNygDgHwvYHfFLn6Oxb3VWj2rA==}
     engines: {node: '>=12'}
     dependencies:
-      chalk: 5.2.0
+      chalk: 5.3.0
       is-unicode-supported: 1.3.0
     dev: true
 
@@ -9192,7 +9205,6 @@ packages:
   /lowercase-keys@2.0.0:
     resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
     engines: {node: '>=8'}
-    dev: true
 
   /lru-cache@10.0.1:
     resolution: {integrity: sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==}
@@ -9342,12 +9354,10 @@ packages:
   /mimic-response@1.0.1:
     resolution: {integrity: sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==}
     engines: {node: '>=4'}
-    dev: true
 
   /mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
-    dev: true
 
   /min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
@@ -9774,7 +9784,6 @@ packages:
   /normalize-url@6.1.0:
     resolution: {integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==}
     engines: {node: '>=10'}
-    dev: true
 
   /npm-run-all@4.1.5:
     resolution: {integrity: sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==}
@@ -10008,7 +10017,7 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
       bl: 5.1.0
-      chalk: 5.2.0
+      chalk: 5.3.0
       cli-cursor: 4.0.0
       cli-spinners: 2.7.0
       is-interactive: 2.0.0
@@ -10025,7 +10034,6 @@ packages:
   /p-cancelable@2.1.1:
     resolution: {integrity: sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==}
     engines: {node: '>=8'}
-    dev: true
 
   /p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
@@ -10137,7 +10145,7 @@ packages:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
     dependencies:
-      '@babel/code-frame': 7.22.13
+      '@babel/code-frame': 7.23.5
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
@@ -10322,7 +10330,7 @@ packages:
     hasBin: true
     dependencies:
       '@types/liftoff': 4.0.0
-      chalk: 5.2.0
+      chalk: 5.3.0
       interpret: 2.2.0
       liftoff: 4.0.0
       minimist: 1.2.8
@@ -10491,7 +10499,6 @@ packages:
     dependencies:
       end-of-stream: 1.4.4
       once: 1.4.0
-    dev: true
 
   /punycode@2.1.1:
     resolution: {integrity: sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==}
@@ -10510,7 +10517,6 @@ packages:
   /quick-lru@5.1.1:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
-    dev: true
 
   /randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
@@ -10675,6 +10681,7 @@ packages:
 
   /regenerator-runtime@0.13.11:
     resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
+    dev: false
 
   /regenerator-runtime@0.14.0:
     resolution: {integrity: sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==}
@@ -10752,7 +10759,6 @@ packages:
 
   /resolve-alpn@1.2.1:
     resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
-    dev: true
 
   /resolve-cwd@3.0.0:
     resolution: {integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==}
@@ -10842,7 +10848,6 @@ packages:
     resolution: {integrity: sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==}
     dependencies:
       lowercase-keys: 2.0.0
-    dev: true
 
   /restore-cursor@3.1.0:
     resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
@@ -12367,6 +12372,7 @@ packages:
 
   /undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+    dev: true
 
   /undici@5.25.4:
     resolution: {integrity: sha512-450yJxT29qKMf3aoudzFpIciqpx6Pji3hEWaXqXmanbXF58LTAGCKxcJjxMXWu3iG+Mudgo3ZUfDB6YDFd/dAw==}
@@ -13274,7 +13280,7 @@ packages:
       '@types/node': 18.17.4
       '@types/ps-tree': 1.1.6
       '@types/which': 3.0.3
-      chalk: 5.2.0
+      chalk: 5.3.0
       fs-extra: 11.1.1
       fx: 31.0.0
       globby: 13.2.2


### PR DESCRIPTION
### Description

Adds a `turbo-telemetry` library that enables tracking telemetry events from javascript packages. 

**Important**
This shares all telemetry state with turbo core's telemetry. This means users only need to disable once across all packages. 
