### PR TITLE
chore(ci): pin Github Actions runner that builds turborepo to macos-12

### DIFF
--- a/.github/workflows/bench-turborepo.yml
+++ b/.github/workflows/bench-turborepo.yml
@@ -56,7 +56,7 @@ jobs:
           - name: ubuntu
             runner: ubuntu-latest
           - name: macos
-            runner: macos-latest
+            runner: macos-12
           - name: windows
             runner: windows-latest
 

--- a/.github/workflows/lsp.yml
+++ b/.github/workflows/lsp.yml
@@ -15,10 +15,10 @@ jobs:
       fail-fast: false
       matrix:
         settings:
-          - host: macos-latest
+          - host: macos-12
             target: "x86_64-apple-darwin"
             container-options: "--rm"
-          - host: macos-latest
+          - host: macos-12
             target: "aarch64-apple-darwin"
             container-options: "--rm"
           - host: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -207,7 +207,7 @@ jobs:
               - "x64"
               - "metal"
           - name: macos
-            runner: macos-latest
+            runner: macos-12
           - name: windows
             runner: windows-latest
     steps:
@@ -260,7 +260,7 @@ jobs:
       matrix:
         os:
           - runner: ubuntu-latest
-          - runner: macos-latest
+          - runner: macos-12
           - runner: windows-latest
     steps:
       # On Windows, set autocrlf to input so that when the repo is cloned down
@@ -652,7 +652,7 @@ jobs:
               - "metal"
             nextest: linux
           - name: macos
-            runner: macos-latest
+            runner: macos-12
             nextest: mac
           - name: windows
             runner: windows-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -357,7 +357,7 @@ jobs:
               - "x64"
               - "metal"
           - name: macos
-            runner: macos-latest
+            runner: macos-12
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
@@ -739,7 +739,7 @@ jobs:
       matrix:
         os:
           - name: macos
-            runner: macos-latest
+            runner: macos-12
           - name: windows
             runner: windows-latest
     runs-on: ${{ matrix.os.runner }}
@@ -832,7 +832,7 @@ jobs:
       matrix:
         os:
           - name: macos
-            runner: macos-latest
+            runner: macos-12
           # Temporarily disable windows bench due to consistent timeouts
           # - name: windows
           #   runner: windows-2019

--- a/.github/workflows/turborepo-library-release.yml
+++ b/.github/workflows/turborepo-library-release.yml
@@ -17,9 +17,9 @@ jobs:
       fail-fast: false
       matrix:
         settings:
-          - host: macos-latest
+          - host: macos-12
             target: "aarch64-apple-darwin"
-          - host: macos-latest
+          - host: macos-12
             target: "x86_64-apple-darwin"
 
           - host: ubuntu-latest

--- a/.github/workflows/turborepo-native-lib-test.yml
+++ b/.github/workflows/turborepo-native-lib-test.yml
@@ -25,7 +25,7 @@ jobs:
               - "x64"
               - "metal"
           - name: macos
-            runner: macos-latest
+            runner: macos-12
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}

--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -106,10 +106,10 @@ jobs:
       fail-fast: false
       matrix:
         settings:
-          - host: macos-latest
+          - host: macos-12
             target: "x86_64-apple-darwin"
             container-options: "--rm"
-          - host: macos-latest
+          - host: macos-12
             target: "aarch64-apple-darwin"
             container-options: "--rm"
           - host: ubuntu-latest


### PR DESCRIPTION
macos-14 appears to not be able to build turborepo successfully
and macos-latest was recently updated to point to macos-14.
Pinning this until we figure out how to make macos-14 work

I didn't change JS package tests or turbopack related things
Closes TURBO-2862