### PR TITLE
chore: fix turborepo-repository MUSL release

### DIFF
--- a/.github/workflows/turborepo-library-release.yml
+++ b/.github/workflows/turborepo-library-release.yml
@@ -45,6 +45,7 @@ jobs:
             target: "x86_64-unknown-linux-musl"
             container: ghcr.io/napi-rs/napi-rs/nodejs-rust:stable-2023-09-17-alpine
             install: |
+              apk update && apk upgrade
               apk add libc6-compat curl
             setup: |
               pnpm install
@@ -53,6 +54,7 @@ jobs:
             target: "aarch64-unknown-linux-musl"
             container: ghcr.io/napi-rs/napi-rs/nodejs-rust:stable-2023-09-17-alpine
             install: |
+              apk update && apk upgrade
               apk add libc6-compat curl
               echo /root/.cargo/bin >> ${GITHUB_PATH}
               echo /usr/local/cargo/bin/rustup >> ${GITHUB_PATH}

--- a/.github/workflows/turborepo-library-release.yml
+++ b/.github/workflows/turborepo-library-release.yml
@@ -49,8 +49,8 @@ jobs:
               apk add libc6-compat curl
               echo /root/.cargo/bin >> ${GITHUB_PATH}
               echo /usr/local/cargo/bin/rustup >> ${GITHUB_PATH}
-              export PATH=/usr/local/cargo/bin/rustup:/root/.cargo/bin:${PATH}
             setup: |
+              export PATH=/usr/local/cargo/bin/rustup:/root/.cargo/bin:${PATH}
               rustup show active-toolchain
               dirname $(rustup which cargo) >> ${GITHUB_PATH}
               pnpm install
@@ -64,7 +64,6 @@ jobs:
               echo /root/.cargo/bin >> ${GITHUB_PATH}
               echo /usr/local/cargo/bin/rustup >> ${GITHUB_PATH}
               echo /aarch64-linux-musl-cross/bin >> ${GITHUB_PATH}
-              export PATH=/aarch64-linux-musl-cross/bin:/usr/local/cargo/bin/rustup:/root/.cargo/bin:${PATH}
             setup: |
               export PATH=/aarch64-linux-musl-cross/bin:/usr/local/cargo/bin/rustup:/root/.cargo/bin:${PATH}
               rustup show active-toolchain

--- a/.github/workflows/turborepo-library-release.yml
+++ b/.github/workflows/turborepo-library-release.yml
@@ -109,13 +109,11 @@ jobs:
         if: ${{ matrix.settings.setup }}
 
       - name: Build native library
+        # For some reason PATH modifications from Setup toolchain aren't populated
+        # when using the nodejs-rust alpine container.
         run: |
-          cd packages/turbo-repository
-          echo $PATH
           export PATH=/usr/local/cargo/bin/rustup:/root/.cargo/bin:${PATH}
-          echo $PATH
-          echo $GITHUB_PATH
-          cat $GITHUB_PATH
+          cd packages/turbo-repository
           ${{ matrix.settings.rust_env }} pnpm build:release --target=${{ matrix.settings.target }}
 
       - name: Upload Artifacts

--- a/.github/workflows/turborepo-library-release.yml
+++ b/.github/workflows/turborepo-library-release.yml
@@ -111,6 +111,8 @@ jobs:
       - name: Build native library
         run: |
           cd packages/turbo-repository
+          echo $PATH
+          cat $GITHUB_PATH
           ${{ matrix.settings.rust_env }} pnpm build:release --target=${{ matrix.settings.target }}
 
       - name: Upload Artifacts

--- a/.github/workflows/turborepo-library-release.yml
+++ b/.github/workflows/turborepo-library-release.yml
@@ -112,6 +112,9 @@ jobs:
         run: |
           cd packages/turbo-repository
           echo $PATH
+          export PATH=/usr/local/cargo/bin/rustup:/root/.cargo/bin:${PATH}
+          echo $PATH
+          echo $GITHUB_PATH
           cat $GITHUB_PATH
           ${{ matrix.settings.rust_env }} pnpm build:release --target=${{ matrix.settings.target }}
 

--- a/.github/workflows/turborepo-library-release.yml
+++ b/.github/workflows/turborepo-library-release.yml
@@ -47,9 +47,13 @@ jobs:
             install: |
               apk update && apk upgrade
               apk add libc6-compat curl
+              echo /root/.cargo/bin >> ${GITHUB_PATH}
+              echo /usr/local/cargo/bin/rustup >> ${GITHUB_PATH}
+              export PATH=/usr/local/cargo/bin/rustup:/root/.cargo/bin:${PATH}
             setup: |
-              pnpm install
               rustup show active-toolchain
+              dirname $(rustup which cargo) >> ${GITHUB_PATH}
+              pnpm install
 
           - host: ubuntu-latest
             target: "aarch64-unknown-linux-musl"
@@ -65,6 +69,7 @@ jobs:
               export PATH=/aarch64-linux-musl-cross/bin:/usr/local/cargo/bin/rustup:/root/.cargo/bin:${PATH}
               rustup show active-toolchain
               rustup target add aarch64-unknown-linux-musl
+              dirname $(rustup which cargo) >> ${GITHUB_PATH}
               pnpm install
             rust_env: CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc RUSTFLAGS="-Ctarget-feature=-crt-static"
 

--- a/.github/workflows/turborepo-library-release.yml
+++ b/.github/workflows/turborepo-library-release.yml
@@ -49,6 +49,7 @@ jobs:
               apk add libc6-compat curl
             setup: |
               pnpm install
+              rustup show active-toolchain
 
           - host: ubuntu-latest
             target: "aarch64-unknown-linux-musl"
@@ -62,9 +63,8 @@ jobs:
               export PATH=/aarch64-linux-musl-cross/bin:/usr/local/cargo/bin/rustup:/root/.cargo/bin:${PATH}
             setup: |
               export PATH=/aarch64-linux-musl-cross/bin:/usr/local/cargo/bin/rustup:/root/.cargo/bin:${PATH}
-              rustup default $(cat ./rust-toolchain)-aarch64-unknown-linux-musl
+              rustup show active-toolchain
               rustup target add aarch64-unknown-linux-musl
-              rustup toolchain install $(cat ./rust-toolchain)
               pnpm install
             rust_env: CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc RUSTFLAGS="-Ctarget-feature=-crt-static"
 


### PR DESCRIPTION
### Description

Changes:
 - Upgrade `curl` version to avoid https://github.com/alpinelinux/docker-alpine/issues/383
 - Do `PATH` alterations in build step as for some reason the alpine container doesn't respect alterations from previous steps.
 - Remove `rustup toolchain install` commands as this would require parsing TOML to extract the Rust version we want. Instead we rely on the behavior of `rustup show` which will install the toolchain override if it isn't installed yet.

### Testing Instructions

Dry run: https://github.com/vercel/turbo/actions/runs/8808289531


Closes TURBO-2869