### PR TITLE
add support for cache_timeout as well as timeout

### DIFF
--- a/crates/turborepo-cache/src/async_cache.rs
+++ b/crates/turborepo-cache/src/async_cache.rs
@@ -186,7 +186,7 @@ impl AsyncCache {
 
 #[cfg(test)]
 mod tests {
-    use std::assert_matches::assert_matches;
+    use std::{assert_matches::assert_matches, time::Duration};
 
     use anyhow::Result;
     use futures::future::try_join_all;
@@ -235,7 +235,13 @@ mod tests {
             }),
         };
 
-        let api_client = APIClient::new(format!("http://localhost:{}", port), 200, "2.0.0", true)?;
+        let api_client = APIClient::new(
+            format!("http://localhost:{}", port),
+            Some(Duration::from_secs(200)),
+            None,
+            "2.0.0",
+            true,
+        )?;
         let api_auth = Some(APIAuth {
             team_id: Some("my-team-id".to_string()),
             token: "my-token".to_string(),
@@ -317,7 +323,13 @@ mod tests {
 
         // Initialize client with invalid API url to ensure that we don't hit the
         // network
-        let api_client = APIClient::new("http://example.com", 200, "2.0.0", true)?;
+        let api_client = APIClient::new(
+            "http://example.com",
+            Some(Duration::from_secs(200)),
+            None,
+            "2.0.0",
+            true,
+        )?;
         let api_auth = Some(APIAuth {
             team_id: Some("my-team-id".to_string()),
             token: "my-token".to_string(),
@@ -405,7 +417,13 @@ mod tests {
             }),
         };
 
-        let api_client = APIClient::new(format!("http://localhost:{}", port), 200, "2.0.0", true)?;
+        let api_client = APIClient::new(
+            format!("http://localhost:{}", port),
+            Some(Duration::from_secs(200)),
+            None,
+            "2.0.0",
+            true,
+        )?;
         let api_auth = Some(APIAuth {
             team_id: Some("my-team-id".to_string()),
             token: "my-token".to_string(),

--- a/crates/turborepo-cache/src/fs.rs
+++ b/crates/turborepo-cache/src/fs.rs
@@ -182,6 +182,8 @@ impl FSCache {
 
 #[cfg(test)]
 mod test {
+    use std::time::Duration;
+
     use anyhow::Result;
     use futures::future::try_join_all;
     use tempfile::tempdir;
@@ -216,7 +218,13 @@ mod test {
         let repo_root_path = AbsoluteSystemPath::from_std_path(repo_root.path())?;
         test_case.initialize(repo_root_path)?;
 
-        let api_client = APIClient::new(format!("http://localhost:{}", port), 200, "2.0.0", true)?;
+        let api_client = APIClient::new(
+            format!("http://localhost:{}", port),
+            Some(Duration::from_secs(200)),
+            None,
+            "2.0.0",
+            true,
+        )?;
         let api_auth = APIAuth {
             team_id: Some("my-team".to_string()),
             token: "my-token".to_string(),

--- a/crates/turborepo-cache/src/http.rs
+++ b/crates/turborepo-cache/src/http.rs
@@ -235,6 +235,8 @@ impl HTTPCache {
 
 #[cfg(test)]
 mod test {
+    use std::time::Duration;
+
     use anyhow::Result;
     use futures::future::try_join_all;
     use tempfile::tempdir;
@@ -276,7 +278,13 @@ mod test {
         let files = &test_case.files;
         let duration = test_case.duration;
 
-        let api_client = APIClient::new(format!("http://localhost:{}", port), 200, "2.0.0", true)?;
+        let api_client = APIClient::new(
+            format!("http://localhost:{}", port),
+            Some(Duration::from_secs(200)),
+            None,
+            "2.0.0",
+            true,
+        )?;
         let opts = CacheOpts::default();
         let api_auth = APIAuth {
             team_id: Some("my-team".to_string()),

--- a/crates/turborepo-lib/src/commands/mod.rs
+++ b/crates/turborepo-lib/src/commands/mod.rs
@@ -1,4 +1,4 @@
-use std::cell::OnceCell;
+use std::{cell::OnceCell, time::Duration};
 
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
 use turborepo_api_client::{APIAuth, APIClient};
@@ -125,9 +125,24 @@ impl CommandBase {
         let config = self.config()?;
         let api_url = config.api_url();
         let timeout = config.timeout();
+        let upload_timeout = config.upload_timeout();
 
-        APIClient::new(api_url, timeout, self.version, config.preflight())
-            .map_err(ConfigError::ApiClient)
+        APIClient::new(
+            api_url,
+            if timeout > 0 {
+                Some(Duration::from_secs(timeout))
+            } else {
+                None
+            },
+            if upload_timeout > 0 {
+                Some(Duration::from_secs(upload_timeout))
+            } else {
+                None
+            },
+            self.version,
+            config.preflight(),
+        )
+        .map_err(ConfigError::ApiClient)
     }
 
     /// Current working directory for the turbo command

--- a/crates/turborepo-lib/src/run/summary/spaces.rs
+++ b/crates/turborepo-lib/src/run/summary/spaces.rs
@@ -351,6 +351,8 @@ fn trim_logs(logs: &[u8], limit: usize) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use anyhow::Result;
     use chrono::Local;
     use pretty_assertions::assert_eq;
@@ -375,7 +377,13 @@ mod tests {
         let port = port_scanner::request_open_port().unwrap();
         let handle = tokio::spawn(start_test_server(port));
 
-        let api_client = APIClient::new(format!("http://localhost:{}", port), 2, "", true)?;
+        let api_client = APIClient::new(
+            format!("http://localhost:{}", port),
+            Some(Duration::from_secs(2)),
+            None,
+            "",
+            true,
+        )?;
 
         let api_auth = Some(APIAuth {
             token: EXPECTED_TOKEN.to_string(),


### PR DESCRIPTION
### Description

We currently have a single API client however some types of calls should be handled differently that others. The cache in particular should not cause a hard error if it times out during upload, only if it fails to connect. `cache_client` is currently only used for uploading artifacts.

TODO: decide on an env var name and add docs. Going to defer to monday's meeting for this.

### Testing Instructions

New unit tests.

Closes TURBO-2974