### PR TITLE
Update rules for PR labeling

### DIFF
--- a/.github/turbo-orchestrator.yml
+++ b/.github/turbo-orchestrator.yml
@@ -46,6 +46,11 @@ labeler:
       when:
         isPRAuthorMatch: "^(gsoltis|anthonyshew|tknickman|mehulkar|chris-olszewski|NicholasLYang|arlyon|Zertsov)$"
 
+    # needs: triage when not any of the turbopack or turborepo team
+    - label: "needs: triage"
+      when:
+        isNotPRAuthorMatch: "^(bgw|ForsakenHarmony|kdy1|kwonoj|padmaia|sokra|wbinnssmith|gsoltis|anthonyshew|tknickman|mehulkar|chris-olszewski|NicholasLYang|arlyon|Zertsov)$"
+
     # areas
     - label: "area: ci"
       when:

--- a/.github/turbo-orchestrator.yml
+++ b/.github/turbo-orchestrator.yml
@@ -44,12 +44,12 @@ labeler:
         isPRAuthorMatch: "^(bgw|ForsakenHarmony|kdy1|kwonoj|padmaia|sokra|wbinnssmith)$"
     - label: "created-by: turborepo"
       when:
-        isPRAuthorMatch: "^(gsoltis|anthonyshew|tknickman|mehulkar|chris-olszewski|NicholasLYang|arlyon|Zertsov)$"
+        isPRAuthorMatch: "^(gsoltis|anthonyshew|tknickman|mehulkar|chris-olszewski|NicholasLYang|arlyon|Zertsov|paulogdm|codybrouwers)$"
 
     # needs: triage when not any of the turbopack or turborepo team
     - label: "needs: triage"
       when:
-        isNotPRAuthorMatch: "^(bgw|ForsakenHarmony|kdy1|kwonoj|padmaia|sokra|wbinnssmith|gsoltis|anthonyshew|tknickman|mehulkar|chris-olszewski|NicholasLYang|arlyon|Zertsov)$"
+        isNotPRAuthorMatch: "^(bgw|ForsakenHarmony|kdy1|kwonoj|padmaia|sokra|wbinnssmith|gsoltis|anthonyshew|tknickman|mehulkar|chris-olszewski|NicholasLYang|arlyon|Zertsov|paulogdm|codybrouwers)$"
 
     # areas
     - label: "area: ci"


### PR DESCRIPTION
I use the [`needs: triage` label][1] during my OSS rotation and [a separate link][3] to find external contributions. Adding this should make it easier to streamline, but also kick out PRs that someone is already owning that I can ignore during triage.

Closes TURBO-2932

[1]: https://github.com/vercel/turbo/issues?q=is%3Aissue+is%3Aopen+label%3A%22needs%3A+triage%22+label%3A%22owned-by%3A+turborepo%22+

[3]: https://github.com/vercel/turbo/pulls?q=is%3Apr+is%3Aopen+sort%3Acreated-desc+-label%3A%22created-by%3A+turbopack%22+-label%3A%22created-by%3A+turborepo%22+-review%3Aapproved+draft%3Afalse+