### PR TITLE
chore(ci): use node 20 in CI

### DIFF
--- a/.github/actions/setup-turborepo-environment/action.yml
+++ b/.github/actions/setup-turborepo-environment/action.yml
@@ -16,6 +16,7 @@ runs:
       uses: ./.github/actions/setup-node
       with:
         extra-flags: --no-optional
+        node-version: "20"
 
     - name: "Setup Rust"
       uses: ./.github/actions/setup-rust


### PR DESCRIPTION
The root package.json and .node-version files are set to node 20,
so we should running our CI on the same version

Testing here: https://github.com/vercel/turbo/pull/7968

Closes TURBO-2805