### PR TITLE
fix(ci): Trying to fix `benchmark-turbopack` workflow

### DIFF
--- a/.github/workflows/bench-turbopack.yml
+++ b/.github/workflows/bench-turbopack.yml
@@ -294,7 +294,11 @@ jobs:
 
       - name: Copy benchmark results
         run: |
-          find artifacts -size 0 -delete
+          if [ ! -d artifacts ]; then
+            echo "Artifacts directory not found. Skipping copy."
+            exit 0
+          fi
+          find artifacts -size 0 -delete || true
           mkdir -p data/${{ steps.date.outputs.year }}/${{ steps.date.outputs.month }}/ubuntu-latest-8-core/${{ steps.date.outputs.date }}-${{ github.sha }}/
           mv artifacts/bench_* data/${{ steps.date.outputs.year }}/${{ steps.date.outputs.month }}/ubuntu-latest-8-core/${{ steps.date.outputs.date }}-${{ github.sha }}/
 


### PR DESCRIPTION
### Description

Trying to fix the workflow by checking if the directory exists, a team member should check. 

![Screenshot_20240521_182347](https://github.com/vercel/turbo/assets/53424436/a4dab48f-9514-4147-93ee-0775aefef624)

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
