### PR TITLE
feat(turbo-ignore): don’t fail on single package repos

### DIFF
--- a/packages/turbo-ignore/__tests__/ignore.test.ts
+++ b/packages/turbo-ignore/__tests__/ignore.test.ts
@@ -677,4 +677,26 @@ describe("turboIgnore()", () => {
 
     mockExec.mockRestore();
   });
+
+  it("allows build if packages is missing", () => {
+    const mockExec = jest
+      .spyOn(child_process, "exec")
+      .mockImplementation((command, options, callback) => {
+        if (callback) {
+          return callback(
+            null,
+            '{"tasks":[]}',
+            "stderr"
+          ) as unknown as ChildProcess;
+        }
+        return {} as unknown as ChildProcess;
+      });
+
+    turboIgnore(undefined, {
+      directory: "__fixtures__/app",
+    });
+
+    expectBuild(mockExit);
+    mockExec.mockRestore();
+  });
 });

--- a/packages/turbo-ignore/src/ignore.ts
+++ b/packages/turbo-ignore/src/ignore.ts
@@ -134,6 +134,11 @@ export function turboIgnore(
         return continueBuild();
       }
       const { packages } = parsed;
+      if (!packages) {
+        info(`Detected single package repo`);
+        return continueBuild();
+      }
+
       if (packages.length > 0) {
         if (packages.length === 1) {
           info(`This commit affects "${workspace}"`);

--- a/packages/turbo-types/src/types/dry.ts
+++ b/packages/turbo-types/src/types/dry.ts
@@ -4,6 +4,6 @@ export interface DryRun {
   version: string;
   turboVersion: string;
   monorepo: boolean;
-  packages: Array<string>;
+  packages?: Array<string>;
   frameworkInference: boolean;
 }


### PR DESCRIPTION
### Description

Single package repo dry runs can not include a packages key at all.

Fixes https://github.com/vercel/turbo/issues/8172

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
