### PR TITLE
fix(cli): fix bad merge conflict resolution

### DIFF
--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -9,7 +9,7 @@ use clap::{
 use clap_complete::{generate, Shell};
 pub use error::Error;
 use serde::{Deserialize, Serialize};
-use tracing::{debug, error, warn};
+use tracing::{debug, error};
 use turbopath::AbsoluteSystemPathBuf;
 use turborepo_api_client::AnonAPIClient;
 use turborepo_repository::inference::{RepoMode, RepoState};
@@ -695,24 +695,6 @@ pub struct ExecutionArgs {
     #[clap(long, requires = "scope-filter-group")]
     pub ignore: Vec<String>,
 
-    /// Avoid saving task results to the cache. Useful for development/watch
-    /// tasks.
-    #[clap(long)]
-    pub no_cache: bool,
-
-    // clap does not have negation flags such as --daemon and --no-daemon
-    // so we need to use a group to enforce that only one of them is set.
-    // we set the long name as [no-]daemon with an alias of daemon such
-    // that we can merge the help text together for both flags
-    // -----------------------
-    #[clap(long = "daemon", group = "daemon-group")]
-    daemon: bool,
-
-    /// Force turbo to either use or not use the local daemon. If unset
-    /// turbo will use the default detection logic.
-    #[clap(long, group = "daemon-group")]
-    no_daemon: bool,
-
     /// Set type of process output logging. Use "full" to show
     /// all output. Use "hash-only" to show only turbo-computed
     /// task hashes. Use "new-only" to show only new output with
@@ -759,9 +741,6 @@ impl ExecutionArgs {
 
         track_usage!(telemetry, self.continue_execution, |val| val);
         track_usage!(telemetry, self.single_package, |val| val);
-        track_usage!(telemetry, self.no_cache, |val| val);
-        track_usage!(telemetry, self.daemon, |val| val);
-        track_usage!(telemetry, self.no_daemon, |val| val);
         track_usage!(telemetry, self.only, |val| val);
         track_usage!(telemetry, self.remote_only, |val| val);
         track_usage!(telemetry, &self.cache_dir, Option::is_some);

--- a/turborepo-tests/integration/tests/no-args.t
+++ b/turborepo-tests/integration/tests/no-args.t
@@ -82,12 +82,6 @@ Make sure exit code is 2 when no args are passed
             Use the given selector to specify package(s) to act as entry points. The syntax mirrors pnpm's syntax, and additional documentation and examples can be found in turbo's documentation https://turbo.build/repo/docs/reference/command-line-reference/run#--filter
         --ignore <IGNORE>
             Files to ignore when calculating changed files from '--filter'. Supports globs
-        --no-cache
-            Avoid saving task results to the cache. Useful for development/watch tasks
-        --daemon
-            
-        --no-daemon
-            Force turbo to either use or not use the local daemon. If unset turbo will use the default detection logic
         --output-logs <OUTPUT_LOGS>
             Set type of process output logging. Use "full" to show all output. Use "hash-only" to show only turbo-computed task hashes. Use "new-only" to show only new output with only hashes for cached tasks. Use "none" to hide process output. (default full) [possible values: full, none, hash-only, new-only, errors-only]
         --log-order <LOG_ORDER>

--- a/turborepo-tests/integration/tests/turbo-help.t
+++ b/turborepo-tests/integration/tests/turbo-help.t
@@ -178,12 +178,6 @@ Test help flag
             Use the given selector to specify package(s) to act as entry points. The syntax mirrors pnpm's syntax, and additional documentation and examples can be found in turbo's documentation https://turbo.build/repo/docs/reference/command-line-reference/run#--filter
         --ignore <IGNORE>
             Files to ignore when calculating changed files from '--filter'. Supports globs
-        --no-cache
-            Avoid saving task results to the cache. Useful for development/watch tasks
-        --daemon
-            
-        --no-daemon
-            Force turbo to either use or not use the local daemon. If unset turbo will use the default detection logic
         --output-logs <OUTPUT_LOGS>
             Set type of process output logging. Use "full" to show all output. Use "hash-only" to show only turbo-computed task hashes. Use "new-only" to show only new output with only hashes for cached tasks. Use "none" to hide process output. (default full) [possible values: full, none, hash-only, new-only, errors-only]
         --log-order <LOG_ORDER>

--- a/turborepo-tests/integration/tests/turbo-help.t
+++ b/turborepo-tests/integration/tests/turbo-help.t
@@ -82,12 +82,6 @@ Test help flag
             Use the given selector to specify package(s) to act as entry points. The syntax mirrors pnpm's syntax, and additional documentation and examples can be found in turbo's documentation https://turbo.build/repo/docs/reference/command-line-reference/run#--filter
         --ignore <IGNORE>
             Files to ignore when calculating changed files from '--filter'. Supports globs
-        --no-cache
-            Avoid saving task results to the cache. Useful for development/watch tasks
-        --daemon
-            
-        --no-daemon
-            Force turbo to either use or not use the local daemon. If unset turbo will use the default detection logic
         --output-logs <OUTPUT_LOGS>
             Set type of process output logging. Use "full" to show all output. Use "hash-only" to show only turbo-computed task hashes. Use "new-only" to show only new output with only hashes for cached tasks. Use "none" to hide process output. (default full) [possible values: full, none, hash-only, new-only, errors-only]
         --log-order <LOG_ORDER>


### PR DESCRIPTION
### Description

I messed up a resolving a merge conflict and didn't migrate some args that moved from `ExecutionArgs` to `RunArgs` in #7613 

### Testing Instructions

Tests on CI pass

Closes TURBO-2872