### PR TITLE
chore(ci): bump protoc version

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -42,14 +42,14 @@ runs:
     - name: Set Up Protoc
       id: set-up-protoc
       continue-on-error: true
-      uses: arduino/setup-protoc@v3.0.0
+      uses: arduino/setup-protoc@v2.1.0
       with:
         version: "26.x"
         repo-token: ${{ inputs.github-token }}
 
     - name: Set Up Protoc (second try)
       if: steps.set-up-protoc.outcome == 'failure'
-      uses: arduino/setup-protoc@v3.0.0
+      uses: arduino/setup-protoc@v2.1.0
       with:
         version: "26.x"
         repo-token: ${{ inputs.github-token }}

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -42,16 +42,16 @@ runs:
     - name: Set Up Protoc
       id: set-up-protoc
       continue-on-error: true
-      uses: arduino/setup-protoc@v1.3.0
+      uses: arduino/setup-protoc@v3.0.0
       with:
-        version: "3.x"
+        version: "26.x"
         repo-token: ${{ inputs.github-token }}
 
     - name: Set Up Protoc (second try)
       if: steps.set-up-protoc.outcome == 'failure'
-      uses: arduino/setup-protoc@v1.3.0
+      uses: arduino/setup-protoc@v3.0.0
       with:
-        version: "3.x"
+        version: "26.x"
         repo-token: ${{ inputs.github-token }}
 
     - name: "Add cargo problem matchers"

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -42,14 +42,14 @@ runs:
     - name: Set Up Protoc
       id: set-up-protoc
       continue-on-error: true
-      uses: arduino/setup-protoc@v1.2.0
+      uses: arduino/setup-protoc@v1.3.0
       with:
         version: "3.x"
         repo-token: ${{ inputs.github-token }}
 
     - name: Set Up Protoc (second try)
       if: steps.set-up-protoc.outcome == 'failure'
-      uses: arduino/setup-protoc@v1.2.0
+      uses: arduino/setup-protoc@v1.3.0
       with:
         version: "3.x"
         repo-token: ${{ inputs.github-token }}

--- a/.github/workflows/bench-turborepo.yml
+++ b/.github/workflows/bench-turborepo.yml
@@ -56,7 +56,7 @@ jobs:
           - name: ubuntu
             runner: ubuntu-latest
           - name: macos
-            runner: macos-12
+            runner: macos-latest
           - name: windows
             runner: windows-latest
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -207,7 +207,7 @@ jobs:
               - "x64"
               - "metal"
           - name: macos
-            runner: macos-12
+            runner: macos-latest
           - name: windows
             runner: windows-latest
     steps:
@@ -260,7 +260,7 @@ jobs:
       matrix:
         os:
           - runner: ubuntu-latest
-          - runner: macos-12
+          - runner: macos-latest
           - runner: windows-latest
     steps:
       # On Windows, set autocrlf to input so that when the repo is cloned down
@@ -357,7 +357,7 @@ jobs:
               - "x64"
               - "metal"
           - name: macos
-            runner: macos-12
+            runner: macos-latest
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
@@ -652,7 +652,7 @@ jobs:
               - "metal"
             nextest: linux
           - name: macos
-            runner: macos-12
+            runner: macos-latest
             nextest: mac
           - name: windows
             runner: windows-latest

--- a/.github/workflows/turborepo-library-release.yml
+++ b/.github/workflows/turborepo-library-release.yml
@@ -17,9 +17,9 @@ jobs:
       fail-fast: false
       matrix:
         settings:
-          - host: macos-12
+          - host: macos-latest
             target: "aarch64-apple-darwin"
-          - host: macos-12
+          - host: macos-latest
             target: "x86_64-apple-darwin"
 
           - host: ubuntu-latest

--- a/.github/workflows/turborepo-native-lib-test.yml
+++ b/.github/workflows/turborepo-native-lib-test.yml
@@ -25,7 +25,7 @@ jobs:
               - "x64"
               - "metal"
           - name: macos
-            runner: macos-12
+            runner: macos-latest
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}

--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -144,7 +144,7 @@ jobs:
         run: ${{ matrix.settings.container-setup }}
 
       - name: Setup Protoc
-        uses: arduino/setup-protoc@v3.0.0
+        uses: arduino/setup-protoc@v2.1.0
         with:
           version: "26.x"
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -115,7 +115,7 @@ jobs:
           - host: ubuntu-latest
             container: ubuntu:xenial
             container-options: "--platform=linux/amd64 --rm"
-            container-setup: "apt-get update && apt-get install -y curl musl-tools sudo"
+            container-setup: "apt-get update && apt-get install -y curl musl-tools sudo unzip"
             target: "x86_64-unknown-linux-musl"
             setup: "apt-get install -y build-essential clang-5.0 lldb-5.0 llvm-5.0-dev libclang-5.0-dev"
           - host: ubuntu-latest

--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -144,8 +144,9 @@ jobs:
         run: ${{ matrix.settings.container-setup }}
 
       - name: Setup Protoc
-        uses: arduino/setup-protoc@v1.2.0
+        uses: arduino/setup-protoc@v3.0.0
         with:
+          version: "26.x"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup capnproto

--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -106,10 +106,10 @@ jobs:
       fail-fast: false
       matrix:
         settings:
-          - host: macos-12
+          - host: macos-latest
             target: "x86_64-apple-darwin"
             container-options: "--rm"
-          - host: macos-12
+          - host: macos-latest
             target: "aarch64-apple-darwin"
             container-options: "--rm"
           - host: ubuntu-latest


### PR DESCRIPTION
### Description

Bumping `setup-protoc` to version 2 as it supports fetching MacOS `arm64` builds which are required for `macos-latest` now that it runs on an M1 chip.
Bumping `protoc` from `3.20` to `3.26` as `3.20` didn't have builds available for MacOS arm64.

Note: Starting with 3.21 the protobuf project has switched it's versioning scheme so the major version 3 is implied. `setup-protoc` matches this as of 2.0.0 so we specify version with the format of `MINOR.PATCH`.
We cannot update to `setup-protoc` to 3.0 as it uses Node20 which requires too high of glibc version for us to support our x86 musl builds.

### Testing Instructions

CI Passes

Verify that library release is able to build on arm64 machines: https://github.com/vercel/turbo/actions/runs/8806177110/job/24170410394

Dry run of release process: https://github.com/vercel/turbo/actions/runs/8807124431


Closes TURBO-2863