### PR TITLE
test: Add an execution test for `paren_remover`

### DIFF
--- a/crates/turbopack-tests/tests/execution/turbopack/minification/paren-remover/input/index.js
+++ b/crates/turbopack-tests/tests/execution/turbopack/minification/paren-remover/input/index.js
@@ -1,0 +1,34 @@
+function toFixed(value, maxDecimals, roundingFunction, optionals) {
+  var splitValue = value.toString().split("."),
+    minDecimals = maxDecimals - (optionals || 0),
+    optionalsRegExp,
+    power,
+    output;
+  var boundedPrecisions;
+  // var unused = 'xxxx';
+  // Use the smallest precision value possible to avoid errors from floating point representation
+  if (splitValue.length === 2) {
+    boundedPrecisions = Math.min(
+      Math.max(splitValue[1].length, minDecimals),
+      maxDecimals
+    );
+  } else {
+    boundedPrecisions = minDecimals;
+  }
+  power = Math.pow(10, boundedPrecisions);
+  // Multiply up by precision, round accurately, then divide and use native toFixed():
+  output = (roundingFunction(value + "e+" + boundedPrecisions) / power).toFixed(
+    boundedPrecisions
+  );
+  if (optionals > maxDecimals - boundedPrecisions) {
+    optionalsRegExp = new RegExp(
+      "\\.?0{1," + (optionals - (maxDecimals - boundedPrecisions)) + "}$"
+    );
+    output = output.replace(optionalsRegExp, "");
+  }
+  return output;
+}
+
+it("should work", () => {
+  expect(toFixed(1.2345, 2, Math.round, 1)).toBe("1.23");
+});


### PR DESCRIPTION
### Description

I copied the test from https://github.com/swc-project/swc/pull/8442. This input file fails if the `paren_remover` is not applied.

### Testing Instructions

Closes PACK-3110
