### PR TITLE
fix(ui): limit viewport size based on term size

### DIFF
--- a/crates/turborepo-ui/src/tui/pane.rs
+++ b/crates/turborepo-ui/src/tui/pane.rs
@@ -133,6 +133,10 @@ impl<W> TerminalPane<W> {
         Ok(())
     }
 
+    pub fn term_size(&self) -> (u16, u16) {
+        (self.rows, self.cols)
+    }
+
     fn selected(&self) -> Option<(&String, &TerminalOutput<W>)> {
         let task_name = self.displayed.as_deref()?;
         self.tasks.get_key_value(task_name)


### PR DESCRIPTION
### Description

With #7822 (and #7805 ) we're using `insert_before` to persist logs. This can panic (https://github.com/ratatui-org/ratatui/issues/999) if the viewport fills the entire terminal.

This PR changes our viewport construction so it now takes terminal size into account. (Previously we always would use 60, even if the terminal didn't have 60 rows)

### Testing Instructions

Use UI with a terminal that has a height of 60 or less.


Closes TURBO-2695