### PR TITLE
fix(vt100): fix scrollback underflow

### DIFF
--- a/crates/turborepo-vt100/src/grid.rs
+++ b/crates/turborepo-vt100/src/grid.rs
@@ -138,7 +138,18 @@ impl Grid {
         self.scrollback
             .iter()
             .skip(scrollback_len - self.scrollback_offset)
-            .chain(self.rows.iter().take(rows_len - self.scrollback_offset))
+            // when scrollback_offset > rows_len (e.g. rows = 3,
+            // scrollback_len = 10, offset = 9) the skip(10 - 9)
+            // will take 9 rows instead of 3. we need to set
+            // the upper bound to rows_len (e.g. 3)
+            .take(rows_len)
+            // same for rows_len - scrollback_offset (e.g. 3 - 9).
+            // it'll panic with overflow. we have to saturate the subtraction.
+            .chain(
+                self.rows
+                    .iter()
+                    .take(rows_len.saturating_sub(self.scrollback_offset)),
+            )
     }
 
     pub fn drawing_rows(&self) -> impl Iterator<Item = &crate::row::Row> {

--- a/crates/turborepo-vt100/tests/scroll.rs
+++ b/crates/turborepo-vt100/tests/scroll.rs
@@ -112,3 +112,25 @@ fn edge_of_screen() {
         b"\x1b[24;75H\x1b[31mfoobar\x1b[24;80H"
     );
 }
+
+#[test]
+fn scrollback_larger_than_rows() {
+    let mut parser = vt100::Parser::new(3, 20, 10);
+
+    parser.process(gen_nums(1..=10, "\r\n").as_bytes());
+
+    // 1. Extra rows returned
+    parser.screen_mut().set_scrollback(4);
+    assert_eq!(parser.screen().contents(), gen_nums(4..=6, "\n"));
+
+    // 2. Subtraction overflow
+    parser.screen_mut().set_scrollback(10);
+    assert_eq!(parser.screen().contents(), gen_nums(1..=3, "\n"));
+}
+
+fn gen_nums(range: std::ops::RangeInclusive<u8>, join: &str) -> String {
+    range
+        .map(|num| num.to_string())
+        .collect::<Vec<String>>()
+        .join(join)
+}


### PR DESCRIPTION
### Description

Port of https://github.com/doy/vt100-rust/pull/11

Should address part of #7843

### Testing Instructions

Unit tests, did quick spot check that this scrolling still works.


Closes TURBO-2700