### PR TITLE
chore: remove --ignore flag

### DIFF
--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -685,13 +685,6 @@ pub struct ExecutionArgs {
     #[clap(short = 'F', long, group = "scope-filter-group")]
     pub filter: Vec<String>,
 
-    //  ignore filters out files from scope and filter, so we require it here
-    // -----------------------
-    /// Files to ignore when calculating changed files from '--filter'.
-    /// Supports globs.
-    #[clap(long, requires = "scope-filter-group")]
-    pub ignore: Vec<String>,
-
     /// Set type of process output logging. Use "full" to show
     /// all output. Use "hash-only" to show only turbo-computed
     /// task hashes. Use "new-only" to show only new output with
@@ -775,10 +768,6 @@ impl ExecutionArgs {
         // track sizes
         if !self.filter.is_empty() {
             telemetry.track_arg_value("filter:length", self.filter.len(), EventType::NonSensitive);
-        }
-
-        if !self.ignore.is_empty() {
-            telemetry.track_arg_value("ignore:length", self.ignore.len(), EventType::NonSensitive);
         }
     }
 }
@@ -1755,38 +1744,6 @@ mod test {
         "graph with output"
 	)]
     #[test_case::test_case(
-		&["turbo", "run", "build", "--filter", "[main]", "--ignore", "foo.js"],
-        Args {
-            command: Some(Command::Run {
-                execution_args: Box::new(ExecutionArgs {
-                    tasks: vec!["build".to_string()],
-                    ignore: vec!["foo.js".to_string()],
-                    filter: vec![String::from("[main]")],
-                    ..get_default_execution_args()
-                }),
-                run_args: Box::new(get_default_run_args())
-            }),
-            ..Args::default()
-        } ;
-        "single ignore"
-	)]
-    #[test_case::test_case(
-		&["turbo", "run", "build", "--filter", "[main]", "--ignore", "foo.js", "--ignore", "bar.js"],
-        Args {
-            command: Some(Command::Run {
-                execution_args: Box::new(ExecutionArgs {
-                    tasks: vec!["build".to_string()],
-                    ignore: vec!["foo.js".to_string(), "bar.js".to_string()],
-                    filter: vec![String::from("[main]")],
-                    ..get_default_execution_args()
-                }),
-                run_args: Box::new(get_default_run_args())
-            }),
-            ..Args::default()
-        } ;
-        "multiple ignores"
-	)]
-    #[test_case::test_case(
 		&["turbo", "run", "build", "--no-cache"],
         Args {
             command: Some(Command::Run {
@@ -2144,11 +2101,6 @@ mod test {
         &["turbo", "run", "build", "--daemon", "--no-daemon"],
         "cannot be used with '--no-daemon'" ;
         "daemon and no-daemon at the same time"
-    )]
-    #[test_case::test_case(
-        &["turbo", "run", "build", "--ignore", "foo/**"],
-        "the following required arguments were not provided" ;
-        "ignore without filter or scope"
     )]
     #[test_case::test_case(
         &["turbo", "run", "build", "--since", "foo"],

--- a/crates/turborepo-lib/src/opts.rs
+++ b/crates/turborepo-lib/src/opts.rs
@@ -286,7 +286,6 @@ pub struct ScopeOpts {
     pub pkg_inference_root: Option<AnchoredSystemPathBuf>,
     pub global_deps: Vec<String>,
     pub filter_patterns: Vec<String>,
-    pub ignore_patterns: Vec<String>,
 }
 
 impl<'a> TryFrom<RunAndExecutionArgs<'a>> for ScopeOpts {
@@ -304,7 +303,6 @@ impl<'a> TryFrom<RunAndExecutionArgs<'a>> for ScopeOpts {
             global_deps: args.execution_args.global_deps.clone(),
             pkg_inference_root,
             filter_patterns: args.execution_args.filter.clone(),
-            ignore_patterns: args.execution_args.ignore.clone(),
         })
     }
 }
@@ -444,7 +442,6 @@ mod test {
             pkg_inference_root: None,
             global_deps: vec![],
             filter_patterns: opts_input.filter_patterns,
-            ignore_patterns: vec![],
         };
         let opts = Opts {
             run_opts,

--- a/crates/turborepo-lib/src/run/scope/filter.rs
+++ b/crates/turborepo-lib/src/run/scope/filter.rs
@@ -124,13 +124,8 @@ impl<'a> FilterResolver<'a, ScopeChangeDetector<'a>> {
             .map(|s| s.as_str())
             .chain(root_turbo_json.global_deps.iter().map(|s| s.as_str()));
 
-        let change_detector = ScopeChangeDetector::new(
-            turbo_root,
-            scm,
-            pkg_graph,
-            global_deps,
-            opts.ignore_patterns.clone(),
-        )?;
+        let change_detector =
+            ScopeChangeDetector::new(turbo_root, scm, pkg_graph, global_deps, vec![])?;
 
         Ok(Self::new_with_change_detector(
             pkg_graph,

--- a/turborepo-tests/integration/tests/conflicting-flags.t
+++ b/turborepo-tests/integration/tests/conflicting-flags.t
@@ -8,13 +8,3 @@ Setup
   For more information, try '--help'.
   
   [1]
-
-  $ ${TURBO} run build --ignore 'app/**'
-   ERROR  the following required arguments were not provided:
-    <--filter <FILTER>>
-  
-  Usage: turbo(\.exe)? run --ignore <IGNORE> <--filter <FILTER>> (re)
-  
-  For more information, try '--help'.
-  
-  [1]

--- a/turborepo-tests/integration/tests/no-args.t
+++ b/turborepo-tests/integration/tests/no-args.t
@@ -80,8 +80,6 @@ Make sure exit code is 2 when no args are passed
             Environment variable mode. Use "loose" to pass the entire existing environment. Use "strict" to use an allowlist specified in turbo.json [default: strict] [possible values: loose, strict]
     -F, --filter <FILTER>
             Use the given selector to specify package(s) to act as entry points. The syntax mirrors pnpm's syntax, and additional documentation and examples can be found in turbo's documentation https://turbo.build/repo/docs/reference/command-line-reference/run#--filter
-        --ignore <IGNORE>
-            Files to ignore when calculating changed files from '--filter'. Supports globs
         --output-logs <OUTPUT_LOGS>
             Set type of process output logging. Use "full" to show all output. Use "hash-only" to show only turbo-computed task hashes. Use "new-only" to show only new output with only hashes for cached tasks. Use "none" to hide process output. (default full) [possible values: full, none, hash-only, new-only, errors-only]
         --log-order <LOG_ORDER>

--- a/turborepo-tests/integration/tests/turbo-help.t
+++ b/turborepo-tests/integration/tests/turbo-help.t
@@ -80,8 +80,6 @@ Test help flag
             Environment variable mode. Use "loose" to pass the entire existing environment. Use "strict" to use an allowlist specified in turbo.json [default: strict] [possible values: loose, strict]
     -F, --filter <FILTER>
             Use the given selector to specify package(s) to act as entry points. The syntax mirrors pnpm's syntax, and additional documentation and examples can be found in turbo's documentation https://turbo.build/repo/docs/reference/command-line-reference/run#--filter
-        --ignore <IGNORE>
-            Files to ignore when calculating changed files from '--filter'. Supports globs
         --output-logs <OUTPUT_LOGS>
             Set type of process output logging. Use "full" to show all output. Use "hash-only" to show only turbo-computed task hashes. Use "new-only" to show only new output with only hashes for cached tasks. Use "none" to hide process output. (default full) [possible values: full, none, hash-only, new-only, errors-only]
         --log-order <LOG_ORDER>
@@ -176,8 +174,6 @@ Test help flag
             Environment variable mode. Use "loose" to pass the entire existing environment. Use "strict" to use an allowlist specified in turbo.json [default: strict] [possible values: loose, strict]
     -F, --filter <FILTER>
             Use the given selector to specify package(s) to act as entry points. The syntax mirrors pnpm's syntax, and additional documentation and examples can be found in turbo's documentation https://turbo.build/repo/docs/reference/command-line-reference/run#--filter
-        --ignore <IGNORE>
-            Files to ignore when calculating changed files from '--filter'. Supports globs
         --output-logs <OUTPUT_LOGS>
             Set type of process output logging. Use "full" to show all output. Use "hash-only" to show only turbo-computed task hashes. Use "new-only" to show only new output with only hashes for cached tasks. Use "none" to hide process output. (default full) [possible values: full, none, hash-only, new-only, errors-only]
         --log-order <LOG_ORDER>


### PR DESCRIPTION
### Description

Removes the `--ignore` flag as it's interaction with other `--filter` flags is hard to explain.

If we want to bring it back, then it should be put it into a configuration file.

I removed the command line flag and how it feeds into the package filtering, but left the underlying implementation of change detector as-is. This should make it easy to bring back this behavior via a configuration file.

### Testing Instructions

Existing tests
