### PR TITLE
fix(turbo-ignore): `packages` can be undefined

### DIFF
--- a/packages/turbo-ignore/src/ignore.ts
+++ b/packages/turbo-ignore/src/ignore.ts
@@ -133,7 +133,7 @@ export function turboIgnore(
         error(`Failed to parse JSON output from \`${command}\`.`);
         return continueBuild();
       }
-      const { packages } = parsed;
+      const { packages = [] } = parsed;
       if (packages.length > 0) {
         if (packages.length === 1) {
           info(`This commit affects "${workspace}"`);


### PR DESCRIPTION
On `monorepo: false`, there is no `packages` value which will throw when `packages.length`.

![Screenshot 2024-05-18 at 1 42 38 AM](https://github.com/vercel/turbo/assets/120007119/a4e5d9ad-61c2-4ef0-b49e-dde6495fabc4)
