### PR TITLE
feat: error on empty package name

### DIFF
--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -325,6 +325,7 @@ impl<'a, T: PackageDiscovery> BuildState<'a, ResolvedPackageManager, T> {
             node_lookup,
             lockfile,
             package_discovery,
+            repo_root,
             ..
         } = self;
 
@@ -337,6 +338,7 @@ impl<'a, T: PackageDiscovery> BuildState<'a, ResolvedPackageManager, T> {
             packages: workspaces,
             lockfile,
             package_manager,
+            repo_root: repo_root.to_owned(),
         })
     }
 }
@@ -536,6 +538,7 @@ impl<'a, T: PackageDiscovery> BuildState<'a, ResolvedLockfile, T> {
             workspace_graph,
             node_lookup,
             lockfile,
+            repo_root,
             ..
         } = self;
         Ok(PackageGraph {
@@ -544,6 +547,7 @@ impl<'a, T: PackageDiscovery> BuildState<'a, ResolvedLockfile, T> {
             packages: workspaces,
             package_manager,
             lockfile,
+            repo_root: repo_root.to_owned(),
         })
     }
 }

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -5,7 +5,9 @@ use std::{
 
 use petgraph::visit::{depth_first_search, Reversed};
 use serde::Serialize;
-use turbopath::{AbsoluteSystemPath, AnchoredSystemPath, AnchoredSystemPathBuf};
+use turbopath::{
+    AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPath, AnchoredSystemPathBuf,
+};
 use turborepo_graph_utils as graph;
 use turborepo_lockfiles::Lockfile;
 
@@ -30,6 +32,7 @@ pub struct PackageGraph {
     packages: HashMap<PackageName, PackageInfo>,
     package_manager: PackageManager,
     lockfile: Option<Box<dyn Lockfile>>,
+    repo_root: AbsoluteSystemPathBuf,
 }
 
 /// The WorkspacePackage follows the Vercel glossary of terms where "Workspace"
@@ -128,7 +131,16 @@ impl PackageGraph {
 
     #[tracing::instrument(skip(self))]
     pub fn validate(&self) -> Result<(), Error> {
-        graph::validate_graph(&self.graph).map_err(Error::InvalidPackageGraph)
+        for info in self.packages.values() {
+            let name = info.package_json.name.as_deref();
+            if matches!(name, None | Some("")) {
+                let package_json_path = self.repo_root.resolve(info.package_json_path());
+                return Err(Error::PackageJsonMissingName(package_json_path));
+            }
+        }
+        graph::validate_graph(&self.graph).map_err(Error::InvalidPackageGraph)?;
+
+        Ok(())
     }
 
     pub fn remove_package_dependencies(&mut self) {
@@ -481,17 +493,24 @@ mod test {
     async fn test_single_package_is_depends_on_root() {
         let root =
             AbsoluteSystemPathBuf::new(if cfg!(windows) { r"C:\repo" } else { "/repo" }).unwrap();
-        let pkg_graph = PackageGraph::builder(&root, PackageJson::default())
-            .with_package_discovery(MockDiscovery)
-            .with_single_package_mode(true)
-            .build()
-            .await
-            .unwrap();
+        let pkg_graph = PackageGraph::builder(
+            &root,
+            PackageJson {
+                name: Some("my-package".to_owned()),
+                ..Default::default()
+            },
+        )
+        .with_package_discovery(MockDiscovery)
+        .with_single_package_mode(true)
+        .build()
+        .await
+        .unwrap();
 
         let closure =
             pkg_graph.transitive_closure(Some(&PackageNode::Workspace(PackageName::Root)));
         assert!(closure.contains(&PackageNode::Root));
-        assert!(pkg_graph.validate().is_ok());
+        let result = pkg_graph.validate();
+        assert!(result.is_ok(), "expected ok {:?}", result);
     }
 
     #[tokio::test]

--- a/turborepo-tests/integration/tests/invalid-package-json.t
+++ b/turborepo-tests/integration/tests/invalid-package-json.t
@@ -1,0 +1,9 @@
+Setup
+  $ . ${TESTDIR}/../../helpers/setup_integration_test.sh
+Clear name field
+  $ jq '.name = ""' apps/my-app/package.json > package.json.new
+  $ mv package.json.new apps/my-app/package.json
+Build should fail due to missing name field
+  $ ${TURBO} build 1> ERR
+  [1]
+  $ grep -F --quiet 'x package.json must have a name field:' ERR


### PR DESCRIPTION
### Description

We now will error if we encounter a package with a missing or empty package name.

This is done in the graph validation step as opposed to construction since we don't want to impose this restriction on `@turbo/repository` users.

### Testing Instructions

Added integration test
