### PR TITLE
chore(turborepo): adjust error message for pipeline

### DIFF
--- a/crates/turborepo-lib/src/config.rs
+++ b/crates/turborepo-lib/src/config.rs
@@ -133,7 +133,7 @@ pub enum Error {
         text: NamedSource,
     },
     #[error("found `pipeline` field instead of `tasks`")]
-    #[diagnostic(help("Deprecated in 2.0: `pipeline` has been renamed to `tasks`"))]
+    #[diagnostic(help("changed in 2.0: `pipeline` has been renamed to `tasks`"))]
     PipelineField {
         #[label("rename `pipeline` field to `tasks`")]
         span: Option<SourceSpan>,


### PR DESCRIPTION
### Description

This was bothering me. We aren't deprecating `pipeline` (deprecation means the feature still exists but we don't recommend using it)

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
