### PR TITLE
Add CI to default passthroughs.

### DIFF
--- a/crates/turborepo-lib/src/task_hash.rs
+++ b/crates/turborepo-lib/src/task_hash.rs
@@ -469,6 +469,7 @@ impl<'a> TaskHasher<'a> {
                         "LANG",
                         "SHELL",
                         "PWD",
+                        "CI",
                         "NODE_OPTIONS",
                         // Vercel specific
                         "VERCEL_*",


### PR DESCRIPTION
### Description

By convention, CI systems will set a `CI` environment variable. Given the ubiquity of this variable, there are some tools that rely on this variable, which is what I think we're seeing in #8281.