### PR TITLE
chore: stabilize ui

### DIFF
--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -202,9 +202,6 @@ pub struct Args {
     pub check_for_update: bool,
     #[clap(long = "__test-run", global = true, hide = true)]
     pub test_run: bool,
-    /// Enable the experimental UI
-    #[clap(long, hide = true, global = true)]
-    pub experimental_ui: bool,
     #[clap(flatten, next_help_heading = "Run Arguments")]
     #[serde(skip)]
     pub run_args: Option<RunArgs>,

--- a/crates/turborepo-lib/src/commands/mod.rs
+++ b/crates/turborepo-lib/src/commands/mod.rs
@@ -68,7 +68,6 @@ impl CommandBase {
             .with_token(self.args.token.clone())
             .with_timeout(self.args.remote_cache_timeout)
             .with_preflight(self.args.preflight.then_some(true))
-            .with_experimental_ui(self.args.experimental_ui.then_some(true))
             .build()
     }
 

--- a/crates/turborepo-lib/src/config.rs
+++ b/crates/turborepo-lib/src/config.rs
@@ -616,7 +616,7 @@ impl TurborepoConfigBuilder {
     create_builder!(with_enabled, enabled, Option<bool>);
     create_builder!(with_preflight, preflight, Option<bool>);
     create_builder!(with_timeout, timeout, Option<u64>);
-    create_builder!(with_experimental_ui, ui, Option<bool>);
+    create_builder!(with_ui, ui, Option<bool>);
 
     pub fn build(&self) -> Result<ConfigurationOptions, Error> {
         // Priority, from least significant to most significant:

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -94,7 +94,7 @@ impl RunBuilder {
             opts.run_opts.experimental_space_id = config.spaces_id().map(|s| s.to_owned());
         }
         let version = base.version();
-        let experimental_ui = config.experimental_ui();
+        let experimental_ui = config.ui();
         let processes = ProcessManager::new(
             // We currently only use a pty if the following are met:
             // - we're attached to a tty

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -123,8 +123,8 @@ pub struct RawTurboJson {
     // Configuration options when interfacing with the remote cache
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) remote_cache: Option<RawRemoteCacheOptions>,
-    #[serde(skip_serializing_if = "Option::is_none", rename = "experimentalUI")]
-    pub experimental_ui: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "ui")]
+    pub ui: Option<bool>,
 
     #[deserializable(rename = "//")]
     #[serde(skip)]
@@ -714,7 +714,7 @@ mod tests {
     use serde_json::json;
     use tempfile::tempdir;
     use test_case::test_case;
-    use turbopath::{AbsoluteSystemPath, AnchoredSystemPath, RelativeUnixPathBuf};
+    use turbopath::{AbsoluteSystemPath, AnchoredSystemPath};
     use turborepo_repository::package_json::PackageJson;
 
     use super::{Pipeline, RawTurboJson, Spanned};
@@ -1048,11 +1048,11 @@ mod tests {
         assert_eq!(actual, expected);
     }
 
-    #[test_case(r#"{ "experimentalUI": true }"#, Some(true) ; "t")]
-    #[test_case(r#"{ "experimentalUI": false }"#, Some(false) ; "f")]
+    #[test_case(r#"{ "ui": false }"#, Some(false) ; "f")]
+    #[test_case(r#"{ "ui": true }"#, Some(true) ; "t")]
     #[test_case(r#"{}"#, None ; "missing")]
-    fn test_experimental_ui(json: &str, expected: Option<bool>) {
+    fn test_ui(json: &str, expected: Option<bool>) {
         let json = RawTurboJson::parse(json, AnchoredSystemPath::new("").unwrap()).unwrap();
-        assert_eq!(json.experimental_ui, expected);
+        assert_eq!(json.ui, expected);
     }
 }


### PR DESCRIPTION
### Description

Rename `experimentalUI` to `ui` along with `TURBO_EXPERIMENTAL_UI` to `TURBO_UI` and removing `--experimental-ui` flag as now this is enabled by default so the flag isn't useful.
### Testing Instructions

Existing test suite / 👀 