### PR TITLE
add client disallowed transform

### DIFF
--- a/crates/turbopack-ecmascript-plugins/src/transform/directives/client_disallowed.rs
+++ b/crates/turbopack-ecmascript-plugins/src/transform/directives/client_disallowed.rs
@@ -1,0 +1,33 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use swc_core::ecma::{ast::Program, transforms::base::resolver, visit::VisitMutWith};
+use turbopack_ecmascript::{CustomTransformer, TransformContext};
+
+use super::{is_client_module, server_to_client_proxy::create_error_proxy_module};
+
+#[derive(Debug)]
+pub struct ClientDisallowedDirectiveTransformer {
+    error_proxy_module: String,
+}
+
+impl ClientDisallowedDirectiveTransformer {
+    pub fn new(error_proxy_module: String) -> Self {
+        Self { error_proxy_module }
+    }
+}
+
+#[async_trait]
+impl CustomTransformer for ClientDisallowedDirectiveTransformer {
+    async fn transform(&self, program: &mut Program, ctx: &TransformContext<'_>) -> Result<()> {
+        if is_client_module(program) {
+            *program = create_error_proxy_module(&self.error_proxy_module);
+            program.visit_mut_with(&mut resolver(
+                ctx.unresolved_mark,
+                ctx.top_level_mark,
+                false,
+            ));
+        }
+
+        Ok(())
+    }
+}

--- a/crates/turbopack-ecmascript-plugins/src/transform/directives/mod.rs
+++ b/crates/turbopack-ecmascript-plugins/src/transform/directives/mod.rs
@@ -1,6 +1,7 @@
 use swc_core::ecma::ast::{Lit, Program};
 
 pub mod client;
+pub mod client_disallowed;
 pub mod server;
 mod server_to_client_proxy;
 

--- a/crates/turbopack-ecmascript-plugins/src/transform/directives/server_to_client_proxy.rs
+++ b/crates/turbopack-ecmascript-plugins/src/transform/directives/server_to_client_proxy.rs
@@ -2,8 +2,8 @@ use swc_core::{
     common::DUMMY_SP,
     ecma::{
         ast::{
-            ImportDecl, ImportSpecifier, ImportStarAsSpecifier, Module, ModuleDecl, ModuleItem,
-            Program,
+            ImportDecl, ImportDefaultSpecifier, ImportSpecifier, ImportStarAsSpecifier, Module,
+            ModuleDecl, ModuleItem, Program,
         },
         utils::private_ident,
     },
@@ -29,6 +29,31 @@ pub fn create_proxy_module(transition_name: &str, target_import: &str) -> Progra
                     (TURBOPACK_HELPER.as_str(), "true"),
                     (ANNOTATION_TRANSITION, transition_name),
                 ])),
+                span: DUMMY_SP,
+                phase: Default::default(),
+            })),
+            ModuleItem::Stmt(quote!(
+                "__turbopack_export_namespace__($proxy);" as Stmt,
+                proxy = ident,
+            )),
+        ],
+        shebang: None,
+        span: DUMMY_SP,
+    })
+}
+
+pub fn create_error_proxy_module(error_proxy_module: &str) -> Program {
+    let ident = private_ident!("errorProxy");
+    Program::Module(Module {
+        body: vec![
+            ModuleItem::ModuleDecl(ModuleDecl::Import(ImportDecl {
+                specifiers: vec![ImportSpecifier::Default(ImportDefaultSpecifier {
+                    local: ident.clone(),
+                    span: DUMMY_SP,
+                })],
+                src: Box::new(error_proxy_module.into()),
+                type_only: false,
+                with: Some(with_clause(&[(TURBOPACK_HELPER.as_str(), "true")])),
                 span: DUMMY_SP,
                 phase: Default::default(),
             })),


### PR DESCRIPTION
### Description

needed for next.js to disallow "use client" on middleware and instrumentation

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
