### PR TITLE
BeforeResolvePluginCondition: allow module filtering as a condition for `BeforeResolvePlugin`s

### DIFF
--- a/crates/turbopack-core/src/resolve/mod.rs
+++ b/crates/turbopack-core/src/resolve/mod.rs
@@ -1416,7 +1416,7 @@ async fn handle_before_resolve_plugins(
 ) -> Result<Option<Vc<ResolveResult>>> {
     for plugin in &options.await?.before_resolve_plugins {
         let condition = plugin.before_resolve_condition().resolve().await?;
-        if !*condition.matches(request).await? {
+        if !condition.await?.matches(request).await? {
             continue;
         }
 


### PR DESCRIPTION
This expands `BeforeResolvePluginCondition` to match on individual modules rather than just the request string.

Needed for https://github.com/vercel/next.js/pull/66622
