### PR TITLE
chore(ci): use node 20 to run JS smoke tests before release

### DIFF
--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -92,6 +92,7 @@ jobs:
         uses: ./.github/actions/setup-turborepo-environment
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
+          node-version: "20"
       - name: Run JS Package Tests
         run: turbo run check-types test --filter="./packages/*" --color
 


### PR DESCRIPTION


Closes TURBO-2822