### PR TITLE
add MPL-2.0-no-copyleft-exception to the allow list

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -10,6 +10,11 @@ allow = [
   "MIT",
   "MIT-0",
   "MPL-2.0",
+  # this requires that we do not redistribute / relicense the code under
+  # one of the MPL secondary licences, which we do not do. this does not
+  # prevent use from licensing the 'larger work' (code that uses this lib)
+  # under a different license.
+  "MPL-2.0-no-copyleft-exception",
   # enum-iterator*
   "0BSD",
   # base16, notify


### PR DESCRIPTION
### Description

In this PR https://github.com/vercel/turbo/pull/8174 the library prehash is licensed using MPL2.0 (great) but without the copyleft exception.

I believe that we are OK. From what I understand this prevents us from making and redistributing changes to this library under one of the MPL secondary licenses ("Secondary License" means either the GNU General Public License, Version 2.0, the GNU Lesser General Public License, Version 2.1, the GNU Affero General Public License, Version 3.0, or any later versions of those licenses).

It does not exclude us from using that library in a 'larger work' that is licensed using a different (compatible) license so for the purpose of distributing a binary it is the same as MPL-2.0

### Testing Instructions

N/A
