### PR TITLE
fix: update integration test to expect correct output

### DIFF
--- a/turborepo-tests/integration/tests/run-caching/root-deps.t
+++ b/turborepo-tests/integration/tests/run-caching/root-deps.t
@@ -11,6 +11,7 @@ Warm the cache
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
     Time:\s+[.0-9]+m?s  (re)
+  
 
 Confirm cache hit
   $ ${TURBO} build --filter=another --output-logs=hash-only
@@ -18,10 +19,12 @@ Confirm cache hit
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
   another:build: cache hit, suppressing logs 6a4c300cb14847b0
-
+  
    Tasks:    1 successful, 1 total
-  Cached:    0 cached, 1 total
-    Time:\s+[.0-9]+m?s  (re)
+  Cached:    1 cached, 1 total
+    Time:\s+[.0-9]+m?s >>> FULL TURBO (re)
+  
+
 
 Change a root internal dependency
   $ touch packages/util/important.txt


### PR DESCRIPTION
### Description

#8277 broke the branch by not properly updating the snapshot for the integration test

### Testing Instructions

CI should pass
