### PR TITLE
chore(telemetry): track dot env usage

### DIFF
--- a/crates/turborepo-lib/src/engine/mod.rs
+++ b/crates/turborepo-lib/src/engine/mod.rs
@@ -16,6 +16,7 @@ use petgraph::Graph;
 use thiserror::Error;
 use turborepo_errors::Spanned;
 use turborepo_repository::package_graph::{PackageGraph, PackageName};
+use turborepo_telemetry::events::generic::GenericEventBuilder;
 
 use crate::{run::task_id::TaskId, task_graph::TaskDefinition};
 
@@ -175,6 +176,12 @@ impl Engine<Built> {
 
     pub fn task_definitions(&self) -> &HashMap<TaskId<'static>, TaskDefinition> {
         &self.task_definitions
+    }
+
+    pub fn track_usage(&self, telemetry: &GenericEventBuilder) {
+        for task in self.task_definitions.values() {
+            telemetry.track_dot_env(task.dot_env.as_deref());
+        }
     }
 
     pub fn validate(

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -311,6 +311,7 @@ impl RunBuilder {
             &root_package_json,
             is_single_package,
         )?;
+        root_turbo_json.track_usage(&run_telemetry);
 
         pkg_dep_graph.validate()?;
 
@@ -358,6 +359,7 @@ impl RunBuilder {
             pkg_dep_graph.remove_package_dependencies();
             engine = self.build_engine(&pkg_dep_graph, &root_turbo_json, &filtered_pkgs)?;
         }
+        engine.track_usage(&run_telemetry);
 
         let color_selector = ColorSelector::default();
 

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -12,6 +12,7 @@ use tracing::debug;
 use turbopath::{AbsoluteSystemPath, AnchoredSystemPath, RelativeUnixPathBuf};
 use turborepo_errors::Spanned;
 use turborepo_repository::{package_graph::ROOT_PKG_NAME, package_json::PackageJson};
+use turborepo_telemetry::events::generic::GenericEventBuilder;
 
 use crate::{
     cli::OutputLogsMode,
@@ -656,6 +657,11 @@ impl TurboJson {
             .iter()
             .flat_map(|validation| validation(self))
             .collect()
+    }
+
+    pub fn track_usage(&self, telemetry: &GenericEventBuilder) {
+        let global_dot_env = self.global_dot_env.as_deref();
+        telemetry.track_global_dot_env(global_dot_env);
     }
 }
 

--- a/crates/turborepo-telemetry/src/events/generic.rs
+++ b/crates/turborepo-telemetry/src/events/generic.rs
@@ -1,6 +1,7 @@
 use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
+use turbopath::RelativeUnixPathBuf;
 use turborepo_vercel_api::telemetry::{TelemetryEvent, TelemetryGenericEvent};
 use uuid::Uuid;
 
@@ -206,6 +207,30 @@ impl GenericEventBuilder {
                 DaemonInitStatus::Started => "started".to_string(),
                 DaemonInitStatus::Failed => "failed".to_string(),
                 DaemonInitStatus::Disabled => "disabled".to_string(),
+            },
+            is_sensitive: EventType::NonSensitive,
+        });
+        self
+    }
+
+    pub fn track_global_dot_env(&self, global_dot_env: Option<&[RelativeUnixPathBuf]>) -> &Self {
+        self.track(Event {
+            key: "global_dot_env".into(),
+            value: match global_dot_env {
+                Some(dot_env) => dot_env.len().to_string(),
+                None => "null".into(),
+            },
+            is_sensitive: EventType::NonSensitive,
+        });
+        self
+    }
+
+    pub fn track_dot_env(&self, dot_env: Option<&[RelativeUnixPathBuf]>) -> &Self {
+        self.track(Event {
+            key: "dot_env".into(),
+            value: match dot_env {
+                Some(dot_env) => dot_env.len().to_string(),
+                None => "null".into(),
             },
             is_sensitive: EventType::NonSensitive,
         });

--- a/crates/turborepo-telemetry/src/events/generic.rs
+++ b/crates/turborepo-telemetry/src/events/generic.rs
@@ -214,26 +214,24 @@ impl GenericEventBuilder {
     }
 
     pub fn track_global_dot_env(&self, global_dot_env: Option<&[RelativeUnixPathBuf]>) -> &Self {
-        self.track(Event {
-            key: "global_dot_env".into(),
-            value: match global_dot_env {
-                Some(dot_env) => dot_env.len().to_string(),
-                None => "null".into(),
-            },
-            is_sensitive: EventType::NonSensitive,
-        });
+        if let Some(global_dot_env) = global_dot_env {
+            self.track(Event {
+                key: "global_dot_env".into(),
+                value: global_dot_env.len().to_string(),
+                is_sensitive: EventType::NonSensitive,
+            });
+        }
         self
     }
 
     pub fn track_dot_env(&self, dot_env: Option<&[RelativeUnixPathBuf]>) -> &Self {
-        self.track(Event {
-            key: "dot_env".into(),
-            value: match dot_env {
-                Some(dot_env) => dot_env.len().to_string(),
-                None => "null".into(),
-            },
-            is_sensitive: EventType::NonSensitive,
-        });
+        if let Some(dot_env) = dot_env {
+            self.track(Event {
+                key: "dot_env".into(),
+                value: dot_env.len().to_string(),
+                is_sensitive: EventType::NonSensitive,
+            });
+        }
         self
     }
 


### PR DESCRIPTION
### Description

Adds tracking for usage of `globalDotEnv` and `dotEnv` in `turbo.json`

### Testing Instructions

👀 


Closes TURBO-2741