### PR TITLE
chore: Update fixtures, test, and schema to tasks key in JS packages

### DIFF
--- a/packages/eslint-plugin-turbo/__fixtures__/configs/single/turbo.json
+++ b/packages/eslint-plugin-turbo/__fixtures__/configs/single/turbo.json
@@ -3,7 +3,7 @@
   "globalEnv": ["NEW_STYLE_GLOBAL_ENV_KEY", "$NEW_STYLE_GLOBAL_ENV_KEY"],
   // old style, global env dependency (deprecated)
   "globalDependencies": ["$GLOBAL_ENV_KEY"],
-  "pipeline": {
+  "tasks": {
     "test": {
       "outputs": ["coverage/**"],
       "dependsOn": ["^build"]

--- a/packages/eslint-plugin-turbo/__fixtures__/workspace-configs/apps/docs/turbo.json
+++ b/packages/eslint-plugin-turbo/__fixtures__/workspace-configs/apps/docs/turbo.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "extends": ["//"],
-  "pipeline": {
+  "tasks": {
     "build": {
       "dotEnv": ["missing1.env", "missing2.env"],
       "env": ["ENV_3"]

--- a/packages/eslint-plugin-turbo/__fixtures__/workspace-configs/apps/web/turbo.json
+++ b/packages/eslint-plugin-turbo/__fixtures__/workspace-configs/apps/web/turbo.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "extends": ["//"],
-  "pipeline": {
+  "tasks": {
     "build": {
       "dotEnv": [".env"],
       "env": ["ENV_2", "NEXT_PUBLIC_*", "!NEXT_PUBLIC_EXCLUDE*"]

--- a/packages/eslint-plugin-turbo/__fixtures__/workspace-configs/packages/ui/turbo.json
+++ b/packages/eslint-plugin-turbo/__fixtures__/workspace-configs/packages/ui/turbo.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "extends": ["//"],
-  "pipeline": {
+  "tasks": {
     "build": {
       "env": ["IS_SERVER"]
     }

--- a/packages/eslint-plugin-turbo/__fixtures__/workspace-configs/turbo.json
+++ b/packages/eslint-plugin-turbo/__fixtures__/workspace-configs/turbo.json
@@ -2,7 +2,7 @@
   "$schema": "https://turbo.build/schema.json",
   "globalEnv": ["CI"],
   "globalDotEnv": [".env", "missing.env"],
-  "pipeline": {
+  "tasks": {
     "build": {
       "env": ["ENV_1"]
     }

--- a/packages/eslint-plugin-turbo/__fixtures__/workspace/turbo.json
+++ b/packages/eslint-plugin-turbo/__fixtures__/workspace/turbo.json
@@ -2,7 +2,7 @@
   "$schema": "https://turbo.build/schema.json",
   "globalEnv": ["UNORDERED", "CI"],
   "globalDotEnv": [".env", "missing.env"],
-  "pipeline": {
+  "tasks": {
     "build": {
       // A workspace's `build` task depends on that workspace's
       // topological dependencies' and devDependencies'

--- a/packages/eslint-plugin-turbo/lib/utils/calculate-inputs.ts
+++ b/packages/eslint-plugin-turbo/lib/utils/calculate-inputs.ts
@@ -314,7 +314,7 @@ export class Project {
         this.projectRoot.turboConfig
       );
 
-      Object.entries(this.projectRoot.turboConfig.pipeline).forEach(
+      Object.entries(this.projectRoot.turboConfig.tasks).forEach(
         ([taskName, taskDefinition]) => {
           const { workspaceName, scriptName } = getTaskAddress(taskName);
           if (workspaceName) {
@@ -341,7 +341,7 @@ export class Project {
         return;
       }
 
-      Object.entries(projectWorkspace.turboConfig.pipeline).forEach(
+      Object.entries(projectWorkspace.turboConfig.tasks).forEach(
         ([taskName, taskDefinition]) => {
           const { workspaceName: erroneousWorkspaceName, scriptName } =
             getTaskAddress(taskName);

--- a/packages/turbo-codemod/__tests__/__fixtures__/clean-globs/clean-globs/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/clean-globs/clean-globs/turbo.json
@@ -2,24 +2,12 @@
   "$schema": "../../../../../../docs/public/schema.json",
   "tasks": {
     "case_1": {
-      "inputs": [
-        "../../app-store/**/**",
-        "**/**/result.json"
-      ],
-      "outputs": [
-        "../../app-store/**/**",
-        "**/**/result.json"
-      ]
+      "inputs": ["../../app-store/**/**", "**/**/result.json"],
+      "outputs": ["../../app-store/**/**", "**/**/result.json"]
     },
     "case_2": {
-      "inputs": [
-        "!**/dist",
-        "!**/node_modules"
-      ],
-      "outputs": [
-        "!**/dist",
-        "!**/node_modules"
-      ]
+      "inputs": ["!**/dist", "!**/node_modules"],
+      "outputs": ["!**/dist", "!**/node_modules"]
     },
     "case_3": {
       "inputs": [

--- a/packages/turbo-codemod/__tests__/__fixtures__/clean-globs/clean-globs/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/clean-globs/clean-globs/turbo.json
@@ -1,13 +1,25 @@
 {
   "$schema": "../../../../../../docs/public/schema.json",
-  "pipeline": {
+  "tasks": {
     "case_1": {
-      "inputs": ["../../app-store/**/**", "**/**/result.json"],
-      "outputs": ["../../app-store/**/**", "**/**/result.json"]
+      "inputs": [
+        "../../app-store/**/**",
+        "**/**/result.json"
+      ],
+      "outputs": [
+        "../../app-store/**/**",
+        "**/**/result.json"
+      ]
     },
     "case_2": {
-      "inputs": ["!**/dist", "!**/node_modules"],
-      "outputs": ["!**/dist", "!**/node_modules"]
+      "inputs": [
+        "!**/dist",
+        "!**/node_modules"
+      ],
+      "outputs": [
+        "!**/dist",
+        "!**/node_modules"
+      ]
     },
     "case_3": {
       "inputs": [

--- a/packages/turbo-codemod/__tests__/__fixtures__/create-turbo-config/both-configs/package.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/create-turbo-config/both-configs/package.json
@@ -6,7 +6,7 @@
   "packageManager": "npm@1.2.3",
   "turbo": {
     "$schema": "https://turbo.build/schema.json",
-    "pipeline": {
+    "tasks": {
       "package-only": {
         "cache": false,
         "persistent": true

--- a/packages/turbo-codemod/__tests__/__fixtures__/create-turbo-config/both-configs/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/create-turbo-config/both-configs/turbo.json
@@ -6,10 +6,7 @@
       "persistent": true
     },
     "build": {
-      "outputs": [
-        ".next/**",
-        "!.next/cache/**"
-      ]
+      "outputs": [".next/**", "!.next/cache/**"]
     },
     "lint": {
       "outputs": []

--- a/packages/turbo-codemod/__tests__/__fixtures__/create-turbo-config/both-configs/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/create-turbo-config/both-configs/turbo.json
@@ -1,12 +1,15 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "pipeline": {
+  "tasks": {
     "turbo-only": {
       "cache": false,
       "persistent": true
     },
     "build": {
-      "outputs": [".next/**", "!.next/cache/**"]
+      "outputs": [
+        ".next/**",
+        "!.next/cache/**"
+      ]
     },
     "lint": {
       "outputs": []

--- a/packages/turbo-codemod/__tests__/__fixtures__/create-turbo-config/no-turbo-json-config/package.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/create-turbo-config/no-turbo-json-config/package.json
@@ -6,7 +6,7 @@
   "packageManager": "npm@1.2.3",
   "turbo": {
     "$schema": "https://turbo.build/schema.json",
-    "pipeline": {
+    "tasks": {
       "build": {
         "outputs": [
           ".next/**",

--- a/packages/turbo-codemod/__tests__/__fixtures__/create-turbo-config/turbo-json-config/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/create-turbo-config/turbo-json-config/turbo.json
@@ -6,10 +6,7 @@
       "persistent": true
     },
     "build": {
-      "outputs": [
-        ".next/**",
-        "!.next/cache/**"
-      ]
+      "outputs": [".next/**", "!.next/cache/**"]
     },
     "lint": {
       "outputs": []

--- a/packages/turbo-codemod/__tests__/__fixtures__/create-turbo-config/turbo-json-config/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/create-turbo-config/turbo-json-config/turbo.json
@@ -1,12 +1,15 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "pipeline": {
+  "tasks": {
     "turbo-only": {
       "cache": false,
       "persistent": true
     },
     "build": {
-      "outputs": [".next/**", "!.next/cache/**"]
+      "outputs": [
+        ".next/**",
+        "!.next/cache/**"
+      ]
     },
     "lint": {
       "outputs": []

--- a/packages/turbo-codemod/__tests__/__fixtures__/migrate-env-var-dependencies/env-dependencies/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/migrate-env-var-dependencies/env-dependencies/turbo.json
@@ -1,18 +1,33 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "globalDependencies": ["$NEXT_PUBLIC_API_KEY", "$STRIPE_API_KEY", ".env"],
-  "pipeline": {
+  "globalDependencies": [
+    "$NEXT_PUBLIC_API_KEY",
+    "$STRIPE_API_KEY",
+    ".env"
+  ],
+  "tasks": {
     "build": {
-      "outputs": [".next/**", "!.next/cache/**"],
-      "dependsOn": ["^build", "$PROD_API_KEY"]
+      "outputs": [
+        ".next/**",
+        "!.next/cache/**"
+      ],
+      "dependsOn": [
+        "^build",
+        "$PROD_API_KEY"
+      ]
     },
     "lint": {
       "outputs": [],
-      "dependsOn": ["$IS_CI"]
+      "dependsOn": [
+        "$IS_CI"
+      ]
     },
     "test": {
       "outputs": [],
-      "dependsOn": ["$IS_CI", "test"]
+      "dependsOn": [
+        "$IS_CI",
+        "test"
+      ]
     },
     "dev": {
       "cache": false

--- a/packages/turbo-codemod/__tests__/__fixtures__/migrate-env-var-dependencies/env-dependencies/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/migrate-env-var-dependencies/env-dependencies/turbo.json
@@ -1,33 +1,18 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "globalDependencies": [
-    "$NEXT_PUBLIC_API_KEY",
-    "$STRIPE_API_KEY",
-    ".env"
-  ],
+  "globalDependencies": ["$NEXT_PUBLIC_API_KEY", "$STRIPE_API_KEY", ".env"],
   "tasks": {
     "build": {
-      "outputs": [
-        ".next/**",
-        "!.next/cache/**"
-      ],
-      "dependsOn": [
-        "^build",
-        "$PROD_API_KEY"
-      ]
+      "outputs": [".next/**", "!.next/cache/**"],
+      "dependsOn": ["^build", "$PROD_API_KEY"]
     },
     "lint": {
       "outputs": [],
-      "dependsOn": [
-        "$IS_CI"
-      ]
+      "dependsOn": ["$IS_CI"]
     },
     "test": {
       "outputs": [],
-      "dependsOn": [
-        "$IS_CI",
-        "test"
-      ]
+      "dependsOn": ["$IS_CI", "test"]
     },
     "dev": {
       "cache": false

--- a/packages/turbo-codemod/__tests__/__fixtures__/migrate-env-var-dependencies/migrated-env-dependencies/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/migrate-env-var-dependencies/migrated-env-dependencies/turbo.json
@@ -1,40 +1,24 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "globalDependencies": [],
-  "globalEnv": [
-    "NEXT_PUBLIC_API_KEY",
-    "STRIPE_API_KEY"
-  ],
+  "globalEnv": ["NEXT_PUBLIC_API_KEY", "STRIPE_API_KEY"],
   "tasks": {
     "build": {
-      "dependsOn": [
-        "^build"
-      ],
-      "env": [
-        "PROD_API_KEY"
-      ],
-      "outputs": [
-        ".next/**",
-        "!.next/cache/**"
-      ]
+      "dependsOn": ["^build"],
+      "env": ["PROD_API_KEY"],
+      "outputs": [".next/**", "!.next/cache/**"]
     },
     "dev": {
       "cache": false
     },
     "lint": {
       "dependsOn": [],
-      "env": [
-        "IS_CI"
-      ],
+      "env": ["IS_CI"],
       "outputs": []
     },
     "test": {
-      "dependsOn": [
-        "test"
-      ],
-      "env": [
-        "IS_CI"
-      ],
+      "dependsOn": ["test"],
+      "env": ["IS_CI"],
       "outputs": []
     }
   }

--- a/packages/turbo-codemod/__tests__/__fixtures__/migrate-env-var-dependencies/migrated-env-dependencies/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/migrate-env-var-dependencies/migrated-env-dependencies/turbo.json
@@ -1,24 +1,40 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "globalDependencies": [],
-  "globalEnv": ["NEXT_PUBLIC_API_KEY", "STRIPE_API_KEY"],
-  "pipeline": {
+  "globalEnv": [
+    "NEXT_PUBLIC_API_KEY",
+    "STRIPE_API_KEY"
+  ],
+  "tasks": {
     "build": {
-      "dependsOn": ["^build"],
-      "env": ["PROD_API_KEY"],
-      "outputs": [".next/**", "!.next/cache/**"]
+      "dependsOn": [
+        "^build"
+      ],
+      "env": [
+        "PROD_API_KEY"
+      ],
+      "outputs": [
+        ".next/**",
+        "!.next/cache/**"
+      ]
     },
     "dev": {
       "cache": false
     },
     "lint": {
       "dependsOn": [],
-      "env": ["IS_CI"],
+      "env": [
+        "IS_CI"
+      ],
       "outputs": []
     },
     "test": {
-      "dependsOn": ["test"],
-      "env": ["IS_CI"],
+      "dependsOn": [
+        "test"
+      ],
+      "env": [
+        "IS_CI"
+      ],
       "outputs": []
     }
   }

--- a/packages/turbo-codemod/__tests__/__fixtures__/migrate-env-var-dependencies/old-config/package.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/migrate-env-var-dependencies/old-config/package.json
@@ -5,7 +5,7 @@
   "devDependencies": {},
   "packageManager": "npm@1.2.3",
   "turbo": {
-    "pipeline": {
+    "tasks": {
       "build-one": {
         "outputs": [
           "foo"

--- a/packages/turbo-codemod/__tests__/__fixtures__/migrate-env-var-dependencies/old-config/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/migrate-env-var-dependencies/old-config/turbo.json
@@ -2,9 +2,7 @@
   "$schema": "https://turbo.build/schema.json",
   "tasks": {
     "build-one": {
-      "outputs": [
-        "foo"
-      ]
+      "outputs": ["foo"]
     },
     "build-two": {
       "outputs": []

--- a/packages/turbo-codemod/__tests__/__fixtures__/migrate-env-var-dependencies/old-config/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/migrate-env-var-dependencies/old-config/turbo.json
@@ -1,8 +1,10 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "pipeline": {
+  "tasks": {
     "build-one": {
-      "outputs": ["foo"]
+      "outputs": [
+        "foo"
+      ]
     },
     "build-two": {
       "outputs": []

--- a/packages/turbo-codemod/__tests__/__fixtures__/migrate-env-var-dependencies/workspace-configs/apps/docs/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/migrate-env-var-dependencies/workspace-configs/apps/docs/turbo.json
@@ -1,9 +1,13 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "extends": ["//"],
-  "pipeline": {
+  "extends": [
+    "//"
+  ],
+  "tasks": {
     "build": {
-      "env": ["ENV_3"]
+      "env": [
+        "ENV_3"
+      ]
     }
   }
 }

--- a/packages/turbo-codemod/__tests__/__fixtures__/migrate-env-var-dependencies/workspace-configs/apps/docs/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/migrate-env-var-dependencies/workspace-configs/apps/docs/turbo.json
@@ -1,13 +1,9 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "extends": [
-    "//"
-  ],
+  "extends": ["//"],
   "tasks": {
     "build": {
-      "env": [
-        "ENV_3"
-      ]
+      "env": ["ENV_3"]
     }
   }
 }

--- a/packages/turbo-codemod/__tests__/__fixtures__/migrate-env-var-dependencies/workspace-configs/apps/web/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/migrate-env-var-dependencies/workspace-configs/apps/web/turbo.json
@@ -1,12 +1,19 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "extends": ["//"],
-  "pipeline": {
+  "extends": [
+    "//"
+  ],
+  "tasks": {
     "build": {
       // old
-      "dependsOn": ["build", "$ENV_2"],
+      "dependsOn": [
+        "build",
+        "$ENV_2"
+      ],
       // new
-      "env": ["ENV_1"]
+      "env": [
+        "ENV_1"
+      ]
     }
   }
 }

--- a/packages/turbo-codemod/__tests__/__fixtures__/migrate-env-var-dependencies/workspace-configs/apps/web/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/migrate-env-var-dependencies/workspace-configs/apps/web/turbo.json
@@ -1,19 +1,12 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "extends": [
-    "//"
-  ],
+  "extends": ["//"],
   "tasks": {
     "build": {
       // old
-      "dependsOn": [
-        "build",
-        "$ENV_2"
-      ],
+      "dependsOn": ["build", "$ENV_2"],
       // new
-      "env": [
-        "ENV_1"
-      ]
+      "env": ["ENV_1"]
     }
   }
 }

--- a/packages/turbo-codemod/__tests__/__fixtures__/migrate-env-var-dependencies/workspace-configs/packages/ui/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/migrate-env-var-dependencies/workspace-configs/packages/ui/turbo.json
@@ -1,9 +1,13 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "extends": ["//"],
-  "pipeline": {
+  "extends": [
+    "//"
+  ],
+  "tasks": {
     "build": {
-      "dependsOn": ["$IS_SERVER"]
+      "dependsOn": [
+        "$IS_SERVER"
+      ]
     }
   }
 }

--- a/packages/turbo-codemod/__tests__/__fixtures__/migrate-env-var-dependencies/workspace-configs/packages/ui/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/migrate-env-var-dependencies/workspace-configs/packages/ui/turbo.json
@@ -1,13 +1,9 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "extends": [
-    "//"
-  ],
+  "extends": ["//"],
   "tasks": {
     "build": {
-      "dependsOn": [
-        "$IS_SERVER"
-      ]
+      "dependsOn": ["$IS_SERVER"]
     }
   }
 }

--- a/packages/turbo-codemod/__tests__/__fixtures__/migrate-env-var-dependencies/workspace-configs/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/migrate-env-var-dependencies/workspace-configs/turbo.json
@@ -1,18 +1,33 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "globalDependencies": ["$NEXT_PUBLIC_API_KEY", "$STRIPE_API_KEY", ".env"],
-  "pipeline": {
+  "globalDependencies": [
+    "$NEXT_PUBLIC_API_KEY",
+    "$STRIPE_API_KEY",
+    ".env"
+  ],
+  "tasks": {
     "build": {
-      "outputs": [".next/**", "!.next/cache/**"],
-      "dependsOn": ["^build", "$PROD_API_KEY"]
+      "outputs": [
+        ".next/**",
+        "!.next/cache/**"
+      ],
+      "dependsOn": [
+        "^build",
+        "$PROD_API_KEY"
+      ]
     },
     "lint": {
       "outputs": [],
-      "dependsOn": ["$IS_TEST"]
+      "dependsOn": [
+        "$IS_TEST"
+      ]
     },
     "test": {
       "outputs": [],
-      "dependsOn": ["$IS_CI", "test"]
+      "dependsOn": [
+        "$IS_CI",
+        "test"
+      ]
     },
     "dev": {
       "cache": false

--- a/packages/turbo-codemod/__tests__/__fixtures__/migrate-env-var-dependencies/workspace-configs/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/migrate-env-var-dependencies/workspace-configs/turbo.json
@@ -1,33 +1,18 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "globalDependencies": [
-    "$NEXT_PUBLIC_API_KEY",
-    "$STRIPE_API_KEY",
-    ".env"
-  ],
+  "globalDependencies": ["$NEXT_PUBLIC_API_KEY", "$STRIPE_API_KEY", ".env"],
   "tasks": {
     "build": {
-      "outputs": [
-        ".next/**",
-        "!.next/cache/**"
-      ],
-      "dependsOn": [
-        "^build",
-        "$PROD_API_KEY"
-      ]
+      "outputs": [".next/**", "!.next/cache/**"],
+      "dependsOn": ["^build", "$PROD_API_KEY"]
     },
     "lint": {
       "outputs": [],
-      "dependsOn": [
-        "$IS_TEST"
-      ]
+      "dependsOn": ["$IS_TEST"]
     },
     "test": {
       "outputs": [],
-      "dependsOn": [
-        "$IS_CI",
-        "test"
-      ]
+      "dependsOn": ["$IS_CI", "test"]
     },
     "dev": {
       "cache": false

--- a/packages/turbo-codemod/__tests__/__fixtures__/migrate/old-turbo/package.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/migrate/old-turbo/package.json
@@ -7,7 +7,7 @@
   },
   "turbo": {
     "$schema": "https://turbo.build/schema.json",
-    "pipeline": {
+    "tasks": {
       "build": {
         "outputs": [
           ".next/**",

--- a/packages/turbo-codemod/__tests__/__fixtures__/rename-output-mode/invalid-output-mode/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/rename-output-mode/invalid-output-mode/turbo.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "pipeline": {
+  "tasks": {
     "build-one": {
       "outputMode": "errors-only"
     },

--- a/packages/turbo-codemod/__tests__/__fixtures__/rename-output-mode/no-output-mode/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/rename-output-mode/no-output-mode/turbo.json
@@ -1,8 +1,10 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "pipeline": {
+  "tasks": {
     "build-one": {
-      "dependsOn": ["build-two"]
+      "dependsOn": [
+        "build-two"
+      ]
     },
     "build-two": {
       "cache": false

--- a/packages/turbo-codemod/__tests__/__fixtures__/rename-output-mode/no-output-mode/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/rename-output-mode/no-output-mode/turbo.json
@@ -2,9 +2,7 @@
   "$schema": "https://turbo.build/schema.json",
   "tasks": {
     "build-one": {
-      "dependsOn": [
-        "build-two"
-      ]
+      "dependsOn": ["build-two"]
     },
     "build-two": {
       "cache": false

--- a/packages/turbo-codemod/__tests__/__fixtures__/rename-output-mode/no-pipeline/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/rename-output-mode/no-pipeline/turbo.json
@@ -1,5 +1,9 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "globalDependencies": ["$NEXT_PUBLIC_API_KEY", "$STRIPE_API_KEY", ".env"],
-  "pipeline": {}
+  "globalDependencies": [
+    "$NEXT_PUBLIC_API_KEY",
+    "$STRIPE_API_KEY",
+    ".env"
+  ],
+  "tasks": {}
 }

--- a/packages/turbo-codemod/__tests__/__fixtures__/rename-output-mode/no-pipeline/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/rename-output-mode/no-pipeline/turbo.json
@@ -1,9 +1,5 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "globalDependencies": [
-    "$NEXT_PUBLIC_API_KEY",
-    "$STRIPE_API_KEY",
-    ".env"
-  ],
+  "globalDependencies": ["$NEXT_PUBLIC_API_KEY", "$STRIPE_API_KEY", ".env"],
   "tasks": {}
 }

--- a/packages/turbo-codemod/__tests__/__fixtures__/rename-output-mode/old-config/package.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/rename-output-mode/old-config/package.json
@@ -5,7 +5,7 @@
   "devDependencies": {},
   "packageManager": "npm@1.2.3",
   "turbo": {
-    "pipeline": {
+    "tasks": {
       "build-one": {
         "outputMode": "errors-only"
       },

--- a/packages/turbo-codemod/__tests__/__fixtures__/rename-output-mode/old-config/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/rename-output-mode/old-config/turbo.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "pipeline": {
+  "tasks": {
     "build-one": {
       "outputMode": "errors-only"
     },

--- a/packages/turbo-codemod/__tests__/__fixtures__/rename-output-mode/old-output-mode/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/rename-output-mode/old-output-mode/turbo.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "pipeline": {
+  "tasks": {
     "build-one": {
       "outputMode": "hash-only"
     },

--- a/packages/turbo-codemod/__tests__/__fixtures__/rename-output-mode/workspace-configs/apps/docs/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/rename-output-mode/workspace-configs/apps/docs/turbo.json
@@ -1,7 +1,9 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "extends": ["//"],
-  "pipeline": {
+  "extends": [
+    "//"
+  ],
+  "tasks": {
     "build": {}
   }
 }

--- a/packages/turbo-codemod/__tests__/__fixtures__/rename-output-mode/workspace-configs/apps/docs/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/rename-output-mode/workspace-configs/apps/docs/turbo.json
@@ -1,8 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "extends": [
-    "//"
-  ],
+  "extends": ["//"],
   "tasks": {
     "build": {}
   }

--- a/packages/turbo-codemod/__tests__/__fixtures__/rename-output-mode/workspace-configs/apps/web/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/rename-output-mode/workspace-configs/apps/web/turbo.json
@@ -1,8 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "extends": [
-    "//"
-  ],
+  "extends": ["//"],
   "tasks": {
     "build": {
       // old

--- a/packages/turbo-codemod/__tests__/__fixtures__/rename-output-mode/workspace-configs/apps/web/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/rename-output-mode/workspace-configs/apps/web/turbo.json
@@ -1,7 +1,9 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "extends": ["//"],
-  "pipeline": {
+  "extends": [
+    "//"
+  ],
+  "tasks": {
     "build": {
       // old
       "outputMode": "none"

--- a/packages/turbo-codemod/__tests__/__fixtures__/rename-output-mode/workspace-configs/packages/ui/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/rename-output-mode/workspace-configs/packages/ui/turbo.json
@@ -1,8 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "extends": [
-    "//"
-  ],
+  "extends": ["//"],
   "tasks": {
     "build-three": {
       "outputMode": "new-only"

--- a/packages/turbo-codemod/__tests__/__fixtures__/rename-output-mode/workspace-configs/packages/ui/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/rename-output-mode/workspace-configs/packages/ui/turbo.json
@@ -1,7 +1,9 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "extends": ["//"],
-  "pipeline": {
+  "extends": [
+    "//"
+  ],
+  "tasks": {
     "build-three": {
       "outputMode": "new-only"
     }

--- a/packages/turbo-codemod/__tests__/__fixtures__/rename-output-mode/workspace-configs/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/rename-output-mode/workspace-configs/turbo.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "pipeline": {
+  "tasks": {
     "build-one": {
       "outputMode": "new-only"
     },

--- a/packages/turbo-codemod/__tests__/__fixtures__/set-default-outputs/invalid-outputs/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/set-default-outputs/invalid-outputs/turbo.json
@@ -2,9 +2,7 @@
   "$schema": "https://turbo.build/schema.json",
   "tasks": {
     "build-one": {
-      "outputs": [
-        "foo"
-      ]
+      "outputs": ["foo"]
     },
     "build-two": {
       "outputs": []

--- a/packages/turbo-codemod/__tests__/__fixtures__/set-default-outputs/invalid-outputs/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/set-default-outputs/invalid-outputs/turbo.json
@@ -1,8 +1,10 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "pipeline": {
+  "tasks": {
     "build-one": {
-      "outputs": ["foo"]
+      "outputs": [
+        "foo"
+      ]
     },
     "build-two": {
       "outputs": []

--- a/packages/turbo-codemod/__tests__/__fixtures__/set-default-outputs/no-outputs/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/set-default-outputs/no-outputs/turbo.json
@@ -1,8 +1,10 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "pipeline": {
+  "tasks": {
     "build-one": {
-      "dependsOn": ["build-two"]
+      "dependsOn": [
+        "build-two"
+      ]
     },
     "build-two": {
       "cache": false

--- a/packages/turbo-codemod/__tests__/__fixtures__/set-default-outputs/no-outputs/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/set-default-outputs/no-outputs/turbo.json
@@ -2,9 +2,7 @@
   "$schema": "https://turbo.build/schema.json",
   "tasks": {
     "build-one": {
-      "dependsOn": [
-        "build-two"
-      ]
+      "dependsOn": ["build-two"]
     },
     "build-two": {
       "cache": false

--- a/packages/turbo-codemod/__tests__/__fixtures__/set-default-outputs/no-pipeline/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/set-default-outputs/no-pipeline/turbo.json
@@ -1,5 +1,9 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "globalDependencies": ["$NEXT_PUBLIC_API_KEY", "$STRIPE_API_KEY", ".env"],
-  "pipeline": {}
+  "globalDependencies": [
+    "$NEXT_PUBLIC_API_KEY",
+    "$STRIPE_API_KEY",
+    ".env"
+  ],
+  "tasks": {}
 }

--- a/packages/turbo-codemod/__tests__/__fixtures__/set-default-outputs/no-pipeline/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/set-default-outputs/no-pipeline/turbo.json
@@ -1,9 +1,5 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "globalDependencies": [
-    "$NEXT_PUBLIC_API_KEY",
-    "$STRIPE_API_KEY",
-    ".env"
-  ],
+  "globalDependencies": ["$NEXT_PUBLIC_API_KEY", "$STRIPE_API_KEY", ".env"],
   "tasks": {}
 }

--- a/packages/turbo-codemod/__tests__/__fixtures__/set-default-outputs/old-config/package.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/set-default-outputs/old-config/package.json
@@ -5,7 +5,7 @@
   "devDependencies": {},
   "packageManager": "npm@1.2.3",
   "turbo": {
-    "pipeline": {
+    "tasks": {
       "build-one": {
         "outputs": [
           "foo"

--- a/packages/turbo-codemod/__tests__/__fixtures__/set-default-outputs/old-config/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/set-default-outputs/old-config/turbo.json
@@ -2,9 +2,7 @@
   "$schema": "https://turbo.build/schema.json",
   "tasks": {
     "build-one": {
-      "outputs": [
-        "foo"
-      ]
+      "outputs": ["foo"]
     },
     "build-two": {
       "outputs": []

--- a/packages/turbo-codemod/__tests__/__fixtures__/set-default-outputs/old-config/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/set-default-outputs/old-config/turbo.json
@@ -1,8 +1,10 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "pipeline": {
+  "tasks": {
     "build-one": {
-      "outputs": ["foo"]
+      "outputs": [
+        "foo"
+      ]
     },
     "build-two": {
       "outputs": []

--- a/packages/turbo-codemod/__tests__/__fixtures__/set-default-outputs/old-outputs/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/set-default-outputs/old-outputs/turbo.json
@@ -2,9 +2,7 @@
   "$schema": "https://turbo.build/schema.json",
   "tasks": {
     "build-one": {
-      "outputs": [
-        "foo"
-      ]
+      "outputs": ["foo"]
     },
     "build-two": {
       "outputs": []

--- a/packages/turbo-codemod/__tests__/__fixtures__/set-default-outputs/old-outputs/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/set-default-outputs/old-outputs/turbo.json
@@ -1,8 +1,10 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "pipeline": {
+  "tasks": {
     "build-one": {
-      "outputs": ["foo"]
+      "outputs": [
+        "foo"
+      ]
     },
     "build-two": {
       "outputs": []

--- a/packages/turbo-codemod/__tests__/__fixtures__/set-default-outputs/workspace-configs/apps/docs/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/set-default-outputs/workspace-configs/apps/docs/turbo.json
@@ -1,7 +1,9 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "extends": ["//"],
-  "pipeline": {
+  "extends": [
+    "//"
+  ],
+  "tasks": {
     "build": {}
   }
 }

--- a/packages/turbo-codemod/__tests__/__fixtures__/set-default-outputs/workspace-configs/apps/docs/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/set-default-outputs/workspace-configs/apps/docs/turbo.json
@@ -1,8 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "extends": [
-    "//"
-  ],
+  "extends": ["//"],
   "tasks": {
     "build": {}
   }

--- a/packages/turbo-codemod/__tests__/__fixtures__/set-default-outputs/workspace-configs/apps/web/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/set-default-outputs/workspace-configs/apps/web/turbo.json
@@ -1,8 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "extends": [
-    "//"
-  ],
+  "extends": ["//"],
   "tasks": {
     "build": {
       // old

--- a/packages/turbo-codemod/__tests__/__fixtures__/set-default-outputs/workspace-configs/apps/web/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/set-default-outputs/workspace-configs/apps/web/turbo.json
@@ -1,7 +1,9 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "extends": ["//"],
-  "pipeline": {
+  "extends": [
+    "//"
+  ],
+  "tasks": {
     "build": {
       // old
       "outputs": []

--- a/packages/turbo-codemod/__tests__/__fixtures__/set-default-outputs/workspace-configs/packages/ui/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/set-default-outputs/workspace-configs/packages/ui/turbo.json
@@ -1,8 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "extends": [
-    "//"
-  ],
+  "extends": ["//"],
   "tasks": {
     "build-three": {}
   }

--- a/packages/turbo-codemod/__tests__/__fixtures__/set-default-outputs/workspace-configs/packages/ui/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/set-default-outputs/workspace-configs/packages/ui/turbo.json
@@ -1,7 +1,9 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "extends": ["//"],
-  "pipeline": {
+  "extends": [
+    "//"
+  ],
+  "tasks": {
     "build-three": {}
   }
 }

--- a/packages/turbo-codemod/__tests__/__fixtures__/set-default-outputs/workspace-configs/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/set-default-outputs/workspace-configs/turbo.json
@@ -2,9 +2,7 @@
   "$schema": "https://turbo.build/schema.json",
   "tasks": {
     "build-one": {
-      "outputs": [
-        "foo"
-      ]
+      "outputs": ["foo"]
     },
     "build-two": {
       "outputs": []

--- a/packages/turbo-codemod/__tests__/__fixtures__/set-default-outputs/workspace-configs/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/set-default-outputs/workspace-configs/turbo.json
@@ -1,8 +1,10 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "pipeline": {
+  "tasks": {
     "build-one": {
-      "outputs": ["foo"]
+      "outputs": [
+        "foo"
+      ]
     },
     "build-two": {
       "outputs": []

--- a/packages/turbo-codemod/__tests__/__fixtures__/stabilize-env-mode/has-both/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/stabilize-env-mode/has-both/turbo.json
@@ -1,19 +1,11 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "experimentalGlobalPassThroughEnv": [
-    "EXPERIMENTAL_GLOBAL_PASSTHROUGH"
-  ],
-  "globalPassThroughEnv": [
-    "GLOBAL_PASSTHROUGH"
-  ],
+  "experimentalGlobalPassThroughEnv": ["EXPERIMENTAL_GLOBAL_PASSTHROUGH"],
+  "globalPassThroughEnv": ["GLOBAL_PASSTHROUGH"],
   "tasks": {
     "build": {
-      "experimentalPassThroughEnv": [
-        "EXPERIMENTAL_TASK_PASSTHROUGH"
-      ],
-      "passThroughEnv": [
-        "TASK_PASSTHROUGH"
-      ]
+      "experimentalPassThroughEnv": ["EXPERIMENTAL_TASK_PASSTHROUGH"],
+      "passThroughEnv": ["TASK_PASSTHROUGH"]
     }
   }
 }

--- a/packages/turbo-codemod/__tests__/__fixtures__/stabilize-env-mode/has-both/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/stabilize-env-mode/has-both/turbo.json
@@ -1,11 +1,19 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "experimentalGlobalPassThroughEnv": ["EXPERIMENTAL_GLOBAL_PASSTHROUGH"],
-  "globalPassThroughEnv": ["GLOBAL_PASSTHROUGH"],
-  "pipeline": {
+  "experimentalGlobalPassThroughEnv": [
+    "EXPERIMENTAL_GLOBAL_PASSTHROUGH"
+  ],
+  "globalPassThroughEnv": [
+    "GLOBAL_PASSTHROUGH"
+  ],
+  "tasks": {
     "build": {
-      "experimentalPassThroughEnv": ["EXPERIMENTAL_TASK_PASSTHROUGH"],
-      "passThroughEnv": ["TASK_PASSTHROUGH"]
+      "experimentalPassThroughEnv": [
+        "EXPERIMENTAL_TASK_PASSTHROUGH"
+      ],
+      "passThroughEnv": [
+        "TASK_PASSTHROUGH"
+      ]
     }
   }
 }

--- a/packages/turbo-codemod/__tests__/__fixtures__/stabilize-env-mode/has-duplicates/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/stabilize-env-mode/has-duplicates/turbo.json
@@ -17,11 +17,7 @@
         "DUPLICATE_TASK",
         "EXPERIMENTAL_TASK_PASSTHROUGH"
       ],
-      "passThroughEnv": [
-        "DUPLICATE_TASK",
-        "DUPLICATE_TASK",
-        "TASK_PASSTHROUGH"
-      ]
+      "passThroughEnv": ["DUPLICATE_TASK", "DUPLICATE_TASK", "TASK_PASSTHROUGH"]
     }
   }
 }

--- a/packages/turbo-codemod/__tests__/__fixtures__/stabilize-env-mode/has-duplicates/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/stabilize-env-mode/has-duplicates/turbo.json
@@ -10,14 +10,18 @@
     "DUPLICATE_GLOBAL",
     "GLOBAL_PASSTHROUGH"
   ],
-  "pipeline": {
+  "tasks": {
     "build": {
       "experimentalPassThroughEnv": [
         "DUPLICATE_TASK",
         "DUPLICATE_TASK",
         "EXPERIMENTAL_TASK_PASSTHROUGH"
       ],
-      "passThroughEnv": ["DUPLICATE_TASK", "DUPLICATE_TASK", "TASK_PASSTHROUGH"]
+      "passThroughEnv": [
+        "DUPLICATE_TASK",
+        "DUPLICATE_TASK",
+        "TASK_PASSTHROUGH"
+      ]
     }
   }
 }

--- a/packages/turbo-codemod/__tests__/__fixtures__/stabilize-env-mode/has-empty/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/stabilize-env-mode/has-empty/turbo.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "experimentalGlobalPassThroughEnv": [],
-  "tasks": {
+  "pipeline": {
     "build": {
       "experimentalPassThroughEnv": []
     }

--- a/packages/turbo-codemod/__tests__/__fixtures__/stabilize-env-mode/has-empty/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/stabilize-env-mode/has-empty/turbo.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "experimentalGlobalPassThroughEnv": [],
-  "pipeline": {
+  "tasks": {
     "build": {
       "experimentalPassThroughEnv": []
     }

--- a/packages/turbo-codemod/__tests__/__fixtures__/stabilize-env-mode/has-neither/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/stabilize-env-mode/has-neither/turbo.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "pipeline": {
+  "tasks": {
     "build": {}
   }
 }

--- a/packages/turbo-codemod/__tests__/__fixtures__/stabilize-env-mode/has-new/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/stabilize-env-mode/has-new/turbo.json
@@ -1,13 +1,9 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "globalPassThroughEnv": [
-    "GLOBAL_PASSTHROUGH"
-  ],
+  "globalPassThroughEnv": ["GLOBAL_PASSTHROUGH"],
   "tasks": {
     "build": {
-      "passThroughEnv": [
-        "TASK_PASSTHROUGH"
-      ]
+      "passThroughEnv": ["TASK_PASSTHROUGH"]
     }
   }
 }

--- a/packages/turbo-codemod/__tests__/__fixtures__/stabilize-env-mode/has-new/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/stabilize-env-mode/has-new/turbo.json
@@ -1,9 +1,13 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "globalPassThroughEnv": ["GLOBAL_PASSTHROUGH"],
-  "pipeline": {
+  "globalPassThroughEnv": [
+    "GLOBAL_PASSTHROUGH"
+  ],
+  "tasks": {
     "build": {
-      "passThroughEnv": ["TASK_PASSTHROUGH"]
+      "passThroughEnv": [
+        "TASK_PASSTHROUGH"
+      ]
     }
   }
 }

--- a/packages/turbo-codemod/__tests__/__fixtures__/stabilize-env-mode/has-old/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/stabilize-env-mode/has-old/turbo.json
@@ -1,13 +1,9 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "experimentalGlobalPassThroughEnv": [
-    "GLOBAL_PASSTHROUGH"
-  ],
+  "experimentalGlobalPassThroughEnv": ["GLOBAL_PASSTHROUGH"],
   "tasks": {
     "build": {
-      "experimentalPassThroughEnv": [
-        "TASK_PASSTHROUGH"
-      ]
+      "experimentalPassThroughEnv": ["TASK_PASSTHROUGH"]
     }
   }
 }

--- a/packages/turbo-codemod/__tests__/__fixtures__/stabilize-env-mode/has-old/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/stabilize-env-mode/has-old/turbo.json
@@ -1,9 +1,13 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "experimentalGlobalPassThroughEnv": ["GLOBAL_PASSTHROUGH"],
-  "pipeline": {
+  "experimentalGlobalPassThroughEnv": [
+    "GLOBAL_PASSTHROUGH"
+  ],
+  "tasks": {
     "build": {
-      "experimentalPassThroughEnv": ["TASK_PASSTHROUGH"]
+      "experimentalPassThroughEnv": [
+        "TASK_PASSTHROUGH"
+      ]
     }
   }
 }

--- a/packages/turbo-codemod/__tests__/__fixtures__/stabilize-env-mode/workspace-configs/apps/docs/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/stabilize-env-mode/workspace-configs/apps/docs/turbo.json
@@ -1,9 +1,15 @@
 {
-  "extends": ["//"],
-  "pipeline": {
+  "extends": [
+    "//"
+  ],
+  "tasks": {
     "build": {
-      "experimentalPassThroughEnv": ["EXPERIMENTAL_DOCS_TASK_PASSTHROUGH"],
-      "passThroughEnv": ["DOCS_TASK_PASSTHROUGH"]
+      "experimentalPassThroughEnv": [
+        "EXPERIMENTAL_DOCS_TASK_PASSTHROUGH"
+      ],
+      "passThroughEnv": [
+        "DOCS_TASK_PASSTHROUGH"
+      ]
     }
   }
 }

--- a/packages/turbo-codemod/__tests__/__fixtures__/stabilize-env-mode/workspace-configs/apps/docs/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/stabilize-env-mode/workspace-configs/apps/docs/turbo.json
@@ -1,15 +1,9 @@
 {
-  "extends": [
-    "//"
-  ],
+  "extends": ["//"],
   "tasks": {
     "build": {
-      "experimentalPassThroughEnv": [
-        "EXPERIMENTAL_DOCS_TASK_PASSTHROUGH"
-      ],
-      "passThroughEnv": [
-        "DOCS_TASK_PASSTHROUGH"
-      ]
+      "experimentalPassThroughEnv": ["EXPERIMENTAL_DOCS_TASK_PASSTHROUGH"],
+      "passThroughEnv": ["DOCS_TASK_PASSTHROUGH"]
     }
   }
 }

--- a/packages/turbo-codemod/__tests__/__fixtures__/stabilize-env-mode/workspace-configs/apps/website/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/stabilize-env-mode/workspace-configs/apps/website/turbo.json
@@ -1,15 +1,9 @@
 {
-  "extends": [
-    "//"
-  ],
+  "extends": ["//"],
   "tasks": {
     "build": {
-      "experimentalPassThroughEnv": [
-        "EXPERIMENTAL_WEBSITE_TASK_PASSTHROUGH"
-      ],
-      "passThroughEnv": [
-        "WEBSITE_TASK_PASSTHROUGH"
-      ]
+      "experimentalPassThroughEnv": ["EXPERIMENTAL_WEBSITE_TASK_PASSTHROUGH"],
+      "passThroughEnv": ["WEBSITE_TASK_PASSTHROUGH"]
     }
   }
 }

--- a/packages/turbo-codemod/__tests__/__fixtures__/stabilize-env-mode/workspace-configs/apps/website/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/stabilize-env-mode/workspace-configs/apps/website/turbo.json
@@ -1,9 +1,15 @@
 {
-  "extends": ["//"],
-  "pipeline": {
+  "extends": [
+    "//"
+  ],
+  "tasks": {
     "build": {
-      "experimentalPassThroughEnv": ["EXPERIMENTAL_WEBSITE_TASK_PASSTHROUGH"],
-      "passThroughEnv": ["WEBSITE_TASK_PASSTHROUGH"]
+      "experimentalPassThroughEnv": [
+        "EXPERIMENTAL_WEBSITE_TASK_PASSTHROUGH"
+      ],
+      "passThroughEnv": [
+        "WEBSITE_TASK_PASSTHROUGH"
+      ]
     }
   }
 }

--- a/packages/turbo-codemod/__tests__/__fixtures__/stabilize-env-mode/workspace-configs/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/stabilize-env-mode/workspace-configs/turbo.json
@@ -1,19 +1,11 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "experimentalGlobalPassThroughEnv": [
-    "EXPERIMENTAL_GLOBAL_PASSTHROUGH"
-  ],
-  "globalPassThroughEnv": [
-    "GLOBAL_PASSTHROUGH"
-  ],
+  "experimentalGlobalPassThroughEnv": ["EXPERIMENTAL_GLOBAL_PASSTHROUGH"],
+  "globalPassThroughEnv": ["GLOBAL_PASSTHROUGH"],
   "tasks": {
     "build": {
-      "experimentalPassThroughEnv": [
-        "EXPERIMENTAL_TASK_PASSTHROUGH"
-      ],
-      "passThroughEnv": [
-        "TASK_PASSTHROUGH"
-      ]
+      "experimentalPassThroughEnv": ["EXPERIMENTAL_TASK_PASSTHROUGH"],
+      "passThroughEnv": ["TASK_PASSTHROUGH"]
     }
   }
 }

--- a/packages/turbo-codemod/__tests__/__fixtures__/stabilize-env-mode/workspace-configs/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/stabilize-env-mode/workspace-configs/turbo.json
@@ -1,11 +1,19 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "experimentalGlobalPassThroughEnv": ["EXPERIMENTAL_GLOBAL_PASSTHROUGH"],
-  "globalPassThroughEnv": ["GLOBAL_PASSTHROUGH"],
-  "pipeline": {
+  "experimentalGlobalPassThroughEnv": [
+    "EXPERIMENTAL_GLOBAL_PASSTHROUGH"
+  ],
+  "globalPassThroughEnv": [
+    "GLOBAL_PASSTHROUGH"
+  ],
+  "tasks": {
     "build": {
-      "experimentalPassThroughEnv": ["EXPERIMENTAL_TASK_PASSTHROUGH"],
-      "passThroughEnv": ["TASK_PASSTHROUGH"]
+      "experimentalPassThroughEnv": [
+        "EXPERIMENTAL_TASK_PASSTHROUGH"
+      ],
+      "passThroughEnv": [
+        "TASK_PASSTHROUGH"
+      ]
     }
   }
 }

--- a/packages/turbo-codemod/__tests__/__fixtures__/transform-env-literals-to-wildcards/has-empty/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/transform-env-literals-to-wildcards/has-empty/turbo.json
@@ -2,7 +2,7 @@
   "$schema": "https://turbo.build/schema.json",
   "globalEnv": [],
   "globalPassThroughEnv": [],
-  "pipeline": {
+  "tasks": {
     "build": {
       "env": [],
       "passThroughEnv": []

--- a/packages/turbo-codemod/__tests__/__fixtures__/transform-env-literals-to-wildcards/has-nothing/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/transform-env-literals-to-wildcards/has-nothing/turbo.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "pipeline": {
+  "tasks": {
     "build": {}
   }
 }

--- a/packages/turbo-codemod/__tests__/__fixtures__/transform-env-literals-to-wildcards/needs-rewriting/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/transform-env-literals-to-wildcards/needs-rewriting/turbo.json
@@ -1,25 +1,11 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "globalEnv": [
-    "NO!",
-    "!!!",
-    "!!!"
-  ],
-  "globalPassThroughEnv": [
-    "DOES",
-    "**BOLD**",
-    "WORK"
-  ],
+  "globalEnv": ["NO!", "!!!", "!!!"],
+  "globalPassThroughEnv": ["DOES", "**BOLD**", "WORK"],
   "tasks": {
     "build": {
-      "env": [
-        "PLAIN",
-        "SMALL_PRINT*"
-      ],
-      "passThroughEnv": [
-        "PASSWORD",
-        "*****"
-      ]
+      "env": ["PLAIN", "SMALL_PRINT*"],
+      "passThroughEnv": ["PASSWORD", "*****"]
     }
   }
 }

--- a/packages/turbo-codemod/__tests__/__fixtures__/transform-env-literals-to-wildcards/needs-rewriting/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/transform-env-literals-to-wildcards/needs-rewriting/turbo.json
@@ -1,11 +1,25 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "globalEnv": ["NO!", "!!!", "!!!"],
-  "globalPassThroughEnv": ["DOES", "**BOLD**", "WORK"],
-  "pipeline": {
+  "globalEnv": [
+    "NO!",
+    "!!!",
+    "!!!"
+  ],
+  "globalPassThroughEnv": [
+    "DOES",
+    "**BOLD**",
+    "WORK"
+  ],
+  "tasks": {
     "build": {
-      "env": ["PLAIN", "SMALL_PRINT*"],
-      "passThroughEnv": ["PASSWORD", "*****"]
+      "env": [
+        "PLAIN",
+        "SMALL_PRINT*"
+      ],
+      "passThroughEnv": [
+        "PASSWORD",
+        "*****"
+      ]
     }
   }
 }

--- a/packages/turbo-codemod/__tests__/__fixtures__/transform-env-literals-to-wildcards/workspace-configs/apps/docs/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/transform-env-literals-to-wildcards/workspace-configs/apps/docs/turbo.json
@@ -1,9 +1,17 @@
 {
-  "extends": ["//"],
-  "pipeline": {
+  "extends": [
+    "//"
+  ],
+  "tasks": {
     "build": {
-      "env": ["NO_DOCS_ENV", "!*!*DOCS"],
-      "passThroughEnv": ["NO_DOCS_PASSTHROUGH_ENV", "!*!*DOCS"]
+      "env": [
+        "NO_DOCS_ENV",
+        "!*!*DOCS"
+      ],
+      "passThroughEnv": [
+        "NO_DOCS_PASSTHROUGH_ENV",
+        "!*!*DOCS"
+      ]
     }
   }
 }

--- a/packages/turbo-codemod/__tests__/__fixtures__/transform-env-literals-to-wildcards/workspace-configs/apps/docs/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/transform-env-literals-to-wildcards/workspace-configs/apps/docs/turbo.json
@@ -1,17 +1,9 @@
 {
-  "extends": [
-    "//"
-  ],
+  "extends": ["//"],
   "tasks": {
     "build": {
-      "env": [
-        "NO_DOCS_ENV",
-        "!*!*DOCS"
-      ],
-      "passThroughEnv": [
-        "NO_DOCS_PASSTHROUGH_ENV",
-        "!*!*DOCS"
-      ]
+      "env": ["NO_DOCS_ENV", "!*!*DOCS"],
+      "passThroughEnv": ["NO_DOCS_PASSTHROUGH_ENV", "!*!*DOCS"]
     }
   }
 }

--- a/packages/turbo-codemod/__tests__/__fixtures__/transform-env-literals-to-wildcards/workspace-configs/apps/website/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/transform-env-literals-to-wildcards/workspace-configs/apps/website/turbo.json
@@ -1,9 +1,17 @@
 {
-  "extends": ["//"],
-  "pipeline": {
+  "extends": [
+    "//"
+  ],
+  "tasks": {
     "build": {
-      "env": ["NO_WEBSITE_ENV", "!*!*WEBSITE"],
-      "passThroughEnv": ["NO_WEBSITE_PASSTHROUGH_ENV", "!*!*WEBSITE"]
+      "env": [
+        "NO_WEBSITE_ENV",
+        "!*!*WEBSITE"
+      ],
+      "passThroughEnv": [
+        "NO_WEBSITE_PASSTHROUGH_ENV",
+        "!*!*WEBSITE"
+      ]
     }
   }
 }

--- a/packages/turbo-codemod/__tests__/__fixtures__/transform-env-literals-to-wildcards/workspace-configs/apps/website/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/transform-env-literals-to-wildcards/workspace-configs/apps/website/turbo.json
@@ -1,17 +1,9 @@
 {
-  "extends": [
-    "//"
-  ],
+  "extends": ["//"],
   "tasks": {
     "build": {
-      "env": [
-        "NO_WEBSITE_ENV",
-        "!*!*WEBSITE"
-      ],
-      "passThroughEnv": [
-        "NO_WEBSITE_PASSTHROUGH_ENV",
-        "!*!*WEBSITE"
-      ]
+      "env": ["NO_WEBSITE_ENV", "!*!*WEBSITE"],
+      "passThroughEnv": ["NO_WEBSITE_PASSTHROUGH_ENV", "!*!*WEBSITE"]
     }
   }
 }

--- a/packages/turbo-codemod/__tests__/__fixtures__/transform-env-literals-to-wildcards/workspace-configs/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/transform-env-literals-to-wildcards/workspace-configs/turbo.json
@@ -1,11 +1,21 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "globalEnv": ["!*!*"],
-  "globalPassThroughEnv": ["!*!*"],
-  "pipeline": {
+  "globalEnv": [
+    "!*!*"
+  ],
+  "globalPassThroughEnv": [
+    "!*!*"
+  ],
+  "tasks": {
     "build": {
-      "env": ["NO_ROOT_ENV", "!*!*ROOT"],
-      "passThroughEnv": ["NO_ROOT_PASSTHROUGH_ENV", "!*!*ROOT"]
+      "env": [
+        "NO_ROOT_ENV",
+        "!*!*ROOT"
+      ],
+      "passThroughEnv": [
+        "NO_ROOT_PASSTHROUGH_ENV",
+        "!*!*ROOT"
+      ]
     }
   }
 }

--- a/packages/turbo-codemod/__tests__/__fixtures__/transform-env-literals-to-wildcards/workspace-configs/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/transform-env-literals-to-wildcards/workspace-configs/turbo.json
@@ -1,21 +1,11 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "globalEnv": [
-    "!*!*"
-  ],
-  "globalPassThroughEnv": [
-    "!*!*"
-  ],
+  "globalEnv": ["!*!*"],
+  "globalPassThroughEnv": ["!*!*"],
   "tasks": {
     "build": {
-      "env": [
-        "NO_ROOT_ENV",
-        "!*!*ROOT"
-      ],
-      "passThroughEnv": [
-        "NO_ROOT_PASSTHROUGH_ENV",
-        "!*!*ROOT"
-      ]
+      "env": ["NO_ROOT_ENV", "!*!*ROOT"],
+      "passThroughEnv": ["NO_ROOT_PASSTHROUGH_ENV", "!*!*ROOT"]
     }
   }
 }

--- a/packages/turbo-codemod/__tests__/create-turbo-config.test.ts
+++ b/packages/turbo-codemod/__tests__/create-turbo-config.test.ts
@@ -326,7 +326,7 @@ describe("create-turbo-config", () => {
 
     // turbo.json should exist
     const turboJsonConfig = JSON.parse(read("turbo.json") || "{}");
-    expect(turboJsonConfig.pipeline).toBeDefined();
+    expect(turboJsonConfig.tasks).toBeDefined();
 
     // no config should exist in package.json
     const packageJsonConfig = JSON.parse(read("package.json") || "{}");

--- a/packages/turbo-codemod/__tests__/migrate.test.ts
+++ b/packages/turbo-codemod/__tests__/migrate.test.ts
@@ -77,7 +77,7 @@ describe("migrate", () => {
     });
     expect(readJson("turbo.json")).toStrictEqual({
       $schema: "https://turbo.build/schema.json",
-      pipeline: {
+      tasks: {
         build: {
           outputs: [".next/**", "!.next/cache/**"],
         },
@@ -234,7 +234,7 @@ describe("migrate", () => {
     });
     expect(readJson("turbo.json")).toStrictEqual({
       $schema: "https://turbo.build/schema.json",
-      pipeline: {
+      tasks: {
         build: {
           outputs: [".next/**", "!.next/cache/**"],
         },
@@ -319,7 +319,7 @@ describe("migrate", () => {
     });
     expect(readJson("turbo.json")).toStrictEqual({
       $schema: "https://turbo.build/schema.json",
-      pipeline: {
+      tasks: {
         build: {
           outputs: [".next/**", "!.next/cache/**"],
         },
@@ -525,7 +525,7 @@ describe("migrate", () => {
     });
     expect(readJson("turbo.json")).toStrictEqual({
       $schema: "https://turbo.build/schema.json",
-      pipeline: {
+      tasks: {
         build: {
           outputs: [".next/**", "!.next/cache/**"],
         },
@@ -633,7 +633,7 @@ describe("migrate", () => {
     });
     expect(readJson("turbo.json")).toStrictEqual({
       $schema: "https://turbo.build/schema.json",
-      pipeline: {
+      tasks: {
         build: {
           outputs: [".next/**", "!.next/cache/**"],
         },

--- a/packages/turbo-codemod/__tests__/rename-output-mode.test.ts
+++ b/packages/turbo-codemod/__tests__/rename-output-mode.test.ts
@@ -21,7 +21,7 @@ describe("rename-output-mode", () => {
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
       $schema: "https://turbo.build/schema.json",
-      pipeline: {
+      tasks: {
         "build-one": {
           outputLogs: "hash-only",
         },
@@ -58,7 +58,7 @@ describe("rename-output-mode", () => {
 
     expect(readJson("turbo.json") || "{}").toStrictEqual({
       $schema: "https://turbo.build/schema.json",
-      pipeline: {
+      tasks: {
         "build-one": {
           outputLogs: "new-only",
         },
@@ -72,7 +72,7 @@ describe("rename-output-mode", () => {
     expect(readJson("apps/docs/turbo.json") || "{}").toStrictEqual({
       $schema: "https://turbo.build/schema.json",
       extends: ["//"],
-      pipeline: {
+      tasks: {
         build: {},
       },
     });
@@ -80,7 +80,7 @@ describe("rename-output-mode", () => {
     expect(readJson("apps/web/turbo.json") || "{}").toStrictEqual({
       $schema: "https://turbo.build/schema.json",
       extends: ["//"],
-      pipeline: {
+      tasks: {
         build: {
           outputLogs: "none",
         },
@@ -90,7 +90,7 @@ describe("rename-output-mode", () => {
     expect(readJson("packages/ui/turbo.json") || "{}").toStrictEqual({
       $schema: "https://turbo.build/schema.json",
       extends: ["//"],
-      pipeline: {
+      tasks: {
         "build-three": {
           outputLogs: "new-only",
         },
@@ -167,7 +167,7 @@ describe("rename-output-mode", () => {
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
       $schema: "https://turbo.build/schema.json",
-      pipeline: {
+      tasks: {
         "build-one": {
           outputLogs: "hash-only",
         },
@@ -233,7 +233,7 @@ describe("rename-output-mode", () => {
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
       $schema: "https://turbo.build/schema.json",
-      pipeline: {
+      tasks: {
         "build-one": {
           outputLogs: "errors-only",
         },
@@ -295,7 +295,7 @@ describe("rename-output-mode", () => {
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
       $schema: "https://turbo.build/schema.json",
       globalDependencies: ["$NEXT_PUBLIC_API_KEY", "$STRIPE_API_KEY", ".env"],
-      pipeline: {},
+      tasks: {},
     });
 
     expect(result.fatalError).toBeUndefined();
@@ -324,7 +324,7 @@ describe("rename-output-mode", () => {
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
       $schema: "https://turbo.build/schema.json",
-      pipeline: {
+      tasks: {
         "build-one": {
           dependsOn: ["build-two"],
         },

--- a/packages/turbo-codemod/__tests__/set-default-outputs.test.ts
+++ b/packages/turbo-codemod/__tests__/set-default-outputs.test.ts
@@ -21,7 +21,7 @@ describe("set-default-outputs", () => {
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
       $schema: "https://turbo.build/schema.json",
-      pipeline: {
+      tasks: {
         "build-one": {
           outputs: ["foo"],
         },
@@ -58,7 +58,7 @@ describe("set-default-outputs", () => {
 
     expect(readJson("turbo.json") || "{}").toStrictEqual({
       $schema: "https://turbo.build/schema.json",
-      pipeline: {
+      tasks: {
         "build-one": {
           outputs: ["foo"],
         },
@@ -72,7 +72,7 @@ describe("set-default-outputs", () => {
     expect(readJson("apps/docs/turbo.json") || "{}").toStrictEqual({
       $schema: "https://turbo.build/schema.json",
       extends: ["//"],
-      pipeline: {
+      tasks: {
         build: {
           outputs: ["dist/**", "build/**"],
         },
@@ -82,7 +82,7 @@ describe("set-default-outputs", () => {
     expect(readJson("apps/web/turbo.json") || "{}").toStrictEqual({
       $schema: "https://turbo.build/schema.json",
       extends: ["//"],
-      pipeline: {
+      tasks: {
         build: {},
       },
     });
@@ -90,7 +90,7 @@ describe("set-default-outputs", () => {
     expect(readJson("packages/ui/turbo.json") || "{}").toStrictEqual({
       $schema: "https://turbo.build/schema.json",
       extends: ["//"],
-      pipeline: {
+      tasks: {
         "build-three": {
           outputs: ["dist/**", "build/**"],
         },
@@ -167,7 +167,7 @@ describe("set-default-outputs", () => {
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
       $schema: "https://turbo.build/schema.json",
-      pipeline: {
+      tasks: {
         "build-one": {
           outputs: ["foo"],
         },
@@ -233,7 +233,7 @@ describe("set-default-outputs", () => {
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
       $schema: "https://turbo.build/schema.json",
-      pipeline: {
+      tasks: {
         "build-one": {
           outputs: ["foo"],
         },
@@ -295,7 +295,7 @@ describe("set-default-outputs", () => {
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
       $schema: "https://turbo.build/schema.json",
       globalDependencies: ["$NEXT_PUBLIC_API_KEY", "$STRIPE_API_KEY", ".env"],
-      pipeline: {},
+      tasks: {},
     });
 
     expect(result.fatalError).toBeUndefined();
@@ -324,7 +324,7 @@ describe("set-default-outputs", () => {
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
       $schema: "https://turbo.build/schema.json",
-      pipeline: {
+      tasks: {
         "build-one": {
           dependsOn: ["build-two"],
           outputs: ["dist/**", "build/**"],

--- a/packages/turbo-codemod/__tests__/stabilize-env-mode.test.ts
+++ b/packages/turbo-codemod/__tests__/stabilize-env-mode.test.ts
@@ -25,7 +25,7 @@ describe.only("stabilize-env-mode", () => {
         "EXPERIMENTAL_GLOBAL_PASSTHROUGH",
         "GLOBAL_PASSTHROUGH",
       ],
-      pipeline: {
+      tasks: {
         build: {
           passThroughEnv: ["EXPERIMENTAL_TASK_PASSTHROUGH", "TASK_PASSTHROUGH"],
         },
@@ -63,7 +63,7 @@ describe.only("stabilize-env-mode", () => {
         "EXPERIMENTAL_GLOBAL_PASSTHROUGH",
         "GLOBAL_PASSTHROUGH",
       ],
-      pipeline: {
+      tasks: {
         build: {
           passThroughEnv: [
             "DUPLICATE_TASK",
@@ -101,7 +101,7 @@ describe.only("stabilize-env-mode", () => {
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
       $schema: "https://turbo.build/schema.json",
       globalPassThroughEnv: [],
-      pipeline: {
+      tasks: {
         build: {
           passThroughEnv: [],
         },
@@ -134,7 +134,7 @@ describe.only("stabilize-env-mode", () => {
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
       $schema: "https://turbo.build/schema.json",
-      pipeline: {
+      tasks: {
         build: {},
       },
     });
@@ -166,7 +166,7 @@ describe.only("stabilize-env-mode", () => {
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
       $schema: "https://turbo.build/schema.json",
       globalPassThroughEnv: ["GLOBAL_PASSTHROUGH"],
-      pipeline: {
+      tasks: {
         build: {
           passThroughEnv: ["TASK_PASSTHROUGH"],
         },
@@ -200,7 +200,7 @@ describe.only("stabilize-env-mode", () => {
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
       $schema: "https://turbo.build/schema.json",
       globalPassThroughEnv: ["GLOBAL_PASSTHROUGH"],
-      pipeline: {
+      tasks: {
         build: {
           passThroughEnv: ["TASK_PASSTHROUGH"],
         },
@@ -237,7 +237,7 @@ describe.only("stabilize-env-mode", () => {
         "EXPERIMENTAL_GLOBAL_PASSTHROUGH",
         "GLOBAL_PASSTHROUGH",
       ],
-      pipeline: {
+      tasks: {
         build: {
           passThroughEnv: ["EXPERIMENTAL_TASK_PASSTHROUGH", "TASK_PASSTHROUGH"],
         },
@@ -246,7 +246,7 @@ describe.only("stabilize-env-mode", () => {
 
     expect(JSON.parse(read("apps/docs/turbo.json") || "{}")).toStrictEqual({
       extends: ["//"],
-      pipeline: {
+      tasks: {
         build: {
           passThroughEnv: [
             "DOCS_TASK_PASSTHROUGH",
@@ -258,7 +258,7 @@ describe.only("stabilize-env-mode", () => {
 
     expect(JSON.parse(read("apps/website/turbo.json") || "{}")).toStrictEqual({
       extends: ["//"],
-      pipeline: {
+      tasks: {
         build: {
           passThroughEnv: [
             "EXPERIMENTAL_WEBSITE_TASK_PASSTHROUGH",

--- a/packages/turbo-codemod/__tests__/transform-env-literals-to-wildcards.test.ts
+++ b/packages/turbo-codemod/__tests__/transform-env-literals-to-wildcards.test.ts
@@ -23,7 +23,7 @@ describe.only("transform-env-literals-to-wildcards", () => {
       $schema: "https://turbo.build/schema.json",
       globalEnv: [],
       globalPassThroughEnv: [],
-      pipeline: {
+      tasks: {
         build: {
           env: [],
           passThroughEnv: [],
@@ -57,7 +57,7 @@ describe.only("transform-env-literals-to-wildcards", () => {
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
       $schema: "https://turbo.build/schema.json",
-      pipeline: {
+      tasks: {
         build: {},
       },
     });
@@ -90,7 +90,7 @@ describe.only("transform-env-literals-to-wildcards", () => {
       $schema: "https://turbo.build/schema.json",
       globalEnv: ["NO!", "\\!!!", "\\!!!"],
       globalPassThroughEnv: ["DOES", "\\*\\*BOLD\\*\\*", "WORK"],
-      pipeline: {
+      tasks: {
         build: {
           env: ["PLAIN", "SMALL_PRINT\\*"],
           passThroughEnv: ["PASSWORD", "\\*\\*\\*\\*\\*"],
@@ -126,7 +126,7 @@ describe.only("transform-env-literals-to-wildcards", () => {
       $schema: "https://turbo.build/schema.json",
       globalEnv: ["\\!\\*!\\*"],
       globalPassThroughEnv: ["\\!\\*!\\*"],
-      pipeline: {
+      tasks: {
         build: {
           env: ["NO_ROOT_ENV", "\\!\\*!\\*ROOT"],
           passThroughEnv: ["NO_ROOT_PASSTHROUGH_ENV", "\\!\\*!\\*ROOT"],
@@ -136,7 +136,7 @@ describe.only("transform-env-literals-to-wildcards", () => {
 
     expect(JSON.parse(read("apps/docs/turbo.json") || "{}")).toStrictEqual({
       extends: ["//"],
-      pipeline: {
+      tasks: {
         build: {
           env: ["NO_DOCS_ENV", "\\!\\*!\\*DOCS"],
           passThroughEnv: ["NO_DOCS_PASSTHROUGH_ENV", "\\!\\*!\\*DOCS"],
@@ -146,7 +146,7 @@ describe.only("transform-env-literals-to-wildcards", () => {
 
     expect(JSON.parse(read("apps/website/turbo.json") || "{}")).toStrictEqual({
       extends: ["//"],
-      pipeline: {
+      tasks: {
         build: {
           env: ["NO_WEBSITE_ENV", "\\!\\*!\\*WEBSITE"],
           passThroughEnv: ["NO_WEBSITE_PASSTHROUGH_ENV", "\\!\\*!\\*WEBSITE"],

--- a/packages/turbo-codemod/src/transforms/clean-globs.ts
+++ b/packages/turbo-codemod/src/transforms/clean-globs.ts
@@ -45,7 +45,7 @@ export function transformer({
 
 function migrateConfig(config: TurboJsonSchema) {
   const mapGlob = (glob: string) => fixGlobPattern(glob);
-  for (const [_, taskDef] of Object.entries(config.pipeline)) {
+  for (const [_, taskDef] of Object.entries(config.tasks)) {
     taskDef.inputs = taskDef.inputs?.map(mapGlob);
     taskDef.outputs = taskDef.outputs?.map(mapGlob);
   }

--- a/packages/turbo-codemod/src/transforms/migrate-env-var-dependencies.ts
+++ b/packages/turbo-codemod/src/transforms/migrate-env-var-dependencies.ts
@@ -15,9 +15,7 @@ const INTRODUCED_IN = "1.5.0";
 export function hasLegacyEnvVarDependencies(config: TurboJsonSchema) {
   const dependsOn = [
     "extends" in config ? [] : config.globalDependencies,
-    Object.values(config.pipeline).flatMap(
-      (pipeline) => pipeline.dependsOn ?? []
-    ),
+    Object.values(config.tasks).flatMap((pipeline) => pipeline.dependsOn ?? []),
   ].flat();
   const envVars = dependsOn.filter((dep) => dep?.startsWith("$"));
   return { hasKeys: Boolean(envVars.length), envVars };
@@ -93,11 +91,11 @@ export function migrateGlobal(config: TurboJsonSchema) {
 
 export function migrateConfig(config: TurboJsonSchema) {
   const migratedConfig = migrateGlobal(config);
-  Object.keys(config.pipeline).forEach((pipelineKey) => {
-    config.pipeline;
-    if (pipelineKey in config.pipeline) {
-      const pipeline = migratedConfig.pipeline[pipelineKey];
-      migratedConfig.pipeline[pipelineKey] = {
+  Object.keys(config.tasks).forEach((pipelineKey) => {
+    config.tasks;
+    if (pipelineKey in config.tasks) {
+      const pipeline = migratedConfig.tasks[pipelineKey];
+      migratedConfig.tasks[pipelineKey] = {
         ...pipeline,
         ...migratePipeline(pipeline),
       };

--- a/packages/turbo-codemod/src/transforms/rename-output-mode.ts
+++ b/packages/turbo-codemod/src/transforms/rename-output-mode.ts
@@ -13,7 +13,7 @@ const DESCRIPTION =
 const INTRODUCED_IN = "2.0.0";
 
 function migrateConfig(config: TurboJsonSchema) {
-  for (const [_, taskDef] of Object.entries(config.pipeline)) {
+  for (const [_, taskDef] of Object.entries(config.tasks)) {
     if (Object.prototype.hasOwnProperty.call(taskDef, "outputMode")) {
       //@ts-expect-error - outputMode is no longer in the schema
       taskDef.outputLogs = taskDef.outputMode as OutputMode;

--- a/packages/turbo-codemod/src/transforms/set-default-outputs.ts
+++ b/packages/turbo-codemod/src/transforms/set-default-outputs.ts
@@ -15,7 +15,7 @@ const DESCRIPTION =
 const INTRODUCED_IN = "1.7.0";
 
 function migrateConfig(config: TurboJsonSchema) {
-  for (const [_, taskDef] of Object.entries(config.pipeline)) {
+  for (const [_, taskDef] of Object.entries(config.tasks)) {
     if (taskDef.cache !== false) {
       if (!taskDef.outputs) {
         taskDef.outputs = DEFAULT_OUTPUTS;

--- a/packages/turbo-codemod/src/transforms/stabilize-env-mode.ts
+++ b/packages/turbo-codemod/src/transforms/stabilize-env-mode.ts
@@ -46,7 +46,7 @@ function migrateRootConfig(config: RootSchema) {
 }
 
 function migrateTaskConfigs(config: TurboJsonSchema) {
-  for (const [_, taskDef] of Object.entries(config.pipeline)) {
+  for (const [_, taskDef] of Object.entries(config.tasks)) {
     const oldConfig = taskDef.experimentalPassThroughEnv;
     const newConfig = taskDef.passThroughEnv;
 

--- a/packages/turbo-codemod/src/transforms/transform-env-literals-to-wildcards.ts
+++ b/packages/turbo-codemod/src/transforms/transform-env-literals-to-wildcards.ts
@@ -41,7 +41,7 @@ function migrateRootConfig(config: RootSchema) {
 }
 
 function migrateTaskConfigs(config: TurboJsonSchema) {
-  for (const [_, taskDef] of Object.entries(config.pipeline)) {
+  for (const [_, taskDef] of Object.entries(config.tasks)) {
     const { env, passThroughEnv } = taskDef;
 
     if (Array.isArray(env)) {

--- a/packages/turbo-types/src/types/config.ts
+++ b/packages/turbo-types/src/types/config.ts
@@ -14,7 +14,7 @@ export interface BaseSchema {
    * @defaultValue `{}`
    */
   // eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style -- it's more readable to specify a name for the key
-  pipeline: {
+  tasks: {
     /**
      * The name of a task that can be executed by turbo. If turbo finds a workspace
      * package with a package.json scripts object with a matching key, it will apply the


### PR DESCRIPTION
This commit also updates the schema that is published to /schema.json
since it is using the same TS types that are used by code functionality. 

I intended to only update `eslint-plugin-turbo`, but that involved updating `@turbo/types`, which 
then trickled into `@turbo/codemod` as well.
