### PR TITLE
fix: correctly serialize ui values

### DIFF
--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -1073,4 +1073,12 @@ mod tests {
         let json = RawTurboJson::parse(json, AnchoredSystemPath::new("").unwrap()).unwrap();
         assert_eq!(json.ui, expected);
     }
+
+    #[test_case(r#"{ "ui":"tui" }"#, r#"{"ui": "tui"}"# ; "tui")]
+    #[test_case(r#"{ "ui":"stream" }"#, r#"{"ui": "stream"}"# ; "stream")]
+    fn test_ui_serialization(input: &str, expected: &str) {
+        let parsed = RawTurboJson::parse(input, AnchoredSystemPath::new("").unwrap()).unwrap();
+        let actual = serde_json::to_string(&parsed).unwrap();
+        assert_eq!(actual, expected);
+    }
 }

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -160,6 +160,7 @@ impl DerefMut for Pipeline {
 }
 
 #[derive(Serialize, Debug, Copy, Clone, Deserializable, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
 pub enum UI {
     Tui,
     Stream,
@@ -1074,8 +1075,8 @@ mod tests {
         assert_eq!(json.ui, expected);
     }
 
-    #[test_case(r#"{ "ui":"tui" }"#, r#"{"ui": "tui"}"# ; "tui")]
-    #[test_case(r#"{ "ui":"stream" }"#, r#"{"ui": "stream"}"# ; "stream")]
+    #[test_case(r#"{ "ui": "tui" }"#, r#"{"ui":"tui"}"# ; "tui")]
+    #[test_case(r#"{ "ui": "stream" }"#, r#"{"ui":"stream"}"# ; "stream")]
     fn test_ui_serialization(input: &str, expected: &str) {
         let parsed = RawTurboJson::parse(input, AnchoredSystemPath::new("").unwrap()).unwrap();
         let actual = serde_json::to_string(&parsed).unwrap();

--- a/turborepo-tests/integration/fixtures/monorepo_with_root_dep/turbo.json
+++ b/turborepo-tests/integration/fixtures/monorepo_with_root_dep/turbo.json
@@ -11,5 +11,6 @@
     "web#build": {
       "dependsOn": ["web#gen"]
     }
-  }
+  },
+  "ui": "stream"
 }

--- a/turborepo-tests/integration/tests/prune/produces-valid-turbo-json.t
+++ b/turborepo-tests/integration/tests/prune/produces-valid-turbo-json.t
@@ -16,7 +16,8 @@ Make sure we prune tasks that reference a pruned workspace
       "build": {
         "outputs": []
       }
-    }
+    },
+    "ui": "stream"
   }
 
 Verify turbo can read the produced turbo.json


### PR DESCRIPTION
### Description

Solves the issue reported here: https://github.com/vercel/turbo/issues/8311#issuecomment-2148968155 

The `biome` deserialization defaults to camel case, whereas the `serde` serialization implementation doesn't.

### Testing Instructions

Added unit tests as well as updated the `prune` test fixture to include `"ui": "stream"`