### PR TITLE
fix(turborepo): factor in negated globs for workspace detection in codemods

### DIFF
--- a/packages/turbo-codemod/__tests__/__fixtures__/add-package-names/ignored-packages/package.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/add-package-names/ignored-packages/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "root",
+  "workspaces": [
+    "packages/*",
+    "!packages/ui"
+  ],
+  "version": "1.0.0",
+  "dependencies": {},
+  "devDependencies": {},
+  "packageManager": "pnpm@8.15.4"
+}

--- a/packages/turbo-codemod/__tests__/__fixtures__/add-package-names/ignored-packages/packages/ui/package.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/add-package-names/ignored-packages/packages/ui/package.json
@@ -1,0 +1,5 @@
+{
+  "version": "1.0.0",
+  "dependencies": {},
+  "devDependencies": {}
+}

--- a/packages/turbo-codemod/__tests__/__fixtures__/add-package-names/ignored-packages/packages/utils/package.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/add-package-names/ignored-packages/packages/utils/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "utils",
+  "version": "1.0.0",
+  "dependencies": {},
+  "devDependencies": {}
+}

--- a/packages/turbo-codemod/__tests__/__fixtures__/add-package-names/ignored-packages/pnpm-workspace.yaml
+++ b/packages/turbo-codemod/__tests__/__fixtures__/add-package-names/ignored-packages/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - "packages/*"
+  - "!packages/ui"

--- a/packages/turbo-codemod/__tests__/add-package-names.test.ts
+++ b/packages/turbo-codemod/__tests__/add-package-names.test.ts
@@ -114,4 +114,36 @@ describe("add-package-names", () => {
       names.add(pkgJson?.name);
     }
   });
+
+  test("ignored packages", async () => {
+    // load the fixture for the test
+    const { root, readJson } = useFixture({
+      fixture: "ignored-packages",
+    });
+
+    // run the transformer
+    const result = await transformer({
+      root,
+      options: { force: false, dryRun: false, print: false },
+    });
+
+    // result should be correct
+    expect(result.fatalError).toBeUndefined();
+    expect(result.changes).toMatchInlineSnapshot(`Object {}`);
+
+    // validate unique names
+    const names = new Set();
+
+    const pkg = "utils";
+    const pkgJson = readJson<{ name: string }>(`packages/${pkg}/package.json`);
+    expect(pkgJson?.name).toBeDefined();
+    expect(names.has(pkgJson?.name)).toBe(false);
+    names.add(pkgJson?.name);
+
+    const unchangedPkg = "ui";
+    const unchangedPkgJson = readJson<{ name: string }>(
+      `packages/${unchangedPkg}/package.json`
+    );
+    expect(unchangedPkgJson?.name).toBeUndefined();
+  });
 });

--- a/packages/turbo-workspaces/src/getWorkspaceDetails.ts
+++ b/packages/turbo-workspaces/src/getWorkspaceDetails.ts
@@ -1,4 +1,3 @@
-import { Workspace } from "@turbo/repository";
 import { ConvertError } from "./errors";
 import { MANAGERS } from "./managers";
 import { directoryInfo } from "./utils";

--- a/packages/turbo-workspaces/src/getWorkspaceDetails.ts
+++ b/packages/turbo-workspaces/src/getWorkspaceDetails.ts
@@ -1,3 +1,4 @@
+import { Workspace } from "@turbo/repository";
 import { ConvertError } from "./errors";
 import { MANAGERS } from "./managers";
 import { directoryInfo } from "./utils";

--- a/packages/turbo-workspaces/src/utils.ts
+++ b/packages/turbo-workspaces/src/utils.ts
@@ -163,14 +163,19 @@ function expandWorkspaces({
   if (!workspaceGlobs) {
     return [];
   }
+  const ignoredGlobs = workspaceGlobs
+    .filter((glob) => glob.startsWith("!"))
+    .map((glob) => glob.slice(1));
+
   return workspaceGlobs
+    .filter((glob) => !glob.startsWith("!"))
     .flatMap((workspaceGlob) => {
       const workspacePackageJsonGlob = [`${workspaceGlob}/package.json`];
       return globSync(workspacePackageJsonGlob, {
         onlyFiles: true,
         absolute: true,
         cwd: workspaceRoot,
-        ignore: ["**/node_modules/**"],
+        ignore: ["**/node_modules/**", ...ignoredGlobs],
       });
     })
     .map((workspacePackageJson) => {


### PR DESCRIPTION
### Description

Closes #8327. We now factor in negated globs

### Testing Instructions

Added a test to `add-package-name` migration that ensures we ignore package covered by negated glob