### PR TITLE
feat: Add lint for `grid-template-areas`

### DIFF
--- a/crates/turbopack-css/src/process.rs
+++ b/crates/turbopack-css/src/process.rs
@@ -926,6 +926,31 @@ impl lightningcss::visitor::Visitor<'_> for CssModuleValidator {
                 }
             }
 
+            lightningcss::properties::Property::GridColumn(p) => {
+                for line in [&p.start, &p.end] {
+                    if let lightningcss::properties::grid::GridLine::Area { name } = line {
+                        self.used_grid_areas.insert(name.to_string());
+                    }
+                }
+            }
+
+            lightningcss::properties::Property::GridRow(p) => {
+                for line in [&p.start, &p.end] {
+                    if let lightningcss::properties::grid::GridLine::Area { name } = line {
+                        self.used_grid_areas.insert(name.to_string());
+                    }
+                }
+            }
+
+            lightningcss::properties::Property::GridRowStart(p)
+            | lightningcss::properties::Property::GridRowEnd(p)
+            | lightningcss::properties::Property::GridColumnStart(p)
+            | lightningcss::properties::Property::GridColumnEnd(p) => {
+                if let lightningcss::properties::grid::GridLine::Area { name } = p {
+                    self.used_grid_areas.insert(name.to_string());
+                }
+            }
+
             lightningcss::properties::Property::GridTemplateAreas(
                 lightningcss::properties::grid::GridTemplateAreas::Areas { areas, .. },
             ) => {

--- a/crates/turbopack-css/src/process.rs
+++ b/crates/turbopack-css/src/process.rs
@@ -959,6 +959,16 @@ impl lightningcss::visitor::Visitor<'_> for CssModuleValidator {
                 }
             }
 
+            lightningcss::properties::Property::GridTemplate(p) => {
+                if let lightningcss::properties::grid::GridTemplateAreas::Areas { areas, .. } =
+                    &mut p.areas
+                {
+                    for area in areas.iter().flatten() {
+                        self.used_grid_templates.insert(area.clone());
+                    }
+                }
+            }
+
             _ => {}
         }
 

--- a/crates/turbopack-css/src/process.rs
+++ b/crates/turbopack-css/src/process.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use anyhow::{bail, Context, Result};
-use indexmap::IndexMap;
+use indexmap::{IndexMap, IndexSet};
 use lightningcss::{
     css_modules::{CssModuleExport, CssModuleExports, CssModuleReference, Pattern, Segment},
     dependencies::{Dependency, ImportDependency, Location, SourceRange},

--- a/crates/turbopack-css/src/process.rs
+++ b/crates/turbopack-css/src/process.rs
@@ -735,7 +735,7 @@ async fn process_content(
 #[derive(Default)]
 struct CssModuleValidator {
     errors: Vec<CssError>,
-    used_grid_areas: HashSet<String>,
+    used_grid_areas: IndexSet<String>,
     used_grid_templates: HashSet<String>,
 }
 impl CssModuleValidator {

--- a/crates/turbopack-css/src/process.rs
+++ b/crates/turbopack-css/src/process.rs
@@ -1481,7 +1481,7 @@ mod tests {
         }
         .grid-container {
             display: grid;
-            grid-template: "my" 100px / "my" 30% "my" 70%;
+            grid-template: "my" "my";
         }
         "#,
         );
@@ -1492,7 +1492,7 @@ mod tests {
         }
         .grid-container {
             display: grid;
-            grid-template: "myArea" 100px / "myArea" 30% "myArea" 70%;
+            grid-template: "myArea" "myArea"
         }
         "#,
         );

--- a/crates/turbopack-css/src/process.rs
+++ b/crates/turbopack-css/src/process.rs
@@ -1240,6 +1240,11 @@ mod tests {
         assert_ne!(lint_swc(code), vec![], "swc: {code}");
     }
 
+    #[track_caller]
+    fn assert_lint_failure_only_lightning_css(code: &str) {
+        assert_ne!(lint_lightningcss(code), vec![], "lightningcss: {code}");
+    }
+
     #[test]
     fn css_module_pure_lint() {
         assert_lint_success(
@@ -1369,6 +1374,18 @@ mod tests {
             r#"
         .item1 {
             grid-area: myArea;
+        }
+        .grid-container {
+            display: grid;
+            grid-template-areas: "myArea myArea";
+        }
+        "#,
+        );
+
+        assert_lint_failure_only_lightning_css(
+            r#"
+        .item1 {
+            grid-area: my;
         }
         .grid-container {
             display: grid;

--- a/crates/turbopack-css/src/process.rs
+++ b/crates/turbopack-css/src/process.rs
@@ -739,6 +739,7 @@ struct CssValidator {
 enum CssError {
     SwcSelectorInModuleNotPure { span: Span },
     LightningCssSelectorInModuleNotPure { selector: String },
+    UnknownGridAreaInModules { name: String },
 }
 
 impl CssError {
@@ -761,6 +762,18 @@ impl CssError {
                 ParsingIssue {
                     file,
                     msg: Vc::cell(format!("{CSS_MODULE_ERROR}, (lightningcss, {selector})")),
+                    source: Vc::cell(None),
+                }
+                .cell()
+                .emit();
+            }
+
+            CssError::UnknownGridAreaInModules { name } => {
+                ParsingIssue {
+                    file,
+                    msg: Vc::cell(format!(
+                        "Cannot find grid-template-areas with name '{name}'"
+                    )),
                     source: Vc::cell(None),
                 }
                 .cell()

--- a/crates/turbopack-css/src/process.rs
+++ b/crates/turbopack-css/src/process.rs
@@ -895,7 +895,18 @@ impl lightningcss::visitor::Visitor<'_> for CssValidator {
     type Error = ();
 
     fn visit_types(&self) -> lightningcss::visitor::VisitTypes {
-        visit_types!(SELECTORS)
+        lightningcss::visitor::VisitTypes::all()
+    }
+
+    fn visit_property(
+        &mut self,
+        property: &mut lightningcss::properties::Property,
+    ) -> Result<(), Self::Error> {
+        match property {
+            lightningcss::properties::Property::GridTemplateAreas(p) => {}
+
+            _ => Ok(()),
+        }
     }
 
     fn visit_selector(

--- a/crates/turbopack-css/src/process.rs
+++ b/crates/turbopack-css/src/process.rs
@@ -1362,4 +1362,19 @@ mod tests {
         }",
         );
     }
+
+    #[test]
+    fn css_module_grid_lint() {
+        assert_lint_success(
+            r#"
+        .item1 {
+            grid-area: myArea;
+        }
+        .grid-container {
+            display: grid;
+            grid-template-areas: "myArea myArea";
+        }
+        "#,
+        );
+    }
 }

--- a/crates/turbopack-css/src/process.rs
+++ b/crates/turbopack-css/src/process.rs
@@ -1428,5 +1428,73 @@ mod tests {
         }
         "#,
         );
+
+        assert_lint_failure_only_lightning_css(
+            r#"
+        .item1 {
+            grid-area-row-start: my;
+        }
+        .grid-container {
+            display: grid;
+            grid-template-areas: "myArea myArea";
+        }
+        "#,
+        );
+        assert_lint_failure_only_lightning_css(
+            r#"
+        .item1 {
+            grid-area-row-end: my;
+        }
+        .grid-container {
+            display: grid;
+            grid-template-areas: "myArea myArea";
+        }
+        "#,
+        );
+        assert_lint_failure_only_lightning_css(
+            r#"
+        .item1 {
+            grid-area-column-start: my;
+        }
+        .grid-container {
+            display: grid;
+            grid-template-areas: "myArea myArea";
+        }
+        "#,
+        );
+        assert_lint_failure_only_lightning_css(
+            r#"
+        .item1 {
+            grid-area-column-end: my;
+        }
+        .grid-container {
+            display: grid;
+            grid-template-areas: "myArea myArea";
+        }
+        "#,
+        );
+
+        assert_lint_success(
+            r#"
+        .item1 {
+            grid-area: my;
+        }
+        .grid-container {
+            display: grid;
+            grid-template: "my" 100px / "my" 30% "my" 70%;
+        }
+        "#,
+        );
+        assert_lint_failure_only_lightning_css(
+            r#"
+        .item1 {
+            grid-area: my;
+        }
+        .grid-container {
+            display: grid;
+            grid-template: "myArea" 100px / "myArea" 30% "myArea" 70%;
+        }
+        "#,
+        );
     }
 }

--- a/crates/turbopack-css/src/process.rs
+++ b/crates/turbopack-css/src/process.rs
@@ -1432,7 +1432,7 @@ mod tests {
         assert_lint_failure_only_lightning_css(
             r#"
         .item1 {
-            grid-area-row-start: my;
+            grid-row-start: my;
         }
         .grid-container {
             display: grid;
@@ -1443,7 +1443,7 @@ mod tests {
         assert_lint_failure_only_lightning_css(
             r#"
         .item1 {
-            grid-area-row-end: my;
+            grid-row-end: my;
         }
         .grid-container {
             display: grid;
@@ -1454,7 +1454,7 @@ mod tests {
         assert_lint_failure_only_lightning_css(
             r#"
         .item1 {
-            grid-area-column-start: my;
+            grid-column-start: my;
         }
         .grid-container {
             display: grid;
@@ -1465,7 +1465,7 @@ mod tests {
         assert_lint_failure_only_lightning_css(
             r#"
         .item1 {
-            grid-area-column-end: my;
+            grid-column-end: my;
         }
         .grid-container {
             display: grid;


### PR DESCRIPTION
### Description

> grid-template-areas and grid-area behaves differently in lightningcss and that leads to some user problems, so we need a check to catches these errors.
> Since lightning css in css modules is renaming grid area names, you have to use grid-area and grid-template-areas in the same file together. Using them in different files would be an error.
> 
> So it would be great to have a check that emits an error when using grid-area in a CSS file but not declaring the name in grid-template-areas.

Closes PACK-3022


### Testing Instructions

I added some tests