### PR TITLE
fix(telemetry): correctly parse alerted date

### DIFF
--- a/packages/turbo-telemetry/src/config.test.ts
+++ b/packages/turbo-telemetry/src/config.test.ts
@@ -240,7 +240,7 @@ describe("TelemetryConfig", () => {
           telemetry_enabled: true,
           telemetry_id: "123456",
           telemetry_salt: "private-salt",
-          telemetry_alerted: new Date(),
+          telemetry_alerted: new Date().toISOString(),
         },
       });
 
@@ -389,7 +389,7 @@ describe("TelemetryConfig", () => {
           telemetry_enabled: true,
           telemetry_id: "123456",
           telemetry_salt: "private-salt",
-          telemetry_alerted: new Date(),
+          telemetry_alerted: new Date().toISOString(),
         },
       });
 
@@ -401,11 +401,6 @@ describe("TelemetryConfig", () => {
     test("should set telemetry_alerted to current date and write the config if telemetry_alerted is undefined", (t) => {
       const mockWriteFileSync = mock.fn();
       t.mock.method(fs, "writeFileSync", mockWriteFileSync);
-      mock.timers.enable({
-        apis: ["Date"],
-        now: new Date("2021-01-01T00:00:00.000Z"),
-      });
-
       const result = telemetryConfig.alertShown();
 
       assert.equal(result, true);

--- a/packages/turbo-telemetry/src/config.ts
+++ b/packages/turbo-telemetry/src/config.ts
@@ -14,7 +14,7 @@ const ConfigSchema = z.object({
   telemetry_enabled: z.boolean(),
   telemetry_id: z.string(),
   telemetry_salt: z.string(),
-  telemetry_alerted: z.date().optional(),
+  telemetry_alerted: z.string().optional(),
 });
 
 type Config = z.infer<typeof ConfigSchema>;
@@ -188,7 +188,7 @@ export class TelemetryConfig {
       return true;
     }
 
-    this.config.telemetry_alerted = new Date();
+    this.config.telemetry_alerted = new Date().toISOString();
     this.tryWrite();
     return true;
   }


### PR DESCRIPTION
### Description

Fix parsing the telemetry config alerted date in the JS lib

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
