### PR TITLE
feat(create-turbo): usage metrics

### DIFF
--- a/packages/create-turbo/__tests__/index.test.ts
+++ b/packages/create-turbo/__tests__/index.test.ts
@@ -6,7 +6,7 @@ import { logger } from "@turbo/utils";
 import type { PackageManager } from "@turbo/utils";
 // imports for mocks
 import * as turboWorkspaces from "@turbo/workspaces";
-import { TelemetryClient, TelemetryConfig } from "@turbo/telemetry";
+import { CreateTurboTelemetry, TelemetryConfig } from "@turbo/telemetry";
 import * as turboUtils from "@turbo/utils";
 import type { CreateCommandArgument } from "../src/commands/create/types";
 import { create } from "../src/commands/create";
@@ -25,21 +25,21 @@ describe("create-turbo", () => {
 
   const mockConsole = spyConsole();
   const mockExit = spyExit();
-  const telemetry = new TelemetryClient(
-    "https://example.com",
-    {
+  const telemetry = new CreateTurboTelemetry({
+    api: "https://example.com",
+    packageInfo: {
       name: "create-turbo",
       version: "1.0.0",
     },
-    new TelemetryConfig({
+    config: new TelemetryConfig({
       configPath: "test-config-path",
       config: {
         telemetry_enabled: false,
         telemetry_id: "telemetry-test-id",
         telemetry_salt: "telemetry-salt",
       },
-    })
-  );
+    }),
+  });
 
   test.each<{ packageManager: PackageManager }>([
     { packageManager: "yarn" },

--- a/packages/create-turbo/__tests__/index.test.ts
+++ b/packages/create-turbo/__tests__/index.test.ts
@@ -6,6 +6,7 @@ import { logger } from "@turbo/utils";
 import type { PackageManager } from "@turbo/utils";
 // imports for mocks
 import * as turboWorkspaces from "@turbo/workspaces";
+import { TelemetryClient, TelemetryConfig } from "@turbo/telemetry";
 import * as turboUtils from "@turbo/utils";
 import type { CreateCommandArgument } from "../src/commands/create/types";
 import { create } from "../src/commands/create";
@@ -24,6 +25,21 @@ describe("create-turbo", () => {
 
   const mockConsole = spyConsole();
   const mockExit = spyExit();
+  const telemetry = new TelemetryClient(
+    "https://example.com",
+    {
+      name: "create-turbo",
+      version: "1.0.0",
+    },
+    new TelemetryConfig({
+      configPath: "test-config-path",
+      config: {
+        telemetry_enabled: false,
+        telemetry_id: "telemetry-test-id",
+        telemetry_salt: "telemetry-salt",
+      },
+    })
+  );
 
   test.each<{ packageManager: PackageManager }>([
     { packageManager: "yarn" },
@@ -75,6 +91,7 @@ describe("create-turbo", () => {
         {
           skipInstall: true,
           example: "default",
+          telemetry,
         }
       );
 
@@ -148,6 +165,7 @@ describe("create-turbo", () => {
         packageManager,
         skipInstall: true,
         example: "default",
+        telemetry,
       });
 
       const expected = `${chalk.bold(
@@ -209,6 +227,7 @@ describe("create-turbo", () => {
       {
         skipInstall: true,
         example: "default",
+        telemetry,
       }
     );
 

--- a/packages/create-turbo/package.json
+++ b/packages/create-turbo/package.json
@@ -34,6 +34,7 @@
   },
   "devDependencies": {
     "@turbo/eslint-config": "workspace:*",
+    "@turbo/telemetry": "workspace:*",
     "@turbo/test-utils": "workspace:*",
     "@turbo/tsconfig": "workspace:*",
     "@turbo/utils": "workspace:*",

--- a/packages/create-turbo/src/cli.ts
+++ b/packages/create-turbo/src/cli.ts
@@ -6,7 +6,7 @@ import chalk from "chalk";
 import { Command, Option } from "commander";
 import { logger } from "@turbo/utils";
 import {
-  type TelemetryClient,
+  type CreateTurboTelemetry,
   initTelemetry,
   withTelemetryCommand,
 } from "@turbo/telemetry";
@@ -16,7 +16,7 @@ import { notifyUpdate } from "./utils/notifyUpdate";
 import { create } from "./commands";
 
 // Global telemetry client
-let telemetryClient: TelemetryClient | undefined;
+let telemetryClient: CreateTurboTelemetry | undefined;
 
 // Support http proxy vars
 const agent = new ProxyAgent();
@@ -31,9 +31,11 @@ createTurboCli
   .description("Create a new Turborepo")
   .usage(`${chalk.bold("<project-directory>")} [options]`)
   .hook("preAction", async (_, thisAction) => {
-    const { telemetry } = await initTelemetry({
-      name: cliPkg.name,
-      version: cliPkg.version,
+    const { telemetry } = await initTelemetry<"create-turbo">({
+      packageInfo: {
+        name: "create-turbo",
+        version: cliPkg.version,
+      },
     });
     // inject telemetry into the action as an option
     thisAction.addOption(

--- a/packages/create-turbo/src/commands/create/types.ts
+++ b/packages/create-turbo/src/commands/create/types.ts
@@ -1,3 +1,4 @@
+import { type TelemetryClient } from "@turbo/telemetry";
 import type { PackageManager } from "@turbo/utils";
 
 export type CreateCommandArgument = string | undefined;
@@ -9,4 +10,5 @@ export interface CreateCommandOptions {
   turboVersion?: string;
   example?: string;
   examplePath?: string;
+  telemetry: TelemetryClient;
 }

--- a/packages/create-turbo/src/commands/create/types.ts
+++ b/packages/create-turbo/src/commands/create/types.ts
@@ -1,4 +1,4 @@
-import { type TelemetryClient } from "@turbo/telemetry";
+import { type CreateTurboTelemetry } from "@turbo/telemetry";
 import type { PackageManager } from "@turbo/utils";
 
 export type CreateCommandArgument = string | undefined;
@@ -10,5 +10,5 @@ export interface CreateCommandOptions {
   turboVersion?: string;
   example?: string;
   examplePath?: string;
-  telemetry: TelemetryClient;
+  telemetry: CreateTurboTelemetry;
 }

--- a/packages/turbo-telemetry/README.md
+++ b/packages/turbo-telemetry/README.md
@@ -11,7 +11,7 @@ This information is used to shape the Turborepo roadmap and prioritize features.
 
 ## Events
 
-Each event must have its own method on the client class. All recorded events can be found by browsing the [event methods on the client class](./src/client.ts).
+Each package must create a subclass of the main telemetry client and implement specific methods for each telemetry event. All recorded events can be found by browsing the [packages classes](./src/events).
 
 ## Usage
 

--- a/packages/turbo-telemetry/src/client.test.ts
+++ b/packages/turbo-telemetry/src/client.test.ts
@@ -21,17 +21,17 @@ describe("TelemetryClient", () => {
       },
     });
 
-    const client = new TelemetryClient(
-      "https://example.com",
-      {
-        name: "test-package",
+    const client = new TelemetryClient({
+      api: "https://example.com",
+      packageInfo: {
+        name: "create-turbo",
         version: "1.0.0",
       },
       config,
-      {
+      opts: {
         batchSize: 2,
-      }
-    );
+      },
+    });
 
     // add two events to trigger the batch flush
     client.trackCommandStatus({
@@ -53,7 +53,7 @@ describe("TelemetryClient", () => {
               id: expect.any(String) as string,
               key: "command:test-command",
               value: "start",
-              package_name: "test-package",
+              package_name: "create-turbo",
               package_version: "1.0.0",
             },
           },
@@ -62,13 +62,13 @@ describe("TelemetryClient", () => {
               id: expect.any(String) as string,
               key: "command:test-command",
               value: "end",
-              package_name: "test-package",
+              package_name: "create-turbo",
               package_version: "1.0.0",
             },
           },
         ],
         headers: {
-          "User-Agent": expect.stringContaining("test-package 1.0.0") as string,
+          "User-Agent": expect.stringContaining("create-turbo 1.0.0") as string,
           "x-turbo-session-id": expect.any(String) as string,
           "x-turbo-telemetry-id": "telemetry-test-id",
         },
@@ -88,14 +88,14 @@ describe("TelemetryClient", () => {
       },
     });
 
-    const client = new TelemetryClient(
-      "https://example.com",
-      {
-        name: "test-package",
+    const client = new TelemetryClient({
+      api: "https://example.com",
+      packageInfo: {
+        name: "create-turbo",
         version: "1.0.0",
       },
-      config
-    );
+      config,
+    });
 
     client.trackCommandStatus({
       command: "test-command",
@@ -115,14 +115,14 @@ describe("TelemetryClient", () => {
       },
     });
 
-    const client = new TelemetryClient(
-      "https://example.com",
-      {
-        name: "test-package",
+    const client = new TelemetryClient({
+      api: "https://example.com",
+      packageInfo: {
+        name: "create-turbo",
         version: "1.0.0",
       },
-      config
-    );
+      config,
+    });
 
     client.trackCommandStatus({
       command: "test-command",
@@ -142,17 +142,17 @@ describe("TelemetryClient", () => {
       },
     });
 
-    const client = new TelemetryClient(
-      "https://example.com",
-      {
-        name: "test-package",
+    const client = new TelemetryClient({
+      api: "https://example.com",
+      packageInfo: {
+        name: "create-turbo",
         version: "1.0.0",
       },
       config,
-      {
+      opts: {
         batchSize: 2,
-      }
-    );
+      },
+    });
 
     // add one event
     client.trackCommandStatus({
@@ -173,13 +173,13 @@ describe("TelemetryClient", () => {
               id: expect.any(String) as string,
               key: "command:test-command",
               value: "start",
-              package_name: "test-package",
+              package_name: "create-turbo",
               package_version: "1.0.0",
             },
           },
         ],
         headers: {
-          "User-Agent": expect.stringContaining("test-package 1.0.0") as string,
+          "User-Agent": expect.stringContaining("create-turbo 1.0.0") as string,
           "x-turbo-session-id": expect.any(String) as string,
           "x-turbo-telemetry-id": "telemetry-test-id",
         },

--- a/packages/turbo-telemetry/src/client.test.ts
+++ b/packages/turbo-telemetry/src/client.test.ts
@@ -34,8 +34,14 @@ describe("TelemetryClient", () => {
     );
 
     // add two events to trigger the batch flush
-    client.trackPackageManager("yarn");
-    client.trackPackageManager("pnpm");
+    client.trackCommandStatus({
+      command: "test-command",
+      status: "start",
+    });
+    client.trackCommandStatus({
+      command: "test-command",
+      status: "end",
+    });
 
     expect(got.post).toHaveBeenCalled();
     expect(got.post).toHaveBeenCalledWith(
@@ -45,8 +51,8 @@ describe("TelemetryClient", () => {
           {
             package: {
               id: expect.any(String) as string,
-              key: "package_manager",
-              value: "yarn",
+              key: "command:test-command",
+              value: "start",
               package_name: "test-package",
               package_version: "1.0.0",
             },
@@ -54,8 +60,8 @@ describe("TelemetryClient", () => {
           {
             package: {
               id: expect.any(String) as string,
-              key: "package_manager",
-              value: "pnpm",
+              key: "command:test-command",
+              value: "end",
               package_name: "test-package",
               package_version: "1.0.0",
             },
@@ -91,7 +97,10 @@ describe("TelemetryClient", () => {
       config
     );
 
-    client.trackPackageManager("yarn");
+    client.trackCommandStatus({
+      command: "test-command",
+      status: "start",
+    });
     expect(got.post).not.toHaveBeenCalled();
     expect(client.hasPendingEvents()).toBe(true);
   });
@@ -115,7 +124,10 @@ describe("TelemetryClient", () => {
       config
     );
 
-    client.trackPackageManager("yarn");
+    client.trackCommandStatus({
+      command: "test-command",
+      status: "start",
+    });
     expect(got.post).not.toHaveBeenCalled();
     expect(client.hasPendingEvents()).toBe(false);
   });
@@ -143,7 +155,10 @@ describe("TelemetryClient", () => {
     );
 
     // add one event
-    client.trackPackageManager("pnpm");
+    client.trackCommandStatus({
+      command: "test-command",
+      status: "start",
+    });
     expect(got.post).not.toHaveBeenCalled();
 
     await client.close();
@@ -156,8 +171,8 @@ describe("TelemetryClient", () => {
           {
             package: {
               id: expect.any(String) as string,
-              key: "package_manager",
-              value: "pnpm",
+              key: "command:test-command",
+              value: "start",
               package_name: "test-package",
               package_version: "1.0.0",
             },

--- a/packages/turbo-telemetry/src/client.ts
+++ b/packages/turbo-telemetry/src/client.ts
@@ -147,17 +147,135 @@ export class TelemetryClient {
     }
   }
 
+  private trackCliOption({
+    option,
+    value,
+  }: {
+    option: string;
+    value: string;
+  }): Event {
+    return this.track({
+      key: `option:${option}`,
+      value,
+    });
+  }
+
+  private trackCliArgument({
+    argument,
+    value,
+  }: {
+    argument: string;
+    value: string;
+  }): Event {
+    return this.track({
+      key: `argument:${argument}`,
+      value,
+    });
+  }
+
+  private trackCliCommand({
+    command,
+    value,
+  }: {
+    command: string;
+    value: string;
+  }): Event {
+    return this.track({
+      key: `command:${command}`,
+      value,
+    });
+  }
+
   ////////////
   // EVENTS //
   ////////////
 
-  /**
-   * Track selected package manager
-   */
-  trackPackageManager(packageManager: string): Event {
-    return this.track({
-      key: "package_manager",
-      value: packageManager,
+  trackCommandStatus({
+    command,
+    status,
+  }: {
+    command: string;
+    status: string;
+  }): Event {
+    return this.trackCliCommand({
+      command,
+      value: status,
     });
+  }
+
+  // CLI Options
+
+  trackOptionExample(value: string | undefined): Event | undefined {
+    if (value) {
+      return this.trackCliOption({
+        option: "example",
+        value,
+      });
+    }
+  }
+
+  trackOptionPackageManager(value: string | undefined): Event | undefined {
+    if (value) {
+      return this.trackCliOption({
+        option: "package_manager",
+        value,
+      });
+    }
+  }
+
+  trackOptionSkipInstall(value: boolean | undefined): Event | undefined {
+    if (value) {
+      return this.trackCliOption({
+        option: "skip_install",
+        value: value.toString(),
+      });
+    }
+  }
+
+  trackOptionSkipTransforms(value: boolean | undefined): Event | undefined {
+    if (value) {
+      return this.trackCliOption({
+        option: "skip_transforms",
+        value: value.toString(),
+      });
+    }
+  }
+
+  trackOptionTurboVersion(value: string | undefined): Event | undefined {
+    if (value) {
+      return this.trackCliOption({
+        option: "turbo_version",
+        value,
+      });
+    }
+  }
+
+  trackOptionExamplePath(value: string | undefined): Event | undefined {
+    if (value) {
+      return this.trackCliOption({
+        option: "example_path",
+        value,
+      });
+    }
+  }
+
+  // CLI Arguments
+
+  trackArgumentDirectory(provided: boolean): Event | undefined {
+    if (provided) {
+      return this.trackCliArgument({
+        argument: "project_directory",
+        value: provided.toString(),
+      });
+    }
+  }
+
+  trackArgumentPackageManager(value: string | undefined): Event | undefined {
+    if (value) {
+      return this.trackCliArgument({
+        argument: "package_manager",
+        value,
+      });
+    }
   }
 }

--- a/packages/turbo-telemetry/src/events/create-turbo.ts
+++ b/packages/turbo-telemetry/src/events/create-turbo.ts
@@ -1,0 +1,76 @@
+import { TelemetryClient } from "../client";
+import type { Event } from "./types";
+
+export class CreateTurboTelemetry extends TelemetryClient {
+  trackOptionExample(value: string | undefined): Event | undefined {
+    if (value) {
+      return this.trackCliOption({
+        option: "example",
+        value,
+      });
+    }
+  }
+
+  trackOptionPackageManager(value: string | undefined): Event | undefined {
+    if (value) {
+      return this.trackCliOption({
+        option: "package_manager",
+        value,
+      });
+    }
+  }
+
+  trackOptionSkipInstall(value: boolean | undefined): Event | undefined {
+    if (value) {
+      return this.trackCliOption({
+        option: "skip_install",
+        value: value.toString(),
+      });
+    }
+  }
+
+  trackOptionSkipTransforms(value: boolean | undefined): Event | undefined {
+    if (value) {
+      return this.trackCliOption({
+        option: "skip_transforms",
+        value: value.toString(),
+      });
+    }
+  }
+
+  trackOptionTurboVersion(value: string | undefined): Event | undefined {
+    if (value) {
+      return this.trackCliOption({
+        option: "turbo_version",
+        value,
+      });
+    }
+  }
+
+  trackOptionExamplePath(value: string | undefined): Event | undefined {
+    if (value) {
+      return this.trackCliOption({
+        option: "example_path",
+        value,
+      });
+    }
+  }
+
+  trackArgumentDirectory(provided: boolean): Event | undefined {
+    if (provided) {
+      return this.trackCliArgument({
+        argument: "project_directory",
+        value: provided.toString(),
+      });
+    }
+  }
+
+  trackArgumentPackageManager(value: string | undefined): Event | undefined {
+    if (value) {
+      return this.trackCliArgument({
+        argument: "package_manager",
+        value,
+      });
+    }
+  }
+}

--- a/packages/turbo-telemetry/src/events/turbo-ignore.ts
+++ b/packages/turbo-telemetry/src/events/turbo-ignore.ts
@@ -1,0 +1,11 @@
+import { TelemetryClient } from "../client";
+import type { Event } from "./types";
+
+export class TurboIgnoreTelemetry extends TelemetryClient {
+  trackExecutionEnv(): Event | undefined {
+    return this.track({
+      key: "execution_env",
+      value: process.env.VERCEL === "1" ? "vercel" : "local",
+    });
+  }
+}

--- a/packages/turbo-telemetry/src/events/types.ts
+++ b/packages/turbo-telemetry/src/events/types.ts
@@ -1,0 +1,21 @@
+import { type CreateTurboTelemetry } from "./create-turbo";
+import { type TurboIgnoreTelemetry } from "./turbo-ignore";
+
+export interface TelemetryClientClasses {
+  "create-turbo": typeof CreateTurboTelemetry;
+  "turbo-ignore": typeof TurboIgnoreTelemetry;
+}
+
+export interface PackageInfo {
+  name: keyof TelemetryClientClasses;
+  version: string;
+}
+
+export interface Event {
+  id: string;
+  key: string;
+  value: string;
+  package_name: string;
+  package_version: string;
+  parent_id: string | undefined;
+}

--- a/packages/turbo-telemetry/src/index.ts
+++ b/packages/turbo-telemetry/src/index.ts
@@ -2,3 +2,6 @@ export { initTelemetry } from "./init";
 export { TelemetryClient } from "./client";
 export { TelemetryConfig } from "./config";
 export { withTelemetryCommand } from "./cli";
+
+// Event Classes
+export { CreateTurboTelemetry } from "./events/create-turbo";

--- a/packages/turbo-telemetry/src/utils.ts
+++ b/packages/turbo-telemetry/src/utils.ts
@@ -2,7 +2,7 @@ import os from "node:os";
 import crypto from "node:crypto";
 import path from "node:path";
 import { configDir } from "dirs-next";
-import type { PackageInfo } from "./client";
+import type { PackageInfo } from "./events/types";
 
 export function buildUserAgent(packageInfo: PackageInfo): string {
   const nodeVersion = process.version;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -194,6 +194,9 @@ importers:
       '@turbo/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config
+      '@turbo/telemetry':
+        specifier: workspace:*
+        version: link:../turbo-telemetry
       '@turbo/test-utils':
         specifier: workspace:*
         version: link:../turbo-test-utils


### PR DESCRIPTION
### Description

Add anonymous usage telemetry to create-turbo. If you have already opted out of turbo telemetry, you have opted out of this telemetry as well. 
