### PR TITLE
Update SWC relay Wasm plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8951,9 +8951,9 @@ dependencies = [
 
 [[package]]
 name = "swc_relay"
-version = "0.44.13"
+version = "0.44.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b36a22861087d88f0ae4d78800b6fd44e2dc5b541f8da53e81388c611bab0ef9"
+checksum = "14a596e01319abf55b8a8c7e36a82aa0d1ac01a18a99ce9b07a7fbcbfd544466"
 dependencies = [
  "once_cell",
  "regex",
@@ -9289,9 +9289,9 @@ dependencies = [
 
 [[package]]
 name = "testing"
-version = "0.35.24"
+version = "0.35.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71dd5265f4921fe51b386b1496c63ac058589d8cd38de6b61489a98c6019a16"
+checksum = "15028f8ec7f95006f4e00e6c5ab6620f322bc6dc208a6cba09afa36375981cec"
 dependencies = [
  "ansi_term",
  "cargo_metadata",
@@ -11438,7 +11438,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.8.5",
+ "rand 0.4.6",
  "static_assertions",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,8 +117,8 @@ swc_core = { version = "0.92.5", features = [
   "ecma_loader_parking_lot",
 ] }
 swc_emotion = { version = "0.72.13" }
-swc_relay = { version = "0.44.13" }
-testing = { version = "0.35.24" }
+swc_relay = { version = "0.44.14" }
+testing = { version = "0.35.25" }
 # Temporary: Reference the latest git minor version of pathfinder_simd until it's published.
 pathfinder_simd = "0.5.3"
 


### PR DESCRIPTION
### Description

Fixes https://github.com/vercel/next.js/issues/64890

When `eagerEsModule` is used, the SWC relay plugin _prepends_ the import statements, and it made server actions transform think `"use server"` is not the first statement.


### Testing Instructions

I added tests to https://github.com/swc-project/plugins/pull/306