### PR TITLE
fix: add NODE_OPTIONS to default pass through env vars

### DIFF
--- a/crates/turborepo-lib/src/task_hash.rs
+++ b/crates/turborepo-lib/src/task_hash.rs
@@ -465,6 +465,7 @@ impl<'a> TaskHasher<'a> {
                 let default_env_var_pass_through_map =
                     self.env_at_execution_start.from_wildcards(&[
                         "SHELL",
+                        "NODE_OPTIONS",
                         // Command Prompt casing of env variables
                         "APPDATA",
                         "PATH",


### PR DESCRIPTION
### Description

[`NODE_OPTIONS`](https://nodejs.org/api/cli.html#node_optionsoptions) can do many things, but it is especially used to bump heap limits. With env mode strict this can cause OOMs when using `turbo`.

### Testing Instructions

👀 
