### PR TITLE
feat(Turborepo): Be explicit about which binary we failed to find

### DIFF
--- a/crates/turborepo-repository/src/package_manager/yarn.rs
+++ b/crates/turborepo-repository/src/package_manager/yarn.rs
@@ -37,7 +37,8 @@ impl<'a> YarnDetector<'a> {
             return Ok(version.clone());
         }
 
-        let yarn_binary = which("yarn")?;
+        let binary = "yarn";
+        let yarn_binary = which(binary).map_err(|e| Error::Which(e, binary.to_string()))?;
         let output = Command::new(yarn_binary)
             .arg("--version")
             .current_dir(self.repo_root)


### PR DESCRIPTION
### Description

 - change `Error::Which` to not be transparent, and to display the binary we tried to find
 - update the calls to `which("bun")` and `which("yarn")` to use the new pattern.

### Testing Instructions

Existing test suite


Closes TURBO-2900