### PR TITLE
fix(codemod): support jsonc when parsing root turbo.json

### DIFF
--- a/packages/turbo-codemod/__tests__/__fixtures__/migrate/turbo-1/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/migrate/turbo-1/turbo.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  // A comment which we allow
   "pipeline": {
     "build": {
       "outputs": [".next/**", "!.next/cache/**"]

--- a/packages/turbo-codemod/package.json
+++ b/packages/turbo-codemod/package.json
@@ -31,6 +31,7 @@
     "gradient-string": "^2.0.0",
     "inquirer": "^8.2.4",
     "inquirer-file-tree-selection-prompt": "^1.0.19",
+    "json5": "^2.2.3",
     "is-git-clean": "^1.1.0",
     "ora": "4.1.1",
     "semver": "^7.3.7",

--- a/packages/turbo-codemod/src/transforms/clean-globs.ts
+++ b/packages/turbo-codemod/src/transforms/clean-globs.ts
@@ -1,10 +1,10 @@
 import path from "node:path";
 import type { SchemaV1 } from "@turbo/types/src/types/config";
-import { readJsonSync } from "fs-extra";
 import { getTurboConfigs } from "@turbo/utils";
 import type { TransformerArgs, Transformer } from "../types";
 import type { TransformerResults } from "../runner";
 import { getTransformerHelpers } from "../utils/getTransformerHelpers";
+import { loadTurboJson } from "../utils/loadTurboJson";
 
 // transformer details
 const TRANSFORMER = "clean-globs";
@@ -24,7 +24,7 @@ export function transformer({
 
   const turboConfigPath = path.join(root, "turbo.json");
 
-  const turboJson = readJsonSync(turboConfigPath) as SchemaV1;
+  const turboJson: SchemaV1 = loadTurboJson(turboConfigPath);
   runner.modifyFile({
     filePath: turboConfigPath,
     after: migrateConfig(turboJson),

--- a/packages/turbo-codemod/src/transforms/migrate-dot-env.ts
+++ b/packages/turbo-codemod/src/transforms/migrate-dot-env.ts
@@ -10,6 +10,7 @@ import type { LegacySchema } from "@turbo/types/src/types/config";
 import type { Transformer, TransformerArgs } from "../types";
 import { getTransformerHelpers } from "../utils/getTransformerHelpers";
 import type { TransformerResults } from "../runner";
+import { loadTurboJson } from "../utils/loadTurboJson";
 
 // transformer details
 const TRANSFORMER = "migrate-dot-env";
@@ -78,7 +79,7 @@ export function transformer({
     });
   }
 
-  const turboJson = readJsonSync(turboConfigPath) as TurboJsonSchema;
+  const turboJson: TurboJsonSchema = loadTurboJson(turboConfigPath);
   runner.modifyFile({
     filePath: turboConfigPath,
     after: migrateConfig(turboJson),

--- a/packages/turbo-codemod/src/transforms/migrate-env-var-dependencies.ts
+++ b/packages/turbo-codemod/src/transforms/migrate-env-var-dependencies.ts
@@ -6,6 +6,7 @@ import type { SchemaV1 } from "@turbo/types/src/types/config";
 import { getTransformerHelpers } from "../utils/getTransformerHelpers";
 import type { TransformerResults } from "../runner";
 import type { Transformer, TransformerArgs } from "../types";
+import { loadTurboJson } from "../utils/loadTurboJson";
 
 // transformer details
 const TRANSFORMER = "migrate-env-var-dependencies";
@@ -145,7 +146,7 @@ export function transformer({
     });
   }
 
-  let turboJson = readJsonSync(turboConfigPath) as SchemaV1;
+  let turboJson: SchemaV1 = loadTurboJson(turboConfigPath);
   if (hasLegacyEnvVarDependencies(turboJson).hasKeys) {
     turboJson = migrateConfig(turboJson);
   }

--- a/packages/turbo-codemod/src/transforms/rename-output-mode.ts
+++ b/packages/turbo-codemod/src/transforms/rename-output-mode.ts
@@ -6,6 +6,7 @@ import type { SchemaV1 } from "@turbo/types/src/types/config";
 import type { Transformer, TransformerArgs } from "../types";
 import { getTransformerHelpers } from "../utils/getTransformerHelpers";
 import type { TransformerResults } from "../runner";
+import { loadTurboJson } from "../utils/loadTurboJson";
 
 // transformer details
 const TRANSFORMER = "rename-output-mode";
@@ -62,7 +63,7 @@ export function transformer({
     });
   }
 
-  const turboJson = readJsonSync(turboConfigPath) as SchemaV1;
+  const turboJson: SchemaV1 = loadTurboJson(turboConfigPath);
   runner.modifyFile({
     filePath: turboConfigPath,
     after: migrateConfig(turboJson),

--- a/packages/turbo-codemod/src/transforms/rename-pipeline.ts
+++ b/packages/turbo-codemod/src/transforms/rename-pipeline.ts
@@ -1,10 +1,11 @@
 import path from "node:path";
-import { readJsonSync, existsSync } from "fs-extra";
+import { existsSync } from "fs-extra";
 import { getTurboConfigs } from "@turbo/utils";
 import type { Schema, SchemaV1 } from "@turbo/types/src/types/config";
 import type { Transformer, TransformerArgs } from "../types";
 import { getTransformerHelpers } from "../utils/getTransformerHelpers";
 import type { TransformerResults } from "../runner";
+import { loadTurboJson } from "../utils/loadTurboJson";
 
 // transformer details
 const TRANSFORMER = "rename-pipeline";
@@ -35,7 +36,7 @@ export function transformer({
     });
   }
 
-  const turboJson = readJsonSync(turboConfigPath) as SchemaV1;
+  const turboJson: SchemaV1 = loadTurboJson(turboConfigPath);
   runner.modifyFile({
     filePath: turboConfigPath,
     after: migrateConfig(turboJson),

--- a/packages/turbo-codemod/src/transforms/set-default-outputs.ts
+++ b/packages/turbo-codemod/src/transforms/set-default-outputs.ts
@@ -5,6 +5,7 @@ import type { SchemaV1 } from "@turbo/types/src/types/config";
 import type { Transformer, TransformerArgs } from "../types";
 import { getTransformerHelpers } from "../utils/getTransformerHelpers";
 import type { TransformerResults } from "../runner";
+import { loadTurboJson } from "../utils/loadTurboJson";
 
 const DEFAULT_OUTPUTS = ["dist/**", "build/**"];
 
@@ -68,7 +69,7 @@ export function transformer({
     });
   }
 
-  const turboJson = readJsonSync(turboConfigPath) as SchemaV1;
+  const turboJson: SchemaV1 = loadTurboJson(turboConfigPath);
   runner.modifyFile({
     filePath: turboConfigPath,
     after: migrateConfig(turboJson),

--- a/packages/turbo-codemod/src/transforms/stabilize-env-mode.ts
+++ b/packages/turbo-codemod/src/transforms/stabilize-env-mode.ts
@@ -5,6 +5,7 @@ import type { SchemaV1, RootSchemaV1 } from "@turbo/types/src/types/config";
 import type { Transformer, TransformerArgs } from "../types";
 import { getTransformerHelpers } from "../utils/getTransformerHelpers";
 import type { TransformerResults } from "../runner";
+import { loadTurboJson } from "../utils/loadTurboJson";
 
 // transformer details
 const TRANSFORMER = "stabilize-env-mode";
@@ -118,7 +119,7 @@ export function transformer({
     });
   }
 
-  const turboJson = readJsonSync(turboConfigPath) as SchemaV1;
+  const turboJson: SchemaV1 = loadTurboJson(turboConfigPath);
   runner.modifyFile({
     filePath: turboConfigPath,
     after: migrateRootConfig(turboJson),

--- a/packages/turbo-codemod/src/transforms/stabilize-ui.ts
+++ b/packages/turbo-codemod/src/transforms/stabilize-ui.ts
@@ -1,9 +1,10 @@
 import path from "node:path";
-import { readJsonSync, existsSync } from "fs-extra";
+import { existsSync } from "fs-extra";
 import type { RootSchema } from "@turbo/types/src/types/config";
 import type { Transformer, TransformerArgs } from "../types";
 import { getTransformerHelpers } from "../utils/getTransformerHelpers";
 import type { TransformerResults } from "../runner";
+import { loadTurboJson } from "../utils/loadTurboJson";
 
 // transformer details
 const TRANSFORMER = "stabilize-ui";
@@ -42,7 +43,7 @@ export function transformer({
     });
   }
 
-  const turboJson = readJsonSync(turboConfigPath) as RootSchema;
+  const turboJson: RootSchema = loadTurboJson(turboConfigPath);
   runner.modifyFile({
     filePath: turboConfigPath,
     after: migrateConfig(turboJson),

--- a/packages/turbo-codemod/src/transforms/transform-env-literals-to-wildcards.ts
+++ b/packages/turbo-codemod/src/transforms/transform-env-literals-to-wildcards.ts
@@ -6,6 +6,7 @@ import type { RootSchemaV1, SchemaV1 } from "@turbo/types/src/types/config";
 import type { Transformer, TransformerArgs } from "../types";
 import { getTransformerHelpers } from "../utils/getTransformerHelpers";
 import type { TransformerResults } from "../runner";
+import { loadTurboJson } from "../utils/loadTurboJson";
 
 // transformer details
 const TRANSFORMER = "transform-env-literals-to-wildcards";
@@ -91,7 +92,7 @@ export function transformer({
     });
   }
 
-  const turboJson = readJsonSync(turboConfigPath) as SchemaV1;
+  const turboJson: SchemaV1 = loadTurboJson(turboConfigPath);
   runner.modifyFile({
     filePath: turboConfigPath,
     after: migrateRootConfig(turboJson),

--- a/packages/turbo-codemod/src/utils/loadTurboJson.ts
+++ b/packages/turbo-codemod/src/utils/loadTurboJson.ts
@@ -1,0 +1,7 @@
+import { readFileSync } from "fs-extra";
+import { parse as JSON5Parse } from "json5";
+
+export function loadTurboJson<T>(filePath: string): T {
+  const contents = readFileSync(filePath, "utf8");
+  return JSON5Parse(contents);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -461,6 +461,9 @@ importers:
       is-git-clean:
         specifier: ^1.1.0
         version: 1.1.0
+      json5:
+        specifier: ^2.2.3
+        version: 2.2.3
       ora:
         specifier: 4.1.1
         version: 4.1.1


### PR DESCRIPTION
### Description

Add a new utility for parsing `turbo.json` that uses JSON5.parse to support comments. This is already used for parsing workspace `turbo.json`s: https://github.com/vercel/turbo/blob/main/packages/turbo-utils/src/getTurboConfigs.ts#L95


Future work is probably unifying all of these read methods to a single one.

### Testing Instructions

Added comment to top level to `turbo-1` fixture. This is a good candidate since the major version upgrade runs all codemods.

👀 
