### PR TITLE
[DO NOT MERGE] feat(codemod): change migrate behavior for majors

### DIFF
--- a/packages/turbo-codemod/src/commands/migrate/index.ts
+++ b/packages/turbo-codemod/src/commands/migrate/index.ts
@@ -111,7 +111,7 @@ export async function migrate(
   }
 
   // step 1
-  const fromVersion = getCurrentVersion(project, options);
+  let fromVersion = getCurrentVersion(project, options);
   if (!fromVersion) {
     return endMigration({
       success: false,
@@ -148,6 +148,12 @@ export async function migrate(
         fromVersion
       )}) is the same as the requested version (${chalk.bold(toVersion)})`,
     });
+  }
+
+  // if migrating "from" to "to" spans a major, floor "from" to ensure all required codemods are run
+  const fromMajor = fromVersion.split(".")[0];
+  if (fromMajor !== toVersion.split(".")[0]) {
+    fromVersion = `${fromMajor}.0.0`;
   }
 
   // step 3


### PR DESCRIPTION
Do not merge yet - we need to make sure that codemods that are _not_ idempotent are handled correctly. I think the only one that isn't is the default outputs code mod, so we need to identify if we need to run it. 

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
Remove legacy filter flags now that they've been deprecated for quite
awhile.

Existing test suite passes. Updated tests that are still applicable and
removed those that aren't.