### PR TITLE
fix(turborepo): Persistent tasks in watch mode

### DIFF
--- a/crates/turborepo-lib/src/engine/mod.rs
+++ b/crates/turborepo-lib/src/engine/mod.rs
@@ -297,7 +297,7 @@ impl Engine<Built> {
                 continue;
             }
 
-            new_graph.add_edge(root_index, index, ());
+            new_graph.add_edge(index, root_index, ());
         }
 
         let task_lookup: HashMap<_, _> = new_graph


### PR DESCRIPTION
### Description

Fixing persistent tasks in watch mode. I accidentally reversed the dependency relation which created a circular dependency which in turn caused a deadlock.

### Testing Instructions

Try out `turbo watch dev` in create turbo

Closes TURBO-3020