### PR TITLE
chore: Remove unused `base16` dependency and dead `hex` wrapper function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,12 +646,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a17bd29f7c70f32e9387f4d4acfa5ea7b7749ef784fb78cf382df97069337b8c"
 
 [[package]]
-name = "base16"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d27c3610c36aee21ce8ac510e6224498de4228ad772a171ed65643a24693a5a8"
-
-[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10166,8 +10160,6 @@ dependencies = [
 name = "turbo-tasks-hash"
 version = "0.1.0"
 dependencies = [
- "base16",
- "hex",
  "md4",
  "turbo-tasks-macros",
  "twox-hash",

--- a/crates/turbo-tasks-hash/Cargo.toml
+++ b/crates/turbo-tasks-hash/Cargo.toml
@@ -13,8 +13,6 @@ bench = false
 workspace = true
 
 [dependencies]
-base16 = "0.2.1"
-hex = "0.4.3"
 md4 = "0.10.1"
 turbo-tasks-macros = { workspace = true }
 twox-hash = "1.6.3"

--- a/crates/turbo-tasks-hash/src/base16.rs
+++ b/crates/turbo-tasks-hash/src/base16.rs
@@ -1,4 +1,0 @@
-/// Encodes an array of bytes as a base16 string.
-pub fn encode_base16(input: &[u8]) -> String {
-    base16::encode_lower(input)
-}

--- a/crates/turbo-tasks-hash/src/hex.rs
+++ b/crates/turbo-tasks-hash/src/hex.rs
@@ -2,8 +2,3 @@
 pub fn encode_hex(n: u64) -> String {
     format!("{:01$x}", n, std::mem::size_of::<u64>() * 2)
 }
-
-/// Encodes a byte slice into a hex string.
-pub fn encode_hex_string(bytes: &[u8]) -> String {
-    hex::encode(bytes)
-}

--- a/crates/turbo-tasks-hash/src/lib.rs
+++ b/crates/turbo-tasks-hash/src/lib.rs
@@ -4,14 +4,12 @@
 //! invalidation, and encoding the hash to an hexadecimal string for use in a
 //! file name.
 
-mod base16;
 mod deterministic_hash;
 mod hex;
 mod md4;
 mod xxh3_hash64;
 
 pub use crate::{
-    base16::encode_base16,
     deterministic_hash::{DeterministicHash, DeterministicHasher},
     hex::{encode_hex, encode_hex_string},
     md4::hash_md4,

--- a/crates/turbo-tasks-hash/src/lib.rs
+++ b/crates/turbo-tasks-hash/src/lib.rs
@@ -11,7 +11,7 @@ mod xxh3_hash64;
 
 pub use crate::{
     deterministic_hash::{DeterministicHash, DeterministicHasher},
-    hex::{encode_hex, encode_hex_string},
+    hex::encode_hex,
     md4::hash_md4,
     xxh3_hash64::{hash_xxh3_hash64, Xxh3Hash64Hasher},
 };

--- a/deny.toml
+++ b/deny.toml
@@ -17,7 +17,7 @@ allow = [
   "MPL-2.0-no-copyleft-exception",
   # enum-iterator*
   "0BSD",
-  # base16, notify
+  # notify
   "CC0-1.0",
   # Inflector, hyper-tungstenite
   "BSD-2-Clause",


### PR DESCRIPTION
### Description

Noticed these dependencies/functions were unused.

For the most part, it's better to do these conversions with the built-in `format!()`.

Parsing base16 could make sense for this as a dependency, but we're not doing that.

### Testing Instructions

```
cargo check
```

Also grepped through next.js to check that we're not using it there.