### PR TITLE
Update getting started docs to disambiguate gitignore pattern

### DIFF
--- a/docs/pages/repo/docs/getting-started/add-to-project.mdx
+++ b/docs/pages/repo/docs/getting-started/add-to-project.mdx
@@ -96,8 +96,8 @@ This means that Turbo can schedule them separately.
 
 Add `.turbo` to your `.gitignore` file. The CLI uses these folders for logs and certain task outputs.
 
-```diff
-+ .turbo
+```sh
+.turbo
 ```
 
 4. **Run the `type-check` and `build` tasks with `turbo`:**

--- a/docs/pages/repo/docs/getting-started/existing-monorepo.mdx
+++ b/docs/pages/repo/docs/getting-started/existing-monorepo.mdx
@@ -151,16 +151,16 @@ npx turbo run deploy
 
 Add `.turbo` to your `.gitignore` file. The CLI uses these folders for logs and certain task outputs.
 
-```diff
-+ .turbo
+```sh
+.turbo
 ```
 
 Make sure that your task artifacts, the files and folders you want cached, are also included in your `.gitignore`.
 
-```diff
-+ build/**
-+ dist/**
-+ .next/**
+```sh
+build/**
+dist/**
+.next/**
 ```
 
 Re-run your npm client's `install` command to check your configuration.


### PR DESCRIPTION
### Description

Update getting started docs to disambiguate gitignore pattern. The existing docs leads you to believe that the glob pattern is `+ .turbo` which *includes* turbo files in your git commits, instead of `.turbo`, which hides them. Removed the `+` to remove this ambiguity. In the Docs UI it isn't obvious that what was shown was a "diff", and that the `+` wasn't part of the pattern, this should remove any doubt as to the intention.

### Testing Instructions

N/A