### PR TITLE
fix(ui): ensure prelude gets printed before ui starts

### DIFF
--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -141,6 +141,10 @@ impl Run {
     }
 
     pub fn start_experimental_ui(&self) -> Option<(AppSender, JoinHandle<Result<(), tui::Error>>)> {
+        // Print prelude here as this needs to happen before the UI is started
+        if self.should_print_prelude {
+            self.print_run_prelude();
+        }
         if !self.experimental_ui {
             return None;
         }
@@ -153,9 +157,6 @@ impl Run {
     }
 
     pub async fn run(&mut self, experimental_ui_sender: Option<AppSender>) -> Result<i32, Error> {
-        if self.should_print_prelude {
-            self.print_run_prelude();
-        }
         if let Some(subscriber) = self.signal_handler.subscribe() {
             let run_cache = self.run_cache.clone();
             tokio::spawn(async move {

--- a/crates/turborepo-ui/src/tui/app.rs
+++ b/crates/turborepo-ui/src/tui/app.rs
@@ -1,5 +1,5 @@
 use std::{
-    io::{self, Stdout},
+    io::{self, Stdout, Write},
     time::{Duration, Instant},
 };
 
@@ -160,6 +160,8 @@ fn poll(interact: bool, receiver: &AppReceiver, deadline: Instant) -> Option<Eve
 fn startup() -> io::Result<Terminal<CrosstermBackend<Stdout>>> {
     crossterm::terminal::enable_raw_mode()?;
     let mut stdout = io::stdout();
+    // Ensure all pending writes are flushed before we switch to alternative screen
+    stdout.flush()?;
     crossterm::execute!(
         stdout,
         crossterm::event::EnableMouseCapture,


### PR DESCRIPTION
### Description

We had a race previously between switching to the alternative screen and the prelude being run. This PR moves the prelude printing to always happen before we switch to the alternative screen.

We also now flush `stdout` to ensure all of the prelude has been written before switching to the alternative screen.

### Testing Instructions

No longer have bleed in `Terminal.app`
<img width="1357" alt="Screenshot 2024-05-31 at 10 52 23 AM" src="https://github.com/vercel/turbo/assets/4131117/6d0d0706-e78c-4847-bdf5-0e6f81d71ca3">
