### PR TITLE
feat(codemod): add logic for major version bump

### DIFF
--- a/packages/turbo-codemod/__tests__/__fixtures__/migrate/turbo-1/package.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/migrate/turbo-1/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "turbo-1",
+  "version": "1.0.0",
+  "dependencies": {},
+  "devDependencies": {
+    "turbo": "1.7.1"
+  }
+}

--- a/packages/turbo-codemod/__tests__/__fixtures__/migrate/turbo-1/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/migrate/turbo-1/turbo.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "pipeline": {
+    "build": {
+      "outputs": [".next/**", "!.next/cache/**"]
+    },
+    "lint": {
+      "dotEnv": [".env.local"],
+      "outputs": []
+    },
+    "test": {
+      "outputMode": "errors-only"
+    },
+    "dev": {
+      "cache": false
+    }
+  },
+  "experimentalUI": true
+}

--- a/packages/turbo-codemod/__tests__/migrate.test.ts
+++ b/packages/turbo-codemod/__tests__/migrate.test.ts
@@ -925,9 +925,9 @@ describe("migrate", () => {
     mockedCheckGitStatus.mockRestore();
   });
 
-  it.only("migrates across majors with all required codemods", async () => {
+  it("migrates across majors with all required codemods", async () => {
     const { root, readJson } = useFixture({
-      fixture: "old-turbo",
+      fixture: "turbo-1",
     });
 
     const packageManager = "pnpm";
@@ -973,24 +973,27 @@ describe("migrate", () => {
     expect(readJson("package.json")).toStrictEqual({
       dependencies: {},
       devDependencies: {
-        turbo: "1.0.0",
+        turbo: "1.7.1",
       },
-      name: "no-turbo-json",
+      name: "turbo-1",
       packageManager: "pnpm@1.2.3",
       version: "1.0.0",
     });
     expect(readJson("turbo.json")).toStrictEqual({
       $schema: "https://turbo.build/schema.json",
-      pipeline: {
+      tasks: {
         build: {
           outputs: [".next/**", "!.next/cache/**"],
         },
         dev: {
           cache: false,
         },
-        lint: {},
+        lint: {
+          inputs: ["$TURBO_DEFAULT$", ".env.local"],
+          outputs: [],
+        },
         test: {
-          outputs: ["dist/**", "build/**"],
+          outputLogs: "errors-only",
         },
       },
     });

--- a/packages/turbo-codemod/src/commands/migrate/index.ts
+++ b/packages/turbo-codemod/src/commands/migrate/index.ts
@@ -111,7 +111,7 @@ export async function migrate(
   }
 
   // step 1
-  let fromVersion = getCurrentVersion(project, options);
+  const fromVersion = getCurrentVersion(project, options);
   if (!fromVersion) {
     return endMigration({
       success: false,

--- a/packages/turbo-codemod/src/commands/migrate/index.ts
+++ b/packages/turbo-codemod/src/commands/migrate/index.ts
@@ -150,12 +150,6 @@ export async function migrate(
     });
   }
 
-  // if migrating "from" to "to" spans a major, floor "from" to ensure all required codemods are run
-  const fromMajor = fromVersion.split(".")[0];
-  if (fromMajor !== toVersion.split(".")[0]) {
-    fromVersion = `${fromMajor}.0.0`;
-  }
-
   // step 3
   const codemods = getTransformsForMigration({ fromVersion, toVersion });
   if (codemods.length === 0) {

--- a/packages/turbo-codemod/src/commands/migrate/index.ts
+++ b/packages/turbo-codemod/src/commands/migrate/index.ts
@@ -111,7 +111,7 @@ export async function migrate(
   }
 
   // step 1
-  const fromVersion = getCurrentVersion(project, options);
+  let fromVersion = getCurrentVersion(project, options);
   if (!fromVersion) {
     return endMigration({
       success: false,
@@ -148,6 +148,12 @@ export async function migrate(
         fromVersion
       )}) is the same as the requested version (${chalk.bold(toVersion)})`,
     });
+  }
+
+  // if migrating "from" to "to" spans a major, floor "from" to ensure all required codemods are run
+  const fromMajor = fromVersion.split(".")[0];
+  if (fromMajor !== toVersion.split(".")[0]) {
+    fromVersion = `${fromMajor}.0.0`;
   }
 
   // step 3

--- a/packages/turbo-codemod/src/transforms/add-package-names.ts
+++ b/packages/turbo-codemod/src/transforms/add-package-names.ts
@@ -8,7 +8,7 @@ import { getTransformerHelpers } from "../utils/getTransformerHelpers";
 // transformer details
 const TRANSFORMER = "add-package-names";
 const DESCRIPTION = "Ensure all packages have a name in their package.json";
-const INTRODUCED_IN = "2.0.0";
+const INTRODUCED_IN = "2.0.0-canary.0";
 
 interface PartialPackageJson {
   name?: string;

--- a/packages/turbo-codemod/src/transforms/migrate-dot-env.ts
+++ b/packages/turbo-codemod/src/transforms/migrate-dot-env.ts
@@ -1,7 +1,12 @@
 import path from "node:path";
 import { readJsonSync, existsSync } from "fs-extra";
-import { type PackageJson, getTurboConfigs } from "@turbo/utils";
+import {
+  type PackageJson,
+  getTurboConfigs,
+  forEachTaskDef,
+} from "@turbo/utils";
 import type { Schema as TurboJsonSchema } from "@turbo/types";
+import type { LegacySchema } from "@turbo/types/src/types/config";
 import type { Transformer, TransformerArgs } from "../types";
 import { getTransformerHelpers } from "../utils/getTransformerHelpers";
 import type { TransformerResults } from "../runner";
@@ -9,9 +14,9 @@ import type { TransformerResults } from "../runner";
 // transformer details
 const TRANSFORMER = "migrate-dot-env";
 const DESCRIPTION = 'Migrate the "dotEnv" entries to "inputs" in `turbo.json`';
-const INTRODUCED_IN = "2.0.0";
+const INTRODUCED_IN = "2.0.0-canary.0";
 
-function migrateConfig(config: TurboJsonSchema) {
+function migrateConfig(config: LegacySchema) {
   if ("globalDotEnv" in config) {
     if (config.globalDotEnv) {
       config.globalDependencies = config.globalDependencies ?? [];
@@ -22,7 +27,7 @@ function migrateConfig(config: TurboJsonSchema) {
     delete config.globalDotEnv;
   }
 
-  for (const [_, taskDef] of Object.entries(config.tasks)) {
+  forEachTaskDef(config, ([_, taskDef]) => {
     if ("dotEnv" in taskDef) {
       if (taskDef.dotEnv) {
         taskDef.inputs = taskDef.inputs ?? ["$TURBO_DEFAULT$"];
@@ -32,7 +37,7 @@ function migrateConfig(config: TurboJsonSchema) {
       }
       delete taskDef.dotEnv;
     }
-  }
+  });
 
   return config;
 }

--- a/packages/turbo-codemod/src/transforms/rename-output-mode.ts
+++ b/packages/turbo-codemod/src/transforms/rename-output-mode.ts
@@ -11,7 +11,7 @@ import type { TransformerResults } from "../runner";
 const TRANSFORMER = "rename-output-mode";
 const DESCRIPTION =
   'Rename the "outputMode" key to "outputLogs" in `turbo.json`';
-const INTRODUCED_IN = "2.0.0";
+const INTRODUCED_IN = "2.0.0-canary.0";
 
 function migrateConfig(config: SchemaV1) {
   for (const [_, taskDef] of Object.entries(config.pipeline)) {

--- a/packages/turbo-codemod/src/transforms/rename-pipeline.ts
+++ b/packages/turbo-codemod/src/transforms/rename-pipeline.ts
@@ -9,7 +9,7 @@ import type { TransformerResults } from "../runner";
 // transformer details
 const TRANSFORMER = "rename-pipeline";
 const DESCRIPTION = 'Rename the "pipeline" key to "tasks" in `turbo.json`';
-const INTRODUCED_IN = "2.0.0";
+const INTRODUCED_IN = "2.0.0-canary.0";
 
 function migrateConfig(config: SchemaV1): Schema {
   const { pipeline, ...rest } = config;

--- a/packages/turbo-codemod/src/transforms/set-default-outputs.ts
+++ b/packages/turbo-codemod/src/transforms/set-default-outputs.ts
@@ -13,6 +13,7 @@ const TRANSFORMER = "set-default-outputs";
 const DESCRIPTION =
   'Add the "outputs" key with defaults where it is missing in `turbo.json`';
 const INTRODUCED_IN = "1.7.0";
+const IDEMPOTENT = false;
 
 function migrateConfig(config: SchemaV1) {
   for (const [_, taskDef] of Object.entries(config.pipeline)) {
@@ -92,6 +93,7 @@ const transformerMeta: Transformer = {
   name: TRANSFORMER,
   description: DESCRIPTION,
   introducedIn: INTRODUCED_IN,
+  idempotent: IDEMPOTENT,
   transformer,
 };
 

--- a/packages/turbo-codemod/src/transforms/stabilize-ui.ts
+++ b/packages/turbo-codemod/src/transforms/stabilize-ui.ts
@@ -8,7 +8,7 @@ import type { TransformerResults } from "../runner";
 // transformer details
 const TRANSFORMER = "stabilize-ui";
 const DESCRIPTION = 'Rename the "experimentalUI" key to "ui" in `turbo.json`';
-const INTRODUCED_IN = "2.0.0";
+const INTRODUCED_IN = "2.0.0-canary.0";
 
 interface ExperimentalSchema extends RootSchema {
   experimentalUI?: boolean;

--- a/packages/turbo-codemod/src/types.ts
+++ b/packages/turbo-codemod/src/types.ts
@@ -4,6 +4,7 @@ export interface Transformer {
   name: string;
   description: string;
   introducedIn: string;
+  idempotent?: boolean;
   transformer: (
     args: TransformerArgs
   ) => Promise<TransformerResults> | TransformerResults;

--- a/packages/turbo-utils/src/getTurboConfigs.ts
+++ b/packages/turbo-utils/src/getTurboConfigs.ts
@@ -208,7 +208,7 @@ export function getWorkspaceConfigs(
 export function forEachTaskDef(
   config: LegacySchema,
   f: (value: [string, Pipeline]) => void
-) {
+): void {
   if ("pipeline" in config) {
     Object.entries(config.pipeline).forEach(f);
   } else {

--- a/packages/turbo-utils/src/index.ts
+++ b/packages/turbo-utils/src/index.ts
@@ -1,6 +1,10 @@
 // utils
 export { getTurboRoot } from "./getTurboRoot";
-export { getTurboConfigs, getWorkspaceConfigs } from "./getTurboConfigs";
+export {
+  getTurboConfigs,
+  getWorkspaceConfigs,
+  forEachTaskDef,
+} from "./getTurboConfigs";
 export { searchUp } from "./searchUp";
 export {
   getAvailablePackageManagers,


### PR DESCRIPTION
### Description

Add migration logic for the 1->2 move.

For the major bump we run all existing transforms that are safe to be run twice to ensure that `turbo.json` is in the desired state. 

A few things to note:
 - We change the introduction version for the 2.0 codemods to the canary to allow for easier testing
 - I updated `migrate-dot-env` to work with either `pipeline` or `tasks` as there isn't a great way to order transforms that are introduced in the same version.
 - Add an idempotent flag to transformers that defaults to `true`. This is used to mark a transformation as one to avoid re-running.

### Testing Instructions

Added unit test for major version migration.

Manual testing on repos via `turbo build --filter='@turbo/codemod'` and then using `node ~/code/turbo/packages/turbo-codemod/dist/cli.js migrate --to 2.0.0-canary.0` (canary is necessary due to 2.0.0 not existing in npm yet).
