### PR TITLE
Inform user about `turbo prune` command

### DIFF
--- a/docs/pages/repo/docs/handbook/deploying-with-docker.mdx
+++ b/docs/pages/repo/docs/handbook/deploying-with-docker.mdx
@@ -127,7 +127,9 @@ RUN apk update
 WORKDIR /app
 RUN yarn global add turbo
 COPY . .
-RUN turbo prune web --docker
+
+# Generate a partial monorepo with a pruned lockfile for a target workspace.
+RUN turbo prune web --docker # Assuming "web" is the name entered in the project's package.json: { name: "web" }
 
 # Add lockfile and package.json's of isolated subworkspace
 FROM base AS installer


### PR DESCRIPTION
### Description

The command `turbo prune web --docker` produces an error if the name in the package.json is not set to web, for example:

```
{
   name: "next-app",
   private: true,
   ...
}
```

It will then throw the error: `package web not found`. This change informs the user that it is being assumed that the name given in the package.json is "web".

![image](https://github.com/vercel/turbo/assets/98240335/6f02ca1f-3697-46ab-ac8e-18f7397b6a50)


### Testing Instructions

1. Create a nextjs project with a name other than `web`, `next-app` for example.
2. Copy the Dockerfile for the nextjs app [found here](https://turbo.build/repo/docs/handbook/deploying-with-docker) in the deploying with docker handbook
3. Run the command `docker-compose up`
4. Expected an Error stating `package web not found`
5. Change the line `RUN turbo prune web --docker` to `RUN turbo prune next-app`
6. Run the command `docker-compose up`
7. It should run successfully
