### PR TITLE
feat(ui): persist all logs

### DIFF
--- a/crates/turborepo-lib/src/task_graph/visitor.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor.rs
@@ -982,12 +982,6 @@ impl ExecContext {
                 if let Err(e) = stdout_writer.flush() {
                     error!("error flushing logs: {e}");
                 }
-                if let TaskOutput::UI(task) = output_client {
-                    let mut persisted_ui = self.prefixed_ui(task.stdout(), task.stdout());
-                    let _ = self
-                        .task_cache
-                        .replay_log_file(persisted_ui.output_prefixed_writer());
-                }
                 if let Err(e) = self
                     .task_cache
                     .on_error(prefixed_ui.output_prefixed_writer())

--- a/crates/turborepo-ui/src/tui/pane.rs
+++ b/crates/turborepo-ui/src/tui/pane.rs
@@ -1,8 +1,16 @@
-use std::{collections::BTreeMap, io::Write};
+use std::{
+    collections::{BTreeMap, HashSet},
+    io::Write,
+};
 
 use ratatui::{
+    backend::Backend,
     style::Style,
-    widgets::{Block, Borders, Widget},
+    widgets::{
+        block::{Position, Title},
+        Block, Borders, Widget,
+    },
+    Terminal,
 };
 use tracing::debug;
 use tui_term::widget::PseudoTerminal;
@@ -23,6 +31,7 @@ struct TerminalOutput<W> {
     cols: u16,
     parser: vt100::Parser,
     stdin: Option<W>,
+    has_been_persisted: bool,
 }
 
 impl<W> TerminalPane<W> {
@@ -102,6 +111,28 @@ impl<W> TerminalPane<W> {
         Ok(())
     }
 
+    pub fn render_screen<B: Backend>(
+        &mut self,
+        task_name: &str,
+        terminal: &mut Terminal<B>,
+    ) -> Result<(), Error> {
+        let task = self.task_mut(task_name)?;
+        task.persist_screen(task_name, terminal)
+    }
+
+    pub fn render_remaining<B: Backend>(
+        &mut self,
+        started_tasks: HashSet<&str>,
+        terminal: &mut Terminal<B>,
+    ) -> Result<(), Error> {
+        for (task_name, task) in self.tasks.iter_mut() {
+            if !task.has_been_persisted && started_tasks.contains(task_name.as_str()) {
+                task.persist_screen(task_name, terminal)?;
+            }
+        }
+        Ok(())
+    }
+
     fn selected(&self) -> Option<(&String, &TerminalOutput<W>)> {
         let task_name = self.displayed.as_deref()?;
         self.tasks.get_key_value(task_name)
@@ -141,6 +172,7 @@ impl<W> TerminalOutput<W> {
             stdin,
             rows,
             cols,
+            has_been_persisted: false,
         }
     }
 
@@ -150,6 +182,27 @@ impl<W> TerminalOutput<W> {
         }
         self.rows = rows;
         self.cols = cols;
+    }
+
+    fn persist_screen<B: Backend>(
+        &mut self,
+        task_name: &str,
+        terminal: &mut Terminal<B>,
+    ) -> Result<(), Error> {
+        let screen = self.parser.entire_screen();
+        let (rows, _) = screen.size();
+        let mut cursor = tui_term::widget::Cursor::default();
+        cursor.hide();
+        let title = format!(" {task_name} >");
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .title(title.as_str())
+            .title(Title::from(title.as_str()).position(Position::Bottom));
+        let term = PseudoTerminal::new(&screen).cursor(cursor).block(block);
+        terminal.insert_before(rows as u16, |buf| term.render(buf.area, buf))?;
+        self.has_been_persisted = true;
+
+        Ok(())
     }
 }
 

--- a/crates/turborepo-ui/src/tui/table.rs
+++ b/crates/turborepo-ui/src/tui/table.rs
@@ -180,6 +180,13 @@ impl TaskTable {
         }
     }
 
+    pub fn tasks_started(&self) -> impl Iterator<Item = &str> + '_ {
+        self.finished
+            .iter()
+            .map(|task| task.name())
+            .chain(self.running.iter().map(|task| task.name()))
+    }
+
     fn finished_rows(&self, duration_width: u16) -> impl Iterator<Item = Row> + '_ {
         self.finished.iter().map(move |task| {
             Row::new(vec![


### PR DESCRIPTION
### Description

This PR changes UI behavior so all task output gets persisted to terminal after the run is finished.

Non-goals of the PR: respecting `--output-mode` for what logs get persisted.

This PR also ditches the "priority" channel for communicating with the rendering thread. This was intended to avoid a scenario where tasks were producing so many events that it took awhile to get to a "stop" event. In reality this introduces so many race conditions of a "stop" event causing events that happened not to be processed leading to missing information e.g. dropping the last line of task output since the stop event takes priority.

### Testing Instructions

Run `turbo` and verify that logs get persisted under various scenarios:
Cache misses:
<img width="1124" alt="Screenshot 2024-03-22 at 1 56 35 PM" src="https://github.com/vercel/turbo/assets/4131117/313aa99f-72d8-49b9-b61b-d75d5c9632fa">


Failures (not displaying tasks that didn't start):
<img width="1130" alt="Screenshot 2024-03-22 at 1 55 59 PM" src="https://github.com/vercel/turbo/assets/4131117/ee019c49-d7a4-4370-a44f-ef4da764bfda">

Cache hits:
<img width="1128" alt="Screenshot 2024-03-22 at 1 55 25 PM" src="https://github.com/vercel/turbo/assets/4131117/097c1ea8-02c7-46b0-bb16-6fbcc82cf292">




Closes TURBO-2692