### PR TITLE
feat(turborepo): Using file hashing for package watching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10859,6 +10859,7 @@ dependencies = [
  "turbopack-static",
  "turbopack-swc-utils",
  "turbopack-test-utils",
+ "turbopack-trace-server",
  "turbopack-trace-utils",
 ]
 
@@ -10920,6 +10921,7 @@ dependencies = [
  "turbopack-node",
  "turbopack-nodejs",
  "turbopack-resolve",
+ "turbopack-trace-server",
  "turbopack-trace-utils",
  "webbrowser",
 ]

--- a/crates/turborepo-lib/src/daemon/server.rs
+++ b/crates/turborepo-lib/src/daemon/server.rs
@@ -136,7 +136,11 @@ impl FileWatching {
             scm,
         ));
 
-        let package_changes_watcher = Arc::new(PackageChangesWatcher::new(repo_root, recv.clone()));
+        let package_changes_watcher = Arc::new(PackageChangesWatcher::new(
+            repo_root,
+            recv.clone(),
+            hash_watcher.clone(),
+        ));
 
         Ok(FileWatching {
             watcher,

--- a/crates/turborepo-lib/src/package_changes_watcher.rs
+++ b/crates/turborepo-lib/src/package_changes_watcher.rs
@@ -214,6 +214,8 @@ impl Subscriber {
             return false;
         }
 
+        tracing::warn!("hashes are the same, no need to rerun");
+
         true
     }
 

--- a/crates/turborepo-lib/src/package_changes_watcher.rs
+++ b/crates/turborepo-lib/src/package_changes_watcher.rs
@@ -11,7 +11,7 @@ use radix_trie::{Trie, TrieCommon};
 use tokio::sync::{broadcast, oneshot, Mutex};
 use turbopath::{AbsoluteSystemPathBuf, AnchoredSystemPath, AnchoredSystemPathBuf};
 use turborepo_filewatch::{
-    hash_watcher::{HashSpec, HashWatcher},
+    hash_watcher::{HashSpec, HashWatcher, InputGlobs},
     NotifyError, OptionalWatch,
 };
 use turborepo_repository::{
@@ -200,7 +200,7 @@ impl Subscriber {
             .get_file_hashes(HashSpec {
                 package_path: pkg.path.clone(),
                 // TODO: Support inputs
-                inputs: None,
+                inputs: InputGlobs::Default,
             })
             .await
         else {


### PR DESCRIPTION
### Description

We leverage the file hash watcher to make watch mode more stable. Basically, once we get a list of changed packages, we query the file hash watcher to see if there are file hashes available. If so, we check if we've seen these file hashes before. If they are, then we don't re-run.

This does have some caveats. For one, file hashes are not exactly correct for whether a task should be re-run. We really should be checking task hashes, but that will require more daemon infrastructure. Also files are most likely the only changes a user will make with watch mode (will they edit env vars? Probably not), so this is good enough.

Also, this will only work on the *second* run, since we need to get the file hash and store it. Maybe even the third if hashing takes too long to get.

### Testing Instructions

I tested on the next.js repo. You can confirm the behavior by looking at the daemon logs and seeing that we don't get a re-run when running `touch foo` multiple times, since the file has the same content.

Closes TURBO-3010