### PR TITLE
chore: pin eslint version

### DIFF
--- a/packages/eslint-plugin-turbo/__fixtures__/workspace/package.json
+++ b/packages/eslint-plugin-turbo/__fixtures__/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "eslint": "latest",
+    "eslint": "8.57.0",
     "eslint-plugin-turbo": "../../"
   }
 }


### PR DESCRIPTION
### Description

eslint 9.0.0 has some breaking changes that our current fixture isn't set up to support. This is [preventing us from releasing](https://github.com/vercel/turbo/actions/runs/8693806507/job/23842782558#step:5:256) new versions of `turbo`.

Future work is to update the fixture to work with eslint 9

### Testing Instructions

`turbo test --filter=eslint-plugin-turbo` now passes


Closes TURBO-2808