### PR TITLE
fix(ui): minor formatting

### DIFF
--- a/crates/turborepo-ui/src/tui/pane.rs
+++ b/crates/turborepo-ui/src/tui/pane.rs
@@ -176,8 +176,8 @@ impl<W> TerminalOutput<W> {
 
     fn title(&self, task_name: &str) -> String {
         match self.status.as_deref() {
-            Some(status) => format!(" {task_name} > {status}"),
-            None => format!(" {task_name} >"),
+            Some(status) => format!(" {task_name} > {status} "),
+            None => format!(" {task_name} > "),
         }
     }
 

--- a/crates/turborepo-ui/src/tui/table.rs
+++ b/crates/turborepo-ui/src/tui/table.rs
@@ -219,6 +219,8 @@ impl<'a> StatefulWidget for &'a TaskTable {
     type State = TableState;
 
     fn render(self, area: Rect, buf: &mut ratatui::prelude::Buffer, state: &mut Self::State) {
+        let width = area.width;
+        let bar = "─".repeat(usize::from(width));
         let table = Table::new(
             self.finished_rows()
                 .chain(self.running_rows())
@@ -232,9 +234,8 @@ impl<'a> StatefulWidget for &'a TaskTable {
         .highlight_style(Style::default().fg(Color::Yellow))
         .column_spacing(0)
         .header(
-            ["Task\n────", "\n─"]
-                .iter()
-                .copied()
+            vec![format!("Task\n{bar}"), "\n─".to_owned()]
+                .into_iter()
                 .map(Cell::from)
                 .collect::<Row>()
                 .height(2),


### PR DESCRIPTION
### Description

Two minor changes to the UI:
 - Add trailing space after title
 - Make dividing line after task table header a single line

### Testing Instructions

<img width="776" alt="Screenshot 2024-05-14 at 8 45 51 AM" src="https://github.com/vercel/turbo/assets/4131117/27f414e0-4136-40f4-b840-91e45e20aff2">

