### PR TITLE
ci(workflow): expands more wasi targets

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -522,7 +522,7 @@ jobs:
 
       - name: Run cargo check for the wasi targets
         run: |
-          RUSTFLAGS="-D warnings -A deprecated" cargo groups check turbopack-wasi --release
+          CARGO_BUILD_TARGET="wasm32-wasi-preview1-threads" RUSTFLAGS="-D warnings -A deprecated" cargo groups check turbopack-wasi --release
 
   turbopack_rust_clippy:
     needs: [turbopack_rust_check]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,13 @@ turbopack = [
 ]
 
 # List of the packages can be compiled against wasm32-wasi target.
-turbopack-wasi = ["path:crates/turbo-tasks-hash"]
+turbopack-wasi = [
+  "path:crates/turbo-tasks-auto-hash-map",
+  "path:crates/turbo-tasks-hash",
+  "path:crates/turbo-tasks-macro",
+  "path:crates/turbo-tasks-macros-shared",
+  "path:crates/turbo-tasks-build",
+]
 
 [workspace.lints.clippy]
 too_many_arguments = "allow"


### PR DESCRIPTION
### TL;DR

This pull request updates the build flags for the 'turbopack' wasm32-wasi target and increases the number of target packages.

### What changed?

In the GitHub workflow file for tests, the `cargo check` command for the 'turbopack-wasi' target now specifies the `CARGO_BUILD_TARGET` environment variable. Additionally, in the 'Cargo.toml' file, the list of packages that can be compiled against the wasm32-wasi target has been expanded to include more turbo-task related crates.

### How to test?

To test these changes, run the GitHub workflows and check whether the 'turbopack' build process and the associated tests succeed.

### Why make this change?

Updating the build flags and target packages for the wasm32-wasi build process in 'turbopack' may lead to better performance and broader feature support.

