### PR TITLE
Turbo tasks: Reuse aggregation context and apply queued updates

### DIFF
--- a/crates/turbo-tasks-memory/src/task.rs
+++ b/crates/turbo-tasks-memory/src/task.rs
@@ -1113,7 +1113,7 @@ impl Task {
                             outdated_dependencies: take(outdated_dependencies),
                         };
                         state.aggregation_leaf.change(
-                            &TaskAggregationContext::new(turbo_tasks, backend),
+                            &aggregation_context,
                             &TaskChange {
                                 dirty_tasks_update: vec![(self.id, -1)],
                                 ..Default::default()
@@ -1248,6 +1248,7 @@ impl Task {
                 }
             }
         }
+        aggregation_context.apply_queued_updates();
     }
 
     pub(crate) fn schedule_when_dirty_from_aggregation(


### PR DESCRIPTION
This resolves an issue that caused Turbopack to panic with https://github.com/vercel/turbo/blob/04e2a9f0cb9439913975a325ce3eb59b46380ff8/crates/turbo-tasks-memory/src/task/aggregation.rs#L211

When marking a task dirty:
- Reuse the aggregation context instead of creating
- Apply queued updates


Closes PACK-2846