### PR TITLE
chore(turbo)!: remove check for legacy turbo config in package.json

### DIFF
--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -9,7 +9,7 @@ use clap::{
 use clap_complete::{generate, Shell};
 pub use error::Error;
 use serde::{Deserialize, Serialize};
-use tracing::{debug, error, warn};
+use tracing::{debug, error};
 use turbopath::AbsoluteSystemPathBuf;
 use turborepo_api_client::AnonAPIClient;
 use turborepo_repository::inference::{RepoMode, RepoState};

--- a/crates/turborepo-lib/src/config.rs
+++ b/crates/turborepo-lib/src/config.rs
@@ -9,7 +9,6 @@ use turbopath::{AbsoluteSystemPathBuf, AnchoredSystemPath};
 use turborepo_auth::{TURBO_TOKEN_DIR, TURBO_TOKEN_FILE, VERCEL_TOKEN_DIR, VERCEL_TOKEN_FILE};
 use turborepo_dirs::{config_dir, vercel_config_dir};
 use turborepo_errors::TURBO_SITE;
-use turborepo_repository::package_json::{Error as PackageJsonError, PackageJson};
 
 pub use crate::turbo_json::RawTurboJson;
 use crate::{commands::CommandBase, turbo_json};
@@ -254,21 +253,6 @@ fn non_empty_str(s: Option<&str>) -> Option<&str> {
 
 trait ResolvedConfigurationOptions {
     fn get_configuration_options(self) -> Result<ConfigurationOptions, Error>;
-}
-
-impl ResolvedConfigurationOptions for PackageJson {
-    fn get_configuration_options(self) -> Result<ConfigurationOptions, Error> {
-        match &self.legacy_turbo_config {
-            Some(legacy_turbo_config) => {
-                let synthetic_raw_turbo_json: RawTurboJson = RawTurboJson::parse(
-                    &legacy_turbo_config.to_string(),
-                    AnchoredSystemPath::new("package.json").unwrap(),
-                )?;
-                synthetic_raw_turbo_json.get_configuration_options()
-            }
-            None => Ok(ConfigurationOptions::default()),
-        }
-    }
 }
 
 impl ResolvedConfigurationOptions for RawTurboJson {
@@ -596,7 +580,6 @@ impl TurborepoConfigBuilder {
 
     pub fn build(&self) -> Result<ConfigurationOptions, Error> {
         // Priority, from least significant to most significant:
-        // - shared configuration (package.json .turbo)
         // - shared configuration (turbo.json)
         // - global configuration (~/.turbo/config.json)
         // - local configuration (<REPO_ROOT>/.turbo/config.json)
@@ -604,16 +587,6 @@ impl TurborepoConfigBuilder {
         // - CLI arguments
         // - builder pattern overrides.
 
-        let root_package_json = PackageJson::load(&self.repo_root.join_component("package.json"))
-            .or_else(|e| {
-            if let PackageJsonError::Io(e) = &e {
-                if matches!(e.kind(), std::io::ErrorKind::NotFound) {
-                    return Ok(Default::default());
-                }
-            }
-
-            Err(e)
-        })?;
         let turbo_json = RawTurboJson::read(
             &self.repo_root,
             AnchoredSystemPath::new("turbo.json").unwrap(),
@@ -635,7 +608,6 @@ impl TurborepoConfigBuilder {
         let override_env_var_config = get_override_env_var_config(&env_vars)?;
 
         let sources = [
-            root_package_json.get_configuration_options(),
             turbo_json.get_configuration_options(),
             global_config.get_configuration_options(),
             global_auth.get_configuration_options(),

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -546,14 +546,6 @@ impl TurboJson {
         root_package_json: &PackageJson,
         include_synthesized_from_root_package_json: bool,
     ) -> Result<TurboJson, Error> {
-        if root_package_json.legacy_turbo_config.is_some() {
-            println!(
-                "[WARNING] \"turbo\" in package.json is no longer supported. Migrate to {} by \
-                 running \"npx @turbo/codemod create-turbo-config\"\n",
-                CONFIG_FILE
-            );
-        }
-
         let turbo_from_files = Self::read(repo_root, &dir.join_component(CONFIG_FILE));
         let turbo_from_trace =
             Self::read(repo_root, &dir.join_components(&TASK_ACCESS_CONFIG_PATH));
@@ -838,14 +830,6 @@ mod tests {
             ),
             ..TurboJson::default()
         }
-    )]
-    #[test_case(
-        Some("{}"),
-        PackageJson {
-            legacy_turbo_config: Some(serde_json::Value::String("build".to_string())),
-            ..PackageJson::default()
-        },
-        TurboJson::default()
     )]
     #[test_case(
         Some(r#"{

--- a/crates/turborepo-repository/src/package_json.rs
+++ b/crates/turborepo-repository/src/package_json.rs
@@ -22,8 +22,6 @@ pub struct PackageJson {
     pub optional_dependencies: Option<BTreeMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub peer_dependencies: Option<BTreeMap<String, String>>,
-    #[serde(rename = "turbo", default, skip_serializing_if = "Option::is_none")]
-    pub legacy_turbo_config: Option<Value>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub scripts: BTreeMap<String, String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -107,20 +105,5 @@ mod test {
         let package_json: PackageJson = serde_json::from_value(json.clone()).unwrap();
         let actual = serde_json::to_value(package_json).unwrap();
         assert_eq!(actual, json);
-    }
-
-    #[test]
-    fn test_legacy_turbo_config() -> Result<()> {
-        let contents = r#"{"turbo": {}}"#;
-        let package_json = serde_json::from_str::<PackageJson>(contents)?;
-
-        assert!(package_json.legacy_turbo_config.is_some());
-
-        let contents = r#"{"turbo": { "globalDependencies": [".env"] } }"#;
-        let package_json = serde_json::from_str::<PackageJson>(contents)?;
-
-        assert!(package_json.legacy_turbo_config.is_some());
-
-        Ok(())
     }
 }


### PR DESCRIPTION
Deletes the handling of the "legacy" config, i.e. the `turbo` key from `package.json`