### PR TITLE
feat(codemod): place tasks last in turbo.json rewrites

### DIFF
--- a/packages/turbo-codemod/src/transforms/rename-pipeline.ts
+++ b/packages/turbo-codemod/src/transforms/rename-pipeline.ts
@@ -14,7 +14,7 @@ const INTRODUCED_IN = "2.0.0-canary.0";
 function migrateConfig(config: SchemaV1): Schema {
   const { pipeline, ...rest } = config;
 
-  return { tasks: pipeline, ...rest };
+  return { ...rest, tasks: pipeline };
 }
 
 export function transformer({


### PR DESCRIPTION
### Description

Change order of the object reconstruction so the spread operator happens first to keep the existing ordering of the keys, but only append tasks.

### Testing Instructions

Run codemod on a test repo
Before:
<img width="566" alt="Screenshot 2024-05-31 at 2 00 24 PM" src="https://github.com/vercel/turbo/assets/4131117/9759fed8-28ef-4802-95c1-192dc10bf575">
After:
<img width="553" alt="Screenshot 2024-05-31 at 1 59 35 PM" src="https://github.com/vercel/turbo/assets/4131117/a197cc75-573e-4448-a51c-523db98a3b41">
