### PR TITLE
fix(gen): isolate generator to `commonjs`

### DIFF
--- a/packages/turbo-gen/src/templates/simple-js/package.json
+++ b/packages/turbo-gen/src/templates/simple-js/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/packages/turbo-gen/src/templates/simple-ts/package.json
+++ b/packages/turbo-gen/src/templates/simple-ts/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}


### PR DESCRIPTION
### Description

As described by #5657, the default `simple-*` templates creates a template that is broken for `"type": "module"` packages.

When digging into this issue I found out that a simple `package.json` with `"type": "commonjs"` solves the problems by telling the runtime to treat the file diferently from the parent package.

### Testing Instructions

- Initialize a new monorepo with `"type": "module"` in the `package.json`
- on this branch it should now be possible to generate the sample generator (either `js` or `ts`) and not have any errors about the module type.
- it should also be possible to run the generator and it should create the file in the project root normally.
resolves #5657