### PR TITLE
chore: bump daemon version

### DIFF
--- a/crates/turborepo-lib/src/daemon/mod.rs
+++ b/crates/turborepo-lib/src/daemon/mod.rs
@@ -100,7 +100,7 @@ pub(crate) mod proto {
     /// - Bump the minor version if adding new features, such that clients can
     ///   mandate at least some set of features on the target server.
     /// - Bump the patch version if making backwards compatible bug fixes.
-    pub const VERSION: &str = "1.11.0";
+    pub const VERSION: &str = "2.0.0";
 
     impl From<PackageManager> for turborepo_repository::package_manager::PackageManager {
         fn from(pm: PackageManager) -> Self {


### PR DESCRIPTION
### Description

Handshake logic works, we just need to bump the daemon version since it's independent(?) of the client version.

Future work is to keep this constant in lockstep with our client version to help us avoid forgetting to bump this.

### Testing Instructions

Verify that running binary in a repo with a running 1.x daemon will result in the daemon getting shut down and a new one being started:
```
2024-05-28T10:17:35.750-0700 [DEBUG] turborepo_lib::daemon::connector: found pid: 6563                                                      
2024-05-28T10:17:35.750-0700 [DEBUG] turborepo_lib::daemon::connector: got daemon with pid: 6563                                                                                                                 
2024-05-28T10:17:35.766-0700 [DEBUG] turborepo_lib::daemon::connector: no pid found, starting daemon                                        
2024-05-28T10:17:35.767-0700 [DEBUG] turborepo_lib::daemon::connector: got daemon with pid: 8593
```
