### PR TITLE
yield a different warning when the cache upload times out

### DIFF
--- a/crates/turborepo-cache/src/http.rs
+++ b/crates/turborepo-cache/src/http.rs
@@ -75,7 +75,10 @@ impl HTTPCache {
             .map(|signer| signer.generate_tag(hash.as_bytes(), &artifact_body))
             .transpose()?;
 
-        self.client
+        tracing::debug!("uploading {}", hash);
+
+        match self
+            .client
             .put_artifact(
                 hash,
                 &artifact_body,
@@ -85,9 +88,20 @@ impl HTTPCache {
                 self.api_auth.team_id.as_deref(),
                 self.api_auth.team_slug.as_deref(),
             )
-            .await?;
-
-        Ok(())
+            .await
+        {
+            Ok(_) => {
+                tracing::debug!("uploaded {}", hash);
+                Ok(())
+            }
+            Err(turborepo_api_client::Error::ReqwestError(e)) if e.is_timeout() => {
+                Err(CacheError::TimeoutError(hash.to_string()))
+            }
+            Err(turborepo_api_client::Error::ReqwestError(e)) if e.is_connect() => {
+                Err(CacheError::ConnectError)
+            }
+            Err(e) => Err(e.into()),
+        }
     }
 
     #[tracing::instrument(skip_all)]

--- a/crates/turborepo-cache/src/lib.rs
+++ b/crates/turborepo-cache/src/lib.rs
@@ -44,6 +44,10 @@ pub enum CacheError {
     InvalidFilePath(String, #[backtrace] Backtrace),
     #[error("failed to contact remote cache: {0}")]
     ApiClientError(Box<turborepo_api_client::Error>, #[backtrace] Backtrace),
+    #[error("the cache artifact for {0} was too large to upload within the timeout")]
+    TimeoutError(String),
+    #[error("could not connect to the cache")]
+    ConnectError,
     #[error("signing artifact failed: {0}")]
     SignatureError(#[from] SignatureError, #[backtrace] Backtrace),
     #[error("invalid duration")]


### PR DESCRIPTION
### Description

In the case of upload timeouts and connection timeouts we can yield a more useful error than the one that reqwest gives us.

Before: `error sending request for url (https://vercel.com/api/v8/artifacts/1e1db6d9c17b138d): operation timed out`
After: `the cache artifact for d6b10341668ff294 was too large to upload within the timeout`
And: `could not connect to the cache`

For complete timeouts and connection timeouts respectively

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->


Closes TURBO-2975