### PR TITLE
chore(linting): implement ESLint flat config for eslint-plugin-turbo

### DIFF
--- a/packages/eslint-config-turbo/README.md
+++ b/packages/eslint-config-turbo/README.md
@@ -1,6 +1,6 @@
 # `eslint-config-turbo`
 
-Ease configuration for Turborepo
+Easy ESLint configuration for Turborepo
 
 ## Installation
 

--- a/packages/eslint-plugin-turbo/README.md
+++ b/packages/eslint-plugin-turbo/README.md
@@ -1,6 +1,6 @@
 # `eslint-plugin-turbo`
 
-Ease configuration for Turborepo
+Easy ESLint configuration for Turborepo
 
 ## Installation
 
@@ -16,7 +16,7 @@ npm install eslint --save-dev
 npm install eslint-plugin-turbo --save-dev
 ```
 
-## Usage
+## Usage (Legacy `eslintrc*`)
 
 Add `turbo` to the plugins section of your `.eslintrc` configuration file. You can omit the `eslint-plugin-` prefix:
 
@@ -36,7 +36,7 @@ Then configure the rules you want to use under the rules section.
 }
 ```
 
-### Example
+## Example (Legacy `eslintrc*`)
 
 ```json
 {
@@ -50,4 +50,53 @@ Then configure the rules you want to use under the rules section.
     ]
   }
 }
+```
+
+## Usage (Flat Config `eslint.config.js`)
+
+In ESLint v8, both the legacy system and the new flat config system are supported. In Eslint v9, only the new system will be supported. See the [official ESLint docs](https://eslint.org/docs/latest/use/configure/configuration-files).
+
+```js
+import turbo from "eslint-plugin-turbo";
+
+export default [turbo.configs["flat/recommended"]];
+```
+
+Otherwise, you may configure the rules you want to use under the rules section.
+
+```js
+import turbo from "eslint-plugin-turbo";
+
+export default [
+  {
+    plugins: {
+      turbo,
+    },
+    rules: {
+      "turbo/no-undeclared-env-vars": "error",
+    },
+  },
+];
+```
+
+## Example (Flat Config `eslint.config.js`)
+
+```js
+import turbo from "eslint-plugin-turbo";
+
+export default [
+  {
+    plugins: {
+      turbo,
+    },
+    rules: {
+      "turbo/no-undeclared-env-vars": [
+        "error",
+        {
+          allowList: ["^ENV_[A-Z]+$"],
+        },
+      ],
+    },
+  },
+];
 ```

--- a/packages/eslint-plugin-turbo/lib/configs/flat/recommended.ts
+++ b/packages/eslint-plugin-turbo/lib/configs/flat/recommended.ts
@@ -1,0 +1,27 @@
+import { RULES } from "../../constants";
+import { Project } from "../../utils/calculate-inputs";
+import noUndeclaredEnvVars from "../../rules/no-undeclared-env-vars";
+
+const project = new Project(process.cwd());
+const cacheKey = project.valid() ? project.key() : Math.random();
+
+const config = {
+  plugins: {
+    turbo: {
+      // prevent circular dependency when importing from "../.."
+      rules: {
+        [RULES.noUndeclaredEnvVars]: noUndeclaredEnvVars,
+      },
+    },
+  },
+  rules: {
+    [`turbo/${RULES.noUndeclaredEnvVars}`]: "error",
+  },
+  settings: {
+    turbo: {
+      cacheKey,
+    },
+  },
+};
+
+export default config;

--- a/packages/eslint-plugin-turbo/lib/index.ts
+++ b/packages/eslint-plugin-turbo/lib/index.ts
@@ -1,8 +1,16 @@
+import { name, version } from "../package.json";
 import { RULES } from "./constants";
 // rules
 import noUndeclaredEnvVars from "./rules/no-undeclared-env-vars";
 // configs
 import recommended from "./configs/recommended";
+import flatRecommended from "./configs/flat/recommended";
+
+// See https://eslint.org/docs/latest/extend/plugins#meta-data-in-plugins
+const meta = {
+  name,
+  version,
+};
 
 const rules = {
   [RULES.noUndeclaredEnvVars]: noUndeclaredEnvVars,
@@ -10,6 +18,7 @@ const rules = {
 
 const configs = {
   recommended,
+  "flat/recommended": flatRecommended,
 };
 
-export { rules, configs };
+export { meta, rules, configs };


### PR DESCRIPTION
### Description

- Closes #7909
- Add "flat/recommended" config to eslint-plugin-turbo
- Add meta property to plugin (required for caching, see [Adding Plugin Meta Information](https://eslint.org/docs/latest/extend/plugin-migration-flat-config#adding-plugin-meta-information))
- Update eslint-plugin-turbo/README.md accordingly with information on using flat config

### Testing Instructions

The rules or any actual functionality isn't changed, just the exports. The current tests all pass and I have tested the equivalent functionality on a separate project:

```js
const eslint = require("@eslint/js");
const turbo = require("eslint-plugin-turbo");


module.exports = [
  eslint.configs.recommended,
  {
    plugins: { turbo },
    rules: {
      ...turbo.configs.recommended.rules,
    },
    settings: {
      ...turbo.configs.recommended.settings,
    },
  },
];