### PR TITLE
Add option for inlining typeof window

### DIFF
--- a/crates/turbopack-ecmascript/Cargo.toml
+++ b/crates/turbopack-ecmascript/Cargo.toml
@@ -55,6 +55,7 @@ swc_core = { workspace = true, features = [
   "ecma_transforms",
   "ecma_transforms_module",
   "ecma_transforms_react",
+  "ecma_transforms_optimization",
   "ecma_transforms_typescript",
   "ecma_transforms_proposal",
   "ecma_quote",

--- a/crates/turbopack-ecmascript/src/transform/mod.rs
+++ b/crates/turbopack-ecmascript/src/transform/mod.rs
@@ -3,13 +3,15 @@ use std::{fmt::Debug, hash::Hash, sync::Arc};
 use anyhow::Result;
 use async_trait::async_trait;
 use swc_core::{
+    atoms::JsWord,
     base::SwcComments,
-    common::{chain, comments::Comments, util::take::Take, Mark, SourceMap},
+    common::{chain, collections::AHashMap, comments::Comments, util::take::Take, Mark, SourceMap},
     ecma::{
         ast::{Module, ModuleItem, Program, Script},
         preset_env::{self, Targets},
         transforms::{
             base::{feature::FeatureFlag, helpers::inject_helpers, Assumptions},
+            optimization::inline_globals2,
             react::react,
         },
         visit::{FoldWith, VisitMutWith},
@@ -38,6 +40,9 @@ pub enum EcmascriptInputTransform {
         import_source: Vc<Option<String>>,
         // swc.jsc.transform.react.runtime,
         runtime: Vc<Option<String>>,
+    },
+    GlobalTypeofs {
+        window_value: String,
     },
     // These options are subset of swc_core::ecma::transforms::typescript::Config, but
     // it doesn't derive `Copy` so repeating values in here
@@ -134,6 +139,18 @@ impl EcmascriptInputTransform {
             ..
         } = ctx;
         match self {
+            EcmascriptInputTransform::GlobalTypeofs { window_value } => {
+                let mut typeofs: AHashMap<JsWord, JsWord> = Default::default();
+                let val = window_value.to_owned();
+                typeofs.insert("window".into(), JsWord::from(val));
+
+                program.visit_mut_with(&mut inline_globals2(
+                    Default::default(),
+                    Default::default(),
+                    Default::default(),
+                    Arc::new(typeofs),
+                ));
+            }
             EcmascriptInputTransform::React {
                 development,
                 refresh,

--- a/crates/turbopack-ecmascript/src/transform/mod.rs
+++ b/crates/turbopack-ecmascript/src/transform/mod.rs
@@ -141,8 +141,7 @@ impl EcmascriptInputTransform {
         match self {
             EcmascriptInputTransform::GlobalTypeofs { window_value } => {
                 let mut typeofs: AHashMap<JsWord, JsWord> = Default::default();
-                let val = window_value.to_owned();
-                typeofs.insert("window".into(), JsWord::from(val));
+                typeofs.insert("window".into(), JsWord::from(&**window_value));
 
                 program.visit_mut_with(&mut inline_globals2(
                     Default::default(),

--- a/crates/turbopack/src/module_options/mod.rs
+++ b/crates/turbopack/src/module_options/mod.rs
@@ -81,6 +81,7 @@ impl ModuleOptions {
             import_externals,
             ignore_dynamic_requests,
             use_swc_css,
+            ref enable_typeof_window_inlining,
             ..
         } = *module_options_context.await?;
         if !rules.is_empty() {
@@ -128,6 +129,15 @@ impl ModuleOptions {
 
         if let Some(env) = preset_env_versions {
             transforms.push(EcmascriptInputTransform::PresetEnv(env));
+        }
+
+        if let Some(enable_typeof_window_inlining) = enable_typeof_window_inlining {
+            transforms.push(EcmascriptInputTransform::GlobalTypeofs {
+                window_value: match enable_typeof_window_inlining {
+                    TypeofWindow::Object => "object".to_string(),
+                    TypeofWindow::Undefined => "undefined".to_string(),
+                },
+            });
         }
 
         let ts_transform = if let Some(options) = enable_typescript_transform {

--- a/crates/turbopack/src/module_options/module_options_context.rs
+++ b/crates/turbopack/src/module_options/module_options_context.rs
@@ -46,6 +46,13 @@ pub enum DecoratorsKind {
     Ecma,
 }
 
+/// The types when replacing `typeof window` with a constant.
+#[derive(Clone, PartialEq, Eq, Debug, TraceRawVcs, Serialize, Deserialize)]
+pub enum TypeofWindow {
+    Object,
+    Undefined,
+}
+
 /// Configuration options for the decorators transform.
 /// This is not part of Typescript transform: while there are typescript
 /// specific transforms (legay decorators), there is an ecma decorator transform
@@ -105,6 +112,7 @@ pub struct JsxTransformOptions {
 #[derive(Default, Clone)]
 #[serde(default)]
 pub struct ModuleOptionsContext {
+    pub enable_typeof_window_inlining: Option<TypeofWindow>,
     pub enable_jsx: Option<Vc<JsxTransformOptions>>,
     pub enable_postcss_transform: Option<Vc<PostCssTransformOptions>>,
     pub enable_webpack_loaders: Option<Vc<WebpackLoadersOptions>>,


### PR DESCRIPTION
### Description

In Next.js with webpack we have a feature to inline `typeof window` in server/client environments. That allows e.g.

```
"use client"
if(typeof window === 'undefined') {
  import('server-only-package')
}
```

Today with Turbopack above code causes `server-only-package` to still be loaded in the browser compilation. Which causes issues like https://github.com/vercel/next.js/issues/66058 where the `if`/`else` condition is used to use different modules for server and client.

This change is required to pass the test in https://github.com/vercel/next.js/issues/66058

Pushing up the Next.js changes in that PR.

<!--
  ✍️ Write a short summary of your work.
  If necessary, include relevant screenshots.
-->

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
