### PR TITLE
fix: upgrade the turbo package in Yarn 4

### DIFF
--- a/packages/turbo-codemod/src/commands/migrate/steps/getTurboUpgradeCommand.ts
+++ b/packages/turbo-codemod/src/commands/migrate/steps/getTurboUpgradeCommand.ts
@@ -58,12 +58,23 @@ function getLocalUpgradeCommand({
         ]);
         // yarn 1.x
       }
+      if (isUsingWorkspaces) {
+        return renderCommand([
+          "yarn",
+          "workspaces",
+          "foreach",
+          "--all",
+          "--include .",
+          "add",
+          `turbo@${to}`,
+          installType === "devDependencies" && "--dev",
+        ]);
+      }
       return renderCommand([
         "yarn",
         "add",
         `turbo@${to}`,
         installType === "devDependencies" && "--dev",
-        isUsingWorkspaces && "-W",
       ]);
 
     case "npm":


### PR DESCRIPTION
### Description

This fixes a failed install when running `npx @turbo/codemod@latest update` while using Yarn 4.

![Screenshot 2024-05-03 at 10 26 15](https://github.com/vercel/turbo/assets/584693/257f75b7-ffb4-4a73-9fc5-e58086aec04c)

`yarn add turbo@latest --dev -W` is not a valid command:
![Screenshot 2024-05-03 at 10 27 05](https://github.com/vercel/turbo/assets/584693/afff20e1-fa09-4b14-a330-610ec1eeac73)

Using yarn version 4.1.0:
![Screenshot 2024-05-03 at 10 27 29](https://github.com/vercel/turbo/assets/584693/3f59be56-f909-4a81-b469-f5e46b2f4ed7)

It seems to me that `-W` is not a valid flag for most yarn commands. The only command I could find is `yarn workspaces foreach`, but that's not the command being issued in this code.

I don't have a great understanding of this codebase, so I did my best to create a version that works. It looks to me that the code is trying to be resilient against which directory the user is at. So I replicated that behavior using `yarn workspaces foreach --all --include .`. It's a trick to run a specific command in the root of the workspace regardless of current location.

I wasn't able to build the repo. I was hoping for a TS only way to build only the codemod package, but I didn't find it. I currently don't have the time to setup the Go & Rust toolchain and I've never used either. I tested this by manually assembling the command from the code and testing that in my repo.

### Testing Instructions

1. Go to a repo with an outdated version of Turbo & Yarn 4 as the package manager.
2. Run the codemod command
3. It should now work after this change.