### PR TITLE
feat: all dependencies of root package contribute to global hash

### DIFF
--- a/crates/turborepo-lib/src/hash/mod.rs
+++ b/crates/turborepo-lib/src/hash/mod.rs
@@ -64,8 +64,9 @@ pub struct TaskHashable<'a> {
 pub struct GlobalHashable<'a> {
     pub global_cache_key: &'static str,
     pub global_file_hash_map: &'a HashMap<turbopath::RelativeUnixPathBuf, String>,
-    // This is None in single package mode
+    // These are None in single package mode
     pub root_external_dependencies_hash: Option<&'a str>,
+    pub root_internal_dependencies_hash: Option<&'a str>,
     pub env: &'a [String],
     pub resolved_env_vars: EnvironmentVariablePairs,
     pub pass_through_env: &'a [String],
@@ -306,6 +307,10 @@ impl From<GlobalHashable<'_>> for Builder<HeapAllocator> {
             builder.set_root_external_deps_hash(root_external_dependencies_hash);
         }
 
+        if let Some(root_internal_dependencies_hash) = hashable.root_internal_dependencies_hash {
+            builder.set_root_internal_deps_hash(root_internal_dependencies_hash);
+        }
+
         {
             let mut entries = builder.reborrow().init_env(hashable.env.len() as u32);
             for (i, env) in hashable.env.iter().enumerate() {
@@ -401,6 +406,7 @@ mod test {
             global_cache_key: "global_cache_key",
             global_file_hash_map: &global_file_hash_map,
             root_external_dependencies_hash: Some("0000000000000000"),
+            root_internal_dependencies_hash: Some("0000000000000001"),
             env: &["env".to_string()],
             resolved_env_vars: vec![],
             pass_through_env: &["pass_through_env".to_string()],
@@ -408,7 +414,7 @@ mod test {
             framework_inference: true,
         };
 
-        assert_eq!(global_hash.hash(), "9f06917065be0a72");
+        assert_eq!(global_hash.hash(), "8d5ecbdc3ff2b3f2");
     }
 
     #[test_case(vec![], "459c029558afe716" ; "empty")]

--- a/crates/turborepo-lib/src/hash/proto.capnp
+++ b/crates/turborepo-lib/src/hash/proto.capnp
@@ -19,7 +19,6 @@ struct TaskHashable {
     resolvedEnvVars @9 :List(Text);
     passThruEnv @10 :List(Text);
     envMode @11 :EnvMode;
-    dotEnv @12 :List(Text);
 
     enum EnvMode {
       loose @0;
@@ -36,11 +35,12 @@ struct GlobalHashable {
   globalCacheKey @0 :Text;
   globalFileHashMap @1 :List(Entry);
   rootExternalDepsHash @2 :Text;
-  env @3 :List(Text);
-  resolvedEnvVars @4 :List(Text);
-  passThroughEnv @5 :List(Text);
-  envMode @6 :EnvMode;
-  frameworkInference @7 :Bool;
+  rootInternalDepsHash @3 :Text;
+  env @4 :List(Text);
+  resolvedEnvVars @5 :List(Text);
+  passThroughEnv @6 :List(Text);
+  envMode @7 :EnvMode;
+  frameworkInference @8 :Bool;
 
 
   enum EnvMode {

--- a/crates/turborepo-lib/src/run/global_hash.rs
+++ b/crates/turborepo-lib/src/run/global_hash.rs
@@ -41,8 +41,9 @@ pub enum Error {
 pub struct GlobalHashableInputs<'a> {
     pub global_cache_key: &'static str,
     pub global_file_hash_map: HashMap<RelativeUnixPathBuf, String>,
-    // This is `None` in single package mode
+    // These are `None` in single package mode
     pub root_external_dependencies_hash: Option<&'a str>,
+    pub root_internal_dependencies_hash: Option<&'a str>,
     pub env: &'a [String],
     // Only Option to allow #[derive(Default)]
     pub resolved_env_vars: Option<DetailedMap>,
@@ -55,6 +56,7 @@ pub struct GlobalHashableInputs<'a> {
 #[allow(clippy::too_many_arguments)]
 pub fn get_global_hash_inputs<'a, L: ?Sized + Lockfile>(
     root_external_dependencies_hash: Option<&'a str>,
+    root_internal_dependencies_hash: Option<&'a str>,
     root_path: &AbsoluteSystemPath,
     package_manager: &PackageManager,
     lockfile: Option<&L>,
@@ -101,6 +103,7 @@ pub fn get_global_hash_inputs<'a, L: ?Sized + Lockfile>(
         global_cache_key: GLOBAL_CACHE_KEY,
         global_file_hash_map,
         root_external_dependencies_hash,
+        root_internal_dependencies_hash,
         env: global_env,
         resolved_env_vars: Some(global_hashable_env_vars),
         pass_through_env: global_pass_through_env,
@@ -176,6 +179,7 @@ impl<'a> GlobalHashableInputs<'a> {
             global_cache_key: self.global_cache_key,
             global_file_hash_map: &self.global_file_hash_map,
             root_external_dependencies_hash: self.root_external_dependencies_hash,
+            root_internal_dependencies_hash: self.root_internal_dependencies_hash,
             env: self.env,
             resolved_env_vars: self
                 .resolved_env_vars
@@ -224,6 +228,7 @@ mod tests {
         #[cfg(not(windows))]
         let file_deps = ["/some/path".to_string()];
         let result = get_global_hash_inputs(
+            None,
             None,
             &root,
             &PackageManager::Pnpm,

--- a/crates/turborepo-lib/src/run/summary/global_hash.rs
+++ b/crates/turborepo-lib/src/run/summary/global_hash.rs
@@ -43,6 +43,7 @@ impl<'a> TryFrom<GlobalHashableInputs<'a>> for GlobalHashSummary<'a> {
             global_cache_key,
             global_file_hash_map,
             root_external_dependencies_hash,
+            root_internal_dependencies_hash,
             env,
             resolved_env_vars,
             pass_through_env,

--- a/crates/turborepo-lib/src/run/summary/global_hash.rs
+++ b/crates/turborepo-lib/src/run/summary/global_hash.rs
@@ -31,6 +31,7 @@ pub struct GlobalHashSummary<'a> {
     pub root_key: &'static str,
     pub files: BTreeMap<RelativeUnixPathBuf, String>,
     pub hash_of_external_dependencies: &'a str,
+    pub hash_of_internal_dependencies: &'a str,
     pub environment_variables: GlobalEnvVarSummary<'a>,
 }
 
@@ -65,6 +66,7 @@ impl<'a> TryFrom<GlobalHashableInputs<'a>> for GlobalHashSummary<'a> {
             files: global_file_hash_map.into_iter().collect(),
             // This can be empty in single package mode
             hash_of_external_dependencies: root_external_dependencies_hash.unwrap_or_default(),
+            hash_of_internal_dependencies: root_internal_dependencies_hash.unwrap_or_default(),
             environment_variables: GlobalEnvVarSummary {
                 specified: GlobalEnvConfiguration {
                     env,

--- a/crates/turborepo-lib/src/task_hash.rs
+++ b/crates/turborepo-lib/src/task_hash.rs
@@ -513,6 +513,30 @@ pub fn get_external_deps_hash(
     LockFilePackages(transitive_deps).hash()
 }
 
+pub fn get_internal_deps_hash(
+    scm: &SCM,
+    root: &AbsoluteSystemPath,
+    package_dirs: HashSet<&AnchoredSystemPath>,
+) -> Result<String, Error> {
+    if package_dirs.is_empty() {
+        return Ok("".into());
+    }
+
+    let file_hashes = package_dirs
+        .into_par_iter()
+        .map(|package_dir| scm.get_package_file_hashes::<&str>(root, package_dir, &[], None))
+        .reduce(
+            || Ok(HashMap::new()),
+            |acc, hashes| {
+                let mut acc = acc?;
+                let hashes = hashes?;
+                acc.extend(hashes.into_iter());
+                Ok(acc)
+            },
+        )?;
+    Ok(FileHashes(file_hashes).hash())
+}
+
 impl TaskHashTracker {
     pub fn new(input_expanded_hashes: HashMap<TaskId<'static>, FileHashes>) -> Self {
         Self {

--- a/turborepo-tests/integration/fixtures/root_deps/.gitignore
+++ b/turborepo-tests/integration/fixtures/root_deps/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.turbo
+.npmrc
+dist

--- a/turborepo-tests/integration/fixtures/root_deps/apps/my-app/package.json
+++ b/turborepo-tests/integration/fixtures/root_deps/apps/my-app/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "my-app",
+  "scripts": {
+    "build": "echo building"
+  },
+  "dependencies": {
+    "util": "*"
+  }
+}

--- a/turborepo-tests/integration/fixtures/root_deps/package.json
+++ b/turborepo-tests/integration/fixtures/root_deps/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "monorepo",
+  "workspaces": [
+    "apps/**",
+    "packages/**"
+  ],
+  "dependencies": {
+    "util": "*"
+  }
+}

--- a/turborepo-tests/integration/fixtures/root_deps/packages/another/package.json
+++ b/turborepo-tests/integration/fixtures/root_deps/packages/another/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "another",
+  "scripts": {
+    "build": "echo building"
+  }
+}

--- a/turborepo-tests/integration/fixtures/root_deps/packages/util/package.json
+++ b/turborepo-tests/integration/fixtures/root_deps/packages/util/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "util",
+  "scripts": {
+    "build": "echo building"
+  }
+}

--- a/turborepo-tests/integration/fixtures/root_deps/turbo.json
+++ b/turborepo-tests/integration/fixtures/root_deps/turbo.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "globalDependencies": ["foo.txt"],
+  "globalEnv": ["SOME_ENV_VAR"],
+  "tasks": {
+    "build": {
+      "env": ["NODE_ENV"],
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"]
+    }
+  }
+}

--- a/turborepo-tests/integration/tests/dry-json/monorepo.t
+++ b/turborepo-tests/integration/tests/dry-json/monorepo.t
@@ -49,7 +49,7 @@ Setup
     "taskId": "my-app#build",
     "task": "build",
     "package": "my-app",
-    "hash": "ed450f573b231cb7",
+    "hash": "270f1ef47a80f1d1",
     "inputs": {
       ".env.local": "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
       "package.json": "1746e0db2361085b5953a6a3beab08c24af5bc08"
@@ -109,7 +109,7 @@ Setup
     "taskId": "util#build",
     "task": "build",
     "package": "util",
-    "hash": "41b033e352a43533",
+    "hash": "fad2a643cb480b55",
     "inputs": {
       "package.json": "e755064fd7893809d10fc067bb409c7ae516327f"
     },

--- a/turborepo-tests/integration/tests/dry-json/monorepo.t
+++ b/turborepo-tests/integration/tests/dry-json/monorepo.t
@@ -15,6 +15,7 @@ Setup
       "foo.txt": "eebae5f3ca7b5831e429e947b7d61edd0de69236"
     },
     "hashOfExternalDependencies": "459c029558afe716",
+    "hashOfInternalDependencies": "",
     "environmentVariables": {
       "specified": {
         "env": [

--- a/turborepo-tests/integration/tests/dry-json/single-package-no-config.t
+++ b/turborepo-tests/integration/tests/dry-json/single-package-no-config.t
@@ -16,6 +16,7 @@ Setup
         "package.json": "8606ff4b95a5330740d8d9d0948faeada64f1f32"
       },
       "hashOfExternalDependencies": "",
+      "hashOfInternalDependencies": "",
       "environmentVariables": {
         "specified": {
           "env": [],

--- a/turborepo-tests/integration/tests/dry-json/single-package-no-config.t
+++ b/turborepo-tests/integration/tests/dry-json/single-package-no-config.t
@@ -32,7 +32,7 @@ Setup
       {
         "taskId": "build",
         "task": "build",
-        "hash": "a6da7b8ddbe2bb84",
+        "hash": "12c592ddc0e53a5c",
         "inputs": {
           ".gitignore": "03b541460c1b836f96f9c0a941ceb48e91a9fd83",
           "package-lock.json": "1c117cce37347befafe3a9cba1b8a609b3600021",

--- a/turborepo-tests/integration/tests/dry-json/single-package-with-deps.t
+++ b/turborepo-tests/integration/tests/dry-json/single-package-with-deps.t
@@ -15,6 +15,7 @@ Setup
         "somefile.txt": "45b983be36b73c0788dc9cbcb76cbb80fc7bb057"
       },
       "hashOfExternalDependencies": "",
+      "hashOfInternalDependencies": "",
       "environmentVariables": {
         "specified": {
           "env": [],

--- a/turborepo-tests/integration/tests/dry-json/single-package-with-deps.t
+++ b/turborepo-tests/integration/tests/dry-json/single-package-with-deps.t
@@ -31,7 +31,7 @@ Setup
       {
         "taskId": "build",
         "task": "build",
-        "hash": "4047a6e65d7dafef",
+        "hash": "81a933c332d3f388",
         "inputs": {
           ".gitignore": "03b541460c1b836f96f9c0a941ceb48e91a9fd83",
           "package-lock.json": "1c117cce37347befafe3a9cba1b8a609b3600021",
@@ -86,7 +86,7 @@ Setup
       {
         "taskId": "test",
         "task": "test",
-        "hash": "89d72e7337505ef6",
+        "hash": "785d8ef1115bde3b",
         "inputs": {
           ".gitignore": "03b541460c1b836f96f9c0a941ceb48e91a9fd83",
           "package-lock.json": "1c117cce37347befafe3a9cba1b8a609b3600021",

--- a/turborepo-tests/integration/tests/dry-json/single-package.t
+++ b/turborepo-tests/integration/tests/dry-json/single-package.t
@@ -31,7 +31,7 @@ Setup
       {
         "taskId": "build",
         "task": "build",
-        "hash": "4047a6e65d7dafef",
+        "hash": "81a933c332d3f388",
         "inputs": {
           ".gitignore": "03b541460c1b836f96f9c0a941ceb48e91a9fd83",
           "package-lock.json": "1c117cce37347befafe3a9cba1b8a609b3600021",

--- a/turborepo-tests/integration/tests/dry-json/single-package.t
+++ b/turborepo-tests/integration/tests/dry-json/single-package.t
@@ -15,6 +15,7 @@ Setup
         "somefile.txt": "45b983be36b73c0788dc9cbcb76cbb80fc7bb057"
       },
       "hashOfExternalDependencies": "",
+      "hashOfInternalDependencies": "",
       "environmentVariables": {
         "specified": {
           "env": [],

--- a/turborepo-tests/integration/tests/dry-run.t
+++ b/turborepo-tests/integration/tests/dry-run.t
@@ -30,7 +30,7 @@ Setup
   my-app#build
     Task                           = build\s* (re)
     Package                        = my-app\s* (re)
-    Hash                           = ed450f573b231cb7
+    Hash                           = 270f1ef47a80f1d1
     Cached (Local)                 = false
     Cached (Remote)                = false
     Directory                      = apps(\/|\\)my-app (re)
@@ -50,7 +50,7 @@ Setup
   util#build
     Task                           = build\s* (re)
     Package                        = util\s* (re)
-    Hash                           = 41b033e352a43533
+    Hash                           = fad2a643cb480b55
     Cached (Local)                 = false
     Cached (Remote)                = false
     Directory                      = packages(\/|\\)util (re)

--- a/turborepo-tests/integration/tests/edit-turbo-json/task.t
+++ b/turborepo-tests/integration/tests/edit-turbo-json/task.t
@@ -6,15 +6,15 @@ Baseline task hashes
   $ ${TURBO} build --dry=json | jq -r '.tasks | sort_by(.taskId)[] | {taskId, hash}'
   {
     "taskId": "another#build",
-    "hash": "78b732d9478d9b83"
+    "hash": "ea00e25531db048f"
   }
   {
     "taskId": "my-app#build",
-    "hash": "ed450f573b231cb7"
+    "hash": "270f1ef47a80f1d1"
   }
   {
     "taskId": "util#build",
-    "hash": "41b033e352a43533"
+    "hash": "fad2a643cb480b55"
   }
 
 Change only my-app#build
@@ -22,15 +22,15 @@ Change only my-app#build
   $ ${TURBO} build --dry=json | jq -r '.tasks | sort_by(.taskId)[] | {taskId, hash}'
   {
     "taskId": "another#build",
-    "hash": "78b732d9478d9b83"
+    "hash": "ea00e25531db048f"
   }
   {
     "taskId": "my-app#build",
-    "hash": "eb391860afd5dfdc"
+    "hash": "b0eb2c24b2a84be5"
   }
   {
     "taskId": "util#build",
-    "hash": "41b033e352a43533"
+    "hash": "fad2a643cb480b55"
   }
 
 Change my-app#build dependsOn
@@ -38,15 +38,15 @@ Change my-app#build dependsOn
   $ ${TURBO} build --dry=json | jq -r '.tasks | sort_by(.taskId)[] | {taskId, hash}'
   {
     "taskId": "another#build",
-    "hash": "78b732d9478d9b83"
+    "hash": "ea00e25531db048f"
   }
   {
     "taskId": "my-app#build",
-    "hash": "d71bf2777e3824b7"
+    "hash": "9e63702de36d25c6"
   }
   {
     "taskId": "util#build",
-    "hash": "41b033e352a43533"
+    "hash": "fad2a643cb480b55"
   }
 
 Non-materially modifying the dep graph does nothing.
@@ -54,15 +54,15 @@ Non-materially modifying the dep graph does nothing.
   $ ${TURBO} build --dry=json | jq -r '.tasks | sort_by(.taskId)[] | {taskId, hash}'
   {
     "taskId": "another#build",
-    "hash": "78b732d9478d9b83"
+    "hash": "ea00e25531db048f"
   }
   {
     "taskId": "my-app#build",
-    "hash": "d71bf2777e3824b7"
+    "hash": "9e63702de36d25c6"
   }
   {
     "taskId": "util#build",
-    "hash": "41b033e352a43533"
+    "hash": "fad2a643cb480b55"
   }
 
 
@@ -71,13 +71,13 @@ Change util#build impacts itself and my-app
   $ ${TURBO} build --dry=json | jq -r '.tasks | sort_by(.taskId)[] | {taskId, hash}'
   {
     "taskId": "another#build",
-    "hash": "78b732d9478d9b83"
+    "hash": "ea00e25531db048f"
   }
   {
     "taskId": "my-app#build",
-    "hash": "550479ca3246010d"
+    "hash": "867bee2191fbd90c"
   }
   {
     "taskId": "util#build",
-    "hash": "d29ee2ca954217ef"
+    "hash": "6f4abe279ba198a8"
   }

--- a/turborepo-tests/integration/tests/global-deps.t
+++ b/turborepo-tests/integration/tests/global-deps.t
@@ -6,7 +6,7 @@ Run a build
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache miss, executing c3e42e9c9ba94cab
+  my-app:build: cache miss, executing 3292edbc955db609
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -18,7 +18,7 @@ Run a build
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache miss, executing ded57f1945fa82be
+  my-app:build: cache miss, executing 7a2d3560117367eb
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -29,7 +29,7 @@ Run a build
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache hit, suppressing logs ded57f1945fa82be
+  my-app:build: cache hit, suppressing logs 7a2d3560117367eb
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total

--- a/turborepo-tests/integration/tests/global-env.t
+++ b/turborepo-tests/integration/tests/global-env.t
@@ -8,7 +8,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  util:build: cache miss, executing 41b033e352a43533
+  util:build: cache miss, executing fad2a643cb480b55
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -19,7 +19,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  util:build: cache hit, suppressing logs 41b033e352a43533
+  util:build: cache hit, suppressing logs fad2a643cb480b55
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total
@@ -30,7 +30,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  util:build: cache miss, executing 8b36aff0371ed688
+  util:build: cache miss, executing a7c44af22f60539c
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -41,7 +41,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  util:build: cache hit, suppressing logs 41b033e352a43533
+  util:build: cache hit, suppressing logs fad2a643cb480b55
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total
@@ -52,7 +52,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  util:build: cache miss, executing b1d5cc042db323ed
+  util:build: cache miss, executing 18e70da6088a7985
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total

--- a/turborepo-tests/integration/tests/persistent-dependencies/6-topological-unimplemented.t
+++ b/turborepo-tests/integration/tests/persistent-dependencies/6-topological-unimplemented.t
@@ -17,7 +17,7 @@
   \xe2\x80\xa2 Packages in scope: app-a, pkg-a (esc)
   \xe2\x80\xa2 Running dev in 2 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  app-a:dev: cache miss, executing 80e89b04d985ccbc
+  app-a:dev: cache miss, executing 6d74f36653305cef
   app-a:dev: 
   app-a:dev: > dev
   app-a:dev: > echo dev-app-a

--- a/turborepo-tests/integration/tests/pkg-inference.t
+++ b/turborepo-tests/integration/tests/pkg-inference.t
@@ -6,7 +6,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  util:build: cache miss, executing 41b033e352a43533
+  util:build: cache miss, executing fad2a643cb480b55
   util:build: 
   util:build: > build
   util:build: > echo building

--- a/turborepo-tests/integration/tests/prune/composable-config.t
+++ b/turborepo-tests/integration/tests/prune/composable-config.t
@@ -11,7 +11,7 @@ Make sure that the internal util package is part of the prune output
   \xe2\x80\xa2 Packages in scope: docs, shared, util (esc)
   \xe2\x80\xa2 Running new-task in 3 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  docs:new-task: cache miss, executing 7e5957e9303be3e2
+  docs:new-task: cache miss, executing 37946d5a79df43a8
   docs:new-task: 
   docs:new-task: > docs@ new-task .*out(\/|\\)apps(\/|\\)docs (re)
   docs:new-task: > echo building

--- a/turborepo-tests/integration/tests/run-caching/excluded-inputs/excluded-inputs.t
+++ b/turborepo-tests/integration/tests/run-caching/excluded-inputs/excluded-inputs.t
@@ -9,7 +9,7 @@ Running build for my-app succeeds
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache miss, executing 87e69a7e18f039da
+  my-app:build: cache miss, executing 92e6e0fa25bd067f
   my-app:build: 
   my-app:build: > build
   my-app:build: > echo building
@@ -26,7 +26,7 @@ Update exluded file and try again
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache hit, replaying logs 87e69a7e18f039da
+  my-app:build: cache hit, replaying logs 92e6e0fa25bd067f
   my-app:build: 
   my-app:build: > build
   my-app:build: > echo building

--- a/turborepo-tests/integration/tests/run-caching/root-deps.t
+++ b/turborepo-tests/integration/tests/run-caching/root-deps.t
@@ -1,0 +1,42 @@
+Setup
+  $ . ${TESTDIR}/../../../helpers/setup_integration_test.sh root_deps
+
+Warm the cache
+  $ ${TURBO} build --filter=another --output-logs=hash-only
+  \xe2\x80\xa2 Packages in scope: another (esc)
+  \xe2\x80\xa2 Running build in 1 packages (esc)
+  \xe2\x80\xa2 Remote caching disabled (esc)
+  another:build: cache miss, executing 22f33d1d910da7f2
+  
+   Tasks:    1 successful, 1 total
+  Cached:    0 cached, 1 total
+    Time:\s+[.0-9]+m?s  (re)
+  
+Change a root internal dependency
+  $ touch packages/util/important.txt
+All tasks should be a cache miss, even ones that don't depend on changed package 
+  $ ${TURBO} build --filter=another --output-logs=hash-only
+  \xe2\x80\xa2 Packages in scope: another (esc)
+  \xe2\x80\xa2 Running build in 1 packages (esc)
+  \xe2\x80\xa2 Remote caching disabled (esc)
+  another:build: cache miss, executing 5dd1314cac1b01ff
+  
+   Tasks:    1 successful, 1 total
+  Cached:    0 cached, 1 total
+    Time:\s+[.0-9]+m?s  (re)
+  
+
+Change a file that is git ignored
+  $ mkdir packages/util/dist
+  $ touch packages/util/dist/unused.txt
+Cache hit since only tracked files contribute to root dep hash
+  $ ${TURBO} build --filter=another --output-logs=hash-only
+  \xe2\x80\xa2 Packages in scope: another (esc)
+  \xe2\x80\xa2 Running build in 1 packages (esc)
+  \xe2\x80\xa2 Remote caching disabled (esc)
+  another:build: cache hit, suppressing logs 5dd1314cac1b01ff
+  
+   Tasks:    1 successful, 1 total
+  Cached:    1 cached, 1 total
+    Time:\s*[\.0-9]+m?s >>> FULL TURBO (re)
+  

--- a/turborepo-tests/integration/tests/run-logging/errors-only.t
+++ b/turborepo-tests/integration/tests/run-logging/errors-only.t
@@ -37,7 +37,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: app-a (esc)
   \xe2\x80\xa2 Running builderror in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  app-a:builderror: cache miss, executing 30379ede8c4fd252
+  app-a:builderror: cache miss, executing e86e4a4ebfa716d6
   app-a:builderror: 
   app-a:builderror: > builderror
   app-a:builderror: > echo error-builderror-app-a && exit 1
@@ -67,7 +67,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: app-a (esc)
   \xe2\x80\xa2 Running builderror2 in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  app-a:builderror2: cache miss, executing 29c91fda7cb5f934
+  app-a:builderror2: cache miss, executing 3b92feb5fb5a32a5
   app-a:builderror2: 
   app-a:builderror2: > builderror2
   app-a:builderror2: > echo error-builderror2-app-a && exit 1

--- a/turborepo-tests/integration/tests/run-logging/log-order-github.t
+++ b/turborepo-tests/integration/tests/run-logging/log-order-github.t
@@ -9,7 +9,7 @@ because otherwise prysk interprets them as multiline commands
   \xe2\x80\xa2 Running build in 2 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
   ::group::my-app:build
-  cache bypass, force executing 15b8c7d115cd7403
+  cache bypass, force executing 387aa1a04fa418fe
   
   >\sbuild (re)
   \>\secho building && sleep 1 && echo done (re)
@@ -18,7 +18,7 @@ because otherwise prysk interprets them as multiline commands
   done
   ::endgroup::
   ::group::util:build
-  cache bypass, force executing a5ccc37ed8b7b2df
+  cache bypass, force executing 348fb645686fa0b8
   
   >\sbuild (re)
   \>\ssleep 0.5 && echo building && sleep 1 && echo completed (re)
@@ -37,7 +37,7 @@ because otherwise prysk interprets them as multiline commands
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
   ::group::util:build
-  util:build: cache bypass, force executing a5ccc37ed8b7b2df
+  util:build: cache bypass, force executing 348fb645686fa0b8
   util:build: 
   util:build: > build
   util:build: > sleep 0.5 && echo building && sleep 1 && echo completed
@@ -57,7 +57,7 @@ Verify that errors are grouped properly
   \xe2\x80\xa2 Running fail in 2 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
   \x1b[;31mutil:fail\x1b[;0m (esc)
-  cache miss, executing 778f804f3d3d75cd
+  cache miss, executing e53b8d17f063e6c0
   
   \> fail (re)
   \> echo failing; exit 1 (re)

--- a/turborepo-tests/integration/tests/run-logging/log-prefix.t
+++ b/turborepo-tests/integration/tests/run-logging/log-prefix.t
@@ -6,7 +6,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: app-a (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  cache miss, executing e0140bf4d9fbed7a
+  cache miss, executing aa8bd45244bccb8b
   
   \> build (re)
   \> echo build-app-a (re)
@@ -30,7 +30,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: app-a (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  cache hit, replaying logs e0140bf4d9fbed7a
+  cache hit, replaying logs aa8bd45244bccb8b
   
   \> build (re)
   \> echo build-app-a (re)
@@ -46,7 +46,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: app-a (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  app-a:build: cache hit, replaying logs e0140bf4d9fbed7a
+  app-a:build: cache hit, replaying logs aa8bd45244bccb8b
   app-a:build: 
   app-a:build: > build
   app-a:build: > echo build-app-a

--- a/turborepo-tests/integration/tests/run-logging/verbosity.t
+++ b/turborepo-tests/integration/tests/run-logging/verbosity.t
@@ -6,7 +6,7 @@ Verbosity level 1
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  util:build: cache bypass, force executing 41b033e352a43533
+  util:build: cache bypass, force executing fad2a643cb480b55
   util:build: 
   util:build: > build
   util:build: > echo building
@@ -21,7 +21,7 @@ Verbosity level 1
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  util:build: cache bypass, force executing 41b033e352a43533
+  util:build: cache bypass, force executing fad2a643cb480b55
   util:build: 
   util:build: > build
   util:build: > echo building

--- a/turborepo-tests/integration/tests/run-summary/discovery.t
+++ b/turborepo-tests/integration/tests/run-summary/discovery.t
@@ -6,7 +6,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache miss, executing ed450f573b231cb7
+  my-app:build: cache miss, executing 270f1ef47a80f1d1
   my-app:build: 
   my-app:build: > build
   my-app:build: > echo building

--- a/turborepo-tests/integration/tests/run-summary/error.t
+++ b/turborepo-tests/integration/tests/run-summary/error.t
@@ -32,7 +32,7 @@ Validate that we got a full task summary for the failed task with an error in .e
     "taskId": "my-app#maybefails",
     "task": "maybefails",
     "package": "my-app",
-    "hash": "5708afa4de2b80ea",
+    "hash": "e766224b19492c97",
     "inputs": {
       ".env.local": "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
       "package.json": "1746e0db2361085b5953a6a3beab08c24af5bc08"

--- a/turborepo-tests/integration/tests/run/continue.t
+++ b/turborepo-tests/integration/tests/run/continue.t
@@ -5,7 +5,7 @@ Run without --continue
   \xe2\x80\xa2 Packages in scope: my-app, other-app, some-lib (esc)
   \xe2\x80\xa2 Running build in 3 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  some-lib:build: cache miss, executing 6a27a9769c374e7b
+  some-lib:build: cache miss, executing 071e589156801650
   some-lib:build: 
   some-lib:build: > build
   some-lib:build: > exit 2
@@ -31,7 +31,7 @@ Run without --continue, and with only errors.
   \xe2\x80\xa2 Packages in scope: my-app, other-app, some-lib (esc)
   \xe2\x80\xa2 Running build in 3 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  some-lib:build: cache miss, executing 6a27a9769c374e7b
+  some-lib:build: cache miss, executing 071e589156801650
   some-lib:build: 
   some-lib:build: > build
   some-lib:build: > exit 2
@@ -56,7 +56,7 @@ Run with --continue
   \xe2\x80\xa2 Packages in scope: my-app, other-app, some-lib (esc)
   \xe2\x80\xa2 Running build in 3 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  some-lib:build: cache miss, executing 6a27a9769c374e7b
+  some-lib:build: cache miss, executing 071e589156801650
   some-lib:build: 
   some-lib:build: > build
   some-lib:build: > exit 2
@@ -66,7 +66,7 @@ Run with --continue
   some-lib:build: npm ERR!   in workspace: some-lib 
   some-lib:build: npm ERR!   at location: (.*)(\/|\\)apps(\/|\\)some-lib  (re)
   some-lib:build: command finished with error, but continuing...
-  other-app:build: cache miss, executing 39fcb4fcad874e05
+  other-app:build: cache miss, executing f7d23d1c894c1f09
   other-app:build: 
   other-app:build: > build
   other-app:build: > exit 3

--- a/turborepo-tests/integration/tests/run/force.t
+++ b/turborepo-tests/integration/tests/run/force.t
@@ -24,7 +24,7 @@ baseline to generate cache
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache miss, executing ed450f573b231cb7
+  my-app:build: cache miss, executing 270f1ef47a80f1d1
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -36,7 +36,7 @@ baseline to generate cache
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache bypass, force executing ed450f573b231cb7
+  my-app:build: cache bypass, force executing 270f1ef47a80f1d1
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -47,7 +47,7 @@ baseline to generate cache
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache bypass, force executing ed450f573b231cb7
+  my-app:build: cache bypass, force executing 270f1ef47a80f1d1
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -58,7 +58,7 @@ baseline to generate cache
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache hit, suppressing logs ed450f573b231cb7
+  my-app:build: cache hit, suppressing logs 270f1ef47a80f1d1
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total
@@ -69,7 +69,7 @@ baseline to generate cache
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache bypass, force executing ed450f573b231cb7
+  my-app:build: cache bypass, force executing 270f1ef47a80f1d1
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -81,7 +81,7 @@ baseline to generate cache
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache hit, suppressing logs ed450f573b231cb7
+  my-app:build: cache hit, suppressing logs 270f1ef47a80f1d1
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total
@@ -92,7 +92,7 @@ baseline to generate cache
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache bypass, force executing ed450f573b231cb7
+  my-app:build: cache bypass, force executing 270f1ef47a80f1d1
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -103,7 +103,7 @@ baseline to generate cache
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache hit, suppressing logs ed450f573b231cb7
+  my-app:build: cache hit, suppressing logs 270f1ef47a80f1d1
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total
@@ -114,7 +114,7 @@ baseline to generate cache
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache bypass, force executing ed450f573b231cb7
+  my-app:build: cache bypass, force executing 270f1ef47a80f1d1
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -126,7 +126,7 @@ baseline to generate cache
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache hit, suppressing logs ed450f573b231cb7
+  my-app:build: cache hit, suppressing logs 270f1ef47a80f1d1
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total
@@ -137,7 +137,7 @@ baseline to generate cache
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache bypass, force executing ed450f573b231cb7
+  my-app:build: cache bypass, force executing 270f1ef47a80f1d1
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -148,7 +148,7 @@ baseline to generate cache
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache hit, suppressing logs ed450f573b231cb7
+  my-app:build: cache hit, suppressing logs 270f1ef47a80f1d1
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total
@@ -159,7 +159,7 @@ baseline to generate cache
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache bypass, force executing ed450f573b231cb7
+  my-app:build: cache bypass, force executing 270f1ef47a80f1d1
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total

--- a/turborepo-tests/integration/tests/run/gitignored-inputs.t
+++ b/turborepo-tests/integration/tests/run/gitignored-inputs.t
@@ -16,7 +16,7 @@ Some helper functions to parse the summary file
 
 Just run the util package, it's simpler
   $ ${TURBO} run build --filter=util --output-logs=hash-only --summarize | grep "util:build: cache"
-  util:build: cache miss, executing ae2e852267f3b5c9
+  util:build: cache miss, executing 355a92b6a1cc5f24
 
   $ FIRST=$(/bin/ls .turbo/runs/*.json | head -n1)
   $ echo $(getSummaryTaskId $FIRST "util#build") | jq -r '.inputs."internal.txt"'
@@ -30,7 +30,7 @@ Change the content of internal.txt
 
 Hash does not change, because it is gitignored
   $ ${TURBO} run build --filter=util --output-logs=hash-only --summarize | grep "util:build: cache"
-  util:build: cache miss, executing 117a08af942aa435
+  util:build: cache miss, executing 511d34a1853ba4ab
 
 The internal.txt hash should be different from the one before
   $ SECOND=$(/bin/ls .turbo/runs/*.json | head -n1)

--- a/turborepo-tests/integration/tests/run/globs.t
+++ b/turborepo-tests/integration/tests/run/globs.t
@@ -5,7 +5,7 @@ Verify that input directory change causes cache miss
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  util:build: cache miss, executing de4d32c1d7909fd6
+  util:build: cache miss, executing d5b281b8322da71e
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -16,7 +16,7 @@ Verify that input directory change causes cache miss
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  util:build: cache miss, executing 9dc5d552226836c8
+  util:build: cache miss, executing 886797b8d9d1a464
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -29,7 +29,7 @@ Verify that input directory change causes cache miss
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  util:build: cache hit, suppressing logs 9dc5d552226836c8
+  util:build: cache hit, suppressing logs 886797b8d9d1a464
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total

--- a/turborepo-tests/integration/tests/run/one-script-error.t
+++ b/turborepo-tests/integration/tests/run/one-script-error.t
@@ -7,13 +7,13 @@ Note that npm reports any failed script as exit code 1, even though we "exit 2"
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running error in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:okay: cache miss, executing 730881de77077bd7
+  my-app:okay: cache miss, executing 96496b6b9252855e
   my-app:okay: 
   my-app:okay: > okay
   my-app:okay: > echo working
   my-app:okay: 
   my-app:okay: working
-  my-app:error: cache miss, executing 6bcb083c31200821
+  my-app:error: cache miss, executing 470e35f414b048e3
   my-app:error: 
   my-app:error: > error
   my-app:error: > exit 2
@@ -38,13 +38,13 @@ Make sure error isn't cached
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running error in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:okay: cache hit, replaying logs 730881de77077bd7
+  my-app:okay: cache hit, replaying logs 96496b6b9252855e
   my-app:okay: 
   my-app:okay: > okay
   my-app:okay: > echo working
   my-app:okay: 
   my-app:okay: working
-  my-app:error: cache miss, executing 6bcb083c31200821
+  my-app:error: cache miss, executing 470e35f414b048e3
   my-app:error: 
   my-app:error: > error
   my-app:error: > exit 2
@@ -69,13 +69,13 @@ Make sure error code isn't swallowed with continue
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running okay2 in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:okay: cache hit, replaying logs 730881de77077bd7
+  my-app:okay: cache hit, replaying logs 96496b6b9252855e
   my-app:okay: 
   my-app:okay: > okay
   my-app:okay: > echo working
   my-app:okay: 
   my-app:okay: working
-  my-app:error: cache miss, executing 6bcb083c31200821
+  my-app:error: cache miss, executing 470e35f414b048e3
   my-app:error: 
   my-app:error: > error
   my-app:error: > exit 2
@@ -85,7 +85,7 @@ Make sure error code isn't swallowed with continue
   my-app:error: npm ERR!   in workspace: my-app 
   my-app:error: npm ERR!   at location: .*apps(\/|\\)my-app  (re)
   my-app:error: command finished with error, but continuing...
-  my-app:okay2: cache miss, executing c9df11d745bab324
+  my-app:okay2: cache miss, executing 17aa4a3dcf0a74a6
   my-app:okay2: 
   my-app:okay2: > okay2
   my-app:okay2: > echo working

--- a/turborepo-tests/integration/tests/run/single-package/dry-run.t
+++ b/turborepo-tests/integration/tests/run/single-package/dry-run.t
@@ -17,7 +17,7 @@ Check
   Tasks to Run
   build
     Task                           = build\s* (re)
-    Hash                           = 4047a6e65d7dafef
+    Hash                           = 81a933c332d3f388
     Cached (Local)                 = false
     Cached (Remote)                = false
     Command                        = echo building > foo.txt

--- a/turborepo-tests/integration/tests/run/single-package/no-config.t
+++ b/turborepo-tests/integration/tests/run/single-package/no-config.t
@@ -19,7 +19,7 @@ Check
   Tasks to Run
   build
     Task                           = build\s* (re)
-    Hash                           = a6da7b8ddbe2bb84
+    Hash                           = 12c592ddc0e53a5c
     Cached (Local)                 = false
     Cached (Remote)                = false
     Command                        = echo building > foo.txt
@@ -50,7 +50,7 @@ Run real once
   $ ${TURBO} run build
   \xe2\x80\xa2 Running build (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  build: cache bypass, force executing a6da7b8ddbe2bb84
+  build: cache bypass, force executing 12c592ddc0e53a5c
   build: 
   build: > build
   build: > echo building > foo.txt
@@ -64,7 +64,7 @@ Run a second time, verify no caching because there is no config
   $ ${TURBO} run build
   \xe2\x80\xa2 Running build (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  build: cache bypass, force executing a6da7b8ddbe2bb84
+  build: cache bypass, force executing 12c592ddc0e53a5c
   build: 
   build: > build
   build: > echo building > foo.txt

--- a/turborepo-tests/integration/tests/run/single-package/run-yarn.t
+++ b/turborepo-tests/integration/tests/run/single-package/run-yarn.t
@@ -5,7 +5,7 @@ Check
   $ ${TURBO} run build
   \xe2\x80\xa2 Running build (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  build: cache miss, executing ed245ad45c9be274
+  build: cache miss, executing 34db97233d5773b8
   build: yarn run v1.22.17
   build: warning package.json: No license field
   build: $ echo building > foo.txt
@@ -18,7 +18,7 @@ Check
   $ ${TURBO} run build
   \xe2\x80\xa2 Running build (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  build: cache hit, replaying logs ed245ad45c9be274
+  build: cache hit, replaying logs 34db97233d5773b8
   build: yarn run v1.22.17
   build: warning package.json: No license field
   build: $ echo building > foo.txt

--- a/turborepo-tests/integration/tests/run/single-package/run.t
+++ b/turborepo-tests/integration/tests/run/single-package/run.t
@@ -5,7 +5,7 @@ Check
   $ ${TURBO} run build
   \xe2\x80\xa2 Running build (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  build: cache miss, executing 4047a6e65d7dafef
+  build: cache miss, executing 81a933c332d3f388
   build: 
   build: > build
   build: > echo building > foo.txt
@@ -22,7 +22,7 @@ Run a second time, verify caching works because there is a config
   $ ${TURBO} run build
   \xe2\x80\xa2 Running build (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  build: cache hit, replaying logs 4047a6e65d7dafef
+  build: cache hit, replaying logs 81a933c332d3f388
   build: 
   build: > build
   build: > echo building > foo.txt

--- a/turborepo-tests/integration/tests/run/single-package/with-deps-dry-run.t
+++ b/turborepo-tests/integration/tests/run/single-package/with-deps-dry-run.t
@@ -17,7 +17,7 @@ Check
   Tasks to Run
   build
     Task                           = build\s* (re)
-    Hash                           = 4047a6e65d7dafef
+    Hash                           = 81a933c332d3f388
     Cached (Local)                 = false
     Cached (Remote)                = false
     Command                        = echo building > foo.txt
@@ -35,7 +35,7 @@ Check
     Framework                      = 
   test
     Task                           = test\s* (re)
-    Hash                           = 89d72e7337505ef6
+    Hash                           = 785d8ef1115bde3b
     Cached (Local)                 = false
     Cached (Remote)                = false
     Command                        = cat foo.txt

--- a/turborepo-tests/integration/tests/run/single-package/with-deps-run.t
+++ b/turborepo-tests/integration/tests/run/single-package/with-deps-run.t
@@ -5,12 +5,12 @@ Check
   $ ${TURBO} run test
   \xe2\x80\xa2 Running test (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  build: cache miss, executing 4047a6e65d7dafef
+  build: cache miss, executing 81a933c332d3f388
   build: 
   build: > build
   build: > echo building > foo.txt
   build: 
-  test: cache miss, executing 89d72e7337505ef6
+  test: cache miss, executing 785d8ef1115bde3b
   test: 
   test: > test
   test: > cat foo.txt
@@ -25,12 +25,12 @@ Run a second time, verify caching works because there is a config
   $ ${TURBO} run test
   \xe2\x80\xa2 Running test (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  build: cache hit, replaying logs 4047a6e65d7dafef
+  build: cache hit, replaying logs 81a933c332d3f388
   build: 
   build: > build
   build: > echo building > foo.txt
   build: 
-  test: cache hit, replaying logs 89d72e7337505ef6
+  test: cache hit, replaying logs 785d8ef1115bde3b
   test: 
   test: > test
   test: > cat foo.txt
@@ -45,8 +45,8 @@ Run with --output-logs=hash-only
   $ ${TURBO} run test --output-logs=hash-only
   \xe2\x80\xa2 Running test (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  build: cache hit, suppressing logs 4047a6e65d7dafef
-  test: cache hit, suppressing logs 89d72e7337505ef6
+  build: cache hit, suppressing logs 81a933c332d3f388
+  test: cache hit, suppressing logs 785d8ef1115bde3b
   
    Tasks:    2 successful, 2 total
   Cached:    2 cached, 2 total

--- a/turborepo-tests/integration/tests/task-dependencies/overwriting.t
+++ b/turborepo-tests/integration/tests/task-dependencies/overwriting.t
@@ -11,7 +11,7 @@ Test
 
 # workspace-a#generate ran
   $ cat tmp.log | grep "workspace-a:generate"
-  workspace-a:generate: cache miss, executing a7a2aa3909d7b0d8
+  workspace-a:generate: cache miss, executing 8ee333277b4c00a0
   workspace-a:generate: 
   workspace-a:generate: > generate
   workspace-a:generate: > echo generate-workspace-a
@@ -19,7 +19,7 @@ Test
   workspace-a:generate: generate-workspace-a
 workspace-a#build ran
   $ cat tmp.log | grep "workspace-a:build"
-  workspace-a:build: cache miss, executing 9ccc135d65c4a495
+  workspace-a:build: cache miss, executing 886936e13f48ddb8
   workspace-a:build: 
   workspace-a:build: > build
   workspace-a:build: > echo build-workspace-a
@@ -32,7 +32,7 @@ workspace-b#generate DID NOT run
 
 workspace-b#build ran
   $ cat tmp.log | grep "workspace-b:build"
-  workspace-b:build: cache miss, executing 02c3fac1077fc71c
+  workspace-b:build: cache miss, executing b10c1a5197eafc5d
   workspace-b:build: 
   workspace-b:build: > build
   workspace-b:build: > echo build-workspace-b

--- a/turborepo-tests/integration/tests/task-dependencies/root-workspace.t
+++ b/turborepo-tests/integration/tests/task-dependencies/root-workspace.t
@@ -5,13 +5,13 @@ This tests asserts that root tasks can depend on workspace#task
   \xe2\x80\xa2 Packages in scope: //, lib-a (esc)
   \xe2\x80\xa2 Running mytask in 2 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  lib-a:build: cache miss, executing 113b85e31603db1c
+  lib-a:build: cache miss, executing 5b761e7ac20ce0a6
   lib-a:build: 
   lib-a:build: > build
   lib-a:build: > echo build-lib-a
   lib-a:build: 
   lib-a:build: build-lib-a
-  //:mytask: cache miss, executing 79bfd20384932bbb
+  //:mytask: cache miss, executing 8a3a7db901b3e8cf
   //:mytask: 
   //:mytask: > mytask
   //:mytask: > echo root-mytask

--- a/turborepo-tests/integration/tests/task-dependencies/topological.t
+++ b/turborepo-tests/integration/tests/task-dependencies/topological.t
@@ -6,13 +6,13 @@ Check my-app#build output
   \xe2\x80\xa2 Packages in scope: //, my-app, util (esc)
   \xe2\x80\xa2 Running build in 3 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  util:build: cache miss, executing fc4462f9a33623c2
+  util:build: cache miss, executing a4a05b282e52a021
   util:build: 
   util:build: > build
   util:build: > echo building
   util:build: 
   util:build: building
-  my-app:build: cache miss, executing bd5855867ade972a
+  my-app:build: cache miss, executing 0e31fb7bb214a760
   my-app:build: 
   my-app:build: > build
   my-app:build: > echo building

--- a/turborepo-tests/integration/tests/workspace-configs/add-keys.t
+++ b/turborepo-tests/integration/tests/workspace-configs/add-keys.t
@@ -14,13 +14,13 @@ Setup
   \xe2\x80\xa2 Packages in scope: add-keys (esc)
   \xe2\x80\xa2 Running add-keys-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  add-keys:add-keys-underlying-task: cache miss, executing b1b44ef21c97573a
+  add-keys:add-keys-underlying-task: cache miss, executing 2bd958e3fcfce743
   add-keys:add-keys-underlying-task: 
   add-keys:add-keys-underlying-task: > add-keys-underlying-task
   add-keys:add-keys-underlying-task: > echo running-add-keys-underlying-task
   add-keys:add-keys-underlying-task: 
   add-keys:add-keys-underlying-task: running-add-keys-underlying-task
-  add-keys:add-keys-task: cache miss, executing 900c42a3c99fcb70
+  add-keys:add-keys-task: cache miss, executing a11556f24e8544ee
   add-keys:add-keys-task: 
   add-keys:add-keys-task: > add-keys-task
   add-keys:add-keys-task: > echo running-add-keys-task > out/foo.min.txt
@@ -48,13 +48,13 @@ Setup
   \xe2\x80\xa2 Packages in scope: add-keys (esc)
   \xe2\x80\xa2 Running add-keys-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  add-keys:add-keys-underlying-task: cache hit, replaying logs b1b44ef21c97573a
+  add-keys:add-keys-underlying-task: cache hit, replaying logs 2bd958e3fcfce743
   add-keys:add-keys-underlying-task: 
   add-keys:add-keys-underlying-task: > add-keys-underlying-task
   add-keys:add-keys-underlying-task: > echo running-add-keys-underlying-task
   add-keys:add-keys-underlying-task: 
   add-keys:add-keys-underlying-task: running-add-keys-underlying-task
-  add-keys:add-keys-task: cache hit, suppressing logs 900c42a3c99fcb70
+  add-keys:add-keys-task: cache hit, suppressing logs a11556f24e8544ee
   
    Tasks:    2 successful, 2 total
   Cached:    2 cached, 2 total
@@ -66,13 +66,13 @@ Setup
   \xe2\x80\xa2 Packages in scope: add-keys (esc)
   \xe2\x80\xa2 Running add-keys-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  add-keys:add-keys-underlying-task: cache miss, executing 8e33b91a6ca8fcd4
+  add-keys:add-keys-underlying-task: cache miss, executing 0ab311c4d79c6364
   add-keys:add-keys-underlying-task: 
   add-keys:add-keys-underlying-task: > add-keys-underlying-task
   add-keys:add-keys-underlying-task: > echo running-add-keys-underlying-task
   add-keys:add-keys-underlying-task: 
   add-keys:add-keys-underlying-task: running-add-keys-underlying-task
-  add-keys:add-keys-task: cache miss, executing c99ca18c10380fb8
+  add-keys:add-keys-task: cache miss, executing f996028b8b4e387b
   add-keys:add-keys-task: 
   add-keys:add-keys-task: > add-keys-task
   add-keys:add-keys-task: > echo running-add-keys-task > out/foo.min.txt
@@ -87,13 +87,13 @@ Setup
   \xe2\x80\xa2 Packages in scope: add-keys (esc)
   \xe2\x80\xa2 Running add-keys-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  add-keys:add-keys-underlying-task: cache hit, replaying logs 8e33b91a6ca8fcd4
+  add-keys:add-keys-underlying-task: cache hit, replaying logs 0ab311c4d79c6364
   add-keys:add-keys-underlying-task: 
   add-keys:add-keys-underlying-task: > add-keys-underlying-task
   add-keys:add-keys-underlying-task: > echo running-add-keys-underlying-task
   add-keys:add-keys-underlying-task: 
   add-keys:add-keys-underlying-task: running-add-keys-underlying-task
-  add-keys:add-keys-task: cache miss, executing de9692b5d6414208
+  add-keys:add-keys-task: cache miss, executing 669ea43ab8c0fc93
   add-keys:add-keys-task: 
   add-keys:add-keys-task: > add-keys-task
   add-keys:add-keys-task: > echo running-add-keys-task > out/foo.min.txt

--- a/turborepo-tests/integration/tests/workspace-configs/add-tasks.t
+++ b/turborepo-tests/integration/tests/workspace-configs/add-tasks.t
@@ -5,7 +5,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: add-tasks (esc)
   \xe2\x80\xa2 Running added-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  add-tasks:added-task: cache miss, executing f0fda27365e9306b
+  add-tasks:added-task: cache miss, executing 86d698d4e34329fd
   add-tasks:added-task: 
   add-tasks:added-task: > added-task
   add-tasks:added-task: > echo running-added-task > out/foo.min.txt

--- a/turborepo-tests/integration/tests/workspace-configs/cache.t
+++ b/turborepo-tests/integration/tests/workspace-configs/cache.t
@@ -13,7 +13,7 @@ This test covers:
   \xe2\x80\xa2 Packages in scope: cached (esc)
   \xe2\x80\xa2 Running cached-task-1 in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  cached:cached-task-1: cache miss, executing aa4b3344d5e068e0
+  cached:cached-task-1: cache miss, executing a49d6b89949c7afa
   cached:cached-task-1: 
   cached:cached-task-1: > cached-task-1
   cached:cached-task-1: > echo cached-task-1 > out/foo.min.txt
@@ -38,7 +38,7 @@ This test covers:
   \xe2\x80\xa2 Packages in scope: cached (esc)
   \xe2\x80\xa2 Running cached-task-2 in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  cached:cached-task-2: cache bypass, force executing 4a1c738de315d340
+  cached:cached-task-2: cache bypass, force executing 44fd51a101b8f481
   cached:cached-task-2: 
   cached:cached-task-2: > cached-task-2
   cached:cached-task-2: > echo cached-task-2 > out/foo.min.txt
@@ -60,7 +60,7 @@ no `cache` config in root, cache:false in workspace
   \xe2\x80\xa2 Packages in scope: cached (esc)
   \xe2\x80\xa2 Running cached-task-3 in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  cached:cached-task-3: cache bypass, force executing 53e08724d086baa4
+  cached:cached-task-3: cache bypass, force executing c0043d1b0a723064
   cached:cached-task-3: 
   cached:cached-task-3: > cached-task-3
   cached:cached-task-3: > echo cached-task-3 > out/foo.min.txt
@@ -84,7 +84,7 @@ we already have a workspace that doesn't have a config
   \xe2\x80\xa2 Packages in scope: missing-workspace-config (esc)
   \xe2\x80\xa2 Running cached-task-4 in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  missing-workspace-config:cached-task-4: cache bypass, force executing b18fb0016b2ba646
+  missing-workspace-config:cached-task-4: cache bypass, force executing 991b90e398c3e30b
   missing-workspace-config:cached-task-4: 
   missing-workspace-config:cached-task-4: > cached-task-4
   missing-workspace-config:cached-task-4: > echo cached-task-4 > out/foo.min.txt

--- a/turborepo-tests/integration/tests/workspace-configs/config-change.t
+++ b/turborepo-tests/integration/tests/workspace-configs/config-change.t
@@ -3,13 +3,13 @@ Setup
 
 # 1. First run, check the hash
   $ ${TURBO} run config-change-task --filter=config-change --dry=json | jq .tasks[0].hash
-  "20a4384e7b8a0cdd"
+  "d93bbb973d5db9f1"
 
 2. Run again and assert task hash stays the same
   $ ${TURBO} run config-change-task --filter=config-change --dry=json | jq .tasks[0].hash
-  "20a4384e7b8a0cdd"
+  "d93bbb973d5db9f1"
 
 3. Change turbo.json and assert that hash changes
   $ cp $TARGET_DIR/apps/config-change/turbo-changed.json $TARGET_DIR/apps/config-change/turbo.json
   $ ${TURBO} run config-change-task --filter=config-change --dry=json | jq .tasks[0].hash
-  "95ceb90873e75c02"
+  "cece46842b2454fe"

--- a/turborepo-tests/integration/tests/workspace-configs/cross-workspace.t
+++ b/turborepo-tests/integration/tests/workspace-configs/cross-workspace.t
@@ -4,13 +4,13 @@ Setup
   \xe2\x80\xa2 Packages in scope: cross-workspace (esc)
   \xe2\x80\xa2 Running cross-workspace-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  blank-pkg:cross-workspace-underlying-task: cache miss, executing 48f39663b18e630a
+  blank-pkg:cross-workspace-underlying-task: cache miss, executing 2ca5991c80f91ba1
   blank-pkg:cross-workspace-underlying-task: 
   blank-pkg:cross-workspace-underlying-task: > cross-workspace-underlying-task
   blank-pkg:cross-workspace-underlying-task: > echo cross-workspace-underlying-task from blank-pkg
   blank-pkg:cross-workspace-underlying-task: 
   blank-pkg:cross-workspace-underlying-task: cross-workspace-underlying-task from blank-pkg
-  cross-workspace:cross-workspace-task: cache miss, executing a78fae9c6961965b
+  cross-workspace:cross-workspace-task: cache miss, executing d94b9c3284307ca2
   cross-workspace:cross-workspace-task: 
   cross-workspace:cross-workspace-task: > cross-workspace-task
   cross-workspace:cross-workspace-task: > echo cross-workspace-task

--- a/turborepo-tests/integration/tests/workspace-configs/missing-workspace-config-deps.t
+++ b/turborepo-tests/integration/tests/workspace-configs/missing-workspace-config-deps.t
@@ -15,14 +15,14 @@ Setup
   \xe2\x80\xa2 Remote caching disabled (esc)
 
   $ cat tmp.log | grep "missing-workspace-config:missing-workspace-config-task-with-deps"
-  missing-workspace-config:missing-workspace-config-task-with-deps: cache miss, executing 41733826c1f80f57
+  missing-workspace-config:missing-workspace-config-task-with-deps: cache miss, executing ddbc8e9c98c1613a
   missing-workspace-config:missing-workspace-config-task-with-deps: 
   missing-workspace-config:missing-workspace-config-task-with-deps: > missing-workspace-config-task-with-deps
   missing-workspace-config:missing-workspace-config-task-with-deps: > echo running-missing-workspace-config-task-with-deps > out/foo.min.txt
   missing-workspace-config:missing-workspace-config-task-with-deps: 
 
   $ cat tmp.log | grep "missing-workspace-config:missing-workspace-config-underlying-task"
-  missing-workspace-config:missing-workspace-config-underlying-task: cache miss, executing 2cfd313fc94ee8b6
+  missing-workspace-config:missing-workspace-config-underlying-task: cache miss, executing 7804b721631ec9dc
   missing-workspace-config:missing-workspace-config-underlying-task: 
   missing-workspace-config:missing-workspace-config-underlying-task: > missing-workspace-config-underlying-task
   missing-workspace-config:missing-workspace-config-underlying-task: > echo running-missing-workspace-config-underlying-task
@@ -30,7 +30,7 @@ Setup
   missing-workspace-config:missing-workspace-config-underlying-task: running-missing-workspace-config-underlying-task
 
   $ cat tmp.log | grep "blank-pkg:missing-workspace-config-underlying-topo-task"
-  blank-pkg:missing-workspace-config-underlying-topo-task: cache miss, executing acee90d9ccd6adb5
+  blank-pkg:missing-workspace-config-underlying-topo-task: cache miss, executing 2ee83ef8fa218e5b
   blank-pkg:missing-workspace-config-underlying-topo-task: 
   blank-pkg:missing-workspace-config-underlying-topo-task: > missing-workspace-config-underlying-topo-task
   blank-pkg:missing-workspace-config-underlying-topo-task: > echo missing-workspace-config-underlying-topo-task from blank-pkg

--- a/turborepo-tests/integration/tests/workspace-configs/missing-workspace-config.t
+++ b/turborepo-tests/integration/tests/workspace-configs/missing-workspace-config.t
@@ -11,7 +11,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: missing-workspace-config (esc)
   \xe2\x80\xa2 Running missing-workspace-config-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  missing-workspace-config:missing-workspace-config-task: cache miss, executing 9033f2738d479c41
+  missing-workspace-config:missing-workspace-config-task: cache miss, executing f9dcb73efb6c5269
   missing-workspace-config:missing-workspace-config-task: 
   missing-workspace-config:missing-workspace-config-task: > missing-workspace-config-task
   missing-workspace-config:missing-workspace-config-task: > echo running-missing-workspace-config-task > out/foo.min.txt
@@ -33,7 +33,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: missing-workspace-config (esc)
   \xe2\x80\xa2 Running missing-workspace-config-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  missing-workspace-config:missing-workspace-config-task: cache hit, suppressing logs 9033f2738d479c41
+  missing-workspace-config:missing-workspace-config-task: cache hit, suppressing logs f9dcb73efb6c5269
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total
@@ -45,7 +45,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: missing-workspace-config (esc)
   \xe2\x80\xa2 Running missing-workspace-config-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  missing-workspace-config:missing-workspace-config-task: cache miss, executing 089b7a4154e2247c
+  missing-workspace-config:missing-workspace-config-task: cache miss, executing a7bd666ff568b7ac
   missing-workspace-config:missing-workspace-config-task: 
   missing-workspace-config:missing-workspace-config-task: > missing-workspace-config-task
   missing-workspace-config:missing-workspace-config-task: > echo running-missing-workspace-config-task > out/foo.min.txt
@@ -62,7 +62,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: missing-workspace-config (esc)
   \xe2\x80\xa2 Running missing-workspace-config-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  missing-workspace-config:missing-workspace-config-task: cache hit, suppressing logs 089b7a4154e2247c
+  missing-workspace-config:missing-workspace-config-task: cache hit, suppressing logs a7bd666ff568b7ac
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total
@@ -73,7 +73,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: missing-workspace-config (esc)
   \xe2\x80\xa2 Running missing-workspace-config-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  missing-workspace-config:missing-workspace-config-task: cache miss, executing b0dd739b01bd5c0f
+  missing-workspace-config:missing-workspace-config-task: cache miss, executing 44b2829e0f461fcc
   missing-workspace-config:missing-workspace-config-task: 
   missing-workspace-config:missing-workspace-config-task: > missing-workspace-config-task
   missing-workspace-config:missing-workspace-config-task: > echo running-missing-workspace-config-task > out/foo.min.txt
@@ -89,7 +89,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: missing-workspace-config (esc)
   \xe2\x80\xa2 Running cached-task-4 in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  missing-workspace-config:cached-task-4: cache bypass, force executing 68b4a1bc2bbfe5d8
+  missing-workspace-config:cached-task-4: cache bypass, force executing 02705cb19702f9db
   missing-workspace-config:cached-task-4: 
   missing-workspace-config:cached-task-4: > cached-task-4
   missing-workspace-config:cached-task-4: > echo cached-task-4 > out/foo.min.txt

--- a/turborepo-tests/integration/tests/workspace-configs/omit-keys-deps.t
+++ b/turborepo-tests/integration/tests/workspace-configs/omit-keys-deps.t
@@ -15,14 +15,14 @@ Setup
   \xe2\x80\xa2 Running omit-keys-task-with-deps in 1 packages (esc)
 
   $ cat tmp.log | grep "omit-keys:omit-keys-task-with-deps"
-  omit-keys:omit-keys-task-with-deps: cache miss, executing bdb68ffb10d89fca
+  omit-keys:omit-keys-task-with-deps: cache miss, executing 1554356833ff5f4b
   omit-keys:omit-keys-task-with-deps: 
   omit-keys:omit-keys-task-with-deps: > omit-keys-task-with-deps
   omit-keys:omit-keys-task-with-deps: > echo running-omit-keys-task-with-deps > out/foo.min.txt
   omit-keys:omit-keys-task-with-deps: 
 
   $ cat tmp.log | grep "omit-keys:omit-keys-underlying-task"
-  omit-keys:omit-keys-underlying-task: cache miss, executing f61e962fa122bb3b
+  omit-keys:omit-keys-underlying-task: cache miss, executing a789ec01db5a0976
   omit-keys:omit-keys-underlying-task: 
   omit-keys:omit-keys-underlying-task: > omit-keys-underlying-task
   omit-keys:omit-keys-underlying-task: > echo running-omit-keys-underlying-task
@@ -30,7 +30,7 @@ Setup
   omit-keys:omit-keys-underlying-task: running-omit-keys-underlying-task
 
   $ cat tmp.log | grep "blank-pkg:omit-keys-underlying-topo-task"
-  blank-pkg:omit-keys-underlying-topo-task: cache miss, executing 7e41e6d75d5fcaa1
+  blank-pkg:omit-keys-underlying-topo-task: cache miss, executing f7bdaf1949934066
   blank-pkg:omit-keys-underlying-topo-task: 
   blank-pkg:omit-keys-underlying-topo-task: > omit-keys-underlying-topo-task
   blank-pkg:omit-keys-underlying-topo-task: > echo omit-keys-underlying-topo-task from blank-pkg

--- a/turborepo-tests/integration/tests/workspace-configs/omit-keys.t
+++ b/turborepo-tests/integration/tests/workspace-configs/omit-keys.t
@@ -14,7 +14,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: omit-keys (esc)
   \xe2\x80\xa2 Running omit-keys-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  omit-keys:omit-keys-task: cache miss, executing 7720930a8a9e9832
+  omit-keys:omit-keys-task: cache miss, executing 2275653d6cc837ea
   omit-keys:omit-keys-task: 
   omit-keys:omit-keys-task: > omit-keys-task
   omit-keys:omit-keys-task: > echo running-omit-keys-task > out/foo.min.txt
@@ -36,7 +36,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: omit-keys (esc)
   \xe2\x80\xa2 Running omit-keys-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  omit-keys:omit-keys-task: cache hit, suppressing logs 7720930a8a9e9832
+  omit-keys:omit-keys-task: cache hit, suppressing logs 2275653d6cc837ea
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total
@@ -48,7 +48,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: omit-keys (esc)
   \xe2\x80\xa2 Running omit-keys-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  omit-keys:omit-keys-task: cache miss, executing 3a68017c72f94e2f
+  omit-keys:omit-keys-task: cache miss, executing 4b42c9ab61970715
   omit-keys:omit-keys-task: 
   omit-keys:omit-keys-task: > omit-keys-task
   omit-keys:omit-keys-task: > echo running-omit-keys-task > out/foo.min.txt
@@ -65,7 +65,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: omit-keys (esc)
   \xe2\x80\xa2 Running omit-keys-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  omit-keys:omit-keys-task: cache hit, suppressing logs 3a68017c72f94e2f
+  omit-keys:omit-keys-task: cache hit, suppressing logs 4b42c9ab61970715
   
    Tasks:    1 successful, 1 total
   Cached:    1 cached, 1 total
@@ -76,7 +76,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: omit-keys (esc)
   \xe2\x80\xa2 Running omit-keys-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  omit-keys:omit-keys-task: cache miss, executing f0b1da3da9634589
+  omit-keys:omit-keys-task: cache miss, executing f79224ef709d0347
   omit-keys:omit-keys-task: 
   omit-keys:omit-keys-task: > omit-keys-task
   omit-keys:omit-keys-task: > echo running-omit-keys-task > out/foo.min.txt

--- a/turborepo-tests/integration/tests/workspace-configs/override-values-deps.t
+++ b/turborepo-tests/integration/tests/workspace-configs/override-values-deps.t
@@ -12,7 +12,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: override-values (esc)
   \xe2\x80\xa2 Running override-values-task-with-deps in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  override-values:override-values-task-with-deps: cache miss, executing 00e16c342cfa94ec
+  override-values:override-values-task-with-deps: cache miss, executing 1a68f7b5fcfe887e
   override-values:override-values-task-with-deps: 
   override-values:override-values-task-with-deps: > override-values-task-with-deps
   override-values:override-values-task-with-deps: > echo running-override-values-task-with-deps > out/foo.min.txt

--- a/turborepo-tests/integration/tests/workspace-configs/override-values.t
+++ b/turborepo-tests/integration/tests/workspace-configs/override-values.t
@@ -11,7 +11,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: override-values (esc)
   \xe2\x80\xa2 Running override-values-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  override-values:override-values-task: cache miss, executing ead3f3edd38fc1fd
+  override-values:override-values-task: cache miss, executing 30f06dcaf1586c63
   override-values:override-values-task: 
   override-values:override-values-task: > override-values-task
   override-values:override-values-task: > echo running-override-values-task > lib/bar.min.txt
@@ -36,7 +36,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: override-values (esc)
   \xe2\x80\xa2 Running override-values-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  override-values:override-values-task: cache hit, replaying logs ead3f3edd38fc1fd
+  override-values:override-values-task: cache hit, replaying logs 30f06dcaf1586c63
   override-values:override-values-task: 
   override-values:override-values-task: > override-values-task
   override-values:override-values-task: > echo running-override-values-task > lib/bar.min.txt
@@ -55,7 +55,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: override-values (esc)
   \xe2\x80\xa2 Running override-values-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  override-values:override-values-task: cache miss, executing 8b11eb45f619dba5
+  override-values:override-values-task: cache miss, executing 9d9fe6991167ac4d
   override-values:override-values-task: 
   override-values:override-values-task: > override-values-task
   override-values:override-values-task: > echo running-override-values-task > lib/bar.min.txt
@@ -71,7 +71,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: override-values (esc)
   \xe2\x80\xa2 Running override-values-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  override-values:override-values-task: cache hit, replaying logs 8b11eb45f619dba5
+  override-values:override-values-task: cache hit, replaying logs 9d9fe6991167ac4d
   override-values:override-values-task: 
   override-values:override-values-task: > override-values-task
   override-values:override-values-task: > echo running-override-values-task > lib/bar.min.txt
@@ -86,7 +86,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: override-values (esc)
   \xe2\x80\xa2 Running override-values-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  override-values:override-values-task: cache miss, executing 50fae434a20ed36e
+  override-values:override-values-task: cache miss, executing 6e7cf8bdd5c83b50
   override-values:override-values-task: 
   override-values:override-values-task: > override-values-task
   override-values:override-values-task: > echo running-override-values-task > lib/bar.min.txt
@@ -101,7 +101,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: override-values (esc)
   \xe2\x80\xa2 Running override-values-task in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  override-values:override-values-task: cache hit, replaying logs 50fae434a20ed36e
+  override-values:override-values-task: cache hit, replaying logs 6e7cf8bdd5c83b50
   override-values:override-values-task: 
   override-values:override-values-task: > override-values-task
   override-values:override-values-task: > echo running-override-values-task > lib/bar.min.txt

--- a/turborepo-tests/integration/tests/workspace-configs/persistent.t
+++ b/turborepo-tests/integration/tests/workspace-configs/persistent.t
@@ -30,13 +30,13 @@ This test covers:
   \xe2\x80\xa2 Packages in scope: persistent (esc)
   \xe2\x80\xa2 Running persistent-task-2-parent in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  persistent:persistent-task-2: cache miss, executing 73c5debabd593f2f
+  persistent:persistent-task-2: cache miss, executing a1be4f21d178a0ac
   persistent:persistent-task-2: 
   persistent:persistent-task-2: > persistent-task-2
   persistent:persistent-task-2: > echo persistent-task-2
   persistent:persistent-task-2: 
   persistent:persistent-task-2: persistent-task-2
-  persistent:persistent-task-2-parent: cache miss, executing 4e085f900c5be969
+  persistent:persistent-task-2-parent: cache miss, executing 3a82d48ad00259f4
   persistent:persistent-task-2-parent: 
   persistent:persistent-task-2-parent: > persistent-task-2-parent
   persistent:persistent-task-2-parent: > echo persistent-task-2-parent


### PR DESCRIPTION
### Description

With this PR we will now factor in all root dependency changes. Not just external packages.

Internal packages are handled by hashing all of the files contained in the package directory that aren't gitignore'd.

This does have performance implications as we can end up globwalking these directories multiple times and hashing the files multiple times if they end up as task inputs. This will be addressed in a future PR.

### Testing Instructions

Added integration test that displays new behavior
