### PR TITLE
feat(mdx): support custom parse construct options

### DIFF
--- a/crates/turbopack-mdx/src/lib.rs
+++ b/crates/turbopack-mdx/src/lib.rs
@@ -2,7 +2,7 @@
 #![feature(arbitrary_self_types)]
 
 use anyhow::{anyhow, Context, Result};
-use mdxjs::{compile, Options};
+use mdxjs::{compile, MdxParseOptions, Options};
 use turbo_tasks::{Value, ValueDefault, Vc};
 use turbo_tasks_fs::{rope::Rope, File, FileContent, FileSystemPath};
 use turbopack_core::{
@@ -31,26 +31,42 @@ fn modifier() -> Vc<String> {
     Vc::cell("mdx".to_string())
 }
 
-/// Subset of mdxjs::Options to allow to inherit turbopack's jsx-related configs
-/// into mdxjs.
 #[turbo_tasks::value(shared)]
 #[derive(PartialOrd, Ord, Hash, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub enum MdxParseConstructs {
+    Commonmark,
+    Gfm,
+}
+
+/// Subset of mdxjs::Options to allow to inherit turbopack's jsx-related configs
+/// into mdxjs. This is thin, near straightforward subset of mdxjs::Options to
+/// enable turbo tasks.
+#[turbo_tasks::value(shared)]
+#[derive(PartialOrd, Ord, Hash, Debug, Clone)]
+#[serde(rename_all = "camelCase", default)]
 pub struct MdxTransformOptions {
-    pub development: bool,
-    pub preserve_jsx: bool,
+    pub development: Option<bool>,
+    pub jsx: Option<bool>,
     pub jsx_runtime: Option<String>,
     pub jsx_import_source: Option<String>,
+    /// The path to a module providing Components to mdx modules.
+    /// The provider must export a useMDXComponents, which is called to access
+    /// an object of components.
     pub provider_import_source: Option<String>,
+    /// Determines how to parse mdx contents.
+    pub mdx_type: Option<MdxParseConstructs>,
 }
 
 impl Default for MdxTransformOptions {
     fn default() -> Self {
         Self {
-            development: true,
-            preserve_jsx: false,
+            development: Some(true),
+            jsx: Some(false),
             jsx_runtime: None,
             jsx_import_source: None,
             provider_import_source: None,
+            mdx_type: Some(MdxParseConstructs::Commonmark),
         }
     }
 }
@@ -112,10 +128,16 @@ async fn into_ecmascript_module_asset(
         None
     };
 
+    let parse_options = match transform_options.mdx_type {
+        Some(MdxParseConstructs::Gfm) => MdxParseOptions::gfm(),
+        _ => MdxParseOptions::default(),
+    };
+
     let options = Options {
-        development: transform_options.development,
+        parse: parse_options,
+        development: transform_options.development.unwrap_or(false),
         provider_import_source: transform_options.provider_import_source.clone(),
-        jsx: transform_options.preserve_jsx, // true means 'preserve' jsx syntax.
+        jsx: transform_options.jsx.unwrap_or(false), // true means 'preserve' jsx syntax.
         jsx_runtime,
         jsx_import_source: transform_options
             .jsx_import_source

--- a/crates/turbopack/src/module_options/mod.rs
+++ b/crates/turbopack/src/module_options/mod.rs
@@ -16,7 +16,6 @@ use turbopack_core::{
 };
 use turbopack_css::CssModuleAssetType;
 use turbopack_ecmascript::{EcmascriptInputTransform, EcmascriptOptions, SpecifiedModuleType};
-use turbopack_mdx::MdxTransformOptions;
 use turbopack_node::transforms::{postcss::PostCssTransform, webpack::WebpackLoaders};
 use turbopack_wasm::source::WebAssemblySourceType;
 
@@ -491,16 +490,14 @@ impl ModuleOptions {
                 (None, None)
             };
 
-            let mdx_options = enable_mdx_rs
-                .unwrap_or(MdxTransformModuleOptions::default())
-                .await?;
+            let mdx_options = &*enable_mdx_rs.unwrap_or(Default::default()).await?;
 
             let mdx_transform_options = (MdxTransformOptions {
-                development: true,
-                preserve_jsx: false,
+                development: Some(true),
+                jsx: Some(false),
                 jsx_runtime,
                 jsx_import_source,
-                provider_import_source: mdx_options.provider_import_source.clone(),
+                ..(mdx_options.clone())
             })
             .cell();
 

--- a/crates/turbopack/src/module_options/module_options_context.rs
+++ b/crates/turbopack/src/module_options/module_options_context.rs
@@ -5,6 +5,7 @@ use turbopack_core::{
     condition::ContextCondition, environment::Environment, resolve::options::ImportMapping,
 };
 use turbopack_ecmascript::{references::esm::UrlRewriteBehavior, TreeShakingMode};
+pub use turbopack_mdx::MdxTransformOptions;
 use turbopack_node::{
     execution_context::ExecutionContext,
     transforms::{postcss::PostCssTransformOptions, webpack::WebpackLoaderItems},
@@ -103,24 +104,6 @@ pub struct JsxTransformOptions {
 #[turbo_tasks::value(shared)]
 #[derive(Default, Clone)]
 #[serde(default)]
-pub struct MdxTransformModuleOptions {
-    /// The path to a module providing Components to mdx modules.
-    /// The provider must export a useMDXComponents, which is called to access
-    /// an object of components.
-    pub provider_import_source: Option<String>,
-}
-
-#[turbo_tasks::value_impl]
-impl MdxTransformModuleOptions {
-    #[turbo_tasks::function]
-    pub fn default() -> Vc<Self> {
-        Self::cell(Default::default())
-    }
-}
-
-#[turbo_tasks::value(shared)]
-#[derive(Default, Clone)]
-#[serde(default)]
 pub struct ModuleOptionsContext {
     pub enable_jsx: Option<Vc<JsxTransformOptions>>,
     pub enable_postcss_transform: Option<Vc<PostCssTransformOptions>>,
@@ -139,7 +122,7 @@ pub struct ModuleOptionsContext {
     pub enable_raw_css: bool,
     // [Note]: currently mdx, and mdx_rs have different configuration entrypoint from next.config.js,
     // however we might want to unify them in the future.
-    pub enable_mdx_rs: Option<Vc<MdxTransformModuleOptions>>,
+    pub enable_mdx_rs: Option<Vc<MdxTransformOptions>>,
     pub preset_env_versions: Option<Vc<Environment>>,
     /// Custom rules to be applied after all default rules.
     pub custom_rules: Vec<ModuleRule>,


### PR DESCRIPTION
### Description

Part 1 for PACK-2978, extending & consolidating existing mdx transform options to support partial set of parse / transform options. Notably to support construct between gfm vs commonmark.

Closes PACK-2979