### PR TITLE
reduce memory and consolidate shared vs transient cells

### DIFF
--- a/crates/turbo-tasks-memory/src/cell.rs
+++ b/crates/turbo-tasks-memory/src/cell.rs
@@ -154,7 +154,7 @@ impl Cell {
             Cell::Empty | Cell::Recomputing { .. } | Cell::TrackedValueless { .. } => {
                 CellContent(None)
             }
-            Cell::Value { content, .. } => content.clone(),
+            Cell::Value { content, .. } => content.to_owned(),
         }
     }
 
@@ -162,6 +162,10 @@ impl Cell {
     /// content has changed.
     /// If clean = true, the task inputs weren't changes since the last
     /// execution and can be assumed to produce the same content again.
+    ///
+    /// Safety: This funtion does not check if the type of the content is the
+    /// same as the type of the cell. It is the caller's responsibility to
+    /// ensure that the content is of the correct type.
     pub fn assign(
         &mut self,
         content: CellContent,

--- a/crates/turbo-tasks-memory/src/cell.rs
+++ b/crates/turbo-tasks-memory/src/cell.rs
@@ -151,7 +151,7 @@ impl Cell {
             CellState::Empty | CellState::Computing { .. } | CellState::TrackedValueless => {
                 CellContent(None)
             }
-            CellState::Value { content, .. } => content.to_owned(),
+            CellState::Value { content } => content.to_owned(),
         }
     }
 

--- a/crates/turbo-tasks-memory/src/memory_backend.rs
+++ b/crates/turbo-tasks-memory/src/memory_backend.rs
@@ -21,7 +21,7 @@ use turbo_prehash::{BuildHasherExt, PassThroughHash, PreHashed};
 use turbo_tasks::{
     backend::{
         Backend, BackendJobId, CellContent, PersistentTaskType, TaskCollectiblesMap,
-        TaskExecutionSpec, TransientTaskType,
+        TaskExecutionSpec, TransientTaskType, TypedCellContent,
     },
     event::EventListener,
     util::{IdFactoryWithReuse, NoMoveVec},
@@ -402,11 +402,13 @@ impl Backend for MemoryBackend {
         index: CellId,
         reader: TaskId,
         turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackend>,
-    ) -> Result<Result<CellContent, EventListener>> {
+    ) -> Result<Result<TypedCellContent, EventListener>> {
         if task_id == reader {
-            Ok(Ok(self.with_task(task_id, |task| {
-                task.with_cell(index, |cell| cell.read_own_content_untracked())
-            })))
+            Ok(Ok(self
+                .with_task(task_id, |task| {
+                    task.with_cell(index, |cell| cell.read_own_content_untracked())
+                })
+                .into_typed(index.type_id)))
         } else {
             Task::add_dependency_to_current(TaskEdge::Cell(task_id, index));
             self.with_task(task_id, |task| {
@@ -417,7 +419,7 @@ impl Backend for MemoryBackend {
                         move || format!("reading {} {} from {}", task_id, index, reader),
                     )
                 }) {
-                    Ok(content) => Ok(Ok(content)),
+                    Ok(content) => Ok(Ok(content.into_typed(index.type_id))),
                     Err(RecomputingCell { listener, schedule }) => {
                         if schedule {
                             task.recompute(self, turbo_tasks);
@@ -434,9 +436,10 @@ impl Backend for MemoryBackend {
         current_task: TaskId,
         index: CellId,
         _turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackend>,
-    ) -> Result<CellContent> {
+    ) -> Result<TypedCellContent> {
         Ok(self.with_task(current_task, |task| {
             task.with_cell(index, |cell| cell.read_own_content_untracked())
+                .into_typed(index.type_id)
         }))
     }
 
@@ -445,7 +448,7 @@ impl Backend for MemoryBackend {
         task_id: TaskId,
         index: CellId,
         turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackend>,
-    ) -> Result<Result<CellContent, EventListener>> {
+    ) -> Result<Result<TypedCellContent, EventListener>> {
         self.with_task(task_id, |task| {
             match task.with_cell_mut(index, self.gc_queue.as_ref(), |cell, _| {
                 cell.read_content_untracked(
@@ -453,7 +456,7 @@ impl Backend for MemoryBackend {
                     move || format!("reading {} {} untracked", task_id, index),
                 )
             }) {
-                Ok(content) => Ok(Ok(content)),
+                Ok(content) => Ok(Ok(content.into_typed(index.type_id))),
                 Err(RecomputingCell { listener, schedule }) => {
                     if schedule {
                         task.recompute(self, turbo_tasks);
@@ -500,6 +503,9 @@ impl Backend for MemoryBackend {
         });
     }
 
+    /// SAFETY: This function does not validate that the data in `content` is of
+    /// the same type as in `index`. It is the caller's responsibility to ensure
+    /// that the content is of the correct type.
     fn update_task_cell(
         &self,
         task: TaskId,

--- a/crates/turbo-tasks/src/backend.rs
+++ b/crates/turbo-tasks/src/backend.rs
@@ -9,10 +9,9 @@ use std::{
     time::Duration,
 };
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{anyhow, Result};
 use auto_hash_map::AutoMap;
 use rustc_hash::FxHasher;
-use serde::{Deserialize, Serialize};
 use tracing::Span;
 
 pub use crate::id::{BackendJobId, ExecutionId};
@@ -333,10 +332,10 @@ pub struct TaskExecutionSpec<'a> {
     pub span: Span,
 }
 
-// TODO technically CellContent is already indexed by the ValueTypeId, so we
-// don't need to store it here
-#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Default)]
 pub struct CellContent(pub Option<SharedReference>);
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct TypedCellContent(pub ValueTypeId, pub CellContent);
 
 impl Display for CellContent {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -347,9 +346,9 @@ impl Display for CellContent {
     }
 }
 
-impl CellContent {
+impl TypedCellContent {
     pub fn cast<T: Any + VcValueType>(self) -> Result<ReadRef<T>> {
-        let data = self.0.ok_or_else(|| anyhow!("Cell is empty"))?;
+        let data = self.1 .0.ok_or_else(|| anyhow!("Cell is empty"))?;
         let data = data
             .downcast()
             .map_err(|_err| anyhow!("Unexpected type in cell"))?;
@@ -358,24 +357,35 @@ impl CellContent {
 
     /// # Safety
     ///
-    /// The caller must ensure that the CellContent contains a vc that
-    /// implements T.
+    /// The caller must ensure that the TypedCellContent contains a vc
+    /// that implements T.
     pub fn cast_trait<T>(self) -> Result<TraitRef<T>>
     where
         T: VcValueTrait + ?Sized,
     {
-        let shared_reference = self.0.ok_or_else(|| anyhow!("Cell is empty"))?;
-        if shared_reference.0.is_none() {
-            bail!("Cell content is untyped");
-        }
+        let shared_reference = self
+            .1
+             .0
+            .ok_or_else(|| anyhow!("Cell is empty"))?
+            .typed(self.0);
         Ok(
-            // Safety: We just checked that the content is typed.
+            // Safety: It is a TypedSharedReference
             TraitRef::new(shared_reference),
         )
     }
 
     pub fn try_cast<T: Any + VcValueType>(self) -> Option<ReadRef<T>> {
-        Some(ReadRef::new_arc(self.0?.downcast().ok()?))
+        Some(ReadRef::new_arc(self.1 .0?.downcast().ok()?))
+    }
+
+    pub fn into_untyped(self) -> CellContent {
+        self.1
+    }
+}
+
+impl CellContent {
+    pub fn into_typed(self, type_id: ValueTypeId) -> TypedCellContent {
+        TypedCellContent(type_id, self)
     }
 }
 
@@ -462,7 +472,7 @@ pub trait Backend: Sync + Send {
         index: CellId,
         reader: TaskId,
         turbo_tasks: &dyn TurboTasksBackendApi<Self>,
-    ) -> Result<Result<CellContent, EventListener>>;
+    ) -> Result<Result<TypedCellContent, EventListener>>;
 
     /// INVALIDATION: Be careful with this, it will not track dependencies, so
     /// using it could break cache invalidation.
@@ -471,7 +481,7 @@ pub trait Backend: Sync + Send {
         task: TaskId,
         index: CellId,
         turbo_tasks: &dyn TurboTasksBackendApi<Self>,
-    ) -> Result<Result<CellContent, EventListener>>;
+    ) -> Result<Result<TypedCellContent, EventListener>>;
 
     /// INVALIDATION: Be careful with this, it will not track dependencies, so
     /// using it could break cache invalidation.
@@ -480,10 +490,10 @@ pub trait Backend: Sync + Send {
         current_task: TaskId,
         index: CellId,
         turbo_tasks: &dyn TurboTasksBackendApi<Self>,
-    ) -> Result<CellContent> {
+    ) -> Result<TypedCellContent> {
         match self.try_read_task_cell_untracked(current_task, index, turbo_tasks)? {
             Ok(content) => Ok(content),
-            Err(_) => Ok(CellContent(None)),
+            Err(_) => Ok(TypedCellContent(index.type_id, CellContent(None))),
         }
     }
 
@@ -574,10 +584,7 @@ impl PersistentTaskType {
         name: Cow<'static, str>,
         this: RawVc,
     ) -> Result<FunctionId> {
-        let CellContent(Some(SharedReference(Some(value_type), _))) = this.into_read().await?
-        else {
-            bail!("Cell is empty or untyped");
-        };
+        let TypedCellContent(value_type, _) = this.into_read().await?;
         Self::resolve_trait_method_from_value(trait_type, value_type, name)
     }
 
@@ -589,12 +596,7 @@ impl PersistentTaskType {
         turbo_tasks: Arc<dyn TurboTasksBackendApi<B>>,
     ) -> Result<RawVc> {
         let this = this.resolve().await?;
-        let CellContent(Some(SharedReference(this_ty, _))) = this.into_read().await? else {
-            bail!("Cell is empty");
-        };
-        let Some(this_ty) = this_ty else {
-            bail!("Cell is untyped");
-        };
+        let TypedCellContent(this_ty, _) = this.into_read().await?;
 
         let native_fn = Self::resolve_trait_method_from_value(trait_type, this_ty, name)?;
         let arg = registry::get_function(native_fn)

--- a/crates/turbo-tasks/src/manager.rs
+++ b/crates/turbo-tasks/src/manager.rs
@@ -26,7 +26,7 @@ use turbo_tasks_malloc::TurboMalloc;
 use crate::{
     backend::{
         Backend, CellContent, PersistentTaskType, TaskCollectiblesMap, TaskExecutionSpec,
-        TransientTaskType,
+        TransientTaskType, TypedCellContent,
     },
     capture_future::{self, CaptureFuture},
     event::{Event, EventListener},
@@ -99,7 +99,7 @@ pub trait TurboTasksApi: TurboTasksCallApi + Sync + Send {
         &self,
         task: TaskId,
         index: CellId,
-    ) -> Result<Result<CellContent, EventListener>>;
+    ) -> Result<Result<TypedCellContent, EventListener>>;
 
     /// INVALIDATION: Be careful with this, it will not track dependencies, so
     /// using it could break cache invalidation.
@@ -107,7 +107,7 @@ pub trait TurboTasksApi: TurboTasksCallApi + Sync + Send {
         &self,
         task: TaskId,
         index: CellId,
-    ) -> Result<Result<CellContent, EventListener>>;
+    ) -> Result<Result<TypedCellContent, EventListener>>;
 
     fn read_task_collectibles(&self, task: TaskId, trait_id: TraitTypeId) -> TaskCollectiblesMap;
 
@@ -121,9 +121,9 @@ pub trait TurboTasksApi: TurboTasksCallApi + Sync + Send {
         &self,
         current_task: TaskId,
         index: CellId,
-    ) -> Result<CellContent>;
+    ) -> Result<TypedCellContent>;
 
-    fn read_own_task_cell(&self, task: TaskId, index: CellId) -> Result<CellContent>;
+    fn read_own_task_cell(&self, task: TaskId, index: CellId) -> Result<TypedCellContent>;
     fn update_own_task_cell(&self, task: TaskId, index: CellId, content: CellContent);
     fn mark_own_task_as_finished(&self, task: TaskId);
 
@@ -978,7 +978,7 @@ impl<B: Backend + 'static> TurboTasksApi for TurboTasks<B> {
         &self,
         task: TaskId,
         index: CellId,
-    ) -> Result<Result<CellContent, EventListener>> {
+    ) -> Result<Result<TypedCellContent, EventListener>> {
         self.backend
             .try_read_task_cell(task, index, current_task("reading Vcs"), self)
     }
@@ -987,7 +987,7 @@ impl<B: Backend + 'static> TurboTasksApi for TurboTasks<B> {
         &self,
         task: TaskId,
         index: CellId,
-    ) -> Result<Result<CellContent, EventListener>> {
+    ) -> Result<Result<TypedCellContent, EventListener>> {
         self.backend.try_read_task_cell_untracked(task, index, self)
     }
 
@@ -995,7 +995,7 @@ impl<B: Backend + 'static> TurboTasksApi for TurboTasks<B> {
         &self,
         current_task: TaskId,
         index: CellId,
-    ) -> Result<CellContent> {
+    ) -> Result<TypedCellContent> {
         self.backend
             .try_read_own_task_cell_untracked(current_task, index, self)
     }
@@ -1042,7 +1042,7 @@ impl<B: Backend + 'static> TurboTasksApi for TurboTasks<B> {
         }
     }
 
-    fn read_own_task_cell(&self, task: TaskId, index: CellId) -> Result<CellContent> {
+    fn read_own_task_cell(&self, task: TaskId, index: CellId) -> Result<TypedCellContent> {
         // INVALIDATION: don't need to track a dependency to itself
         self.try_read_own_task_cell_untracked(task, index)
     }
@@ -1504,7 +1504,7 @@ pub(crate) async fn read_task_cell(
     this: &dyn TurboTasksApi,
     id: TaskId,
     index: CellId,
-) -> Result<CellContent> {
+) -> Result<TypedCellContent> {
     loop {
         match this.try_read_task_cell(id, index)? {
             Ok(result) => return Ok(result),
@@ -1540,10 +1540,7 @@ impl CurrentCellRef {
             tt.update_own_task_cell(
                 self.current_task,
                 self.index,
-                CellContent(Some(SharedReference::new(
-                    Some(self.index.type_id),
-                    triomphe::Arc::new(update),
-                ))),
+                CellContent(Some(SharedReference::new(triomphe::Arc::new(update)))),
             )
         }
     }
@@ -1564,18 +1561,15 @@ impl CurrentCellRef {
         tt.update_own_task_cell(
             self.current_task,
             self.index,
-            CellContent(Some(SharedReference::new(
-                Some(self.index.type_id),
-                triomphe::Arc::new(new_content),
-            ))),
+            CellContent(Some(SharedReference::new(triomphe::Arc::new(new_content)))),
         )
     }
 
     pub fn update_shared_reference(&self, shared_ref: SharedReference) {
         let tt = turbo_tasks();
         let content = tt.read_own_task_cell(self.current_task, self.index).ok();
-        let update = if let Some(CellContent(Some(content))) = content {
-            content != shared_ref
+        let update = if let Some(TypedCellContent(_, CellContent(shared_ref_exp))) = content {
+            shared_ref_exp.as_ref().ne(&Some(&shared_ref))
         } else {
             true
         };

--- a/crates/turbo-tasks/src/raw_vc.rs
+++ b/crates/turbo-tasks/src/raw_vc.rs
@@ -13,14 +13,11 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::{
-    backend::CellContent,
+    backend::{CellContent, TypedCellContent},
     event::EventListener,
     manager::{read_task_cell, read_task_output, TurboTasksApi},
-    registry::{
-        get_value_type, {self},
-    },
-    turbo_tasks, CollectiblesSource, SharedReference, TaskId, TraitTypeId, ValueTypeId, Vc,
-    VcValueTrait,
+    registry::{self, get_value_type},
+    turbo_tasks, CollectiblesSource, TaskId, TraitTypeId, ValueTypeId, Vc, VcValueTrait,
 };
 
 #[derive(Error, Debug)]
@@ -113,15 +110,11 @@ impl RawVc {
                     let content = read_task_cell(&*tt, task, index)
                         .await
                         .map_err(|source| ResolveTypeError::ReadError { source })?;
-                    if let CellContent(Some(shared_reference)) = content {
-                        if let SharedReference(Some(value_type), _) = shared_reference {
-                            if get_value_type(value_type).has_trait(&trait_type) {
-                                return Ok(Some(RawVc::TaskCell(task, index)));
-                            } else {
-                                return Ok(None);
-                            }
+                    if let TypedCellContent(value_type, CellContent(Some(_))) = content {
+                        if get_value_type(value_type).has_trait(&trait_type) {
+                            return Ok(Some(RawVc::TaskCell(task, index)));
                         } else {
-                            return Err(ResolveTypeError::UntypedContent);
+                            return Ok(None);
                         }
                     } else {
                         return Err(ResolveTypeError::NoContent);
@@ -149,15 +142,11 @@ impl RawVc {
                     let content = read_task_cell(&*tt, task, index)
                         .await
                         .map_err(|source| ResolveTypeError::ReadError { source })?;
-                    if let CellContent(Some(shared_reference)) = content {
-                        if let SharedReference(Some(cell_value_type), _) = shared_reference {
-                            if cell_value_type == value_type {
-                                return Ok(Some(RawVc::TaskCell(task, index)));
-                            } else {
-                                return Ok(None);
-                            }
+                    if let TypedCellContent(cell_value_type, CellContent(Some(_))) = content {
+                        if cell_value_type == value_type {
+                            return Ok(Some(RawVc::TaskCell(task, index)));
                         } else {
-                            return Err(ResolveTypeError::UntypedContent);
+                            return Ok(None);
                         }
                     } else {
                         return Err(ResolveTypeError::NoContent);
@@ -317,7 +306,7 @@ impl ReadRawVcFuture {
 }
 
 impl Future for ReadRawVcFuture {
-    type Output = Result<CellContent>;
+    type Output = Result<TypedCellContent>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
         self.turbo_tasks.notify_scheduled_tasks();

--- a/crates/turbo-tasks/src/read_ref.rs
+++ b/crates/turbo-tasks/src/read_ref.rs
@@ -243,10 +243,7 @@ where
     /// reference.
     pub fn cell(read_ref: ReadRef<T>) -> Vc<T> {
         let local_cell = find_cell_by_type(T::get_value_type_id());
-        local_cell.update_shared_reference(SharedReference::new(
-            Some(T::get_value_type_id()),
-            read_ref.0,
-        ));
+        local_cell.update_shared_reference(SharedReference::new(read_ref.0));
         Vc {
             node: local_cell.into(),
             _t: PhantomData,

--- a/crates/turbo-tasks/src/task/shared_reference.rs
+++ b/crates/turbo-tasks/src/task/shared_reference.rs
@@ -14,29 +14,42 @@ use crate::{
     ValueTypeId,
 };
 
-/// A type-erased wrapper for [`triomphe::Arc`].
+/// A reference to a piece of data
 #[derive(Clone)]
-pub struct SharedReference(
-    pub Option<ValueTypeId>,
-    pub triomphe::Arc<dyn Any + Send + Sync>,
-);
+pub struct SharedReference(pub triomphe::Arc<dyn Any + Send + Sync>);
 
 impl SharedReference {
-    pub fn new(type_id: Option<ValueTypeId>, data: triomphe::Arc<impl Any + Send + Sync>) -> Self {
-        Self(type_id, data.unsize(coerce_to_any_send_sync()))
+    pub fn new(data: triomphe::Arc<impl Any + Send + Sync>) -> Self {
+        Self(data.unsize(coerce_to_any_send_sync()))
+    }
+}
+
+/// A reference to a piece of data with type information
+#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Debug)]
+pub struct TypedSharedReference(pub ValueTypeId, pub SharedReference);
+
+impl SharedReference {
+    pub fn downcast<T: Any + Send + Sync>(self) -> Result<triomphe::Arc<T>, Self> {
+        match downcast_triomphe_arc(self.0) {
+            Ok(data) => Ok(data),
+            Err(data) => Err(Self(data)),
+        }
     }
 
-    pub fn downcast<T: Any + Send + Sync>(self) -> Result<triomphe::Arc<T>, Self> {
-        match downcast_triomphe_arc(self.1) {
-            Ok(data) => Ok(data),
-            Err(data) => Err(Self(self.0, data)),
-        }
+    pub(crate) fn typed(&self, type_id: ValueTypeId) -> TypedSharedReference {
+        TypedSharedReference(type_id, self.clone())
+    }
+}
+
+impl TypedSharedReference {
+    pub(crate) fn untyped(&self) -> (ValueTypeId, SharedReference) {
+        (self.0, self.1.clone())
     }
 }
 
 impl Hash for SharedReference {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        Hash::hash(&(&*self.1 as *const (dyn Any + Send + Sync)), state)
+        Hash::hash(&(&*self.0 as *const (dyn Any + Send + Sync)), state)
     }
 }
 impl PartialEq for SharedReference {
@@ -44,57 +57,63 @@ impl PartialEq for SharedReference {
     // only compares their addresses.
     #[allow(ambiguous_wide_pointer_comparisons)]
     fn eq(&self, other: &Self) -> bool {
-        triomphe::Arc::ptr_eq(&self.1, &other.1)
+        triomphe::Arc::ptr_eq(&self.0, &other.0)
     }
 }
 impl Eq for SharedReference {}
-
+impl PartialOrd for SharedReference {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl Ord for SharedReference {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        Ord::cmp(
+            &(&*self.0 as *const (dyn Any + Send + Sync)).cast::<()>(),
+            &(&*other.0 as *const (dyn Any + Send + Sync)).cast::<()>(),
+        )
+    }
+}
 impl Debug for SharedReference {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple("SharedReference")
-            .field(&self.0)
-            .field(&self.1)
-            .finish()
+        f.debug_tuple("SharedReference").field(&self.0).finish()
     }
 }
 
-impl Serialize for SharedReference {
+impl Serialize for TypedSharedReference {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
-        if let SharedReference(Some(ty), arc) = self {
-            let value_type = registry::get_value_type(*ty);
-            if let Some(serializable) = value_type.any_as_serializable(arc) {
-                let mut t = serializer.serialize_tuple(2)?;
-                t.serialize_element(registry::get_value_type_global_name(*ty))?;
-                t.serialize_element(serializable)?;
-                t.end()
-            } else {
-                Err(serde::ser::Error::custom(format!(
-                    "{:?} is not serializable",
-                    arc
-                )))
-            }
+        let TypedSharedReference(ty, SharedReference(arc)) = self;
+        let value_type = registry::get_value_type(*ty);
+        if let Some(serializable) = value_type.any_as_serializable(arc) {
+            let mut t = serializer.serialize_tuple(2)?;
+            t.serialize_element(registry::get_value_type_global_name(*ty))?;
+            t.serialize_element(serializable)?;
+            t.end()
         } else {
-            Err(serde::ser::Error::custom(
-                "untyped values are not serializable",
-            ))
+            Err(serde::ser::Error::custom(format!(
+                "{:?} is not serializable",
+                arc
+            )))
         }
     }
 }
 
 impl Display for SharedReference {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if let Some(ty) = self.0 {
-            write!(f, "value of type {}", registry::get_value_type(ty).name)
-        } else {
-            write!(f, "untyped value")
-        }
+        write!(f, "untyped value")
     }
 }
 
-impl<'de> Deserialize<'de> for SharedReference {
+impl Display for TypedSharedReference {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "value of type {}", registry::get_value_type(self.0).name)
+    }
+}
+
+impl<'de> Deserialize<'de> for TypedSharedReference {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
@@ -102,7 +121,7 @@ impl<'de> Deserialize<'de> for SharedReference {
         struct Visitor;
 
         impl<'de> serde::de::Visitor<'de> for Visitor {
-            type Value = SharedReference;
+            type Value = TypedSharedReference;
 
             fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
                 formatter.write_str("a serializable shared reference")
@@ -117,7 +136,7 @@ impl<'de> Deserialize<'de> for SharedReference {
                         if let Some(seed) = registry::get_value_type(ty).get_any_deserialize_seed()
                         {
                             if let Some(value) = seq.next_element_seed(seed)? {
-                                Ok(SharedReference::new(Some(ty), value.into()))
+                                Ok(TypedSharedReference(ty, SharedReference::new(value.into())))
                             } else {
                                 Err(serde::de::Error::invalid_length(
                                     1,

--- a/crates/turbo-tasks/src/task/task_input.rs
+++ b/crates/turbo-tasks/src/task/task_input.rs
@@ -5,8 +5,7 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    magic_any::MagicAny, vc::ResolvedVc, RcStr, TaskId, TransientInstance, TransientValue, Value,
-    ValueTypeId, Vc,
+    MagicAny, RcStr, ResolvedVc, TaskId, TransientInstance, TransientValue, Value, ValueTypeId, Vc,
 };
 
 /// Trait to implement in order for a type to be accepted as a

--- a/crates/turbo-tasks/src/vc/cast.rs
+++ b/crates/turbo-tasks/src/vc/cast.rs
@@ -2,7 +2,7 @@ use std::{marker::PhantomData, mem::ManuallyDrop};
 
 use anyhow::Result;
 
-use crate::{backend::CellContent, ReadRef, TraitRef, VcRead, VcValueTrait, VcValueType};
+use crate::{backend::TypedCellContent, ReadRef, TraitRef, VcRead, VcValueTrait, VcValueType};
 
 /// Trait defined to share behavior between values and traits within
 /// [`ReadRawVcFuture`][crate::ReadRawVcFuture]. See [`VcValueTypeCast`] and
@@ -12,7 +12,7 @@ use crate::{backend::CellContent, ReadRef, TraitRef, VcRead, VcValueTrait, VcVal
 pub trait VcCast: private::Sealed {
     type Output;
 
-    fn cast(content: CellContent) -> Result<Self::Output>;
+    fn cast(content: TypedCellContent) -> Result<Self::Output>;
 }
 
 /// Casts an arbitrary cell content into a [`ReadRef<T>`].
@@ -26,7 +26,7 @@ where
 {
     type Output = ReadRef<T>;
 
-    fn cast(content: CellContent) -> Result<Self::Output> {
+    fn cast(content: TypedCellContent) -> Result<Self::Output> {
         Ok(
             // Safety: the `VcValueType` implementor must guarantee that both `T` and
             // `Repr` are #[repr(transparent)].
@@ -57,7 +57,7 @@ where
 {
     type Output = TraitRef<T>;
 
-    fn cast(content: CellContent) -> Result<Self::Output> {
+    fn cast(content: TypedCellContent) -> Result<Self::Output> {
         // Safety: Constructor ensures the cell content points to a value that
         // implements T
         content.cast_trait::<T>()


### PR DESCRIPTION
### Description

This change reworks the structure to drop an option such that data which is colocated with its type information doesn't need to store it twice.

### Testing Instructions

Existing tests should suffice.