### PR TITLE
chore: pin node version to 18.20.2

### DIFF
--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -138,6 +138,7 @@ jobs:
         with:
           windows: ${{ matrix.os.runner == 'windows-latest' }}
           github-token: "${{ secrets.GITHUB_TOKEN }}"
+          node-version: "18.20.2"
 
       - name: Install Global Turbo
         uses: ./.github/actions/install-global-turbo
@@ -194,6 +195,7 @@ jobs:
         with:
           windows: ${{ matrix.os.runner == 'windows-latest' }}
           github-token: "${{ secrets.GITHUB_TOKEN }}"
+          node-version: "18.20.2"
 
       - name: Install Global Turbo
         uses: ./.github/actions/install-global-turbo
@@ -236,6 +238,7 @@ jobs:
         uses: ./.github/actions/setup-turborepo-environment
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
+          node-version: "18.20.2"
 
       - name: Install Global Turbo
         uses: ./.github/actions/install-global-turbo
@@ -305,6 +308,7 @@ jobs:
         uses: ./.github/actions/setup-turborepo-environment
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
+          node-version: "18.20.2"
 
       - name: Run cargo check
         run: |
@@ -371,6 +375,7 @@ jobs:
         with:
           windows: ${{ matrix.os.runner == 'windows-latest' }}
           github-token: "${{ secrets.GITHUB_TOKEN }}"
+          node-version: "18.20.2"
 
       - name: Run tests
         timeout-minutes: 120


### PR DESCRIPTION
### Description

It seems that something with the [Node 18.20.2 -> 18.20.3](https://github.com/actions/runner-images/pull/9941/files#diff-66aec6097318276b09842a3ba2caf3037afbd8dadca2dfcdf76631100613ea69L26) bump in `ubuntu-latest` is breaking how we expect corepack to behave. 

Pinning it for now.



### Testing Instructions

CI
