### PR TITLE
feat: Re-run dependent tasks in watch mode

### DIFF
--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -1346,17 +1346,17 @@ fn warn_all_deprecated_flags(args: &Args) {
         warn_flag_removal("--cpuprofile");
     }
 
-    if let Some(Command::Run(run_args)) = args.command.as_ref() {
-        if run_args.since.is_some() {
+    if let Some(Command::Run { execution_args, .. }) = args.command.as_ref() {
+        if execution_args.since.is_some() {
             warn_flag_removal("--since");
         }
-        if !run_args.scope.is_empty() {
+        if !execution_args.scope.is_empty() {
             warn_flag_removal("--scope");
         }
-        if run_args.include_dependencies {
+        if execution_args.include_dependencies {
             warn_flag_removal("--include-dependencies");
         }
-        if run_args.no_deps {
+        if execution_args.no_deps {
             warn_flag_removal("--no-deps");
         }
     }

--- a/crates/turborepo-lib/src/commands/run.rs
+++ b/crates/turborepo-lib/src/commands/run.rs
@@ -5,7 +5,7 @@ use turborepo_telemetry::events::command::CommandEventBuilder;
 use crate::{commands::CommandBase, run, run::builder::RunBuilder, signal::SignalHandler};
 
 #[cfg(windows)]
-pub async fn get_signal() -> Result<impl Future<Output = Option<()>>, run::Error> {
+pub fn get_signal() -> Result<impl Future<Output = Option<()>>, run::Error> {
     let mut ctrl_c = tokio::signal::windows::ctrl_c().map_err(run::Error::SignalHandler)?;
     Ok(async move { ctrl_c.recv().await })
 }

--- a/crates/turborepo-lib/src/engine/execute.rs
+++ b/crates/turborepo-lib/src/engine/execute.rs
@@ -55,7 +55,7 @@ pub struct StopExecution;
 impl Engine {
     /// Execute a task graph by sending task ids to the visitor
     /// while respecting concurrency limits.
-    /// The visitor is expected to handle any error handling on it's end.
+    /// The visitor is expected to handle any error handling on its end.
     /// We enforce this by only allowing the returning of a sentinel error
     /// type which will stop any further execution of tasks.
     /// This will not stop any task which is currently running, simply it will

--- a/crates/turborepo-lib/src/engine/mod.rs
+++ b/crates/turborepo-lib/src/engine/mod.rs
@@ -135,10 +135,7 @@ impl Engine<Built> {
     /// Creates an instance of `Engine` that only contains tasks that depend on
     /// tasks from a given package. This is useful for watch mode, where we
     /// need to re-run only a portion of the task graph.
-    pub fn create_engine_for_subgraph(
-        &self,
-        changed_package: &PackageName,
-    ) -> Result<Engine<Built>, BuilderError> {
+    pub fn create_engine_for_subgraph(&self, changed_package: &PackageName) -> Engine<Built> {
         let entrypoint_indices: &[petgraph::graph::NodeIndex] = self
             .package_tasks
             .get(changed_package)
@@ -181,7 +178,7 @@ impl Engine<Built> {
             })
             .collect();
 
-        Ok(Engine {
+        Engine {
             marker: std::marker::PhantomData,
             root_index: self.root_index,
             task_graph: new_graph,
@@ -189,7 +186,7 @@ impl Engine<Built> {
             task_definitions: self.task_definitions.clone(),
             task_locations: self.task_locations.clone(),
             package_tasks: self.package_tasks.clone(),
-        })
+        }
     }
 
     pub fn dependencies(&self, task_id: &TaskId) -> Option<HashSet<&TaskNode>> {

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -451,7 +451,7 @@ impl RunBuilder {
         // If we have an initial task, we prune out the engine to only
         // tasks that are reachable from that initial task.
         if let Some(entrypoint_package) = &self.entrypoint_package {
-            engine = engine.create_engine_for_subgraph(entrypoint_package)?;
+            engine = engine.create_engine_for_subgraph(entrypoint_package);
         }
 
         if !self.opts.run_opts.parallel {

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -59,6 +59,11 @@ pub struct RunBuilder {
     experimental_ui: bool,
     api_client: APIClient,
     analytics_sender: Option<AnalyticsSender>,
+    // In watch mode, we can have a changed package that we want to serve as an entrypoint.
+    // We will then prune away any tasks that do not depend on tasks inside
+    // this package.
+    entrypoint_package: Option<PackageName>,
+    should_print_prelude_override: Option<bool>,
 }
 
 impl RunBuilder {
@@ -98,6 +103,7 @@ impl RunBuilder {
             (!cfg!(windows) || experimental_ui),
         );
         let CommandBase { repo_root, ui, .. } = base;
+
         Ok(Self {
             processes,
             opts,
@@ -108,7 +114,19 @@ impl RunBuilder {
             version,
             experimental_ui,
             analytics_sender: None,
+            entrypoint_package: None,
+            should_print_prelude_override: None,
         })
+    }
+
+    pub fn with_entrypoint_package(mut self, entrypoint_package: PackageName) -> Self {
+        self.entrypoint_package = Some(entrypoint_package);
+        self
+    }
+
+    pub fn hide_prelude(mut self) -> Self {
+        self.should_print_prelude_override = Some(false);
+        self
     }
 
     fn connect_process_manager(&self, signal_subscriber: SignalSubscriber) {
@@ -377,6 +395,10 @@ impl RunBuilder {
             self.opts.run_opts.env_mode = EnvMode::Strict;
         }
 
+        let should_print_prelude = self.should_print_prelude_override.unwrap_or_else(|| {
+            self.opts.run_opts.dry_run.is_none() && self.opts.run_opts.graph.is_none()
+        });
+
         Ok(Run {
             version: self.version,
             ui: self.ui,
@@ -397,6 +419,7 @@ impl RunBuilder {
             engine: Arc::new(engine),
             run_cache,
             signal_handler: signal_handler.clone(),
+            should_print_prelude,
         })
     }
 
@@ -406,7 +429,7 @@ impl RunBuilder {
         root_turbo_json: &TurboJson,
         filtered_pkgs: &HashSet<PackageName>,
     ) -> Result<Engine, Error> {
-        let engine = EngineBuilder::new(
+        let mut engine = EngineBuilder::new(
             &self.repo_root,
             pkg_dep_graph,
             self.opts.run_opts.single_package,
@@ -424,6 +447,12 @@ impl RunBuilder {
             Spanned::new(TaskName::from(task.as_str()).into_owned())
         }))
         .build()?;
+
+        // If we have an initial task, we prune out the engine to only
+        // tasks that are reachable from that initial task.
+        if let Some(entrypoint_package) = &self.entrypoint_package {
+            engine = engine.create_engine_for_subgraph(entrypoint_package)?;
+        }
 
         if !self.opts.run_opts.parallel {
             engine

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -60,6 +60,7 @@ pub struct Run {
     signal_handler: SignalHandler,
     engine: Arc<Engine>,
     task_access: TaskAccess,
+    should_print_prelude: bool,
 }
 
 impl Run {
@@ -95,7 +96,7 @@ impl Run {
     }
 
     pub async fn run(&self) -> Result<i32, Error> {
-        if self.opts.run_opts.dry_run.is_none() && self.opts.run_opts.graph.is_none() {
+        if self.should_print_prelude {
             self.print_run_prelude();
         }
         if let Some(subscriber) = self.signal_handler.subscribe() {

--- a/crates/turborepo-lib/src/run/task_id.rs
+++ b/crates/turborepo-lib/src/run/task_id.rs
@@ -43,6 +43,15 @@ impl<'a> From<TaskId<'a>> for String {
     }
 }
 
+impl TaskId<'static> {
+    pub fn from_static(package: String, task: String) -> Self {
+        TaskId {
+            package: package.into(),
+            task: task.into(),
+        }
+    }
+}
+
 impl<'a> TaskId<'a> {
     pub fn new(package: &'a str, task: &'a str) -> Self {
         TaskId::try_from(task).unwrap_or_else(|_| Self {

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -604,6 +604,22 @@ impl TurboJson {
             }
         };
 
+        if repo_root.join_component("Cargo.toml").exists() {
+            turbo_json.pipeline.insert(
+                TaskName::from("build").into_root_task(),
+                Spanned::new(RawTaskDefinition {
+                    cache: Some(Spanned::new(true)),
+                    inputs: Some(vec![
+                        Spanned::new("Cargo.toml".into()),
+                        Spanned::new("Cargo.lock".into()),
+                        Spanned::new("**/*.rs".into()),
+                    ]),
+                    outputs: Some(vec![Spanned::new("target".into())]),
+                    ..RawTaskDefinition::default()
+                }),
+            );
+        }
+
         // TODO: Add location info from package.json
         for script_name in root_package_json.scripts.keys() {
             let task_name = TaskName::from(script_name.as_str());

--- a/turborepo-tests/integration/tests/conflicting-flags.t
+++ b/turborepo-tests/integration/tests/conflicting-flags.t
@@ -1,9 +1,9 @@
 Setup
   $ . ${TESTDIR}/../../helpers/setup_integration_test.sh
   $ ${TURBO} run build --daemon --no-daemon
-   ERROR  the argument '--daemon' cannot be used with '--no-daemon'
+   ERROR  the argument '--[no-]daemon' cannot be used with '--no-daemon'
   
-  Usage: turbo(\.exe)? run --daemon (re)
+  Usage: turbo(\.exe)? run --\[no-\]daemon (re)
   
   For more information, try '--help'.
   

--- a/turborepo-tests/integration/tests/no-args.t
+++ b/turborepo-tests/integration/tests/no-args.t
@@ -19,6 +19,7 @@ Make sure exit code is 2 when no args are passed
     logout      Logout to your Vercel account
     prune       Prepare a subset of your monorepo
     run         Run tasks across projects in your monorepo
+    watch       Arguments used in run and watch
     unlink      Unlink the current directory from your Vercel organization and disable Remote Caching
   
   Options:
@@ -41,16 +42,32 @@ Make sure exit code is 2 when no args are passed
     -h, --help                            Print help
   
   Run Arguments:
-        --cache-dir <CACHE_DIR>
-            Override the filesystem cache directory [env: TURBO_CACHE_DIR=]
         --cache-workers <CACHE_WORKERS>
             Set the number of concurrent cache operations (default 10) [default: 10]
+        --dry-run [<DRY_RUN>]
+            [possible values: text, json]
+        --graph [<GRAPH>]
+            Generate a graph of the task execution and output to a file when a filename is specified (.svg, .png, .jpg, .pdf, .json, .html, .mermaid, .dot). Outputs dot graph to stdout when if no filename is provided
+        --no-cache
+            Avoid saving task results to the cache. Useful for development/watch tasks
+        --[no-]daemon
+            Force turbo to either use or not use the local daemon. If unset turbo will use the default detection logic
+        --profile <PROFILE>
+            File to write turbo's performance profile output into. You can load the file up in chrome://tracing to see which parts of your build were slow
+        --anon-profile <ANON_PROFILE>
+            File to write turbo's performance profile output into. All identifying data omitted from the profile
+        --remote-cache-read-only [<BOOL>]
+            Treat remote cache as read only [env: TURBO_REMOTE_CACHE_READ_ONLY=] [default: false] [possible values: true, false]
+        --summarize [<SUMMARIZE>]
+            Generate a summary of the turbo run [env: TURBO_RUN_SUMMARY=] [possible values: true, false]
+        --parallel
+            Execute all tasks in parallel
+        --cache-dir <CACHE_DIR>
+            Override the filesystem cache directory [env: TURBO_CACHE_DIR=]
         --concurrency <CONCURRENCY>
             Limit the concurrency of task execution. Use 1 for serial (i.e. one-at-a-time) execution
         --continue
             Continue execution even if a task exits with an error or non-zero exit code. The default behavior is to bail
-        --dry-run [<DRY_RUN>]
-            [possible values: text, json]
         --single-package
             Run turbo in single-package mode
         --force [<FORCE>]
@@ -59,8 +76,6 @@ Make sure exit code is 2 when no args are passed
             Specify whether or not to do framework inference for tasks [default: true] [possible values: true, false]
         --global-deps <GLOBAL_DEPS>
             Specify glob of global filesystem dependencies to be hashed. Useful for .env and files
-        --graph [<GRAPH>]
-            Generate a graph of the task execution and output to a file when a filename is specified (.svg, .png, .jpg, .pdf, .json, .html, .mermaid, .dot). Outputs dot graph to stdout when if no filename is provided
         --env-mode [<ENV_MODE>]
             Environment variable mode. Use "loose" to pass the entire existing environment. Use "strict" to use an allowlist specified in turbo.json. Use "infer" to defer to existence of "passThroughEnv" or "globalPassThroughEnv" in turbo.json. (default infer) [default: infer] [possible values: infer, loose, strict]
     -F, --filter <FILTER>
@@ -75,30 +90,14 @@ Make sure exit code is 2 when no args are passed
             DEPRECATED: Include the dependencies of tasks in execution
         --no-deps
             DEPRECATED: Exclude dependent task consumers from execution
-        --no-cache
-            Avoid saving task results to the cache. Useful for development/watch tasks
-        --daemon
-            
-        --no-daemon
-            Force turbo to either use or not use the local daemon. If unset turbo will use the default detection logic
         --output-logs <OUTPUT_LOGS>
             Set type of process output logging. Use "full" to show all output. Use "hash-only" to show only turbo-computed task hashes. Use "new-only" to show only new output with only hashes for cached tasks. Use "none" to hide process output. (default full) [possible values: full, none, hash-only, new-only, errors-only]
         --log-order <LOG_ORDER>
             Set type of task output order. Use "stream" to show output as soon as it is available. Use "grouped" to show output when a command has finished execution. Use "auto" to let turbo decide based on its own heuristics. (default auto) [env: TURBO_LOG_ORDER=] [default: auto] [possible values: auto, stream, grouped]
         --only
             Only executes the tasks specified, does not execute parent tasks
-        --parallel
-            Execute all tasks in parallel
-        --profile <PROFILE>
-            File to write turbo's performance profile output into. You can load the file up in chrome://tracing to see which parts of your build were slow
-        --anon-profile <ANON_PROFILE>
-            File to write turbo's performance profile output into. All identifying data omitted from the profile
         --remote-only [<BOOL>]
             Ignore the local filesystem cache for all tasks. Only allow reading and caching artifacts using the remote cache [env: TURBO_REMOTE_ONLY=] [default: false] [possible values: true, false]
-        --remote-cache-read-only [<BOOL>]
-            Treat remote cache as read only [env: TURBO_REMOTE_CACHE_READ_ONLY=] [default: false] [possible values: true, false]
-        --summarize [<SUMMARIZE>]
-            Generate a summary of the turbo run [env: TURBO_RUN_SUMMARY=] [possible values: true, false]
         --log-prefix <LOG_PREFIX>
             Use "none" to remove prefixes from task logs. Use "task" to get task id prefixing. Use "auto" to let turbo decide how to prefix the logs based on the execution environment. In most cases this will be the same as "task". Note that tasks running in parallel interleave their logs, so removing prefixes can make it difficult to associate logs with tasks. Use --log-order=grouped to prevent interleaving. (default auto) [default: auto] [possible values: auto, none, task]
   [1]

--- a/turborepo-tests/integration/tests/turbo-help.t
+++ b/turborepo-tests/integration/tests/turbo-help.t
@@ -19,6 +19,7 @@ Test help flag
     logout      Logout to your Vercel account
     prune       Prepare a subset of your monorepo
     run         Run tasks across projects in your monorepo
+    watch       Arguments used in run and watch
     unlink      Unlink the current directory from your Vercel organization and disable Remote Caching
   
   Options:
@@ -41,16 +42,32 @@ Test help flag
     -h, --help                            Print help
   
   Run Arguments:
-        --cache-dir <CACHE_DIR>
-            Override the filesystem cache directory [env: TURBO_CACHE_DIR=]
         --cache-workers <CACHE_WORKERS>
             Set the number of concurrent cache operations (default 10) [default: 10]
+        --dry-run [<DRY_RUN>]
+            [possible values: text, json]
+        --graph [<GRAPH>]
+            Generate a graph of the task execution and output to a file when a filename is specified (.svg, .png, .jpg, .pdf, .json, .html, .mermaid, .dot). Outputs dot graph to stdout when if no filename is provided
+        --no-cache
+            Avoid saving task results to the cache. Useful for development/watch tasks
+        --[no-]daemon
+            Force turbo to either use or not use the local daemon. If unset turbo will use the default detection logic
+        --profile <PROFILE>
+            File to write turbo's performance profile output into. You can load the file up in chrome://tracing to see which parts of your build were slow
+        --anon-profile <ANON_PROFILE>
+            File to write turbo's performance profile output into. All identifying data omitted from the profile
+        --remote-cache-read-only [<BOOL>]
+            Treat remote cache as read only [env: TURBO_REMOTE_CACHE_READ_ONLY=] [default: false] [possible values: true, false]
+        --summarize [<SUMMARIZE>]
+            Generate a summary of the turbo run [env: TURBO_RUN_SUMMARY=] [possible values: true, false]
+        --parallel
+            Execute all tasks in parallel
+        --cache-dir <CACHE_DIR>
+            Override the filesystem cache directory [env: TURBO_CACHE_DIR=]
         --concurrency <CONCURRENCY>
             Limit the concurrency of task execution. Use 1 for serial (i.e. one-at-a-time) execution
         --continue
             Continue execution even if a task exits with an error or non-zero exit code. The default behavior is to bail
-        --dry-run [<DRY_RUN>]
-            [possible values: text, json]
         --single-package
             Run turbo in single-package mode
         --force [<FORCE>]
@@ -59,8 +76,6 @@ Test help flag
             Specify whether or not to do framework inference for tasks [default: true] [possible values: true, false]
         --global-deps <GLOBAL_DEPS>
             Specify glob of global filesystem dependencies to be hashed. Useful for .env and files
-        --graph [<GRAPH>]
-            Generate a graph of the task execution and output to a file when a filename is specified (.svg, .png, .jpg, .pdf, .json, .html, .mermaid, .dot). Outputs dot graph to stdout when if no filename is provided
         --env-mode [<ENV_MODE>]
             Environment variable mode. Use "loose" to pass the entire existing environment. Use "strict" to use an allowlist specified in turbo.json. Use "infer" to defer to existence of "passThroughEnv" or "globalPassThroughEnv" in turbo.json. (default infer) [default: infer] [possible values: infer, loose, strict]
     -F, --filter <FILTER>
@@ -75,30 +90,14 @@ Test help flag
             DEPRECATED: Include the dependencies of tasks in execution
         --no-deps
             DEPRECATED: Exclude dependent task consumers from execution
-        --no-cache
-            Avoid saving task results to the cache. Useful for development/watch tasks
-        --daemon
-            
-        --no-daemon
-            Force turbo to either use or not use the local daemon. If unset turbo will use the default detection logic
         --output-logs <OUTPUT_LOGS>
             Set type of process output logging. Use "full" to show all output. Use "hash-only" to show only turbo-computed task hashes. Use "new-only" to show only new output with only hashes for cached tasks. Use "none" to hide process output. (default full) [possible values: full, none, hash-only, new-only, errors-only]
         --log-order <LOG_ORDER>
             Set type of task output order. Use "stream" to show output as soon as it is available. Use "grouped" to show output when a command has finished execution. Use "auto" to let turbo decide based on its own heuristics. (default auto) [env: TURBO_LOG_ORDER=] [default: auto] [possible values: auto, stream, grouped]
         --only
             Only executes the tasks specified, does not execute parent tasks
-        --parallel
-            Execute all tasks in parallel
-        --profile <PROFILE>
-            File to write turbo's performance profile output into. You can load the file up in chrome://tracing to see which parts of your build were slow
-        --anon-profile <ANON_PROFILE>
-            File to write turbo's performance profile output into. All identifying data omitted from the profile
         --remote-only [<BOOL>]
             Ignore the local filesystem cache for all tasks. Only allow reading and caching artifacts using the remote cache [env: TURBO_REMOTE_ONLY=] [default: false] [possible values: true, false]
-        --remote-cache-read-only [<BOOL>]
-            Treat remote cache as read only [env: TURBO_REMOTE_CACHE_READ_ONLY=] [default: false] [possible values: true, false]
-        --summarize [<SUMMARIZE>]
-            Generate a summary of the turbo run [env: TURBO_RUN_SUMMARY=] [possible values: true, false]
         --log-prefix <LOG_PREFIX>
             Use "none" to remove prefixes from task logs. Use "task" to get task id prefixing. Use "auto" to let turbo decide how to prefix the logs based on the execution environment. In most cases this will be the same as "task". Note that tasks running in parallel interleave their logs, so removing prefixes can make it difficult to associate logs with tasks. Use --log-order=grouped to prevent interleaving. (default auto) [default: auto] [possible values: auto, none, task]
 
@@ -124,6 +123,7 @@ Test help flag
     logout      Logout to your Vercel account
     prune       Prepare a subset of your monorepo
     run         Run tasks across projects in your monorepo
+    watch       Arguments used in run and watch
     unlink      Unlink the current directory from your Vercel organization and disable Remote Caching
   
   Options:
@@ -146,16 +146,32 @@ Test help flag
     -h, --help                            Print help
   
   Run Arguments:
-        --cache-dir <CACHE_DIR>
-            Override the filesystem cache directory [env: TURBO_CACHE_DIR=]
         --cache-workers <CACHE_WORKERS>
             Set the number of concurrent cache operations (default 10) [default: 10]
+        --dry-run [<DRY_RUN>]
+            [possible values: text, json]
+        --graph [<GRAPH>]
+            Generate a graph of the task execution and output to a file when a filename is specified (.svg, .png, .jpg, .pdf, .json, .html, .mermaid, .dot). Outputs dot graph to stdout when if no filename is provided
+        --no-cache
+            Avoid saving task results to the cache. Useful for development/watch tasks
+        --[no-]daemon
+            Force turbo to either use or not use the local daemon. If unset turbo will use the default detection logic
+        --profile <PROFILE>
+            File to write turbo's performance profile output into. You can load the file up in chrome://tracing to see which parts of your build were slow
+        --anon-profile <ANON_PROFILE>
+            File to write turbo's performance profile output into. All identifying data omitted from the profile
+        --remote-cache-read-only [<BOOL>]
+            Treat remote cache as read only [env: TURBO_REMOTE_CACHE_READ_ONLY=] [default: false] [possible values: true, false]
+        --summarize [<SUMMARIZE>]
+            Generate a summary of the turbo run [env: TURBO_RUN_SUMMARY=] [possible values: true, false]
+        --parallel
+            Execute all tasks in parallel
+        --cache-dir <CACHE_DIR>
+            Override the filesystem cache directory [env: TURBO_CACHE_DIR=]
         --concurrency <CONCURRENCY>
             Limit the concurrency of task execution. Use 1 for serial (i.e. one-at-a-time) execution
         --continue
             Continue execution even if a task exits with an error or non-zero exit code. The default behavior is to bail
-        --dry-run [<DRY_RUN>]
-            [possible values: text, json]
         --single-package
             Run turbo in single-package mode
         --force [<FORCE>]
@@ -164,8 +180,6 @@ Test help flag
             Specify whether or not to do framework inference for tasks [default: true] [possible values: true, false]
         --global-deps <GLOBAL_DEPS>
             Specify glob of global filesystem dependencies to be hashed. Useful for .env and files
-        --graph [<GRAPH>]
-            Generate a graph of the task execution and output to a file when a filename is specified (.svg, .png, .jpg, .pdf, .json, .html, .mermaid, .dot). Outputs dot graph to stdout when if no filename is provided
         --env-mode [<ENV_MODE>]
             Environment variable mode. Use "loose" to pass the entire existing environment. Use "strict" to use an allowlist specified in turbo.json. Use "infer" to defer to existence of "passThroughEnv" or "globalPassThroughEnv" in turbo.json. (default infer) [default: infer] [possible values: infer, loose, strict]
     -F, --filter <FILTER>
@@ -180,30 +194,14 @@ Test help flag
             DEPRECATED: Include the dependencies of tasks in execution
         --no-deps
             DEPRECATED: Exclude dependent task consumers from execution
-        --no-cache
-            Avoid saving task results to the cache. Useful for development/watch tasks
-        --daemon
-            
-        --no-daemon
-            Force turbo to either use or not use the local daemon. If unset turbo will use the default detection logic
         --output-logs <OUTPUT_LOGS>
             Set type of process output logging. Use "full" to show all output. Use "hash-only" to show only turbo-computed task hashes. Use "new-only" to show only new output with only hashes for cached tasks. Use "none" to hide process output. (default full) [possible values: full, none, hash-only, new-only, errors-only]
         --log-order <LOG_ORDER>
             Set type of task output order. Use "stream" to show output as soon as it is available. Use "grouped" to show output when a command has finished execution. Use "auto" to let turbo decide based on its own heuristics. (default auto) [env: TURBO_LOG_ORDER=] [default: auto] [possible values: auto, stream, grouped]
         --only
             Only executes the tasks specified, does not execute parent tasks
-        --parallel
-            Execute all tasks in parallel
-        --profile <PROFILE>
-            File to write turbo's performance profile output into. You can load the file up in chrome://tracing to see which parts of your build were slow
-        --anon-profile <ANON_PROFILE>
-            File to write turbo's performance profile output into. All identifying data omitted from the profile
         --remote-only [<BOOL>]
             Ignore the local filesystem cache for all tasks. Only allow reading and caching artifacts using the remote cache [env: TURBO_REMOTE_ONLY=] [default: false] [possible values: true, false]
-        --remote-cache-read-only [<BOOL>]
-            Treat remote cache as read only [env: TURBO_REMOTE_CACHE_READ_ONLY=] [default: false] [possible values: true, false]
-        --summarize [<SUMMARIZE>]
-            Generate a summary of the turbo run [env: TURBO_RUN_SUMMARY=] [possible values: true, false]
         --log-prefix <LOG_PREFIX>
             Use "none" to remove prefixes from task logs. Use "task" to get task id prefixing. Use "auto" to let turbo decide how to prefix the logs based on the execution environment. In most cases this will be the same as "task". Note that tasks running in parallel interleave their logs, so removing prefixes can make it difficult to associate logs with tasks. Use --log-order=grouped to prevent interleaving. (default auto) [default: auto] [possible values: auto, none, task]
 


### PR DESCRIPTION
### Description

Instead of using `--filter` in our re-running of tasks for watch mode, we instead prune the task graph to run the changed task and its dependent tasks. This has the benefit of following the task graph and not the package graph.

### Testing Instructions

You can verify this works by creating a task dependency relation that is not in the package graph. So, make a `ui#test` task that depends on a `docs#test` task, but don't have `ui` depend on `docs`. Then verify that when the `docs` are changed, we re-run the `ui#test` task too.


Closes TURBO-2752