### PR TITLE
fix(ui): no longer attempt to read from stdin if non-tty

### DIFF
--- a/crates/turborepo-ui/src/tui/app.rs
+++ b/crates/turborepo-ui/src/tui/app.rs
@@ -13,13 +13,13 @@ use tracing::debug;
 const PANE_SIZE_RATIO: f32 = 3.0 / 4.0;
 const FRAMERATE: Duration = Duration::from_millis(3);
 
-use super::{input, AppReceiver, Error, Event, TaskTable, TerminalPane};
+use super::{input, AppReceiver, Error, Event, InputOptions, TaskTable, TerminalPane};
 
 pub struct App<I> {
     table: TaskTable,
     pane: TerminalPane<I>,
     done: bool,
-    interact: bool,
+    input_options: InputOptions,
 }
 
 pub enum Direction {
@@ -34,7 +34,11 @@ impl<I> App<I> {
             table: TaskTable::new(tasks.clone()),
             pane: TerminalPane::new(rows, cols, tasks),
             done: false,
-            interact: false,
+            input_options: InputOptions {
+                interact: false,
+                // Check if stdin is a tty that we should read input from
+                tty_stdin: atty::is(atty::Stream::Stdin),
+            },
         };
         // Start with first task selected
         this.next();
@@ -60,7 +64,7 @@ impl<I> App<I> {
             return;
         };
         if self.pane.has_stdin(selected_task) {
-            self.interact = interact;
+            self.input_options.interact = interact;
             self.pane.highlight(interact);
         }
     }
@@ -87,7 +91,7 @@ impl<I> App<I> {
 impl<I: std::io::Write> App<I> {
     pub fn forward_input(&mut self, bytes: &[u8]) -> Result<(), Error> {
         // If we aren't in interactive mode, ignore input
-        if !self.interact {
+        if !self.input_options.interact {
             return Ok(());
         }
         let selected_task = self
@@ -131,7 +135,7 @@ fn run_app_inner<B: Backend + std::io::Write>(
     // Render initial state to paint the screen
     terminal.draw(|f| view(app, f))?;
     let mut last_render = Instant::now();
-    while let Some(event) = poll(app.interact, &receiver, last_render + FRAMERATE) {
+    while let Some(event) = poll(app.input_options, &receiver, last_render + FRAMERATE) {
         update(app, event)?;
         if app.done {
             break;
@@ -147,8 +151,8 @@ fn run_app_inner<B: Backend + std::io::Write>(
 
 /// Blocking poll for events, will only return None if app handle has been
 /// dropped
-fn poll(interact: bool, receiver: &AppReceiver, deadline: Instant) -> Option<Event> {
-    match input(interact) {
+fn poll(input_options: InputOptions, receiver: &AppReceiver, deadline: Instant) -> Option<Event> {
+    match input(input_options) {
         Ok(Some(event)) => Some(event),
         Ok(None) => receiver.recv(deadline).ok(),
         // Unable to read from stdin, shut down and attempt to clean up

--- a/crates/turborepo-ui/src/tui/input.rs
+++ b/crates/turborepo-ui/src/tui/input.rs
@@ -4,8 +4,21 @@ use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 
 use super::{event::Event, Error};
 
+#[derive(Debug, Clone, Copy)]
+pub struct InputOptions {
+    pub interact: bool,
+    pub tty_stdin: bool,
+}
 /// Return any immediately available event
-pub fn input(interact: bool) -> Result<Option<Event>, Error> {
+pub fn input(options: InputOptions) -> Result<Option<Event>, Error> {
+    let InputOptions {
+        interact,
+        tty_stdin,
+    } = options;
+    // If stdin is not a tty, then we do not attempt to read from it
+    if !tty_stdin {
+        return Ok(None);
+    }
     // poll with 0 duration will only return true if event::read won't need to wait
     // for input
     if crossterm::event::poll(Duration::from_millis(0))? {

--- a/crates/turborepo-ui/src/tui/mod.rs
+++ b/crates/turborepo-ui/src/tui/mod.rs
@@ -10,7 +10,7 @@ mod task;
 pub use app::run_app;
 use event::{Event, TaskResult};
 pub use handle::{AppReceiver, AppSender, TuiTask};
-use input::input;
+use input::{input, InputOptions};
 pub use pane::TerminalPane;
 pub use table::TaskTable;
 


### PR DESCRIPTION
### Description

Fixes #8323

The TUI was crashing as it was failing when attempting to read from `stdin` that was closed by `pre-commit`. The fix is to not read from `stdin` if there isn't user input coming from there.

### Testing Instructions

Closing `stdin` should no longer cause `turbo` to crash if stdout is still a TTY e.g. `turbo_dev build < /dev/null`

Also verify that reproduction https://github.com/isaacharrisholt/turborepo-precommit-bug/tree/main no longer crashes when using changes from this PR.
