### PR TITLE
fix rustc bug in turbopack-trace-server

### DIFF
--- a/crates/turbopack-trace-server/src/span_ref.rs
+++ b/crates/turbopack-trace-server/src/span_ref.rs
@@ -332,9 +332,9 @@ impl<'a> SpanRef<'a> {
     pub fn bottom_up(self) -> impl Iterator<Item = SpanBottomUpRef<'a>> {
         self.extra()
             .bottom_up
-            .get_or_init(|| build_bottom_up_graph([self]))
+            .get_or_init(|| build_bottom_up_graph([self].into_iter()))
             .iter()
-            .map(|bottom_up| SpanBottomUpRef {
+            .map(move |bottom_up| SpanBottomUpRef {
                 bottom_up: bottom_up.clone(),
                 store: self.store,
             })


### PR DESCRIPTION
### Description

unfortunately there is a rustc bug that crashes when the typechecking in run in this crate during compiles for next-swc when using `Either<impl Iterator, impl Iterator>`. Solution is to use a Boxed iterator

### Testing Instructions

Existing tests OK
