### PR TITLE
chore(ci): switch from action-rs/toolchain to actions-rust-lang/setup-rust-toolchain

### DIFF
--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -150,7 +150,7 @@ jobs:
       - name: Rust Setup
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          target: ${{ inputs.targets }}
+          target: ${{ matrix.settings.target }}
           # needed to not make it override the defaults
           rustflags: ""
           # we want more specific settings

--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -147,6 +147,14 @@ jobs:
       - name: Setup capnproto
         uses: ./.github/actions/setup-capnproto
 
+      - name: Setup Rust Up
+        if: ${{ matrix.settings.container-setup }}
+        # setup-rust-toolchain uses the --retry-connrefused flag with curl to install rustup
+        # this flag was added in curl 7.52.0, but the Ubuntu version we use only has 7.47.0
+        run: |
+          curl --proto '=https' --tlsv1.2 --retry 10 --location --silent --show-error --fail "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
+          echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> $GITHUB_PATH
+
       - name: Rust Setup
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:

--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -148,11 +148,13 @@ jobs:
         uses: ./.github/actions/setup-capnproto
 
       - name: Rust Setup
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          profile: minimal
-          override: true
-          target: ${{ matrix.settings.target }}
+          target: ${{ inputs.targets }}
+          # needed to not make it override the defaults
+          rustflags: ""
+          # we want more specific settings
+          cache: false
 
       - name: Build Setup
         shell: bash


### PR DESCRIPTION
### Description

#7409 deleted `rust-toolchain` in favor of `rust-toolchain.toml` which isn't supported by the no longer maintained `action-rs/toolchain`

This broke our release process: https://github.com/vercel/turbo/actions/runs/8695260821/job/23846306200#step:7:12

### Testing Instructions

[Release dry run](https://github.com/vercel/turbo/actions/runs/8697187026)

Closes TURBO-2810