### PR TITLE
fix(ui): disable TUI if log order is specified

### DIFF
--- a/crates/turborepo-lib/src/commands/mod.rs
+++ b/crates/turborepo-lib/src/commands/mod.rs
@@ -68,6 +68,15 @@ impl CommandBase {
             .with_token(self.args.token.clone())
             .with_timeout(self.args.remote_cache_timeout)
             .with_preflight(self.args.preflight.then_some(true))
+            .with_ui(self.args.execution_args.as_ref().and_then(|args| {
+                if !args.log_order.compatible_with_tui() {
+                    Some(false)
+                } else {
+                    // If the argument is compatible with the TUI this does not mean we should
+                    // override other configs
+                    None
+                }
+            }))
             .build()
     }
 


### PR DESCRIPTION
### Description

The concept of log ordering doesn't apply to the TUI. If a user requests a specific log order we should disable the TUI to achieve that.

This PR disables the TUI if a user specifies a non-default `--log-order`

### Testing Instructions

```
[0 olszewski@chriss-mbp] /tmp/turbov2 $ turbo_dev build --log-order=grouped
• Packages in scope: app-a, app-b, pkg-a, pkg-b, tooling-config
• Running build in 5 packages
• Remote caching disabled
app-b:build: cache hit (outputs already on disk), replaying logs 5fa82274708c3b22
app-b:build: 
app-b:build: > build
app-b:build: > mkdir -p dist && echo "Your application output!" > dist/app-output.txt && echo "Application B is built!"
app-b:build: 
app-b:build: Application B is built!
pkg-b:prebuild: cache hit (outputs already on disk), replaying logs cf6a216ade97c1f2
pkg-b:prebuild: 
pkg-b:prebuild: > prebuild
pkg-b:prebuild: > echo "Executing pre-build step..."
pkg-b:prebuild: 
pkg-b:prebuild: Executing pre-build step...
pkg-a:build: cache hit (outputs already on disk), replaying logs 45a40140a1fcba1d
pkg-a:build: 
pkg-a:build: > build
pkg-a:build: > echo "Building at the speed of Turbo." > output-file.txt && cat output-file.txt
pkg-a:build: 
pkg-a:build: Building at the speed of Turbo.
pkg-b:build: cache hit (outputs already on disk), replaying logs aa0f1c8d82393ebe
pkg-b:build: 
pkg-b:build: > prebuild
pkg-b:build: > echo "Executing pre-build step..."
pkg-b:build: 
pkg-b:build: Executing pre-build step...
pkg-b:build: 
pkg-b:build: > build
pkg-b:build: > echo "Welcome to the Turboverse." > output-file.txt && cat output-file.txt
pkg-b:build: 
pkg-b:build: Welcome to the Turboverse.
app-a:build: cache hit (outputs already on disk), replaying logs 0b6d877af7e9385c
app-a:build: 
app-a:build: > build
app-a:build: > mkdir -p dist && echo "Your application output!" > dist/app-output.txt && echo "Application A is built!"
app-a:build: 
app-a:build: Application A is built!

 Tasks:    5 successful, 5 total
Cached:    5 cached, 5 total
  Time:    81ms >>> FULL TURBO
```
