### PR TITLE
fix(telemetry): support bad init

### DIFF
--- a/packages/create-turbo/src/commands/create/index.ts
+++ b/packages/create-turbo/src/commands/create/index.ts
@@ -24,19 +24,19 @@ import type { CreateCommandArgument, CreateCommandOptions } from "./types";
 const { turboGradient, turboLoader, info, error, warn } = logger;
 
 function trackOptions(opts: CreateCommandOptions) {
-  opts.telemetry.trackOptionPackageManager(opts.packageManager);
-  opts.telemetry.trackOptionSkipInstall(opts.skipInstall);
-  opts.telemetry.trackOptionSkipTransforms(opts.skipTransforms);
-  opts.telemetry.trackOptionExample(opts.example);
-  opts.telemetry.trackOptionTurboVersion(opts.turboVersion);
-  opts.telemetry.trackOptionExamplePath(opts.examplePath);
+  opts.telemetry?.trackOptionPackageManager(opts.packageManager);
+  opts.telemetry?.trackOptionSkipInstall(opts.skipInstall);
+  opts.telemetry?.trackOptionSkipTransforms(opts.skipTransforms);
+  opts.telemetry?.trackOptionExample(opts.example);
+  opts.telemetry?.trackOptionTurboVersion(opts.turboVersion);
+  opts.telemetry?.trackOptionExamplePath(opts.examplePath);
 }
 
 function handleErrors(
   err: unknown,
   telemetry: CreateCommandOptions["telemetry"]
 ) {
-  telemetry.trackCommandStatus({ command: "create", status: "error" });
+  telemetry?.trackCommandStatus({ command: "create", status: "error" });
   // handle errors from ../../transforms
   if (err instanceof TransformError) {
     error(chalk.bold(err.transform), chalk.red(err.message));
@@ -73,9 +73,9 @@ export async function create(
   opts: CreateCommandOptions
 ) {
   // track CLI command start
-  opts.telemetry.trackCommandStatus({ command: "create", status: "start" });
-  opts.telemetry.trackArgumentPackageManager(packageManagerCmd);
-  opts.telemetry.trackArgumentDirectory(Boolean(directory));
+  opts.telemetry?.trackCommandStatus({ command: "create", status: "start" });
+  opts.telemetry?.trackArgumentPackageManager(packageManagerCmd);
+  opts.telemetry?.trackArgumentDirectory(Boolean(directory));
   trackOptions(opts);
 
   const {
@@ -290,5 +290,5 @@ export async function create(
     logger.log(chalk.cyan(`  ${packageManagerMeta.executable} turbo login`));
     logger.log();
   }
-  opts.telemetry.trackCommandStatus({ command: "create", status: "end" });
+  opts.telemetry?.trackCommandStatus({ command: "create", status: "end" });
 }

--- a/packages/create-turbo/src/commands/create/types.ts
+++ b/packages/create-turbo/src/commands/create/types.ts
@@ -10,5 +10,5 @@ export interface CreateCommandOptions {
   turboVersion?: string;
   example?: string;
   examplePath?: string;
-  telemetry: CreateTurboTelemetry;
+  telemetry: CreateTurboTelemetry | undefined;
 }

--- a/packages/turbo-telemetry/src/config.test.ts
+++ b/packages/turbo-telemetry/src/config.test.ts
@@ -49,7 +49,7 @@ describe("TelemetryConfig", () => {
       expect(mockDefaultConfigPath).toHaveBeenCalled();
       expect(mockReadFileSync).toHaveBeenCalledWith(mockConfigPath, "utf-8");
       expect(result).toBeInstanceOf(TelemetryConfig);
-      expect(result.id).toEqual("654321");
+      expect(result?.id).toEqual("654321");
     });
   });
 

--- a/packages/turbo-telemetry/src/config.ts
+++ b/packages/turbo-telemetry/src/config.ts
@@ -30,11 +30,15 @@ export class TelemetryConfig {
     this.configPath = configPath;
   }
 
-  static async fromDefaultConfig() {
-    const configPath = await defaultConfigPath();
-    const file = readFileSync(configPath, "utf-8");
-    const config = JSON.parse(file) as Config;
-    return new TelemetryConfig({ configPath, config });
+  static async fromDefaultConfig(): Promise<TelemetryConfig | undefined> {
+    try {
+      const configPath = await defaultConfigPath();
+      const file = readFileSync(configPath, "utf-8");
+      const config = JSON.parse(file) as Config;
+      return new TelemetryConfig({ configPath, config });
+    } catch (e) {
+      return undefined;
+    }
   }
 
   write() {

--- a/packages/turbo-telemetry/src/init.ts
+++ b/packages/turbo-telemetry/src/init.ts
@@ -17,22 +17,28 @@ export async function initTelemetry<T extends keyof TelemetryClientClasses>({
 }: {
   packageInfo: PackageInfo;
   opts?: Args["opts"];
-}): Promise<{ telemetry: InstanceType<TelemetryClientClasses[T]> }> {
+}): Promise<{
+  telemetry: InstanceType<TelemetryClientClasses[T]> | undefined;
+}> {
   // lookup the correct client
   const Client = telemetryClients[packageInfo.name];
 
   // read the config
   const config = await TelemetryConfig.fromDefaultConfig();
-  config.showAlert();
-  // initialize the given client
-  const telemetry = new Client({
-    api: TELEMETRY_API,
-    packageInfo,
-    config,
-    opts,
-  });
+  if (config) {
+    config.showAlert();
+    // initialize the given client
+    const telemetry = new Client({
+      api: TELEMETRY_API,
+      packageInfo,
+      config,
+      opts,
+    });
 
-  return { telemetry } as {
-    telemetry: InstanceType<TelemetryClientClasses[T]>;
-  };
+    return { telemetry } as {
+      telemetry: InstanceType<TelemetryClientClasses[T]>;
+    };
+  }
+
+  return { telemetry: undefined };
 }


### PR DESCRIPTION
### Description

If something goes wrong with telemetry init (bad file, bad perms etc.) we shouldn't error, just proceed without.

Fixes https://github.com/vercel/turbo/issues/7880

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->


Closes TURBO-2744