### PR TITLE
chore: migrate dot-env migration to support latest schema

### DIFF
--- a/packages/turbo-codemod/__tests__/__fixtures__/migrate-dot-env/no-dot-env/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/migrate-dot-env/no-dot-env/turbo.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "pipeline": {
+  "tasks": {
     "build-one": {
       "dependsOn": ["build-two"]
     },

--- a/packages/turbo-codemod/__tests__/__fixtures__/migrate-dot-env/no-pipeline/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/migrate-dot-env/no-pipeline/turbo.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "globalDependencies": ["$NEXT_PUBLIC_API_KEY", "$STRIPE_API_KEY", ".env"],
-  "pipeline": {}
+  "tasks": {}
 }

--- a/packages/turbo-codemod/__tests__/__fixtures__/migrate-dot-env/with-dot-env/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/migrate-dot-env/with-dot-env/turbo.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "globalDotEnv": [".env"],
-  "pipeline": {
+  "tasks": {
     "build-one": {
       "dotEnv": ["build-one/.env"]
     },

--- a/packages/turbo-codemod/__tests__/__fixtures__/migrate-dot-env/workspace-configs/apps/docs/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/migrate-dot-env/workspace-configs/apps/docs/turbo.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "extends": ["//"],
-  "pipeline": {
+  "tasks": {
     "build": {}
   }
 }

--- a/packages/turbo-codemod/__tests__/__fixtures__/migrate-dot-env/workspace-configs/apps/web/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/migrate-dot-env/workspace-configs/apps/web/turbo.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "extends": ["//"],
-  "pipeline": {
+  "tasks": {
     "build": {
       // old
       "dotEnv": [".env"],

--- a/packages/turbo-codemod/__tests__/__fixtures__/migrate-dot-env/workspace-configs/packages/ui/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/migrate-dot-env/workspace-configs/packages/ui/turbo.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "extends": ["//"],
-  "pipeline": {
+  "tasks": {
     "build-three": {
       "dotEnv": [".env"]
     }

--- a/packages/turbo-codemod/__tests__/__fixtures__/migrate-dot-env/workspace-configs/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/migrate-dot-env/workspace-configs/turbo.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "pipeline": {
+  "tasks": {
     "build-one": {
       "dotEnv": ["build-one/.env"]
     },

--- a/packages/turbo-codemod/__tests__/migrate-dot-env.test.ts
+++ b/packages/turbo-codemod/__tests__/migrate-dot-env.test.ts
@@ -22,7 +22,7 @@ describe("migrate-dot-env", () => {
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
       $schema: "https://turbo.build/schema.json",
       globalDependencies: [".env"],
-      pipeline: {
+      tasks: {
         "build-one": {
           inputs: ["$TURBO_DEFAULT$", "build-one/.env"],
         },
@@ -59,7 +59,7 @@ describe("migrate-dot-env", () => {
 
     expect(readJson("turbo.json") || "{}").toStrictEqual({
       $schema: "https://turbo.build/schema.json",
-      pipeline: {
+      tasks: {
         "build-one": {
           inputs: ["$TURBO_DEFAULT$", "build-one/.env"],
         },
@@ -73,7 +73,7 @@ describe("migrate-dot-env", () => {
     expect(readJson("apps/docs/turbo.json") || "{}").toStrictEqual({
       $schema: "https://turbo.build/schema.json",
       extends: ["//"],
-      pipeline: {
+      tasks: {
         build: {},
       },
     });
@@ -81,7 +81,7 @@ describe("migrate-dot-env", () => {
     expect(readJson("apps/web/turbo.json") || "{}").toStrictEqual({
       $schema: "https://turbo.build/schema.json",
       extends: ["//"],
-      pipeline: {
+      tasks: {
         build: {
           inputs: ["src/**/*.ts", ".env"],
         },
@@ -91,7 +91,7 @@ describe("migrate-dot-env", () => {
     expect(readJson("packages/ui/turbo.json") || "{}").toStrictEqual({
       $schema: "https://turbo.build/schema.json",
       extends: ["//"],
-      pipeline: {
+      tasks: {
         "build-three": {
           inputs: ["$TURBO_DEFAULT$", ".env"],
         },
@@ -169,7 +169,7 @@ describe("migrate-dot-env", () => {
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
       $schema: "https://turbo.build/schema.json",
       globalDependencies: [".env"],
-      pipeline: {
+      tasks: {
         "build-one": {
           inputs: ["$TURBO_DEFAULT$", "build-one/.env"],
         },
@@ -236,7 +236,7 @@ describe("migrate-dot-env", () => {
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
       $schema: "https://turbo.build/schema.json",
       globalDependencies: ["$NEXT_PUBLIC_API_KEY", "$STRIPE_API_KEY", ".env"],
-      pipeline: {},
+      tasks: {},
     });
 
     expect(result.fatalError).toBeUndefined();
@@ -265,7 +265,7 @@ describe("migrate-dot-env", () => {
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
       $schema: "https://turbo.build/schema.json",
-      pipeline: {
+      tasks: {
         "build-one": {
           dependsOn: ["build-two"],
         },

--- a/packages/turbo-codemod/src/transforms/migrate-dot-env.ts
+++ b/packages/turbo-codemod/src/transforms/migrate-dot-env.ts
@@ -22,7 +22,7 @@ function migrateConfig(config: TurboJsonSchema) {
     delete config.globalDotEnv;
   }
 
-  for (const [_, taskDef] of Object.entries(config.pipeline)) {
+  for (const [_, taskDef] of Object.entries(config.tasks)) {
     if ("dotEnv" in taskDef) {
       if (taskDef.dotEnv) {
         taskDef.inputs = taskDef.inputs ?? ["$TURBO_DEFAULT$"];


### PR DESCRIPTION
### Description

#8253 and #8248 ended up landing close enough that they broke the branch. This PR updates the latter to use `tasks` instead of `pipeline`.

### Testing Instructions

CI
