### PR TITLE
chore(ui): upgrade tui-term

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10495,8 +10495,9 @@ checksum = "7b3e06c9b9d80ed6b745c7159c40b311ad2916abb34a49e9be2653b90db0d8dd"
 
 [[package]]
 name = "tui-term"
-version = "0.1.8"
-source = "git+https://github.com/a-kenji/tui-term.git?rev=96da15fb9974bb8f77b0e937abbdb2c3b8e932aa#96da15fb9974bb8f77b0e937abbdb2c3b8e932aa"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4612d4537b4c9f69192596f5b48516b2faf5442fafab885e999e6195cd19463f"
 dependencies = [
  "ratatui",
 ]
@@ -12009,7 +12010,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "rand 0.8.5",
  "static_assertions",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -286,8 +286,7 @@ tokio-util = { version = "0.7.7", features = ["io"] }
 tracing = "0.1.37"
 tracing-appender = "0.2.2"
 tracing-subscriber = "0.3.16"
-# Latest release (0.1.8) doesn't include necessary changes for us to use our vendored vt100
-tui-term = { git = "https://github.com/a-kenji/tui-term.git", rev = "96da15fb9974bb8f77b0e937abbdb2c3b8e932aa", default-features = false }
+tui-term = { version = "0.1.9", default-features = false }
 url = "2.2.2"
 urlencoding = "2.1.2"
 webbrowser = "0.8.7"


### PR DESCRIPTION
### Description
`tui-term` has released `0.1.9` which has the functionality we require to use it with our `vt100` fork

### Testing Instructions

Verify build and that terminal renders as expected:
<img width="1174" alt="Screenshot 2024-03-29 at 10 24 30 AM" src="https://github.com/vercel/turbo/assets/4131117/86176094-9c53-4f2b-9b49-510831cad794">



Closes TURBO-2734