### PR TITLE
feat: change values of "ui" in turbo.json

### DIFF
--- a/crates/turborepo-lib/src/config.rs
+++ b/crates/turborepo-lib/src/config.rs
@@ -294,7 +294,7 @@ impl ResolvedConfigurationOptions for RawTurboJson {
             .experimental_spaces
             .and_then(|spaces| spaces.id)
             .map(|spaces_id| spaces_id.into());
-        opts.ui = self.ui;
+        opts.ui = self.ui.map(|ui| ui.use_tui());
         Ok(opts)
     }
 }

--- a/packages/turbo-codemod/__tests__/stabilize-ui.test.ts
+++ b/packages/turbo-codemod/__tests__/stabilize-ui.test.ts
@@ -92,7 +92,7 @@ describe("stabilize-ui", () => {
           outputs: ["dist"],
         },
       },
-      ui: false,
+      ui: "stream",
     });
 
     expect(result.fatalError).toBeUndefined();

--- a/packages/turbo-codemod/src/transforms/stabilize-ui.ts
+++ b/packages/turbo-codemod/src/transforms/stabilize-ui.ts
@@ -20,7 +20,7 @@ function migrateConfig(config: ExperimentalSchema): RootSchema {
   delete config.experimentalUI;
   // If UI is enabled we can just remove the config now that it's enabled by default
   if (ui !== undefined && !ui) {
-    config.ui = ui;
+    config.ui = "stream";
   }
   return config;
 }

--- a/packages/turbo-types/src/types/config.ts
+++ b/packages/turbo-types/src/types/config.ts
@@ -135,9 +135,9 @@ export interface RootSchema extends BaseSchema {
    *
    * Documentation: https://turbo.build/repo/docs/reference/configuration#experimentalui
    *
-   * @defaultValue `true`
+   * @defaultValue `"tui"`
    */
-  ui?: boolean;
+  ui?: UI;
 }
 
 export type LegacyRootSchema = RootSchema & LegacyBaseSchema;
@@ -319,6 +319,8 @@ export type OutputMode =
   | "new-only"
   | "errors-only"
   | "none";
+
+export type UI = "tui" | "stream";
 
 export type AnchoredUnixPath = string;
 export type EnvWildcard = string;


### PR DESCRIPTION
### Description

It was mentioned that `"ui": false` doesn't make much sense. We replace that in this PR with `"tui"` for the rich terminal output and `"stream"` for the non-TTY behavior.

### Testing Instructions

Updated migration and unit tests. Quick manual check on a test repo.
<img width="798" alt="Screenshot 2024-06-04 at 8 51 53 AM" src="https://github.com/vercel/turbo/assets/4131117/ed8aa9a0-bb04-4618-a782-5af02e5867e2">

