### PR TITLE
chore: remove cpuprofile flag

### DIFF
--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -162,9 +162,6 @@ pub struct Args {
     /// Force color usage in the terminal
     #[clap(long, global = true)]
     pub color: bool,
-    /// Specify a file to save a cpu profile
-    #[clap(long = "cpuprofile", global = true, value_parser)]
-    pub cpu_profile: Option<String>,
     /// The directory in which to run turbo
     #[clap(long, global = true, value_parser)]
     pub cwd: Option<Utf8PathBuf>,
@@ -396,7 +393,6 @@ impl Args {
         track_usage!(tel, &self.login, Option::is_some);
         track_usage!(tel, &self.cwd, Option::is_some);
         track_usage!(tel, &self.heap, Option::is_some);
-        track_usage!(tel, &self.cpu_profile, Option::is_some);
         track_usage!(tel, &self.team, Option::is_some);
         track_usage!(tel, &self.token, Option::is_some);
         track_usage!(tel, &self.trace, Option::is_some);

--- a/turborepo-tests/integration/tests/no-args.t
+++ b/turborepo-tests/integration/tests/no-args.t
@@ -28,7 +28,6 @@ Make sure exit code is 2 when no args are passed
         --no-update-notifier              Disable the turbo update notification
         --api <API>                       Override the endpoint for API calls
         --color                           Force color usage in the terminal
-        --cpuprofile <CPU_PROFILE>        Specify a file to save a cpu profile
         --cwd <CWD>                       The directory in which to run turbo
         --heap <HEAP>                     Specify a file to save a pprof heap profile
         --login <LOGIN>                   Override the login endpoint

--- a/turborepo-tests/integration/tests/turbo-help.t
+++ b/turborepo-tests/integration/tests/turbo-help.t
@@ -28,7 +28,6 @@ Test help flag
         --no-update-notifier              Disable the turbo update notification
         --api <API>                       Override the endpoint for API calls
         --color                           Force color usage in the terminal
-        --cpuprofile <CPU_PROFILE>        Specify a file to save a cpu profile
         --cwd <CWD>                       The directory in which to run turbo
         --heap <HEAP>                     Specify a file to save a pprof heap profile
         --login <LOGIN>                   Override the login endpoint
@@ -122,7 +121,6 @@ Test help flag
         --no-update-notifier              Disable the turbo update notification
         --api <API>                       Override the endpoint for API calls
         --color                           Force color usage in the terminal
-        --cpuprofile <CPU_PROFILE>        Specify a file to save a cpu profile
         --cwd <CWD>                       The directory in which to run turbo
         --heap <HEAP>                     Specify a file to save a pprof heap profile
         --login <LOGIN>                   Override the login endpoint
@@ -199,7 +197,6 @@ Test help flag for link command
         --no-update-notifier              Disable the turbo update notification
         --api <API>                       Override the endpoint for API calls
         --color                           Force color usage in the terminal
-        --cpuprofile <CPU_PROFILE>        Specify a file to save a cpu profile
         --cwd <CWD>                       The directory in which to run turbo
         --heap <HEAP>                     Specify a file to save a pprof heap profile
         --login <LOGIN>                   Override the login endpoint
@@ -225,7 +222,6 @@ Test help flag for unlink command
         --no-update-notifier              Disable the turbo update notification
         --api <API>                       Override the endpoint for API calls
         --color                           Force color usage in the terminal
-        --cpuprofile <CPU_PROFILE>        Specify a file to save a cpu profile
         --cwd <CWD>                       The directory in which to run turbo
         --heap <HEAP>                     Specify a file to save a pprof heap profile
         --login <LOGIN>                   Override the login endpoint
@@ -252,7 +248,6 @@ Test help flag for login command
         --no-update-notifier              Disable the turbo update notification
         --api <API>                       Override the endpoint for API calls
         --color                           Force color usage in the terminal
-        --cpuprofile <CPU_PROFILE>        Specify a file to save a cpu profile
         --cwd <CWD>                       The directory in which to run turbo
         --heap <HEAP>                     Specify a file to save a pprof heap profile
         --login <LOGIN>                   Override the login endpoint
@@ -278,7 +273,6 @@ Test help flag for logout command
         --no-update-notifier              Disable the turbo update notification
         --api <API>                       Override the endpoint for API calls
         --color                           Force color usage in the terminal
-        --cpuprofile <CPU_PROFILE>        Specify a file to save a cpu profile
         --cwd <CWD>                       The directory in which to run turbo
         --heap <HEAP>                     Specify a file to save a pprof heap profile
         --login <LOGIN>                   Override the login endpoint


### PR DESCRIPTION
### Description

This flag hasn't ever been respected in Rust. Use 2.0 to remove the frontend

### Testing Instructions

Integration tests / 👀 