### PR TITLE
feat: factor engines into global cache key

### DIFF
--- a/crates/turborepo-lib/src/hash/mod.rs
+++ b/crates/turborepo-lib/src/hash/mod.rs
@@ -432,7 +432,7 @@ mod test {
             framework_inference: true,
         };
 
-        assert_eq!(global_hash.hash(), "08ed059da61137ab");
+        assert_eq!(global_hash.hash(), "215cf70acde752ce");
     }
 
     #[test_case(vec![], "459c029558afe716" ; "empty")]

--- a/crates/turborepo-lib/src/hash/mod.rs
+++ b/crates/turborepo-lib/src/hash/mod.rs
@@ -66,6 +66,7 @@ pub struct GlobalHashable<'a> {
     pub global_file_hash_map: &'a HashMap<turbopath::RelativeUnixPathBuf, String>,
     // These are None in single package mode
     pub root_external_dependencies_hash: Option<&'a str>,
+    pub root_internal_dependencies_hash: Option<&'a str>,
     pub engines: HashMap<&'a str, &'a str>,
     pub env: &'a [String],
     pub resolved_env_vars: EnvironmentVariablePairs,
@@ -424,6 +425,7 @@ mod test {
             global_cache_key: "global_cache_key",
             global_file_hash_map: &global_file_hash_map,
             root_external_dependencies_hash: Some("0000000000000000"),
+            root_internal_dependencies_hash: Some("0000000000000001"),
             engines: Default::default(),
             env: &["env".to_string()],
             resolved_env_vars: vec![],
@@ -432,7 +434,7 @@ mod test {
             framework_inference: true,
         };
 
-        assert_eq!(global_hash.hash(), "215cf70acde752ce");
+        assert_eq!(global_hash.hash(), "5072bd005ec02799");
     }
 
     #[test_case(vec![], "459c029558afe716" ; "empty")]

--- a/crates/turborepo-lib/src/hash/mod.rs
+++ b/crates/turborepo-lib/src/hash/mod.rs
@@ -66,7 +66,7 @@ pub struct GlobalHashable<'a> {
     pub global_file_hash_map: &'a HashMap<turbopath::RelativeUnixPathBuf, String>,
     // These are None in single package mode
     pub root_external_dependencies_hash: Option<&'a str>,
-    pub root_internal_dependencies_hash: Option<&'a str>,
+    pub engines: HashMap<&'a str, &'a str>,
     pub env: &'a [String],
     pub resolved_env_vars: EnvironmentVariablePairs,
     pub pass_through_env: &'a [String],
@@ -303,6 +303,24 @@ impl From<GlobalHashable<'_>> for Builder<HeapAllocator> {
             }
         }
 
+        {
+            let mut entries = builder
+                .reborrow()
+                .init_engines(hashable.engines.len() as u32);
+
+            // get a sorted iterator over keys and values of the hashmap
+            // and set the entries in the capnp message
+
+            let mut hashable: Vec<_> = hashable.engines.iter().collect();
+            hashable.sort_by(|a, b| a.0.cmp(b.0));
+
+            for (i, (key, value)) in hashable.iter().enumerate() {
+                let mut entry = entries.reborrow().get(i as u32);
+                entry.set_key(key);
+                entry.set_value(value);
+            }
+        }
+
         if let Some(root_external_dependencies_hash) = hashable.root_external_dependencies_hash {
             builder.set_root_external_deps_hash(root_external_dependencies_hash);
         }
@@ -406,7 +424,7 @@ mod test {
             global_cache_key: "global_cache_key",
             global_file_hash_map: &global_file_hash_map,
             root_external_dependencies_hash: Some("0000000000000000"),
-            root_internal_dependencies_hash: Some("0000000000000001"),
+            engines: Default::default(),
             env: &["env".to_string()],
             resolved_env_vars: vec![],
             pass_through_env: &["pass_through_env".to_string()],
@@ -414,7 +432,7 @@ mod test {
             framework_inference: true,
         };
 
-        assert_eq!(global_hash.hash(), "8d5ecbdc3ff2b3f2");
+        assert_eq!(global_hash.hash(), "08ed059da61137ab");
     }
 
     #[test_case(vec![], "459c029558afe716" ; "empty")]

--- a/crates/turborepo-lib/src/hash/proto.capnp
+++ b/crates/turborepo-lib/src/hash/proto.capnp
@@ -41,6 +41,7 @@ struct GlobalHashable {
   passThroughEnv @6 :List(Text);
   envMode @7 :EnvMode;
   frameworkInference @8 :Bool;
+  engines @9 :List(Entry);
 
 
   enum EnvMode {

--- a/crates/turborepo-lib/src/run/global_hash.rs
+++ b/crates/turborepo-lib/src/run/global_hash.rs
@@ -103,9 +103,7 @@ pub fn get_global_hash_inputs<'a, L: ?Sized + Lockfile>(
 
     debug!(
         "external deps hash: {}",
-        root_external_dependencies_hash
-            .as_deref()
-            .unwrap_or("no hash (single package)")
+        root_external_dependencies_hash.unwrap_or("no hash (single package)")
     );
 
     Ok(GlobalHashableInputs {
@@ -188,8 +186,8 @@ impl<'a> GlobalHashableInputs<'a> {
         let global_hashable = GlobalHashable {
             global_cache_key: self.global_cache_key,
             global_file_hash_map: &self.global_file_hash_map,
-            root_external_dependencies_hash: self.root_external_dependencies_hash.as_deref(),
-            root_internal_dependencies_hash: self.root_internal_dependencies_hash.as_deref(),
+            root_external_dependencies_hash: self.root_external_dependencies_hash,
+            root_internal_dependencies_hash: self.root_internal_dependencies_hash,
             engines: self.engines.clone().unwrap_or_default(),
             env: self.env,
             resolved_env_vars: self

--- a/crates/turborepo-lib/src/run/global_hash.rs
+++ b/crates/turborepo-lib/src/run/global_hash.rs
@@ -48,6 +48,7 @@ pub struct GlobalHashableInputs<'a> {
     // This is `None` in single package mode
     pub root_external_dependencies_hash: Option<String>,
     pub root_internal_dependencies_hash: Option<String>,
+    pub engines: Option<HashMap<&'a str, &'a str>>,
     pub env: &'a [String],
     // Only Option to allow #[derive(Default)]
     pub resolved_env_vars: Option<DetailedMap>,
@@ -60,7 +61,7 @@ pub struct GlobalHashableInputs<'a> {
 #[allow(clippy::too_many_arguments)]
 pub fn get_global_hash_inputs<'a, L: ?Sized + Lockfile>(
     is_monorepo: bool,
-    root_package: &PackageInfo,
+    root_package: &'a PackageInfo,
     root_path: &AbsoluteSystemPath,
     package_manager: &PackageManager,
     lockfile: Option<&L>,
@@ -74,6 +75,8 @@ pub fn get_global_hash_inputs<'a, L: ?Sized + Lockfile>(
 ) -> Result<GlobalHashableInputs<'a>, Error> {
     let root_external_dependencies_hash =
         is_monorepo.then(|| get_external_deps_hash(&root_package.transitive_dependencies));
+
+    let engines = root_package.package_json.engines();
 
     let global_hashable_env_vars =
         get_global_hashable_env_vars(env_at_execution_start, global_env)?;
@@ -113,6 +116,7 @@ pub fn get_global_hash_inputs<'a, L: ?Sized + Lockfile>(
         global_file_hash_map,
         root_external_dependencies_hash,
         root_internal_dependencies_hash,
+        engines,
         env: global_env,
         resolved_env_vars: Some(global_hashable_env_vars),
         pass_through_env: global_pass_through_env,
@@ -189,6 +193,7 @@ impl<'a> GlobalHashableInputs<'a> {
             global_file_hash_map: &self.global_file_hash_map,
             root_external_dependencies_hash: self.root_external_dependencies_hash.as_deref(),
             root_internal_dependencies_hash: self.root_internal_dependencies_hash.as_deref(),
+            engines: self.engines.clone().unwrap_or_default(),
             env: self.env,
             resolved_env_vars: self
                 .resolved_env_vars
@@ -231,6 +236,7 @@ mod tests {
             .unwrap();
 
         let env_var_map = EnvironmentVariableMap::default();
+        let package_info = PackageInfo::default();
         let lockfile: Option<&dyn Lockfile> = None;
         #[cfg(windows)]
         let file_deps = ["C:\\some\\path".to_string()];
@@ -238,7 +244,7 @@ mod tests {
         let file_deps = ["/some/path".to_string()];
         let result = get_global_hash_inputs(
             false,
-            &PackageInfo::default(),
+            &package_info,
             &root,
             &PackageManager::Pnpm,
             lockfile,

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -37,7 +37,7 @@ use crate::{
     run::{global_hash::get_global_hash_inputs, summary::RunTracker, task_access::TaskAccess},
     signal::SignalHandler,
     task_graph::Visitor,
-    task_hash::{get_external_deps_hash, get_internal_deps_hash, PackageInputsHashes},
+    task_hash::PackageInputsHashes,
     turbo_json::TurboJson,
     DaemonClient, DaemonConnector,
 };

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -256,19 +256,6 @@ impl Run {
 
         let is_monorepo = !self.opts.run_opts.single_package;
 
-        let root_external_dependencies_hash =
-            is_monorepo.then(|| get_external_deps_hash(&root_workspace.transitive_dependencies));
-
-        let root_internal_dependencies_hash = is_monorepo
-            .then(|| {
-                get_internal_deps_hash(
-                    &self.scm,
-                    &self.repo_root,
-                    self.pkg_dep_graph.root_internal_package_dependencies(),
-                )
-            })
-            .transpose()?;
-
         let global_hash_inputs = {
             let env_mode = self.opts.run_opts.env_mode;
             let pass_through_env = match env_mode {
@@ -280,8 +267,8 @@ impl Run {
             };
 
             get_global_hash_inputs(
-                root_external_dependencies_hash.as_deref(),
-                root_internal_dependencies_hash.as_deref(),
+                is_monorepo,
+                root_workspace,
                 &self.repo_root,
                 self.pkg_dep_graph.package_manager(),
                 self.pkg_dep_graph.lockfile(),

--- a/crates/turborepo-lib/src/run/summary/global_hash.rs
+++ b/crates/turborepo-lib/src/run/summary/global_hash.rs
@@ -30,8 +30,8 @@ pub struct GlobalEnvVarSummary<'a> {
 pub struct GlobalHashSummary<'a> {
     pub root_key: &'static str,
     pub files: BTreeMap<RelativeUnixPathBuf, String>,
-    pub hash_of_external_dependencies: String,
-    pub hash_of_internal_dependencies: String,
+    pub hash_of_external_dependencies: &'a str,
+    pub hash_of_internal_dependencies: &'a str,
     pub environment_variables: GlobalEnvVarSummary<'a>,
     pub engines: Option<BTreeMap<&'a str, &'a str>>,
 }

--- a/crates/turborepo-lib/src/run/summary/global_hash.rs
+++ b/crates/turborepo-lib/src/run/summary/global_hash.rs
@@ -30,8 +30,8 @@ pub struct GlobalEnvVarSummary<'a> {
 pub struct GlobalHashSummary<'a> {
     pub root_key: &'static str,
     pub files: BTreeMap<RelativeUnixPathBuf, String>,
-    pub hash_of_external_dependencies: &'a str,
-    pub hash_of_internal_dependencies: &'a str,
+    pub hash_of_external_dependencies: String,
+    pub hash_of_internal_dependencies: String,
     pub environment_variables: GlobalEnvVarSummary<'a>,
 }
 

--- a/crates/turborepo-lib/src/run/summary/global_hash.rs
+++ b/crates/turborepo-lib/src/run/summary/global_hash.rs
@@ -33,6 +33,7 @@ pub struct GlobalHashSummary<'a> {
     pub hash_of_external_dependencies: String,
     pub hash_of_internal_dependencies: String,
     pub environment_variables: GlobalEnvVarSummary<'a>,
+    pub engines: Option<BTreeMap<&'a str, &'a str>>,
 }
 
 impl<'a> TryFrom<GlobalHashableInputs<'a>> for GlobalHashSummary<'a> {
@@ -48,6 +49,7 @@ impl<'a> TryFrom<GlobalHashableInputs<'a>> for GlobalHashSummary<'a> {
             resolved_env_vars,
             pass_through_env,
             env_at_execution_start,
+            engines,
             ..
         } = global_hashable_inputs;
 
@@ -61,6 +63,8 @@ impl<'a> TryFrom<GlobalHashableInputs<'a>> for GlobalHashSummary<'a> {
                 },
             )
             .transpose()?;
+
+        let engines = engines.map(|engines| engines.into_iter().collect());
 
         Ok(Self {
             root_key: global_cache_key,
@@ -81,6 +85,7 @@ impl<'a> TryFrom<GlobalHashableInputs<'a>> for GlobalHashSummary<'a> {
                     .map(|vars| vars.by_source.matching.to_secret_hashable()),
                 pass_through,
             },
+            engines,
         })
     }
 }

--- a/crates/turborepo-lib/src/run/summary/mod.rs
+++ b/crates/turborepo-lib/src/run/summary/mod.rs
@@ -538,6 +538,20 @@ impl<'a> RunSummary<'a> {
                 .unwrap_or_default()
                 .join(", ")
         )?;
+        cwriteln!(
+            tab_writer,
+            ui,
+            GREY,
+            "  Engines Values\t=\t{}",
+            self.global_hash_summary
+                .engines
+                .as_ref()
+                .map(|engines| engines
+                    .iter()
+                    .map(|(key, value)| format!("{key}={value}"))
+                    .join(", "))
+                .unwrap_or_default()
+        )?;
 
         tab_writer.flush()?;
         println!();

--- a/crates/turborepo-repository/src/package_json.rs
+++ b/crates/turborepo-repository/src/package_json.rs
@@ -1,4 +1,7 @@
-use std::{collections::BTreeMap, str::FromStr};
+use std::{
+    collections::{BTreeMap, HashMap},
+    str::FromStr,
+};
 
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
@@ -78,6 +81,19 @@ impl PackageJson {
             .get(script_name)
             .filter(|command| !command.is_empty())
             .map(|command| command.as_str())
+    }
+
+    pub fn engines(&self) -> Option<HashMap<&str, &str>> {
+        let engines = self.other.get("engines")?.as_object()?;
+        Some(
+            engines
+                .iter()
+                .filter_map(|(key, value)| {
+                    let value = value.as_str()?;
+                    Some((key.as_str(), value))
+                })
+                .collect(),
+        )
     }
 }
 

--- a/turborepo-tests/integration/tests/dry-json/monorepo.t
+++ b/turborepo-tests/integration/tests/dry-json/monorepo.t
@@ -15,7 +15,6 @@ Setup
       "foo.txt": "eebae5f3ca7b5831e429e947b7d61edd0de69236"
     },
     "hashOfExternalDependencies": "459c029558afe716",
-    "hashOfInternalDependencies": "",
     "environmentVariables": {
       "specified": {
         "env": [
@@ -26,7 +25,8 @@ Setup
       "configured": [],
       "inferred": [],
       "passthrough": null
-    }
+    },
+    "engines": null
   }
 
   $ cat tmpjson.log | jq 'keys'
@@ -50,7 +50,7 @@ Setup
     "taskId": "my-app#build",
     "task": "build",
     "package": "my-app",
-    "hash": "270f1ef47a80f1d1",
+    "hash": "4dc68e628703cbf4",
     "inputs": {
       ".env.local": "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
       "package.json": "1746e0db2361085b5953a6a3beab08c24af5bc08"
@@ -110,7 +110,7 @@ Setup
     "taskId": "util#build",
     "task": "build",
     "package": "util",
-    "hash": "fad2a643cb480b55",
+    "hash": "728076a89c49afbf",
     "inputs": {
       "package.json": "e755064fd7893809d10fc067bb409c7ae516327f"
     },

--- a/turborepo-tests/integration/tests/dry-json/monorepo.t
+++ b/turborepo-tests/integration/tests/dry-json/monorepo.t
@@ -15,6 +15,7 @@ Setup
       "foo.txt": "eebae5f3ca7b5831e429e947b7d61edd0de69236"
     },
     "hashOfExternalDependencies": "459c029558afe716",
+    "hashOfInternalDependencies": "",
     "environmentVariables": {
       "specified": {
         "env": [
@@ -50,7 +51,7 @@ Setup
     "taskId": "my-app#build",
     "task": "build",
     "package": "my-app",
-    "hash": "4dc68e628703cbf4",
+    "hash": "0555ce94ca234049",
     "inputs": {
       ".env.local": "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
       "package.json": "1746e0db2361085b5953a6a3beab08c24af5bc08"
@@ -110,7 +111,7 @@ Setup
     "taskId": "util#build",
     "task": "build",
     "package": "util",
-    "hash": "728076a89c49afbf",
+    "hash": "bf1798d3e46e1b48",
     "inputs": {
       "package.json": "e755064fd7893809d10fc067bb409c7ae516327f"
     },

--- a/turborepo-tests/integration/tests/dry-json/single-package-no-config.t
+++ b/turborepo-tests/integration/tests/dry-json/single-package-no-config.t
@@ -16,7 +16,6 @@ Setup
         "package.json": "8606ff4b95a5330740d8d9d0948faeada64f1f32"
       },
       "hashOfExternalDependencies": "",
-      "hashOfInternalDependencies": "",
       "environmentVariables": {
         "specified": {
           "env": [],
@@ -25,7 +24,8 @@ Setup
         "configured": [],
         "inferred": [],
         "passthrough": null
-      }
+      },
+      "engines": null
     },
     "envMode": "strict",
     "frameworkInference": true,
@@ -33,7 +33,7 @@ Setup
       {
         "taskId": "build",
         "task": "build",
-        "hash": "12c592ddc0e53a5c",
+        "hash": "5c3c1742edb70bb8",
         "inputs": {
           ".gitignore": "03b541460c1b836f96f9c0a941ceb48e91a9fd83",
           "package-lock.json": "1c117cce37347befafe3a9cba1b8a609b3600021",

--- a/turborepo-tests/integration/tests/dry-json/single-package-no-config.t
+++ b/turborepo-tests/integration/tests/dry-json/single-package-no-config.t
@@ -16,6 +16,7 @@ Setup
         "package.json": "8606ff4b95a5330740d8d9d0948faeada64f1f32"
       },
       "hashOfExternalDependencies": "",
+      "hashOfInternalDependencies": "",
       "environmentVariables": {
         "specified": {
           "env": [],
@@ -33,7 +34,7 @@ Setup
       {
         "taskId": "build",
         "task": "build",
-        "hash": "5c3c1742edb70bb8",
+        "hash": "e2b99dad85a4ff66",
         "inputs": {
           ".gitignore": "03b541460c1b836f96f9c0a941ceb48e91a9fd83",
           "package-lock.json": "1c117cce37347befafe3a9cba1b8a609b3600021",

--- a/turborepo-tests/integration/tests/dry-json/single-package-with-deps.t
+++ b/turborepo-tests/integration/tests/dry-json/single-package-with-deps.t
@@ -15,7 +15,6 @@ Setup
         "somefile.txt": "45b983be36b73c0788dc9cbcb76cbb80fc7bb057"
       },
       "hashOfExternalDependencies": "",
-      "hashOfInternalDependencies": "",
       "environmentVariables": {
         "specified": {
           "env": [],
@@ -24,7 +23,8 @@ Setup
         "configured": [],
         "inferred": [],
         "passthrough": null
-      }
+      },
+      "engines": null
     },
     "envMode": "strict",
     "frameworkInference": true,
@@ -32,7 +32,7 @@ Setup
       {
         "taskId": "build",
         "task": "build",
-        "hash": "81a933c332d3f388",
+        "hash": "6c1cecf7f99d0166",
         "inputs": {
           ".gitignore": "03b541460c1b836f96f9c0a941ceb48e91a9fd83",
           "package-lock.json": "1c117cce37347befafe3a9cba1b8a609b3600021",
@@ -87,7 +87,7 @@ Setup
       {
         "taskId": "test",
         "task": "test",
-        "hash": "785d8ef1115bde3b",
+        "hash": "d241ae86a1a24a2e",
         "inputs": {
           ".gitignore": "03b541460c1b836f96f9c0a941ceb48e91a9fd83",
           "package-lock.json": "1c117cce37347befafe3a9cba1b8a609b3600021",

--- a/turborepo-tests/integration/tests/dry-json/single-package-with-deps.t
+++ b/turborepo-tests/integration/tests/dry-json/single-package-with-deps.t
@@ -15,6 +15,7 @@ Setup
         "somefile.txt": "45b983be36b73c0788dc9cbcb76cbb80fc7bb057"
       },
       "hashOfExternalDependencies": "",
+      "hashOfInternalDependencies": "",
       "environmentVariables": {
         "specified": {
           "env": [],
@@ -32,7 +33,7 @@ Setup
       {
         "taskId": "build",
         "task": "build",
-        "hash": "6c1cecf7f99d0166",
+        "hash": "7ece7b62aad25615",
         "inputs": {
           ".gitignore": "03b541460c1b836f96f9c0a941ceb48e91a9fd83",
           "package-lock.json": "1c117cce37347befafe3a9cba1b8a609b3600021",
@@ -87,7 +88,7 @@ Setup
       {
         "taskId": "test",
         "task": "test",
-        "hash": "d241ae86a1a24a2e",
+        "hash": "cb5839f7284aa5f3",
         "inputs": {
           ".gitignore": "03b541460c1b836f96f9c0a941ceb48e91a9fd83",
           "package-lock.json": "1c117cce37347befafe3a9cba1b8a609b3600021",

--- a/turborepo-tests/integration/tests/dry-json/single-package.t
+++ b/turborepo-tests/integration/tests/dry-json/single-package.t
@@ -15,6 +15,7 @@ Setup
         "somefile.txt": "45b983be36b73c0788dc9cbcb76cbb80fc7bb057"
       },
       "hashOfExternalDependencies": "",
+      "hashOfInternalDependencies": "",
       "environmentVariables": {
         "specified": {
           "env": [],
@@ -32,7 +33,7 @@ Setup
       {
         "taskId": "build",
         "task": "build",
-        "hash": "6c1cecf7f99d0166",
+        "hash": "7ece7b62aad25615",
         "inputs": {
           ".gitignore": "03b541460c1b836f96f9c0a941ceb48e91a9fd83",
           "package-lock.json": "1c117cce37347befafe3a9cba1b8a609b3600021",

--- a/turborepo-tests/integration/tests/dry-json/single-package.t
+++ b/turborepo-tests/integration/tests/dry-json/single-package.t
@@ -15,7 +15,6 @@ Setup
         "somefile.txt": "45b983be36b73c0788dc9cbcb76cbb80fc7bb057"
       },
       "hashOfExternalDependencies": "",
-      "hashOfInternalDependencies": "",
       "environmentVariables": {
         "specified": {
           "env": [],
@@ -24,7 +23,8 @@ Setup
         "configured": [],
         "inferred": [],
         "passthrough": null
-      }
+      },
+      "engines": null
     },
     "envMode": "strict",
     "frameworkInference": true,
@@ -32,7 +32,7 @@ Setup
       {
         "taskId": "build",
         "task": "build",
-        "hash": "81a933c332d3f388",
+        "hash": "6c1cecf7f99d0166",
         "inputs": {
           ".gitignore": "03b541460c1b836f96f9c0a941ceb48e91a9fd83",
           "package-lock.json": "1c117cce37347befafe3a9cba1b8a609b3600021",

--- a/turborepo-tests/integration/tests/dry-run.t
+++ b/turborepo-tests/integration/tests/dry-run.t
@@ -18,7 +18,7 @@ Setup
   Global Hash Inputs
     Global Files                          = 1
     External Dependencies Hash            = 459c029558afe716
-    Global Cache Key                      = HEY STELLLLLLLAAAAAAAAAAAAA
+    Global Cache Key                      = I can\xe2\x80\x99t see ya, but I know you\xe2\x80\x99re here (esc)
     Global Env Vars                       = SOME_ENV_VAR
     Global Env Vars Values                = 
     Inferred Global Env Vars Values       = 
@@ -31,7 +31,7 @@ Setup
   my-app#build
     Task                           = build\s* (re)
     Package                        = my-app\s* (re)
-    Hash                           = 4dc68e628703cbf4
+    Hash                           = 0555ce94ca234049
     Cached \(Local\)                 = false\s* (re)
     Cached \(Remote\)                = false\s* (re)
     Directory                      = apps(\/|\\)my-app\s* (re)
@@ -51,7 +51,7 @@ Setup
   util#build
     Task                           = build\s* (re)
     Package                        = util\s* (re)
-    Hash                           = 728076a89c49afbf
+    Hash                           = bf1798d3e46e1b48
     Cached \(Local\)                 = false\s* (re)
     Cached \(Remote\)                = false\s* (re)
     Directory                      = packages(\/|\\)util\s* (re)

--- a/turborepo-tests/integration/tests/dry-run.t
+++ b/turborepo-tests/integration/tests/dry-run.t
@@ -18,53 +18,54 @@ Setup
   Global Hash Inputs
     Global Files                          = 1
     External Dependencies Hash            = 459c029558afe716
-    Global Cache Key                      = I can\xe2\x80\x99t see ya, but I know you\xe2\x80\x99re here (esc)
+    Global Cache Key                      = HEY STELLLLLLLAAAAAAAAAAAAA
     Global Env Vars                       = SOME_ENV_VAR
     Global Env Vars Values                = 
     Inferred Global Env Vars Values       = 
     Global Passed Through Env Vars        = 
     Global Passed Through Env Vars Values = 
+    Engines Values                        = 
 
 # Part 3 are Tasks to Run, and we have to validate each task separately
   $ cat tmp-3.txt | grep "my-app#build" -A 17
   my-app#build
     Task                           = build\s* (re)
     Package                        = my-app\s* (re)
-    Hash                           = 270f1ef47a80f1d1
-    Cached (Local)                 = false
-    Cached (Remote)                = false
-    Directory                      = apps(\/|\\)my-app (re)
-    Command                        = echo building
-    Outputs                        = apple.json, banana.txt
-    Log File                       = apps(\/|\\)my-app(\/|\\).turbo(\/|\\)turbo-build.log (re)
-    Dependencies                   = 
-    Dependents                     = 
-    Inputs Files Considered        = 2
-    Env Vars                       = 
-    Env Vars Values                = 
-    Inferred Env Vars Values       = 
-    Passed Through Env Vars        = 
-    Passed Through Env Vars Values = 
+    Hash                           = 4dc68e628703cbf4
+    Cached \(Local\)                 = false\s* (re)
+    Cached \(Remote\)                = false\s* (re)
+    Directory                      = apps(\/|\\)my-app\s* (re)
+    Command                        = echo building\s* (re)
+    Outputs                        = apple.json, banana.txt\s* (re)
+    Log File                       = apps(\/|\\)my-app(\/|\\)\.turbo(\/|\\)turbo-build\.log\s* (re)
+    Dependencies                   =\s* (re)
+    Dependents                     =\s* (re)
+    Inputs Files Considered        = 2\s* (re)
+    Env Vars                       =\s* (re)
+    Env Vars Values                =\s* (re)
+    Inferred Env Vars Values       =\s* (re)
+    Passed Through Env Vars        =\s* (re)
+    Passed Through Env Vars Values =\s* (re)
 
   $ cat tmp-3.txt | grep "util#build" -A 17
   util#build
     Task                           = build\s* (re)
     Package                        = util\s* (re)
-    Hash                           = fad2a643cb480b55
-    Cached (Local)                 = false
-    Cached (Remote)                = false
-    Directory                      = packages(\/|\\)util (re)
-    Command                        = echo building
-    Outputs                        = 
-    Log File                       = packages(\/|\\)util(\/|\\).turbo(\/|\\)turbo-build.log (re)
-    Dependencies                   = 
-    Dependents                     = 
-    Inputs Files Considered        = 1
-    Env Vars                       = NODE_ENV
-    Env Vars Values                = 
-    Inferred Env Vars Values       = 
-    Passed Through Env Vars        = 
-    Passed Through Env Vars Values = 
+    Hash                           = 728076a89c49afbf
+    Cached \(Local\)                 = false\s* (re)
+    Cached \(Remote\)                = false\s* (re)
+    Directory                      = packages(\/|\\)util\s* (re)
+    Command                        = echo building\s* (re)
+    Outputs                        =\s* (re)
+    Log File                       = packages(\/|\\)util(\/|\\)\.turbo(\/|\\)turbo-build\.log\s* (re)
+    Dependencies                   =\s* (re)
+    Dependents                     =\s* (re)
+    Inputs Files Considered        = 1\s* (re)
+    Env Vars                       = NODE_ENV\s* (re)
+    Env Vars Values                =\s* (re)
+    Inferred Env Vars Values       =\s* (re)
+    Passed Through Env Vars        =\s* (re)
+    Passed Through Env Vars Values =\s* (re)
 
 # Run the task with NODE_ENV set and see it in summary. Use util package so it's just one package
   $ NODE_ENV=banana ${TURBO} run build --dry --filter=util | grep "Environment Variables"

--- a/turborepo-tests/integration/tests/edit-turbo-json/task.t
+++ b/turborepo-tests/integration/tests/edit-turbo-json/task.t
@@ -6,15 +6,15 @@ Baseline task hashes
   $ ${TURBO} build --dry=json | jq -r '.tasks | sort_by(.taskId)[] | {taskId, hash}'
   {
     "taskId": "another#build",
-    "hash": "ea00e25531db048f"
+    "hash": "90d25abdd579d2bf"
   }
   {
     "taskId": "my-app#build",
-    "hash": "270f1ef47a80f1d1"
+    "hash": "4dc68e628703cbf4"
   }
   {
     "taskId": "util#build",
-    "hash": "fad2a643cb480b55"
+    "hash": "728076a89c49afbf"
   }
 
 Change only my-app#build
@@ -22,15 +22,15 @@ Change only my-app#build
   $ ${TURBO} build --dry=json | jq -r '.tasks | sort_by(.taskId)[] | {taskId, hash}'
   {
     "taskId": "another#build",
-    "hash": "ea00e25531db048f"
+    "hash": "90d25abdd579d2bf"
   }
   {
     "taskId": "my-app#build",
-    "hash": "b0eb2c24b2a84be5"
+    "hash": "467895752c6e4d42"
   }
   {
     "taskId": "util#build",
-    "hash": "fad2a643cb480b55"
+    "hash": "728076a89c49afbf"
   }
 
 Change my-app#build dependsOn
@@ -38,15 +38,15 @@ Change my-app#build dependsOn
   $ ${TURBO} build --dry=json | jq -r '.tasks | sort_by(.taskId)[] | {taskId, hash}'
   {
     "taskId": "another#build",
-    "hash": "ea00e25531db048f"
+    "hash": "90d25abdd579d2bf"
   }
   {
     "taskId": "my-app#build",
-    "hash": "9e63702de36d25c6"
+    "hash": "9ff4347eebe225a1"
   }
   {
     "taskId": "util#build",
-    "hash": "fad2a643cb480b55"
+    "hash": "728076a89c49afbf"
   }
 
 Non-materially modifying the dep graph does nothing.
@@ -54,15 +54,15 @@ Non-materially modifying the dep graph does nothing.
   $ ${TURBO} build --dry=json | jq -r '.tasks | sort_by(.taskId)[] | {taskId, hash}'
   {
     "taskId": "another#build",
-    "hash": "ea00e25531db048f"
+    "hash": "90d25abdd579d2bf"
   }
   {
     "taskId": "my-app#build",
-    "hash": "9e63702de36d25c6"
+    "hash": "9ff4347eebe225a1"
   }
   {
     "taskId": "util#build",
-    "hash": "fad2a643cb480b55"
+    "hash": "728076a89c49afbf"
   }
 
 
@@ -71,13 +71,13 @@ Change util#build impacts itself and my-app
   $ ${TURBO} build --dry=json | jq -r '.tasks | sort_by(.taskId)[] | {taskId, hash}'
   {
     "taskId": "another#build",
-    "hash": "ea00e25531db048f"
+    "hash": "90d25abdd579d2bf"
   }
   {
     "taskId": "my-app#build",
-    "hash": "867bee2191fbd90c"
+    "hash": "fa7a059de209da9b"
   }
   {
     "taskId": "util#build",
-    "hash": "6f4abe279ba198a8"
+    "hash": "7b57a7ca5e311e4d"
   }

--- a/turborepo-tests/integration/tests/edit-turbo-json/task.t
+++ b/turborepo-tests/integration/tests/edit-turbo-json/task.t
@@ -6,15 +6,15 @@ Baseline task hashes
   $ ${TURBO} build --dry=json | jq -r '.tasks | sort_by(.taskId)[] | {taskId, hash}'
   {
     "taskId": "another#build",
-    "hash": "90d25abdd579d2bf"
+    "hash": "3639431fdcdf9f9e"
   }
   {
     "taskId": "my-app#build",
-    "hash": "4dc68e628703cbf4"
+    "hash": "0555ce94ca234049"
   }
   {
     "taskId": "util#build",
-    "hash": "728076a89c49afbf"
+    "hash": "bf1798d3e46e1b48"
   }
 
 Change only my-app#build
@@ -22,15 +22,15 @@ Change only my-app#build
   $ ${TURBO} build --dry=json | jq -r '.tasks | sort_by(.taskId)[] | {taskId, hash}'
   {
     "taskId": "another#build",
-    "hash": "90d25abdd579d2bf"
+    "hash": "3639431fdcdf9f9e"
   }
   {
     "taskId": "my-app#build",
-    "hash": "467895752c6e4d42"
+    "hash": "6eea03fab6f9a8c8"
   }
   {
     "taskId": "util#build",
-    "hash": "728076a89c49afbf"
+    "hash": "bf1798d3e46e1b48"
   }
 
 Change my-app#build dependsOn
@@ -38,15 +38,15 @@ Change my-app#build dependsOn
   $ ${TURBO} build --dry=json | jq -r '.tasks | sort_by(.taskId)[] | {taskId, hash}'
   {
     "taskId": "another#build",
-    "hash": "90d25abdd579d2bf"
+    "hash": "3639431fdcdf9f9e"
   }
   {
     "taskId": "my-app#build",
-    "hash": "9ff4347eebe225a1"
+    "hash": "8637a0f5db686164"
   }
   {
     "taskId": "util#build",
-    "hash": "728076a89c49afbf"
+    "hash": "bf1798d3e46e1b48"
   }
 
 Non-materially modifying the dep graph does nothing.
@@ -54,15 +54,15 @@ Non-materially modifying the dep graph does nothing.
   $ ${TURBO} build --dry=json | jq -r '.tasks | sort_by(.taskId)[] | {taskId, hash}'
   {
     "taskId": "another#build",
-    "hash": "90d25abdd579d2bf"
+    "hash": "3639431fdcdf9f9e"
   }
   {
     "taskId": "my-app#build",
-    "hash": "9ff4347eebe225a1"
+    "hash": "8637a0f5db686164"
   }
   {
     "taskId": "util#build",
-    "hash": "728076a89c49afbf"
+    "hash": "bf1798d3e46e1b48"
   }
 
 
@@ -71,13 +71,13 @@ Change util#build impacts itself and my-app
   $ ${TURBO} build --dry=json | jq -r '.tasks | sort_by(.taskId)[] | {taskId, hash}'
   {
     "taskId": "another#build",
-    "hash": "90d25abdd579d2bf"
+    "hash": "3639431fdcdf9f9e"
   }
   {
     "taskId": "my-app#build",
-    "hash": "fa7a059de209da9b"
+    "hash": "2721f01b53b758d0"
   }
   {
     "taskId": "util#build",
-    "hash": "7b57a7ca5e311e4d"
+    "hash": "74c8eb9bab702b4b"
   }

--- a/turborepo-tests/integration/tests/engines.t
+++ b/turborepo-tests/integration/tests/engines.t
@@ -5,14 +5,14 @@ Setup
 
 Check a hash
   $ ${TURBO} build --dry=json --filter=my-app | jq ".tasks.[0].hash"
-  "400bbcde4783a90b"
+  "e1b18c14c735bc25"
 Change engines
   $ jq '.engines = {"node": ">=16"}' package.json > package.json.new
   $ mv package.json.new package.json
 
 Verify hash has changed
   $ ${TURBO} build --dry=json --filter=my-app | jq ".tasks.[0].hash"
-  "2e17118379796bbb"
+  "639b83eff0f48891"
 
 Verify engines are part of global cache inputs
   $ ${TURBO} build --dry=json | jq '.globalCacheInputs.engines'

--- a/turborepo-tests/integration/tests/engines.t
+++ b/turborepo-tests/integration/tests/engines.t
@@ -1,0 +1,21 @@
+Setup
+  $ . ${TESTDIR}/../../helpers/setup_integration_test.sh
+  $ jq '.engines = {"node": ">=12"}' package.json > package.json.new
+  $ mv package.json.new package.json
+
+Check a hash
+  $ ${TURBO} build --dry=json --filter=my-app | jq '.tasks.[0].hash'
+  "400bbcde4783a90b"
+Change engines
+  $ jq '.engines = {"node": ">=16"}' package.json > package.json.new
+  $ mv package.json.new package.json
+
+Verify hash has changed
+  $ ${TURBO} build --dry=json --filter=my-app | jq '.tasks.[0].hash'
+  "2e17118379796bbb"
+
+Verify engines are part of global cache inputs
+  $ ${TURBO} build --dry=json | jq '.globalCacheInputs.engines'
+  {
+    "node": ">=16"
+  }

--- a/turborepo-tests/integration/tests/engines.t
+++ b/turborepo-tests/integration/tests/engines.t
@@ -4,14 +4,14 @@ Setup
   $ mv package.json.new package.json
 
 Check a hash
-  $ ${TURBO} build --dry=json --filter=my-app | jq '.tasks.[0].hash'
+  $ ${TURBO} build --dry=json --filter=my-app | jq ".tasks.[0].hash"
   "400bbcde4783a90b"
 Change engines
   $ jq '.engines = {"node": ">=16"}' package.json > package.json.new
   $ mv package.json.new package.json
 
 Verify hash has changed
-  $ ${TURBO} build --dry=json --filter=my-app | jq '.tasks.[0].hash'
+  $ ${TURBO} build --dry=json --filter=my-app | jq ".tasks.[0].hash"
   "2e17118379796bbb"
 
 Verify engines are part of global cache inputs

--- a/turborepo-tests/integration/tests/engines.t
+++ b/turborepo-tests/integration/tests/engines.t
@@ -4,15 +4,15 @@ Setup
   $ mv package.json.new package.json
 
 Check a hash
-  $ ${TURBO} build --dry=json --filter=my-app | jq ".tasks.[0].hash"
-  "e1b18c14c735bc25"
+  $ ${TURBO} build --dry=json --filter=my-app | jq '.tasks | last | .hash'
+  "56d7eb9a31d82ee0"
 Change engines
   $ jq '.engines = {"node": ">=16"}' package.json > package.json.new
   $ mv package.json.new package.json
 
 Verify hash has changed
-  $ ${TURBO} build --dry=json --filter=my-app | jq ".tasks.[0].hash"
-  "639b83eff0f48891"
+  $ ${TURBO} build --dry=json --filter=my-app | jq ".tasks | last | .hash"
+  "1d8b8596ae37a40c"
 
 Verify engines are part of global cache inputs
   $ ${TURBO} build --dry=json | jq '.globalCacheInputs.engines'

--- a/turborepo-tests/integration/tests/global-deps.t
+++ b/turborepo-tests/integration/tests/global-deps.t
@@ -6,7 +6,7 @@ Run a build
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache miss, executing d930bae670df2f3c
+  my-app:build: cache miss, executing 2a57e19ce0b2cfd5
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -18,7 +18,7 @@ Run a build
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache miss, executing fdbc268e2766ec41
+  my-app:build: cache miss, executing 3883869b5e1dc9cf
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -29,7 +29,7 @@ Run a build
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache hit, suppressing logs 7a2d3560117367eb
+  my-app:build: cache hit, suppressing logs 3883869b5e1dc9cf
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total

--- a/turborepo-tests/integration/tests/global-deps.t
+++ b/turborepo-tests/integration/tests/global-deps.t
@@ -6,7 +6,7 @@ Run a build
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache miss, executing 3292edbc955db609
+  my-app:build: cache miss, executing d930bae670df2f3c
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -18,7 +18,7 @@ Run a build
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache miss, executing 7a2d3560117367eb
+  my-app:build: cache miss, executing fdbc268e2766ec41
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total

--- a/turborepo-tests/integration/tests/global-env.t
+++ b/turborepo-tests/integration/tests/global-env.t
@@ -8,7 +8,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  util:build: cache miss, executing fad2a643cb480b55
+  util:build: cache miss, executing 728076a89c49afbf
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -19,7 +19,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  util:build: cache hit, suppressing logs fad2a643cb480b55
+  util:build: cache hit, suppressing logs 728076a89c49afbf
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total
@@ -30,7 +30,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  util:build: cache miss, executing a7c44af22f60539c
+  util:build: cache miss, executing 2dcaff0115928c16
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -41,7 +41,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  util:build: cache hit, suppressing logs fad2a643cb480b55
+  util:build: cache hit, suppressing logs 728076a89c49afbf
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total
@@ -52,7 +52,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  util:build: cache miss, executing 18e70da6088a7985
+  util:build: cache miss, executing fec5ab9927aa9018
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total

--- a/turborepo-tests/integration/tests/global-env.t
+++ b/turborepo-tests/integration/tests/global-env.t
@@ -8,7 +8,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  util:build: cache miss, executing 728076a89c49afbf
+  util:build: cache miss, executing bf1798d3e46e1b48
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -19,7 +19,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  util:build: cache hit, suppressing logs 728076a89c49afbf
+  util:build: cache hit, suppressing logs bf1798d3e46e1b48
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total
@@ -30,7 +30,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  util:build: cache miss, executing 2dcaff0115928c16
+  util:build: cache miss, executing 265e40ee03ae83ec
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -41,7 +41,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  util:build: cache hit, suppressing logs 728076a89c49afbf
+  util:build: cache hit, suppressing logs bf1798d3e46e1b48
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total
@@ -52,7 +52,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  util:build: cache miss, executing fec5ab9927aa9018
+  util:build: cache miss, executing b8f403756f67074c
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total

--- a/turborepo-tests/integration/tests/persistent-dependencies/6-topological-unimplemented.t
+++ b/turborepo-tests/integration/tests/persistent-dependencies/6-topological-unimplemented.t
@@ -17,7 +17,7 @@
   \xe2\x80\xa2 Packages in scope: app-a, pkg-a (esc)
   \xe2\x80\xa2 Running dev in 2 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  app-a:dev: cache miss, executing 2ba73becb39b6cd9
+  app-a:dev: cache miss, executing 7def3a3e7f1235de
   app-a:dev: 
   app-a:dev: > dev
   app-a:dev: > echo dev-app-a

--- a/turborepo-tests/integration/tests/persistent-dependencies/6-topological-unimplemented.t
+++ b/turborepo-tests/integration/tests/persistent-dependencies/6-topological-unimplemented.t
@@ -17,7 +17,7 @@
   \xe2\x80\xa2 Packages in scope: app-a, pkg-a (esc)
   \xe2\x80\xa2 Running dev in 2 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  app-a:dev: cache miss, executing 6d74f36653305cef
+  app-a:dev: cache miss, executing 2ba73becb39b6cd9
   app-a:dev: 
   app-a:dev: > dev
   app-a:dev: > echo dev-app-a

--- a/turborepo-tests/integration/tests/pkg-inference.t
+++ b/turborepo-tests/integration/tests/pkg-inference.t
@@ -6,7 +6,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  util:build: cache miss, executing 728076a89c49afbf
+  util:build: cache miss, executing bf1798d3e46e1b48
   util:build: 
   util:build: > build
   util:build: > echo building

--- a/turborepo-tests/integration/tests/pkg-inference.t
+++ b/turborepo-tests/integration/tests/pkg-inference.t
@@ -6,7 +6,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  util:build: cache miss, executing fad2a643cb480b55
+  util:build: cache miss, executing 728076a89c49afbf
   util:build: 
   util:build: > build
   util:build: > echo building

--- a/turborepo-tests/integration/tests/prune/composable-config.t
+++ b/turborepo-tests/integration/tests/prune/composable-config.t
@@ -11,7 +11,7 @@ Make sure that the internal util package is part of the prune output
   \xe2\x80\xa2 Packages in scope: docs, shared, util (esc)
   \xe2\x80\xa2 Running new-task in 3 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  docs:new-task: cache miss, executing 37946d5a79df43a8
+  docs:new-task: cache miss, executing 73e253af9e02222a
   docs:new-task: 
   docs:new-task: > docs@ new-task .*out(\/|\\)apps(\/|\\)docs (re)
   docs:new-task: > echo building

--- a/turborepo-tests/integration/tests/prune/composable-config.t
+++ b/turborepo-tests/integration/tests/prune/composable-config.t
@@ -11,7 +11,7 @@ Make sure that the internal util package is part of the prune output
   \xe2\x80\xa2 Packages in scope: docs, shared, util (esc)
   \xe2\x80\xa2 Running new-task in 3 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  docs:new-task: cache miss, executing 73e253af9e02222a
+  docs:new-task: cache miss, executing 869a9c24e803c5d6
   docs:new-task: 
   docs:new-task: > docs@ new-task .*out(\/|\\)apps(\/|\\)docs (re)
   docs:new-task: > echo building

--- a/turborepo-tests/integration/tests/run-caching/excluded-inputs/excluded-inputs.t
+++ b/turborepo-tests/integration/tests/run-caching/excluded-inputs/excluded-inputs.t
@@ -9,7 +9,7 @@ Running build for my-app succeeds
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache miss, executing c57477b17ebc0894
+  my-app:build: cache miss, executing e228bd94fd46352c
   my-app:build: 
   my-app:build: > build
   my-app:build: > echo building
@@ -26,7 +26,7 @@ Update exluded file and try again
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache hit, replaying logs c57477b17ebc0894
+  my-app:build: cache hit, replaying logs e228bd94fd46352c
   my-app:build: 
   my-app:build: > build
   my-app:build: > echo building

--- a/turborepo-tests/integration/tests/run-caching/excluded-inputs/excluded-inputs.t
+++ b/turborepo-tests/integration/tests/run-caching/excluded-inputs/excluded-inputs.t
@@ -9,7 +9,7 @@ Running build for my-app succeeds
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache miss, executing 92e6e0fa25bd067f
+  my-app:build: cache miss, executing c57477b17ebc0894
   my-app:build: 
   my-app:build: > build
   my-app:build: > echo building
@@ -26,7 +26,7 @@ Update exluded file and try again
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache hit, replaying logs 92e6e0fa25bd067f
+  my-app:build: cache hit, replaying logs c57477b17ebc0894
   my-app:build: 
   my-app:build: > build
   my-app:build: > echo building

--- a/turborepo-tests/integration/tests/run-caching/root-deps.t
+++ b/turborepo-tests/integration/tests/run-caching/root-deps.t
@@ -6,7 +6,7 @@ Warm the cache
   \xe2\x80\xa2 Packages in scope: another (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  another:build: cache miss, executing 22f33d1d910da7f2
+  another:build: cache miss, executing 2e4e289aeb0b6055
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -19,7 +19,7 @@ All tasks should be a cache miss, even ones that don't depend on changed package
   \xe2\x80\xa2 Packages in scope: another (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  another:build: cache miss, executing 5dd1314cac1b01ff
+  another:build: cache miss, executing ebc7de7a6c0c5543
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -34,7 +34,7 @@ Cache hit since only tracked files contribute to root dep hash
   \xe2\x80\xa2 Packages in scope: another (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  another:build: cache hit, suppressing logs 5dd1314cac1b01ff
+  another:build: cache hit, suppressing logs ebc7de7a6c0c5543
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total

--- a/turborepo-tests/integration/tests/run-logging/errors-only.t
+++ b/turborepo-tests/integration/tests/run-logging/errors-only.t
@@ -37,7 +37,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: app-a (esc)
   \xe2\x80\xa2 Running builderror in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  app-a:builderror: cache miss, executing f04abedd2cd08143
+  app-a:builderror: cache miss, executing 7e337a3261100818
   app-a:builderror: 
   app-a:builderror: > builderror
   app-a:builderror: > echo error-builderror-app-a && exit 1
@@ -67,7 +67,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: app-a (esc)
   \xe2\x80\xa2 Running builderror2 in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  app-a:builderror2: cache miss, executing afea12cd69b5cd5f
+  app-a:builderror2: cache miss, executing 3731518fa339b920
   app-a:builderror2: 
   app-a:builderror2: > builderror2
   app-a:builderror2: > echo error-builderror2-app-a && exit 1

--- a/turborepo-tests/integration/tests/run-logging/errors-only.t
+++ b/turborepo-tests/integration/tests/run-logging/errors-only.t
@@ -37,7 +37,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: app-a (esc)
   \xe2\x80\xa2 Running builderror in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  app-a:builderror: cache miss, executing e86e4a4ebfa716d6
+  app-a:builderror: cache miss, executing f04abedd2cd08143
   app-a:builderror: 
   app-a:builderror: > builderror
   app-a:builderror: > echo error-builderror-app-a && exit 1
@@ -67,7 +67,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: app-a (esc)
   \xe2\x80\xa2 Running builderror2 in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  app-a:builderror2: cache miss, executing 3b92feb5fb5a32a5
+  app-a:builderror2: cache miss, executing afea12cd69b5cd5f
   app-a:builderror2: 
   app-a:builderror2: > builderror2
   app-a:builderror2: > echo error-builderror2-app-a && exit 1

--- a/turborepo-tests/integration/tests/run-logging/log-order-github.t
+++ b/turborepo-tests/integration/tests/run-logging/log-order-github.t
@@ -9,7 +9,7 @@ because otherwise prysk interprets them as multiline commands
   \xe2\x80\xa2 Running build in 2 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
   ::group::my-app:build
-  cache bypass, force executing 387aa1a04fa418fe
+  cache bypass, force executing 3d87aeda7bb12f8c
   
   >\sbuild (re)
   \>\secho building && sleep 1 && echo done (re)
@@ -18,7 +18,7 @@ because otherwise prysk interprets them as multiline commands
   done
   ::endgroup::
   ::group::util:build
-  cache bypass, force executing 348fb645686fa0b8
+  cache bypass, force executing 9b39d81e0be215f8
   
   >\sbuild (re)
   \>\ssleep 0.5 && echo building && sleep 1 && echo completed (re)
@@ -37,7 +37,7 @@ because otherwise prysk interprets them as multiline commands
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
   ::group::util:build
-  util:build: cache bypass, force executing 348fb645686fa0b8
+  util:build: cache bypass, force executing 9b39d81e0be215f8
   util:build: 
   util:build: > build
   util:build: > sleep 0.5 && echo building && sleep 1 && echo completed
@@ -57,7 +57,7 @@ Verify that errors are grouped properly
   \xe2\x80\xa2 Running fail in 2 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
   \x1b[;31mutil:fail\x1b[;0m (esc)
-  cache miss, executing e53b8d17f063e6c0
+  cache miss, executing c7abe7481b67fe3d
   
   \> fail (re)
   \> echo failing; exit 1 (re)

--- a/turborepo-tests/integration/tests/run-logging/log-order-github.t
+++ b/turborepo-tests/integration/tests/run-logging/log-order-github.t
@@ -9,7 +9,7 @@ because otherwise prysk interprets them as multiline commands
   \xe2\x80\xa2 Running build in 2 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
   ::group::my-app:build
-  cache bypass, force executing 3d87aeda7bb12f8c
+  cache bypass, force executing 0af90ec6a57471be
   
   >\sbuild (re)
   \>\secho building && sleep 1 && echo done (re)
@@ -18,7 +18,7 @@ because otherwise prysk interprets them as multiline commands
   done
   ::endgroup::
   ::group::util:build
-  cache bypass, force executing 9b39d81e0be215f8
+  cache bypass, force executing 2da422600daca8be
   
   >\sbuild (re)
   \>\ssleep 0.5 && echo building && sleep 1 && echo completed (re)
@@ -37,7 +37,7 @@ because otherwise prysk interprets them as multiline commands
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
   ::group::util:build
-  util:build: cache bypass, force executing 9b39d81e0be215f8
+  util:build: cache bypass, force executing 2da422600daca8be
   util:build: 
   util:build: > build
   util:build: > sleep 0.5 && echo building && sleep 1 && echo completed
@@ -57,7 +57,7 @@ Verify that errors are grouped properly
   \xe2\x80\xa2 Running fail in 2 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
   \x1b[;31mutil:fail\x1b[;0m (esc)
-  cache miss, executing c7abe7481b67fe3d
+  cache miss, executing 91d719104281046f
   
   \> fail (re)
   \> echo failing; exit 1 (re)

--- a/turborepo-tests/integration/tests/run-logging/log-prefix.t
+++ b/turborepo-tests/integration/tests/run-logging/log-prefix.t
@@ -6,7 +6,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: app-a (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  cache miss, executing aa8bd45244bccb8b
+  cache miss, executing f4eeb1c5857c8c9a
   
   \> build (re)
   \> echo build-app-a (re)
@@ -30,7 +30,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: app-a (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  cache hit, replaying logs aa8bd45244bccb8b
+  cache hit, replaying logs f4eeb1c5857c8c9a
   
   \> build (re)
   \> echo build-app-a (re)
@@ -46,7 +46,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: app-a (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  app-a:build: cache hit, replaying logs aa8bd45244bccb8b
+  app-a:build: cache hit, replaying logs f4eeb1c5857c8c9a
   app-a:build: 
   app-a:build: > build
   app-a:build: > echo build-app-a

--- a/turborepo-tests/integration/tests/run-logging/log-prefix.t
+++ b/turborepo-tests/integration/tests/run-logging/log-prefix.t
@@ -6,7 +6,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: app-a (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  cache miss, executing f4eeb1c5857c8c9a
+  cache miss, executing 612027951a2848ce
   
   \> build (re)
   \> echo build-app-a (re)
@@ -30,7 +30,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: app-a (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  cache hit, replaying logs f4eeb1c5857c8c9a
+  cache hit, replaying logs 612027951a2848ce
   
   \> build (re)
   \> echo build-app-a (re)
@@ -46,7 +46,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: app-a (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  app-a:build: cache hit, replaying logs f4eeb1c5857c8c9a
+  app-a:build: cache hit, replaying logs 612027951a2848ce
   app-a:build: 
   app-a:build: > build
   app-a:build: > echo build-app-a

--- a/turborepo-tests/integration/tests/run-logging/verbosity.t
+++ b/turborepo-tests/integration/tests/run-logging/verbosity.t
@@ -6,7 +6,7 @@ Verbosity level 1
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  util:build: cache bypass, force executing fad2a643cb480b55
+  util:build: cache bypass, force executing 728076a89c49afbf
   util:build: 
   util:build: > build
   util:build: > echo building
@@ -21,7 +21,7 @@ Verbosity level 1
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  util:build: cache bypass, force executing fad2a643cb480b55
+  util:build: cache bypass, force executing 728076a89c49afbf
   util:build: 
   util:build: > build
   util:build: > echo building

--- a/turborepo-tests/integration/tests/run-logging/verbosity.t
+++ b/turborepo-tests/integration/tests/run-logging/verbosity.t
@@ -6,7 +6,7 @@ Verbosity level 1
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  util:build: cache bypass, force executing 728076a89c49afbf
+  util:build: cache bypass, force executing bf1798d3e46e1b48
   util:build: 
   util:build: > build
   util:build: > echo building
@@ -21,7 +21,7 @@ Verbosity level 1
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  util:build: cache bypass, force executing 728076a89c49afbf
+  util:build: cache bypass, force executing bf1798d3e46e1b48
   util:build: 
   util:build: > build
   util:build: > echo building

--- a/turborepo-tests/integration/tests/run-summary/discovery.t
+++ b/turborepo-tests/integration/tests/run-summary/discovery.t
@@ -6,7 +6,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache miss, executing 270f1ef47a80f1d1
+  my-app:build: cache miss, executing 4dc68e628703cbf4
   my-app:build: 
   my-app:build: > build
   my-app:build: > echo building

--- a/turborepo-tests/integration/tests/run-summary/discovery.t
+++ b/turborepo-tests/integration/tests/run-summary/discovery.t
@@ -6,7 +6,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache miss, executing 4dc68e628703cbf4
+  my-app:build: cache miss, executing 0555ce94ca234049
   my-app:build: 
   my-app:build: > build
   my-app:build: > echo building

--- a/turborepo-tests/integration/tests/run-summary/error.t
+++ b/turborepo-tests/integration/tests/run-summary/error.t
@@ -32,7 +32,7 @@ Validate that we got a full task summary for the failed task with an error in .e
     "taskId": "my-app#maybefails",
     "task": "maybefails",
     "package": "my-app",
-    "hash": "818f9216a562c31e",
+    "hash": "9f05a7188fdf4e93",
     "inputs": {
       ".env.local": "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
       "package.json": "1746e0db2361085b5953a6a3beab08c24af5bc08"

--- a/turborepo-tests/integration/tests/run-summary/error.t
+++ b/turborepo-tests/integration/tests/run-summary/error.t
@@ -32,7 +32,7 @@ Validate that we got a full task summary for the failed task with an error in .e
     "taskId": "my-app#maybefails",
     "task": "maybefails",
     "package": "my-app",
-    "hash": "e766224b19492c97",
+    "hash": "818f9216a562c31e",
     "inputs": {
       ".env.local": "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
       "package.json": "1746e0db2361085b5953a6a3beab08c24af5bc08"

--- a/turborepo-tests/integration/tests/run/continue.t
+++ b/turborepo-tests/integration/tests/run/continue.t
@@ -5,7 +5,7 @@ Run without --continue
   \xe2\x80\xa2 Packages in scope: my-app, other-app, some-lib (esc)
   \xe2\x80\xa2 Running build in 3 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  some-lib:build: cache miss, executing 77a0b77ce046a30f
+  some-lib:build: cache miss, executing ab8c4a02e3facf55
   some-lib:build: 
   some-lib:build: > build
   some-lib:build: > exit 2
@@ -31,7 +31,7 @@ Run without --continue, and with only errors.
   \xe2\x80\xa2 Packages in scope: my-app, other-app, some-lib (esc)
   \xe2\x80\xa2 Running build in 3 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  some-lib:build: cache miss, executing 77a0b77ce046a30f
+  some-lib:build: cache miss, executing ab8c4a02e3facf55
   some-lib:build: 
   some-lib:build: > build
   some-lib:build: > exit 2
@@ -56,7 +56,7 @@ Run with --continue
   \xe2\x80\xa2 Packages in scope: my-app, other-app, some-lib (esc)
   \xe2\x80\xa2 Running build in 3 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  some-lib:build: cache miss, executing 77a0b77ce046a30f
+  some-lib:build: cache miss, executing ab8c4a02e3facf55
   some-lib:build: 
   some-lib:build: > build
   some-lib:build: > exit 2
@@ -66,7 +66,7 @@ Run with --continue
   some-lib:build: npm ERR!   in workspace: some-lib 
   some-lib:build: npm ERR!   at location: (.*)(\/|\\)apps(\/|\\)some-lib  (re)
   some-lib:build: command finished with error, but continuing...
-  other-app:build: cache miss, executing 81e40fa0749e0190
+  other-app:build: cache miss, executing babf2f6b1d6ace47
   other-app:build: 
   other-app:build: > build
   other-app:build: > exit 3

--- a/turborepo-tests/integration/tests/run/continue.t
+++ b/turborepo-tests/integration/tests/run/continue.t
@@ -5,7 +5,7 @@ Run without --continue
   \xe2\x80\xa2 Packages in scope: my-app, other-app, some-lib (esc)
   \xe2\x80\xa2 Running build in 3 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  some-lib:build: cache miss, executing 071e589156801650
+  some-lib:build: cache miss, executing 77a0b77ce046a30f
   some-lib:build: 
   some-lib:build: > build
   some-lib:build: > exit 2
@@ -31,7 +31,7 @@ Run without --continue, and with only errors.
   \xe2\x80\xa2 Packages in scope: my-app, other-app, some-lib (esc)
   \xe2\x80\xa2 Running build in 3 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  some-lib:build: cache miss, executing 071e589156801650
+  some-lib:build: cache miss, executing 77a0b77ce046a30f
   some-lib:build: 
   some-lib:build: > build
   some-lib:build: > exit 2
@@ -56,7 +56,7 @@ Run with --continue
   \xe2\x80\xa2 Packages in scope: my-app, other-app, some-lib (esc)
   \xe2\x80\xa2 Running build in 3 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  some-lib:build: cache miss, executing 071e589156801650
+  some-lib:build: cache miss, executing 77a0b77ce046a30f
   some-lib:build: 
   some-lib:build: > build
   some-lib:build: > exit 2
@@ -66,7 +66,7 @@ Run with --continue
   some-lib:build: npm ERR!   in workspace: some-lib 
   some-lib:build: npm ERR!   at location: (.*)(\/|\\)apps(\/|\\)some-lib  (re)
   some-lib:build: command finished with error, but continuing...
-  other-app:build: cache miss, executing f7d23d1c894c1f09
+  other-app:build: cache miss, executing 81e40fa0749e0190
   other-app:build: 
   other-app:build: > build
   other-app:build: > exit 3

--- a/turborepo-tests/integration/tests/run/force.t
+++ b/turborepo-tests/integration/tests/run/force.t
@@ -24,7 +24,7 @@ baseline to generate cache
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache miss, executing 270f1ef47a80f1d1
+  my-app:build: cache miss, executing 4dc68e628703cbf4
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -36,7 +36,7 @@ baseline to generate cache
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache bypass, force executing 270f1ef47a80f1d1
+  my-app:build: cache bypass, force executing 4dc68e628703cbf4
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -47,7 +47,7 @@ baseline to generate cache
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache bypass, force executing 270f1ef47a80f1d1
+  my-app:build: cache bypass, force executing 4dc68e628703cbf4
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -58,7 +58,7 @@ baseline to generate cache
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache hit, suppressing logs 270f1ef47a80f1d1
+  my-app:build: cache hit, suppressing logs 4dc68e628703cbf4
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total
@@ -69,7 +69,7 @@ baseline to generate cache
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache bypass, force executing 270f1ef47a80f1d1
+  my-app:build: cache bypass, force executing 4dc68e628703cbf4
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -81,7 +81,7 @@ baseline to generate cache
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache hit, suppressing logs 270f1ef47a80f1d1
+  my-app:build: cache hit, suppressing logs 4dc68e628703cbf4
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total
@@ -92,7 +92,7 @@ baseline to generate cache
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache bypass, force executing 270f1ef47a80f1d1
+  my-app:build: cache bypass, force executing 4dc68e628703cbf4
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -103,7 +103,7 @@ baseline to generate cache
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache hit, suppressing logs 270f1ef47a80f1d1
+  my-app:build: cache hit, suppressing logs 4dc68e628703cbf4
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total
@@ -114,7 +114,7 @@ baseline to generate cache
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache bypass, force executing 270f1ef47a80f1d1
+  my-app:build: cache bypass, force executing 4dc68e628703cbf4
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -126,7 +126,7 @@ baseline to generate cache
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache hit, suppressing logs 270f1ef47a80f1d1
+  my-app:build: cache hit, suppressing logs 4dc68e628703cbf4
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total
@@ -137,7 +137,7 @@ baseline to generate cache
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache bypass, force executing 270f1ef47a80f1d1
+  my-app:build: cache bypass, force executing 4dc68e628703cbf4
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -148,7 +148,7 @@ baseline to generate cache
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache hit, suppressing logs 270f1ef47a80f1d1
+  my-app:build: cache hit, suppressing logs 4dc68e628703cbf4
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total
@@ -159,7 +159,7 @@ baseline to generate cache
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache bypass, force executing 270f1ef47a80f1d1
+  my-app:build: cache bypass, force executing 4dc68e628703cbf4
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total

--- a/turborepo-tests/integration/tests/run/force.t
+++ b/turborepo-tests/integration/tests/run/force.t
@@ -24,7 +24,7 @@ baseline to generate cache
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache miss, executing 4dc68e628703cbf4
+  my-app:build: cache miss, executing 0555ce94ca234049
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -36,7 +36,7 @@ baseline to generate cache
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache bypass, force executing 4dc68e628703cbf4
+  my-app:build: cache bypass, force executing 0555ce94ca234049
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -47,7 +47,7 @@ baseline to generate cache
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache bypass, force executing 4dc68e628703cbf4
+  my-app:build: cache bypass, force executing 0555ce94ca234049
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -58,7 +58,7 @@ baseline to generate cache
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache hit, suppressing logs 4dc68e628703cbf4
+  my-app:build: cache hit, suppressing logs 0555ce94ca234049
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total
@@ -69,7 +69,7 @@ baseline to generate cache
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache bypass, force executing 4dc68e628703cbf4
+  my-app:build: cache bypass, force executing 0555ce94ca234049
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -81,7 +81,7 @@ baseline to generate cache
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache hit, suppressing logs 4dc68e628703cbf4
+  my-app:build: cache hit, suppressing logs 0555ce94ca234049
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total
@@ -92,7 +92,7 @@ baseline to generate cache
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache bypass, force executing 4dc68e628703cbf4
+  my-app:build: cache bypass, force executing 0555ce94ca234049
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -103,7 +103,7 @@ baseline to generate cache
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache hit, suppressing logs 4dc68e628703cbf4
+  my-app:build: cache hit, suppressing logs 0555ce94ca234049
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total
@@ -114,7 +114,7 @@ baseline to generate cache
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache bypass, force executing 4dc68e628703cbf4
+  my-app:build: cache bypass, force executing 0555ce94ca234049
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -126,7 +126,7 @@ baseline to generate cache
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache hit, suppressing logs 4dc68e628703cbf4
+  my-app:build: cache hit, suppressing logs 0555ce94ca234049
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total
@@ -137,7 +137,7 @@ baseline to generate cache
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache bypass, force executing 4dc68e628703cbf4
+  my-app:build: cache bypass, force executing 0555ce94ca234049
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -148,7 +148,7 @@ baseline to generate cache
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache hit, suppressing logs 4dc68e628703cbf4
+  my-app:build: cache hit, suppressing logs 0555ce94ca234049
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total
@@ -159,7 +159,7 @@ baseline to generate cache
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache bypass, force executing 4dc68e628703cbf4
+  my-app:build: cache bypass, force executing 0555ce94ca234049
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total

--- a/turborepo-tests/integration/tests/run/gitignored-inputs.t
+++ b/turborepo-tests/integration/tests/run/gitignored-inputs.t
@@ -16,7 +16,7 @@ Some helper functions to parse the summary file
 
 Just run the util package, it's simpler
   $ ${TURBO} run build --filter=util --output-logs=hash-only --summarize | grep "util:build: cache"
-  util:build: cache miss, executing f66dc775ee90556b
+  util:build: cache miss, executing 11cff3dd389fdfed
 
   $ FIRST=$(/bin/ls .turbo/runs/*.json | head -n1)
   $ echo $(getSummaryTaskId $FIRST "util#build") | jq -r '.inputs."internal.txt"'
@@ -30,7 +30,7 @@ Change the content of internal.txt
 
 Hash does not change, because it is gitignored
   $ ${TURBO} run build --filter=util --output-logs=hash-only --summarize | grep "util:build: cache"
-  util:build: cache miss, executing ea19e87de329400a
+  util:build: cache miss, executing a489883a3c7cd307
 
 The internal.txt hash should be different from the one before
   $ SECOND=$(/bin/ls .turbo/runs/*.json | head -n1)

--- a/turborepo-tests/integration/tests/run/gitignored-inputs.t
+++ b/turborepo-tests/integration/tests/run/gitignored-inputs.t
@@ -16,7 +16,7 @@ Some helper functions to parse the summary file
 
 Just run the util package, it's simpler
   $ ${TURBO} run build --filter=util --output-logs=hash-only --summarize | grep "util:build: cache"
-  util:build: cache miss, executing 355a92b6a1cc5f24
+  util:build: cache miss, executing f66dc775ee90556b
 
   $ FIRST=$(/bin/ls .turbo/runs/*.json | head -n1)
   $ echo $(getSummaryTaskId $FIRST "util#build") | jq -r '.inputs."internal.txt"'
@@ -30,7 +30,7 @@ Change the content of internal.txt
 
 Hash does not change, because it is gitignored
   $ ${TURBO} run build --filter=util --output-logs=hash-only --summarize | grep "util:build: cache"
-  util:build: cache miss, executing 511d34a1853ba4ab
+  util:build: cache miss, executing ea19e87de329400a
 
 The internal.txt hash should be different from the one before
   $ SECOND=$(/bin/ls .turbo/runs/*.json | head -n1)

--- a/turborepo-tests/integration/tests/run/globs.t
+++ b/turborepo-tests/integration/tests/run/globs.t
@@ -5,7 +5,7 @@ Verify that input directory change causes cache miss
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  util:build: cache miss, executing ee36380619eef23f
+  util:build: cache miss, executing 5af1a9188f522439
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -16,7 +16,7 @@ Verify that input directory change causes cache miss
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  util:build: cache miss, executing b3870988a1d4b631
+  util:build: cache miss, executing 1b809be951dcbf2e
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -29,7 +29,7 @@ Verify that input directory change causes cache miss
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  util:build: cache hit, suppressing logs b3870988a1d4b631
+  util:build: cache hit, suppressing logs 1b809be951dcbf2e
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total

--- a/turborepo-tests/integration/tests/run/globs.t
+++ b/turborepo-tests/integration/tests/run/globs.t
@@ -5,7 +5,7 @@ Verify that input directory change causes cache miss
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  util:build: cache miss, executing d5b281b8322da71e
+  util:build: cache miss, executing ee36380619eef23f
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -16,7 +16,7 @@ Verify that input directory change causes cache miss
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  util:build: cache miss, executing 886797b8d9d1a464
+  util:build: cache miss, executing b3870988a1d4b631
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -29,7 +29,7 @@ Verify that input directory change causes cache miss
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  util:build: cache hit, suppressing logs 886797b8d9d1a464
+  util:build: cache hit, suppressing logs b3870988a1d4b631
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total

--- a/turborepo-tests/integration/tests/run/one-script-error.t
+++ b/turborepo-tests/integration/tests/run/one-script-error.t
@@ -7,13 +7,13 @@ Note that npm reports any failed script as exit code 1, even though we "exit 2"
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running error in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:okay: cache miss, executing 96496b6b9252855e
+  my-app:okay: cache miss, executing f380e9788612986c
   my-app:okay: 
   my-app:okay: > okay
   my-app:okay: > echo working
   my-app:okay: 
   my-app:okay: working
-  my-app:error: cache miss, executing 470e35f414b048e3
+  my-app:error: cache miss, executing fbaac99bdef3d400
   my-app:error: 
   my-app:error: > error
   my-app:error: > exit 2
@@ -38,13 +38,13 @@ Make sure error isn't cached
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running error in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:okay: cache hit, replaying logs 96496b6b9252855e
+  my-app:okay: cache hit, replaying logs f380e9788612986c
   my-app:okay: 
   my-app:okay: > okay
   my-app:okay: > echo working
   my-app:okay: 
   my-app:okay: working
-  my-app:error: cache miss, executing 470e35f414b048e3
+  my-app:error: cache miss, executing fbaac99bdef3d400
   my-app:error: 
   my-app:error: > error
   my-app:error: > exit 2
@@ -69,13 +69,13 @@ Make sure error code isn't swallowed with continue
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running okay2 in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:okay: cache hit, replaying logs 96496b6b9252855e
+  my-app:okay: cache hit, replaying logs f380e9788612986c
   my-app:okay: 
   my-app:okay: > okay
   my-app:okay: > echo working
   my-app:okay: 
   my-app:okay: working
-  my-app:error: cache miss, executing 470e35f414b048e3
+  my-app:error: cache miss, executing fbaac99bdef3d400
   my-app:error: 
   my-app:error: > error
   my-app:error: > exit 2
@@ -85,7 +85,7 @@ Make sure error code isn't swallowed with continue
   my-app:error: npm ERR!   in workspace: my-app 
   my-app:error: npm ERR!   at location: .*apps(\/|\\)my-app  (re)
   my-app:error: command finished with error, but continuing...
-  my-app:okay2: cache miss, executing 17aa4a3dcf0a74a6
+  my-app:okay2: cache miss, executing d5f63e25e30711a2
   my-app:okay2: 
   my-app:okay2: > okay2
   my-app:okay2: > echo working

--- a/turborepo-tests/integration/tests/run/one-script-error.t
+++ b/turborepo-tests/integration/tests/run/one-script-error.t
@@ -7,13 +7,13 @@ Note that npm reports any failed script as exit code 1, even though we "exit 2"
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running error in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:okay: cache miss, executing f380e9788612986c
+  my-app:okay: cache miss, executing 61545c7738a28273
   my-app:okay: 
   my-app:okay: > okay
   my-app:okay: > echo working
   my-app:okay: 
   my-app:okay: working
-  my-app:error: cache miss, executing fbaac99bdef3d400
+  my-app:error: cache miss, executing fe9f1118e6072fce
   my-app:error: 
   my-app:error: > error
   my-app:error: > exit 2
@@ -38,13 +38,13 @@ Make sure error isn't cached
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running error in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:okay: cache hit, replaying logs f380e9788612986c
+  my-app:okay: cache hit, replaying logs 61545c7738a28273
   my-app:okay: 
   my-app:okay: > okay
   my-app:okay: > echo working
   my-app:okay: 
   my-app:okay: working
-  my-app:error: cache miss, executing fbaac99bdef3d400
+  my-app:error: cache miss, executing fe9f1118e6072fce
   my-app:error: 
   my-app:error: > error
   my-app:error: > exit 2
@@ -69,13 +69,13 @@ Make sure error code isn't swallowed with continue
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running okay2 in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:okay: cache hit, replaying logs f380e9788612986c
+  my-app:okay: cache hit, replaying logs 61545c7738a28273
   my-app:okay: 
   my-app:okay: > okay
   my-app:okay: > echo working
   my-app:okay: 
   my-app:okay: working
-  my-app:error: cache miss, executing fbaac99bdef3d400
+  my-app:error: cache miss, executing fe9f1118e6072fce
   my-app:error: 
   my-app:error: > error
   my-app:error: > exit 2
@@ -85,7 +85,7 @@ Make sure error code isn't swallowed with continue
   my-app:error: npm ERR!   in workspace: my-app 
   my-app:error: npm ERR!   at location: .*apps(\/|\\)my-app  (re)
   my-app:error: command finished with error, but continuing...
-  my-app:okay2: cache miss, executing d5f63e25e30711a2
+  my-app:okay2: cache miss, executing a24768ab20e24dd3
   my-app:okay2: 
   my-app:okay2: > okay2
   my-app:okay2: > echo working

--- a/turborepo-tests/integration/tests/run/single-package/dry-run.t
+++ b/turborepo-tests/integration/tests/run/single-package/dry-run.t
@@ -7,7 +7,7 @@ Check
   Global Hash Inputs
     Global Files                          = 3
     External Dependencies Hash            = 
-    Global Cache Key                      = HEY STELLLLLLLAAAAAAAAAAAAA
+    Global Cache Key                      = I can\xe2\x80\x99t see ya, but I know you\xe2\x80\x99re here (esc)
     Global Env Vars                       = 
     Global Env Vars Values                = 
     Inferred Global Env Vars Values       = 
@@ -18,7 +18,7 @@ Check
   Tasks to Run
   build
     Task                           = build\s* (re)
-    Hash                           = 6c1cecf7f99d0166
+    Hash                           = 7ece7b62aad25615
     Cached \(Local\)                 = false\s* (re)
     Cached \(Remote\)                = false\s* (re)
     Command                        = echo building > foo.txt\s* (re)

--- a/turborepo-tests/integration/tests/run/single-package/dry-run.t
+++ b/turborepo-tests/integration/tests/run/single-package/dry-run.t
@@ -7,25 +7,26 @@ Check
   Global Hash Inputs
     Global Files                          = 3
     External Dependencies Hash            = 
-    Global Cache Key                      = I can\xe2\x80\x99t see ya, but I know you\xe2\x80\x99re here (esc)
+    Global Cache Key                      = HEY STELLLLLLLAAAAAAAAAAAAA
     Global Env Vars                       = 
     Global Env Vars Values                = 
     Inferred Global Env Vars Values       = 
     Global Passed Through Env Vars        = 
     Global Passed Through Env Vars Values = 
+    Engines Values                        = 
   
   Tasks to Run
   build
     Task                           = build\s* (re)
-    Hash                           = 81a933c332d3f388
-    Cached (Local)                 = false
-    Cached (Remote)                = false
-    Command                        = echo building > foo.txt
-    Outputs                        = foo.txt
-    Log File                       = .turbo(\/|\\)turbo-build.log (re)
-    Dependencies                   = 
-    Dependents                     = 
-    Inputs Files Considered        = 5
+    Hash                           = 6c1cecf7f99d0166
+    Cached \(Local\)                 = false\s* (re)
+    Cached \(Remote\)                = false\s* (re)
+    Command                        = echo building > foo.txt\s* (re)
+    Outputs                        = foo.txt\s* (re)
+    Log File                       = .turbo(\/|\\)turbo-build.log\s* (re)
+    Dependencies                   =\s* (re)
+    Dependents                     =\s* (re)
+    Inputs Files Considered        = 5\s* (re)
     Env Vars                       = 
     Env Vars Values                = 
     Inferred Env Vars Values       = 

--- a/turborepo-tests/integration/tests/run/single-package/no-config.t
+++ b/turborepo-tests/integration/tests/run/single-package/no-config.t
@@ -9,25 +9,26 @@ Check
   Global Hash Inputs
     Global Files                          = 2\s* (re)
     External Dependencies Hash            =\s* (re)
-    Global Cache Key                      = I can\xe2\x80\x99t see ya, but I know you\xe2\x80\x99re here (esc)
+    Global Cache Key                      = HEY STELLLLLLLAAAAAAAAAAAAA\s* (re)
     Global Env Vars                       = 
     Global Env Vars Values                = 
     Inferred Global Env Vars Values       = 
     Global Passed Through Env Vars        = 
     Global Passed Through Env Vars Values = 
+    Engines Values                        = 
   
   Tasks to Run
   build
     Task                           = build\s* (re)
-    Hash                           = 12c592ddc0e53a5c
-    Cached (Local)                 = false
-    Cached (Remote)                = false
-    Command                        = echo building > foo.txt
-    Outputs                        = 
-    Log File                       = .turbo(\/|\\)turbo-build.log (re)
-    Dependencies                   = 
-    Dependents                     = 
-    Inputs Files Considered        = 4
+    Hash                           = 5c3c1742edb70bb8
+    Cached \(Local\)                 = false\s* (re)
+    Cached \(Remote\)                = false\s* (re)
+    Command                        = echo building > foo.txt\s* (re)
+    Outputs                        =\s* (re)
+    Log File                       = .turbo(\/|\\)turbo-build.log\s* (re)
+    Dependencies                   =\s* (re)
+    Dependents                     =\s* (re)
+    Inputs Files Considered        = 4\s* (re)
     Env Vars                       = 
     Env Vars Values                = 
     Inferred Env Vars Values       = 
@@ -50,7 +51,7 @@ Run real once
   $ ${TURBO} run build
   \xe2\x80\xa2 Running build (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  build: cache bypass, force executing 12c592ddc0e53a5c
+  build: cache bypass, force executing 5c3c1742edb70bb8
   build: 
   build: > build
   build: > echo building > foo.txt
@@ -64,7 +65,7 @@ Run a second time, verify no caching because there is no config
   $ ${TURBO} run build
   \xe2\x80\xa2 Running build (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  build: cache bypass, force executing 12c592ddc0e53a5c
+  build: cache bypass, force executing 5c3c1742edb70bb8
   build: 
   build: > build
   build: > echo building > foo.txt

--- a/turborepo-tests/integration/tests/run/single-package/no-config.t
+++ b/turborepo-tests/integration/tests/run/single-package/no-config.t
@@ -9,7 +9,7 @@ Check
   Global Hash Inputs
     Global Files                          = 2\s* (re)
     External Dependencies Hash            =\s* (re)
-    Global Cache Key                      = HEY STELLLLLLLAAAAAAAAAAAAA\s* (re)
+    Global Cache Key                      = I can\xe2\x80\x99t see ya, but I know you\xe2\x80\x99re here (esc)
     Global Env Vars                       = 
     Global Env Vars Values                = 
     Inferred Global Env Vars Values       = 
@@ -20,7 +20,7 @@ Check
   Tasks to Run
   build
     Task                           = build\s* (re)
-    Hash                           = 5c3c1742edb70bb8
+    Hash                           = e2b99dad85a4ff66
     Cached \(Local\)                 = false\s* (re)
     Cached \(Remote\)                = false\s* (re)
     Command                        = echo building > foo.txt\s* (re)
@@ -51,7 +51,7 @@ Run real once
   $ ${TURBO} run build
   \xe2\x80\xa2 Running build (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  build: cache bypass, force executing 5c3c1742edb70bb8
+  build: cache bypass, force executing e2b99dad85a4ff66
   build: 
   build: > build
   build: > echo building > foo.txt
@@ -65,7 +65,7 @@ Run a second time, verify no caching because there is no config
   $ ${TURBO} run build
   \xe2\x80\xa2 Running build (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  build: cache bypass, force executing 5c3c1742edb70bb8
+  build: cache bypass, force executing e2b99dad85a4ff66
   build: 
   build: > build
   build: > echo building > foo.txt

--- a/turborepo-tests/integration/tests/run/single-package/run-yarn.t
+++ b/turborepo-tests/integration/tests/run/single-package/run-yarn.t
@@ -5,7 +5,7 @@ Check
   $ ${TURBO} run build
   \xe2\x80\xa2 Running build (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  build: cache miss, executing 4b04480f003a4447
+  build: cache miss, executing a6fef17cc2efc81c
   build: yarn run v1.22.17
   build: warning package.json: No license field
   build: $ echo building > foo.txt
@@ -18,7 +18,7 @@ Check
   $ ${TURBO} run build
   \xe2\x80\xa2 Running build (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  build: cache hit, replaying logs 4b04480f003a4447
+  build: cache hit, replaying logs a6fef17cc2efc81c
   build: yarn run v1.22.17
   build: warning package.json: No license field
   build: $ echo building > foo.txt

--- a/turborepo-tests/integration/tests/run/single-package/run-yarn.t
+++ b/turborepo-tests/integration/tests/run/single-package/run-yarn.t
@@ -5,7 +5,7 @@ Check
   $ ${TURBO} run build
   \xe2\x80\xa2 Running build (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  build: cache miss, executing 34db97233d5773b8
+  build: cache miss, executing 4b04480f003a4447
   build: yarn run v1.22.17
   build: warning package.json: No license field
   build: $ echo building > foo.txt
@@ -18,7 +18,7 @@ Check
   $ ${TURBO} run build
   \xe2\x80\xa2 Running build (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  build: cache hit, replaying logs 34db97233d5773b8
+  build: cache hit, replaying logs 4b04480f003a4447
   build: yarn run v1.22.17
   build: warning package.json: No license field
   build: $ echo building > foo.txt

--- a/turborepo-tests/integration/tests/run/single-package/run.t
+++ b/turborepo-tests/integration/tests/run/single-package/run.t
@@ -5,7 +5,7 @@ Check
   $ ${TURBO} run build
   \xe2\x80\xa2 Running build (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  build: cache miss, executing 6c1cecf7f99d0166
+  build: cache miss, executing 7ece7b62aad25615
   build: 
   build: > build
   build: > echo building > foo.txt
@@ -22,7 +22,7 @@ Run a second time, verify caching works because there is a config
   $ ${TURBO} run build
   \xe2\x80\xa2 Running build (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  build: cache hit, replaying logs 6c1cecf7f99d0166
+  build: cache hit, replaying logs 7ece7b62aad25615
   build: 
   build: > build
   build: > echo building > foo.txt

--- a/turborepo-tests/integration/tests/run/single-package/run.t
+++ b/turborepo-tests/integration/tests/run/single-package/run.t
@@ -5,7 +5,7 @@ Check
   $ ${TURBO} run build
   \xe2\x80\xa2 Running build (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  build: cache miss, executing 81a933c332d3f388
+  build: cache miss, executing 6c1cecf7f99d0166
   build: 
   build: > build
   build: > echo building > foo.txt
@@ -22,7 +22,7 @@ Run a second time, verify caching works because there is a config
   $ ${TURBO} run build
   \xe2\x80\xa2 Running build (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  build: cache hit, replaying logs 81a933c332d3f388
+  build: cache hit, replaying logs 6c1cecf7f99d0166
   build: 
   build: > build
   build: > echo building > foo.txt

--- a/turborepo-tests/integration/tests/run/single-package/with-deps-dry-run.t
+++ b/turborepo-tests/integration/tests/run/single-package/with-deps-dry-run.t
@@ -7,7 +7,7 @@ Check
   Global Hash Inputs
     Global Files                          = 3
     External Dependencies Hash            = 
-    Global Cache Key                      = HEY STELLLLLLLAAAAAAAAAAAAA
+    Global Cache Key                      = I can\xe2\x80\x99t see ya, but I know you\xe2\x80\x99re here (esc)
     Global Env Vars                       = 
     Global Env Vars Values                = 
     Inferred Global Env Vars Values       = 
@@ -18,7 +18,7 @@ Check
   Tasks to Run
   build
     Task                           = build\s* (re)
-    Hash                           = 6c1cecf7f99d0166
+    Hash                           = 7ece7b62aad25615
     Cached \(Local\)                 = false\s* (re)
     Cached \(Remote\)                = false\s* (re)
     Command                        = echo building > foo.txt\s* (re)
@@ -36,7 +36,7 @@ Check
     Framework                      = 
   test
     Task                           = test\s* (re)
-    Hash                           = d241ae86a1a24a2e
+    Hash                           = cb5839f7284aa5f3
     Cached \(Local\)                 = false\s* (re)
     Cached \(Remote\)                = false\s* (re)
     Command                        = cat foo.txt\s* (re)

--- a/turborepo-tests/integration/tests/run/single-package/with-deps-dry-run.t
+++ b/turborepo-tests/integration/tests/run/single-package/with-deps-dry-run.t
@@ -7,25 +7,26 @@ Check
   Global Hash Inputs
     Global Files                          = 3
     External Dependencies Hash            = 
-    Global Cache Key                      = I can\xe2\x80\x99t see ya, but I know you\xe2\x80\x99re here (esc)
+    Global Cache Key                      = HEY STELLLLLLLAAAAAAAAAAAAA
     Global Env Vars                       = 
     Global Env Vars Values                = 
     Inferred Global Env Vars Values       = 
     Global Passed Through Env Vars        = 
     Global Passed Through Env Vars Values = 
+    Engines Values                        = 
   
   Tasks to Run
   build
     Task                           = build\s* (re)
-    Hash                           = 81a933c332d3f388
-    Cached (Local)                 = false
-    Cached (Remote)                = false
-    Command                        = echo building > foo.txt
-    Outputs                        = foo.txt
-    Log File                       = .turbo(\/|\\)turbo-build.log (re)
-    Dependencies                   = 
-    Dependents                     = test
-    Inputs Files Considered        = 5
+    Hash                           = 6c1cecf7f99d0166
+    Cached \(Local\)                 = false\s* (re)
+    Cached \(Remote\)                = false\s* (re)
+    Command                        = echo building > foo.txt\s* (re)
+    Outputs                        = foo.txt\s* (re)
+    Log File                       = .turbo(\/|\\)turbo-build.log\s* (re)
+    Dependencies                   =\s* (re)
+    Dependents                     = test\s* (re)
+    Inputs Files Considered        = 5\s* (re)
     Env Vars                       = 
     Env Vars Values                = 
     Inferred Env Vars Values       = 
@@ -35,15 +36,15 @@ Check
     Framework                      = 
   test
     Task                           = test\s* (re)
-    Hash                           = 785d8ef1115bde3b
-    Cached (Local)                 = false
-    Cached (Remote)                = false
-    Command                        = cat foo.txt
-    Outputs                        = 
-    Log File                       = .turbo(\/|\\)turbo-test.log (re)
-    Dependencies                   = build
-    Dependents                     = 
-    Inputs Files Considered        = 5
+    Hash                           = d241ae86a1a24a2e
+    Cached \(Local\)                 = false\s* (re)
+    Cached \(Remote\)                = false\s* (re)
+    Command                        = cat foo.txt\s* (re)
+    Outputs                        =\s* (re)
+    Log File                       = .turbo(\/|\\)turbo-test.log\s* (re)
+    Dependencies                   = build\s* (re)
+    Dependents                     =\s* (re)
+    Inputs Files Considered        = 5\s* (re)
     Env Vars                       = 
     Env Vars Values                = 
     Inferred Env Vars Values       = 

--- a/turborepo-tests/integration/tests/run/single-package/with-deps-run.t
+++ b/turborepo-tests/integration/tests/run/single-package/with-deps-run.t
@@ -21,12 +21,6 @@ Check
   Cached:    0 cached, 2 total
     Time:\s*[\.0-9]+m?s  (re)
   
-<<<<<<< HEAD
-=======
->>>>>>> b668d5abb3 (chore: remove task dotEnv field)
-<<<<<<< HEAD
-=======
->>>>>>> b668d5abb3 (chore: remove task dotEnv field)
 Run a second time, verify caching works because there is a config
   $ ${TURBO} run test
   \xe2\x80\xa2 Running test (esc)
@@ -47,12 +41,6 @@ Run a second time, verify caching works because there is a config
   Cached:    2 cached, 2 total
     Time:\s*[\.0-9]+m?s >>> FULL TURBO (re)
   
-<<<<<<< HEAD
-=======
->>>>>>> b668d5abb3 (chore: remove task dotEnv field)
-<<<<<<< HEAD
-=======
->>>>>>> b668d5abb3 (chore: remove task dotEnv field)
 Run with --output-logs=hash-only
   $ ${TURBO} run test --output-logs=hash-only
   \xe2\x80\xa2 Running test (esc)
@@ -64,9 +52,6 @@ Run with --output-logs=hash-only
   Cached:    2 cached, 2 total
     Time:\s*[\.0-9]+m?s >>> FULL TURBO (re)
   
-<<<<<<< HEAD
-=======
->>>>>>> b668d5abb3 (chore: remove task dotEnv field)
 Run with --output-logs=errors-only
   $ ${TURBO} run test --output-logs=errors-only
   \xe2\x80\xa2 Running test (esc)

--- a/turborepo-tests/integration/tests/run/single-package/with-deps-run.t
+++ b/turborepo-tests/integration/tests/run/single-package/with-deps-run.t
@@ -5,12 +5,12 @@ Check
   $ ${TURBO} run test
   \xe2\x80\xa2 Running test (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  build: cache miss, executing 81a933c332d3f388
+  build: cache miss, executing 6c1cecf7f99d0166
   build: 
   build: > build
   build: > echo building > foo.txt
   build: 
-  test: cache miss, executing 785d8ef1115bde3b
+  test: cache miss, executing d241ae86a1a24a2e
   test: 
   test: > test
   test: > cat foo.txt
@@ -21,16 +21,22 @@ Check
   Cached:    0 cached, 2 total
     Time:\s*[\.0-9]+m?s  (re)
   
+<<<<<<< HEAD
+=======
+>>>>>>> b668d5abb3 (chore: remove task dotEnv field)
+<<<<<<< HEAD
+=======
+>>>>>>> b668d5abb3 (chore: remove task dotEnv field)
 Run a second time, verify caching works because there is a config
   $ ${TURBO} run test
   \xe2\x80\xa2 Running test (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  build: cache hit, replaying logs 81a933c332d3f388
+  build: cache hit, replaying logs 6c1cecf7f99d0166
   build: 
   build: > build
   build: > echo building > foo.txt
   build: 
-  test: cache hit, replaying logs 785d8ef1115bde3b
+  test: cache hit, replaying logs d241ae86a1a24a2e
   test: 
   test: > test
   test: > cat foo.txt
@@ -41,18 +47,26 @@ Run a second time, verify caching works because there is a config
   Cached:    2 cached, 2 total
     Time:\s*[\.0-9]+m?s >>> FULL TURBO (re)
   
+<<<<<<< HEAD
+=======
+>>>>>>> b668d5abb3 (chore: remove task dotEnv field)
+<<<<<<< HEAD
+=======
+>>>>>>> b668d5abb3 (chore: remove task dotEnv field)
 Run with --output-logs=hash-only
   $ ${TURBO} run test --output-logs=hash-only
   \xe2\x80\xa2 Running test (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  build: cache hit, suppressing logs 81a933c332d3f388
-  test: cache hit, suppressing logs 785d8ef1115bde3b
+  build: cache hit, suppressing logs 6c1cecf7f99d0166
+  test: cache hit, suppressing logs d241ae86a1a24a2e
   
    Tasks:    2 successful, 2 total
   Cached:    2 cached, 2 total
     Time:\s*[\.0-9]+m?s >>> FULL TURBO (re)
   
-
+<<<<<<< HEAD
+=======
+>>>>>>> b668d5abb3 (chore: remove task dotEnv field)
 Run with --output-logs=errors-only
   $ ${TURBO} run test --output-logs=errors-only
   \xe2\x80\xa2 Running test (esc)

--- a/turborepo-tests/integration/tests/run/single-package/with-deps-run.t
+++ b/turborepo-tests/integration/tests/run/single-package/with-deps-run.t
@@ -5,12 +5,12 @@ Check
   $ ${TURBO} run test
   \xe2\x80\xa2 Running test (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  build: cache miss, executing 6c1cecf7f99d0166
+  build: cache miss, executing 7ece7b62aad25615
   build: 
   build: > build
   build: > echo building > foo.txt
   build: 
-  test: cache miss, executing d241ae86a1a24a2e
+  test: cache miss, executing cb5839f7284aa5f3
   test: 
   test: > test
   test: > cat foo.txt
@@ -31,12 +31,12 @@ Run a second time, verify caching works because there is a config
   $ ${TURBO} run test
   \xe2\x80\xa2 Running test (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  build: cache hit, replaying logs 6c1cecf7f99d0166
+  build: cache hit, replaying logs 7ece7b62aad25615
   build: 
   build: > build
   build: > echo building > foo.txt
   build: 
-  test: cache hit, replaying logs d241ae86a1a24a2e
+  test: cache hit, replaying logs cb5839f7284aa5f3
   test: 
   test: > test
   test: > cat foo.txt
@@ -57,8 +57,8 @@ Run with --output-logs=hash-only
   $ ${TURBO} run test --output-logs=hash-only
   \xe2\x80\xa2 Running test (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  build: cache hit, suppressing logs 6c1cecf7f99d0166
-  test: cache hit, suppressing logs d241ae86a1a24a2e
+  build: cache hit, suppressing logs 7ece7b62aad25615
+  test: cache hit, suppressing logs cb5839f7284aa5f3
   
    Tasks:    2 successful, 2 total
   Cached:    2 cached, 2 total

--- a/turborepo-tests/integration/tests/task-dependencies/overwriting.t
+++ b/turborepo-tests/integration/tests/task-dependencies/overwriting.t
@@ -11,7 +11,7 @@ Test
 
 # workspace-a#generate ran
   $ cat tmp.log | grep "workspace-a:generate"
-  workspace-a:generate: cache miss, executing 8ee333277b4c00a0
+  workspace-a:generate: cache miss, executing 6d5613420b938e65
   workspace-a:generate: 
   workspace-a:generate: > generate
   workspace-a:generate: > echo generate-workspace-a
@@ -19,7 +19,7 @@ Test
   workspace-a:generate: generate-workspace-a
 workspace-a#build ran
   $ cat tmp.log | grep "workspace-a:build"
-  workspace-a:build: cache miss, executing 886936e13f48ddb8
+  workspace-a:build: cache miss, executing fa4e8c2cffdc2a49
   workspace-a:build: 
   workspace-a:build: > build
   workspace-a:build: > echo build-workspace-a
@@ -32,7 +32,7 @@ workspace-b#generate DID NOT run
 
 workspace-b#build ran
   $ cat tmp.log | grep "workspace-b:build"
-  workspace-b:build: cache miss, executing b10c1a5197eafc5d
+  workspace-b:build: cache miss, executing 6ae425867ec16302
   workspace-b:build: 
   workspace-b:build: > build
   workspace-b:build: > echo build-workspace-b

--- a/turborepo-tests/integration/tests/task-dependencies/overwriting.t
+++ b/turborepo-tests/integration/tests/task-dependencies/overwriting.t
@@ -11,7 +11,7 @@ Test
 
 # workspace-a#generate ran
   $ cat tmp.log | grep "workspace-a:generate"
-  workspace-a:generate: cache miss, executing 6d5613420b938e65
+  workspace-a:generate: cache miss, executing 9177da2f682aeeb7
   workspace-a:generate: 
   workspace-a:generate: > generate
   workspace-a:generate: > echo generate-workspace-a
@@ -19,7 +19,7 @@ Test
   workspace-a:generate: generate-workspace-a
 workspace-a#build ran
   $ cat tmp.log | grep "workspace-a:build"
-  workspace-a:build: cache miss, executing fa4e8c2cffdc2a49
+  workspace-a:build: cache miss, executing f6fe0ec4a3ecb04b
   workspace-a:build: 
   workspace-a:build: > build
   workspace-a:build: > echo build-workspace-a
@@ -32,7 +32,7 @@ workspace-b#generate DID NOT run
 
 workspace-b#build ran
   $ cat tmp.log | grep "workspace-b:build"
-  workspace-b:build: cache miss, executing 6ae425867ec16302
+  workspace-b:build: cache miss, executing b0cbf81d4cce38a4
   workspace-b:build: 
   workspace-b:build: > build
   workspace-b:build: > echo build-workspace-b

--- a/turborepo-tests/integration/tests/task-dependencies/root-workspace.t
+++ b/turborepo-tests/integration/tests/task-dependencies/root-workspace.t
@@ -5,13 +5,13 @@ This tests asserts that root tasks can depend on workspace#task
   \xe2\x80\xa2 Packages in scope: //, lib-a (esc)
   \xe2\x80\xa2 Running mytask in 2 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  lib-a:build: cache miss, executing 5b761e7ac20ce0a6
+  lib-a:build: cache miss, executing 6251d5c56a3ddb43
   lib-a:build: 
   lib-a:build: > build
   lib-a:build: > echo build-lib-a
   lib-a:build: 
   lib-a:build: build-lib-a
-  //:mytask: cache miss, executing 8a3a7db901b3e8cf
+  //:mytask: cache miss, executing 0b577bd9bd02ad77
   //:mytask: 
   //:mytask: > mytask
   //:mytask: > echo root-mytask

--- a/turborepo-tests/integration/tests/task-dependencies/root-workspace.t
+++ b/turborepo-tests/integration/tests/task-dependencies/root-workspace.t
@@ -5,13 +5,13 @@ This tests asserts that root tasks can depend on workspace#task
   \xe2\x80\xa2 Packages in scope: //, lib-a (esc)
   \xe2\x80\xa2 Running mytask in 2 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  lib-a:build: cache miss, executing 6251d5c56a3ddb43
+  lib-a:build: cache miss, executing eddc59f63124ca26
   lib-a:build: 
   lib-a:build: > build
   lib-a:build: > echo build-lib-a
   lib-a:build: 
   lib-a:build: build-lib-a
-  //:mytask: cache miss, executing 0b577bd9bd02ad77
+  //:mytask: cache miss, executing 82474628cac2e34c
   //:mytask: 
   //:mytask: > mytask
   //:mytask: > echo root-mytask

--- a/turborepo-tests/integration/tests/task-dependencies/topological.t
+++ b/turborepo-tests/integration/tests/task-dependencies/topological.t
@@ -6,13 +6,13 @@ Check my-app#build output
   \xe2\x80\xa2 Packages in scope: //, my-app, util (esc)
   \xe2\x80\xa2 Running build in 3 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  util:build: cache miss, executing 7a33745406acbff6
+  util:build: cache miss, executing 3d1f83b683510099
   util:build: 
   util:build: > build
   util:build: > echo building
   util:build: 
   util:build: building
-  my-app:build: cache miss, executing 79ef55818c4f1b63
+  my-app:build: cache miss, executing a24fb33a97cce572
   my-app:build: 
   my-app:build: > build
   my-app:build: > echo building

--- a/turborepo-tests/integration/tests/task-dependencies/topological.t
+++ b/turborepo-tests/integration/tests/task-dependencies/topological.t
@@ -6,13 +6,13 @@ Check my-app#build output
   \xe2\x80\xa2 Packages in scope: //, my-app, util (esc)
   \xe2\x80\xa2 Running build in 3 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  util:build: cache miss, executing a4a05b282e52a021
+  util:build: cache miss, executing 7a33745406acbff6
   util:build: 
   util:build: > build
   util:build: > echo building
   util:build: 
   util:build: building
-  my-app:build: cache miss, executing 0e31fb7bb214a760
+  my-app:build: cache miss, executing 79ef55818c4f1b63
   my-app:build: 
   my-app:build: > build
   my-app:build: > echo building

--- a/turborepo-tests/integration/tests/workspace-configs/add-keys.t
+++ b/turborepo-tests/integration/tests/workspace-configs/add-keys.t
@@ -30,12 +30,6 @@ Setup
   Cached:    0 cached, 2 total
     Time:\s*[\.0-9]+m?s  (re)
   
-<<<<<<< HEAD
-=======
->>>>>>> 37c3c596f1 (chore: update integration tests)
-<<<<<<< HEAD
-=======
->>>>>>> 37c3c596f1 (chore: update integration tests)
   $ HASH=$(cat tmp.log | grep -E "add-keys:add-keys-task.* executing .*" | awk '{print $5}')
   $ tar -tf $TARGET_DIR/.turbo/cache/$HASH.tar.zst;
   apps/add-keys/.turbo/turbo-add-keys-task.log

--- a/turborepo-tests/integration/tests/workspace-configs/add-keys.t
+++ b/turborepo-tests/integration/tests/workspace-configs/add-keys.t
@@ -14,13 +14,13 @@ Setup
   \xe2\x80\xa2 Packages in scope: add-keys (esc)
   \xe2\x80\xa2 Running add-keys-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  add-keys:add-keys-underlying-task: cache miss, executing 0e8875f26fc52424
+  add-keys:add-keys-underlying-task: cache miss, executing 1ce848eeaff2dbd4
   add-keys:add-keys-underlying-task: 
   add-keys:add-keys-underlying-task: > add-keys-underlying-task
   add-keys:add-keys-underlying-task: > echo running-add-keys-underlying-task
   add-keys:add-keys-underlying-task: 
   add-keys:add-keys-underlying-task: running-add-keys-underlying-task
-  add-keys:add-keys-task: cache miss, executing 8532886eeb41bd24
+  add-keys:add-keys-task: cache miss, executing b16339834937fd9e
   add-keys:add-keys-task: 
   add-keys:add-keys-task: > add-keys-task
   add-keys:add-keys-task: > echo running-add-keys-task > out/foo.min.txt
@@ -48,13 +48,13 @@ Setup
   \xe2\x80\xa2 Packages in scope: add-keys (esc)
   \xe2\x80\xa2 Running add-keys-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  add-keys:add-keys-underlying-task: cache hit, replaying logs 0e8875f26fc52424
+  add-keys:add-keys-underlying-task: cache hit, replaying logs 1ce848eeaff2dbd4
   add-keys:add-keys-underlying-task: 
   add-keys:add-keys-underlying-task: > add-keys-underlying-task
   add-keys:add-keys-underlying-task: > echo running-add-keys-underlying-task
   add-keys:add-keys-underlying-task: 
   add-keys:add-keys-underlying-task: running-add-keys-underlying-task
-  add-keys:add-keys-task: cache hit, suppressing logs 8532886eeb41bd24
+  add-keys:add-keys-task: cache hit, suppressing logs b16339834937fd9e
   
    Tasks:    2 successful, 2 total
   Cached:    2 cached, 2 total
@@ -66,13 +66,13 @@ Setup
   \xe2\x80\xa2 Packages in scope: add-keys (esc)
   \xe2\x80\xa2 Running add-keys-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  add-keys:add-keys-underlying-task: cache miss, executing 94fb44718b2fc83e
+  add-keys:add-keys-underlying-task: cache miss, executing 8a894e7cb2c0a1ea
   add-keys:add-keys-underlying-task: 
   add-keys:add-keys-underlying-task: > add-keys-underlying-task
   add-keys:add-keys-underlying-task: > echo running-add-keys-underlying-task
   add-keys:add-keys-underlying-task: 
   add-keys:add-keys-underlying-task: running-add-keys-underlying-task
-  add-keys:add-keys-task: cache miss, executing 5a179edda92480f9
+  add-keys:add-keys-task: cache miss, executing df66730da80eec8e
   add-keys:add-keys-task: 
   add-keys:add-keys-task: > add-keys-task
   add-keys:add-keys-task: > echo running-add-keys-task > out/foo.min.txt
@@ -87,13 +87,13 @@ Setup
   \xe2\x80\xa2 Packages in scope: add-keys (esc)
   \xe2\x80\xa2 Running add-keys-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  add-keys:add-keys-underlying-task: cache hit, replaying logs 94fb44718b2fc83e
+  add-keys:add-keys-underlying-task: cache hit, replaying logs 8a894e7cb2c0a1ea
   add-keys:add-keys-underlying-task: 
   add-keys:add-keys-underlying-task: > add-keys-underlying-task
   add-keys:add-keys-underlying-task: > echo running-add-keys-underlying-task
   add-keys:add-keys-underlying-task: 
   add-keys:add-keys-underlying-task: running-add-keys-underlying-task
-  add-keys:add-keys-task: cache miss, executing 441efbfc91d4b6c9
+  add-keys:add-keys-task: cache miss, executing 96c5e85515972df5
   add-keys:add-keys-task: 
   add-keys:add-keys-task: > add-keys-task
   add-keys:add-keys-task: > echo running-add-keys-task > out/foo.min.txt

--- a/turborepo-tests/integration/tests/workspace-configs/add-keys.t
+++ b/turborepo-tests/integration/tests/workspace-configs/add-keys.t
@@ -14,13 +14,13 @@ Setup
   \xe2\x80\xa2 Packages in scope: add-keys (esc)
   \xe2\x80\xa2 Running add-keys-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  add-keys:add-keys-underlying-task: cache miss, executing 2bd958e3fcfce743
+  add-keys:add-keys-underlying-task: cache miss, executing 0e8875f26fc52424
   add-keys:add-keys-underlying-task: 
   add-keys:add-keys-underlying-task: > add-keys-underlying-task
   add-keys:add-keys-underlying-task: > echo running-add-keys-underlying-task
   add-keys:add-keys-underlying-task: 
   add-keys:add-keys-underlying-task: running-add-keys-underlying-task
-  add-keys:add-keys-task: cache miss, executing a11556f24e8544ee
+  add-keys:add-keys-task: cache miss, executing 8532886eeb41bd24
   add-keys:add-keys-task: 
   add-keys:add-keys-task: > add-keys-task
   add-keys:add-keys-task: > echo running-add-keys-task > out/foo.min.txt
@@ -48,13 +48,13 @@ Setup
   \xe2\x80\xa2 Packages in scope: add-keys (esc)
   \xe2\x80\xa2 Running add-keys-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  add-keys:add-keys-underlying-task: cache hit, replaying logs 2bd958e3fcfce743
+  add-keys:add-keys-underlying-task: cache hit, replaying logs 0e8875f26fc52424
   add-keys:add-keys-underlying-task: 
   add-keys:add-keys-underlying-task: > add-keys-underlying-task
   add-keys:add-keys-underlying-task: > echo running-add-keys-underlying-task
   add-keys:add-keys-underlying-task: 
   add-keys:add-keys-underlying-task: running-add-keys-underlying-task
-  add-keys:add-keys-task: cache hit, suppressing logs a11556f24e8544ee
+  add-keys:add-keys-task: cache hit, suppressing logs 8532886eeb41bd24
   
    Tasks:    2 successful, 2 total
   Cached:    2 cached, 2 total
@@ -66,13 +66,13 @@ Setup
   \xe2\x80\xa2 Packages in scope: add-keys (esc)
   \xe2\x80\xa2 Running add-keys-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  add-keys:add-keys-underlying-task: cache miss, executing 0ab311c4d79c6364
+  add-keys:add-keys-underlying-task: cache miss, executing 94fb44718b2fc83e
   add-keys:add-keys-underlying-task: 
   add-keys:add-keys-underlying-task: > add-keys-underlying-task
   add-keys:add-keys-underlying-task: > echo running-add-keys-underlying-task
   add-keys:add-keys-underlying-task: 
   add-keys:add-keys-underlying-task: running-add-keys-underlying-task
-  add-keys:add-keys-task: cache miss, executing f996028b8b4e387b
+  add-keys:add-keys-task: cache miss, executing 5a179edda92480f9
   add-keys:add-keys-task: 
   add-keys:add-keys-task: > add-keys-task
   add-keys:add-keys-task: > echo running-add-keys-task > out/foo.min.txt
@@ -87,13 +87,13 @@ Setup
   \xe2\x80\xa2 Packages in scope: add-keys (esc)
   \xe2\x80\xa2 Running add-keys-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  add-keys:add-keys-underlying-task: cache hit, replaying logs 0ab311c4d79c6364
+  add-keys:add-keys-underlying-task: cache hit, replaying logs 94fb44718b2fc83e
   add-keys:add-keys-underlying-task: 
   add-keys:add-keys-underlying-task: > add-keys-underlying-task
   add-keys:add-keys-underlying-task: > echo running-add-keys-underlying-task
   add-keys:add-keys-underlying-task: 
   add-keys:add-keys-underlying-task: running-add-keys-underlying-task
-  add-keys:add-keys-task: cache miss, executing 669ea43ab8c0fc93
+  add-keys:add-keys-task: cache miss, executing 441efbfc91d4b6c9
   add-keys:add-keys-task: 
   add-keys:add-keys-task: > add-keys-task
   add-keys:add-keys-task: > echo running-add-keys-task > out/foo.min.txt

--- a/turborepo-tests/integration/tests/workspace-configs/add-tasks.t
+++ b/turborepo-tests/integration/tests/workspace-configs/add-tasks.t
@@ -5,7 +5,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: add-tasks (esc)
   \xe2\x80\xa2 Running added-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  add-tasks:added-task: cache miss, executing 86d698d4e34329fd
+  add-tasks:added-task: cache miss, executing 9391814d1b5b7c3b
   add-tasks:added-task: 
   add-tasks:added-task: > added-task
   add-tasks:added-task: > echo running-added-task > out/foo.min.txt

--- a/turborepo-tests/integration/tests/workspace-configs/add-tasks.t
+++ b/turborepo-tests/integration/tests/workspace-configs/add-tasks.t
@@ -5,7 +5,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: add-tasks (esc)
   \xe2\x80\xa2 Running added-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  add-tasks:added-task: cache miss, executing 9391814d1b5b7c3b
+  add-tasks:added-task: cache miss, executing 0c8333ca7685d45f
   add-tasks:added-task: 
   add-tasks:added-task: > added-task
   add-tasks:added-task: > echo running-added-task > out/foo.min.txt

--- a/turborepo-tests/integration/tests/workspace-configs/cache.t
+++ b/turborepo-tests/integration/tests/workspace-configs/cache.t
@@ -13,7 +13,7 @@ This test covers:
   \xe2\x80\xa2 Packages in scope: cached (esc)
   \xe2\x80\xa2 Running cached-task-1 in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  cached:cached-task-1: cache miss, executing 9e3395829722ac4e
+  cached:cached-task-1: cache miss, executing da2166fcfd7b56bd
   cached:cached-task-1: 
   cached:cached-task-1: > cached-task-1
   cached:cached-task-1: > echo cached-task-1 > out/foo.min.txt
@@ -38,7 +38,7 @@ This test covers:
   \xe2\x80\xa2 Packages in scope: cached (esc)
   \xe2\x80\xa2 Running cached-task-2 in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  cached:cached-task-2: cache bypass, force executing 2cfd3544dd81bce7
+  cached:cached-task-2: cache bypass, force executing e42e6c8e2ae6a672
   cached:cached-task-2: 
   cached:cached-task-2: > cached-task-2
   cached:cached-task-2: > echo cached-task-2 > out/foo.min.txt
@@ -60,7 +60,7 @@ no `cache` config in root, cache:false in workspace
   \xe2\x80\xa2 Packages in scope: cached (esc)
   \xe2\x80\xa2 Running cached-task-3 in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  cached:cached-task-3: cache bypass, force executing f10b21eea83c963e
+  cached:cached-task-3: cache bypass, force executing 86ce94afb18567d7
   cached:cached-task-3: 
   cached:cached-task-3: > cached-task-3
   cached:cached-task-3: > echo cached-task-3 > out/foo.min.txt
@@ -84,7 +84,7 @@ we already have a workspace that doesn't have a config
   \xe2\x80\xa2 Packages in scope: missing-workspace-config (esc)
   \xe2\x80\xa2 Running cached-task-4 in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  missing-workspace-config:cached-task-4: cache bypass, force executing a742da0575f5ca35
+  missing-workspace-config:cached-task-4: cache bypass, force executing f164838b2fe93185
   missing-workspace-config:cached-task-4: 
   missing-workspace-config:cached-task-4: > cached-task-4
   missing-workspace-config:cached-task-4: > echo cached-task-4 > out/foo.min.txt

--- a/turborepo-tests/integration/tests/workspace-configs/cache.t
+++ b/turborepo-tests/integration/tests/workspace-configs/cache.t
@@ -13,7 +13,7 @@ This test covers:
   \xe2\x80\xa2 Packages in scope: cached (esc)
   \xe2\x80\xa2 Running cached-task-1 in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  cached:cached-task-1: cache miss, executing a49d6b89949c7afa
+  cached:cached-task-1: cache miss, executing 9e3395829722ac4e
   cached:cached-task-1: 
   cached:cached-task-1: > cached-task-1
   cached:cached-task-1: > echo cached-task-1 > out/foo.min.txt
@@ -38,7 +38,7 @@ This test covers:
   \xe2\x80\xa2 Packages in scope: cached (esc)
   \xe2\x80\xa2 Running cached-task-2 in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  cached:cached-task-2: cache bypass, force executing 44fd51a101b8f481
+  cached:cached-task-2: cache bypass, force executing 2cfd3544dd81bce7
   cached:cached-task-2: 
   cached:cached-task-2: > cached-task-2
   cached:cached-task-2: > echo cached-task-2 > out/foo.min.txt
@@ -60,7 +60,7 @@ no `cache` config in root, cache:false in workspace
   \xe2\x80\xa2 Packages in scope: cached (esc)
   \xe2\x80\xa2 Running cached-task-3 in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  cached:cached-task-3: cache bypass, force executing c0043d1b0a723064
+  cached:cached-task-3: cache bypass, force executing f10b21eea83c963e
   cached:cached-task-3: 
   cached:cached-task-3: > cached-task-3
   cached:cached-task-3: > echo cached-task-3 > out/foo.min.txt
@@ -84,7 +84,7 @@ we already have a workspace that doesn't have a config
   \xe2\x80\xa2 Packages in scope: missing-workspace-config (esc)
   \xe2\x80\xa2 Running cached-task-4 in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  missing-workspace-config:cached-task-4: cache bypass, force executing 991b90e398c3e30b
+  missing-workspace-config:cached-task-4: cache bypass, force executing a742da0575f5ca35
   missing-workspace-config:cached-task-4: 
   missing-workspace-config:cached-task-4: > cached-task-4
   missing-workspace-config:cached-task-4: > echo cached-task-4 > out/foo.min.txt

--- a/turborepo-tests/integration/tests/workspace-configs/config-change.t
+++ b/turborepo-tests/integration/tests/workspace-configs/config-change.t
@@ -3,13 +3,13 @@ Setup
 
 # 1. First run, check the hash
   $ ${TURBO} run config-change-task --filter=config-change --dry=json | jq .tasks[0].hash
-  "38f031e7ff4d4089"
+  "4fbfb44c77d14468"
 
 2. Run again and assert task hash stays the same
   $ ${TURBO} run config-change-task --filter=config-change --dry=json | jq .tasks[0].hash
-  "38f031e7ff4d4089"
+  "4fbfb44c77d14468"
 
 3. Change turbo.json and assert that hash changes
   $ cp $TARGET_DIR/apps/config-change/turbo-changed.json $TARGET_DIR/apps/config-change/turbo.json
   $ ${TURBO} run config-change-task --filter=config-change --dry=json | jq .tasks[0].hash
-  "e100adf0b01751c4"
+  "01e59b7f88f8a211"

--- a/turborepo-tests/integration/tests/workspace-configs/config-change.t
+++ b/turborepo-tests/integration/tests/workspace-configs/config-change.t
@@ -3,13 +3,13 @@ Setup
 
 # 1. First run, check the hash
   $ ${TURBO} run config-change-task --filter=config-change --dry=json | jq .tasks[0].hash
-  "d93bbb973d5db9f1"
+  "38f031e7ff4d4089"
 
 2. Run again and assert task hash stays the same
   $ ${TURBO} run config-change-task --filter=config-change --dry=json | jq .tasks[0].hash
-  "d93bbb973d5db9f1"
+  "38f031e7ff4d4089"
 
 3. Change turbo.json and assert that hash changes
   $ cp $TARGET_DIR/apps/config-change/turbo-changed.json $TARGET_DIR/apps/config-change/turbo.json
   $ ${TURBO} run config-change-task --filter=config-change --dry=json | jq .tasks[0].hash
-  "cece46842b2454fe"
+  "e100adf0b01751c4"

--- a/turborepo-tests/integration/tests/workspace-configs/cross-workspace.t
+++ b/turborepo-tests/integration/tests/workspace-configs/cross-workspace.t
@@ -4,13 +4,13 @@ Setup
   \xe2\x80\xa2 Packages in scope: cross-workspace (esc)
   \xe2\x80\xa2 Running cross-workspace-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  blank-pkg:cross-workspace-underlying-task: cache miss, executing 2ca5991c80f91ba1
+  blank-pkg:cross-workspace-underlying-task: cache miss, executing 789f5a4c2be4a213
   blank-pkg:cross-workspace-underlying-task: 
   blank-pkg:cross-workspace-underlying-task: > cross-workspace-underlying-task
   blank-pkg:cross-workspace-underlying-task: > echo cross-workspace-underlying-task from blank-pkg
   blank-pkg:cross-workspace-underlying-task: 
   blank-pkg:cross-workspace-underlying-task: cross-workspace-underlying-task from blank-pkg
-  cross-workspace:cross-workspace-task: cache miss, executing d94b9c3284307ca2
+  cross-workspace:cross-workspace-task: cache miss, executing e1fa3da49faa2804
   cross-workspace:cross-workspace-task: 
   cross-workspace:cross-workspace-task: > cross-workspace-task
   cross-workspace:cross-workspace-task: > echo cross-workspace-task

--- a/turborepo-tests/integration/tests/workspace-configs/cross-workspace.t
+++ b/turborepo-tests/integration/tests/workspace-configs/cross-workspace.t
@@ -4,13 +4,13 @@ Setup
   \xe2\x80\xa2 Packages in scope: cross-workspace (esc)
   \xe2\x80\xa2 Running cross-workspace-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  blank-pkg:cross-workspace-underlying-task: cache miss, executing 789f5a4c2be4a213
+  blank-pkg:cross-workspace-underlying-task: cache miss, executing 39566f6362976823
   blank-pkg:cross-workspace-underlying-task: 
   blank-pkg:cross-workspace-underlying-task: > cross-workspace-underlying-task
   blank-pkg:cross-workspace-underlying-task: > echo cross-workspace-underlying-task from blank-pkg
   blank-pkg:cross-workspace-underlying-task: 
   blank-pkg:cross-workspace-underlying-task: cross-workspace-underlying-task from blank-pkg
-  cross-workspace:cross-workspace-task: cache miss, executing e1fa3da49faa2804
+  cross-workspace:cross-workspace-task: cache miss, executing bce507a110930f07
   cross-workspace:cross-workspace-task: 
   cross-workspace:cross-workspace-task: > cross-workspace-task
   cross-workspace:cross-workspace-task: > echo cross-workspace-task

--- a/turborepo-tests/integration/tests/workspace-configs/missing-workspace-config-deps.t
+++ b/turborepo-tests/integration/tests/workspace-configs/missing-workspace-config-deps.t
@@ -15,14 +15,14 @@ Setup
   \xe2\x80\xa2 Remote caching disabled (esc)
 
   $ cat tmp.log | grep "missing-workspace-config:missing-workspace-config-task-with-deps"
-  missing-workspace-config:missing-workspace-config-task-with-deps: cache miss, executing ddbc8e9c98c1613a
+  missing-workspace-config:missing-workspace-config-task-with-deps: cache miss, executing 55f72796263e7103
   missing-workspace-config:missing-workspace-config-task-with-deps: 
   missing-workspace-config:missing-workspace-config-task-with-deps: > missing-workspace-config-task-with-deps
   missing-workspace-config:missing-workspace-config-task-with-deps: > echo running-missing-workspace-config-task-with-deps > out/foo.min.txt
   missing-workspace-config:missing-workspace-config-task-with-deps: 
 
   $ cat tmp.log | grep "missing-workspace-config:missing-workspace-config-underlying-task"
-  missing-workspace-config:missing-workspace-config-underlying-task: cache miss, executing 7804b721631ec9dc
+  missing-workspace-config:missing-workspace-config-underlying-task: cache miss, executing be9790215045f8e9
   missing-workspace-config:missing-workspace-config-underlying-task: 
   missing-workspace-config:missing-workspace-config-underlying-task: > missing-workspace-config-underlying-task
   missing-workspace-config:missing-workspace-config-underlying-task: > echo running-missing-workspace-config-underlying-task
@@ -30,7 +30,7 @@ Setup
   missing-workspace-config:missing-workspace-config-underlying-task: running-missing-workspace-config-underlying-task
 
   $ cat tmp.log | grep "blank-pkg:missing-workspace-config-underlying-topo-task"
-  blank-pkg:missing-workspace-config-underlying-topo-task: cache miss, executing 2ee83ef8fa218e5b
+  blank-pkg:missing-workspace-config-underlying-topo-task: cache miss, executing c75fee69e4fcf953
   blank-pkg:missing-workspace-config-underlying-topo-task: 
   blank-pkg:missing-workspace-config-underlying-topo-task: > missing-workspace-config-underlying-topo-task
   blank-pkg:missing-workspace-config-underlying-topo-task: > echo missing-workspace-config-underlying-topo-task from blank-pkg

--- a/turborepo-tests/integration/tests/workspace-configs/missing-workspace-config-deps.t
+++ b/turborepo-tests/integration/tests/workspace-configs/missing-workspace-config-deps.t
@@ -15,14 +15,14 @@ Setup
   \xe2\x80\xa2 Remote caching disabled (esc)
 
   $ cat tmp.log | grep "missing-workspace-config:missing-workspace-config-task-with-deps"
-  missing-workspace-config:missing-workspace-config-task-with-deps: cache miss, executing 55f72796263e7103
+  missing-workspace-config:missing-workspace-config-task-with-deps: cache miss, executing 27111702ff2c516b
   missing-workspace-config:missing-workspace-config-task-with-deps: 
   missing-workspace-config:missing-workspace-config-task-with-deps: > missing-workspace-config-task-with-deps
   missing-workspace-config:missing-workspace-config-task-with-deps: > echo running-missing-workspace-config-task-with-deps > out/foo.min.txt
   missing-workspace-config:missing-workspace-config-task-with-deps: 
 
   $ cat tmp.log | grep "missing-workspace-config:missing-workspace-config-underlying-task"
-  missing-workspace-config:missing-workspace-config-underlying-task: cache miss, executing be9790215045f8e9
+  missing-workspace-config:missing-workspace-config-underlying-task: cache miss, executing abd612282d80ada6
   missing-workspace-config:missing-workspace-config-underlying-task: 
   missing-workspace-config:missing-workspace-config-underlying-task: > missing-workspace-config-underlying-task
   missing-workspace-config:missing-workspace-config-underlying-task: > echo running-missing-workspace-config-underlying-task
@@ -30,7 +30,7 @@ Setup
   missing-workspace-config:missing-workspace-config-underlying-task: running-missing-workspace-config-underlying-task
 
   $ cat tmp.log | grep "blank-pkg:missing-workspace-config-underlying-topo-task"
-  blank-pkg:missing-workspace-config-underlying-topo-task: cache miss, executing c75fee69e4fcf953
+  blank-pkg:missing-workspace-config-underlying-topo-task: cache miss, executing 9cc1b75893929720
   blank-pkg:missing-workspace-config-underlying-topo-task: 
   blank-pkg:missing-workspace-config-underlying-topo-task: > missing-workspace-config-underlying-topo-task
   blank-pkg:missing-workspace-config-underlying-topo-task: > echo missing-workspace-config-underlying-topo-task from blank-pkg

--- a/turborepo-tests/integration/tests/workspace-configs/missing-workspace-config.t
+++ b/turborepo-tests/integration/tests/workspace-configs/missing-workspace-config.t
@@ -11,7 +11,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: missing-workspace-config (esc)
   \xe2\x80\xa2 Running missing-workspace-config-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  missing-workspace-config:missing-workspace-config-task: cache miss, executing 496aa3afaf362f78
+  missing-workspace-config:missing-workspace-config-task: cache miss, executing 924463dcfeefce9e
   missing-workspace-config:missing-workspace-config-task: 
   missing-workspace-config:missing-workspace-config-task: > missing-workspace-config-task
   missing-workspace-config:missing-workspace-config-task: > echo running-missing-workspace-config-task > out/foo.min.txt
@@ -33,7 +33,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: missing-workspace-config (esc)
   \xe2\x80\xa2 Running missing-workspace-config-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  missing-workspace-config:missing-workspace-config-task: cache hit, suppressing logs 496aa3afaf362f78
+  missing-workspace-config:missing-workspace-config-task: cache hit, suppressing logs 924463dcfeefce9e
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total
@@ -45,7 +45,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: missing-workspace-config (esc)
   \xe2\x80\xa2 Running missing-workspace-config-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  missing-workspace-config:missing-workspace-config-task: cache miss, executing 2ff3b762c104f455
+  missing-workspace-config:missing-workspace-config-task: cache miss, executing 6393b168ee1654c5
   missing-workspace-config:missing-workspace-config-task: 
   missing-workspace-config:missing-workspace-config-task: > missing-workspace-config-task
   missing-workspace-config:missing-workspace-config-task: > echo running-missing-workspace-config-task > out/foo.min.txt
@@ -62,7 +62,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: missing-workspace-config (esc)
   \xe2\x80\xa2 Running missing-workspace-config-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  missing-workspace-config:missing-workspace-config-task: cache hit, suppressing logs 2ff3b762c104f455
+  missing-workspace-config:missing-workspace-config-task: cache hit, suppressing logs 6393b168ee1654c5
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total
@@ -73,7 +73,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: missing-workspace-config (esc)
   \xe2\x80\xa2 Running missing-workspace-config-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  missing-workspace-config:missing-workspace-config-task: cache miss, executing 3c62156738224dd0
+  missing-workspace-config:missing-workspace-config-task: cache miss, executing e70657c42c4e2edb
   missing-workspace-config:missing-workspace-config-task: 
   missing-workspace-config:missing-workspace-config-task: > missing-workspace-config-task
   missing-workspace-config:missing-workspace-config-task: > echo running-missing-workspace-config-task > out/foo.min.txt
@@ -89,7 +89,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: missing-workspace-config (esc)
   \xe2\x80\xa2 Running cached-task-4 in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  missing-workspace-config:cached-task-4: cache bypass, force executing d75b7f6edfb55f16
+  missing-workspace-config:cached-task-4: cache bypass, force executing 95ba5489441bdc13
   missing-workspace-config:cached-task-4: 
   missing-workspace-config:cached-task-4: > cached-task-4
   missing-workspace-config:cached-task-4: > echo cached-task-4 > out/foo.min.txt

--- a/turborepo-tests/integration/tests/workspace-configs/missing-workspace-config.t
+++ b/turborepo-tests/integration/tests/workspace-configs/missing-workspace-config.t
@@ -11,7 +11,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: missing-workspace-config (esc)
   \xe2\x80\xa2 Running missing-workspace-config-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  missing-workspace-config:missing-workspace-config-task: cache miss, executing f9dcb73efb6c5269
+  missing-workspace-config:missing-workspace-config-task: cache miss, executing 496aa3afaf362f78
   missing-workspace-config:missing-workspace-config-task: 
   missing-workspace-config:missing-workspace-config-task: > missing-workspace-config-task
   missing-workspace-config:missing-workspace-config-task: > echo running-missing-workspace-config-task > out/foo.min.txt
@@ -33,7 +33,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: missing-workspace-config (esc)
   \xe2\x80\xa2 Running missing-workspace-config-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  missing-workspace-config:missing-workspace-config-task: cache hit, suppressing logs f9dcb73efb6c5269
+  missing-workspace-config:missing-workspace-config-task: cache hit, suppressing logs 496aa3afaf362f78
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total
@@ -45,7 +45,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: missing-workspace-config (esc)
   \xe2\x80\xa2 Running missing-workspace-config-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  missing-workspace-config:missing-workspace-config-task: cache miss, executing a7bd666ff568b7ac
+  missing-workspace-config:missing-workspace-config-task: cache miss, executing 2ff3b762c104f455
   missing-workspace-config:missing-workspace-config-task: 
   missing-workspace-config:missing-workspace-config-task: > missing-workspace-config-task
   missing-workspace-config:missing-workspace-config-task: > echo running-missing-workspace-config-task > out/foo.min.txt
@@ -62,7 +62,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: missing-workspace-config (esc)
   \xe2\x80\xa2 Running missing-workspace-config-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  missing-workspace-config:missing-workspace-config-task: cache hit, suppressing logs a7bd666ff568b7ac
+  missing-workspace-config:missing-workspace-config-task: cache hit, suppressing logs 2ff3b762c104f455
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total
@@ -73,7 +73,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: missing-workspace-config (esc)
   \xe2\x80\xa2 Running missing-workspace-config-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  missing-workspace-config:missing-workspace-config-task: cache miss, executing 44b2829e0f461fcc
+  missing-workspace-config:missing-workspace-config-task: cache miss, executing 3c62156738224dd0
   missing-workspace-config:missing-workspace-config-task: 
   missing-workspace-config:missing-workspace-config-task: > missing-workspace-config-task
   missing-workspace-config:missing-workspace-config-task: > echo running-missing-workspace-config-task > out/foo.min.txt
@@ -89,7 +89,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: missing-workspace-config (esc)
   \xe2\x80\xa2 Running cached-task-4 in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  missing-workspace-config:cached-task-4: cache bypass, force executing 02705cb19702f9db
+  missing-workspace-config:cached-task-4: cache bypass, force executing d75b7f6edfb55f16
   missing-workspace-config:cached-task-4: 
   missing-workspace-config:cached-task-4: > cached-task-4
   missing-workspace-config:cached-task-4: > echo cached-task-4 > out/foo.min.txt

--- a/turborepo-tests/integration/tests/workspace-configs/omit-keys-deps.t
+++ b/turborepo-tests/integration/tests/workspace-configs/omit-keys-deps.t
@@ -15,14 +15,14 @@ Setup
   \xe2\x80\xa2 Running omit-keys-task-with-deps in 1 packages (esc)
 
   $ cat tmp.log | grep "omit-keys:omit-keys-task-with-deps"
-  omit-keys:omit-keys-task-with-deps: cache miss, executing 0f1f9ecf7431e794
+  omit-keys:omit-keys-task-with-deps: cache miss, executing bbb54c4130d16663
   omit-keys:omit-keys-task-with-deps: 
   omit-keys:omit-keys-task-with-deps: > omit-keys-task-with-deps
   omit-keys:omit-keys-task-with-deps: > echo running-omit-keys-task-with-deps > out/foo.min.txt
   omit-keys:omit-keys-task-with-deps: 
 
   $ cat tmp.log | grep "omit-keys:omit-keys-underlying-task"
-  omit-keys:omit-keys-underlying-task: cache miss, executing d79d573c06e04f73
+  omit-keys:omit-keys-underlying-task: cache miss, executing 1aa42011f41a10f1
   omit-keys:omit-keys-underlying-task: 
   omit-keys:omit-keys-underlying-task: > omit-keys-underlying-task
   omit-keys:omit-keys-underlying-task: > echo running-omit-keys-underlying-task
@@ -30,7 +30,7 @@ Setup
   omit-keys:omit-keys-underlying-task: running-omit-keys-underlying-task
 
   $ cat tmp.log | grep "blank-pkg:omit-keys-underlying-topo-task"
-  blank-pkg:omit-keys-underlying-topo-task: cache miss, executing aa4d0e4e89753438
+  blank-pkg:omit-keys-underlying-topo-task: cache miss, executing 4510d84de8b1d9b7
   blank-pkg:omit-keys-underlying-topo-task: 
   blank-pkg:omit-keys-underlying-topo-task: > omit-keys-underlying-topo-task
   blank-pkg:omit-keys-underlying-topo-task: > echo omit-keys-underlying-topo-task from blank-pkg

--- a/turborepo-tests/integration/tests/workspace-configs/omit-keys-deps.t
+++ b/turborepo-tests/integration/tests/workspace-configs/omit-keys-deps.t
@@ -15,14 +15,14 @@ Setup
   \xe2\x80\xa2 Running omit-keys-task-with-deps in 1 packages (esc)
 
   $ cat tmp.log | grep "omit-keys:omit-keys-task-with-deps"
-  omit-keys:omit-keys-task-with-deps: cache miss, executing 1554356833ff5f4b
+  omit-keys:omit-keys-task-with-deps: cache miss, executing 0f1f9ecf7431e794
   omit-keys:omit-keys-task-with-deps: 
   omit-keys:omit-keys-task-with-deps: > omit-keys-task-with-deps
   omit-keys:omit-keys-task-with-deps: > echo running-omit-keys-task-with-deps > out/foo.min.txt
   omit-keys:omit-keys-task-with-deps: 
 
   $ cat tmp.log | grep "omit-keys:omit-keys-underlying-task"
-  omit-keys:omit-keys-underlying-task: cache miss, executing a789ec01db5a0976
+  omit-keys:omit-keys-underlying-task: cache miss, executing d79d573c06e04f73
   omit-keys:omit-keys-underlying-task: 
   omit-keys:omit-keys-underlying-task: > omit-keys-underlying-task
   omit-keys:omit-keys-underlying-task: > echo running-omit-keys-underlying-task
@@ -30,7 +30,7 @@ Setup
   omit-keys:omit-keys-underlying-task: running-omit-keys-underlying-task
 
   $ cat tmp.log | grep "blank-pkg:omit-keys-underlying-topo-task"
-  blank-pkg:omit-keys-underlying-topo-task: cache miss, executing f7bdaf1949934066
+  blank-pkg:omit-keys-underlying-topo-task: cache miss, executing aa4d0e4e89753438
   blank-pkg:omit-keys-underlying-topo-task: 
   blank-pkg:omit-keys-underlying-topo-task: > omit-keys-underlying-topo-task
   blank-pkg:omit-keys-underlying-topo-task: > echo omit-keys-underlying-topo-task from blank-pkg

--- a/turborepo-tests/integration/tests/workspace-configs/omit-keys.t
+++ b/turborepo-tests/integration/tests/workspace-configs/omit-keys.t
@@ -14,7 +14,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: omit-keys (esc)
   \xe2\x80\xa2 Running omit-keys-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  omit-keys:omit-keys-task: cache miss, executing bc07933c7270bb58
+  omit-keys:omit-keys-task: cache miss, executing 3494dd1d95d1479e
   omit-keys:omit-keys-task: 
   omit-keys:omit-keys-task: > omit-keys-task
   omit-keys:omit-keys-task: > echo running-omit-keys-task > out/foo.min.txt
@@ -36,7 +36,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: omit-keys (esc)
   \xe2\x80\xa2 Running omit-keys-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  omit-keys:omit-keys-task: cache hit, suppressing logs bc07933c7270bb58
+  omit-keys:omit-keys-task: cache hit, suppressing logs 3494dd1d95d1479e
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total
@@ -48,7 +48,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: omit-keys (esc)
   \xe2\x80\xa2 Running omit-keys-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  omit-keys:omit-keys-task: cache miss, executing fb3a8550e8fa3364
+  omit-keys:omit-keys-task: cache miss, executing dc03a583d6fdaaf2
   omit-keys:omit-keys-task: 
   omit-keys:omit-keys-task: > omit-keys-task
   omit-keys:omit-keys-task: > echo running-omit-keys-task > out/foo.min.txt
@@ -65,7 +65,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: omit-keys (esc)
   \xe2\x80\xa2 Running omit-keys-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  omit-keys:omit-keys-task: cache hit, suppressing logs fb3a8550e8fa3364
+  omit-keys:omit-keys-task: cache hit, suppressing logs dc03a583d6fdaaf2
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total
@@ -76,7 +76,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: omit-keys (esc)
   \xe2\x80\xa2 Running omit-keys-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  omit-keys:omit-keys-task: cache miss, executing 8a71eefee85ac18a
+  omit-keys:omit-keys-task: cache miss, executing 56670bf5aef6bb90
   omit-keys:omit-keys-task: 
   omit-keys:omit-keys-task: > omit-keys-task
   omit-keys:omit-keys-task: > echo running-omit-keys-task > out/foo.min.txt

--- a/turborepo-tests/integration/tests/workspace-configs/omit-keys.t
+++ b/turborepo-tests/integration/tests/workspace-configs/omit-keys.t
@@ -14,7 +14,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: omit-keys (esc)
   \xe2\x80\xa2 Running omit-keys-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  omit-keys:omit-keys-task: cache miss, executing 2275653d6cc837ea
+  omit-keys:omit-keys-task: cache miss, executing bc07933c7270bb58
   omit-keys:omit-keys-task: 
   omit-keys:omit-keys-task: > omit-keys-task
   omit-keys:omit-keys-task: > echo running-omit-keys-task > out/foo.min.txt
@@ -36,7 +36,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: omit-keys (esc)
   \xe2\x80\xa2 Running omit-keys-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  omit-keys:omit-keys-task: cache hit, suppressing logs 2275653d6cc837ea
+  omit-keys:omit-keys-task: cache hit, suppressing logs bc07933c7270bb58
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total
@@ -48,7 +48,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: omit-keys (esc)
   \xe2\x80\xa2 Running omit-keys-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  omit-keys:omit-keys-task: cache miss, executing 4b42c9ab61970715
+  omit-keys:omit-keys-task: cache miss, executing fb3a8550e8fa3364
   omit-keys:omit-keys-task: 
   omit-keys:omit-keys-task: > omit-keys-task
   omit-keys:omit-keys-task: > echo running-omit-keys-task > out/foo.min.txt
@@ -65,7 +65,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: omit-keys (esc)
   \xe2\x80\xa2 Running omit-keys-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  omit-keys:omit-keys-task: cache hit, suppressing logs 4b42c9ab61970715
+  omit-keys:omit-keys-task: cache hit, suppressing logs fb3a8550e8fa3364
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total
@@ -76,7 +76,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: omit-keys (esc)
   \xe2\x80\xa2 Running omit-keys-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  omit-keys:omit-keys-task: cache miss, executing f79224ef709d0347
+  omit-keys:omit-keys-task: cache miss, executing 8a71eefee85ac18a
   omit-keys:omit-keys-task: 
   omit-keys:omit-keys-task: > omit-keys-task
   omit-keys:omit-keys-task: > echo running-omit-keys-task > out/foo.min.txt

--- a/turborepo-tests/integration/tests/workspace-configs/override-values-deps.t
+++ b/turborepo-tests/integration/tests/workspace-configs/override-values-deps.t
@@ -12,7 +12,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: override-values (esc)
   \xe2\x80\xa2 Running override-values-task-with-deps in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  override-values:override-values-task-with-deps: cache miss, executing 1a68f7b5fcfe887e
+  override-values:override-values-task-with-deps: cache miss, executing 56b80c599d31185e
   override-values:override-values-task-with-deps: 
   override-values:override-values-task-with-deps: > override-values-task-with-deps
   override-values:override-values-task-with-deps: > echo running-override-values-task-with-deps > out/foo.min.txt

--- a/turborepo-tests/integration/tests/workspace-configs/override-values-deps.t
+++ b/turborepo-tests/integration/tests/workspace-configs/override-values-deps.t
@@ -12,7 +12,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: override-values (esc)
   \xe2\x80\xa2 Running override-values-task-with-deps in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  override-values:override-values-task-with-deps: cache miss, executing 56b80c599d31185e
+  override-values:override-values-task-with-deps: cache miss, executing 9b51bda96ea87896
   override-values:override-values-task-with-deps: 
   override-values:override-values-task-with-deps: > override-values-task-with-deps
   override-values:override-values-task-with-deps: > echo running-override-values-task-with-deps > out/foo.min.txt

--- a/turborepo-tests/integration/tests/workspace-configs/override-values.t
+++ b/turborepo-tests/integration/tests/workspace-configs/override-values.t
@@ -11,7 +11,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: override-values (esc)
   \xe2\x80\xa2 Running override-values-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  override-values:override-values-task: cache miss, executing 5058b09f436c9af8
+  override-values:override-values-task: cache miss, executing ca440a0f61cee7ea
   override-values:override-values-task: 
   override-values:override-values-task: > override-values-task
   override-values:override-values-task: > echo running-override-values-task > lib/bar.min.txt
@@ -36,7 +36,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: override-values (esc)
   \xe2\x80\xa2 Running override-values-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  override-values:override-values-task: cache hit, replaying logs 5058b09f436c9af8
+  override-values:override-values-task: cache hit, replaying logs ca440a0f61cee7ea
   override-values:override-values-task: 
   override-values:override-values-task: > override-values-task
   override-values:override-values-task: > echo running-override-values-task > lib/bar.min.txt
@@ -55,7 +55,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: override-values (esc)
   \xe2\x80\xa2 Running override-values-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  override-values:override-values-task: cache miss, executing 96e37e09376aac95
+  override-values:override-values-task: cache miss, executing 41f4985cf22b4f8e
   override-values:override-values-task: 
   override-values:override-values-task: > override-values-task
   override-values:override-values-task: > echo running-override-values-task > lib/bar.min.txt
@@ -71,7 +71,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: override-values (esc)
   \xe2\x80\xa2 Running override-values-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  override-values:override-values-task: cache hit, replaying logs 96e37e09376aac95
+  override-values:override-values-task: cache hit, replaying logs 41f4985cf22b4f8e
   override-values:override-values-task: 
   override-values:override-values-task: > override-values-task
   override-values:override-values-task: > echo running-override-values-task > lib/bar.min.txt
@@ -86,7 +86,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: override-values (esc)
   \xe2\x80\xa2 Running override-values-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  override-values:override-values-task: cache miss, executing 477830ff01971475
+  override-values:override-values-task: cache miss, executing e78785787e17e37e
   override-values:override-values-task: 
   override-values:override-values-task: > override-values-task
   override-values:override-values-task: > echo running-override-values-task > lib/bar.min.txt
@@ -101,7 +101,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: override-values (esc)
   \xe2\x80\xa2 Running override-values-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  override-values:override-values-task: cache hit, replaying logs 477830ff01971475
+  override-values:override-values-task: cache hit, replaying logs e78785787e17e37e
   override-values:override-values-task: 
   override-values:override-values-task: > override-values-task
   override-values:override-values-task: > echo running-override-values-task > lib/bar.min.txt

--- a/turborepo-tests/integration/tests/workspace-configs/override-values.t
+++ b/turborepo-tests/integration/tests/workspace-configs/override-values.t
@@ -21,9 +21,6 @@ Setup
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
-<<<<<<< HEAD
-=======
->>>>>>> 37c3c596f1 (chore: update integration tests)
   $ HASH=$(cat tmp.log | grep -E "override-values:override-values-task.* executing .*" | awk '{print $5}')
   $ tar -tf $TARGET_DIR/.turbo/cache/$HASH.tar.zst;
   apps/override-values/.turbo/turbo-override-values-task.log
@@ -46,9 +43,6 @@ Setup
   Cached:    1 cached, 1 total
     Time:\s*[\.0-9]+m?s >>> FULL TURBO (re)
   
-<<<<<<< HEAD
-=======
->>>>>>> 37c3c596f1 (chore: update integration tests)
 3. Change input file and assert cache miss
   $ echo "more text" >> $TARGET_DIR/apps/override-values/src/bar.txt
   $ ${TURBO} run override-values-task --filter=override-values

--- a/turborepo-tests/integration/tests/workspace-configs/override-values.t
+++ b/turborepo-tests/integration/tests/workspace-configs/override-values.t
@@ -11,7 +11,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: override-values (esc)
   \xe2\x80\xa2 Running override-values-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  override-values:override-values-task: cache miss, executing 30f06dcaf1586c63
+  override-values:override-values-task: cache miss, executing 5058b09f436c9af8
   override-values:override-values-task: 
   override-values:override-values-task: > override-values-task
   override-values:override-values-task: > echo running-override-values-task > lib/bar.min.txt
@@ -36,7 +36,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: override-values (esc)
   \xe2\x80\xa2 Running override-values-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  override-values:override-values-task: cache hit, replaying logs 30f06dcaf1586c63
+  override-values:override-values-task: cache hit, replaying logs 5058b09f436c9af8
   override-values:override-values-task: 
   override-values:override-values-task: > override-values-task
   override-values:override-values-task: > echo running-override-values-task > lib/bar.min.txt
@@ -55,7 +55,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: override-values (esc)
   \xe2\x80\xa2 Running override-values-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  override-values:override-values-task: cache miss, executing 9d9fe6991167ac4d
+  override-values:override-values-task: cache miss, executing 96e37e09376aac95
   override-values:override-values-task: 
   override-values:override-values-task: > override-values-task
   override-values:override-values-task: > echo running-override-values-task > lib/bar.min.txt
@@ -71,7 +71,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: override-values (esc)
   \xe2\x80\xa2 Running override-values-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  override-values:override-values-task: cache hit, replaying logs 9d9fe6991167ac4d
+  override-values:override-values-task: cache hit, replaying logs 96e37e09376aac95
   override-values:override-values-task: 
   override-values:override-values-task: > override-values-task
   override-values:override-values-task: > echo running-override-values-task > lib/bar.min.txt
@@ -86,7 +86,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: override-values (esc)
   \xe2\x80\xa2 Running override-values-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  override-values:override-values-task: cache miss, executing 6e7cf8bdd5c83b50
+  override-values:override-values-task: cache miss, executing 477830ff01971475
   override-values:override-values-task: 
   override-values:override-values-task: > override-values-task
   override-values:override-values-task: > echo running-override-values-task > lib/bar.min.txt
@@ -101,7 +101,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: override-values (esc)
   \xe2\x80\xa2 Running override-values-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  override-values:override-values-task: cache hit, replaying logs 6e7cf8bdd5c83b50
+  override-values:override-values-task: cache hit, replaying logs 477830ff01971475
   override-values:override-values-task: 
   override-values:override-values-task: > override-values-task
   override-values:override-values-task: > echo running-override-values-task > lib/bar.min.txt

--- a/turborepo-tests/integration/tests/workspace-configs/persistent.t
+++ b/turborepo-tests/integration/tests/workspace-configs/persistent.t
@@ -30,13 +30,13 @@ This test covers:
   \xe2\x80\xa2 Packages in scope: persistent (esc)
   \xe2\x80\xa2 Running persistent-task-2-parent in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  persistent:persistent-task-2: cache miss, executing a1be4f21d178a0ac
+  persistent:persistent-task-2: cache miss, executing 9f0db0b17878a8a5
   persistent:persistent-task-2: 
   persistent:persistent-task-2: > persistent-task-2
   persistent:persistent-task-2: > echo persistent-task-2
   persistent:persistent-task-2: 
   persistent:persistent-task-2: persistent-task-2
-  persistent:persistent-task-2-parent: cache miss, executing 3a82d48ad00259f4
+  persistent:persistent-task-2-parent: cache miss, executing e2d6f0e4f45f6bfd
   persistent:persistent-task-2-parent: 
   persistent:persistent-task-2-parent: > persistent-task-2-parent
   persistent:persistent-task-2-parent: > echo persistent-task-2-parent

--- a/turborepo-tests/integration/tests/workspace-configs/persistent.t
+++ b/turborepo-tests/integration/tests/workspace-configs/persistent.t
@@ -30,13 +30,13 @@ This test covers:
   \xe2\x80\xa2 Packages in scope: persistent (esc)
   \xe2\x80\xa2 Running persistent-task-2-parent in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  persistent:persistent-task-2: cache miss, executing 9f0db0b17878a8a5
+  persistent:persistent-task-2: cache miss, executing 7f08cefb45c613d2
   persistent:persistent-task-2: 
   persistent:persistent-task-2: > persistent-task-2
   persistent:persistent-task-2: > echo persistent-task-2
   persistent:persistent-task-2: 
   persistent:persistent-task-2: persistent-task-2
-  persistent:persistent-task-2-parent: cache miss, executing e2d6f0e4f45f6bfd
+  persistent:persistent-task-2-parent: cache miss, executing affde90eaca06703
   persistent:persistent-task-2-parent: 
   persistent:persistent-task-2-parent: > persistent-task-2-parent
   persistent:persistent-task-2-parent: > echo persistent-task-2-parent


### PR DESCRIPTION
### Description

Changing the `engines` field in the root `package.json` can affect the execution of tasks so it should affect the global cache.

This PR adds the `engines` struct to the global cache key.

### Testing Instructions

Added new integration test verifying that changing `engines` results in a cache miss.
