### PR TITLE
docs(storybook): update documentation to the latest versions available for pnpm installation

### DIFF
--- a/docs/pages/repo/docs/handbook/tools/storybook.mdx
+++ b/docs/pages/repo/docs/handbook/tools/storybook.mdx
@@ -78,7 +78,7 @@ Next, we need to scaffold Storybook:
 
       ```shell
       cd workshop
-      pnpm dlx sb init --skip-install
+      pnpm dlx sb init
       pnpm install --save-dev @storybook/cli   # Manually install deps and CLI
       ```
 
@@ -157,7 +157,7 @@ And `yarn install` to make sure that your `ui` package is installed in the `work
   // ...
   {
     "dependencies": {
-      "ui": "workspace:*",
+      "@repo/ui": "workspace:*",
       // ...
     }
   }
@@ -170,7 +170,7 @@ And `pnpm install` one more time to make sure that your `ui` package is installe
 3. Replace the `Button` import in the `Button.stories.tsx` so that it comes from your `ui` package:
 
 ```jsx filename="apps/workshop/src/stories/Button.stories.tsx"
-import { Button } from 'ui'
+import { Button } from '@repo/ui/button'
 ```
 
 ### 4. Align tasks


### PR DESCRIPTION
### For pnpm installation

### Description

Starting a project with TurboRepo, Storybook 8+, and Next.js 14 with App Router, I encountered issues using the current guides, which prevented an effective installation. This fork aims to update the documentation to address these issues, providing clear, updated steps for a successful installation of these technologies. Evidence of initial challenges and positive outcomes following the suggested documentation adjustments are included, making the process smoother for future users.

I hope the suggested changes prove useful to the community. I'd like to thank the Vercel development team for providing us with powerful and innovative tools, facilitating the advancement of our projects with cutting-edge technology.

### Testing Instructions

In the project development process, the first issue emerged when using **pnpm dlx sb init --skip-install**, leading to complications. To tackle a second issue regarding dependencies, **"ui": "workspace:*"** was replaced with **"@repo/ui": "workspace:*"**, modifying the declaration approach. For the third issue, importing components was adjusted from **import { Button } from 'ui'** **to import { Button } from '@repo/ui/button'**, solving import problems. These suggested changes showcased an improvement in the final results.

### Using pnpm dlx sb init --skip-install led to the first issue.

<img width="1174" alt="SCR-20240413-plba" src="https://github.com/vercel/turbo/assets/7276016/929d12cb-8096-4ae0-a0d4-23a30575060a">

### Replacing "ui": "workspace:*" with "@repo/ui": "workspace:*" addressed a dependency problem.

**before**

<img width="845" alt="SCR-20240413-posk" src="https://github.com/vercel/turbo/assets/7276016/4122fa02-2835-46cd-99a2-6794d3302999">

**after**

<img width="835" alt="SCR-20240413-ppbd" src="https://github.com/vercel/turbo/assets/7276016/5b909b17-08ba-4d51-92e0-f33ef9454154">

### Changing imports from import { Button } from 'ui' to import { Button } from '@repo/ui/button' fixed import issues.

**before**

<img width="613" alt="SCR-20240413-ppiz" src="https://github.com/vercel/turbo/assets/7276016/348c0540-bc37-4493-869f-e6dc30067069">

**after**

<img width="572" alt="SCR-20240413-pppz" src="https://github.com/vercel/turbo/assets/7276016/9087dfc1-c5c2-4141-ba15-7befd3cb914c">

### Final Outcome: The implementation of these changes led to a successful setup and integration.

<img width="1122" alt="SCR-20240413-psgm" src="https://github.com/vercel/turbo/assets/7276016/fb0f6dee-20e5-4514-abdd-0a88fd88fa0b">