### PR TITLE
chore: pin global turbo to 1.x release

### DIFF
--- a/.github/actions/install-global-turbo/action.yml
+++ b/.github/actions/install-global-turbo/action.yml
@@ -6,7 +6,8 @@ runs:
   steps:
     - name: Install Turbo globally
       shell: bash
+      # Until we are migrate ourselves to 2.0 we pin to the latest 1.x release
       run: |
         VERSION=$(npm view turbo --json | jq -r '.versions | last')
         echo "Latest published version: $VERSION"
-        npm i -g turbo@$VERSION
+        npm i -g turbo@1.13.4-canary.5


### PR DESCRIPTION
### Description

Just so we don't accidentally break all of our workflows when we cut a 2.0 canary we should pin ourselves to the latest 1.x release.

Once a 2.0 canary is released we will migrate ourselves and unpin the version.

### Testing Instructions

CI
