### PR TITLE
Postcss: fix failures processing .postcssrc.json

### DIFF
--- a/crates/turbopack/src/module_options/mod.rs
+++ b/crates/turbopack/src/module_options/mod.rs
@@ -220,7 +220,7 @@ impl ModuleOptions {
         );
 
         let mut rules = vec![
-            ModuleRule::new(
+            ModuleRule::new_all(
                 ModuleRuleCondition::ResourcePathEndsWith(".json".to_string()),
                 vec![ModuleRuleEffect::ModuleType(ModuleType::Json)],
             ),


### PR DESCRIPTION
We create `Internal` `ReferenceType`s for these config files that need to be processed as JSON. This sets the ModuleEffect for JSON types to run on all references, like other file types.

Test TBD
