### PR TITLE
fix(turborepo): Optional lock with env var

### DIFF
--- a/crates/turborepo-scm/src/ls_tree.rs
+++ b/crates/turborepo-scm/src/ls_tree.rs
@@ -13,7 +13,8 @@ impl Git {
     pub fn git_ls_tree(&self, root_path: &AbsoluteSystemPathBuf) -> Result<GitHashes, Error> {
         let mut hashes = GitHashes::new();
         let mut git = Command::new(self.bin.as_std_path())
-            .args(["ls-tree", "--no-optional-locks", "-r", "-z", "HEAD"])
+            .args(["ls-tree", "-r", "-z", "HEAD"])
+            .env("GIT_OPTIONAL_LOCKS", "false")
             .current_dir(root_path)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())

--- a/crates/turborepo-scm/src/status.rs
+++ b/crates/turborepo-scm/src/status.rs
@@ -19,13 +19,13 @@ impl Git {
         let mut git = Command::new(self.bin.as_std_path())
             .args([
                 "status",
-                "--no-optional-locks",
                 "--untracked-files",
                 "--no-renames",
                 "-z",
                 "--",
                 ".",
             ])
+            .env("GIT_OPTIONAL_LOCKS", "false")
             .current_dir(root_path)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())


### PR DESCRIPTION
### Description

#8244 broke main, since apparently the `--no-optional-lock` flag was introduced relatively recently. Instead, we pass an env variable through.

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
