### PR TITLE
chore: override bad api url on ubuntu runners

### DIFF
--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -147,7 +147,7 @@ jobs:
           if [ -z "${RUSTC_WRAPPER}" ]; then
             unset RUSTC_WRAPPER
           fi
-          turbo run build --filter=cli --color --env-mode=strict --token=${{ secrets.TURBO_TOKEN }} --team=${{ vars.TURBO_TEAM }}
+          TURBO_API= turbo run build --filter=cli --color --env-mode=strict --token=${{ secrets.TURBO_TOKEN }} --team=${{ vars.TURBO_TEAM }}
         shell: bash
         env:
           SCCACHE_BUCKET: turborepo-sccache


### PR DESCRIPTION
### Description

On the self hosted Ubuntu runners `TURBO_API` is set to a URL that the Turbo Team doesn't have permission to access leading to a loss of the remote cache functionality.
e.g.
<img width="882" alt="Screenshot 2024-05-28 at 2 31 29 PM" src="https://github.com/vercel/turbo/assets/4131117/1c43a540-77a1-412d-a078-2bbdbaf4159d">
https://github.com/vercel/turbo/actions/runs/9276119063/job/25522446449#step:7:478

This PR overrides this env var so we can leverage the remote cache.

### Testing Instructions

The Ubuntu build of `turbo` should be a cache hit on this PR
<img width="773" alt="Screenshot 2024-05-28 at 2 51 38 PM" src="https://github.com/vercel/turbo/assets/4131117/8e3944ff-3043-4686-a1c7-e603f60f02d8">

https://github.com/actions/runner-images/pull/9941/files#diff-66aec6097318276b09842a3ba2caf3037afbd8dadca2dfcdf76631100613ea69L26
