### PR TITLE
feat(Turborepo): support inputs for file hash watching

### DIFF
--- a/crates/turborepo-filewatch/src/globwatcher.rs
+++ b/crates/turborepo-filewatch/src/globwatcher.rs
@@ -33,6 +33,10 @@ impl GlobSet {
         inputs.extend(self.exclude_raw.iter().cloned());
         inputs
     }
+
+    pub fn matches(&self, input: &RelativeUnixPath) -> bool {
+        self.include.values().any(|glob| glob.is_match(input)) && !self.exclude.is_match(input)
+    }
 }
 
 impl std::fmt::Debug for GlobSet {
@@ -132,6 +136,16 @@ impl GlobSet {
             (includes, excludes)
         };
         Self::from_raw(includes, excludes)
+    }
+
+    pub fn is_package_local(&self) -> bool {
+        self.include
+            .keys()
+            .all(|raw_glob| !raw_glob.starts_with("../"))
+            && self
+                .exclude_raw
+                .iter()
+                .all(|raw_glob| !raw_glob.starts_with("../"))
     }
 }
 

--- a/crates/turborepo-paths/src/anchored_system_path.rs
+++ b/crates/turborepo-paths/src/anchored_system_path.rs
@@ -152,6 +152,15 @@ impl AnchoredSystemPath {
             }
         }
     }
+
+    // Note that this defers to Path::strip_prefix, which operates on components,
+    // and therefore enforces boundaries at path dividers.
+    pub fn strip_prefix(&self, other: &Self) -> Option<AnchoredSystemPathBuf> {
+        self.0
+            .strip_prefix(&other.0)
+            .ok()
+            .map(|path| AnchoredSystemPathBuf(path.to_owned()))
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
### Description

 - adds support for `inputs` that are contained within a package to daemon file hashing. `inputs` are tracked after the first request for them.

### Testing Instructions

Added tests that use `inputs`.

Closes TURBO-2762