### PR TITLE
fix(ui): account for border when reserving size for logs

### DIFF
--- a/crates/turborepo-ui/src/tui/pane.rs
+++ b/crates/turborepo-ui/src/tui/pane.rs
@@ -203,7 +203,9 @@ impl<W> TerminalOutput<W> {
             .title(title.as_str())
             .title(Title::from(title.as_str()).position(Position::Bottom));
         let term = PseudoTerminal::new(&screen).cursor(cursor).block(block);
-        terminal.insert_before(rows as u16, |buf| term.render(buf.area, buf))?;
+        terminal.insert_before((rows as u16).saturating_add(2), |buf| {
+            term.render(buf.area, buf)
+        })?;
         self.has_been_persisted = true;
 
         Ok(())


### PR DESCRIPTION
### Description

🤦 I forgot to account for the border that we're adding to task logs.

I believe this will address the odd output seen in [this comment](https://github.com/vercel/turbo/issues/7843#issuecomment-2021162101)

### Testing Instructions
Before
<img width="1143" alt="Screenshot 2024-03-26 at 1 32 41 PM" src="https://github.com/vercel/turbo/assets/4131117/79a5f9d8-7a00-4b1d-8df3-4b0d7400bb60">

After
<img width="1144" alt="Screenshot 2024-03-26 at 1 31 24 PM" src="https://github.com/vercel/turbo/assets/4131117/0314b408-80c2-44c4-9fd2-30671dd686c1">


Closes TURBO-2701