### PR TITLE
Fix typo in Turborepo task-graph documentation

### DIFF
--- a/docs/pages/repo/docs/core-concepts/monorepos/task-graph.mdx
+++ b/docs/pages/repo/docs/core-concepts/monorepos/task-graph.mdx
@@ -12,7 +12,7 @@ Graph.
 
 Turborepo uses a data structure called a [directed acyclic graph (DAG)][1] to
 understand your repository and its tasks. A graph is made up of "nodes" and
-"edges". In our Task Graph, the nodes are tasks and the edges are the the
+"edges". In our Task Graph, the nodes are tasks and the edges are the
 dependencies between tasks. A _directed_ graph indicates that the edges
 connecting each node have a direction, so if Task A points to Task B, we can say
 that Task A depends on Task B. The direction of the edge depends on which task


### PR DESCRIPTION
### Description

Remove the repeated word "the" before 'dependencies' to improve readability and clarity.

The fix, just remove a repeated work in the following sentence:

> In our Task Graph, the nodes are tasks and the edges are the dependencies between tasks.

### Testing Instructions

Head over to the page [The Task Graph](https://turbo.build/repo/docs/core-concepts/monorepos/task-graph) and on the second paragraph, the word "the" is repeated in the sentence

> In our Task Graph, the nodes are tasks and the edges are the the dependencies between tasks.

