### PR TITLE
Upgrade lightningcss, disable grid scoping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1029,7 +1029,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "either",
- "indexmap 2.2.3",
+ "indexmap 2.2.6",
  "itertools 0.12.0",
  "nom",
  "once_cell",
@@ -3222,7 +3222,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.11",
- "indexmap 2.2.3",
+ "indexmap 2.2.6",
  "slab",
  "tokio",
  "tokio-util",
@@ -3701,9 +3701,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.3"
+version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
@@ -4242,9 +4242,9 @@ dependencies = [
 
 [[package]]
 name = "lightningcss"
-version = "1.0.0-alpha.55"
+version = "1.0.0-alpha.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bd5bed3814fb631bfc1e24c2be6f7e86a9837c660909acab79a38374dcb8798"
+checksum = "668e9f1774a4dda9e2233ad0f78c6987878bcf4201d2085bc3517a7f84d0ee92"
 dependencies = [
  "ahash 0.8.9",
  "bitflags 2.5.0",
@@ -4254,6 +4254,7 @@ dependencies = [
  "dashmap",
  "data-encoding",
  "getrandom",
+ "indexmap 2.2.6",
  "itertools 0.10.5",
  "lazy_static",
  "lightningcss-derive",
@@ -5214,7 +5215,7 @@ checksum = "2033cc3b0e72446d3321866db0954804b9ca559ad692480205053f6aea4bfc15"
 dependencies = [
  "dashmap",
  "dunce",
- "indexmap 2.2.3",
+ "indexmap 2.2.6",
  "json-strip-comments",
  "once_cell",
  "rustc-hash",
@@ -5239,9 +5240,9 @@ dependencies = [
 
 [[package]]
 name = "parcel_selectors"
-version = "0.26.4"
+version = "0.26.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05d74befe2d076330d9a58bf9ca2da424568724ab278adf15fb5718253133887"
+checksum = "ce9c47a67c66fee4a5a42756f9784d92941bd0ab2b653539a9e90521a44b66f0"
 dependencies = [
  "bitflags 2.5.0",
  "cssparser",
@@ -6898,7 +6899,7 @@ version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
 dependencies = [
- "indexmap 2.2.3",
+ "indexmap 2.2.6",
  "itoa",
  "ryu",
  "serde",
@@ -7021,7 +7022,7 @@ version = "0.9.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cc7a1570e38322cfe4154732e5110f887ea57e22b76f4bfd32b5bdd3368666c"
 dependencies = [
- "indexmap 2.2.3",
+ "indexmap 2.2.6",
  "itoa",
  "ryu",
  "serde",
@@ -7679,7 +7680,7 @@ dependencies = [
  "base64 0.21.4",
  "dashmap",
  "either",
- "indexmap 2.2.3",
+ "indexmap 2.2.6",
  "jsonc-parser 0.21.0",
  "lru 0.10.0",
  "napi",
@@ -7756,7 +7757,7 @@ dependencies = [
  "anyhow",
  "crc",
  "dashmap",
- "indexmap 2.2.3",
+ "indexmap 2.2.6",
  "is-macro",
  "once_cell",
  "parking_lot",
@@ -7858,7 +7859,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7be1a689e146be1eae53139482cb061dcf0fa01dff296bbe7b96fff92d8e2936"
 dependencies = [
  "anyhow",
- "indexmap 2.2.3",
+ "indexmap 2.2.6",
  "serde",
  "serde_json",
  "sourcemap",
@@ -8155,7 +8156,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "248532f9ae603be6bf4763f66f74ad0dfd82d6307be876ccf4c5d081826a1161"
 dependencies = [
  "arrayvec 0.7.4",
- "indexmap 2.2.3",
+ "indexmap 2.2.6",
  "is-macro",
  "serde",
  "serde_derive",
@@ -8375,7 +8376,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "535bbb8adbdf730302f477948557a26e5cd73854d4543c0630e05132ffa16d8a"
 dependencies = [
  "arrayvec 0.7.4",
- "indexmap 2.2.3",
+ "indexmap 2.2.6",
  "num-bigint",
  "num_cpus",
  "once_cell",
@@ -8432,7 +8433,7 @@ checksum = "b5969314bf66a4cca45b0401689dd0c74e568c69243ce46f2342d59219e1283c"
 dependencies = [
  "anyhow",
  "dashmap",
- "indexmap 2.2.3",
+ "indexmap 2.2.6",
  "once_cell",
  "preset_env_base",
  "rustc-hash",
@@ -8507,7 +8508,7 @@ checksum = "eddb95c2bdad1c9c29edf35712e1e0f9b9ddc1cdb5ba2d582fd93468cb075a03"
 dependencies = [
  "better_scoped_tls",
  "bitflags 2.5.0",
- "indexmap 2.2.3",
+ "indexmap 2.2.6",
  "once_cell",
  "phf 0.11.2",
  "rayon",
@@ -8544,7 +8545,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d4e2942c5d8b7afdf81b8d1eec2f4a961aa9fc89ab05ebe5cbd0f6066b60afc"
 dependencies = [
  "arrayvec 0.7.4",
- "indexmap 2.2.3",
+ "indexmap 2.2.6",
  "is-macro",
  "num-bigint",
  "rayon",
@@ -8595,7 +8596,7 @@ dependencies = [
  "Inflector",
  "anyhow",
  "bitflags 2.5.0",
- "indexmap 2.2.3",
+ "indexmap 2.2.6",
  "is-macro",
  "path-clean 0.1.0",
  "pathdiff",
@@ -8620,7 +8621,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32ea30b3df748236c619409f222f0ba68ebeebc08dfff109d2195664a15689f9"
 dependencies = [
  "dashmap",
- "indexmap 2.2.3",
+ "indexmap 2.2.6",
  "once_cell",
  "petgraph",
  "rayon",
@@ -8666,7 +8667,7 @@ checksum = "565a76c4ca47ce31d78301c0beab878e4c2cb4f624691254d834ec8c0e236755"
 dependencies = [
  "base64 0.21.4",
  "dashmap",
- "indexmap 2.2.3",
+ "indexmap 2.2.6",
  "once_cell",
  "rayon",
  "serde",
@@ -8732,7 +8733,7 @@ version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d140be135c1af1726ee02406ad210c6598b3399303974d884b1b681563602c9"
 dependencies = [
- "indexmap 2.2.3",
+ "indexmap 2.2.6",
  "rustc-hash",
  "swc_atoms",
  "swc_common",
@@ -8749,7 +8750,7 @@ version = "0.128.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe5242670bc74e0a0b64b9d4912b37be36944517ce0881314162aeb4381272c3"
 dependencies = [
- "indexmap 2.2.3",
+ "indexmap 2.2.6",
  "num_cpus",
  "once_cell",
  "rayon",
@@ -8831,7 +8832,7 @@ version = "0.21.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3fdd64bc3d161d6c1ea9a8ae5779e4ba132afc67e7b8ece5420bfc9c6e1275d"
 dependencies = [
- "indexmap 2.2.3",
+ "indexmap 2.2.6",
  "petgraph",
  "rustc-hash",
  "swc_common",
@@ -9635,7 +9636,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.2.3",
+ "indexmap 2.2.6",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -9648,7 +9649,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
- "indexmap 2.2.3",
+ "indexmap 2.2.6",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -12161,7 +12162,7 @@ checksum = "d21472954ee9443235ca32522b17fc8f0fe58e2174556266a0d9766db055cc52"
 dependencies = [
  "anyhow",
  "derive_builder",
- "indexmap 2.2.3",
+ "indexmap 2.2.6",
  "semver 1.0.23",
  "serde",
  "serde_cbor",
@@ -12323,7 +12324,7 @@ version = "0.110.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dfcdb72d96f01e6c85b6bf20102e7423bdbaad5c337301bab2bbf253d26413c"
 dependencies = [
- "indexmap 2.2.3",
+ "indexmap 2.2.6",
  "semver 1.0.23",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7569,9 +7569,9 @@ dependencies = [
 
 [[package]]
 name = "styled_jsx"
-version = "0.73.20"
+version = "0.73.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "441654f465db08fc2c3c36c598c89e8d27fb445d4c97263fb701b07029e9755b"
+checksum = "17e38b2334f6613c9e811cc776bc9d2329c288f4dc125df68615fe6cf19b48ae"
 dependencies = [
  "anyhow",
  "lightningcss",
@@ -11429,7 +11429,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.4.6",
+ "rand 0.8.5",
  "static_assertions",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,7 +111,7 @@ miette = { version = "5.10.0", features = ["fancy"] }
 mdxjs = "0.2.2"
 modularize_imports = { version = "0.68.14" }
 styled_components = { version = "0.96.15" }
-styled_jsx = { version = "0.73.20" }
+styled_jsx = { version = "0.73.21" }
 swc_core = { version = "0.92.5", features = [
   "ecma_loader_lru",
   "ecma_loader_parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -240,7 +240,7 @@ indicatif = "0.17.3"
 indoc = "2.0.0"
 itertools = "0.10.5"
 lazy_static = "1.4.0"
-lightningcss = { version = "1.0.0-alpha.50", features = [
+lightningcss = { version = "1.0.0-alpha.56", features = [
   "serde",
   "visitor",
   "into_owned",

--- a/crates/turbopack-css/src/process.rs
+++ b/crates/turbopack-css/src/process.rs
@@ -1229,6 +1229,8 @@ mod tests {
                 css_modules: Some(lightningcss::css_modules::Config {
                     pattern: Pattern::default(),
                     dashed_idents: false,
+                    grid: false,
+                    ..Default::default()
                 }),
                 ..Default::default()
             },

--- a/crates/turbopack-css/src/process.rs
+++ b/crates/turbopack-css/src/process.rs
@@ -547,6 +547,8 @@ async fn process_content(
                     ],
                 },
                 dashed_idents: false,
+                grid: false,
+                ..Default::default()
             }),
 
             _ => None,

--- a/crates/turbopack-tests/tests/snapshot/css/css-modules/output/crates_turbopack-tests_tests_snapshot_css_css-modules_input_8abc52._.js
+++ b/crates/turbopack-tests/tests/snapshot/css/css-modules/output/crates_turbopack-tests_tests_snapshot_css_css-modules_input_8abc52._.js
@@ -3,11 +3,6 @@
 "[project]/crates/turbopack-tests/tests/snapshot/css/css-modules/input/style.module.css [test] (css module)": (({ r: __turbopack_require__, f: __turbopack_module_context__, i: __turbopack_import__, s: __turbopack_esm__, v: __turbopack_export_value__, n: __turbopack_export_namespace__, c: __turbopack_cache__, M: __turbopack_modules__, l: __turbopack_load__, j: __turbopack_dynamic__, P: __turbopack_resolve_absolute_path__, U: __turbopack_relative_url__, R: __turbopack_resolve_module_id_path__, g: global, __dirname }) => (() => {
 
 __turbopack_export_value__({
-  "actions": "style-module__mnEziG__actions",
-  "avatar": "style-module__mnEziG__avatar",
-  "checkbox": "style-module__mnEziG__checkbox",
-  "content": "style-module__mnEziG__content",
-  "menu": "style-module__mnEziG__menu",
   "module-style": "style-module__mnEziG__module-style",
 });
 

--- a/crates/turbopack-tests/tests/snapshot/css/css-modules/output/crates_turbopack-tests_tests_snapshot_css_css-modules_input_8abc52._.js.map
+++ b/crates/turbopack-tests/tests/snapshot/css/css-modules/output/crates_turbopack-tests_tests_snapshot_css_css-modules_input_8abc52._.js.map
@@ -2,8 +2,8 @@
   "version": 3,
   "sources": [],
   "sections": [
-    {"offset": {"line": 4, "column": 0}, "map": {"version":3,"sources":["turbopack://[project]/crates/turbopack-tests/tests/snapshot/css/css-modules/input/style.module.css [test] (css module)"],"sourcesContent":["__turbopack_export_value__({\n  \"actions\": \"style-module__mnEziG__actions\",\n  \"avatar\": \"style-module__mnEziG__avatar\",\n  \"checkbox\": \"style-module__mnEziG__checkbox\",\n  \"content\": \"style-module__mnEziG__content\",\n  \"menu\": \"style-module__mnEziG__menu\",\n  \"module-style\": \"style-module__mnEziG__module-style\",\n});\n"],"names":[],"mappings":"AAAA;AACA;AACA;AACA;AACA;AACA;AACA;AACA"}},
-    {"offset": {"line": 12, "column": 0}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}},
-    {"offset": {"line": 17, "column": 0}, "map": {"version":3,"sources":["turbopack://[project]/crates/turbopack-tests/tests/snapshot/css/css-modules/input/index.js"],"sourcesContent":["import style from \"./style.module.css\";\n\nconsole.log(style, import(\"./style.module.css\"));\n"],"names":[],"mappings":";;;;AAEA,QAAQ,GAAG,CAAC,kMAAA,CAAA,UAAK"}},
-    {"offset": {"line": 22, "column": 0}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}}]
+    {"offset": {"line": 4, "column": 0}, "map": {"version":3,"sources":["turbopack://[project]/crates/turbopack-tests/tests/snapshot/css/css-modules/input/style.module.css [test] (css module)"],"sourcesContent":["__turbopack_export_value__({\n  \"module-style\": \"style-module__mnEziG__module-style\",\n});\n"],"names":[],"mappings":"AAAA;AACA;AACA"}},
+    {"offset": {"line": 7, "column": 0}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}},
+    {"offset": {"line": 12, "column": 0}, "map": {"version":3,"sources":["turbopack://[project]/crates/turbopack-tests/tests/snapshot/css/css-modules/input/index.js"],"sourcesContent":["import style from \"./style.module.css\";\n\nconsole.log(style, import(\"./style.module.css\"));\n"],"names":[],"mappings":";;;;AAEA,QAAQ,GAAG,CAAC,kMAAA,CAAA,UAAK"}},
+    {"offset": {"line": 17, "column": 0}, "map": {"version":3,"sources":[],"names":[],"mappings":"A"}}]
 }

--- a/crates/turbopack-tests/tests/snapshot/css/css-modules/output/crates_turbopack-tests_tests_snapshot_css_css-modules_input_style_module_71f14f.css
+++ b/crates/turbopack-tests/tests/snapshot/css/css-modules/output/crates_turbopack-tests_tests_snapshot_css_css-modules_input_style_module_71f14f.css
@@ -1,6 +1,6 @@
 /* [project]/crates/turbopack-tests/tests/snapshot/css/css-modules/input/style.module.css [test] (css) */
 .style-module__mnEziG__module-style {
-  grid-template-areas: "style-module__mnEziG__checkbox style-module__mnEziG__avatar style-module__mnEziG__content style-module__mnEziG__actions style-module__mnEziG__menu";
+  grid-template-areas: "checkbox avatar content actions menu";
 }
 
 

--- a/crates/turbopack-tests/tests/snapshot/css/css-modules/output/crates_turbopack-tests_tests_snapshot_css_css-modules_input_style_module_7d7e1c.css
+++ b/crates/turbopack-tests/tests/snapshot/css/css-modules/output/crates_turbopack-tests_tests_snapshot_css_css-modules_input_style_module_7d7e1c.css
@@ -1,6 +1,6 @@
 /* [project]/crates/turbopack-tests/tests/snapshot/css/css-modules/input/style.module.css [test] (css) */
 .style-module__mnEziG__module-style {
-  grid-template-areas: "style-module__mnEziG__checkbox style-module__mnEziG__avatar style-module__mnEziG__content style-module__mnEziG__actions style-module__mnEziG__menu";
+  grid-template-areas: "checkbox avatar content actions menu";
 }
 
 /*# sourceMappingURL=crates_turbopack-tests_tests_snapshot_css_css-modules_input_style_module_7d7e1c.css.map*/


### PR DESCRIPTION
### Description

Implements https://github.com/parcel-bundler/lightningcss/pull/739/files.

Grid scoping in CSS Modules is disabled because Webpack CSS Modules handling doesn't handle grid currently. This ensures moving from Webpack to Turbopack doesn't have mismatching behavior around CSS grid.

<!--
  ✍️ Write a short summary of your work.
  If necessary, include relevant screenshots.
-->

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
