### PR TITLE
feat(webpack-loaders): support dummy span interface

### DIFF
--- a/crates/turbopack-node/js/src/transforms/webpack-loaders.ts
+++ b/crates/turbopack-node/js/src/transforms/webpack-loaders.ts
@@ -132,6 +132,10 @@ class DummySpan {
   async traceAsyncFn<T>(fn: (span: DummySpan) => T | Promise<T>): Promise<T> {
     return await fn(this);
   }
+
+  stop() {
+    return;
+  }
 }
 
 type ResolveOptions = {


### PR DESCRIPTION
### 

Minor fix to next.js specific loader won't fail if they try to stop current span.

Closes PACK-3033