### PR TITLE
feat(turborepo): new ui + watch mode

### DIFF
--- a/crates/turborepo-lib/src/commands/run.rs
+++ b/crates/turborepo-lib/src/commands/run.rs
@@ -1,5 +1,6 @@
 use std::future::Future;
 
+use tracing::error;
 use turborepo_telemetry::events::command::CommandEventBuilder;
 
 use crate::{commands::CommandBase, run, run::builder::RunBuilder, signal::SignalHandler};
@@ -42,10 +43,23 @@ pub async fn run(base: CommandBase, telemetry: CommandEventBuilder) -> Result<i3
             .with_analytics_sender(analytics_sender)
             .build(&handler, telemetry)
             .await?;
-        let result = run.run().await;
+
+        let (sender, handle) = run
+            .has_experimental_ui()
+            .then(|| run.start_experimental_ui())
+            .unzip();
+
+        let result = run.run(sender.clone()).await;
 
         if let Some(analytics_handle) = analytics_handle {
             analytics_handle.close_with_timeout().await;
+        }
+
+        if let (Some(handle), Some(sender)) = (handle, sender) {
+            sender.stop();
+            if let Err(e) = handle.await.expect("render thread panicked") {
+                error!("error encountered rendering tui: {e}");
+            }
         }
 
         result

--- a/crates/turborepo-lib/src/commands/run.rs
+++ b/crates/turborepo-lib/src/commands/run.rs
@@ -44,10 +44,7 @@ pub async fn run(base: CommandBase, telemetry: CommandEventBuilder) -> Result<i3
             .build(&handler, telemetry)
             .await?;
 
-        let (sender, handle) = run
-            .has_experimental_ui()
-            .then(|| run.start_experimental_ui())
-            .unzip();
+        let (sender, handle) = run.start_experimental_ui().unzip();
 
         let result = run.run(sender.clone()).await;
 

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -17,6 +17,7 @@ use std::{collections::HashSet, io::Write, sync::Arc};
 pub use cache::{CacheOutput, ConfigCache, Error as CacheError, RunCache, TaskCache};
 use chrono::{DateTime, Local};
 use rayon::iter::ParallelBridge;
+use tokio::task::JoinHandle;
 use tracing::debug;
 use turbopath::AbsoluteSystemPathBuf;
 use turborepo_api_client::{APIAuth, APIClient};
@@ -25,7 +26,7 @@ use turborepo_env::EnvironmentVariableMap;
 use turborepo_repository::package_graph::{PackageGraph, PackageName};
 use turborepo_scm::SCM;
 use turborepo_telemetry::events::generic::GenericEventBuilder;
-use turborepo_ui::{cprint, cprintln, BOLD_GREY, GREY, UI};
+use turborepo_ui::{cprint, cprintln, tui, tui::AppSender, BOLD_GREY, GREY, UI};
 
 pub use crate::run::error::Error;
 use crate::{
@@ -45,7 +46,6 @@ use crate::{
 pub struct Run {
     version: &'static str,
     ui: UI,
-    experimental_ui: bool,
     start_at: DateTime<Local>,
     processes: ProcessManager,
     run_telemetry: GenericEventBuilder,
@@ -64,6 +64,7 @@ pub struct Run {
     task_access: TaskAccess,
     daemon: Option<DaemonClient<DaemonConnector>>,
     should_print_prelude: bool,
+    experimental_ui: bool,
 }
 
 impl Run {
@@ -117,7 +118,19 @@ impl Run {
         new_run
     }
 
-    pub async fn run(&mut self) -> Result<i32, Error> {
+    pub fn has_experimental_ui(&self) -> bool {
+        self.experimental_ui
+    }
+
+    pub fn start_experimental_ui(&self) -> (AppSender, JoinHandle<Result<(), tui::Error>>) {
+        let task_names = self.engine.tasks_with_command(&self.pkg_dep_graph);
+        let (sender, receiver) = AppSender::new();
+        let handle = tokio::task::spawn_blocking(move || tui::run_app(task_names, receiver));
+
+        (sender, handle)
+    }
+
+    pub async fn run(&mut self, experimental_ui_sender: Option<AppSender>) -> Result<i32, Error> {
         if self.should_print_prelude {
             self.print_run_prelude();
         }
@@ -240,7 +253,7 @@ impl Run {
             self.processes.clone(),
             &self.repo_root,
             global_env,
-            self.experimental_ui,
+            experimental_ui_sender,
         );
 
         if self.opts.run_opts.dry_run.is_some() {
@@ -279,6 +292,7 @@ impl Run {
                 &self.engine,
                 &self.env_at_execution_start,
                 self.opts.scope_opts.pkg_inference_root.as_deref(),
+                self.experimental_ui,
             )
             .await?;
 

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -122,12 +122,16 @@ impl Run {
         self.experimental_ui
     }
 
-    pub fn start_experimental_ui(&self) -> (AppSender, JoinHandle<Result<(), tui::Error>>) {
+    pub fn start_experimental_ui(&self) -> Option<(AppSender, JoinHandle<Result<(), tui::Error>>)> {
+        if !self.experimental_ui {
+            return None;
+        }
+
         let task_names = self.engine.tasks_with_command(&self.pkg_dep_graph);
         let (sender, receiver) = AppSender::new();
         let handle = tokio::task::spawn_blocking(move || tui::run_app(task_names, receiver));
 
-        (sender, handle)
+        Some((sender, handle))
     }
 
     pub async fn run(&mut self, experimental_ui_sender: Option<AppSender>) -> Result<i32, Error> {

--- a/crates/turborepo-lib/src/run/watch.rs
+++ b/crates/turborepo-lib/src/run/watch.rs
@@ -92,7 +92,7 @@ pub enum Error {
     #[error("package change error")]
     PackageChange(#[from] tonic::Status),
     #[error("could not connect to UI thread")]
-    UISendError(String),
+    UISend(String),
 }
 
 impl WatchClient {
@@ -301,7 +301,7 @@ impl WatchClient {
                     let task_names = self.run.engine.tasks_with_command(&self.run.pkg_dep_graph);
                     sender
                         .update_tasks(task_names)
-                        .map_err(|err| Error::UISendError(err.to_string()))?;
+                        .map_err(|err| Error::UISend(err.to_string()))?;
                 }
 
                 if self.run.has_persistent_tasks() {

--- a/crates/turborepo-lib/src/task_graph/visitor.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor.rs
@@ -24,7 +24,7 @@ use turborepo_telemetry::events::{
     generic::GenericEventBuilder, task::PackageTaskEventBuilder, EventBuilder, TrackedErrors,
 };
 use turborepo_ui::{
-    tui::{self, TuiTask},
+    tui::{self, AppSender, TuiTask},
     ColorSelector, OutputClient, OutputSink, OutputWriter, PrefixedUI, UI,
 };
 use which::which;
@@ -63,7 +63,7 @@ pub struct Visitor<'a> {
     sink: OutputSink<StdWriter>,
     task_hasher: TaskHasher<'a>,
     ui: UI,
-    experimental_ui: bool,
+    experimental_ui_sender: Option<AppSender>,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -108,7 +108,7 @@ impl<'a> Visitor<'a> {
         manager: ProcessManager,
         repo_root: &'a AbsoluteSystemPath,
         global_env: EnvironmentVariableMap,
-        experimental_ui: bool,
+        experimental_ui_sender: Option<AppSender>,
     ) -> Self {
         let task_hasher = TaskHasher::new(
             package_inputs_hashes,
@@ -135,7 +135,7 @@ impl<'a> Visitor<'a> {
             task_hasher,
             ui,
             global_env,
-            experimental_ui,
+            experimental_ui_sender,
         }
     }
 
@@ -147,16 +147,6 @@ impl<'a> Visitor<'a> {
     ) -> Result<Vec<TaskError>, Error> {
         let concurrency = self.run_opts.concurrency as usize;
         let (node_sender, mut node_stream) = mpsc::channel(concurrency);
-
-        let (ui, render_thread_handle) = if self.experimental_ui {
-            let task_names = engine.tasks_with_command(&self.package_graph);
-
-            let (handle, receiver) = tui::AppSender::new();
-            let app = tokio::task::spawn_blocking(move || tui::run_app(task_names, receiver));
-            (Some(handle), Some(app))
-        } else {
-            (None, None)
-        };
 
         let engine_handle = {
             let engine = engine.clone();
@@ -285,7 +275,7 @@ impl<'a> Visitor<'a> {
                     let vendor_behavior =
                         Vendor::infer().and_then(|vendor| vendor.behavior.as_ref());
 
-                    let output_client = if let Some(handle) = &ui {
+                    let output_client = if let Some(handle) = &self.experimental_ui_sender {
                         TaskOutput::UI(handle.task(info.to_string()))
                     } else {
                         TaskOutput::Direct(self.output_client(&info, vendor_behavior))
@@ -321,16 +311,6 @@ impl<'a> Visitor<'a> {
             }
         }
         drop(factory);
-        if let Some(handle) = ui {
-            handle.stop();
-            if let Err(e) = render_thread_handle
-                .unwrap()
-                .await
-                .expect("render thread panicked")
-            {
-                error!("error encountered rendering tui: {e}");
-            }
-        }
 
         if !internal_errors.is_empty() {
             return Err(Error::InternalErrors(
@@ -366,6 +346,7 @@ impl<'a> Visitor<'a> {
         engine: &Engine,
         env_at_execution_start: &EnvironmentVariableMap,
         pkg_inference_root: Option<&AnchoredSystemPath>,
+        has_experimental_ui: bool,
     ) -> Result<(), Error> {
         let Self {
             package_graph,
@@ -394,6 +375,7 @@ impl<'a> Visitor<'a> {
                 engine,
                 task_hasher.task_hash_tracker(),
                 env_at_execution_start,
+                has_experimental_ui,
             )
             .await?)
     }
@@ -495,7 +477,7 @@ impl<'a> Visitor<'a> {
     pub fn dry_run(&mut self) {
         self.dry = true;
         // No need to start a TUI on dry run
-        self.experimental_ui = false;
+        self.experimental_ui_sender = None;
     }
 }
 
@@ -665,7 +647,7 @@ impl<'a> ExecContextFactory<'a> {
         ExecContext {
             engine: self.engine.clone(),
             ui: self.visitor.ui,
-            experimental_ui: self.visitor.experimental_ui,
+            experimental_ui: self.visitor.experimental_ui_sender.is_some(),
             is_github_actions: self.visitor.run_opts.is_github_actions,
             pretty_prefix: self
                 .visitor

--- a/crates/turborepo-lib/src/task_graph/visitor.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor.rs
@@ -331,6 +331,8 @@ impl<'a> Visitor<'a> {
 
     /// Finishes visiting the tasks, creates the run summary, and either
     /// prints, saves, or sends it to spaces.
+
+    #[allow(clippy::too_many_arguments)]
     #[tracing::instrument(skip(
         self,
         packages,

--- a/crates/turborepo-ui/src/tui/app.rs
+++ b/crates/turborepo-ui/src/tui/app.rs
@@ -80,6 +80,7 @@ impl<I> App<I> {
 
     pub fn update_tasks(&mut self, tasks: Vec<String>) {
         self.table = TaskTable::new(tasks.clone());
+        self.next();
     }
 }
 

--- a/crates/turborepo-ui/src/tui/app.rs
+++ b/crates/turborepo-ui/src/tui/app.rs
@@ -126,7 +126,6 @@ fn run_app_inner<B: Backend + std::io::Write>(
     // Render initial state to paint the screen
     terminal.draw(|f| view(app, f))?;
     let mut last_render = Instant::now();
-
     while let Some(event) = poll(app.interact, &receiver, last_render + FRAMERATE) {
         update(app, event)?;
         if app.done {

--- a/crates/turborepo-ui/src/tui/app.rs
+++ b/crates/turborepo-ui/src/tui/app.rs
@@ -77,6 +77,10 @@ impl<I> App<I> {
     pub fn term_size(&self) -> (u16, u16) {
         self.pane.term_size()
     }
+
+    pub fn update_tasks(&mut self, tasks: Vec<String>) {
+        self.table = TaskTable::new(tasks.clone());
+    }
 }
 
 impl<I: std::io::Write> App<I> {
@@ -237,6 +241,10 @@ fn update(
         }
         Event::SetStdin { task, stdin } => {
             app.pane.insert_stdin(&task, Some(stdin))?;
+        }
+        Event::UpdateTasks { tasks } => {
+            app.update_tasks(tasks);
+            app.table.tick();
         }
     }
     Ok(None)

--- a/crates/turborepo-ui/src/tui/event.rs
+++ b/crates/turborepo-ui/src/tui/event.rs
@@ -29,6 +29,9 @@ pub enum Event {
     Input {
         bytes: Vec<u8>,
     },
+    UpdateTasks {
+        tasks: Vec<String>,
+    },
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]

--- a/crates/turborepo-ui/src/tui/handle.rs
+++ b/crates/turborepo-ui/src/tui/handle.rs
@@ -56,6 +56,11 @@ impl AppSender {
         // it'll be a no-op.
         self.primary.send(Event::Stop).ok();
     }
+
+    /// Update the list of tasks displayed in the TUI
+    pub fn update_tasks(&self, tasks: Vec<String>) -> Result<(), mpsc::SendError<Event>> {
+        self.primary.send(Event::UpdateTasks { tasks })
+    }
 }
 
 impl AppReceiver {

--- a/crates/turborepo-ui/src/tui/handle.rs
+++ b/crates/turborepo-ui/src/tui/handle.rs
@@ -70,10 +70,7 @@ impl AppReceiver {
         match self.primary.recv_deadline(deadline) {
             Ok(event) => Ok(event),
             Err(mpsc::RecvTimeoutError::Timeout) => Ok(Event::Tick),
-            Err(mpsc::RecvTimeoutError::Disconnected) => {
-                error!("disconnected!");
-                Err(mpsc::RecvError)
-            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => Err(mpsc::RecvError),
         }
     }
 }

--- a/crates/turborepo-ui/src/tui/handle.rs
+++ b/crates/turborepo-ui/src/tui/handle.rs
@@ -71,7 +71,7 @@ impl AppReceiver {
             Ok(event) => Ok(event),
             Err(mpsc::RecvTimeoutError::Timeout) => Ok(Event::Tick),
             Err(mpsc::RecvTimeoutError::Disconnected) => {
-                println!("disconnected!!");
+                error!("disconnected!");
                 Err(mpsc::RecvError)
             }
         }

--- a/crates/turborepo-ui/src/tui/handle.rs
+++ b/crates/turborepo-ui/src/tui/handle.rs
@@ -65,7 +65,10 @@ impl AppReceiver {
         match self.primary.recv_deadline(deadline) {
             Ok(event) => Ok(event),
             Err(mpsc::RecvTimeoutError::Timeout) => Ok(Event::Tick),
-            Err(mpsc::RecvTimeoutError::Disconnected) => Err(mpsc::RecvError),
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                println!("disconnected!!");
+                Err(mpsc::RecvError)
+            }
         }
     }
 }

--- a/crates/turborepo-ui/src/tui/input.rs
+++ b/crates/turborepo-ui/src/tui/input.rs
@@ -23,7 +23,7 @@ pub fn input(interact: bool) -> Result<Option<Event>, Error> {
     }
 }
 
-/// Converts a crostterm key event into a TUI interaction event
+/// Converts a crossterm key event into a TUI interaction event
 fn translate_key_event(interact: bool, key_event: KeyEvent) -> Option<Event> {
     // On Windows events for releasing a key are produced
     // We skip these to avoid emitting 2 events per key press.

--- a/crates/turborepo-ui/src/tui/table.rs
+++ b/crates/turborepo-ui/src/tui/table.rs
@@ -100,7 +100,7 @@ impl TaskTable {
             let finished = self.finished.remove(finished_idx);
             let old_row_idx = finished_idx;
             let new_row_idx = self.finished.len() + self.running.len();
-            let running = finished.start();
+            let running = Task::new(finished.name().to_string()).start();
             self.running.push(running);
 
             if let Some(selected_idx) = self.scroll.selected() {

--- a/crates/turborepo-ui/src/tui/task.rs
+++ b/crates/turborepo-ui/src/tui/task.rs
@@ -70,8 +70,16 @@ impl Task<Running> {
 }
 
 impl Task<Finished> {
-    pub fn start(&self) -> Instant {
+    pub fn start_time(&self) -> Instant {
         self.state.start
+    }
+    pub fn start(self) -> Task<Running> {
+        Task {
+            name: self.name,
+            state: Running {
+                start: Instant::now(),
+            },
+        }
     }
 
     pub fn end(&self) -> Instant {

--- a/crates/turborepo-ui/src/tui/task.rs
+++ b/crates/turborepo-ui/src/tui/task.rs
@@ -70,16 +70,8 @@ impl Task<Running> {
 }
 
 impl Task<Finished> {
-    pub fn start_time(&self) -> Instant {
+    pub fn start(&self) -> Instant {
         self.state.start
-    }
-    pub fn start(self) -> Task<Running> {
-        Task {
-            name: self.name,
-            state: Running {
-                start: Instant::now(),
-            },
-        }
     }
 
     pub fn end(&self) -> Instant {


### PR DESCRIPTION
### Description

Integrates new UI with watch mode. Pulls out the UI handle and sender outside the `Visitor` and `Run` struct, so it can be owned by the `WatchClient`. Also adds an `Event` for updating the task names, so on rediscovery we can keep using the same UI thread but just update the task names.

### Testing Instructions

Give it a shot!


Closes TURBO-2801