### PR TITLE
Warn instead of print when no locally installed  version.

### DIFF
--- a/crates/turborepo-lib/src/shim.rs
+++ b/crates/turborepo-lib/src/shim.rs
@@ -609,7 +609,7 @@ fn run_correct_turbo(
         let should_warn_on_global = env::var(TURBO_GLOBAL_WARNING_DISABLED)
             .map_or(true, |disable| !matches!(disable.as_str(), "1" | "true"));
         if should_warn_on_global {
-            eprintln!("No locally installed `turbo` found. Using version: {version}.");
+            warn!("No locally installed `turbo` found. Using version: {version}.");
         }
         Ok(cli::run(Some(repo_state), subscriber, ui)?)
     }

--- a/crates/turborepo-lib/src/shim.rs
+++ b/crates/turborepo-lib/src/shim.rs
@@ -17,7 +17,7 @@ use semver::Version;
 use serde::Deserialize;
 use thiserror::Error;
 use tiny_gradient::{GradientStr, RGB};
-use tracing::debug;
+use tracing::{debug, warn};
 use turbo_updater::display_update_check;
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
 use turborepo_repository::{


### PR DESCRIPTION
### Description

Let's make sure we give an extra little bump in this situation. A warn, instead of only a `println!`. Realistically, this isn't a situation that folks want to be getting themselves into often/purposefully.
