### PR TITLE
feat(filter): no longer infer scope in filters

### DIFF
--- a/crates/turborepo-lib/src/run/scope/filter.rs
+++ b/crates/turborepo-lib/src/run/scope/filter.rs
@@ -1024,24 +1024,6 @@ mod test {
         );
     }
 
-    #[test]
-    fn match_multiple_scoped() {
-        let resolver = make_project(
-            &[],
-            &["packages/@foo/bar", "packages/@types/bar"],
-            None,
-            TestChangeDetector::new(&[]),
-        );
-        let packages = resolver
-            .get_filtered_packages(vec![TargetSelector {
-                name_pattern: "bar".to_string(),
-                ..Default::default()
-            }])
-            .unwrap();
-
-        assert_eq!(packages, HashSet::new());
-    }
-
     #[test_case(
         vec![
             TargetSelector {


### PR DESCRIPTION
### Description

Previously we would infer scope for name filters if there was exactly one matching package.
e.g. `turbo build --filter=ui` would run `@a/ui#build` if there was a `@a/ui` package in the workspace

This is confusing and can result in accidentally breaking filters when a conflicting package is added e.g. adding `@b/ui` would cause *no* tasks to be run along with a zero exit code.

### Testing Instructions

Updated unit test to verify inference no longer works and using the explicit package name still works.
