### PR TITLE
chore: remove legacy filter flags

### DIFF
--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -685,37 +685,12 @@ pub struct RunArgs {
     #[clap(short = 'F', long, group = "scope-filter-group")]
     pub filter: Vec<String>,
 
-    /// DEPRECATED: Specify package(s) to act as entry
-    /// points for task execution. Supports globs.
-    #[clap(long, group = "scope-filter-group")]
-    pub scope: Vec<String>,
-
     //  ignore filters out files from scope and filter, so we require it here
     // -----------------------
     /// Files to ignore when calculating changed files from '--filter'.
     /// Supports globs.
     #[clap(long, requires = "scope-filter-group")]
     pub ignore: Vec<String>,
-
-    //  since only works with scope, so we require it here
-    // -----------------------
-    /// DEPRECATED: Limit/Set scope to changed packages
-    /// since a mergebase. This uses the git diff ${target_branch}...
-    /// mechanism to identify which packages have changed.
-    #[clap(long, requires = "scope")]
-    pub since: Option<String>,
-
-    //  include_dependencies only works with scope, so we require it here
-    // -----------------------
-    /// DEPRECATED: Include the dependencies of tasks in execution.
-    #[clap(long, requires = "scope")]
-    pub include_dependencies: bool,
-
-    //  no_deps only works with scope, so we require it here
-    // -----------------------
-    /// DEPRECATED: Exclude dependent task consumers from execution.
-    #[clap(long, requires = "scope")]
-    pub no_deps: bool,
 
     /// Avoid saving task results to the cache. Useful for development/watch
     /// tasks.
@@ -829,9 +804,7 @@ impl RunArgs {
 
         // default to true
         track_usage!(telemetry, self.continue_execution, |val| val);
-        track_usage!(telemetry, self.include_dependencies, |val| val);
         track_usage!(telemetry, self.single_package, |val| val);
-        track_usage!(telemetry, self.no_deps, |val| val);
         track_usage!(telemetry, self.no_cache, |val| val);
         track_usage!(telemetry, self.daemon, |val| val);
         track_usage!(telemetry, self.no_daemon, |val| val);
@@ -844,7 +817,6 @@ impl RunArgs {
         track_usage!(telemetry, &self.cache_dir, Option::is_some);
         track_usage!(telemetry, &self.profile, Option::is_some);
         track_usage!(telemetry, &self.force, Option::is_some);
-        track_usage!(telemetry, &self.since, Option::is_some);
         track_usage!(telemetry, &self.pkg_inference_root, Option::is_some);
         track_usage!(telemetry, &self.anon_profile, Option::is_some);
         track_usage!(telemetry, &self.summarize, Option::is_some);
@@ -892,10 +864,6 @@ impl RunArgs {
         // track sizes
         if !self.filter.is_empty() {
             telemetry.track_arg_value("filter:length", self.filter.len(), EventType::NonSensitive);
-        }
-
-        if !self.scope.is_empty() {
-            telemetry.track_arg_value("scope:length", self.scope.len(), EventType::NonSensitive);
         }
 
         if !self.ignore.is_empty() {
@@ -1686,19 +1654,6 @@ mod test {
         "multiple ignores"
 	)]
     #[test_case::test_case(
-		&["turbo", "run", "build", "--scope", "test", "--include-dependencies"],
-        Args {
-            command: Some(Command::Run(Box::new(RunArgs {
-                tasks: vec!["build".to_string()],
-                include_dependencies: true,
-                scope: vec!["test".to_string()],
-                ..get_default_run_args()
-            }))),
-            ..Args::default()
-        } ;
-        "include dependencies"
-	)]
-    #[test_case::test_case(
 		&["turbo", "run", "build", "--no-cache"],
         Args {
             command: Some(Command::Run(Box::new(RunArgs {
@@ -1730,19 +1685,6 @@ mod test {
             }))),
             ..Args::default()
         }
-	)]
-    #[test_case::test_case(
-		&["turbo", "run", "build", "--scope", "test", "--no-deps"],
-        Args {
-            command: Some(Command::Run(Box::new(RunArgs {
-                tasks: vec!["build".to_string()],
-                scope: vec!["test".to_string()],
-                no_deps: true,
-                ..get_default_run_args()
-            }))),
-            ..Args::default()
-        } ;
-        "no deps"
 	)]
     #[test_case::test_case(
 		&["turbo", "run", "build", "--output-logs", "full"],
@@ -1915,30 +1857,6 @@ mod test {
         "remote_only=false works"
 	)]
     #[test_case::test_case(
-		&["turbo", "run", "build", "--scope", "foo", "--scope", "bar"],
-        Args {
-            command: Some(Command::Run(Box::new(RunArgs {
-                tasks: vec!["build".to_string()],
-                scope: vec!["foo".to_string(), "bar".to_string()],
-                ..get_default_run_args()
-            }))),
-            ..Args::default()
-        }
-	)]
-    #[test_case::test_case(
-		&["turbo", "run", "build", "--scope", "test", "--since", "foo"],
-        Args {
-            command: Some(Command::Run(Box::new(RunArgs {
-                tasks: vec!["build".to_string()],
-                scope: vec!["test".to_string()],
-                since: Some("foo".to_string()),
-                ..get_default_run_args()
-            }))),
-            ..Args::default()
-        } ;
-        "scope and since"
-	)]
-    #[test_case::test_case(
 		&["turbo", "build"],
         Args {
             run_args: Some(RunArgs {
@@ -1983,17 +1901,17 @@ mod test {
     )]
     #[test_case::test_case(
         &["turbo", "run", "build", "--since", "foo"],
-        "the following required arguments were not provided" ;
+        "unexpected argument '--since' found" ;
         "since without filter or scope"
     )]
     #[test_case::test_case(
         &["turbo", "run", "build", "--include-dependencies"],
-        "the following required arguments were not provided" ;
+        "unexpected argument '--include-dependencies' found" ;
         "include-dependencies without filter or scope"
     )]
     #[test_case::test_case(
         &["turbo", "run", "build", "--no-deps"],
-        "the following required arguments were not provided" ;
+        "unexpected argument '--no-deps' found" ;
         "no-deps without filter or scope"
     )]
     fn test_parse_run_failures(args: &[&str], expected: &str) {

--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -1020,7 +1020,6 @@ pub async fn run(
     root_telemetry.track_cpus(num_cpus::get());
     // track args
     cli_args.track(&root_telemetry);
-    warn_all_deprecated_flags(&cli_args);
 
     let cli_result = match cli_args.command.as_ref().unwrap() {
         Command::Bin { .. } => {
@@ -1229,39 +1228,6 @@ pub async fn run(
     }
 
     cli_result
-}
-
-fn warn_all_deprecated_flags(args: &Args) {
-    if args.trace.is_some() {
-        warn_flag_removal("--trace");
-    }
-
-    if args.heap.is_some() {
-        warn_flag_removal("--heap");
-    }
-
-    if args.cpu_profile.is_some() {
-        warn_flag_removal("--cpuprofile");
-    }
-
-    if let Some(Command::Run(run_args)) = args.command.as_ref() {
-        if run_args.since.is_some() {
-            warn_flag_removal("--since");
-        }
-        if !run_args.scope.is_empty() {
-            warn_flag_removal("--scope");
-        }
-        if run_args.include_dependencies {
-            warn_flag_removal("--include-dependencies");
-        }
-        if run_args.no_deps {
-            warn_flag_removal("--no-deps");
-        }
-    }
-}
-
-fn warn_flag_removal(flag: &str) {
-    warn!("{flag} is deprecated and will be removed in 2.0");
 }
 
 #[cfg(test)]

--- a/turborepo-tests/integration/tests/bad-flag.t
+++ b/turborepo-tests/integration/tests/bad-flag.t
@@ -19,7 +19,7 @@ Bad flag with an implied run command should display run flags
   
     tip: to pass '--bad-flag' as a value, use '-- --bad-flag'
   
-  Usage: turbo(\.exe)? <--cache-dir <CACHE_DIR>|--cache-workers <CACHE_WORKERS>|--concurrency <CONCURRENCY>|--continue|--dry-run [<DRY_RUN>]|--single-package|--filter <FILTER>|--force [<FORCE>]|--framework-inference [<BOOL>]|--global-deps <GLOBAL_DEPS>|--graph [<GRAPH>]|--env-mode [<ENV_MODE>]|--ignore <IGNORE>|--include-dependencies|--no-cache|--no-daemon|--no-deps|--output-logs <OUTPUT_LOGS>|--log-order <LOG_ORDER>|--only|--parallel|--pkg-inference-root <PKG_INFERENCE_ROOT>|--profile <PROFILE>|--remote-only [<BOOL>]|--scope <SCOPE>|--since <SINCE>|--summarize [<SUMMARIZE>]|--log-prefix <LOG_PREFIX>|TASKS|PASS_THROUGH_ARGS|--experimental-space-id <EXPERIMENTAL_SPACE_ID>> (re)
+  Usage: turbo(\.exe)? <--cache-dir <CACHE_DIR>|--cache-workers <CACHE_WORKERS>|--concurrency <CONCURRENCY>|--continue|--dry-run [<DRY_RUN>]|--single-package|--filter <FILTER>|--force [<FORCE>]|--framework-inference [<BOOL>]|--global-deps <GLOBAL_DEPS>|--graph [<GRAPH>]|--env-mode [<ENV_MODE>]|--ignore <IGNORE>|--no-cache|--no-daemon|--output-logs <OUTPUT_LOGS>|--log-order <LOG_ORDER>|--only|--parallel|--pkg-inference-root <PKG_INFERENCE_ROOT>|--profile <PROFILE>|--remote-only [<BOOL>]|--summarize [<SUMMARIZE>]|--log-prefix <LOG_PREFIX>|TASKS|PASS_THROUGH_ARGS|--experimental-space-id <EXPERIMENTAL_SPACE_ID>> (re)
   
   For more information, try '--help'.
   

--- a/turborepo-tests/integration/tests/conflicting-flags.t
+++ b/turborepo-tests/integration/tests/conflicting-flags.t
@@ -8,38 +8,12 @@ Setup
   For more information, try '--help'.
   
   [1]
-  $ ${TURBO} run build --since main
-   ERROR  the following required arguments were not provided:
-    --scope <SCOPE>
-  
-  Usage: turbo(\.exe)? run --scope <SCOPE> --since <SINCE> (re)
-  
-  For more information, try '--help'.
-  
-  [1]
+
   $ ${TURBO} run build --ignore 'app/**'
    ERROR  the following required arguments were not provided:
-    <--filter <FILTER>|--scope <SCOPE>>
+    <--filter <FILTER>>
   
-  Usage: turbo(\.exe)? run --ignore <IGNORE> <--filter <FILTER>|--scope <SCOPE>> (re)
-  
-  For more information, try '--help'.
-  
-  [1]
-  $ ${TURBO} run build --no-deps
-   ERROR  the following required arguments were not provided:
-    --scope <SCOPE>
-  
-  Usage: turbo(\.exe)? run --scope <SCOPE> --no-deps (re)
-  
-  For more information, try '--help'.
-  
-  [1]
-  $ ${TURBO} run build --include-dependencies
-   ERROR  the following required arguments were not provided:
-    --scope <SCOPE>
-  
-  Usage: turbo(\.exe)? run --scope <SCOPE> --include-dependencies (re)
+  Usage: turbo(\.exe)? run --ignore <IGNORE> <--filter <FILTER>> (re)
   
   For more information, try '--help'.
   

--- a/turborepo-tests/integration/tests/no-args.t
+++ b/turborepo-tests/integration/tests/no-args.t
@@ -65,16 +65,8 @@ Make sure exit code is 2 when no args are passed
             Environment variable mode. Use "loose" to pass the entire existing environment. Use "strict" to use an allowlist specified in turbo.json. Use "infer" to defer to existence of "passThroughEnv" or "globalPassThroughEnv" in turbo.json. (default infer) [default: infer] [possible values: infer, loose, strict]
     -F, --filter <FILTER>
             Use the given selector to specify package(s) to act as entry points. The syntax mirrors pnpm's syntax, and additional documentation and examples can be found in turbo's documentation https://turbo.build/repo/docs/reference/command-line-reference/run#--filter
-        --scope <SCOPE>
-            DEPRECATED: Specify package(s) to act as entry points for task execution. Supports globs
         --ignore <IGNORE>
             Files to ignore when calculating changed files from '--filter'. Supports globs
-        --since <SINCE>
-            DEPRECATED: Limit/Set scope to changed packages since a mergebase. This uses the git diff ${target_branch}... mechanism to identify which packages have changed
-        --include-dependencies
-            DEPRECATED: Include the dependencies of tasks in execution
-        --no-deps
-            DEPRECATED: Exclude dependent task consumers from execution
         --no-cache
             Avoid saving task results to the cache. Useful for development/watch tasks
         --daemon

--- a/turborepo-tests/integration/tests/turbo-help.t
+++ b/turborepo-tests/integration/tests/turbo-help.t
@@ -65,16 +65,8 @@ Test help flag
             Environment variable mode. Use "loose" to pass the entire existing environment. Use "strict" to use an allowlist specified in turbo.json. Use "infer" to defer to existence of "passThroughEnv" or "globalPassThroughEnv" in turbo.json. (default infer) [default: infer] [possible values: infer, loose, strict]
     -F, --filter <FILTER>
             Use the given selector to specify package(s) to act as entry points. The syntax mirrors pnpm's syntax, and additional documentation and examples can be found in turbo's documentation https://turbo.build/repo/docs/reference/command-line-reference/run#--filter
-        --scope <SCOPE>
-            DEPRECATED: Specify package(s) to act as entry points for task execution. Supports globs
         --ignore <IGNORE>
             Files to ignore when calculating changed files from '--filter'. Supports globs
-        --since <SINCE>
-            DEPRECATED: Limit/Set scope to changed packages since a mergebase. This uses the git diff ${target_branch}... mechanism to identify which packages have changed
-        --include-dependencies
-            DEPRECATED: Include the dependencies of tasks in execution
-        --no-deps
-            DEPRECATED: Exclude dependent task consumers from execution
         --no-cache
             Avoid saving task results to the cache. Useful for development/watch tasks
         --daemon
@@ -170,16 +162,8 @@ Test help flag
             Environment variable mode. Use "loose" to pass the entire existing environment. Use "strict" to use an allowlist specified in turbo.json. Use "infer" to defer to existence of "passThroughEnv" or "globalPassThroughEnv" in turbo.json. (default infer) [default: infer] [possible values: infer, loose, strict]
     -F, --filter <FILTER>
             Use the given selector to specify package(s) to act as entry points. The syntax mirrors pnpm's syntax, and additional documentation and examples can be found in turbo's documentation https://turbo.build/repo/docs/reference/command-line-reference/run#--filter
-        --scope <SCOPE>
-            DEPRECATED: Specify package(s) to act as entry points for task execution. Supports globs
         --ignore <IGNORE>
             Files to ignore when calculating changed files from '--filter'. Supports globs
-        --since <SINCE>
-            DEPRECATED: Limit/Set scope to changed packages since a mergebase. This uses the git diff ${target_branch}... mechanism to identify which packages have changed
-        --include-dependencies
-            DEPRECATED: Include the dependencies of tasks in execution
-        --no-deps
-            DEPRECATED: Exclude dependent task consumers from execution
         --no-cache
             Avoid saving task results to the cache. Useful for development/watch tasks
         --daemon


### PR DESCRIPTION
### Description

Remove legacy filter flags now that they've been deprecated for quite awhile.

### Testing Instructions

Existing test suite passes. Updated tests that are still applicable and removed those that aren't.
