### PR TITLE
chore: Improved errors for watch mode

### DIFF
--- a/crates/turborepo-lib/src/daemon/client.rs
+++ b/crates/turborepo-lib/src/daemon/client.rs
@@ -1,6 +1,7 @@
 use std::{io, time::Duration};
 
 use globwalk::ValidatedGlob;
+use miette::Diagnostic;
 use thiserror::Error;
 use tonic::{Code, IntoRequest, Status};
 use tracing::info;
@@ -200,7 +201,7 @@ fn format_repo_relative_glob(glob: &str) -> String {
     glob.replace(':', "\\:")
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum DaemonError {
     /// The server was connected but is now unavailable.
     #[error("server is unavailable: {0}")]
@@ -208,8 +209,9 @@ pub enum DaemonError {
     #[error("error opening socket: {0}")]
     SocketOpen(#[from] SocketOpenError),
     /// The server is running a different version of turborepo.
-    #[error("version mismatch: {0:?}")]
-    VersionMismatch(Option<String>),
+    #[error("version mismatch: {0}")]
+    #[diagnostic(help("try restarting the daemon with `turbo daemon restart`."))]
+    VersionMismatch(String),
     /// There is an issue with the underlying grpc transport.
     #[error("bad grpc transport: {0}")]
     GrpcTransport(#[from] tonic::transport::Error),
@@ -255,10 +257,10 @@ pub enum DaemonError {
 impl From<Status> for DaemonError {
     fn from(status: Status) -> DaemonError {
         match status.code() {
-            Code::FailedPrecondition => {
-                DaemonError::VersionMismatch(Some(status.message().to_owned()))
+            Code::FailedPrecondition => DaemonError::VersionMismatch(status.message().to_owned()),
+            Code::Unimplemented => {
+                DaemonError::VersionMismatch("rpc not implemented on daemon".to_string())
             }
-            Code::Unimplemented => DaemonError::VersionMismatch(None),
             Code::Unavailable => DaemonError::Unavailable(status.message().to_string()),
             c => DaemonError::GrpcFailure(c),
         }

--- a/crates/turborepo-lib/src/run/watch.rs
+++ b/crates/turborepo-lib/src/run/watch.rs
@@ -23,6 +23,7 @@ pub struct WatchClient {}
 #[derive(Debug, Error, Diagnostic)]
 pub enum Error {
     #[error("failed to connect to daemon")]
+    #[diagnostic(transparent)]
     Daemon(#[from] DaemonError),
     #[error("failed to connect to daemon")]
     DaemonConnector(#[from] DaemonConnectorError),
@@ -33,6 +34,7 @@ pub enum Error {
     #[error("could not start turbo")]
     Start(std::io::Error),
     #[error(transparent)]
+    #[diagnostic(transparent)]
     Run(#[from] run::Error),
     #[error("`--since` is not supported in watch mode")]
     SinceNotSupported,


### PR DESCRIPTION
### Description

Some of our error messages were a little opaque for watch mode. This threads the diagnostic code through the watch mode errors and adds some help text.

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->


Closes TURBO-2856