### PR TITLE
Fix(commands/prune.rs): Add More detail in MissingWorkspace error

### DIFF
--- a/crates/turborepo-lib/src/commands/prune.rs
+++ b/crates/turborepo-lib/src/commands/prune.rs
@@ -43,7 +43,7 @@ pub enum Error {
     WorkspaceAtFilesystemRoot,
     #[error("at least one target must be specified")]
     NoWorkspaceSpecified,
-    #[error("invalid scope: package {0} not found")]
+    #[error("invalid scope: package with name {0} in package.json not found")]
     MissingWorkspace(PackageName),
     #[error("Cannot prune without parsed lockfile")]
     MissingLockfile,


### PR DESCRIPTION
### Description

Related to https://github.com/vercel/turbo/pull/7948, in running the `turbo prune` when specifying a package name, it is assumed that the package name is the name of the **folder** in `apps/web` or `packages/eslint-config`. The real case is that the package name is the name found in the `package.json` file in the `apps/*` directory.


![](https://private-user-images.githubusercontent.com/98240335/321965428-6f02ca1f-3697-46ab-ac8e-18f7397b6a50.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MTMxNzI3NTEsIm5iZiI6MTcxMzE3MjQ1MSwicGF0aCI6Ii85ODI0MDMzNS8zMjE5NjU0MjgtNmYwMmNhMWYtMzY5Ny00NmFiLWFjOGUtMThmNzM5N2I2YTUwLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDA0MTUlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQwNDE1VDA5MTQxMVomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWZiNDNjMTVhNTYwODQ5YjEwMzlkYjhiMTI5MTBiY2FhMmNmMWJmNGVkZjAyZTZhOTdmNjQyODgwZGY0NWM4Y2YmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JmFjdG9yX2lkPTAma2V5X2lkPTAmcmVwb19pZD0wIn0.LnyiaG_okxX13DaQhxCMCY8PMQOh1TbCGL0TqVbXVDo)

This pull requests adds more detail and clarity towards the uncertainty of defining what the package means.

**Files Edited**
Line 46 of https://github.com/vercel/turbo/blob/main/crates/turborepo-lib/src/commands/prune.rs
```rs
    #[error("invalid scope: package {0} not found")]
    MissingWorkspace(PackageName),
```
to
```rs
    #[error("invalid scope: package with name {0} in package.json not found")]
    MissingWorkspace(PackageName),
```
