### PR TITLE
chore: differentiate rust changes from building turbo

### DIFF
--- a/cli/turbo.json
+++ b/cli/turbo.json
@@ -2,15 +2,9 @@
   "$schema": "../docs/public/schema.json",
   "extends": ["//"],
   "pipeline": {
-    "build": {
+    // A task that is used for detecting if any turborepo Rust sources change
+    "rust-src": {
       "env": ["RUNNER_OS"],
-      "outputs": [
-        "../target/debug/turbo",
-        "../target/debug/turbo.exe",
-        "../target/release/turbo",
-        "../target/release/turbo.exe"
-      ],
-
       "inputs": [
         "../version.txt",
         "../crates/turborepo*/**/*.rs", // Rust crates
@@ -19,6 +13,15 @@
         "../Cargo.lock",
         "!../crates/**/target"
       ]
+    },
+    "build": {
+      "outputs": [
+        "../target/debug/turbo",
+        "../target/debug/turbo.exe",
+        "../target/release/turbo",
+        "../target/release/turbo.exe"
+      ],
+      "dependsOn": ["rust-src"]
     }
   }
 }

--- a/packages/turbo-repository/turbo.json
+++ b/packages/turbo-repository/turbo.json
@@ -6,7 +6,7 @@
   "pipeline": {
     "build": {
       "dependsOn": [
-        "cli#build"
+        "cli#rust-src"
       ]
     },
     "test": {


### PR DESCRIPTION
### Description

This PR adds a new dummy task that will be invalidated whenever turborepo related Rust code changes.

I noticed we were building the `turbo` binary when running our [JS tests](https://github.com/vercel/turbo/actions/runs/8724966454/job/23936836212#step:6:993). This is due to `turborepo-repository` depending on `cli#build`, but I believe that we really just want it invalidate on any Rust code changes.

### Testing Instructions

Verify that updating a Rust file causes a cache miss for both `turbo build --filter=cli` and `turbo build --filter=turborepo-repository`.
