### PR TITLE
fix(Turborepo): Fix as_inputs to include !

### DIFF
--- a/crates/turborepo-filewatch/src/globwatcher.rs
+++ b/crates/turborepo-filewatch/src/globwatcher.rs
@@ -24,6 +24,7 @@ type Hash = String;
 pub struct GlobSet {
     include: HashMap<String, wax::Glob<'static>>,
     exclude: Any<'static>,
+    // Note that these globs do not include the leading '!' character
     exclude_raw: BTreeSet<String>,
 }
 

--- a/crates/turborepo-filewatch/src/globwatcher.rs
+++ b/crates/turborepo-filewatch/src/globwatcher.rs
@@ -30,7 +30,7 @@ pub struct GlobSet {
 impl GlobSet {
     pub fn as_inputs(&self) -> Vec<String> {
         let mut inputs: Vec<String> = self.include.keys().cloned().collect();
-        inputs.extend(self.exclude_raw.iter().cloned());
+        inputs.extend(self.exclude_raw.iter().map(|s| format!("!{}", s)));
         inputs
     }
 

--- a/crates/turborepo-filewatch/src/hash_watcher.rs
+++ b/crates/turborepo-filewatch/src/hash_watcher.rs
@@ -1314,12 +1314,14 @@ mod tests {
             .create_with_contents("dist file")
             .unwrap();
         dist_path
-            .join_component("extra")
+            .join_component("extra-file")
             .create_with_contents("extra file")
             .unwrap();
-        let foo_inputs =
-            GlobSet::from_raw_unfiltered(vec!["!dist/extra".to_string(), "**/*-file".to_string()])
-                .unwrap();
+        let foo_inputs = GlobSet::from_raw_unfiltered(vec![
+            "!dist/extra-file".to_string(),
+            "**/*-file".to_string(),
+        ])
+        .unwrap();
         let foo_spec = HashSpec {
             package_path: repo_root.anchor(&foo_path).unwrap(),
             inputs: InputGlobs::Specific(foo_inputs),


### PR DESCRIPTION
### Description

 - `GlobSet::as_inputs` now prefixes exclusions with `!` so they are properly parsed

### Testing Instructions

Added new hash watching test with exclusions in the inputs.

Fixes #8112