### PR TITLE
feat(filter): error on invalid filters

### DIFF
--- a/crates/turborepo-lib/src/run/scope/filter.rs
+++ b/crates/turborepo-lib/src/run/scope/filter.rs
@@ -751,6 +751,9 @@ mod test {
             change_detector,
         );
 
+        // TempDir's drop implementation will mark the folder as ready for cleanup
+        // which can lead to non-deterministic test results if the folder is removed
+        // before the test finishes.
         (temp_folder, resolver)
     }
 

--- a/crates/turborepo-lib/src/run/scope/simple_glob.rs
+++ b/crates/turborepo-lib/src/run/scope/simple_glob.rs
@@ -24,6 +24,10 @@ impl SimpleGlob {
             Ok(SimpleGlob::String(pattern.to_string()))
         }
     }
+
+    pub fn is_exact(&self) -> bool {
+        matches!(self, Self::String(_))
+    }
 }
 
 impl Match for SimpleGlob {

--- a/crates/turborepo-lib/src/run/scope/target_selector.rs
+++ b/crates/turborepo-lib/src/run/scope/target_selector.rs
@@ -18,7 +18,7 @@ pub struct TargetSelector {
     pub exclude: bool,
     pub exclude_self: bool,
     pub follow_prod_deps_only: bool,
-    pub parent_dir: AnchoredSystemPathBuf,
+    pub parent_dir: Option<AnchoredSystemPathBuf>,
     pub name_pattern: String,
     pub git_range: Option<GitRange>,
     pub raw: String,
@@ -79,7 +79,7 @@ impl FromStr for TargetSelector {
                         exclude,
                         include_dependencies,
                         include_dependents,
-                        parent_dir: relative_path?,
+                        parent_dir: Some(relative_path?),
                         raw: raw_selector.to_string(),
                         ..Default::default()
                     })
@@ -103,7 +103,7 @@ impl FromStr for TargetSelector {
             .name("name")
             .map_or(String::new(), |m| m.as_str().to_string());
 
-        let mut parent_dir = AnchoredSystemPathBuf::default();
+        let mut parent_dir = None;
 
         if let Some(directory) = captures.name("directory") {
             let directory = directory.as_str().to_string();
@@ -114,14 +114,16 @@ impl FromStr for TargetSelector {
                     .into_os_string()
                     .into_string()
                     .expect("directory was valid utf8 before cleaning");
-                parent_dir = AnchoredSystemPathBuf::try_from(clean_directory.as_str())
-                    .map_err(|_| InvalidSelectorError::InvalidAnchoredPath(directory))?;
+                parent_dir = Some(
+                    AnchoredSystemPathBuf::try_from(clean_directory.as_str())
+                        .map_err(|_| InvalidSelectorError::InvalidAnchoredPath(directory))?,
+                );
             }
         }
 
         let git_range = if let Some(commits) = captures.name("commits") {
             let commits_str = if let Some(commits) = commits.as_str().strip_prefix("...") {
-                if parent_dir == AnchoredSystemPathBuf::default() && name_pattern.is_empty() {
+                if parent_dir.is_none() && name_pattern.is_empty() {
                     return Err(InvalidSelectorError::CantMatchDependencies);
                 }
                 pre_add_dependencies = true;
@@ -233,23 +235,23 @@ mod test {
     #[test_case("...foo...", TargetSelector { name_pattern: "foo".to_string(), raw: "...foo...".to_string(), include_dependents: true, include_dependencies: true, ..Default::default() }; "dot dot dot foo dot dot dot")]
     #[test_case("foo^...", TargetSelector { name_pattern: "foo".to_string(), raw: "foo^...".to_string(), include_dependencies: true, exclude_self: true, ..Default::default() }; "foo caret dot dot dot")]
     #[test_case("...^foo", TargetSelector { name_pattern: "foo".to_string(), raw: "...^foo".to_string(), include_dependents: true, exclude_self: true, ..Default::default() }; "dot dot dot caret foo")]
-    #[test_case("../foo", TargetSelector { raw: "../foo".to_string(), parent_dir: AnchoredSystemPathBuf::try_from(if cfg!(windows) { "..\\foo" } else { "../foo" }).unwrap(), ..Default::default() }; "dot dot slash foo")]
-    #[test_case("./foo", TargetSelector { raw: "./foo".to_string(), parent_dir: AnchoredSystemPathBuf::try_from("foo").unwrap(), ..Default::default() }; "dot slash foo")]
-    #[test_case("./foo/*", TargetSelector { raw: "./foo/*".to_string(), parent_dir: AnchoredSystemPathBuf::try_from(if cfg!(windows) { "foo\\*" } else { "foo/*" }).unwrap(), ..Default::default() }; "dot slash foo star")]
-    #[test_case("...{./foo}", TargetSelector { raw: "...{./foo}".to_string(), parent_dir: AnchoredSystemPathBuf::try_from("foo").unwrap(), include_dependents: true, ..Default::default() }; "dot dot dot curly bracket foo")]
-    #[test_case(".", TargetSelector { raw: ".".to_string(), parent_dir: AnchoredSystemPathBuf::try_from(".").unwrap(), ..Default::default() }; "parent dir dot")]
-    #[test_case("..", TargetSelector { raw: "..".to_string(), parent_dir: AnchoredSystemPathBuf::try_from("..").unwrap(), ..Default::default() }; "parent dir dot dot")]
+    #[test_case("../foo", TargetSelector { raw: "../foo".to_string(), parent_dir: Some(AnchoredSystemPathBuf::try_from(if cfg!(windows) { "..\\foo" } else { "../foo" }).unwrap()), ..Default::default() }; "dot dot slash foo")]
+    #[test_case("./foo", TargetSelector { raw: "./foo".to_string(), parent_dir: Some(AnchoredSystemPathBuf::try_from("foo").unwrap()), ..Default::default() }; "dot slash foo")]
+    #[test_case("./foo/*", TargetSelector { raw: "./foo/*".to_string(), parent_dir: Some(AnchoredSystemPathBuf::try_from(if cfg!(windows) { "foo\\*" } else { "foo/*" }).unwrap()), ..Default::default() }; "dot slash foo star")]
+    #[test_case("...{./foo}", TargetSelector { raw: "...{./foo}".to_string(), parent_dir: Some(AnchoredSystemPathBuf::try_from("foo").unwrap()), include_dependents: true, ..Default::default() }; "dot dot dot curly bracket foo")]
+    #[test_case(".", TargetSelector { raw: ".".to_string(), parent_dir: Some(AnchoredSystemPathBuf::try_from(".").unwrap()), ..Default::default() }; "parent dir dot")]
+    #[test_case("..", TargetSelector { raw: "..".to_string(), parent_dir: Some(AnchoredSystemPathBuf::try_from("..").unwrap()), ..Default::default() }; "parent dir dot dot")]
     #[test_case("[master]", TargetSelector { raw: "[master]".to_string(), git_range: Some(GitRange { from_ref: "master".to_string(), to_ref: None }), ..Default::default() }; "square brackets master")]
     #[test_case("[from...to]", TargetSelector { raw: "[from...to]".to_string(), git_range: Some(GitRange { from_ref: "from".to_string(), to_ref: Some("to".to_string()) }), ..Default::default() }; "[from...to]")]
-    #[test_case("{foo}[master]", TargetSelector { raw: "{foo}[master]".to_string(), git_range: Some(GitRange { from_ref: "master".to_string(), to_ref: None }), parent_dir: AnchoredSystemPathBuf::try_from("foo").unwrap(), ..Default::default() }; "{foo}[master]")]
-    #[test_case("pattern{foo}[master]", TargetSelector { raw: "pattern{foo}[master]".to_string(), git_range: Some(GitRange { from_ref: "master".to_string(), to_ref: None }), parent_dir: AnchoredSystemPathBuf::try_from("foo").unwrap(), name_pattern: "pattern".to_string(), ..Default::default() }; "pattern{foo}[master]")]
+    #[test_case("{foo}[master]", TargetSelector { raw: "{foo}[master]".to_string(), git_range: Some(GitRange { from_ref: "master".to_string(), to_ref: None }), parent_dir: Some(AnchoredSystemPathBuf::try_from("foo").unwrap()), ..Default::default() }; "{foo}[master]")]
+    #[test_case("pattern{foo}[master]", TargetSelector { raw: "pattern{foo}[master]".to_string(), git_range: Some(GitRange { from_ref: "master".to_string(), to_ref: None }), parent_dir: Some(AnchoredSystemPathBuf::try_from("foo").unwrap()), name_pattern: "pattern".to_string(), ..Default::default() }; "pattern{foo}[master]")]
     #[test_case("[master]...", TargetSelector { raw: "[master]...".to_string(), git_range: Some(GitRange { from_ref: "master".to_string(), to_ref: None }), include_dependencies: true, ..Default::default() }; "square brackets master dot dot dot")]
     #[test_case("...[master]", TargetSelector { raw: "...[master]".to_string(), git_range: Some(GitRange { from_ref: "master".to_string(), to_ref: None }), include_dependents: true, ..Default::default() }; "dot dot dot master square brackets")]
     #[test_case("...[master]...", TargetSelector { raw: "...[master]...".to_string(), git_range: Some(GitRange { from_ref: "master".to_string(), to_ref: None }), include_dependencies: true, include_dependents: true, ..Default::default() }; "dot dot dot master square brackets dot dot dot")]
     #[test_case("...[from...to]...", TargetSelector { raw: "...[from...to]...".to_string(), git_range: Some(GitRange { from_ref: "from".to_string(), to_ref: Some("to".to_string()) }), include_dependencies: true, include_dependents: true, ..Default::default() }; "dot dot dot [from...to] dot dot dot")]
     #[test_case("foo...[master]", TargetSelector { raw: "foo...[master]".to_string(), git_range: Some(GitRange { from_ref: "master".to_string(), to_ref: None }), name_pattern: "foo".to_string(), match_dependencies: true, ..Default::default() }; "foo...[master]")]
     #[test_case("foo...[master]...", TargetSelector { raw: "foo...[master]...".to_string(), git_range: Some(GitRange { from_ref: "master".to_string(), to_ref: None }), name_pattern: "foo".to_string(), match_dependencies: true, include_dependencies: true, ..Default::default() }; "foo...[master] dot dot dot")]
-    #[test_case("{foo}...[master]", TargetSelector { raw: "{foo}...[master]".to_string(), git_range: Some(GitRange { from_ref: "master".to_string(), to_ref: None }), parent_dir: AnchoredSystemPathBuf::try_from("foo").unwrap(), match_dependencies: true, ..Default::default() }; "curly brackets foo...[master]")]
+    #[test_case("{foo}...[master]", TargetSelector { raw: "{foo}...[master]".to_string(), git_range: Some(GitRange { from_ref: "master".to_string(), to_ref: None }), parent_dir: Some(AnchoredSystemPathBuf::try_from("foo").unwrap()), match_dependencies: true, ..Default::default() }; "curly brackets foo...[master]")]
     fn parse_target_selector(raw_selector: &str, want: TargetSelector) {
         let result = TargetSelector::from_str(raw_selector);
 

--- a/crates/turborepo-paths/src/relative_unix_path.rs
+++ b/crates/turborepo-paths/src/relative_unix_path.rs
@@ -52,6 +52,10 @@ impl RelativeUnixPath {
         self.0.is_empty()
     }
 
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
     pub fn to_owned(&self) -> RelativeUnixPathBuf {
         RelativeUnixPathBuf(self.0.to_owned())
     }

--- a/crates/turborepo-paths/src/relative_unix_path_buf.rs
+++ b/crates/turborepo-paths/src/relative_unix_path_buf.rs
@@ -34,10 +34,6 @@ impl RelativeUnixPathBuf {
         self.0
     }
 
-    pub fn as_str(&self) -> &str {
-        self.0.as_str()
-    }
-
     pub fn make_canonical_for_tar(&mut self, is_dir: bool) {
         if is_dir && !self.0.ends_with('/') {
             self.0.push('/');

--- a/turborepo-tests/integration/tests/dry-json/monorepo-no-changes.t
+++ b/turborepo-tests/integration/tests/dry-json/monorepo-no-changes.t
@@ -2,13 +2,17 @@ Setup
   $ . ${TESTDIR}/../../../helpers/setup_integration_test.sh
 
 # Save JSON to tmp file so we don't need to keep re-running the build
-  $ ${TURBO} run build --dry=json --filter=main > tmpjson.log
+  $ ${TURBO} run build --dry=json --filter='[main]' > tmpjson.log
 
   $ cat tmpjson.log | jq .packages
-  []
+  [
+    "//"
+  ]
 
 # Save JSON to tmp file so we don't need to keep re-running the build
-  $ ${TURBO} run build --dry=json --filter=main > tmpjson.log
+  $ ${TURBO} run build --dry=json --filter='[main]' > tmpjson.log
 
   $ cat tmpjson.log | jq .packages
-  []
+  [
+    "//"
+  ]

--- a/turborepo-tests/integration/tests/dry-json/single-package-no-change.t
+++ b/turborepo-tests/integration/tests/dry-json/single-package-no-change.t
@@ -2,7 +2,7 @@ Setup
   $ . ${TESTDIR}/../../../helpers/setup_integration_test.sh single_package
 
 # Save JSON to tmp file so we don't need to keep re-running the build
-  $ ${TURBO} run build --dry=json --filter=main > tmpjson.log
+  $ ${TURBO} run build --dry=json --filter='[main]' > tmpjson.log
 
   $ cat tmpjson.log | jq .packages
   null

--- a/turborepo-tests/integration/tests/filter-run.t
+++ b/turborepo-tests/integration/tests/filter-run.t
@@ -41,3 +41,8 @@ Setup
     Time:\s*[\.0-9]+m?s  (re)
   
 
+Non existent package name should error
+  $ ${TURBO} run build --filter="foo" --output-logs none
+    x No package found with name 'foo' in workspace
+  
+  [1]

--- a/turborepo-tests/integration/tests/inference/has-workspaces.t
+++ b/turborepo-tests/integration/tests/inference/has-workspaces.t
@@ -2,22 +2,27 @@ Setup
   $ . ${TESTDIR}/../../../helpers/setup_integration_test.sh inference/has_workspaces
 
   $ cd $TARGET_DIR && ${TURBO} run build --filter=nothing -vv 1> ROOT 2>&1
+  [1]
   $ grep --quiet 'pkg_inference_root set' ROOT
   [1]
-  $ grep --quiet "No tasks were executed as part of this run." ROOT
+  $ grep --quiet "No package found with name 'nothing' in workspace" ROOT
 
   $ cd $TARGET_DIR/apps/web && ${TURBO} run build --filter=nothing -vv 1> WEB 2>&1
+  [1]
   $ grep --quiet 'pkg_inference_root set to "apps[\/\\]web"' WEB
-  $ grep --quiet "No tasks were executed as part of this run." WEB
+  $ grep --quiet "No package found with name 'nothing' in workspace" WEB
 
   $ cd $TARGET_DIR/crates && ${TURBO} run build --filter=nothing -vv 1> CRATES 2>&1
+  [1]
   $ grep --quiet 'pkg_inference_root set to "crates"' CRATES
-  $ grep --quiet "No tasks were executed as part of this run." CRATES
+  $ grep --quiet "No package found with name 'nothing' in workspace" CRATES
 
   $ cd $TARGET_DIR/crates/super-crate/tests/test-package && ${TURBO} run build --filter=nothing -vv 1> TEST_PACKAGE 2>&1
+  [1]
   $ grep --quiet -E 'pkg_inference_root set to "crates[\/\\]super-crate[\/\\]tests[\/\\]test-package"' TEST_PACKAGE
-  $ grep --quiet "No tasks were executed as part of this run." TEST_PACKAGE
+  $ grep --quiet "No package found with name 'nothing' in workspace" TEST_PACKAGE
 
   $ cd $TARGET_DIR/packages/ui-library/src && ${TURBO} run build --filter=nothing -vv 1> UI_LIBRARY 2>&1
+  [1]
   $ grep --quiet -E 'pkg_inference_root set to "packages[\/\\]ui-library[\/\\]src"' UI_LIBRARY
-  $ grep --quiet "No tasks were executed as part of this run." UI_LIBRARY
+  $ grep --quiet "No package found with name 'nothing' in workspace" UI_LIBRARY

--- a/turborepo-tests/integration/tests/inference/nested-workspaces.t
+++ b/turborepo-tests/integration/tests/inference/nested-workspaces.t
@@ -3,20 +3,24 @@ Setup
   $ . ${TESTDIR}/nested_workspaces_setup.sh $(pwd)/nested_workspaces
 
   $ cd $TARGET_DIR/outer && ${TURBO} run build --filter=nothing -vv 1> OUTER 2>&1
+  [1]
   $ grep --quiet -E "Repository Root: .*[\/\\]nested_workspaces[\/\\]outer" OUTER
-  $ grep --quiet "No tasks were executed as part of this run." OUTER
+  $ grep --quiet "No package found with name 'nothing' in workspace" OUTER
 
   $ cd $TARGET_DIR/outer/apps && ${TURBO} run build --filter=nothing -vv 1> OUTER_APPS 2>&1
+  [1]
   $ grep --quiet -E "Repository Root: .*[\/\\]nested_workspaces[\/\\]outer" OUTER_APPS
-  $ grep --quiet "No tasks were executed as part of this run." OUTER_APPS
+  $ grep --quiet "No package found with name 'nothing' in workspace" OUTER_APPS
 
   $ cd $TARGET_DIR/outer/inner && ${TURBO} run build --filter=nothing -vv 1> OUTER_INNER 2>&1
+  [1]
   $ grep --quiet -E "Repository Root: .*[\/\\]nested_workspaces[\/\\]outer[\/\\]inner" OUTER_INNER
-  $ grep --quiet "No tasks were executed as part of this run." OUTER_INNER
+  $ grep --quiet "No package found with name 'nothing' in workspace" OUTER_INNER
 
   $ cd $TARGET_DIR/outer/inner/apps && ${TURBO} run build --filter=nothing -vv 1> OUTER_INNER_APPS 2>&1
+  [1]
   $ grep --quiet -E "Repository Root: .*[\/\\]nested_workspaces[\/\\]outer[\/\\]inner" OUTER_INNER_APPS
-  $ grep --quiet "No tasks were executed as part of this run." OUTER_INNER_APPS
+  $ grep --quiet "No package found with name 'nothing' in workspace" OUTER_INNER_APPS
 
 Locate a repository with no turbo.json. We'll get the right root, but there's nothing to run
   $ cd $TARGET_DIR/outer/inner-no-turbo && ${TURBO} run build --filter=nothing -vv 1> INNER_NO_TURBO 2>&1
@@ -45,12 +49,14 @@ Locate a repository with no turbo.json. We'll get the right root and inference d
   $ grep --quiet "| Follow directions at https://turbo.build/repo/docs to create one" OUTER_NO_TURBO_APPS
 
   $ cd $TARGET_DIR/outer-no-turbo/inner && ${TURBO} run build --filter=nothing -vv 1> OUTER_NO_TURBO_INNER 2>&1
+  [1]
   $ grep --quiet -E "Repository Root: .*[\/\\]nested_workspaces[\/\\]outer-no-turbo[\/\\]inner" OUTER_NO_TURBO_INNER
-  $ grep --quiet "No tasks were executed as part of this run." OUTER_NO_TURBO_INNER
+  $ grep --quiet "No package found with name 'nothing' in workspace" OUTER_NO_TURBO_INNER
 
   $ cd $TARGET_DIR/outer-no-turbo/inner/apps && ${TURBO} run build --filter=nothing -vv 1> OUTER_NO_TURBO_INNER_APPS 2>&1
+  [1]
   $ grep --quiet -E "Repository Root: .*[\/\\]nested_workspaces[\/\\]outer-no-turbo[\/\\]inner" OUTER_NO_TURBO_INNER_APPS
-  $ grep --quiet "No tasks were executed as part of this run." OUTER_NO_TURBO_INNER_APPS
+  $ grep --quiet "No package found with name 'nothing' in workspace" OUTER_NO_TURBO_INNER_APPS
 
   $ cd $TARGET_DIR/outer-no-turbo/inner-no-turbo && ${TURBO} run build --filter=nothing -vv 1> INNER_NO_TURBO 2>&1
   [1]

--- a/turborepo-tests/integration/tests/inference/no-workspaces.t
+++ b/turborepo-tests/integration/tests/inference/no-workspaces.t
@@ -3,32 +3,15 @@ Setup
   $ . ${TESTDIR}/no_workspaces_setup.sh $(pwd)/no_workspaces
 
   $ cd $TARGET_DIR && ${TURBO} run build --filter=nothing
-  \xe2\x80\xa2 Running build (esc)
-  \xe2\x80\xa2 Remote caching disabled (esc)
+    x No package found with name 'nothing' in workspace
   
-  No tasks were executed as part of this run.
-  
-   Tasks:    0 successful, 0 total
-  Cached:    0 cached, 0 total
-    Time:\s*[\.0-9]+m?s  (re)
-  
+  [1]
+
   $ cd $TARGET_DIR/parent && ${TURBO} run build --filter=nothing
-  \xe2\x80\xa2 Running build (esc)
-  \xe2\x80\xa2 Remote caching disabled (esc)
+    x No package found with name 'nothing' in workspace
   
-  No tasks were executed as part of this run.
-  
-   Tasks:    0 successful, 0 total
-  Cached:    0 cached, 0 total
-    Time:\s*[\.0-9]+m?s  (re)
-  
+  [1]
   $ cd $TARGET_DIR/parent/child && ${TURBO} run build --filter=nothing
-  \xe2\x80\xa2 Running build (esc)
-  \xe2\x80\xa2 Remote caching disabled (esc)
+    x No package found with name 'nothing' in workspace
   
-  No tasks were executed as part of this run.
-  
-   Tasks:    0 successful, 0 total
-  Cached:    0 cached, 0 total
-    Time:\s*[\.0-9]+m?s  (re)
-  
+  [1]


### PR DESCRIPTION
### Description

This PR changes `--filter` so it now will error on certain malformed filters:
 - Name filters with no globs that don't match any packages e.g. `--filter=fo` instead of `--filter=foo`
 - Directory filters that reference a directory that doesn't exist: e.g. `--filter='./pakcages/*'`

Each commit of the PR can be reviewed on it's own.

### Testing Instructions

Updated existing unit tests. Added additional ones along with an integration test.