### PR TITLE
Add instructions for custom server

### DIFF
--- a/docs/pages/pack/docs/index.mdx
+++ b/docs/pages/pack/docs/index.mdx
@@ -71,6 +71,16 @@ Add `--turbo` to your `next dev` command:
 }
 ```
 
+If you are using a custom server, set the `TURBOPACK` environment variable to `1`:
+
+```json
+{
+  "scripts": {
+    "dev": "TURBOPACK=1 node server.js"
+  }
+}
+```
+
 ## Next Steps
 
 Want to learn more about Turbopack? Here's a deep dive on what we think makes it special.


### PR DESCRIPTION
### Description

I added instructions for using Turbopack in development with a custom Next.js server. 

### Testing Instructions

Create a custom Next.js server, and run it with the `TURBOPACK` env set to `1`. The server should now be using turbopack.
