### PR TITLE
fix(ui): disable UI on all dry runs

### DIFF
--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -145,7 +145,8 @@ impl Run {
         if self.should_print_prelude {
             self.print_run_prelude();
         }
-        if !self.experimental_ui {
+        // Don't start UI if doing a dry run
+        if !self.experimental_ui || self.opts.run_opts.dry_run.is_some() {
             return None;
         }
 


### PR DESCRIPTION
### Description

The UI does not make sense for dry runs. I didn't notice this since I would usually pipe the dry run output somewhere e.g. `turbo build --dry=json > run.json`.

### Testing Instructions

Verify that `turbo build --dry` and `turbo build --dry=json` no longer start up the UI
