### PR TITLE
fix(turborepo): Watch mode not responding to changes

### DIFF
--- a/crates/turborepo-lib/src/run/watch.rs
+++ b/crates/turborepo-lib/src/run/watch.rs
@@ -1,11 +1,10 @@
-use std::collections::HashSet;
+use std::{cell::RefCell, collections::HashSet, sync::Mutex};
 
 use futures::StreamExt;
 use miette::{Diagnostic, SourceSpan};
 use thiserror::Error;
 use tokio::{
     select,
-    sync::watch,
     task::{yield_now, JoinHandle},
 };
 use turborepo_repository::package_graph::PackageName;
@@ -22,7 +21,7 @@ use crate::{
     DaemonConnector, DaemonPaths,
 };
 
-pub enum ChangedPackages {
+enum ChangedPackages {
     All,
     Some(HashSet<PackageName>),
 }
@@ -88,10 +87,6 @@ pub enum Error {
     SignalInterrupt,
     #[error("package change error")]
     PackageChange(#[from] tonic::Status),
-    #[error("changed packages channel closed, cannot receive new changes")]
-    ChangedPackagesRecv(#[from] watch::error::RecvError),
-    #[error("changed packages channel closed, cannot send new changes")]
-    ChangedPackagesSend(#[from] watch::error::SendError<ChangedPackages>),
 }
 
 impl WatchClient {
@@ -139,12 +134,12 @@ impl WatchClient {
 
         let signal_subscriber = self.handler.subscribe().ok_or(Error::NoSignalHandler)?;
 
-        let (changed_pkgs_tx, mut changed_pkgs_rx) = watch::channel(ChangedPackages::default());
+        let changed_packages = Mutex::new(RefCell::new(ChangedPackages::default()));
 
         let event_fut = async {
             while let Some(event) = events.next().await {
                 let event = event?;
-                Self::handle_change_event(&changed_pkgs_tx, event.event.unwrap()).await?;
+                Self::handle_change_event(&changed_packages, event.event.unwrap()).await?;
             }
 
             Err(Error::ConnectionClosed)
@@ -152,11 +147,9 @@ impl WatchClient {
 
         let run_fut = async {
             loop {
-                changed_pkgs_rx.changed().await?;
-                let changed_pkgs = changed_pkgs_rx.borrow_and_update();
-
-                self.execute_run(&changed_pkgs).await?;
-
+                if !changed_packages.lock().unwrap().borrow().is_empty() {
+                    self.execute_run(&changed_packages).await?;
+                }
                 yield_now().await;
             }
         };
@@ -178,7 +171,7 @@ impl WatchClient {
     }
 
     async fn handle_change_event(
-        changed_packages_tx: &watch::Sender<ChangedPackages>,
+        changed_packages: &Mutex<RefCell<ChangedPackages>>,
         event: proto::package_change_event::Event,
     ) -> Result<(), Error> {
         // Should we recover here?
@@ -188,17 +181,17 @@ impl WatchClient {
             }) => {
                 let package_name = PackageName::from(package_name);
 
-                changed_packages_tx.send_if_modified(|changed_pkgs| match changed_pkgs {
-                    ChangedPackages::All => false,
+                match changed_packages.lock().unwrap().get_mut() {
+                    ChangedPackages::All => {
+                        // If we've already changed all packages, ignore
+                    }
                     ChangedPackages::Some(ref mut pkgs) => {
                         pkgs.insert(package_name);
-
-                        true
                     }
-                });
+                }
             }
             proto::package_change_event::Event::RediscoverPackages(_) => {
-                changed_packages_tx.send(ChangedPackages::All)?;
+                *changed_packages.lock().unwrap().get_mut() = ChangedPackages::All;
             }
             proto::package_change_event::Event::Error(proto::PackageChangeError { message }) => {
                 return Err(DaemonError::Unavailable(message).into());
@@ -208,17 +201,20 @@ impl WatchClient {
         Ok(())
     }
 
-    async fn execute_run(&mut self, changed_packages: &ChangedPackages) -> Result<i32, Error> {
+    async fn execute_run(
+        &mut self,
+        changed_packages: &Mutex<RefCell<ChangedPackages>>,
+    ) -> Result<i32, Error> {
+        let changed_packages = changed_packages.lock().unwrap().take();
         // Should we recover here?
         match changed_packages {
             ChangedPackages::Some(packages) => {
                 let packages = packages
-                    .iter()
+                    .into_iter()
                     .filter(|pkg| {
                         // If not in the filtered pkgs, ignore
                         self.run.filtered_pkgs.contains(pkg)
                     })
-                    .cloned()
                     .collect();
 
                 let mut args = self.base.args().clone();


### PR DESCRIPTION
### Description

When I converted to a `watch` channel, I ended up introducing an annoying bug. Basically you can't tell if the value has been read already in a `watch` channel. So if you send a rediscover, then with subsequent events it's impossible to determine if the rediscover has been seen and you should send a new event, or if it's not seen and therefore you should send nothing.

I fixed this by reverting back to the lock version and addressed @gsoltis's comments by using a tokio Mutex which yields to the runtime when grabbing the lock.

### Testing Instructions

Validated that we get the right change events. Also validated that with regular Mutex and no `yield_now`, we get a deadlock, while with tokio Mutex and no `yield_now` we don't deadlock.
