### PR TITLE
Switch from ld (the default linker) to using lld for GNU Linux targets

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -15,11 +15,18 @@ rustdocflags = ["-Znormalize-docs"]
 [target.x86_64-pc-windows-msvc]
 linker = "rust-lld"
 
-[target.aarch64-apple-darwin]
+[target.'cfg(target_os = "macos")']
 linker = "rust-lld"
 
-[target.x86_64-apple-darwin]
-linker = "rust-lld"
+[target.'cfg(all(target_os = "linux", target_env = "gnu"))']
+rustflags = [
+  "--cfg",
+  "tokio_unstable",
+  "-Zshare-generics=y",
+  "-Zthreads=8",
+  "-Csymbol-mangling-version=v0",
+  "-Clink-arg=-fuse-ld=lld",
+]
 
 [alias]
 xtask = "run --package xtask --"

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -34,6 +34,11 @@ runs:
         # we want more specific settings
         cache: false
 
+    - name: "Install LLD (LLVM Linker) for Linux"
+      if: runner.os == 'Linux'
+      shell: bash
+      run: sudo apt-get -y update && sudo apt-get install -y lld
+
     - name: "Set Windows default host to MinGW"
       if: ${{ inputs.windows == 'true' }}
       shell: bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,10 @@ Thanks for your interest in contributing to Turbo!
 - [Rust](https://www.rust-lang.org/tools/install)
 - [cargo-groups](https://github.com/nicholaslyang/cargo-groups) (used to group crates into Turborepo-specific ones and Turbopack-specific ones)
 
+### Linux Dependencies
+
+- LLD (LLVM Linker), as it's not installed by default on many Linux distributions (e.g. `apt install lld`).
+
 ## Contributing to Turborepo
 
 ### Building Turborepo


### PR DESCRIPTION
**What's wrong with `ld`?** It's very slow and uses a lot of memory.

**Why `lld`?** It's fast, mature, and well-supported. Meta and Google use it for all their linking workloads. We're already using it for macos and x86-64 Windows. There is [ongoing work to make it the default for rustc](https://github.com/rust-lang/rust/issues/71515), and it already is default on a few platforms.

**Why not `mold`?** Mold is generally faster, but the margin is slim enough for our workloads that it doesn't really matter. Mold only recently got support for LTO, doesn't support v0 rust symbol demanging, doesn't support BOLT (though we don't use that yet), etc. Mold is maturing quickly, but `lld` still seems like the "safer" choice.

# Benchmark Caveats

This is using https://github.com/bgw/benchmark-scripts. That machine has a bunch of CPU cores disabled, so the benchmark is running on 4 cores without SMT. With higher core/thread counts, mold will almost certainly perform better as it's heavily multi-threaded. However, I think these benchmarks do enough to show that the real enemy is `ld`, and `lld` is close enough to `mold`.

# Turbopack Warm Build

Modify a string in an error message inside of `crates/turbopack-ecmascript/src/minify.rs`. This guarantees forced recompilation of all dependent crates without meaninfully changing any behavior. Then run:

```
time RUSTFLAGS=... cargo build -p turbopack-cli
```

## With GNU ld (2.40)

Without RUSTFLAGS

```
real    1m24.296s
```

## With Mold (1.10.1, Debian 12)

Using `RUSTFLAGS=-Clink-arg=-fuse-ld=mold`

```
real    0m38.189s
```

## With LLD (14.0.6, Debian 12)

Using `RUSTFLAGS=-Clink-arg=-fuse-ld=lld`

```
real    0m39.810s
```

# Turbopack Cold Build

```
rm -rf target/ && time RUSTFLAGS=... cargo build -p turbopack-cli
```

## With GNU ld (2.40)

Without RUSTFLAGS

```
real    11m24.960s
```

## With Mold (1.10.1, Debian 12)

Using `RUSTFLAGS=-Clink-arg=-fuse-ld=mold`

```
real    10m14.209s
```

## With LLD (14.0.6, Debian 12)

Using `RUSTFLAGS=-Clink-arg=-fuse-ld=lld`

```
real    10m15.404s
```

# Turborepo Cold Build

```
rm -rf target/ && time RUSTFLAGS=... cargo build -p turbo
```

## With GNU ld (2.40)

Without RUSTFLAGS

```
real    5m22.796s
```

## With Mold (1.10.1, Debian 12)

Using `RUSTFLAGS=-Clink-arg=-fuse-ld=mold`

```
real    4m53.936s
```

## With LLD (14.0.6, Debian 12)

Using `RUSTFLAGS=-Clink-arg=-fuse-ld=lld`

```
real    4m54.182s
```

# Tests Cold Build

This produces a large number of binary targets in parallel.

```
rm -rf target/ && time RUSTFLAGS=-Clink-arg=-fuse-ld=mold cargo nextest run -- dummy_filter_build_only_dont_run_any_tests
```

## With GNU ld (2.40)

Without RUSTFLAGS

*No numbers, as this OOMs (!!!) (16GB of RAM)*

## With Mold (1.10.1, Debian 12)

Using `RUSTFLAGS=-Clink-arg=-fuse-ld=mold`

```
real    15m29.912s
```

## With LLD (14.0.6, Debian 12)

Using `RUSTFLAGS=-Clink-arg=-fuse-ld=lld`

```
real    15m19.553s
```