### PR TITLE
Implement bindings for Turbopack trace server

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,6 +161,7 @@ turbopack-static = { path = "crates/turbopack-static" }
 turbopack-swc-utils = { path = "crates/turbopack-swc-utils" }
 turbopack-test-utils = { path = "crates/turbopack-test-utils" }
 turbopack-tests = { path = "crates/turbopack-tests" }
+turbopack-trace-server = { path = "crates/turbopack-trace-server" }
 turbopack-trace-utils = { path = "crates/turbopack-trace-utils" }
 turbopack-wasm = { path = "crates/turbopack-wasm" }
 turbopath = { path = "crates/turborepo-paths" }

--- a/crates/turbopack-binding/Cargo.toml
+++ b/crates/turbopack-binding/Cargo.toml
@@ -139,6 +139,7 @@ __turbopack_ecmascript_hmr_protocol = [
   "turbopack-ecmascript-hmr-protocol",
 ]
 __turbopack_trace_utils = ["__turbopack", "turbopack-trace-utils"]
+__turbopack_trace_server = ["__turbopack", "turbopack-trace-server"]
 
 __turbopack_env = ["__turbopack", "turbopack-env"]
 __turbopack_image = ["__turbopack", "turbopack-image"]
@@ -236,4 +237,5 @@ turbopack-nodejs = { optional = true, workspace = true }
 turbopack-static = { optional = true, workspace = true }
 turbopack-swc-utils = { optional = true, workspace = true }
 turbopack-test-utils = { optional = true, workspace = true }
+turbopack-trace-server = { optional = true, workspace = true }
 turbopack-trace-utils = { optional = true, workspace = true }

--- a/crates/turbopack-binding/src/lib.rs
+++ b/crates/turbopack-binding/src/lib.rs
@@ -96,6 +96,8 @@ pub mod turbopack {
     pub use turbopack_test_utils as test_utils;
     #[cfg(feature = "__turbopack_tests")]
     pub use turbopack_tests as tests;
+    #[cfg(feature = "__turbopack_trace_server")]
+    pub use turbopack_trace_server as trace_server;
     #[cfg(feature = "__turbopack_trace_utils")]
     pub use turbopack_trace_utils as trace_utils;
 }

--- a/crates/turbopack-cli/Cargo.toml
+++ b/crates/turbopack-cli/Cargo.toml
@@ -68,6 +68,7 @@ turbopack-env = { workspace = true }
 turbopack-node = { workspace = true }
 turbopack-nodejs = { workspace = true }
 turbopack-resolve = { workspace = true }
+turbopack-trace-server = { workspace = true }
 turbopack-trace-utils = { workspace = true }
 webbrowser = { workspace = true }
 

--- a/crates/turbopack-trace-server/src/lib.rs
+++ b/crates/turbopack-trace-server/src/lib.rs
@@ -1,0 +1,30 @@
+#![feature(iter_intersperse)]
+#![feature(hash_raw_entry)]
+#![feature(box_patterns)]
+
+use std::{path::PathBuf, sync::Arc};
+
+use self::{reader::TraceReader, server::serve, store_container::StoreContainer};
+
+mod bottom_up;
+mod reader;
+mod self_time_tree;
+mod server;
+mod span;
+mod span_bottom_up_ref;
+mod span_graph_ref;
+mod span_ref;
+mod store;
+mod store_container;
+mod u64_empty_string;
+mod u64_string;
+mod viewer;
+
+pub fn start_turbopack_trace_server(path: PathBuf) {
+    let store = Arc::new(StoreContainer::new());
+    let reader = TraceReader::spawn(store.clone(), path);
+
+    serve(store).unwrap();
+
+    reader.join().unwrap();
+}


### PR DESCRIPTION
### Description

Implement turbopack_bindings for the trace server. Added under `turbopack_bindings::turbopack::trace_server`. Currently only exposing one function: `turbopack_bindings::turbopack::trace_server::start_turbopack_trace_server`

<!--
  ✍️ Write a short summary of your work.
  If necessary, include relevant screenshots.
-->

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
