### PR TITLE
Use ast-grep GitHub action and pin versions

### DIFF
--- a/.github/workflows/turbopack-test.yml
+++ b/.github/workflows/turbopack-test.yml
@@ -210,6 +210,13 @@ jobs:
     runs-on: ubuntu-latest
     name: Turbopack ast-grep lint
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+        with:
+          targets: wasm32-unknown-unknown
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Set turbopack paths
         run: echo "GITHUB_TURBOPACK_PATHS=$(cargo groups list turbopack | awk '{ print $2 }' | tr '\n' ' ')" >> $GITHUB_ENV
       - name: Checkout

--- a/.github/workflows/turbopack-test.yml
+++ b/.github/workflows/turbopack-test.yml
@@ -204,6 +204,21 @@ jobs:
         run: |
           CARGO_BUILD_TARGET="wasm32-wasip1-threads" RUSTFLAGS="-D warnings -A deprecated" cargo groups check turbopack-wasi --release
 
+  # From https://github.com/ast-grep/action/tree/v1.5/?tab=readme-ov-file#inputs
+  ast_grep_lint:
+    runs-on: ubuntu-latest
+    name: Turbopack ast-grep lint
+    steps:
+      - name: Set turbopack paths
+        run: echo "GITHUB_TURBOPACK_PATHS=$(cargo groups list turbopack | awk '{ print $2 }' | tr '\n' ' ')" >> $GITHUB_ENV
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: ast-grep lint step
+        uses: wbinnssmith/action@wbinnssmith/paths-schema
+        with:
+          paths: ${{ env.GITHUB_TURBOPACK_PATHS }}
+          version: 0.23.0
+
   turbopack_rust_clippy:
     needs: [turbopack_rust_check]
     name: Turbopack rust clippy
@@ -225,10 +240,6 @@ jobs:
       - name: Run cargo clippy
         run: |
           RUSTFLAGS="-D warnings -A deprecated" cargo groups clippy turbopack --features rustls-tls
-
-      - name: Run ast-grep lints
-        run: |
-          npx --package @ast-grep/cli -- ast-grep scan $(cargo groups list turbopack | awk '{ print $2 }' | tr '\n' ' ')
 
   next_dev_check:
     needs: [determine_jobs]

--- a/.github/workflows/turbopack-test.yml
+++ b/.github/workflows/turbopack-test.yml
@@ -206,6 +206,7 @@ jobs:
 
   # From https://github.com/ast-grep/action/tree/v1.5/?tab=readme-ov-file#inputs
   ast_grep_lint:
+    needs: [turbopack_rust_check]
     runs-on: ubuntu-latest
     name: Turbopack ast-grep lint
     steps:
@@ -214,7 +215,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: ast-grep lint step
-        uses: wbinnssmith/action@wbinnssmith/paths-schema
+        uses: wbinnssmith/action@wbinnssmith/npm-build
         with:
           paths: ${{ env.GITHUB_TURBOPACK_PATHS }}
           version: 0.23.0

--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -323,6 +323,8 @@ jobs:
         run: echo "GITHUB_TURBOREPO_PATHS=$(cargo groups list turborepo | awk '{ print $2 }' | tr '\n' ' ')" >> $GITHUB_ENV
       - name: Checkout
         uses: actions/checkout@v4
+      - name: TEST
+        run: echo "$GITHUB_TURBOREPO_PATHS"
       - name: ast-grep lint step
         uses: wbinnssmith/action@wbinnssmith/paths-schema
         with:

--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -316,6 +316,7 @@ jobs:
 
   # From https://github.com/ast-grep/action/tree/v1.5/?tab=readme-ov-file#inputs
   ast_grep_lint:
+    needs: [rust_check]
     runs-on: ubuntu-latest
     name: Turborepo ast-grep lint
     steps:
@@ -323,12 +324,10 @@ jobs:
         run: echo "GITHUB_TURBOREPO_PATHS=$(cargo groups list turborepo | awk '{ print $2 }' | tr '\n' ' ')" >> $GITHUB_ENV
       - name: Checkout
         uses: actions/checkout@v4
-      - name: TEST
-        run: echo "$GITHUB_TURBOREPO_PATHS"
       - name: ast-grep lint step
-        uses: wbinnssmith/action@wbinnssmith/paths-schema
+        uses: wbinnssmith/action@wbinnssmith/npm-build
         with:
-          paths: crates
+          paths: ${{ env.GITHUB_TURBOPACK_PATHS }}
           config: sgconfig.yml
           version: 0.23.0
 

--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -314,6 +314,21 @@ jobs:
         run: |
           cargo groups check turborepo-libraries --features rustls-tls
 
+  # From https://github.com/ast-grep/action/tree/v1.5/?tab=readme-ov-file#inputs
+  ast_grep_lint:
+    runs-on: ubuntu-latest
+    name: Turborepo ast-grep lint
+    steps:
+      - name: Set turborepo paths
+        run: echo "GITHUB_TURBOREPO_PATHS=$(cargo groups list turborepo | awk '{ print $2 }' | tr '\n' ' ')" >> $GITHUB_ENV
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: ast-grep lint step
+        uses: wbinnssmith/action@wbinnssmith/paths-schema
+        with:
+          paths: ${{ env.GITHUB_TURBOREPO_PATHS }}
+          version: 0.23.0
+
   rust_clippy:
     needs: [rust_check]
     name: Turborepo rust clippy
@@ -334,10 +349,6 @@ jobs:
       - name: Run cargo clippy
         run: |
           cargo groups clippy turborepo-libraries --features rustls-tls -- --deny clippy::all
-
-      - name: Run ast-grep lints
-        run: |
-          npx --package @ast-grep/cli -- ast-grep scan $(cargo groups list turborepo-libraries | awk '{ print $2 }' | tr '\n' ' ')
 
   rust_test:
     needs: [rust_check]

--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -334,7 +334,6 @@ jobs:
         uses: wbinnssmith/action@wbinnssmith/npm-build
         with:
           paths: ${{ env.GITHUB_TURBOPACK_PATHS }}
-          config: sgconfig.yml
           version: 0.23.0
 
   rust_clippy:

--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -329,6 +329,7 @@ jobs:
         uses: wbinnssmith/action@wbinnssmith/paths-schema
         with:
           paths: crates
+          config: sgconfig.yml
           version: 0.23.0
 
   rust_clippy:

--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -320,6 +320,12 @@ jobs:
     runs-on: ubuntu-latest
     name: Turborepo ast-grep lint
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Turborepo Environment
+        uses: ./.github/actions/setup-turborepo-environment
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Set turborepo paths
         run: echo "GITHUB_TURBOREPO_PATHS=$(cargo groups list turborepo | awk '{ print $2 }' | tr '\n' ' ')" >> $GITHUB_ENV
       - name: Checkout

--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -328,7 +328,7 @@ jobs:
       - name: ast-grep lint step
         uses: wbinnssmith/action@wbinnssmith/paths-schema
         with:
-          paths: ${{ env.GITHUB_TURBOREPO_PATHS }}
+          paths: crates
           version: 0.23.0
 
   rust_clippy:

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -17,6 +17,7 @@
     "windmilleng.vscode-go-autotest",
     "yzhang.markdown-all-in-one",
     "zxh404.vscode-proto3",
-    "mihaipopescu.Cram"
+    "mihaipopescu.Cram",
+    "ast-grep.ast-grep-vscode"
   ]
 }


### PR DESCRIPTION
This uses the official ast-grep GitHub Action [0] instead of installing it from npm in the clippy job.

Thanks for the suggestion from @HerringtonDarkholme!

[0] https://github.com/ast-grep/action
[1] https://github.com/vercel/turbo/pull/5637#issuecomment-1666751193
