### PR TITLE
fix(codemod): respect --dry flag

### DIFF
--- a/packages/turbo-codemod/__tests__/add-package-manager.test.ts
+++ b/packages/turbo-codemod/__tests__/add-package-manager.test.ts
@@ -29,7 +29,7 @@ const TEST_CASES: Array<TestCase> = [
     existingPackageManagerString: undefined,
     packageManager: "npm",
     packageManagerVersion: "7.0.0",
-    options: { force: false, dry: false, print: false },
+    options: { force: false, dryRun: false, print: false },
     result: {
       changes: {
         "package.json": {
@@ -46,7 +46,7 @@ const TEST_CASES: Array<TestCase> = [
     existingPackageManagerString: undefined,
     packageManager: "npm",
     packageManagerVersion: "7.0.0",
-    options: { force: false, dry: true, print: false },
+    options: { force: false, dryRun: true, print: false },
     result: {
       changes: {
         "package.json": {
@@ -63,7 +63,7 @@ const TEST_CASES: Array<TestCase> = [
     existingPackageManagerString: undefined,
     packageManager: "yarn",
     packageManagerVersion: "1.2.3",
-    options: { force: false, dry: false, print: true },
+    options: { force: false, dryRun: false, print: true },
     result: {
       changes: {
         "package.json": {
@@ -80,7 +80,7 @@ const TEST_CASES: Array<TestCase> = [
     existingPackageManagerString: undefined,
     packageManager: "pnpm",
     packageManagerVersion: "1.2.3",
-    options: { force: false, dry: true, print: true },
+    options: { force: false, dryRun: true, print: true },
     result: {
       changes: {
         "package.json": {
@@ -97,7 +97,7 @@ const TEST_CASES: Array<TestCase> = [
     existingPackageManagerString: "npm@1.2.3",
     packageManager: "npm",
     packageManagerVersion: "1.2.3",
-    options: { force: false, dry: false, print: false },
+    options: { force: false, dryRun: false, print: false },
     result: {
       changes: {
         "package.json": {
@@ -114,7 +114,7 @@ const TEST_CASES: Array<TestCase> = [
     existingPackageManagerString: "turbo@1.7.0",
     packageManager: "pnpm",
     packageManagerVersion: "1.2.3",
-    options: { force: false, dry: false, print: false },
+    options: { force: false, dryRun: false, print: false },
     result: {
       changes: {
         "package.json": {
@@ -180,7 +180,9 @@ describe("add-package-manager-2", () => {
       expect(mockGetWorkspaceDetails).toHaveBeenCalled();
 
       expect(JSON.parse(read("package.json") || "{}").packageManager).toEqual(
-        options.dry ? undefined : `${packageManager}@${packageManagerVersion}`
+        options.dryRun
+          ? undefined
+          : `${packageManager}@${packageManagerVersion}`
       );
 
       // result should be correct
@@ -194,9 +196,13 @@ describe("add-package-manager-2", () => {
       expect(repeatResult.fatalError).toBeUndefined();
       expect(repeatResult.changes).toMatchObject({
         "package.json": {
-          action: options.dry ? "skipped" : "unchanged",
-          additions: options.dry ? result.changes["package.json"].additions : 0,
-          deletions: options.dry ? result.changes["package.json"].deletions : 0,
+          action: options.dryRun ? "skipped" : "unchanged",
+          additions: options.dryRun
+            ? result.changes["package.json"].additions
+            : 0,
+          deletions: options.dryRun
+            ? result.changes["package.json"].deletions
+            : 0,
         },
       });
 
@@ -221,7 +227,7 @@ describe("add-package-manager-2", () => {
       // run the transformer
       const result = await transformer({
         root,
-        options: { force: false, dry: false, print: false },
+        options: { force: false, dryRun: false, print: false },
       });
 
       expect(mockGetWorkspaceDetails).toHaveBeenCalledTimes(1);
@@ -263,7 +269,7 @@ describe("add-package-manager-2", () => {
       // run the transformer
       const result = await transformer({
         root,
-        options: { force: false, dry: false, print: false },
+        options: { force: false, dryRun: false, print: false },
       });
 
       expect(mockGetAvailablePackageManagers).toHaveBeenCalledTimes(1);
@@ -317,7 +323,7 @@ describe("add-package-manager-2", () => {
       // run the transformer
       const result = await transformer({
         root,
-        options: { force: false, dry: false, print: false },
+        options: { force: false, dryRun: false, print: false },
       });
 
       // package manager should still not exist (we couldn't write it)

--- a/packages/turbo-codemod/__tests__/add-package-names.test.ts
+++ b/packages/turbo-codemod/__tests__/add-package-names.test.ts
@@ -16,7 +16,7 @@ describe("add-package-names", () => {
     // run the transformer
     const result = await transformer({
       root,
-      options: { force: false, dry: false, print: false },
+      options: { force: false, dryRun: false, print: false },
     });
 
     // result should be correct
@@ -58,7 +58,7 @@ describe("add-package-names", () => {
     // run the transformer
     const result = await transformer({
       root,
-      options: { force: false, dry: false, print: false },
+      options: { force: false, dryRun: false, print: false },
     });
 
     // result should be correct
@@ -95,7 +95,7 @@ describe("add-package-names", () => {
     // run the transformer
     const result = await transformer({
       root,
-      options: { force: false, dry: false, print: false },
+      options: { force: false, dryRun: false, print: false },
     });
 
     // result should be correct

--- a/packages/turbo-codemod/__tests__/clean-globs.test.ts
+++ b/packages/turbo-codemod/__tests__/clean-globs.test.ts
@@ -16,7 +16,7 @@ describe("clean-globs", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: false, print: false },
+      options: { force: false, dryRun: false, print: false },
     });
 
     // result should be correct

--- a/packages/turbo-codemod/__tests__/create-turbo-config.test.ts
+++ b/packages/turbo-codemod/__tests__/create-turbo-config.test.ts
@@ -21,7 +21,7 @@ describe("create-turbo-config", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: false, print: false },
+      options: { force: false, dryRun: false, print: false },
     });
 
     // turbo.json should now exist (and match the package.json config)
@@ -58,7 +58,7 @@ describe("create-turbo-config", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: false, print: false },
+      options: { force: false, dryRun: false, print: false },
     });
 
     // turbo.json should now exist (and match the package.json config)
@@ -84,7 +84,7 @@ describe("create-turbo-config", () => {
     // run the transformer
     const repeatResult = transformer({
       root,
-      options: { force: false, dry: false, print: false },
+      options: { force: false, dryRun: false, print: false },
     });
     // result should be correct
     expect(repeatResult.fatalError).toBeUndefined();
@@ -117,7 +117,7 @@ describe("create-turbo-config", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: true, print: false },
+      options: { force: false, dryRun: true, print: false },
     });
 
     // turbo.json still not exist (dry run)
@@ -154,7 +154,7 @@ describe("create-turbo-config", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: false, print: true },
+      options: { force: false, dryRun: false, print: true },
     });
 
     // turbo.json should now exist (and match the package.json config)
@@ -191,7 +191,7 @@ describe("create-turbo-config", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: true, print: true },
+      options: { force: false, dryRun: true, print: true },
     });
 
     // turbo.json still not exist (dry run)
@@ -229,7 +229,7 @@ describe("create-turbo-config", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: false, print: false },
+      options: { force: false, dryRun: false, print: false },
     });
 
     // turbo.json should still not exist
@@ -266,7 +266,7 @@ describe("create-turbo-config", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: false, print: false },
+      options: { force: false, dryRun: false, print: false },
     });
 
     // turbo.json should still not exist
@@ -293,7 +293,7 @@ describe("create-turbo-config", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: false, print: false },
+      options: { force: false, dryRun: false, print: false },
     });
 
     // turbo.json should still exist
@@ -336,7 +336,7 @@ describe("create-turbo-config", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: false, print: false },
+      options: { force: false, dryRun: false, print: false },
     });
 
     // make sure we didn't change the package.json
@@ -383,7 +383,7 @@ describe("create-turbo-config", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: false, print: false },
+      options: { force: false, dryRun: false, print: false },
     });
 
     // turbo.json should still not exist (error writing)

--- a/packages/turbo-codemod/__tests__/migrate-dot-env.test.ts
+++ b/packages/turbo-codemod/__tests__/migrate-dot-env.test.ts
@@ -16,7 +16,7 @@ describe("migrate-dot-env", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: false, print: false },
+      options: { force: false, dryRun: false, print: false },
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
@@ -54,7 +54,7 @@ describe("migrate-dot-env", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: false, print: false },
+      options: { force: false, dryRun: false, print: false },
     });
 
     expect(readJson("turbo.json") || "{}").toStrictEqual({
@@ -136,7 +136,7 @@ describe("migrate-dot-env", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: true, print: false },
+      options: { force: false, dryRun: true, print: false },
     });
 
     // make sure it didn't change
@@ -163,7 +163,7 @@ describe("migrate-dot-env", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: false, print: true },
+      options: { force: false, dryRun: false, print: true },
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
@@ -203,7 +203,7 @@ describe("migrate-dot-env", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: true, print: false },
+      options: { force: false, dryRun: true, print: false },
     });
 
     // make sure it didn't change
@@ -230,7 +230,7 @@ describe("migrate-dot-env", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: false, print: false },
+      options: { force: false, dryRun: false, print: false },
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
@@ -260,7 +260,7 @@ describe("migrate-dot-env", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: false, print: false },
+      options: { force: false, dryRun: false, print: false },
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
@@ -301,7 +301,7 @@ describe("migrate-dot-env", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: false, print: false },
+      options: { force: false, dryRun: false, print: false },
     });
 
     expect(read("turbo.json")).toBeUndefined();

--- a/packages/turbo-codemod/__tests__/migrate-env-var-dependencies.test.ts
+++ b/packages/turbo-codemod/__tests__/migrate-env-var-dependencies.test.ts
@@ -391,7 +391,7 @@ describe("migrate-env-var-dependencies", () => {
       // run the transformer
       const result = transformer({
         root,
-        options: { force: false, dry: false, print: false },
+        options: { force: false, dryRun: false, print: false },
       });
 
       expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
@@ -441,7 +441,7 @@ describe("migrate-env-var-dependencies", () => {
       // run the transformer
       const result = transformer({
         root,
-        options: { force: false, dry: false, print: false },
+        options: { force: false, dryRun: false, print: false },
       });
 
       expect(readJson("turbo.json") || "{}").toStrictEqual({
@@ -525,7 +525,7 @@ describe("migrate-env-var-dependencies", () => {
       // run the transformer
       const result = transformer({
         root,
-        options: { force: false, dry: false, print: false },
+        options: { force: false, dryRun: false, print: false },
       });
 
       expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
@@ -568,7 +568,7 @@ describe("migrate-env-var-dependencies", () => {
       // run the transformer
       const repeatResult = transformer({
         root,
-        options: { force: false, dry: false, print: false },
+        options: { force: false, dryRun: false, print: false },
       });
 
       expect(repeatResult.fatalError).toBeUndefined();
@@ -594,7 +594,7 @@ describe("migrate-env-var-dependencies", () => {
       // run the transformer
       const result = transformer({
         root,
-        options: { force: false, dry: true, print: false },
+        options: { force: false, dryRun: true, print: false },
       });
 
       // make sure it didn't change
@@ -621,7 +621,7 @@ describe("migrate-env-var-dependencies", () => {
       // run the transformer
       const result = transformer({
         root,
-        options: { force: false, dry: false, print: true },
+        options: { force: false, dryRun: false, print: true },
       });
 
       expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
@@ -673,7 +673,7 @@ describe("migrate-env-var-dependencies", () => {
       // run the transformer
       const result = transformer({
         root,
-        options: { force: false, dry: true, print: true },
+        options: { force: false, dryRun: true, print: true },
       });
 
       // make sure it didn't change
@@ -702,7 +702,7 @@ describe("migrate-env-var-dependencies", () => {
       // run the transformer
       const result = transformer({
         root,
-        options: { force: false, dry: false, print: false },
+        options: { force: false, dryRun: false, print: false },
       });
 
       expect(JSON.parse(read("turbo.json") || "{}")).toEqual(turboJson);
@@ -730,7 +730,7 @@ describe("migrate-env-var-dependencies", () => {
       // run the transformer
       const result = transformer({
         root,
-        options: { force: false, dry: false, print: false },
+        options: { force: false, dryRun: false, print: false },
       });
 
       expect(read("turbo.json")).toBeUndefined();
@@ -749,7 +749,7 @@ describe("migrate-env-var-dependencies", () => {
       // run the transformer
       const result = transformer({
         root,
-        options: { force: false, dry: false, print: false },
+        options: { force: false, dryRun: false, print: false },
       });
 
       expect(result.fatalError).toBeDefined();

--- a/packages/turbo-codemod/__tests__/migrate.test.ts
+++ b/packages/turbo-codemod/__tests__/migrate.test.ts
@@ -61,7 +61,7 @@ describe("migrate", () => {
 
     await migrate(root, {
       force: false,
-      dry: false,
+      dryRun: false,
       print: false,
       install: false,
     });
@@ -151,7 +151,7 @@ describe("migrate", () => {
 
     await migrate(root, {
       force: false,
-      dry: true,
+      dryRun: true,
       print: false,
       install: true,
     });
@@ -217,7 +217,7 @@ describe("migrate", () => {
 
     await migrate(root, {
       force: false,
-      dry: false,
+      dryRun: false,
       print: false,
       install: false,
       to: "1.7.0",
@@ -302,7 +302,7 @@ describe("migrate", () => {
 
     await migrate(root, {
       force: false,
-      dry: false,
+      dryRun: false,
       print: false,
       install: false,
       from: "1.0.0",
@@ -376,7 +376,7 @@ describe("migrate", () => {
 
     await migrate(root, {
       force: false,
-      dry: false,
+      dryRun: false,
       print: false,
       install: false,
     });
@@ -429,7 +429,7 @@ describe("migrate", () => {
 
     await migrate(root, {
       force: false,
-      dry: false,
+      dryRun: false,
       print: false,
       install: true,
     });
@@ -509,7 +509,7 @@ describe("migrate", () => {
 
     await migrate(root, {
       force: false,
-      dry: false,
+      dryRun: false,
       print: false,
       install: true,
     });
@@ -617,7 +617,7 @@ describe("migrate", () => {
 
     await migrate(root, {
       force: false,
-      dry: false,
+      dryRun: false,
       print: false,
       install: true,
     });
@@ -701,7 +701,7 @@ describe("migrate", () => {
 
     await migrate(root, {
       force: false,
-      dry: false,
+      dryRun: false,
       print: false,
       install: false,
     });
@@ -747,7 +747,7 @@ describe("migrate", () => {
 
     await migrate(root, {
       force: false,
-      dry: false,
+      dryRun: false,
       print: false,
       install: false,
     });
@@ -794,7 +794,7 @@ describe("migrate", () => {
 
     await migrate(root, {
       force: false,
-      dry: false,
+      dryRun: false,
       print: false,
       install: false,
     });
@@ -851,7 +851,7 @@ describe("migrate", () => {
 
     await migrate(root, {
       force: false,
-      dry: true,
+      dryRun: true,
       print: false,
       install: true,
     });
@@ -885,7 +885,7 @@ describe("migrate", () => {
 
     await migrate("~/path/that/does/not/exist", {
       force: false,
-      dry: false,
+      dryRun: false,
       print: false,
       install: false,
     });
@@ -911,7 +911,7 @@ describe("migrate", () => {
 
     await migrate(root, {
       force: false,
-      dry: false,
+      dryRun: false,
       print: false,
       install: false,
     });
@@ -965,7 +965,7 @@ describe("migrate", () => {
 
     await migrate(root, {
       force: false,
-      dry: false,
+      dryRun: false,
       print: false,
       install: false,
     });

--- a/packages/turbo-codemod/__tests__/rename-output-mode.test.ts
+++ b/packages/turbo-codemod/__tests__/rename-output-mode.test.ts
@@ -16,7 +16,7 @@ describe("rename-output-mode", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: false, print: false },
+      options: { force: false, dryRun: false, print: false },
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
@@ -53,7 +53,7 @@ describe("rename-output-mode", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: false, print: false },
+      options: { force: false, dryRun: false, print: false },
     });
 
     expect(readJson("turbo.json") || "{}").toStrictEqual({
@@ -135,7 +135,7 @@ describe("rename-output-mode", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: true, print: false },
+      options: { force: false, dryRun: true, print: false },
     });
 
     // make sure it didn't change
@@ -162,7 +162,7 @@ describe("rename-output-mode", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: false, print: true },
+      options: { force: false, dryRun: false, print: true },
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
@@ -201,7 +201,7 @@ describe("rename-output-mode", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: true, print: false },
+      options: { force: false, dryRun: true, print: false },
     });
 
     // make sure it didn't change
@@ -228,7 +228,7 @@ describe("rename-output-mode", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: false, print: false },
+      options: { force: false, dryRun: false, print: false },
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
@@ -289,7 +289,7 @@ describe("rename-output-mode", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: false, print: false },
+      options: { force: false, dryRun: false, print: false },
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
@@ -319,7 +319,7 @@ describe("rename-output-mode", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: false, print: false },
+      options: { force: false, dryRun: false, print: false },
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
@@ -360,7 +360,7 @@ describe("rename-output-mode", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: false, print: false },
+      options: { force: false, dryRun: false, print: false },
     });
 
     expect(read("turbo.json")).toBeUndefined();
@@ -379,7 +379,7 @@ describe("rename-output-mode", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: false, print: false },
+      options: { force: false, dryRun: false, print: false },
     });
 
     expect(result.fatalError).toBeDefined();

--- a/packages/turbo-codemod/__tests__/rename-pipeline.ts
+++ b/packages/turbo-codemod/__tests__/rename-pipeline.ts
@@ -16,7 +16,7 @@ describe("rename-pipeline", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: false, print: false },
+      options: { force: false, dryRun: false, print: false },
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
@@ -50,7 +50,7 @@ describe("rename-pipeline", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: false, print: false },
+      options: { force: false, dryRun: false, print: false },
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
@@ -130,7 +130,7 @@ describe("rename-pipeline", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: false, print: false },
+      options: { force: false, dryRun: false, print: false },
     });
 
     expect(read("turbo.json")).toBeUndefined();

--- a/packages/turbo-codemod/__tests__/set-default-outputs.test.ts
+++ b/packages/turbo-codemod/__tests__/set-default-outputs.test.ts
@@ -16,7 +16,7 @@ describe("set-default-outputs", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: false, print: false },
+      options: { force: false, dryRun: false, print: false },
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
@@ -53,7 +53,7 @@ describe("set-default-outputs", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: false, print: false },
+      options: { force: false, dryRun: false, print: false },
     });
 
     expect(readJson("turbo.json") || "{}").toStrictEqual({
@@ -135,7 +135,7 @@ describe("set-default-outputs", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: true, print: false },
+      options: { force: false, dryRun: true, print: false },
     });
 
     // make sure it didn't change
@@ -162,7 +162,7 @@ describe("set-default-outputs", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: false, print: true },
+      options: { force: false, dryRun: false, print: true },
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
@@ -201,7 +201,7 @@ describe("set-default-outputs", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: true, print: false },
+      options: { force: false, dryRun: true, print: false },
     });
 
     // make sure it didn't change
@@ -228,7 +228,7 @@ describe("set-default-outputs", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: false, print: false },
+      options: { force: false, dryRun: false, print: false },
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
@@ -289,7 +289,7 @@ describe("set-default-outputs", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: false, print: false },
+      options: { force: false, dryRun: false, print: false },
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
@@ -319,7 +319,7 @@ describe("set-default-outputs", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: false, print: false },
+      options: { force: false, dryRun: false, print: false },
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
@@ -362,7 +362,7 @@ describe("set-default-outputs", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: false, print: false },
+      options: { force: false, dryRun: false, print: false },
     });
 
     expect(read("turbo.json")).toBeUndefined();
@@ -381,7 +381,7 @@ describe("set-default-outputs", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: false, print: false },
+      options: { force: false, dryRun: false, print: false },
     });
 
     expect(result.fatalError).toBeDefined();

--- a/packages/turbo-codemod/__tests__/stabilize-env-mode.test.ts
+++ b/packages/turbo-codemod/__tests__/stabilize-env-mode.test.ts
@@ -16,7 +16,7 @@ describe("stabilize-env-mode", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: false, print: false },
+      options: { force: false, dryRun: false, print: false },
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
@@ -53,7 +53,7 @@ describe("stabilize-env-mode", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: false, print: false },
+      options: { force: false, dryRun: false, print: false },
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
@@ -95,7 +95,7 @@ describe("stabilize-env-mode", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: false, print: false },
+      options: { force: false, dryRun: false, print: false },
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
@@ -129,7 +129,7 @@ describe("stabilize-env-mode", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: false, print: false },
+      options: { force: false, dryRun: false, print: false },
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
@@ -160,7 +160,7 @@ describe("stabilize-env-mode", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: false, print: false },
+      options: { force: false, dryRun: false, print: false },
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
@@ -194,7 +194,7 @@ describe("stabilize-env-mode", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: false, print: false },
+      options: { force: false, dryRun: false, print: false },
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
@@ -228,7 +228,7 @@ describe("stabilize-env-mode", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: false, print: false },
+      options: { force: false, dryRun: false, print: false },
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
@@ -301,7 +301,7 @@ describe("stabilize-env-mode", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: false, print: false },
+      options: { force: false, dryRun: false, print: false },
     });
 
     expect(read("turbo.json")).toBeUndefined();
@@ -320,7 +320,7 @@ describe("stabilize-env-mode", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: false, print: false },
+      options: { force: false, dryRun: false, print: false },
     });
 
     expect(result.fatalError).toBeDefined();

--- a/packages/turbo-codemod/__tests__/stabilize-ui.test.ts
+++ b/packages/turbo-codemod/__tests__/stabilize-ui.test.ts
@@ -16,7 +16,7 @@ describe("stabilize-ui", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: false, print: false },
+      options: { force: false, dryRun: false, print: false },
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
@@ -49,7 +49,7 @@ describe("stabilize-ui", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: false, print: false },
+      options: { force: false, dryRun: false, print: false },
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
@@ -82,7 +82,7 @@ describe("stabilize-ui", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: false, print: false },
+      options: { force: false, dryRun: false, print: false },
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
@@ -118,7 +118,7 @@ describe("stabilize-ui", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: false, print: false },
+      options: { force: false, dryRun: false, print: false },
     });
 
     expect(read("turbo.json")).toBeUndefined();

--- a/packages/turbo-codemod/__tests__/transform-env-literals-to-wildcards.test.ts
+++ b/packages/turbo-codemod/__tests__/transform-env-literals-to-wildcards.test.ts
@@ -16,7 +16,7 @@ describe.only("transform-env-literals-to-wildcards", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: false, print: false },
+      options: { force: false, dryRun: false, print: false },
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
@@ -52,7 +52,7 @@ describe.only("transform-env-literals-to-wildcards", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: false, print: false },
+      options: { force: false, dryRun: false, print: false },
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
@@ -83,7 +83,7 @@ describe.only("transform-env-literals-to-wildcards", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: false, print: false },
+      options: { force: false, dryRun: false, print: false },
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
@@ -119,7 +119,7 @@ describe.only("transform-env-literals-to-wildcards", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: false, print: false },
+      options: { force: false, dryRun: false, print: false },
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
@@ -187,7 +187,7 @@ describe.only("transform-env-literals-to-wildcards", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: false, print: false },
+      options: { force: false, dryRun: false, print: false },
     });
 
     expect(read("turbo.json")).toBeUndefined();
@@ -206,7 +206,7 @@ describe.only("transform-env-literals-to-wildcards", () => {
     // run the transformer
     const result = transformer({
       root,
-      options: { force: false, dry: false, print: false },
+      options: { force: false, dryRun: false, print: false },
     });
 
     expect(result.fatalError).toBeDefined();

--- a/packages/turbo-codemod/__tests__/transform.test.ts
+++ b/packages/turbo-codemod/__tests__/transform.test.ts
@@ -51,7 +51,7 @@ describe("transform", () => {
     await transform("add-package-manager", root as MigrateCommandArgument, {
       list: false,
       force: false,
-      dry: false,
+      dryRun: false,
       print: false,
     });
 
@@ -109,7 +109,7 @@ describe("transform", () => {
     await transform("add-package-manager", root, {
       list: false,
       force: false,
-      dry: true,
+      dryRun: true,
       print: true,
     });
 
@@ -141,7 +141,7 @@ describe("transform", () => {
     await transform("add-package-manager", root, {
       list: true,
       force: false,
-      dry: false,
+      dryRun: false,
       print: false,
     });
 
@@ -156,7 +156,7 @@ describe("transform", () => {
     await transform("not-a-real-option", root, {
       list: false,
       force: false,
-      dry: false,
+      dryRun: false,
       print: false,
     });
 
@@ -171,7 +171,7 @@ describe("transform", () => {
     await transform("add-package-manager", "~/path/that/does/not/exist", {
       list: false,
       force: false,
-      dry: false,
+      dryRun: false,
       print: false,
     });
 

--- a/packages/turbo-codemod/src/commands/migrate/index.ts
+++ b/packages/turbo-codemod/src/commands/migrate/index.ts
@@ -53,7 +53,7 @@ export async function migrate(
   options: MigrateCommandOptions
 ) {
   // check git status
-  if (!options.dry) {
+  if (!options.dryRun) {
     checkGitStatus({ directory, force: options.force });
   }
 
@@ -161,7 +161,7 @@ export async function migrate(
 
   // shutdown the turbo daemon before running codemods and upgrading
   // the daemon can handle version mismatches, but we do this as an extra precaution
-  if (!options.dry) {
+  if (!options.dryRun) {
     shutdownDaemon({ project });
   }
 
@@ -224,7 +224,7 @@ export async function migrate(
 
   // install
   if (options.install) {
-    if (options.dry) {
+    if (options.dryRun) {
       logger.log(
         `Upgrading turbo with ${chalk.bold(upgradeCommand)} ${chalk.dim(
           "(dry run)"

--- a/packages/turbo-codemod/src/commands/transform/index.ts
+++ b/packages/turbo-codemod/src/commands/transform/index.ts
@@ -22,7 +22,7 @@ export async function transform(
   }
 
   // check git status
-  if (!options.dry) {
+  if (!options.dryRun) {
     checkGitStatus({ directory, force: options.force });
   }
 

--- a/packages/turbo-codemod/src/runner/Runner.ts
+++ b/packages/turbo-codemod/src/runner/Runner.ts
@@ -21,7 +21,7 @@ export class Runner {
   constructor(options: UtilityArgs) {
     this.transform = options.transformer;
     this.rootPath = options.rootPath;
-    this.dry = options.dry;
+    this.dry = options.dryRun;
     this.print = options.print;
     this.logger = new Logger(options);
   }

--- a/packages/turbo-codemod/src/types.ts
+++ b/packages/turbo-codemod/src/types.ts
@@ -12,7 +12,7 @@ export interface Transformer {
 
 export interface TransformerOptions {
   force: boolean;
-  dry: boolean;
+  dryRun: boolean;
   print: boolean;
 }
 

--- a/packages/turbo-codemod/src/utils/logger.ts
+++ b/packages/turbo-codemod/src/utils/logger.ts
@@ -7,7 +7,7 @@ export class Logger {
 
   constructor(args: UtilityArgs) {
     this.transform = args.transformer;
-    this.dry = args.dry;
+    this.dry = args.dryRun;
   }
 
   _log(...args: Array<unknown>) {


### PR DESCRIPTION
### Description

In a silly turn of events, the object returned by the CLI has a `dryRun` field and not a `dry` field as expected.

### Testing Instructions

Make sure `--dry` and `--dry-run` are respected. (Note that the pipeline rename transform is "skipped")
```
[0 olszewski@Chriss-MacBook-Pro] /tmp/codemod-tests $ node ~/code/vercel/turborepo/packages/turbo-codemod/dist/cli.js migrate --to=2.0.0-canary.2 --dry
? Where is the root of the repo to migrate? .
Upgrading turbo from 1.13.3 to 2.0.0-canary.2 (11 required codemods)

(1/11) Running add-package-manager
 INFO  Set "packageManager" key in root "package.json" file...
 UNCHANGED  package.json

Results:
┌──────────────┬─────────────┬───────────┬───────────┬────────┐
│ (index)      │ action      │ additions │ deletions │ error  │
├──────────────┼─────────────┼───────────┼───────────┼────────┤
│ package.json │ 'unchanged' │ 0         │ 0         │ 'None' │
└──────────────┴─────────────┴───────────┴───────────┴────────┘

... 
(10/11) Running rename-pipeline
 INFO  Renaming `pipeline` key in turbo.json to `tasks`
 SKIPPED  turbo.json

Results:
┌────────────┬───────────┬───────────┬───────────┬────────┐
│ (index)    │ action    │ additions │ deletions │ error  │
├────────────┼───────────┼───────────┼───────────┼────────┤
│ turbo.json │ 'skipped' │ 1         │ 1         │ 'None' │
└────────────┴───────────┴───────────┴───────────┴────────┘

(11/11) Running stabilize-ui
 INFO  Renaming `experimentalUI` key in turbo.json to `ui`
 UNCHANGED  turbo.json

Results:
┌────────────┬─────────────┬───────────┬───────────┬────────┐
│ (index)    │ action      │ additions │ deletions │ error  │
├────────────┼─────────────┼───────────┼───────────┼────────┤
│ turbo.json │ 'unchanged' │ 0         │ 0         │ 'None' │
└────────────┴─────────────┴───────────┴───────────┴────────┘

Upgrading turbo with npm install turbo@2.0.0-canary.2 --save-dev (dry run)

Migration completed
[0 olszewski@Chriss-MacBook-Pro] /tmp/codemod-tests $ git st
On branch main
nothing to commit, working tree clean
```
