### PR TITLE
feat: enable UI by default

### DIFF
--- a/crates/turborepo-lib/src/config.rs
+++ b/crates/turborepo-lib/src/config.rs
@@ -268,7 +268,7 @@ impl ConfigurationOptions {
     }
 
     pub fn experimental_ui(&self) -> bool {
-        self.experimental_ui.unwrap_or_default() && atty::is(atty::Stream::Stdout)
+        self.experimental_ui.unwrap_or(true) && atty::is(atty::Stream::Stdout)
     }
 }
 
@@ -782,7 +782,7 @@ mod test {
         assert_eq!(config.team_slug(), None);
         assert_eq!(config.team_id(), None);
         assert_eq!(config.token(), None);
-        assert!(!config.experimental_ui());
+        assert!(config.experimental_ui());
         assert!(!config.preflight());
     }
 

--- a/crates/turborepo-lib/src/config.rs
+++ b/crates/turborepo-lib/src/config.rs
@@ -782,7 +782,7 @@ mod test {
         assert_eq!(config.team_slug(), None);
         assert_eq!(config.team_id(), None);
         assert_eq!(config.token(), None);
-        assert!(config.experimental_ui());
+        assert!(!config.experimental_ui());
         assert!(!config.preflight());
     }
 


### PR DESCRIPTION
### Description

TSIA

### Testing Instructions

~~Unit test update shows that default is now true~~ I forgot that these tests don't run in a TTY so they still won't have the UI enabled.

Manual test that a fresh repo with no `experimentalUI` key in `turbo.json` will use the UI.
