### PR TITLE
fix(sourcemap): update sourcemap, remove checker

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -269,7 +269,7 @@ smallvec = { version = "1.13.1", features = [
   "union",
   "const_new",
 ] }
-sourcemap = "6.0.2"
+sourcemap = "6.4.1"
 syn = "1.0.107"
 tempfile = "3.3.0"
 test-case = "3.0.0"

--- a/crates/turbopack-core/src/source_map/mod.rs
+++ b/crates/turbopack-core/src/source_map/mod.rs
@@ -316,9 +316,6 @@ impl SourceMap {
             SourceMap::Decoded(map) => {
                 let mut token = map
                     .lookup_token(line as u32, column as u32)
-                    // The sourcemap crate incorrectly returns a previous line's token when there's
-                    // not a match on this line.
-                    .filter(|t| t.get_dst_line() == line as u32)
                     .map(Token::from)
                     .unwrap_or_else(|| {
                         Token::Synthetic(SyntheticToken {


### PR DESCRIPTION
### Description

While debugging https://vercel.slack.com/archives/C03EWR7LGEN/p1711146825831219?thread_ts=1711143217.892349&cid=C03EWR7LGEN, found out sourcemap lookup fails on certain source and always returns synthetictoken only.

Weirdly, the guards in this PR https://github.com/vercel/turbo/pull/7823/files#diff-2ce67e28c5b3144ec6f7a89167f3c96da9f9e268abf3fd685ce881d75a4cd8a5L319 is preventing those lookup - removing it makes correct sourcemap lookup occurs. I updated pkg to the version what swc uses and removed + ran next.js tests, seems like most of tests are running just fine 

(https://github.com/vercel/next.js/pull/63624)

Still not 100% sure if this'll be ok or not, if not open to change for the correct fixes. Some related fixes https://github.com/getsentry/rust-sourcemap/pull/60 might be the reason we don't see any regressions in the test.