### PR TITLE
fix(turbopack-node) postcss.config.js path resolution on Windows

### DIFF
--- a/crates/turbopack-node/src/transforms/postcss.rs
+++ b/crates/turbopack-node/src/transforms/postcss.rs
@@ -255,7 +255,7 @@ pub(crate) async fn config_loader_source(
             // https://github.com/nodejs/node/issues/31710
             // convert it to a file:// URL, which works on all platforms
             const configUrl = pathToFileURL(configPath).toString();
-            const mod = await __turbopack_external_import__(configPath);
+            const mod = await __turbopack_external_import__(configUrl);
 
             export default mod.default ?? mod;
         "#,

--- a/crates/turbopack-node/src/transforms/postcss.rs
+++ b/crates/turbopack-node/src/transforms/postcss.rs
@@ -248,8 +248,13 @@ pub(crate) async fn config_loader_source(
     // Bundling would break the ability to use `require.resolve` in the config file.
     let code = formatdoc! {
         r#"
-            const configPath = `${{process.cwd()}}/{config_path}`;
+            import { pathToFileUrl } from 'url';
 
+            const configPath = `${{process.cwd()}}/{config_path}`;
+            // Absolute paths don't work with ESM imports on Windows:
+            // https://github.com/nodejs/node/issues/31710
+            // convert it to a file:// URL, which works on all platforms
+            const configUrl = pathToFileUrl(configPath).toString();
             const mod = await __turbopack_external_import__(configPath);
 
             export default mod.default ?? mod;

--- a/crates/turbopack-node/src/transforms/postcss.rs
+++ b/crates/turbopack-node/src/transforms/postcss.rs
@@ -248,9 +248,9 @@ pub(crate) async fn config_loader_source(
     // Bundling would break the ability to use `require.resolve` in the config file.
     let code = formatdoc! {
         r#"
-            import { pathToFileUrl } from 'url';
+            import {{ pathToFileUrl }} from 'url';
 
-            const configPath = `${{process.cwd()}}/{config_path}`;
+            const configPath = `${{process.cwd()}}/${{{config_path}}}`;
             // Absolute paths don't work with ESM imports on Windows:
             // https://github.com/nodejs/node/issues/31710
             // convert it to a file:// URL, which works on all platforms
@@ -259,7 +259,7 @@ pub(crate) async fn config_loader_source(
 
             export default mod.default ?? mod;
         "#,
-        config_path = config_path,
+        config_path = serde_json::to_string(&config_path).expect("a string should be serializable"),
     };
 
     Ok(Vc::upcast(VirtualSource::new(

--- a/crates/turbopack-node/src/transforms/postcss.rs
+++ b/crates/turbopack-node/src/transforms/postcss.rs
@@ -248,13 +248,13 @@ pub(crate) async fn config_loader_source(
     // Bundling would break the ability to use `require.resolve` in the config file.
     let code = formatdoc! {
         r#"
-            import {{ pathToFileUrl }} from 'url';
+            import {{ pathToFileURL }} from 'url';
 
             const configPath = `${{process.cwd()}}/${{{config_path}}}`;
             // Absolute paths don't work with ESM imports on Windows:
             // https://github.com/nodejs/node/issues/31710
             // convert it to a file:// URL, which works on all platforms
-            const configUrl = pathToFileUrl(configPath).toString();
+            const configUrl = pathToFileURL(configPath).toString();
             const mod = await __turbopack_external_import__(configPath);
 
             export default mod.default ?? mod;


### PR DESCRIPTION
### Description

Absolute paths don't work for imports on windows because `c:\` is interpreted as a URI scheme. The workaround is to use an unambiguous `file://` URI.

Fixes https://github.com/vercel/next.js/issues/63755

Similar to https://github.com/vercel/next.js/pull/64386

### Testing Instructions

<details>
<summary>patch next.js's Cargo.toml to point to the updated branch</summary>

```
bgw@BENJAMINWOOCDA2 CLANGARM64 ~/Documents/next.js (canary)
$ git diff Cargo.toml
diff --git a/Cargo.toml b/Cargo.toml
index ffabdcc19..3ce91bc04 100644
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,11 @@ swc_core = { version = "0.90.30", features = [
 testing = { version = "0.35.22" }

 # Turbo crates
-turbopack-binding = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240416.1" }
+turbopack-binding = { git = "https://github.com/vercel/turbo.git", branch = "bgw/windows-postcss-config-path" }
 # [TODO]: need to refactor embed_directory! macro usages, as well as resolving turbo_tasks::function, macros..
-turbo-tasks = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240416.1" }
+turbo-tasks = { git = "https://github.com/vercel/turbo.git", branch = "bgw/windows-postcss-config-path" }
 # [TODO]: need to refactor embed_directory! macro usage in next-core
-turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", tag = "turbopack-240416.1" }
+turbo-tasks-fs = { git = "https://github.com/vercel/turbo.git", branch = "bgw/windows-postcss-config-path" }

 # General Deps
```
</details>

<details>
<summary>build the next-swc binary</summary>

```
cd next.js
turbo run build-native-no-plugin-woa-release
```
</details>

<details>
<summary>Run `next dev` in the test repo</summary>

```bash
cd ~/Documents/browserslist-file-resolution-turbo-win32
__INTERNAL_CUSTOM_TURBOPACK_BINDINGS=~/Documents/next.js/packages/next-swc/native/next-swc.win32-arm64-msvc.node node_modules/.bin/next dev --turbo
```

![Screenshot 2024-04-16 at 5 37 19 PM](https://github.com/vercel/turbo/assets/180404/fdd628c6-6354-44fb-b8ce-73aaee8e99c2)
</details>

Closes PACK-2972