### PR TITLE
Remove async-trait from a few crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11406,7 +11406,6 @@ dependencies = [
 name = "turborepo-analytics"
 version = "0.1.0"
 dependencies = [
- "async-trait",
  "futures 0.3.30",
  "thiserror",
  "tokio",
@@ -11421,7 +11420,6 @@ name = "turborepo-api-client"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-trait",
  "chrono",
  "http",
  "lazy_static",
@@ -11814,7 +11812,6 @@ dependencies = [
 name = "turborepo-telemetry"
 version = "0.1.0"
 dependencies = [
- "async-trait",
  "chrono",
  "config",
  "futures 0.3.30",

--- a/crates/turborepo-analytics/Cargo.toml
+++ b/crates/turborepo-analytics/Cargo.toml
@@ -10,7 +10,6 @@ license = "MPL-2.0"
 workspace = true
 
 [dependencies]
-async-trait = { workspace = true }
 futures.workspace = true
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full", "time"] }

--- a/crates/turborepo-analytics/src/lib.rs
+++ b/crates/turborepo-analytics/src/lib.rs
@@ -184,7 +184,6 @@ mod tests {
         time::Duration,
     };
 
-    use async_trait::async_trait;
     use tokio::{
         select,
         sync::{mpsc, mpsc::UnboundedReceiver},
@@ -207,7 +206,6 @@ mod tests {
         }
     }
 
-    #[async_trait]
     impl AnalyticsClient for DummyClient {
         async fn record_analytics(
             &self,

--- a/crates/turborepo-api-client/Cargo.toml
+++ b/crates/turborepo-api-client/Cargo.toml
@@ -20,7 +20,6 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-async-trait = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
 lazy_static = { workspace = true }
 regex = { workspace = true }

--- a/crates/turborepo-api-client/src/analytics.rs
+++ b/crates/turborepo-api-client/src/analytics.rs
@@ -1,19 +1,18 @@
-use async_trait::async_trait;
+use std::future::Future;
+
 use reqwest::Method;
 pub use turborepo_vercel_api::{AnalyticsEvent, CacheEvent, CacheSource};
 
 use crate::{retry, APIAuth, APIClient, Error};
 
-#[async_trait]
 pub trait AnalyticsClient {
-    async fn record_analytics(
+    fn record_analytics(
         &self,
         api_auth: &APIAuth,
         events: Vec<AnalyticsEvent>,
-    ) -> Result<(), Error>;
+    ) -> impl Future<Output = Result<(), Error>> + Send;
 }
 
-#[async_trait]
 impl AnalyticsClient for APIClient {
     #[tracing::instrument(skip_all)]
     async fn record_analytics(

--- a/crates/turborepo-api-client/src/telemetry.rs
+++ b/crates/turborepo-api-client/src/telemetry.rs
@@ -1,4 +1,5 @@
-use async_trait::async_trait;
+use std::future::Future;
+
 use reqwest::Method;
 use turborepo_vercel_api::telemetry::TelemetryEvent;
 
@@ -6,17 +7,15 @@ use crate::{retry, AnonAPIClient, Error};
 
 const TELEMETRY_ENDPOINT: &str = "/api/turborepo/v1/events";
 
-#[async_trait]
 pub trait TelemetryClient {
-    async fn record_telemetry(
+    fn record_telemetry(
         &self,
         events: Vec<TelemetryEvent>,
         telemetry_id: &str,
         session_id: &str,
-    ) -> Result<(), Error>;
+    ) -> impl Future<Output = Result<(), Error>> + Send;
 }
 
-#[async_trait]
 impl TelemetryClient for AnonAPIClient {
     async fn record_telemetry(
         &self,

--- a/crates/turborepo-auth/src/auth/login.rs
+++ b/crates/turborepo-auth/src/auth/login.rs
@@ -200,7 +200,6 @@ mod tests {
         }
     }
 
-    #[async_trait]
     impl Client for MockApiClient {
         async fn get_user(&self, token: &str) -> turborepo_api_client::Result<UserResponse> {
             if token.is_empty() {
@@ -269,7 +268,6 @@ mod tests {
         }
     }
 
-    #[async_trait]
     impl TokenClient for MockApiClient {
         async fn get_metadata(
             &self,
@@ -301,7 +299,6 @@ mod tests {
         }
     }
 
-    #[async_trait]
     impl CacheClient for MockApiClient {
         async fn get_artifact(
             &self,

--- a/crates/turborepo-auth/src/auth/logout.rs
+++ b/crates/turborepo-auth/src/auth/logout.rs
@@ -82,7 +82,6 @@ impl<T: TokenClient> LogoutOptions<T> {
 mod tests {
     use std::backtrace::Backtrace;
 
-    use async_trait::async_trait;
     use reqwest::{RequestBuilder, Response};
     use tempfile::tempdir;
     use turbopath::AbsoluteSystemPathBuf;
@@ -100,7 +99,6 @@ mod tests {
         pub succeed_delete_request: bool,
     }
 
-    #[async_trait]
     impl Client for MockApiClient {
         async fn get_user(&self, _token: &str) -> turborepo_api_client::Result<UserResponse> {
             unimplemented!("get_user")
@@ -143,7 +141,6 @@ mod tests {
         }
     }
 
-    #[async_trait]
     impl TokenClient for MockApiClient {
         async fn delete_token(&self, _token: &str) -> turborepo_api_client::Result<()> {
             if self.succeed_delete_request {

--- a/crates/turborepo-auth/src/auth/sso.rs
+++ b/crates/turborepo-auth/src/auth/sso.rs
@@ -191,7 +191,6 @@ mod tests {
         }
     }
 
-    #[async_trait]
     impl Client for MockApiClient {
         async fn get_user(&self, token: &str) -> turborepo_api_client::Result<UserResponse> {
             if token.is_empty() {
@@ -267,7 +266,6 @@ mod tests {
         }
     }
 
-    #[async_trait]
     impl TokenClient for MockApiClient {
         async fn get_metadata(
             &self,
@@ -298,7 +296,6 @@ mod tests {
         }
     }
 
-    #[async_trait]
     impl CacheClient for MockApiClient {
         async fn get_artifact(
             &self,

--- a/crates/turborepo-auth/src/lib.rs
+++ b/crates/turborepo-auth/src/lib.rs
@@ -266,7 +266,6 @@ fn is_token_active(metadata: &ResponseTokenMetadata, current_time: u128) -> bool
 mod tests {
     use std::backtrace::Backtrace;
 
-    use async_trait::async_trait;
     use reqwest::{Method, Response};
     use tempfile::tempdir;
     use turbopath::AbsoluteSystemPathBuf;
@@ -396,7 +395,6 @@ mod tests {
         pub response: MockCachingResponse,
     }
 
-    #[async_trait]
     impl CacheClient for MockCacheClient {
         async fn get_artifact(
             &self,

--- a/crates/turborepo-telemetry/Cargo.toml
+++ b/crates/turborepo-telemetry/Cargo.toml
@@ -16,7 +16,6 @@ test-case = { workspace = true }
 turborepo-vercel-api-mock = { workspace = true }
 
 [dependencies]
-async-trait = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
 config = { version = "0.13.4", default-features = false, features = ["json"] }
 futures = { workspace = true }

--- a/crates/turborepo-telemetry/src/lib.rs
+++ b/crates/turborepo-telemetry/src/lib.rs
@@ -256,7 +256,6 @@ mod tests {
         time::Duration,
     };
 
-    use async_trait::async_trait;
     use tokio::{
         select,
         sync::{mpsc, mpsc::UnboundedReceiver},
@@ -281,7 +280,6 @@ mod tests {
         }
     }
 
-    #[async_trait]
     impl TelemetryClient for DummyClient {
         async fn record_telemetry(
             &self,


### PR DESCRIPTION
### Description

- Removed `async-trait` dependency from `turborepo-analytics` and `turborepo-api-client`
- Refactored implementation of async functions in `turborepo-api-client` and `turborepo-telemetry`

This crate isn't needed on newer rust toolchains (as long as you are not using trait objects).

### Testing Instructions

If it compiles it's good enough.


Closes TURBO-2973