### PR TITLE
chore(@turbo/utils): update tests/fixtures to use tasks key

### DIFF
--- a/packages/turbo-utils/__fixtures__/common/old-workspace-config/turbo.json
+++ b/packages/turbo-utils/__fixtures__/common/old-workspace-config/turbo.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "globalDependencies": ["**/.env.*local"],
-  "pipeline": {
+  "tasks": {
     "build": {
       "outputs": [".next/**", "!.next/cache/**"]
     },

--- a/packages/turbo-utils/__fixtures__/common/single-package/turbo.json
+++ b/packages/turbo-utils/__fixtures__/common/single-package/turbo.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "globalEnv": ["UNORDERED", "CI"],
-  "pipeline": {
+  "tasks": {
     "build": {
       // A workspace's `build` task depends on that workspace's
       // topological dependencies' and devDependencies'

--- a/packages/turbo-utils/__fixtures__/common/workspace-configs/apps/web/turbo.json
+++ b/packages/turbo-utils/__fixtures__/common/workspace-configs/apps/web/turbo.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "extends": ["//"],
-  "pipeline": {
+  "tasks": {
     "build": {
       "env": ["ENV_2"]
     }

--- a/packages/turbo-utils/__fixtures__/common/workspace-configs/packages/ui/turbo.json
+++ b/packages/turbo-utils/__fixtures__/common/workspace-configs/packages/ui/turbo.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "extends": ["//"],
-  "pipeline": {
+  "tasks": {
     "build": {
       "env": ["IS_SERVER"]
     }

--- a/packages/turbo-utils/__fixtures__/common/workspace-configs/packages/utils/turbo.json
+++ b/packages/turbo-utils/__fixtures__/common/workspace-configs/packages/utils/turbo.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://turbo.build/schema.json",
   // invalid config - missing extends
-  "pipeline": {
+  "tasks": {
     "build": {
       "env": ["IS_SERVER"]
     }

--- a/packages/turbo-utils/__fixtures__/common/workspace-configs/turbo.json
+++ b/packages/turbo-utils/__fixtures__/common/workspace-configs/turbo.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "globalEnv": ["CI"],
-  "pipeline": {
+  "tasks": {
     "build": {
       "env": ["ENV_1"]
     }

--- a/packages/turbo-utils/__tests__/getTurboConfigs.test.ts
+++ b/packages/turbo-utils/__tests__/getTurboConfigs.test.ts
@@ -20,7 +20,7 @@ describe("getTurboConfigs", () => {
           "UNORDERED",
           "CI",
         ],
-        "pipeline": Object {
+        "tasks": Object {
           "build": Object {
             "dependsOn": Array [
               "^build",
@@ -66,7 +66,7 @@ describe("getTurboConfigs", () => {
         "globalEnv": Array [
           "CI",
         ],
-        "pipeline": Object {
+        "tasks": Object {
           "build": Object {
             "env": Array [
               "ENV_1",
@@ -82,7 +82,7 @@ describe("getTurboConfigs", () => {
         "extends": Array [
           "//",
         ],
-        "pipeline": Object {
+        "tasks": Object {
           "build": Object {
             "env": Array [
               "ENV_2",
@@ -99,7 +99,7 @@ describe("getTurboConfigs", () => {
         "extends": Array [
           "//",
         ],
-        "pipeline": Object {
+        "tasks": Object {
           "build": Object {
             "env": Array [
               "IS_SERVER",
@@ -122,7 +122,7 @@ describe("getTurboConfigs", () => {
         "globalDependencies": Array [
           "**/.env.*local",
         ],
-        "pipeline": Object {
+        "tasks": Object {
           "build": Object {
             "outputs": Array [
               ".next/**",


### PR DESCRIPTION
I've confirmed that `turbo test -F @turbo/utils` passes on this branch