### PR TITLE
fix(pnpm): support pnpm lockfile v9

### DIFF
--- a/crates/turborepo-lockfiles/fixtures/pnpm-v9.yaml
+++ b/crates/turborepo-lockfiles/fixtures/pnpm-v9.yaml
@@ -1,0 +1,125 @@
+lockfileVersion: "9.0"
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+  .:
+    devDependencies:
+      turbo:
+        specifier: canary
+        version: 1.13.3-canary.1
+
+  apps/apps-a:
+    dependencies:
+      pkg-a:
+        specifier: workspace:*
+        version: link:../../packages/pkg-a
+      tooling-config:
+        specifier: workspace:*
+        version: link:../../packages/tooling-config
+
+  apps/apps-b:
+    dependencies:
+      tooling-config:
+        specifier: workspace:*
+        version: link:../../packages/tooling-config
+
+  packages/pkg-a:
+    dependencies:
+      tooling-config:
+        specifier: workspace:*
+        version: link:../tooling-config
+
+  packages/pkg-b:
+    dependencies:
+      tooling-config:
+        specifier: workspace:*
+        version: link:../tooling-config
+
+  packages/tooling-config: {}
+
+packages:
+  turbo-darwin-64@1.13.3-canary.1:
+    resolution:
+      {
+        integrity: sha512-1xfKCf/d7mD7oGT1qBnD5pYsZfI43Wftlo/N0GTpBLDjKhfJifBvng9ns5grhs79wNiIdDxYYGt6pHOUzc+6YQ==,
+      }
+    cpu: [x64]
+    os: [darwin]
+
+  turbo-darwin-arm64@1.13.3-canary.1:
+    resolution:
+      {
+        integrity: sha512-uNK9QnlDJBLuaR7l4/68AoKByQ+q+rT9OyvizzUV2KZ8r2u/Sv+f3GiV48qxtG1duYlWLlLnDGuEnUPKEq0WZg==,
+      }
+    cpu: [arm64]
+    os: [darwin]
+
+  turbo-linux-64@1.13.3-canary.1:
+    resolution:
+      {
+        integrity: sha512-D/RRtqHch0I5q/Pod7mgLPGrvjcDpvBe95yp5hNy59+ZSyKHlkDrm/pQaA/+6mdjHEQB8eIL/18nrKx/B5qduA==,
+      }
+    cpu: [x64]
+    os: [linux]
+
+  turbo-linux-arm64@1.13.3-canary.1:
+    resolution:
+      {
+        integrity: sha512-FXwgkadDZr6mPLN7lmlc0ESRZFfXDONEKTQbDV9h4n/7I0HOehMM0CrWZsptoekKEKFEqQDxZo5QXFDZON0cww==,
+      }
+    cpu: [arm64]
+    os: [linux]
+
+  turbo-windows-64@1.13.3-canary.1:
+    resolution:
+      {
+        integrity: sha512-ce6TENLbCeFAWVrJtLMOjv7FkPCpfSNvczFpaolbOB9omPW3uO4hXMbpqk14hgsU8OsmMt61rLzI38L0miJuEw==,
+      }
+    cpu: [x64]
+    os: [win32]
+
+  turbo-windows-arm64@1.13.3-canary.1:
+    resolution:
+      {
+        integrity: sha512-7sm8tZRqcmWo/D3Mb513/diVZuFC6rwz/ZaW8IGsEcLrUdqq6qSRlW6e7ZsfOMR7cO6geeGhuFsJg8ILOETTgw==,
+      }
+    cpu: [arm64]
+    os: [win32]
+
+  turbo@1.13.3-canary.1:
+    resolution:
+      {
+        integrity: sha512-bxOFjIhBxwWiExjUyTV2KOP6P28M5TOHUaM6YKRR2oPtKoQpIGUmYP+DCxG+icjaLXviUJRHU4YxzEOaL9Bf6A==,
+      }
+    hasBin: true
+
+snapshots:
+  turbo-darwin-64@1.13.3-canary.1:
+    optional: true
+
+  turbo-darwin-arm64@1.13.3-canary.1:
+    optional: true
+
+  turbo-linux-64@1.13.3-canary.1:
+    optional: true
+
+  turbo-linux-arm64@1.13.3-canary.1:
+    optional: true
+
+  turbo-windows-64@1.13.3-canary.1:
+    optional: true
+
+  turbo-windows-arm64@1.13.3-canary.1:
+    optional: true
+
+  turbo@1.13.3-canary.1:
+    optionalDependencies:
+      turbo-darwin-64: 1.13.3-canary.1
+      turbo-darwin-arm64: 1.13.3-canary.1
+      turbo-linux-64: 1.13.3-canary.1
+      turbo-linux-arm64: 1.13.3-canary.1
+      turbo-windows-64: 1.13.3-canary.1
+      turbo-windows-arm64: 1.13.3-canary.1

--- a/crates/turborepo-lockfiles/src/pnpm/dep_path.rs
+++ b/crates/turborepo-lockfiles/src/pnpm/dep_path.rs
@@ -32,7 +32,7 @@ impl<'a> DepPath<'a> {
         input: &'a str,
     ) -> Result<Self, nom::error::Error<String>> {
         let (_, dep_path) = match version {
-            SupportedLockfileVersion::V7 => parse_dep_path_v7(input),
+            SupportedLockfileVersion::V7AndV9 => parse_dep_path_v7(input),
             SupportedLockfileVersion::V5 | SupportedLockfileVersion::V6 => parse_dep_path(input),
         }
         .map_err(|e| e.to_owned())

--- a/crates/turborepo-lockfiles/src/pnpm/mod.rs
+++ b/crates/turborepo-lockfiles/src/pnpm/mod.rs
@@ -33,7 +33,10 @@ enum VersionFormat {
 enum SupportedLockfileVersion {
     V5,
     V6,
-    V7,
+    // As of pnpm@9.0.0-rc.0 the lockfile version will now match the pnpm version
+    // Lockfile version 7.0 and 9.0 are both the same version
+    // See https://github.com/pnpm/pnpm/pull/7861
+    V7AndV9,
 }
 
 pub fn pnpm_subgraph(


### PR DESCRIPTION
### Description

Closes #7993

Only thing that required updating is that as of `9.0.0-rc.0` the lockfile version was updated to `9.0` instead of `7.0` that was used from `9.0.0-alpha.0`-`9.0.0-beta.3`. I believe this was the only change made since I added support for lockfile v7 in #7853.

### Testing Instructions

Added roundtrip test along with unit test for package resolution.

Manual test with repro provided in #7993
```
[0 olszewski@chriss-mbp] /tmp/pnpm-prune-repro $ turbo_dev --skip-infer prune app-a 
Generating pruned monorepo for app-a in /private/tmp/pnpm-prune-repro/out
 - Added app-a
 - Added pkg-a
 - Added tooling-config
[0 olszewski@chriss-mbp] /tmp/pnpm-prune-repro $ cd out 
[0 olszewski@chriss-mbp] /tmp/pnpm-prune-repro/out $ pnpm i --frozen-lockfile
Scope: all 4 workspace projects
Lockfile is up to date, resolution step is skipped
Packages: +2
++
Progress: resolved 2, reused 2, downloaded 0, added 2, done

devDependencies:
+ turbo 1.13.3-canary.1

Done in 245ms
```


Closes TURBO-2826