### PR TITLE
fix(pnpm): support new pnpm9 default link-workspace-packages

### DIFF
--- a/crates/turborepo-lib/src/daemon/mod.rs
+++ b/crates/turborepo-lib/src/daemon/mod.rs
@@ -110,6 +110,7 @@ pub(crate) mod proto {
                 PackageManager::Berry => Self::Berry,
                 PackageManager::Pnpm => Self::Pnpm,
                 PackageManager::Pnpm6 => Self::Pnpm6,
+                PackageManager::Pnpm9 => Self::Pnpm9,
                 PackageManager::Bun => Self::Bun,
             }
         }
@@ -123,6 +124,7 @@ pub(crate) mod proto {
                 turborepo_repository::package_manager::PackageManager::Berry => Self::Berry,
                 turborepo_repository::package_manager::PackageManager::Pnpm => Self::Pnpm,
                 turborepo_repository::package_manager::PackageManager::Pnpm6 => Self::Pnpm6,
+                turborepo_repository::package_manager::PackageManager::Pnpm9 => Self::Pnpm9,
                 turborepo_repository::package_manager::PackageManager::Bun => Self::Bun,
             }
         }

--- a/crates/turborepo-lib/src/daemon/proto/turbod.proto
+++ b/crates/turborepo-lib/src/daemon/proto/turbod.proto
@@ -110,4 +110,5 @@ enum PackageManager {
   Pnpm6 = 3;
   Yarn = 4;
   Bun = 5;
+  Pnpm9 = 6;
 }

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -368,6 +368,7 @@ impl<'a, T: PackageDiscovery> BuildState<'a, ResolvedWorkspaces, T> {
                         self.repo_root,
                         &entry.package_json_path,
                         &self.workspaces,
+                        package_manager,
                         npmrc.as_ref(),
                         entry.package_json.all_dependencies(),
                     ),
@@ -554,6 +555,7 @@ impl Dependencies {
         repo_root: &AbsoluteSystemPath,
         workspace_json_path: &AnchoredSystemPathBuf,
         workspaces: &HashMap<PackageName, PackageInfo>,
+        package_manager: PackageManager,
         npmrc: Option<&NpmRc>,
         dependencies: I,
     ) -> Self {
@@ -563,7 +565,8 @@ impl Dependencies {
             .expect("package.json path should have parent");
         let mut internal = HashSet::new();
         let mut external = BTreeMap::new();
-        let splitter = DependencySplitter::new(repo_root, workspace_dir, workspaces, npmrc);
+        let splitter =
+            DependencySplitter::new(repo_root, workspace_dir, workspaces, package_manager, npmrc);
         for (name, version) in dependencies.into_iter() {
             if let Some(workspace) = splitter.is_internal(name, version) {
                 internal.insert(workspace);

--- a/crates/turborepo-repository/src/package_graph/dep_splitter.rs
+++ b/crates/turborepo-repository/src/package_graph/dep_splitter.rs
@@ -6,6 +6,7 @@ use turbopath::{
 };
 
 use super::{npmrc::NpmRc, PackageInfo, PackageName};
+use crate::package_manager::PackageManager;
 
 pub struct DependencySplitter<'a> {
     repo_root: &'a AbsoluteSystemPath,
@@ -19,17 +20,16 @@ impl<'a> DependencySplitter<'a> {
         repo_root: &'a AbsoluteSystemPath,
         workspace_dir: &'a AbsoluteSystemPath,
         workspaces: &'a HashMap<PackageName, PackageInfo>,
+        package_manager: PackageManager,
         npmrc: Option<&'a NpmRc>,
     ) -> Self {
         Self {
             repo_root,
             workspace_dir,
             workspaces,
-            // TODO: default needs to depend on package manager as pnpm 9 changes the default to
-            // false
             link_workspace_packages: npmrc
                 .and_then(|npmrc| npmrc.link_workspace_packages)
-                .unwrap_or(true),
+                .unwrap_or(!matches!(package_manager, PackageManager::Pnpm9)),
         }
     }
 

--- a/crates/turborepo-repository/src/package_manager/pnpm.rs
+++ b/crates/turborepo-repository/src/package_manager/pnpm.rs
@@ -25,8 +25,12 @@ impl<'a> PnpmDetector<'a> {
 
     pub fn detect_pnpm6_or_pnpm(version: &Version) -> Result<PackageManager, Error> {
         let pnpm6_constraint: Range = "<7.0.0".parse()?;
+        // TODO actually do this
+        let pnpm9_constraint: Range = ">=9.0.0-alpha.0".parse()?;
         if pnpm6_constraint.satisfies(version) {
             Ok(PackageManager::Pnpm6)
+        } else if pnpm9_constraint.satisfies(version) {
+            Ok(PackageManager::Pnpm9)
         } else {
             Ok(PackageManager::Pnpm)
         }
@@ -95,6 +99,7 @@ mod test {
     use std::collections::BTreeMap;
 
     use serde_json::json;
+    use test_case::test_case;
     use turbopath::RelativeUnixPathBuf;
 
     use super::*;
@@ -125,6 +130,19 @@ mod test {
                     .collect::<BTreeMap<_, _>>()
             )
             .as_ref()
+        );
+    }
+
+    #[test_case("6.0.0", PackageManager::Pnpm6)]
+    #[test_case("7.0.0", PackageManager::Pnpm)]
+    #[test_case("8.0.0", PackageManager::Pnpm)]
+    #[test_case("9.0.0", PackageManager::Pnpm9)]
+    #[test_case("9.0.0-alpha.0", PackageManager::Pnpm9)]
+    fn test_version_detection(version: &str, expected: PackageManager) {
+        let version = Version::parse(version).unwrap();
+        assert_eq!(
+            PnpmDetector::detect_pnpm6_or_pnpm(&version).unwrap(),
+            expected
         );
     }
 }


### PR DESCRIPTION
### Description

With [PNPM 9](https://github.com/pnpm/pnpm/releases/tag/v9.0.0-alpha.0), [link-workspace-packages]() is now defaulting to `false` meaning that unless the `workspace` protocol is explicitly used, packages from the registry will be preferred over workspace packages.

It's odd to have 3 variants of the PNPM package manager, but that is the current state of the world. Unsure of why we changed from a generic interface to a enum in the Go->Rust port, but we'll probably want to go back to that world to reduce match statement complexity.

### Testing Instructions

Unit tests for package manager detection. Quick spot check in a `create-turbo` repo with workspace deps updates so they don't use `workspace` protocol.


