### PR TITLE
fix(turborepo): Remove optional git locks

### DIFF
--- a/crates/turborepo-scm/src/git.rs
+++ b/crates/turborepo-scm/src/git.rs
@@ -184,21 +184,9 @@ impl Git {
         file_path: &AbsoluteSystemPath,
     ) -> Result<Vec<u8>, Error> {
         let anchored_file_path = self.root.anchor(file_path)?;
-        let mut command = Command::new(self.bin.as_std_path());
-        let command = command
-            .arg("show")
-            .arg(format!("{}:{}", from_commit, anchored_file_path.as_str()))
-            .current_dir(&self.root);
+        let arg = format!("{}:{}", from_commit, anchored_file_path.as_str());
 
-        let output = command.output()?;
-        if output.status.success() {
-            Ok(output.stdout)
-        } else {
-            Err(Error::Git(
-                String::from_utf8_lossy(&output.stderr).to_string(),
-                Backtrace::capture(),
-            ))
-        }
+        self.execute_git_command(&["show", &arg], "")
     }
 }
 

--- a/crates/turborepo-scm/src/git.rs
+++ b/crates/turborepo-scm/src/git.rs
@@ -133,7 +133,10 @@ impl Git {
 
     fn execute_git_command(&self, args: &[&str], pathspec: &str) -> Result<Vec<u8>, Error> {
         let mut command = Command::new(self.bin.as_std_path());
-        command.args(args).current_dir(&self.root);
+        command
+            .args(args)
+            .current_dir(&self.root)
+            .env("GIT_OPTIONAL_LOCKS", "false");
 
         if !pathspec.is_empty() {
             command.arg("--").arg(pathspec);

--- a/crates/turborepo-scm/src/ls_tree.rs
+++ b/crates/turborepo-scm/src/ls_tree.rs
@@ -13,7 +13,7 @@ impl Git {
     pub fn git_ls_tree(&self, root_path: &AbsoluteSystemPathBuf) -> Result<GitHashes, Error> {
         let mut hashes = GitHashes::new();
         let mut git = Command::new(self.bin.as_std_path())
-            .args(["ls-tree", "-r", "-z", "HEAD"])
+            .args(["ls-tree", "--no-optional-locks", "-r", "-z", "HEAD"])
             .current_dir(root_path)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())

--- a/crates/turborepo-scm/src/status.rs
+++ b/crates/turborepo-scm/src/status.rs
@@ -19,6 +19,7 @@ impl Git {
         let mut git = Command::new(self.bin.as_std_path())
             .args([
                 "status",
+                "--no-optional-locks",
                 "--untracked-files",
                 "--no-renames",
                 "-z",


### PR DESCRIPTION
### Description

We weren't passing `--no-optional-locks` when calling git. This was unnecessarily locking the index when we didn't need to. Now we pass the flag. 

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
