### PR TITLE
chore: remove `globalDotEnv` and `dotEnv` fields

### DIFF
--- a/crates/turborepo-lib/src/engine/mod.rs
+++ b/crates/turborepo-lib/src/engine/mod.rs
@@ -16,7 +16,6 @@ use petgraph::Graph;
 use thiserror::Error;
 use turborepo_errors::Spanned;
 use turborepo_repository::package_graph::{PackageGraph, PackageName};
-use turborepo_telemetry::events::generic::GenericEventBuilder;
 
 use crate::{run::task_id::TaskId, task_graph::TaskDefinition};
 
@@ -378,12 +377,6 @@ impl Engine<Built> {
 
     pub fn task_definitions(&self) -> &HashMap<TaskId<'static>, TaskDefinition> {
         &self.task_definitions
-    }
-
-    pub fn track_usage(&self, telemetry: &GenericEventBuilder) {
-        for task in self.task_definitions.values() {
-            telemetry.track_dot_env(task.dot_env.as_deref());
-        }
     }
 
     pub fn validate(

--- a/crates/turborepo-lib/src/hash/mod.rs
+++ b/crates/turborepo-lib/src/hash/mod.rs
@@ -73,7 +73,6 @@ pub struct GlobalHashable<'a> {
     pub pass_through_env: &'a [String],
     pub env_mode: EnvMode,
     pub framework_inference: bool,
-    pub dot_env: &'a [turbopath::RelativeUnixPathBuf],
 }
 
 pub struct LockFilePackages(pub Vec<turborepo_lockfiles::Package>);
@@ -411,8 +410,6 @@ mod test {
             pass_through_env: &["pass_through_env".to_string()],
             env_mode: EnvMode::Infer,
             framework_inference: true,
-
-            dot_env: &[turbopath::RelativeUnixPathBuf::new("dotenv".to_string()).unwrap()],
         };
 
         assert_eq!(global_hash.hash(), "2144612ff08bddb9");

--- a/crates/turborepo-lib/src/hash/mod.rs
+++ b/crates/turborepo-lib/src/hash/mod.rs
@@ -60,7 +60,6 @@ pub struct TaskHashable<'a> {
     pub(crate) resolved_env_vars: EnvVarPairs,
     pub(crate) pass_through_env: &'a [String],
     pub(crate) env_mode: ResolvedEnvMode,
-    pub(crate) dot_env: &'a [turbopath::RelativeUnixPathBuf],
 }
 
 #[derive(Debug, Clone)]
@@ -254,15 +253,6 @@ impl From<TaskHashable<'_>> for Builder<HeapAllocator> {
         }
 
         {
-            let mut dotenv_builder = builder
-                .reborrow()
-                .init_dot_env(task_hashable.dot_env.len() as u32);
-            for (i, env) in task_hashable.dot_env.iter().enumerate() {
-                dotenv_builder.set(i as u32, env.as_str());
-            }
-        }
-
-        {
             let mut resolved_env_vars_builder = builder
                 .reborrow()
                 .init_resolved_env_vars(task_hashable.resolved_env_vars.len() as u32);
@@ -352,15 +342,6 @@ impl From<GlobalHashable<'_>> for Builder<HeapAllocator> {
 
         builder.set_framework_inference(hashable.framework_inference);
 
-        {
-            let mut dot_env = builder
-                .reborrow()
-                .init_dot_env(hashable.dot_env.len() as u32);
-            for (i, env) in hashable.dot_env.iter().enumerate() {
-                dot_env.set(i as u32, env.as_str());
-            }
-        }
-
         // We're okay to unwrap here because we haven't hit the nesting
         // limit and the message will not have cycles.
         let size = builder
@@ -407,10 +388,9 @@ mod test {
             resolved_env_vars: vec![],
             pass_through_env: &["pass_thru_env".to_string()],
             env_mode: ResolvedEnvMode::Loose,
-            dot_env: &[turbopath::RelativeUnixPathBuf::new("dotenv".to_string()).unwrap()],
         };
 
-        assert_eq!(task_hashable.hash(), "ff765ee2f83bc034");
+        assert_eq!(task_hashable.hash(), "1f8b13161f57fca1");
     }
 
     #[test]
@@ -435,7 +415,7 @@ mod test {
             dot_env: &[turbopath::RelativeUnixPathBuf::new("dotenv".to_string()).unwrap()],
         };
 
-        assert_eq!(global_hash.hash(), "c0ddf8138bd686e8");
+        assert_eq!(global_hash.hash(), "2144612ff08bddb9");
     }
 
     #[test_case(vec![], "459c029558afe716" ; "empty")]

--- a/crates/turborepo-lib/src/hash/proto.capnp
+++ b/crates/turborepo-lib/src/hash/proto.capnp
@@ -41,7 +41,6 @@ struct GlobalHashable {
   passThroughEnv @5 :List(Text);
   envMode @6 :EnvMode;
   frameworkInference @7 :Bool;
-  dotEnv @8 :List(Text);
 
 
   enum EnvMode {

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -337,7 +337,6 @@ impl RunBuilder {
             &root_package_json,
             is_single_package,
         )?;
-        root_turbo_json.track_usage(&run_telemetry);
 
         pkg_dep_graph.validate()?;
 

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -375,7 +375,6 @@ impl RunBuilder {
             pkg_dep_graph.remove_package_dependencies();
             engine = self.build_engine(&pkg_dep_graph, &root_turbo_json, &filtered_pkgs)?;
         }
-        engine.track_usage(&run_telemetry);
 
         let color_selector = ColorSelector::default();
 

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -230,7 +230,6 @@ impl Run {
                 pass_through_env,
                 env_mode,
                 self.opts.run_opts.framework_inference,
-                self.root_turbo_json.global_dot_env.as_deref(),
                 &self.scm,
             )?
         };

--- a/crates/turborepo-lib/src/run/summary/global_hash.rs
+++ b/crates/turborepo-lib/src/run/summary/global_hash.rs
@@ -31,7 +31,6 @@ pub struct GlobalHashSummary<'a> {
     pub root_key: &'static str,
     pub files: BTreeMap<RelativeUnixPathBuf, String>,
     pub hash_of_external_dependencies: &'a str,
-    pub global_dot_env: Option<&'a [RelativeUnixPathBuf]>,
     pub environment_variables: GlobalEnvVarSummary<'a>,
 }
 
@@ -46,7 +45,6 @@ impl<'a> TryFrom<GlobalHashableInputs<'a>> for GlobalHashSummary<'a> {
             env,
             resolved_env_vars,
             pass_through_env,
-            dot_env,
             env_at_execution_start,
             ..
         } = global_hashable_inputs;
@@ -80,8 +78,6 @@ impl<'a> TryFrom<GlobalHashableInputs<'a>> for GlobalHashSummary<'a> {
                     .map(|vars| vars.by_source.matching.to_secret_hashable()),
                 pass_through,
             },
-
-            global_dot_env: dot_env,
         })
     }
 }

--- a/crates/turborepo-lib/src/run/summary/mod.rs
+++ b/crates/turborepo-lib/src/run/summary/mod.rs
@@ -661,16 +661,6 @@ impl<'a> RunSummary<'a> {
                 "  Inputs Files Considered\t=\t{}",
                 task.shared.inputs.len()
             )?;
-            cwriteln!(
-                tab_writer,
-                ui,
-                GREY,
-                "  .env Files Considered\t=\t{}",
-                task.shared
-                    .dot_env
-                    .as_ref()
-                    .map_or(0, |dot_env| dot_env.len())
-            )?;
 
             cwriteln!(
                 tab_writer,

--- a/crates/turborepo-lib/src/run/summary/mod.rs
+++ b/crates/turborepo-lib/src/run/summary/mod.rs
@@ -503,16 +503,6 @@ impl<'a> RunSummary<'a> {
             tab_writer,
             ui,
             GREY,
-            "  Global .env Files Considered\t=\t{}",
-            self.global_hash_summary
-                .global_dot_env
-                .unwrap_or_default()
-                .len()
-        )?;
-        cwriteln!(
-            tab_writer,
-            ui,
-            GREY,
             "  Global Env Vars\t=\t{}",
             self.global_hash_summary
                 .environment_variables

--- a/crates/turborepo-lib/src/run/summary/task.rs
+++ b/crates/turborepo-lib/src/run/summary/task.rs
@@ -81,7 +81,6 @@ pub(crate) struct SharedTaskSummary<T> {
     pub framework: String,
     pub env_mode: EnvMode,
     pub environment_variables: TaskEnvVarSummary,
-    pub dot_env: Option<Vec<RelativeUnixPathBuf>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub execution: Option<TaskExecutionSummary>,
 }
@@ -104,7 +103,6 @@ pub struct TaskSummaryTaskDefinition {
     persistent: bool,
     env: Vec<String>,
     pass_through_env: Option<Vec<String>>,
-    dot_env: Option<Vec<RelativeUnixPathBuf>>,
     interactive: bool,
 }
 
@@ -233,7 +231,6 @@ impl From<SharedTaskSummary<TaskId<'static>>> for SharedTaskSummary<String> {
             execution,
             env_mode,
             environment_variables,
-            dot_env,
             ..
         } = value;
         Self {
@@ -261,7 +258,6 @@ impl From<SharedTaskSummary<TaskId<'static>>> for SharedTaskSummary<String> {
             execution,
             env_mode,
             environment_variables,
-            dot_env,
         }
     }
 }
@@ -277,7 +273,6 @@ impl From<TaskDefinition> for TaskSummaryTaskDefinition {
             cache,
             mut env,
             pass_through_env,
-            dot_env,
             topological_dependencies,
             task_dependencies,
             mut inputs,
@@ -318,8 +313,6 @@ impl From<TaskDefinition> for TaskSummaryTaskDefinition {
             interactive,
             env,
             pass_through_env,
-            // This should _not_ be sorted.
-            dot_env,
         }
     }
 }
@@ -378,7 +371,6 @@ mod test {
             "interactive": false,
             "env": [],
             "passThroughEnv": null,
-            "dotEnv": null,
         })
         ; "resolved task definition"
     )]

--- a/crates/turborepo-lib/src/run/summary/task_factory.rs
+++ b/crates/turborepo-lib/src/run/summary/task_factory.rs
@@ -197,7 +197,6 @@ impl<'a> TaskSummaryFactory<'a> {
                 self.env_at_start,
             )
             .expect("invalid glob in task definition should have been caught earlier"),
-            dot_env: task_definition.dot_env.clone(),
             execution,
         })
     }

--- a/crates/turborepo-lib/src/task_graph/mod.rs
+++ b/crates/turborepo-lib/src/task_graph/mod.rs
@@ -49,8 +49,6 @@ pub struct TaskDefinition {
 
     pub(crate) pass_through_env: Option<Vec<String>>,
 
-    pub(crate) dot_env: Option<Vec<RelativeUnixPathBuf>>,
-
     // TopologicalDependencies are tasks from package dependencies.
     // E.g. "build" is a topological dependency in:
     // dependsOn: ['^build'].
@@ -92,7 +90,6 @@ impl Default for TaskDefinition {
             inputs: Default::default(),
             output_logs: Default::default(),
             persistent: Default::default(),
-            dot_env: Default::default(),
             interactive: Default::default(),
         }
     }

--- a/crates/turborepo-lib/src/task_hash.rs
+++ b/crates/turborepo-lib/src/task_hash.rs
@@ -178,7 +178,7 @@ impl PackageInputsHashes {
                             }
                         }
                     });
-                let mut hash_object = match hash_object {
+                let hash_object = match hash_object {
                     Some(hash_object) => hash_object,
                     None => {
                         let local_hash_result = scm.get_package_file_hashes(
@@ -193,22 +193,6 @@ impl PackageInputsHashes {
                         }
                     }
                 };
-                if let Some(dot_env) = &task_definition.dot_env {
-                    if !dot_env.is_empty() {
-                        let absolute_package_path = repo_root.resolve(package_path);
-                        let dot_env_object = match scm.hash_existing_of(
-                            &absolute_package_path,
-                            dot_env.iter().map(|p| p.to_anchored_system_path_buf()),
-                        ) {
-                            Ok(dot_env_object) => dot_env_object,
-                            Err(err) => return Some(Err(err.into())),
-                        };
-
-                        for (key, value) in dot_env_object {
-                            hash_object.insert(key, value);
-                        }
-                    }
-                }
 
                 let file_hashes = FileHashes(hash_object);
                 let hash = file_hashes.clone().hash();
@@ -404,7 +388,6 @@ impl<'a> TaskHasher<'a> {
                 .as_deref()
                 .unwrap_or_default(),
             env_mode: task_env_mode,
-            dot_env: task_definition.dot_env.as_deref().unwrap_or_default(),
         };
 
         let task_hash = task_hashable.calculate_task_hash();

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -10,10 +10,9 @@ use miette::{NamedSource, SourceSpan};
 use serde::{Deserialize, Serialize};
 use struct_iterable::Iterable;
 use tracing::debug;
-use turbopath::{AbsoluteSystemPath, AnchoredSystemPath, RelativeUnixPathBuf};
+use turbopath::{AbsoluteSystemPath, AnchoredSystemPath};
 use turborepo_errors::Spanned;
 use turborepo_repository::{package_graph::ROOT_PKG_NAME, package_json::PackageJson};
-use turborepo_telemetry::events::generic::GenericEventBuilder;
 
 use crate::{
     cli::OutputLogsMode,
@@ -50,7 +49,6 @@ pub struct TurboJson {
     path: Option<Arc<str>>,
     pub(crate) extends: Spanned<Vec<String>>,
     pub(crate) global_deps: Vec<String>,
-    pub(crate) global_dot_env: Option<Vec<RelativeUnixPathBuf>>,
     pub(crate) global_env: Vec<String>,
     pub(crate) global_pass_through_env: Option<Vec<String>>,
     pub(crate) tasks: Pipeline,
@@ -115,9 +113,6 @@ pub struct RawTurboJson {
     global_env: Option<Vec<Spanned<UnescapedString>>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     global_pass_through_env: Option<Vec<Spanned<UnescapedString>>>,
-    // .env files to consider, in order.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    global_dot_env: Option<Vec<UnescapedString>>,
     // Tasks is a map of task entries which define the task graph
     // and cache behavior on a per task or per package-task basis.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -489,19 +484,6 @@ impl TryFrom<RawTurboJson> for TurboJson {
 
                 global_deps
             },
-            global_dot_env: raw_turbo
-                .global_dot_env
-                .map(|env| -> Result<Vec<RelativeUnixPathBuf>, Error> {
-                    let mut global_dot_env = Vec::new();
-                    for dot_env_path in env {
-                        let type_checked_path = RelativeUnixPathBuf::new(dot_env_path)?;
-                        // These are _explicitly_ not sorted.
-                        global_dot_env.push(type_checked_path);
-                    }
-
-                    Ok(global_dot_env)
-                })
-                .transpose()?,
             tasks: raw_turbo.tasks.unwrap_or_default(),
             // copy these over, we don't need any changes here.
             extends: raw_turbo
@@ -628,11 +610,6 @@ impl TurboJson {
             .collect()
     }
 
-    pub fn track_usage(&self, telemetry: &GenericEventBuilder) {
-        let global_dot_env = self.global_dot_env.as_deref();
-        telemetry.track_global_dot_env(global_dot_env);
-    }
-
     pub fn has_root_tasks(&self) -> bool {
         self.tasks
             .iter()
@@ -749,12 +726,6 @@ mod tests {
             ..TurboJson::default()
         }
     ; "global dependencies (sorted)")]
-    #[test_case(r#"{ "globalDotEnv": [".env.local", ".env"] }"#,
-        TurboJson {
-            global_dot_env: Some(vec![RelativeUnixPathBuf::new(".env.local").unwrap(), RelativeUnixPathBuf::new(".env").unwrap()]),
-            ..TurboJson::default()
-        }
-    ; "global dot env (unsorted)")]
     #[test_case(r#"{ "globalPassThroughEnv": ["GITHUB_TOKEN", "AWS_SECRET_KEY"] }"#,
         TurboJson {
             global_pass_through_env: Some(vec!["AWS_SECRET_KEY".to_string(), "GITHUB_TOKEN".to_string()]),

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -170,8 +170,6 @@ pub struct RawTaskDefinition {
     #[serde(skip_serializing_if = "Option::is_none")]
     depends_on: Option<Spanned<Vec<Spanned<UnescapedString>>>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    dot_env: Option<Spanned<Vec<UnescapedString>>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     env: Option<Vec<Spanned<UnescapedString>>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     inputs: Option<Vec<Spanned<UnescapedString>>>,
@@ -216,7 +214,6 @@ impl RawTaskDefinition {
         set_field!(self, other, persistent);
         set_field!(self, other, env);
         set_field!(self, other, pass_through_env);
-        set_field!(self, other, dot_env);
         set_field!(self, other, interactive);
     }
 }
@@ -355,21 +352,6 @@ impl TryFrom<RawTaskDefinition> for TaskDefinition {
             })
             .transpose()?;
 
-        let dot_env = raw_task
-            .dot_env
-            .map(|env| -> Result<Vec<RelativeUnixPathBuf>, Error> {
-                // Going to _at least_ be an empty array.
-                let mut dot_env = Vec::new();
-                for dot_env_path in env.into_inner() {
-                    let type_checked_path = RelativeUnixPathBuf::new(dot_env_path)?;
-                    // These are _explicitly_ not sorted.
-                    dot_env.push(type_checked_path);
-                }
-
-                Ok(dot_env)
-            })
-            .transpose()?;
-
         Ok(TaskDefinition {
             outputs,
             cache,
@@ -378,7 +360,6 @@ impl TryFrom<RawTaskDefinition> for TaskDefinition {
             env,
             inputs,
             pass_through_env,
-            dot_env,
             output_logs: *raw_task.output_logs.unwrap_or_default(),
             persistent: *raw_task.persistent.unwrap_or_default(),
             interactive,
@@ -897,26 +878,8 @@ mod tests {
     ; "just persistent"
     )]
     #[test_case(
-        r#"{ "dotEnv": [] }"#,
-        RawTaskDefinition {
-            dot_env: Some(Spanned {
-                value: Vec::new(),
-                range: Some(12..14),
-                path: None,
-                text: None,
-            }),
-            ..RawTaskDefinition::default()
-        },
-        TaskDefinition {
-            dot_env: Some(Vec::new()),
-            ..Default::default()
-        }
-        ; "empty dotenv"
-    )]
-    #[test_case(
         r#"{
           "dependsOn": ["cli#build"],
-          "dotEnv": ["package/a/.env"],
           "env": ["OS"],
           "passThroughEnv": ["AWS_SECRET_KEY"],
           "outputs": ["package/a/dist"],
@@ -928,18 +891,16 @@ mod tests {
         }"#,
         RawTaskDefinition {
             depends_on: Some(Spanned::new(vec![Spanned::<UnescapedString>::new("cli#build".into()).with_range(26..37)]).with_range(25..38)),
-            dot_env: Some(Spanned::new(vec!["package/a/.env".into()]).with_range(60..78)),
-            env: Some(vec![Spanned::<UnescapedString>::new("OS".into()).with_range(98..102)]),
-            pass_through_env: Some(vec![Spanned::<UnescapedString>::new("AWS_SECRET_KEY".into()).with_range(134..150)]),
-            outputs: Some(vec![Spanned::<UnescapedString>::new("package/a/dist".into()).with_range(175..191)]),
-            cache: Some(Spanned::new(false).with_range(213..218)),
-            inputs: Some(vec![Spanned::<UnescapedString>::new("package/a/src/**".into()).with_range(241..259)]),
-            output_logs: Some(Spanned::new(OutputLogsMode::Full).with_range(286..292)),
-            persistent: Some(Spanned::new(true).with_range(318..322)),
-            interactive: Some(Spanned::new(true).with_range(349..353)),
+            env: Some(vec![Spanned::<UnescapedString>::new("OS".into()).with_range(58..62)]),
+            pass_through_env: Some(vec![Spanned::<UnescapedString>::new("AWS_SECRET_KEY".into()).with_range(94..110)]),
+            outputs: Some(vec![Spanned::<UnescapedString>::new("package/a/dist".into()).with_range(135..151)]),
+            cache: Some(Spanned::new(false).with_range(173..178)),
+            inputs: Some(vec![Spanned::<UnescapedString>::new("package/a/src/**".into()).with_range(201..219)]),
+            output_logs: Some(Spanned::new(OutputLogsMode::Full).with_range(246..252)),
+            persistent: Some(Spanned::new(true).with_range(278..282)),
+            interactive: Some(Spanned::new(true).with_range(309..313)),
         },
         TaskDefinition {
-          dot_env: Some(vec![RelativeUnixPathBuf::new("package/a/.env").unwrap()]),
           env: vec!["OS".to_string()],
           outputs: TaskOutputs {
               inclusions: vec!["package/a/dist".to_string()],
@@ -959,7 +920,6 @@ mod tests {
     #[test_case(
         r#"{
               "dependsOn": ["cli#build"],
-              "dotEnv": ["package\\a\\.env"],
               "env": ["OS"],
               "passThroughEnv": ["AWS_SECRET_KEY"],
               "outputs": ["package\\a\\dist"],
@@ -970,18 +930,16 @@ mod tests {
             }"#,
         RawTaskDefinition {
             depends_on: Some(Spanned::new(vec![Spanned::<UnescapedString>::new("cli#build".into()).with_range(30..41)]).with_range(29..42)),
-            dot_env: Some(Spanned::new(vec!["package\\a\\.env".into()]).with_range(68..88)),
-            env: Some(vec![Spanned::<UnescapedString>::new("OS".into()).with_range(112..116)]),
-            pass_through_env: Some(vec![Spanned::<UnescapedString>::new("AWS_SECRET_KEY".into()).with_range(152..168)]),
-            outputs: Some(vec![Spanned::<UnescapedString>::new("package\\a\\dist".into()).with_range(197..215)]),
-            cache: Some(Spanned::new(false).with_range(241..246)),
-            inputs: Some(vec![Spanned::<UnescapedString>::new("package\\a\\src\\**".into()).with_range(273..294)]),
-            output_logs: Some(Spanned::new(OutputLogsMode::Full).with_range(325..331)),
-            persistent: Some(Spanned::new(true).with_range(361..365)),
+            env: Some(vec![Spanned::<UnescapedString>::new("OS".into()).with_range(66..70)]),
+            pass_through_env: Some(vec![Spanned::<UnescapedString>::new("AWS_SECRET_KEY".into()).with_range(106..122)]),
+            outputs: Some(vec![Spanned::<UnescapedString>::new("package\\a\\dist".into()).with_range(151..169)]),
+            cache: Some(Spanned::new(false).with_range(195..200)),
+            inputs: Some(vec![Spanned::<UnescapedString>::new("package\\a\\src\\**".into()).with_range(227..248)]),
+            output_logs: Some(Spanned::new(OutputLogsMode::Full).with_range(279..285)),
+            persistent: Some(Spanned::new(true).with_range(315..319)),
             interactive: None,
         },
         TaskDefinition {
-            dot_env: Some(vec![RelativeUnixPathBuf::new("package\\a\\.env").unwrap()]),
             env: vec!["OS".to_string()],
             outputs: TaskOutputs {
                 inclusions: vec!["package\\a\\dist".to_string()],

--- a/crates/turborepo-lib/src/turbo_json/parser.rs
+++ b/crates/turborepo-lib/src/turbo_json/parser.rs
@@ -182,7 +182,6 @@ impl WithMetadata for RawTaskDefinition {
         if let Some(depends_on) = &mut self.depends_on {
             depends_on.value.add_text(text.clone());
         }
-        self.dot_env.add_text(text.clone());
         self.env.add_text(text.clone());
         self.inputs.add_text(text.clone());
         self.pass_through_env.add_text(text.clone());
@@ -197,7 +196,6 @@ impl WithMetadata for RawTaskDefinition {
         if let Some(depends_on) = &mut self.depends_on {
             depends_on.value.add_path(path.clone());
         }
-        self.dot_env.add_path(path.clone());
         self.env.add_path(path.clone());
         self.inputs.add_path(path.clone());
         self.pass_through_env.add_path(path.clone());

--- a/crates/turborepo-telemetry/src/events/generic.rs
+++ b/crates/turborepo-telemetry/src/events/generic.rs
@@ -1,7 +1,6 @@
 use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
-use turbopath::RelativeUnixPathBuf;
 use turborepo_vercel_api::telemetry::{TelemetryEvent, TelemetryGenericEvent};
 use uuid::Uuid;
 
@@ -210,28 +209,6 @@ impl GenericEventBuilder {
             },
             is_sensitive: EventType::NonSensitive,
         });
-        self
-    }
-
-    pub fn track_global_dot_env(&self, global_dot_env: Option<&[RelativeUnixPathBuf]>) -> &Self {
-        if let Some(global_dot_env) = global_dot_env {
-            self.track(Event {
-                key: "global_dot_env".into(),
-                value: global_dot_env.len().to_string(),
-                is_sensitive: EventType::NonSensitive,
-            });
-        }
-        self
-    }
-
-    pub fn track_dot_env(&self, dot_env: Option<&[RelativeUnixPathBuf]>) -> &Self {
-        if let Some(dot_env) = dot_env {
-            self.track(Event {
-                key: "dot_env".into(),
-                value: dot_env.len().to_string(),
-                is_sensitive: EventType::NonSensitive,
-            });
-        }
         self
     }
 

--- a/turborepo-tests/integration/fixtures/basic_monorepo/turbo.json
+++ b/turborepo-tests/integration/fixtures/basic_monorepo/turbo.json
@@ -9,8 +9,8 @@
     },
     // this comment verifies that turbo can read .json files with comments
     "my-app#build": {
-      "outputs": ["banana.txt", "apple.json"],
-      "dotEnv": [".env.local"]
+      "inputs": ["$TURBO_DEFAULT$", ".env.local"],
+      "outputs": ["banana.txt", "apple.json"]
     },
 
     "something": {},

--- a/turborepo-tests/integration/fixtures/dir_globs/turbo.json
+++ b/turborepo-tests/integration/fixtures/dir_globs/turbo.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "pipeline": {
+  "tasks": {
     "build": {
       "inputs": ["src/"],
       "outputs": ["dist"]

--- a/turborepo-tests/integration/fixtures/global_deps/turbo.json
+++ b/turborepo-tests/integration/fixtures/global_deps/turbo.json
@@ -10,7 +10,7 @@
     // this comment verifies that turbo can read .json files with comments
     "my-app#build": {
       "outputs": ["banana.txt", "apple.json"],
-      "dotEnv": [".env.local"]
+      "inputs": ["$TURBO_DEFAULT$", ".env.local"]
     },
 
     "something": {},

--- a/turborepo-tests/integration/fixtures/turbo-configs/invalid-env-var.json
+++ b/turborepo-tests/integration/fixtures/turbo-configs/invalid-env-var.json
@@ -10,7 +10,7 @@
     // this comment verifies that turbo can read .json files with comments
     "my-app#build": {
       "outputs": ["banana.txt", "apple.json"],
-      "dotEnv": [".env.local"]
+      "inputs": ["$TURBO_DEFAULT$", ".env.local"]
     },
 
     "something": {},

--- a/turborepo-tests/integration/fixtures/turbo-configs/package-task.json
+++ b/turborepo-tests/integration/fixtures/turbo-configs/package-task.json
@@ -7,7 +7,7 @@
     // this comment verifies that turbo can read .json files with comments
     "my-app#build": {
       "outputs": ["banana.txt", "apple.json"],
-      "dotEnv": [".env.local"]
+      "inputs": ["$TURBO_DEFAULT$", ".env.local"]
     }
   }
 }

--- a/turborepo-tests/integration/fixtures/turbo-configs/parse-error.json
+++ b/turborepo-tests/integration/fixtures/turbo-configs/parse-error.json
@@ -10,7 +10,7 @@
     // this comment verifies that turbo can read .json files with comments
     "my-app#build": {
       "outputs": ["banana.txt", "apple.json"]5,
-      "dotEnv": [".env.local"]
+      "inputs": ["$TURBO_DEFAULT$", ".env.local"]
     },
 
     "something": {},

--- a/turborepo-tests/integration/fixtures/turbo-configs/spaces-failure.json
+++ b/turborepo-tests/integration/fixtures/turbo-configs/spaces-failure.json
@@ -10,7 +10,7 @@
     // this comment verifies that turbo can read .json files with comments
     "my-app#build": {
       "outputs": ["banana.txt", "apple.json"],
-      "dotEnv": [".env.local"]
+      "inputs": ["$TURBO_DEFAULT$", ".env.local"]
     },
 
     "something": {},

--- a/turborepo-tests/integration/fixtures/turbo-configs/syntax-error.json
+++ b/turborepo-tests/integration/fixtures/turbo-configs/syntax-error.json
@@ -10,7 +10,7 @@
     // this comment verifies that turbo can read .json files with comments
     "my-app#build": {
       "outputs": ["banana.txt", "apple.json"]42,
-      "dotEnv": [".env.local"
+      "inputs": [".env.local"
     },
 
     "something": {},

--- a/turborepo-tests/integration/tests/bad-turbo-json.t
+++ b/turborepo-tests/integration/tests/bad-turbo-json.t
@@ -15,7 +15,7 @@ Run build with package task in non-root turbo.json
     7 |         // this comment verifies that turbo can read .json files with comments
     8 | ,->     "my-app#build": {
     9 | |         "outputs": ["banana.txt", "apple.json"],
-   10 | |         "dotEnv": [".env.local"]
+   10 | |         "inputs": ["$TURBO_DEFAULT$", ".env.local"]
    11 | |->     }
       : `---- unnecessary package syntax found here
    12 |       }
@@ -92,13 +92,13 @@ Run build with syntax errors in turbo.json
    11 |     "my-app#build": {
    12 |       "outputs": ["banana.txt", "apple.json"]42,
       :                                              ^^
-   13 |       "dotEnv": [".env.local"
+   13 |       "inputs": [".env.local"
       `----
   Error: turbo_json_parse_error
   
     x expected `,` but instead found `}`
       ,-[13:1]
-   13 |       "dotEnv": [".env.local"
+   13 |       "inputs": [".env.local"
    14 |     },
       :     ^
    15 | 

--- a/turborepo-tests/integration/tests/dry-json/monorepo.t
+++ b/turborepo-tests/integration/tests/dry-json/monorepo.t
@@ -15,7 +15,6 @@ Setup
       "foo.txt": "eebae5f3ca7b5831e429e947b7d61edd0de69236"
     },
     "hashOfExternalDependencies": "459c029558afe716",
-    "globalDotEnv": null,
     "environmentVariables": {
       "specified": {
         "env": [

--- a/turborepo-tests/integration/tests/dry-json/monorepo.t
+++ b/turborepo-tests/integration/tests/dry-json/monorepo.t
@@ -50,7 +50,7 @@ Setup
     "taskId": "my-app#build",
     "task": "build",
     "package": "my-app",
-    "hash": "f5b905676d8a275c",
+    "hash": "61394a550211cbe8",
     "inputs": {
       ".env.local": "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
       "package.json": "1746e0db2361085b5953a6a3beab08c24af5bc08"
@@ -80,14 +80,14 @@ Setup
       ],
       "cache": true,
       "dependsOn": [],
-      "inputs": [],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        ".env.local"
+      ],
       "outputLogs": "full",
       "persistent": false,
       "env": [],
       "passThroughEnv": null,
-      "dotEnv": [
-        ".env.local"
-      ],
       "interactive": false
     },
     "expandedOutputs": [],
@@ -101,10 +101,7 @@ Setup
       "configured": [],
       "inferred": [],
       "passthrough": null
-    },
-    "dotEnv": [
-      ".env.local"
-    ]
+    }
   }
 
 # Validate output of util#build task
@@ -113,7 +110,7 @@ Setup
     "taskId": "util#build",
     "task": "build",
     "package": "util",
-    "hash": "1ce33e04f265f95c",
+    "hash": "d30fc4474534c30e",
     "inputs": {
       "package.json": "e755064fd7893809d10fc067bb409c7ae516327f"
     },
@@ -143,7 +140,6 @@ Setup
         "NODE_ENV"
       ],
       "passThroughEnv": null,
-      "dotEnv": null,
       "interactive": false
     },
     "expandedOutputs": [],
@@ -159,8 +155,7 @@ Setup
       "configured": [],
       "inferred": [],
       "passthrough": null
-    },
-    "dotEnv": null
+    }
   }
 
 Run again with NODE_ENV set and see the value in the summary. --filter=util workspace so the output is smaller

--- a/turborepo-tests/integration/tests/dry-json/single-package-no-config.t
+++ b/turborepo-tests/integration/tests/dry-json/single-package-no-config.t
@@ -16,7 +16,6 @@ Setup
         "package.json": "8606ff4b95a5330740d8d9d0948faeada64f1f32"
       },
       "hashOfExternalDependencies": "",
-      "globalDotEnv": null,
       "environmentVariables": {
         "specified": {
           "env": [],

--- a/turborepo-tests/integration/tests/dry-json/single-package-no-config.t
+++ b/turborepo-tests/integration/tests/dry-json/single-package-no-config.t
@@ -33,7 +33,7 @@ Setup
       {
         "taskId": "build",
         "task": "build",
-        "hash": "bfac661137d88079",
+        "hash": "10229b8c4ed48f95",
         "inputs": {
           ".gitignore": "03b541460c1b836f96f9c0a941ceb48e91a9fd83",
           "package-lock.json": "1c117cce37347befafe3a9cba1b8a609b3600021",
@@ -63,7 +63,6 @@ Setup
           "persistent": false,
           "env": [],
           "passThroughEnv": null,
-          "dotEnv": null,
           "interactive": false
         },
         "expandedOutputs": [],
@@ -77,8 +76,7 @@ Setup
           "configured": [],
           "inferred": [],
           "passthrough": null
-        },
-        "dotEnv": null
+        }
       }
     ],
     "user": ".*", (re)

--- a/turborepo-tests/integration/tests/dry-json/single-package-with-deps.t
+++ b/turborepo-tests/integration/tests/dry-json/single-package-with-deps.t
@@ -15,7 +15,6 @@ Setup
         "somefile.txt": "45b983be36b73c0788dc9cbcb76cbb80fc7bb057"
       },
       "hashOfExternalDependencies": "",
-      "globalDotEnv": null,
       "environmentVariables": {
         "specified": {
           "env": [],

--- a/turborepo-tests/integration/tests/dry-json/single-package-with-deps.t
+++ b/turborepo-tests/integration/tests/dry-json/single-package-with-deps.t
@@ -31,7 +31,7 @@ Setup
       {
         "taskId": "build",
         "task": "build",
-        "hash": "e48ea8d453fe3216",
+        "hash": "fbef1dba65f21ba4",
         "inputs": {
           ".gitignore": "03b541460c1b836f96f9c0a941ceb48e91a9fd83",
           "package-lock.json": "1c117cce37347befafe3a9cba1b8a609b3600021",
@@ -68,7 +68,6 @@ Setup
           "persistent": false,
           "env": [],
           "passThroughEnv": null,
-          "dotEnv": null,
           "interactive": false
         },
         "expandedOutputs": [],
@@ -82,13 +81,12 @@ Setup
           "configured": [],
           "inferred": [],
           "passthrough": null
-        },
-        "dotEnv": null
+        }
       },
       {
         "taskId": "test",
         "task": "test",
-        "hash": "92fa9e0daec0e1ec",
+        "hash": "75187c3aff97a0a8",
         "inputs": {
           ".gitignore": "03b541460c1b836f96f9c0a941ceb48e91a9fd83",
           "package-lock.json": "1c117cce37347befafe3a9cba1b8a609b3600021",
@@ -123,7 +121,6 @@ Setup
           "persistent": false,
           "env": [],
           "passThroughEnv": null,
-          "dotEnv": null,
           "interactive": false
         },
         "expandedOutputs": [],
@@ -137,8 +134,7 @@ Setup
           "configured": [],
           "inferred": [],
           "passthrough": null
-        },
-        "dotEnv": null
+        }
       }
     ],
     "user": ".*", (re)

--- a/turborepo-tests/integration/tests/dry-json/single-package.t
+++ b/turborepo-tests/integration/tests/dry-json/single-package.t
@@ -15,7 +15,6 @@ Setup
         "somefile.txt": "45b983be36b73c0788dc9cbcb76cbb80fc7bb057"
       },
       "hashOfExternalDependencies": "",
-      "globalDotEnv": null,
       "environmentVariables": {
         "specified": {
           "env": [],

--- a/turborepo-tests/integration/tests/dry-json/single-package.t
+++ b/turborepo-tests/integration/tests/dry-json/single-package.t
@@ -31,7 +31,7 @@ Setup
       {
         "taskId": "build",
         "task": "build",
-        "hash": "e48ea8d453fe3216",
+        "hash": "fbef1dba65f21ba4",
         "inputs": {
           ".gitignore": "03b541460c1b836f96f9c0a941ceb48e91a9fd83",
           "package-lock.json": "1c117cce37347befafe3a9cba1b8a609b3600021",
@@ -66,7 +66,6 @@ Setup
           "persistent": false,
           "env": [],
           "passThroughEnv": null,
-          "dotEnv": null,
           "interactive": false
         },
         "expandedOutputs": [],
@@ -80,8 +79,7 @@ Setup
           "configured": [],
           "inferred": [],
           "passthrough": null
-        },
-        "dotEnv": null
+        }
       }
     ],
     "user": ".*", (re)

--- a/turborepo-tests/integration/tests/dry-run.t
+++ b/turborepo-tests/integration/tests/dry-run.t
@@ -19,7 +19,6 @@ Setup
     Global Files                          = 1
     External Dependencies Hash            = 459c029558afe716
     Global Cache Key                      = HEY STELLLLLLLAAAAAAAAAAAAA
-    Global .env Files Considered          = 0
     Global Env Vars                       = SOME_ENV_VAR
     Global Env Vars Values                = 
     Inferred Global Env Vars Values       = 

--- a/turborepo-tests/integration/tests/dry-run.t
+++ b/turborepo-tests/integration/tests/dry-run.t
@@ -27,11 +27,11 @@ Setup
     Global Passed Through Env Vars Values = 
 
 # Part 3 are Tasks to Run, and we have to validate each task separately
-  $ cat tmp-3.txt | grep "my-app#build" -A 18
+  $ cat tmp-3.txt | grep "my-app#build" -A 17
   my-app#build
     Task                           = build\s* (re)
     Package                        = my-app\s* (re)
-    Hash                           = f5b905676d8a275c\s* (re)
+    Hash                           = 61394a550211cbe8\s* (re)
     Cached \(Local\)                 = false\s* (re)
     Cached \(Remote\)                = false\s* (re)
     Directory                      = apps(\/|\\)my-app\s* (re)
@@ -41,18 +41,17 @@ Setup
     Dependencies                   =\s* (re)
     Dependents                     =\s* (re)
     Inputs Files Considered        = 2\s* (re)
-    .env Files Considered          = 1\s* (re)
     Env Vars                       =\s* (re)
     Env Vars Values                =\s* (re)
     Inferred Env Vars Values       =\s* (re)
     Passed Through Env Vars        =\s* (re)
     Passed Through Env Vars Values =\s* (re)
 
-  $ cat tmp-3.txt | grep "util#build" -A 18
+  $ cat tmp-3.txt | grep "util#build" -A 17
   util#build
     Task                           = build\s* (re)
     Package                        = util\s* (re)
-    Hash                           = 1ce33e04f265f95c\s* (re)
+    Hash                           = d30fc4474534c30e\s* (re)
     Cached \(Local\)                 = false\s* (re)
     Cached \(Remote\)                = false\s* (re)
     Directory                      = packages(\/|\\)util\s* (re)
@@ -62,7 +61,6 @@ Setup
     Dependencies                   =\s* (re)
     Dependents                     =\s* (re)
     Inputs Files Considered        = 1\s* (re)
-    .env Files Considered          = 0\s* (re)
     Env Vars                       = NODE_ENV\s* (re)
     Env Vars Values                =\s* (re)
     Inferred Env Vars Values       =\s* (re)

--- a/turborepo-tests/integration/tests/edit-turbo-json/task.t
+++ b/turborepo-tests/integration/tests/edit-turbo-json/task.t
@@ -6,15 +6,15 @@ Baseline task hashes
   $ ${TURBO} build --dry=json | jq -r '.tasks | sort_by(.taskId)[] | {taskId, hash}'
   {
     "taskId": "another#build",
-    "hash": "02f55362198a6c3d"
+    "hash": "1d62465edaa86a4e"
   }
   {
     "taskId": "my-app#build",
-    "hash": "8a8944ef32696847"
+    "hash": "61394a550211cbe8"
   }
   {
     "taskId": "util#build",
-    "hash": "1ce33e04f265f95c"
+    "hash": "d30fc4474534c30e"
   }
 
 Change only my-app#build
@@ -22,15 +22,15 @@ Change only my-app#build
   $ ${TURBO} build --dry=json | jq -r '.tasks | sort_by(.taskId)[] | {taskId, hash}'
   {
     "taskId": "another#build",
-    "hash": "02f55362198a6c3d"
+    "hash": "1d62465edaa86a4e"
   }
   {
     "taskId": "my-app#build",
-    "hash": "83bb5352c916557e"
+    "hash": "1d7be3c12072f23c"
   }
   {
     "taskId": "util#build",
-    "hash": "1ce33e04f265f95c"
+    "hash": "d30fc4474534c30e"
   }
 
 Change my-app#build dependsOn
@@ -38,15 +38,15 @@ Change my-app#build dependsOn
   $ ${TURBO} build --dry=json | jq -r '.tasks | sort_by(.taskId)[] | {taskId, hash}'
   {
     "taskId": "another#build",
-    "hash": "02f55362198a6c3d"
+    "hash": "1d62465edaa86a4e"
   }
   {
     "taskId": "my-app#build",
-    "hash": "346838a5f9d9a530"
+    "hash": "ccf2441853eb8930"
   }
   {
     "taskId": "util#build",
-    "hash": "1ce33e04f265f95c"
+    "hash": "d30fc4474534c30e"
   }
 
 Non-materially modifying the dep graph does nothing.
@@ -54,15 +54,15 @@ Non-materially modifying the dep graph does nothing.
   $ ${TURBO} build --dry=json | jq -r '.tasks | sort_by(.taskId)[] | {taskId, hash}'
   {
     "taskId": "another#build",
-    "hash": "02f55362198a6c3d"
+    "hash": "1d62465edaa86a4e"
   }
   {
     "taskId": "my-app#build",
-    "hash": "346838a5f9d9a530"
+    "hash": "ccf2441853eb8930"
   }
   {
     "taskId": "util#build",
-    "hash": "1ce33e04f265f95c"
+    "hash": "d30fc4474534c30e"
   }
 
 
@@ -71,13 +71,13 @@ Change util#build impacts itself and my-app
   $ ${TURBO} build --dry=json | jq -r '.tasks | sort_by(.taskId)[] | {taskId, hash}'
   {
     "taskId": "another#build",
-    "hash": "02f55362198a6c3d"
+    "hash": "1d62465edaa86a4e"
   }
   {
     "taskId": "my-app#build",
-    "hash": "b15e1a917912cd09"
+    "hash": "71c6f7392eeebdc1"
   }
   {
     "taskId": "util#build",
-    "hash": "2ee29eb57d7f69b3"
+    "hash": "73e9903a46832238"
   }

--- a/turborepo-tests/integration/tests/global-deps.t
+++ b/turborepo-tests/integration/tests/global-deps.t
@@ -6,7 +6,7 @@ Run a build
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache miss, executing 81165ceb4ed0e31f
+  my-app:build: cache miss, executing beb8106f9ebe42f9
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -18,7 +18,7 @@ Run a build
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache miss, executing 7bc88ba3e84628fd
+  my-app:build: cache miss, executing ab899db87390362e
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total

--- a/turborepo-tests/integration/tests/global-env.t
+++ b/turborepo-tests/integration/tests/global-env.t
@@ -8,7 +8,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  util:build: cache miss, executing 1ce33e04f265f95c
+  util:build: cache miss, executing d30fc4474534c30e
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -19,7 +19,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  util:build: cache hit, suppressing logs 1ce33e04f265f95c
+  util:build: cache hit, suppressing logs d30fc4474534c30e
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total
@@ -30,7 +30,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  util:build: cache miss, executing 70278c4ec3fb5ac9
+  util:build: cache miss, executing b67982f6f3a6f305
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -41,7 +41,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  util:build: cache hit, suppressing logs 1ce33e04f265f95c
+  util:build: cache hit, suppressing logs d30fc4474534c30e
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total
@@ -52,7 +52,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  util:build: cache miss, executing 8b12fdc0e2d94c8d
+  util:build: cache miss, executing 83ec044d1376f47b
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total

--- a/turborepo-tests/integration/tests/persistent-dependencies/6-topological-unimplemented.t
+++ b/turborepo-tests/integration/tests/persistent-dependencies/6-topological-unimplemented.t
@@ -17,7 +17,7 @@
   \xe2\x80\xa2 Packages in scope: app-a, pkg-a (esc)
   \xe2\x80\xa2 Running dev in 2 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  app-a:dev: cache miss, executing 6ae3691e15cf83ab
+  app-a:dev: cache miss, executing 123f031c97be8067
   app-a:dev: 
   app-a:dev: > dev
   app-a:dev: > echo dev-app-a

--- a/turborepo-tests/integration/tests/pkg-inference.t
+++ b/turborepo-tests/integration/tests/pkg-inference.t
@@ -6,7 +6,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  util:build: cache miss, executing 1ce33e04f265f95c
+  util:build: cache miss, executing d30fc4474534c30e
   util:build: 
   util:build: > build
   util:build: > echo building

--- a/turborepo-tests/integration/tests/prune/composable-config.t
+++ b/turborepo-tests/integration/tests/prune/composable-config.t
@@ -11,7 +11,7 @@ Make sure that the internal util package is part of the prune output
   \xe2\x80\xa2 Packages in scope: docs, shared, util (esc)
   \xe2\x80\xa2 Running new-task in 3 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  docs:new-task: cache miss, executing 0fb91dc0d3d46797
+  docs:new-task: cache miss, executing 021bcd5005a1c133
   docs:new-task: 
   docs:new-task: > docs@ new-task .*out(\/|\\)apps(\/|\\)docs (re)
   docs:new-task: > echo building

--- a/turborepo-tests/integration/tests/run-caching/excluded-inputs/excluded-inputs.t
+++ b/turborepo-tests/integration/tests/run-caching/excluded-inputs/excluded-inputs.t
@@ -9,7 +9,7 @@ Running build for my-app succeeds
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache miss, executing 2fa14ad1b3e50ac8
+  my-app:build: cache miss, executing 493990a10ad3129e
   my-app:build: 
   my-app:build: > build
   my-app:build: > echo building
@@ -26,7 +26,7 @@ Update exluded file and try again
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache hit, replaying logs 2fa14ad1b3e50ac8
+  my-app:build: cache hit, replaying logs 493990a10ad3129e
   my-app:build: 
   my-app:build: > build
   my-app:build: > echo building

--- a/turborepo-tests/integration/tests/run-logging/errors-only.t
+++ b/turborepo-tests/integration/tests/run-logging/errors-only.t
@@ -37,7 +37,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: app-a (esc)
   \xe2\x80\xa2 Running builderror in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  app-a:builderror: cache miss, executing 63f09c22afb626a8
+  app-a:builderror: cache miss, executing a434651ebfd5e29b
   app-a:builderror: 
   app-a:builderror: > builderror
   app-a:builderror: > echo error-builderror-app-a && exit 1
@@ -67,7 +67,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: app-a (esc)
   \xe2\x80\xa2 Running builderror2 in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  app-a:builderror2: cache miss, executing 7303c469d075d34c
+  app-a:builderror2: cache miss, executing 37f4f3e6503bb5d2
   app-a:builderror2: 
   app-a:builderror2: > builderror2
   app-a:builderror2: > echo error-builderror2-app-a && exit 1

--- a/turborepo-tests/integration/tests/run-logging/log-order-github.t
+++ b/turborepo-tests/integration/tests/run-logging/log-order-github.t
@@ -9,7 +9,7 @@ because otherwise prysk interprets them as multiline commands
   \xe2\x80\xa2 Running build in 2 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
   ::group::my-app:build
-  cache bypass, force executing c1d33a8183d8cf0b
+  cache bypass, force executing ee861306d76acfba
   
   >\sbuild (re)
   \>\secho building && sleep 1 && echo done (re)
@@ -18,7 +18,7 @@ because otherwise prysk interprets them as multiline commands
   done
   ::endgroup::
   ::group::util:build
-  cache bypass, force executing ff1050c513839636
+  cache bypass, force executing d2c8604a72ebce55
   
   >\sbuild (re)
   \>\ssleep 0.5 && echo building && sleep 1 && echo completed (re)
@@ -37,7 +37,7 @@ because otherwise prysk interprets them as multiline commands
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
   ::group::util:build
-  util:build: cache bypass, force executing ff1050c513839636
+  util:build: cache bypass, force executing d2c8604a72ebce55
   util:build: 
   util:build: > build
   util:build: > sleep 0.5 && echo building && sleep 1 && echo completed
@@ -57,7 +57,7 @@ Verify that errors are grouped properly
   \xe2\x80\xa2 Running fail in 2 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
   \x1b[;31mutil:fail\x1b[;0m (esc)
-  cache miss, executing 122cca10fdcda4f0
+  cache miss, executing c2f80a6e64adbc38
   
   \> fail (re)
   \> echo failing; exit 1 (re)

--- a/turborepo-tests/integration/tests/run-logging/log-prefix.t
+++ b/turborepo-tests/integration/tests/run-logging/log-prefix.t
@@ -6,7 +6,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: app-a (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  cache miss, executing 6b91fee8d61438d4
+  cache miss, executing 91de4eaf400f908e
   
   \> build (re)
   \> echo build-app-a (re)
@@ -30,7 +30,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: app-a (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  cache hit, replaying logs 6b91fee8d61438d4
+  cache hit, replaying logs 91de4eaf400f908e
   
   \> build (re)
   \> echo build-app-a (re)
@@ -46,7 +46,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: app-a (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  app-a:build: cache hit, replaying logs 6b91fee8d61438d4
+  app-a:build: cache hit, replaying logs 91de4eaf400f908e
   app-a:build: 
   app-a:build: > build
   app-a:build: > echo build-app-a

--- a/turborepo-tests/integration/tests/run-logging/verbosity.t
+++ b/turborepo-tests/integration/tests/run-logging/verbosity.t
@@ -6,7 +6,7 @@ Verbosity level 1
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  util:build: cache bypass, force executing 1ce33e04f265f95c
+  util:build: cache bypass, force executing d30fc4474534c30e
   util:build: 
   util:build: > build
   util:build: > echo building
@@ -21,7 +21,7 @@ Verbosity level 1
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  util:build: cache bypass, force executing 1ce33e04f265f95c
+  util:build: cache bypass, force executing d30fc4474534c30e
   util:build: 
   util:build: > build
   util:build: > echo building

--- a/turborepo-tests/integration/tests/run-summary/discovery.t
+++ b/turborepo-tests/integration/tests/run-summary/discovery.t
@@ -6,7 +6,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache miss, executing f5b905676d8a275c
+  my-app:build: cache miss, executing 61394a550211cbe8
   my-app:build: 
   my-app:build: > build
   my-app:build: > echo building

--- a/turborepo-tests/integration/tests/run-summary/error.t
+++ b/turborepo-tests/integration/tests/run-summary/error.t
@@ -32,7 +32,7 @@ Validate that we got a full task summary for the failed task with an error in .e
     "taskId": "my-app#maybefails",
     "task": "maybefails",
     "package": "my-app",
-    "hash": "9626dfcd1fbbdc68",
+    "hash": "8f681db4d5b591ee",
     "inputs": {
       ".env.local": "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
       "package.json": "1746e0db2361085b5953a6a3beab08c24af5bc08"
@@ -61,7 +61,6 @@ Validate that we got a full task summary for the failed task with an error in .e
       "persistent": false,
       "env": [],
       "passThroughEnv": null,
-      "dotEnv": null,
       "interactive": false
     },
     "expandedOutputs": [],
@@ -76,7 +75,6 @@ Validate that we got a full task summary for the failed task with an error in .e
       "inferred": [],
       "passthrough": null
     },
-    "dotEnv": null,
     "execution": {
       "startTime": [0-9]+, (re)
       "endTime": [0-9]+, (re)

--- a/turborepo-tests/integration/tests/run-summary/single-package.t
+++ b/turborepo-tests/integration/tests/run-summary/single-package.t
@@ -72,7 +72,6 @@ Check
     "command",
     "dependencies",
     "dependents",
-    "dotEnv",
     "envMode",
     "environmentVariables",
     "excludedOutputs",

--- a/turborepo-tests/integration/tests/run/continue.t
+++ b/turborepo-tests/integration/tests/run/continue.t
@@ -5,7 +5,7 @@ Run without --continue
   \xe2\x80\xa2 Packages in scope: my-app, other-app, some-lib (esc)
   \xe2\x80\xa2 Running build in 3 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  some-lib:build: cache miss, executing 768adc25648baff5
+  some-lib:build: cache miss, executing 223a3af003231594
   some-lib:build: 
   some-lib:build: > build
   some-lib:build: > exit 2
@@ -31,7 +31,7 @@ Run without --continue, and with only errors.
   \xe2\x80\xa2 Packages in scope: my-app, other-app, some-lib (esc)
   \xe2\x80\xa2 Running build in 3 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  some-lib:build: cache miss, executing 768adc25648baff5
+  some-lib:build: cache miss, executing 223a3af003231594
   some-lib:build: 
   some-lib:build: > build
   some-lib:build: > exit 2
@@ -56,7 +56,7 @@ Run with --continue
   \xe2\x80\xa2 Packages in scope: my-app, other-app, some-lib (esc)
   \xe2\x80\xa2 Running build in 3 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  some-lib:build: cache miss, executing 768adc25648baff5
+  some-lib:build: cache miss, executing 223a3af003231594
   some-lib:build: 
   some-lib:build: > build
   some-lib:build: > exit 2
@@ -66,7 +66,7 @@ Run with --continue
   some-lib:build: npm ERR!   in workspace: some-lib 
   some-lib:build: npm ERR!   at location: (.*)(\/|\\)apps(\/|\\)some-lib  (re)
   some-lib:build: command finished with error, but continuing...
-  other-app:build: cache miss, executing a40a9e67334d0ae6
+  other-app:build: cache miss, executing 30cb4d864c805a98
   other-app:build: 
   other-app:build: > build
   other-app:build: > exit 3

--- a/turborepo-tests/integration/tests/run/force.t
+++ b/turborepo-tests/integration/tests/run/force.t
@@ -24,7 +24,7 @@ baseline to generate cache
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache miss, executing f5b905676d8a275c
+  my-app:build: cache miss, executing 61394a550211cbe8
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -36,7 +36,7 @@ baseline to generate cache
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache bypass, force executing f5b905676d8a275c
+  my-app:build: cache bypass, force executing 61394a550211cbe8
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -47,7 +47,7 @@ baseline to generate cache
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache bypass, force executing f5b905676d8a275c
+  my-app:build: cache bypass, force executing 61394a550211cbe8
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -58,7 +58,7 @@ baseline to generate cache
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache hit, suppressing logs f5b905676d8a275c
+  my-app:build: cache hit, suppressing logs 61394a550211cbe8
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total
@@ -69,7 +69,7 @@ baseline to generate cache
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache bypass, force executing f5b905676d8a275c
+  my-app:build: cache bypass, force executing 61394a550211cbe8
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -81,7 +81,7 @@ baseline to generate cache
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache hit, suppressing logs f5b905676d8a275c
+  my-app:build: cache hit, suppressing logs 61394a550211cbe8
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total
@@ -92,7 +92,7 @@ baseline to generate cache
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache bypass, force executing f5b905676d8a275c
+  my-app:build: cache bypass, force executing 61394a550211cbe8
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -103,7 +103,7 @@ baseline to generate cache
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache hit, suppressing logs f5b905676d8a275c
+  my-app:build: cache hit, suppressing logs 61394a550211cbe8
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total
@@ -114,7 +114,7 @@ baseline to generate cache
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache bypass, force executing f5b905676d8a275c
+  my-app:build: cache bypass, force executing 61394a550211cbe8
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -126,7 +126,7 @@ baseline to generate cache
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache hit, suppressing logs f5b905676d8a275c
+  my-app:build: cache hit, suppressing logs 61394a550211cbe8
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total
@@ -137,7 +137,7 @@ baseline to generate cache
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache bypass, force executing f5b905676d8a275c
+  my-app:build: cache bypass, force executing 61394a550211cbe8
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -148,7 +148,7 @@ baseline to generate cache
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache hit, suppressing logs f5b905676d8a275c
+  my-app:build: cache hit, suppressing logs 61394a550211cbe8
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total
@@ -159,7 +159,7 @@ baseline to generate cache
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache bypass, force executing f5b905676d8a275c
+  my-app:build: cache bypass, force executing 61394a550211cbe8
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total

--- a/turborepo-tests/integration/tests/run/gitignored-inputs.t
+++ b/turborepo-tests/integration/tests/run/gitignored-inputs.t
@@ -16,7 +16,7 @@ Some helper functions to parse the summary file
 
 Just run the util package, it's simpler
   $ ${TURBO} run build --filter=util --output-logs=hash-only --summarize | grep "util:build: cache"
-  util:build: cache miss, executing 2f6ab59379ddcb93
+  util:build: cache miss, executing 546eb92dc465adf3
 
   $ FIRST=$(/bin/ls .turbo/runs/*.json | head -n1)
   $ echo $(getSummaryTaskId $FIRST "util#build") | jq -r '.inputs."internal.txt"'
@@ -30,7 +30,7 @@ Change the content of internal.txt
 
 Hash does not change, because it is gitignored
   $ ${TURBO} run build --filter=util --output-logs=hash-only --summarize | grep "util:build: cache"
-  util:build: cache miss, executing a26c95f27f26f89c
+  util:build: cache miss, executing 4e08438130b53119
 
 The internal.txt hash should be different from the one before
   $ SECOND=$(/bin/ls .turbo/runs/*.json | head -n1)

--- a/turborepo-tests/integration/tests/run/globs.t
+++ b/turborepo-tests/integration/tests/run/globs.t
@@ -5,7 +5,7 @@ Verify that input directory change causes cache miss
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  util:build: cache miss, executing 1b15024312fdecef
+  util:build: cache miss, executing feb6c37d2db8dda5
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -16,7 +16,7 @@ Verify that input directory change causes cache miss
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  util:build: cache miss, executing 31adf3c5481a64c7
+  util:build: cache miss, executing 5ca84fbcfb192408
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -29,7 +29,7 @@ Verify that input directory change causes cache miss
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  util:build: cache hit, suppressing logs 31adf3c5481a64c7
+  util:build: cache hit, suppressing logs 5ca84fbcfb192408
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total

--- a/turborepo-tests/integration/tests/run/one-script-error.t
+++ b/turborepo-tests/integration/tests/run/one-script-error.t
@@ -7,13 +7,13 @@ Note that npm reports any failed script as exit code 1, even though we "exit 2"
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running error in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:okay: cache miss, executing ffe52e38e68be53e
+  my-app:okay: cache miss, executing 90bba097751d6fc5
   my-app:okay: 
   my-app:okay: > okay
   my-app:okay: > echo working
   my-app:okay: 
   my-app:okay: working
-  my-app:error: cache miss, executing 8d3be716599fe376
+  my-app:error: cache miss, executing 6da0be6250fdaee0
   my-app:error: 
   my-app:error: > error
   my-app:error: > exit 2
@@ -38,13 +38,13 @@ Make sure error isn't cached
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running error in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:okay: cache hit, replaying logs ffe52e38e68be53e
+  my-app:okay: cache hit, replaying logs 90bba097751d6fc5
   my-app:okay: 
   my-app:okay: > okay
   my-app:okay: > echo working
   my-app:okay: 
   my-app:okay: working
-  my-app:error: cache miss, executing 8d3be716599fe376
+  my-app:error: cache miss, executing 6da0be6250fdaee0
   my-app:error: 
   my-app:error: > error
   my-app:error: > exit 2
@@ -69,13 +69,13 @@ Make sure error code isn't swallowed with continue
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running okay2 in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:okay: cache hit, replaying logs ffe52e38e68be53e
+  my-app:okay: cache hit, replaying logs 90bba097751d6fc5
   my-app:okay: 
   my-app:okay: > okay
   my-app:okay: > echo working
   my-app:okay: 
   my-app:okay: working
-  my-app:error: cache miss, executing 8d3be716599fe376
+  my-app:error: cache miss, executing 6da0be6250fdaee0
   my-app:error: 
   my-app:error: > error
   my-app:error: > exit 2
@@ -85,7 +85,7 @@ Make sure error code isn't swallowed with continue
   my-app:error: npm ERR!   in workspace: my-app 
   my-app:error: npm ERR!   at location: .*apps(\/|\\)my-app  (re)
   my-app:error: command finished with error, but continuing...
-  my-app:okay2: cache miss, executing 13c728e793c08f30
+  my-app:okay2: cache miss, executing 9a07ba5887a54500
   my-app:okay2: 
   my-app:okay2: > okay2
   my-app:okay2: > echo working

--- a/turborepo-tests/integration/tests/run/single-package/dry-run.t
+++ b/turborepo-tests/integration/tests/run/single-package/dry-run.t
@@ -17,7 +17,7 @@ Check
   Tasks to Run
   build
     Task                           = build\s* (re)
-    Hash                           = e48ea8d453fe3216\s* (re)
+    Hash                           = fbef1dba65f21ba4
     Cached \(Local\)                 = false\s* (re)
     Cached \(Remote\)                = false\s* (re)
     Command                        = echo building > foo.txt\s* (re)
@@ -26,11 +26,10 @@ Check
     Dependencies                   =\s* (re)
     Dependents                     =\s* (re)
     Inputs Files Considered        = 5\s* (re)
-    .env Files Considered          = 0\s* (re)
-    Env Vars                       =\s* (re)
-    Env Vars Values                =\s* (re)
-    Inferred Env Vars Values       =\s* (re)
-    Passed Through Env Vars        =\s* (re)
-    Passed Through Env Vars Values =\s* (re)
-    Resolved Task Definition       = {"outputs":["foo.txt"],"cache":true,"dependsOn":[],"inputs":[],"outputLogs":"full","persistent":false,"env":[],"passThroughEnv":null,"dotEnv":null,"interactive":false}
-    Framework                      =\s* (re)
+    Env Vars                       = 
+    Env Vars Values                = 
+    Inferred Env Vars Values       = 
+    Passed Through Env Vars        = 
+    Passed Through Env Vars Values = 
+    Resolved Task Definition       = {"outputs":["foo.txt"],"cache":true,"dependsOn":[],"inputs":[],"outputLogs":"full","persistent":false,"env":[],"passThroughEnv":null,"interactive":false}
+    Framework                      = 

--- a/turborepo-tests/integration/tests/run/single-package/dry-run.t
+++ b/turborepo-tests/integration/tests/run/single-package/dry-run.t
@@ -8,7 +8,6 @@ Check
     Global Files                          = 3
     External Dependencies Hash            = 
     Global Cache Key                      = HEY STELLLLLLLAAAAAAAAAAAAA
-    Global .env Files Considered          = 0
     Global Env Vars                       = 
     Global Env Vars Values                = 
     Inferred Global Env Vars Values       = 

--- a/turborepo-tests/integration/tests/run/single-package/no-config.t
+++ b/turborepo-tests/integration/tests/run/single-package/no-config.t
@@ -20,7 +20,7 @@ Check
   Tasks to Run
   build
     Task                           = build\s* (re)
-    Hash                           = bfac661137d88079
+    Hash                           = 10229b8c4ed48f95
     Cached \(Local\)                 = false\s* (re)
     Cached \(Remote\)                = false\s* (re)
     Command                        = echo building > foo.txt\s* (re)
@@ -29,14 +29,13 @@ Check
     Dependencies                   =\s* (re)
     Dependents                     =\s* (re)
     Inputs Files Considered        = 4\s* (re)
-    .env Files Considered          = 0\s* (re)
-    Env Vars                       =\s* (re)
-    Env Vars Values                =\s* (re)
-    Inferred Env Vars Values       =\s* (re)
-    Passed Through Env Vars        =\s* (re)
-    Passed Through Env Vars Values =\s* (re)
-    Resolved Task Definition       = {"outputs":[],"cache":false,"dependsOn":[],"inputs":[],"outputLogs":"full","persistent":false,"env":[],"passThroughEnv":null,"dotEnv":null,"interactive":false}
-    Framework                      =\s* (re)
+    Env Vars                       = 
+    Env Vars Values                = 
+    Inferred Env Vars Values       = 
+    Passed Through Env Vars        = 
+    Passed Through Env Vars Values = 
+    Resolved Task Definition       = {"outputs":[],"cache":false,"dependsOn":[],"inputs":[],"outputLogs":"full","persistent":false,"env":[],"passThroughEnv":null,"interactive":false}
+    Framework                      = 
 
   $ ${TURBO} run build --graph
   
@@ -52,7 +51,7 @@ Run real once
   $ ${TURBO} run build
   \xe2\x80\xa2 Running build (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  build: cache bypass, force executing bfac661137d88079
+  build: cache bypass, force executing 10229b8c4ed48f95
   build: 
   build: > build
   build: > echo building > foo.txt
@@ -66,7 +65,7 @@ Run a second time, verify no caching because there is no config
   $ ${TURBO} run build
   \xe2\x80\xa2 Running build (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  build: cache bypass, force executing bfac661137d88079
+  build: cache bypass, force executing 10229b8c4ed48f95
   build: 
   build: > build
   build: > echo building > foo.txt

--- a/turborepo-tests/integration/tests/run/single-package/no-config.t
+++ b/turborepo-tests/integration/tests/run/single-package/no-config.t
@@ -10,12 +10,11 @@ Check
     Global Files                          = 2\s* (re)
     External Dependencies Hash            =\s* (re)
     Global Cache Key                      = HEY STELLLLLLLAAAAAAAAAAAAA\s* (re)
-    Global .env Files Considered          = 0\s* (re)
-    Global Env Vars                       =\s* (re)
-    Global Env Vars Values                =\s* (re)
-    Inferred Global Env Vars Values       =\s* (re)
-    Global Passed Through Env Vars        =\s* (re)
-    Global Passed Through Env Vars Values =\s* (re)
+    Global Env Vars                       = 
+    Global Env Vars Values                = 
+    Inferred Global Env Vars Values       = 
+    Global Passed Through Env Vars        = 
+    Global Passed Through Env Vars Values = 
   
   Tasks to Run
   build

--- a/turborepo-tests/integration/tests/run/single-package/run-yarn.t
+++ b/turborepo-tests/integration/tests/run/single-package/run-yarn.t
@@ -5,7 +5,7 @@ Check
   $ ${TURBO} run build
   \xe2\x80\xa2 Running build (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  build: cache miss, executing 72f505390b93a0dc
+  build: cache miss, executing 178267ee3c25fe0a
   build: yarn run v1.22.17
   build: warning package.json: No license field
   build: $ echo building > foo.txt
@@ -18,7 +18,7 @@ Check
   $ ${TURBO} run build
   \xe2\x80\xa2 Running build (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  build: cache hit, replaying logs 72f505390b93a0dc
+  build: cache hit, replaying logs 178267ee3c25fe0a
   build: yarn run v1.22.17
   build: warning package.json: No license field
   build: $ echo building > foo.txt

--- a/turborepo-tests/integration/tests/run/single-package/run.t
+++ b/turborepo-tests/integration/tests/run/single-package/run.t
@@ -5,7 +5,7 @@ Check
   $ ${TURBO} run build
   \xe2\x80\xa2 Running build (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  build: cache miss, executing e48ea8d453fe3216
+  build: cache miss, executing fbef1dba65f21ba4
   build: 
   build: > build
   build: > echo building > foo.txt
@@ -22,7 +22,7 @@ Run a second time, verify caching works because there is a config
   $ ${TURBO} run build
   \xe2\x80\xa2 Running build (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  build: cache hit, replaying logs e48ea8d453fe3216
+  build: cache hit, replaying logs fbef1dba65f21ba4
   build: 
   build: > build
   build: > echo building > foo.txt

--- a/turborepo-tests/integration/tests/run/single-package/with-deps-dry-run.t
+++ b/turborepo-tests/integration/tests/run/single-package/with-deps-dry-run.t
@@ -17,7 +17,7 @@ Check
   Tasks to Run
   build
     Task                           = build\s* (re)
-    Hash                           = e48ea8d453fe3216\s* (re)
+    Hash                           = fbef1dba65f21ba4
     Cached \(Local\)                 = false\s* (re)
     Cached \(Remote\)                = false\s* (re)
     Command                        = echo building > foo.txt\s* (re)
@@ -26,17 +26,16 @@ Check
     Dependencies                   =\s* (re)
     Dependents                     = test\s* (re)
     Inputs Files Considered        = 5\s* (re)
-    .env Files Considered          = 0\s* (re)
-    Env Vars                       =\s* (re)
-    Env Vars Values                =\s* (re)
-    Inferred Env Vars Values       =\s* (re)
-    Passed Through Env Vars        =\s* (re)
-    Passed Through Env Vars Values =\s* (re)
-    Resolved Task Definition       = {"outputs":["foo.txt"],"cache":true,"dependsOn":[],"inputs":[],"outputLogs":"full","persistent":false,"env":[],"passThroughEnv":null,"dotEnv":null,"interactive":false}
-    Framework                      =\s* (re)
+    Env Vars                       = 
+    Env Vars Values                = 
+    Inferred Env Vars Values       = 
+    Passed Through Env Vars        = 
+    Passed Through Env Vars Values = 
+    Resolved Task Definition       = {"outputs":["foo.txt"],"cache":true,"dependsOn":[],"inputs":[],"outputLogs":"full","persistent":false,"env":[],"passThroughEnv":null,"interactive":false}
+    Framework                      = 
   test
     Task                           = test\s* (re)
-    Hash                           = 92fa9e0daec0e1ec\s* (re)
+    Hash                           = 75187c3aff97a0a8
     Cached \(Local\)                 = false\s* (re)
     Cached \(Remote\)                = false\s* (re)
     Command                        = cat foo.txt\s* (re)
@@ -45,11 +44,10 @@ Check
     Dependencies                   = build\s* (re)
     Dependents                     =\s* (re)
     Inputs Files Considered        = 5\s* (re)
-    .env Files Considered          = 0\s* (re)
-    Env Vars                       =\s* (re)
-    Env Vars Values                =\s* (re)
-    Inferred Env Vars Values       =\s* (re)
-    Passed Through Env Vars        =\s* (re)
-    Passed Through Env Vars Values =\s* (re)
-    Resolved Task Definition       = {"outputs":[],"cache":true,"dependsOn":["build"],"inputs":[],"outputLogs":"full","persistent":false,"env":[],"passThroughEnv":null,"dotEnv":null,"interactive":false}
-    Framework                      =\s* (re)
+    Env Vars                       = 
+    Env Vars Values                = 
+    Inferred Env Vars Values       = 
+    Passed Through Env Vars        = 
+    Passed Through Env Vars Values = 
+    Resolved Task Definition       = {"outputs":[],"cache":true,"dependsOn":["build"],"inputs":[],"outputLogs":"full","persistent":false,"env":[],"passThroughEnv":null,"interactive":false}
+    Framework                      = 

--- a/turborepo-tests/integration/tests/run/single-package/with-deps-dry-run.t
+++ b/turborepo-tests/integration/tests/run/single-package/with-deps-dry-run.t
@@ -8,7 +8,6 @@ Check
     Global Files                          = 3
     External Dependencies Hash            = 
     Global Cache Key                      = HEY STELLLLLLLAAAAAAAAAAAAA
-    Global .env Files Considered          = 0
     Global Env Vars                       = 
     Global Env Vars Values                = 
     Inferred Global Env Vars Values       = 

--- a/turborepo-tests/integration/tests/run/single-package/with-deps-run.t
+++ b/turborepo-tests/integration/tests/run/single-package/with-deps-run.t
@@ -5,20 +5,12 @@ Check
   $ ${TURBO} run test
   \xe2\x80\xa2 Running test (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-<<<<<<< HEAD
-  build: cache miss, executing e48ea8d453fe3216
-=======
-  build: cache miss, executing 21b3f16d0cd4a89c
->>>>>>> b668d5abb3 (chore: remove task dotEnv field)
+  build: cache miss, executing fbef1dba65f21ba4
   build: 
   build: > build
   build: > echo building > foo.txt
   build: 
-<<<<<<< HEAD
-  test: cache miss, executing 92fa9e0daec0e1ec
-=======
-  test: cache miss, executing 23c168552034dd2f
->>>>>>> b668d5abb3 (chore: remove task dotEnv field)
+  test: cache miss, executing 75187c3aff97a0a8
   test: 
   test: > test
   test: > cat foo.txt
@@ -29,24 +21,22 @@ Check
   Cached:    0 cached, 2 total
     Time:\s*[\.0-9]+m?s  (re)
   
+<<<<<<< HEAD
+=======
+>>>>>>> b668d5abb3 (chore: remove task dotEnv field)
+<<<<<<< HEAD
+=======
+>>>>>>> b668d5abb3 (chore: remove task dotEnv field)
 Run a second time, verify caching works because there is a config
   $ ${TURBO} run test
   \xe2\x80\xa2 Running test (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-<<<<<<< HEAD
-  build: cache hit, replaying logs e48ea8d453fe3216
-=======
-  build: cache hit, replaying logs 21b3f16d0cd4a89c
->>>>>>> b668d5abb3 (chore: remove task dotEnv field)
+  build: cache hit, replaying logs fbef1dba65f21ba4
   build: 
   build: > build
   build: > echo building > foo.txt
   build: 
-<<<<<<< HEAD
-  test: cache hit, replaying logs 92fa9e0daec0e1ec
-=======
-  test: cache hit, replaying logs 23c168552034dd2f
->>>>>>> b668d5abb3 (chore: remove task dotEnv field)
+  test: cache hit, replaying logs 75187c3aff97a0a8
   test: 
   test: > test
   test: > cat foo.txt
@@ -57,22 +47,26 @@ Run a second time, verify caching works because there is a config
   Cached:    2 cached, 2 total
     Time:\s*[\.0-9]+m?s >>> FULL TURBO (re)
   
+<<<<<<< HEAD
+=======
+>>>>>>> b668d5abb3 (chore: remove task dotEnv field)
+<<<<<<< HEAD
+=======
+>>>>>>> b668d5abb3 (chore: remove task dotEnv field)
 Run with --output-logs=hash-only
   $ ${TURBO} run test --output-logs=hash-only
   \xe2\x80\xa2 Running test (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-<<<<<<< HEAD
-  build: cache hit, suppressing logs e48ea8d453fe3216
-  test: cache hit, suppressing logs 92fa9e0daec0e1ec
-=======
-  build: cache hit, suppressing logs 21b3f16d0cd4a89c
-  test: cache hit, suppressing logs 23c168552034dd2f
->>>>>>> b668d5abb3 (chore: remove task dotEnv field)
+  build: cache hit, suppressing logs fbef1dba65f21ba4
+  test: cache hit, suppressing logs 75187c3aff97a0a8
   
    Tasks:    2 successful, 2 total
   Cached:    2 cached, 2 total
     Time:\s*[\.0-9]+m?s >>> FULL TURBO (re)
   
+<<<<<<< HEAD
+=======
+>>>>>>> b668d5abb3 (chore: remove task dotEnv field)
 Run with --output-logs=errors-only
   $ ${TURBO} run test --output-logs=errors-only
   \xe2\x80\xa2 Running test (esc)

--- a/turborepo-tests/integration/tests/run/single-package/with-deps-run.t
+++ b/turborepo-tests/integration/tests/run/single-package/with-deps-run.t
@@ -5,12 +5,20 @@ Check
   $ ${TURBO} run test
   \xe2\x80\xa2 Running test (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
+<<<<<<< HEAD
   build: cache miss, executing e48ea8d453fe3216
+=======
+  build: cache miss, executing 21b3f16d0cd4a89c
+>>>>>>> b668d5abb3 (chore: remove task dotEnv field)
   build: 
   build: > build
   build: > echo building > foo.txt
   build: 
+<<<<<<< HEAD
   test: cache miss, executing 92fa9e0daec0e1ec
+=======
+  test: cache miss, executing 23c168552034dd2f
+>>>>>>> b668d5abb3 (chore: remove task dotEnv field)
   test: 
   test: > test
   test: > cat foo.txt
@@ -25,12 +33,20 @@ Run a second time, verify caching works because there is a config
   $ ${TURBO} run test
   \xe2\x80\xa2 Running test (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
+<<<<<<< HEAD
   build: cache hit, replaying logs e48ea8d453fe3216
+=======
+  build: cache hit, replaying logs 21b3f16d0cd4a89c
+>>>>>>> b668d5abb3 (chore: remove task dotEnv field)
   build: 
   build: > build
   build: > echo building > foo.txt
   build: 
+<<<<<<< HEAD
   test: cache hit, replaying logs 92fa9e0daec0e1ec
+=======
+  test: cache hit, replaying logs 23c168552034dd2f
+>>>>>>> b668d5abb3 (chore: remove task dotEnv field)
   test: 
   test: > test
   test: > cat foo.txt
@@ -45,8 +61,13 @@ Run with --output-logs=hash-only
   $ ${TURBO} run test --output-logs=hash-only
   \xe2\x80\xa2 Running test (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
+<<<<<<< HEAD
   build: cache hit, suppressing logs e48ea8d453fe3216
   test: cache hit, suppressing logs 92fa9e0daec0e1ec
+=======
+  build: cache hit, suppressing logs 21b3f16d0cd4a89c
+  test: cache hit, suppressing logs 23c168552034dd2f
+>>>>>>> b668d5abb3 (chore: remove task dotEnv field)
   
    Tasks:    2 successful, 2 total
   Cached:    2 cached, 2 total

--- a/turborepo-tests/integration/tests/task-dependencies/overwriting.t
+++ b/turborepo-tests/integration/tests/task-dependencies/overwriting.t
@@ -11,7 +11,7 @@ Test
 
 # workspace-a#generate ran
   $ cat tmp.log | grep "workspace-a:generate"
-  workspace-a:generate: cache miss, executing b876a84c09681ba1
+  workspace-a:generate: cache miss, executing 8e1618d20f6303dc
   workspace-a:generate: 
   workspace-a:generate: > generate
   workspace-a:generate: > echo generate-workspace-a
@@ -19,7 +19,7 @@ Test
   workspace-a:generate: generate-workspace-a
 workspace-a#build ran
   $ cat tmp.log | grep "workspace-a:build"
-  workspace-a:build: cache miss, executing 264da930a689be4e
+  workspace-a:build: cache miss, executing 50df012517e672e6
   workspace-a:build: 
   workspace-a:build: > build
   workspace-a:build: > echo build-workspace-a
@@ -32,7 +32,7 @@ workspace-b#generate DID NOT run
 
 workspace-b#build ran
   $ cat tmp.log | grep "workspace-b:build"
-  workspace-b:build: cache miss, executing 36137fdec800ec2e
+  workspace-b:build: cache miss, executing a4ecaf3902039f0c
   workspace-b:build: 
   workspace-b:build: > build
   workspace-b:build: > echo build-workspace-b

--- a/turborepo-tests/integration/tests/task-dependencies/root-worksapce.t
+++ b/turborepo-tests/integration/tests/task-dependencies/root-worksapce.t
@@ -5,13 +5,13 @@ This tests asserts that root tasks can depend on workspace#task
   \xe2\x80\xa2 Packages in scope: //, lib-a (esc)
   \xe2\x80\xa2 Running mytask in 2 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  lib-a:build: cache miss, executing 5f3e63ff10e1a66a
+  lib-a:build: cache miss, executing cd724fed7c588f9d
   lib-a:build: 
   lib-a:build: > build
   lib-a:build: > echo build-lib-a
   lib-a:build: 
   lib-a:build: build-lib-a
-  //:mytask: cache miss, executing 43a7ee3e788e9884
+  //:mytask: cache miss, executing 4998aef8c3bccdea
   //:mytask: 
   //:mytask: > mytask
   //:mytask: > echo root-mytask

--- a/turborepo-tests/integration/tests/task-dependencies/topological.t
+++ b/turborepo-tests/integration/tests/task-dependencies/topological.t
@@ -6,13 +6,13 @@ Check my-app#build output
   \xe2\x80\xa2 Packages in scope: //, my-app, util (esc)
   \xe2\x80\xa2 Running build in 3 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  util:build: cache miss, executing d8a403c3594c01e7
+  util:build: cache miss, executing c6b545f723eb2015
   util:build: 
   util:build: > build
   util:build: > echo building
   util:build: 
   util:build: building
-  my-app:build: cache miss, executing 6f5a797f7b88130e
+  my-app:build: cache miss, executing b9d1448560566404
   my-app:build: 
   my-app:build: > build
   my-app:build: > echo building

--- a/turborepo-tests/integration/tests/workspace-configs/add-keys.t
+++ b/turborepo-tests/integration/tests/workspace-configs/add-keys.t
@@ -14,13 +14,13 @@ Setup
   \xe2\x80\xa2 Packages in scope: add-keys (esc)
   \xe2\x80\xa2 Running add-keys-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  add-keys:add-keys-underlying-task: cache miss, executing 3f949b336a7c0682
+  add-keys:add-keys-underlying-task: cache miss, executing 7b8d0e4150f525f1
   add-keys:add-keys-underlying-task: 
   add-keys:add-keys-underlying-task: > add-keys-underlying-task
   add-keys:add-keys-underlying-task: > echo running-add-keys-underlying-task
   add-keys:add-keys-underlying-task: 
   add-keys:add-keys-underlying-task: running-add-keys-underlying-task
-  add-keys:add-keys-task: cache miss, executing 2d68b2b4d0de7dff
+  add-keys:add-keys-task: cache miss, executing d67e79a3677e5e90
   add-keys:add-keys-task: 
   add-keys:add-keys-task: > add-keys-task
   add-keys:add-keys-task: > echo running-add-keys-task > out/foo.min.txt
@@ -42,13 +42,13 @@ Setup
   \xe2\x80\xa2 Packages in scope: add-keys (esc)
   \xe2\x80\xa2 Running add-keys-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  add-keys:add-keys-underlying-task: cache hit, replaying logs 3f949b336a7c0682
+  add-keys:add-keys-underlying-task: cache hit, replaying logs 7b8d0e4150f525f1
   add-keys:add-keys-underlying-task: 
   add-keys:add-keys-underlying-task: > add-keys-underlying-task
   add-keys:add-keys-underlying-task: > echo running-add-keys-underlying-task
   add-keys:add-keys-underlying-task: 
   add-keys:add-keys-underlying-task: running-add-keys-underlying-task
-  add-keys:add-keys-task: cache hit, suppressing logs 2d68b2b4d0de7dff
+  add-keys:add-keys-task: cache hit, suppressing logs d67e79a3677e5e90
   
    Tasks:    2 successful, 2 total
   Cached:    2 cached, 2 total
@@ -60,13 +60,13 @@ Setup
   \xe2\x80\xa2 Packages in scope: add-keys (esc)
   \xe2\x80\xa2 Running add-keys-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  add-keys:add-keys-underlying-task: cache miss, executing c898b461c762109e
+  add-keys:add-keys-underlying-task: cache miss, executing 4486bc731e70d399
   add-keys:add-keys-underlying-task: 
   add-keys:add-keys-underlying-task: > add-keys-underlying-task
   add-keys:add-keys-underlying-task: > echo running-add-keys-underlying-task
   add-keys:add-keys-underlying-task: 
   add-keys:add-keys-underlying-task: running-add-keys-underlying-task
-  add-keys:add-keys-task: cache miss, executing f6215c2d01b0a3d6
+  add-keys:add-keys-task: cache miss, executing a0611f6cbc16dae2
   add-keys:add-keys-task: 
   add-keys:add-keys-task: > add-keys-task
   add-keys:add-keys-task: > echo running-add-keys-task > out/foo.min.txt
@@ -81,13 +81,13 @@ Setup
   \xe2\x80\xa2 Packages in scope: add-keys (esc)
   \xe2\x80\xa2 Running add-keys-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  add-keys:add-keys-underlying-task: cache hit, replaying logs c898b461c762109e
+  add-keys:add-keys-underlying-task: cache hit, replaying logs 4486bc731e70d399
   add-keys:add-keys-underlying-task: 
   add-keys:add-keys-underlying-task: > add-keys-underlying-task
   add-keys:add-keys-underlying-task: > echo running-add-keys-underlying-task
   add-keys:add-keys-underlying-task: 
   add-keys:add-keys-underlying-task: running-add-keys-underlying-task
-  add-keys:add-keys-task: cache miss, executing bd4d6cef8c9e78be
+  add-keys:add-keys-task: cache miss, executing 4e213910a9f5424a
   add-keys:add-keys-task: 
   add-keys:add-keys-task: > add-keys-task
   add-keys:add-keys-task: > echo running-add-keys-task > out/foo.min.txt

--- a/turborepo-tests/integration/tests/workspace-configs/add-tasks.t
+++ b/turborepo-tests/integration/tests/workspace-configs/add-tasks.t
@@ -5,7 +5,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: add-tasks (esc)
   \xe2\x80\xa2 Running added-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  add-tasks:added-task: cache miss, executing 0c5330f15cf6887a
+  add-tasks:added-task: cache miss, executing d820864cd1c0cf4f
   add-tasks:added-task: 
   add-tasks:added-task: > added-task
   add-tasks:added-task: > echo running-added-task > out/foo.min.txt

--- a/turborepo-tests/integration/tests/workspace-configs/cache.t
+++ b/turborepo-tests/integration/tests/workspace-configs/cache.t
@@ -13,7 +13,7 @@ This test covers:
   \xe2\x80\xa2 Packages in scope: cached (esc)
   \xe2\x80\xa2 Running cached-task-1 in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  cached:cached-task-1: cache miss, executing afd2b0c00a8996af
+  cached:cached-task-1: cache miss, executing 21deabfcd122b4f1
   cached:cached-task-1: 
   cached:cached-task-1: > cached-task-1
   cached:cached-task-1: > echo cached-task-1 > out/foo.min.txt
@@ -38,7 +38,7 @@ This test covers:
   \xe2\x80\xa2 Packages in scope: cached (esc)
   \xe2\x80\xa2 Running cached-task-2 in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  cached:cached-task-2: cache bypass, force executing 6580d2dfa8add55b
+  cached:cached-task-2: cache bypass, force executing 16a7b4fae5625489
   cached:cached-task-2: 
   cached:cached-task-2: > cached-task-2
   cached:cached-task-2: > echo cached-task-2 > out/foo.min.txt
@@ -60,7 +60,7 @@ no `cache` config in root, cache:false in workspace
   \xe2\x80\xa2 Packages in scope: cached (esc)
   \xe2\x80\xa2 Running cached-task-3 in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  cached:cached-task-3: cache bypass, force executing 1df473e4a0ec177d
+  cached:cached-task-3: cache bypass, force executing c532469fc19ac3f9
   cached:cached-task-3: 
   cached:cached-task-3: > cached-task-3
   cached:cached-task-3: > echo cached-task-3 > out/foo.min.txt
@@ -84,7 +84,7 @@ we already have a workspace that doesn't have a config
   \xe2\x80\xa2 Packages in scope: missing-workspace-config (esc)
   \xe2\x80\xa2 Running cached-task-4 in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  missing-workspace-config:cached-task-4: cache bypass, force executing 0876b71b756eb6da
+  missing-workspace-config:cached-task-4: cache bypass, force executing 3ad36069ee49ca14
   missing-workspace-config:cached-task-4: 
   missing-workspace-config:cached-task-4: > cached-task-4
   missing-workspace-config:cached-task-4: > echo cached-task-4 > out/foo.min.txt

--- a/turborepo-tests/integration/tests/workspace-configs/config-change.t
+++ b/turborepo-tests/integration/tests/workspace-configs/config-change.t
@@ -3,13 +3,13 @@ Setup
 
 # 1. First run, check the hash
   $ ${TURBO} run config-change-task --filter=config-change --dry=json | jq .tasks[0].hash
-  "b795d055df35b872"
+  "e0471b5eddce1aab"
 
 2. Run again and assert task hash stays the same
   $ ${TURBO} run config-change-task --filter=config-change --dry=json | jq .tasks[0].hash
-  "b795d055df35b872"
+  "e0471b5eddce1aab"
 
 3. Change turbo.json and assert that hash changes
   $ cp $TARGET_DIR/apps/config-change/turbo-changed.json $TARGET_DIR/apps/config-change/turbo.json
   $ ${TURBO} run config-change-task --filter=config-change --dry=json | jq .tasks[0].hash
-  "5ab2f944ad74ef44"
+  "41e50d2dc738d0f8"

--- a/turborepo-tests/integration/tests/workspace-configs/cross-workspace.t
+++ b/turborepo-tests/integration/tests/workspace-configs/cross-workspace.t
@@ -4,13 +4,13 @@ Setup
   \xe2\x80\xa2 Packages in scope: cross-workspace (esc)
   \xe2\x80\xa2 Running cross-workspace-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  blank-pkg:cross-workspace-underlying-task: cache miss, executing 791d863fb4d9b806
+  blank-pkg:cross-workspace-underlying-task: cache miss, executing 6002174173495dbf
   blank-pkg:cross-workspace-underlying-task: 
   blank-pkg:cross-workspace-underlying-task: > cross-workspace-underlying-task
   blank-pkg:cross-workspace-underlying-task: > echo cross-workspace-underlying-task from blank-pkg
   blank-pkg:cross-workspace-underlying-task: 
   blank-pkg:cross-workspace-underlying-task: cross-workspace-underlying-task from blank-pkg
-  cross-workspace:cross-workspace-task: cache miss, executing a412d64fde39f2be
+  cross-workspace:cross-workspace-task: cache miss, executing 6dd8e4d2ceda14c4
   cross-workspace:cross-workspace-task: 
   cross-workspace:cross-workspace-task: > cross-workspace-task
   cross-workspace:cross-workspace-task: > echo cross-workspace-task

--- a/turborepo-tests/integration/tests/workspace-configs/missing-workspace-config-deps.t
+++ b/turborepo-tests/integration/tests/workspace-configs/missing-workspace-config-deps.t
@@ -15,14 +15,14 @@ Setup
   \xe2\x80\xa2 Remote caching disabled (esc)
 
   $ cat tmp.log | grep "missing-workspace-config:missing-workspace-config-task-with-deps"
-  missing-workspace-config:missing-workspace-config-task-with-deps: cache miss, executing c151f24ca66771e5
+  missing-workspace-config:missing-workspace-config-task-with-deps: cache miss, executing e3c2ce9dfb0e09f0
   missing-workspace-config:missing-workspace-config-task-with-deps: 
   missing-workspace-config:missing-workspace-config-task-with-deps: > missing-workspace-config-task-with-deps
   missing-workspace-config:missing-workspace-config-task-with-deps: > echo running-missing-workspace-config-task-with-deps > out/foo.min.txt
   missing-workspace-config:missing-workspace-config-task-with-deps: 
 
   $ cat tmp.log | grep "missing-workspace-config:missing-workspace-config-underlying-task"
-  missing-workspace-config:missing-workspace-config-underlying-task: cache miss, executing 26878c99d9f1f2ad
+  missing-workspace-config:missing-workspace-config-underlying-task: cache miss, executing 1bf9a4ec81009b46
   missing-workspace-config:missing-workspace-config-underlying-task: 
   missing-workspace-config:missing-workspace-config-underlying-task: > missing-workspace-config-underlying-task
   missing-workspace-config:missing-workspace-config-underlying-task: > echo running-missing-workspace-config-underlying-task
@@ -30,7 +30,7 @@ Setup
   missing-workspace-config:missing-workspace-config-underlying-task: running-missing-workspace-config-underlying-task
 
   $ cat tmp.log | grep "blank-pkg:missing-workspace-config-underlying-topo-task"
-  blank-pkg:missing-workspace-config-underlying-topo-task: cache miss, executing 360fb5a29b92db26
+  blank-pkg:missing-workspace-config-underlying-topo-task: cache miss, executing 47524700b306888a
   blank-pkg:missing-workspace-config-underlying-topo-task: 
   blank-pkg:missing-workspace-config-underlying-topo-task: > missing-workspace-config-underlying-topo-task
   blank-pkg:missing-workspace-config-underlying-topo-task: > echo missing-workspace-config-underlying-topo-task from blank-pkg

--- a/turborepo-tests/integration/tests/workspace-configs/missing-workspace-config.t
+++ b/turborepo-tests/integration/tests/workspace-configs/missing-workspace-config.t
@@ -11,7 +11,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: missing-workspace-config (esc)
   \xe2\x80\xa2 Running missing-workspace-config-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  missing-workspace-config:missing-workspace-config-task: cache miss, executing fa2b3189d6b42055
+  missing-workspace-config:missing-workspace-config-task: cache miss, executing be6ec3d0f0471849
   missing-workspace-config:missing-workspace-config-task: 
   missing-workspace-config:missing-workspace-config-task: > missing-workspace-config-task
   missing-workspace-config:missing-workspace-config-task: > echo running-missing-workspace-config-task > out/foo.min.txt
@@ -33,7 +33,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: missing-workspace-config (esc)
   \xe2\x80\xa2 Running missing-workspace-config-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  missing-workspace-config:missing-workspace-config-task: cache hit, suppressing logs fa2b3189d6b42055
+  missing-workspace-config:missing-workspace-config-task: cache hit, suppressing logs be6ec3d0f0471849
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total
@@ -45,7 +45,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: missing-workspace-config (esc)
   \xe2\x80\xa2 Running missing-workspace-config-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  missing-workspace-config:missing-workspace-config-task: cache miss, executing 2fcb67955fb2c7b7
+  missing-workspace-config:missing-workspace-config-task: cache miss, executing b39bb84af921847c
   missing-workspace-config:missing-workspace-config-task: 
   missing-workspace-config:missing-workspace-config-task: > missing-workspace-config-task
   missing-workspace-config:missing-workspace-config-task: > echo running-missing-workspace-config-task > out/foo.min.txt
@@ -62,7 +62,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: missing-workspace-config (esc)
   \xe2\x80\xa2 Running missing-workspace-config-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  missing-workspace-config:missing-workspace-config-task: cache hit, suppressing logs 2fcb67955fb2c7b7
+  missing-workspace-config:missing-workspace-config-task: cache hit, suppressing logs b39bb84af921847c
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total
@@ -73,7 +73,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: missing-workspace-config (esc)
   \xe2\x80\xa2 Running missing-workspace-config-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  missing-workspace-config:missing-workspace-config-task: cache miss, executing 3ad30dba93a44cfc
+  missing-workspace-config:missing-workspace-config-task: cache miss, executing 4f8cbf0317430e42
   missing-workspace-config:missing-workspace-config-task: 
   missing-workspace-config:missing-workspace-config-task: > missing-workspace-config-task
   missing-workspace-config:missing-workspace-config-task: > echo running-missing-workspace-config-task > out/foo.min.txt
@@ -89,7 +89,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: missing-workspace-config (esc)
   \xe2\x80\xa2 Running cached-task-4 in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  missing-workspace-config:cached-task-4: cache bypass, force executing a3402b79e54983c6
+  missing-workspace-config:cached-task-4: cache bypass, force executing c33b6bab007f82f7
   missing-workspace-config:cached-task-4: 
   missing-workspace-config:cached-task-4: > cached-task-4
   missing-workspace-config:cached-task-4: > echo cached-task-4 > out/foo.min.txt

--- a/turborepo-tests/integration/tests/workspace-configs/omit-keys-deps.t
+++ b/turborepo-tests/integration/tests/workspace-configs/omit-keys-deps.t
@@ -15,14 +15,14 @@ Setup
   \xe2\x80\xa2 Running omit-keys-task-with-deps in 1 packages (esc)
 
   $ cat tmp.log | grep "omit-keys:omit-keys-task-with-deps"
-  omit-keys:omit-keys-task-with-deps: cache miss, executing f25fd75100c8bbc8
+  omit-keys:omit-keys-task-with-deps: cache miss, executing ba0de8c23e1f20f2
   omit-keys:omit-keys-task-with-deps: 
   omit-keys:omit-keys-task-with-deps: > omit-keys-task-with-deps
   omit-keys:omit-keys-task-with-deps: > echo running-omit-keys-task-with-deps > out/foo.min.txt
   omit-keys:omit-keys-task-with-deps: 
 
   $ cat tmp.log | grep "omit-keys:omit-keys-underlying-task"
-  omit-keys:omit-keys-underlying-task: cache miss, executing 43511d15677eaa27
+  omit-keys:omit-keys-underlying-task: cache miss, executing 885430a20f708165
   omit-keys:omit-keys-underlying-task: 
   omit-keys:omit-keys-underlying-task: > omit-keys-underlying-task
   omit-keys:omit-keys-underlying-task: > echo running-omit-keys-underlying-task
@@ -30,7 +30,7 @@ Setup
   omit-keys:omit-keys-underlying-task: running-omit-keys-underlying-task
 
   $ cat tmp.log | grep "blank-pkg:omit-keys-underlying-topo-task"
-  blank-pkg:omit-keys-underlying-topo-task: cache miss, executing e9fad778a6d981e0
+  blank-pkg:omit-keys-underlying-topo-task: cache miss, executing 1e075d887938cdcb
   blank-pkg:omit-keys-underlying-topo-task: 
   blank-pkg:omit-keys-underlying-topo-task: > omit-keys-underlying-topo-task
   blank-pkg:omit-keys-underlying-topo-task: > echo omit-keys-underlying-topo-task from blank-pkg

--- a/turborepo-tests/integration/tests/workspace-configs/omit-keys.t
+++ b/turborepo-tests/integration/tests/workspace-configs/omit-keys.t
@@ -14,7 +14,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: omit-keys (esc)
   \xe2\x80\xa2 Running omit-keys-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  omit-keys:omit-keys-task: cache miss, executing c2b676fcb84b4e03
+  omit-keys:omit-keys-task: cache miss, executing 28d0677a62c0aa7a
   omit-keys:omit-keys-task: 
   omit-keys:omit-keys-task: > omit-keys-task
   omit-keys:omit-keys-task: > echo running-omit-keys-task > out/foo.min.txt
@@ -36,7 +36,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: omit-keys (esc)
   \xe2\x80\xa2 Running omit-keys-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  omit-keys:omit-keys-task: cache hit, suppressing logs c2b676fcb84b4e03
+  omit-keys:omit-keys-task: cache hit, suppressing logs 28d0677a62c0aa7a
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total
@@ -48,7 +48,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: omit-keys (esc)
   \xe2\x80\xa2 Running omit-keys-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  omit-keys:omit-keys-task: cache miss, executing 8b89b146ef1ffbf0
+  omit-keys:omit-keys-task: cache miss, executing c3e410b01cce8dd2
   omit-keys:omit-keys-task: 
   omit-keys:omit-keys-task: > omit-keys-task
   omit-keys:omit-keys-task: > echo running-omit-keys-task > out/foo.min.txt
@@ -65,7 +65,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: omit-keys (esc)
   \xe2\x80\xa2 Running omit-keys-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  omit-keys:omit-keys-task: cache hit, suppressing logs 8b89b146ef1ffbf0
+  omit-keys:omit-keys-task: cache hit, suppressing logs c3e410b01cce8dd2
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total
@@ -76,7 +76,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: omit-keys (esc)
   \xe2\x80\xa2 Running omit-keys-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  omit-keys:omit-keys-task: cache miss, executing 4dfc7e5dc9674f95
+  omit-keys:omit-keys-task: cache miss, executing 382ecc9fe3be2294
   omit-keys:omit-keys-task: 
   omit-keys:omit-keys-task: > omit-keys-task
   omit-keys:omit-keys-task: > echo running-omit-keys-task > out/foo.min.txt

--- a/turborepo-tests/integration/tests/workspace-configs/override-values-deps.t
+++ b/turborepo-tests/integration/tests/workspace-configs/override-values-deps.t
@@ -12,7 +12,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: override-values (esc)
   \xe2\x80\xa2 Running override-values-task-with-deps in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  override-values:override-values-task-with-deps: cache miss, executing c3c6987056362501
+  override-values:override-values-task-with-deps: cache miss, executing 81fe3129c1a9147c
   override-values:override-values-task-with-deps: 
   override-values:override-values-task-with-deps: > override-values-task-with-deps
   override-values:override-values-task-with-deps: > echo running-override-values-task-with-deps > out/foo.min.txt
@@ -34,7 +34,6 @@ Setup
     "persistent": false,
     "env": [],
     "passThroughEnv": null,
-    "dotEnv": null,
     "interactive": false
   }
 
@@ -50,6 +49,5 @@ Setup
     "persistent": false,
     "env": [],
     "passThroughEnv": null,
-    "dotEnv": null,
     "interactive": false
   }

--- a/turborepo-tests/integration/tests/workspace-configs/override-values.t
+++ b/turborepo-tests/integration/tests/workspace-configs/override-values.t
@@ -11,7 +11,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: override-values (esc)
   \xe2\x80\xa2 Running override-values-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  override-values:override-values-task: cache miss, executing b56cb877f87bf1f9
+  override-values:override-values-task: cache miss, executing 6c14afaa74bffc4a
   override-values:override-values-task: 
   override-values:override-values-task: > override-values-task
   override-values:override-values-task: > echo running-override-values-task > lib/bar.min.txt
@@ -33,7 +33,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: override-values (esc)
   \xe2\x80\xa2 Running override-values-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  override-values:override-values-task: cache hit, replaying logs b56cb877f87bf1f9
+  override-values:override-values-task: cache hit, replaying logs 6c14afaa74bffc4a
   override-values:override-values-task: 
   override-values:override-values-task: > override-values-task
   override-values:override-values-task: > echo running-override-values-task > lib/bar.min.txt
@@ -49,7 +49,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: override-values (esc)
   \xe2\x80\xa2 Running override-values-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  override-values:override-values-task: cache miss, executing 4ac0e68522256f92
+  override-values:override-values-task: cache miss, executing 044ce2c43ae740f8
   override-values:override-values-task: 
   override-values:override-values-task: > override-values-task
   override-values:override-values-task: > echo running-override-values-task > lib/bar.min.txt
@@ -65,7 +65,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: override-values (esc)
   \xe2\x80\xa2 Running override-values-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  override-values:override-values-task: cache hit, replaying logs 4ac0e68522256f92
+  override-values:override-values-task: cache hit, replaying logs 044ce2c43ae740f8
   override-values:override-values-task: 
   override-values:override-values-task: > override-values-task
   override-values:override-values-task: > echo running-override-values-task > lib/bar.min.txt
@@ -80,7 +80,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: override-values (esc)
   \xe2\x80\xa2 Running override-values-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  override-values:override-values-task: cache miss, executing 40bcc05a158ee40d
+  override-values:override-values-task: cache miss, executing 961e6285b43ebb88
   override-values:override-values-task: 
   override-values:override-values-task: > override-values-task
   override-values:override-values-task: > echo running-override-values-task > lib/bar.min.txt
@@ -95,7 +95,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: override-values (esc)
   \xe2\x80\xa2 Running override-values-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  override-values:override-values-task: cache hit, replaying logs 40bcc05a158ee40d
+  override-values:override-values-task: cache hit, replaying logs 961e6285b43ebb88
   override-values:override-values-task: 
   override-values:override-values-task: > override-values-task
   override-values:override-values-task: > echo running-override-values-task > lib/bar.min.txt

--- a/turborepo-tests/integration/tests/workspace-configs/persistent.t
+++ b/turborepo-tests/integration/tests/workspace-configs/persistent.t
@@ -30,13 +30,13 @@ This test covers:
   \xe2\x80\xa2 Packages in scope: persistent (esc)
   \xe2\x80\xa2 Running persistent-task-2-parent in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  persistent:persistent-task-2: cache miss, executing 051e4c844cef1000
+  persistent:persistent-task-2: cache miss, executing 0053dfd3e40fd7e9
   persistent:persistent-task-2: 
   persistent:persistent-task-2: > persistent-task-2
   persistent:persistent-task-2: > echo persistent-task-2
   persistent:persistent-task-2: 
   persistent:persistent-task-2: persistent-task-2
-  persistent:persistent-task-2-parent: cache miss, executing 938a86455b404310
+  persistent:persistent-task-2-parent: cache miss, executing d91647fc86c1a419
   persistent:persistent-task-2-parent: 
   persistent:persistent-task-2-parent: > persistent-task-2-parent
   persistent:persistent-task-2-parent: > echo persistent-task-2-parent


### PR DESCRIPTION
### Description

This PR removes `globalDotEnv`/`dotEnv` in favor of `globalDependencies` and `inputs` which is now fairly ergonomic to use with the addition of `$TURBO_DEFAULTS$`.

This PR does *not* update the corresponding JS types.

### Testing Instructions

Updated existing integration tests
