### PR TITLE
fix(Turborepo): Disable the new corepack notification

### DIFF
--- a/turborepo-tests/integration/package.json
+++ b/turborepo-tests/integration/package.json
@@ -1,8 +1,8 @@
 {
   "name": "turborepo-tests-integration",
   "scripts": {
-    "test": "cross-env ./node_modules/.bin/prysk tests",
-    "test:interactive": "cross-env PRYSK_INTERACTIVE=true ./node_modules/.bin/prysk tests",
+    "test": "cross-env COREPACK_ENABLE_DOWNLOAD_PROMPT=0 ./node_modules/.bin/prysk tests",
+    "test:interactive": "cross-env COREPACK_ENABLE_DOWNLOAD_PROMPT=0 PRYSK_INTERACTIVE=true ./node_modules/.bin/prysk tests",
     "test:parallel": ".cram_env/bin/pytest -n auto tests --prysk-shell=`which bash`",
     "pretest:parallel": ".cram_env/bin/pip3 install --quiet pytest \"prysk[pytest-plugin]\" pytest-xdist"
   },


### PR DESCRIPTION
### Description

 - sets `COREPACK_ENABLE_DOWNLOAD_PROMPT=0` for the integration tests

Newer versions of `corepack` have extra text output when downloading a version, but the environment variable can disable it 

### Testing Instructions

Observe GH Actions integration tests passing.

Closes TURBO-2753