### PR TITLE
Fix Turbopack benchmark for next@canary

### DIFF
--- a/crates/turbopack-bench/README.md
+++ b/crates/turbopack-bench/README.md
@@ -29,6 +29,12 @@ and optionally filter the benchmarks run to specific bundlers, such as:
 cargo bench -p turbopack-bench -p turbopack-cli -- "hmr_to_eval/(Turbopack CSR|Vite)"
 ```
 
+or a specific suite:
+
+```sh
+cargo bench -p turbopack-bench -- "bench_hydration/Next\.js canary Turbo RSC"
+```
+
 **Note**: The Turbopack benchmark suite includes a mix of server-side rendered and client-only rendered examples -- these are reflected in "CSR" or "SSR" in the benchmark name. Turbopack supports both, while some other bundlers only support client-rendered examples. Take that into account when comparing CSR results against SSR.
 
 **Hint**: These benchmarks take a long time to complete, since they try to capture at least 10 samples for every scenario. There is a `TURBOPACK_BENCH_PROGRESS=1` env var to show values while the benchmarks are running.

--- a/crates/turbopack-bench/src/bundlers/nextjs/mod.rs
+++ b/crates/turbopack-bench/src/bundlers/nextjs/mod.rs
@@ -162,7 +162,7 @@ impl NextJsVersion {
             NextJsVersion::V12 => "^18.2.0",
             NextJsVersion::V13 => "^18.2.0",
             NextJsVersion::V14 => "^18.2.0",
-            NextJsVersion::Canary => "^18.2.0",
+            NextJsVersion::Canary => "rc",
         }
     }
 

--- a/crates/turbopack-bench/src/util/mod.rs
+++ b/crates/turbopack-bench/src/util/mod.rs
@@ -70,7 +70,7 @@ pub fn build_test(module_count: usize, bundler: &dyn Bundler) -> TestApp {
     .unwrap();
 
     let npm = command("npm")
-        .args(["install", "--prefer-offline", "--loglevel=error"])
+        .args(["install", "--loglevel=error"])
         .current_dir(test_app.path())
         .output()
         .unwrap();


### PR DESCRIPTION
### Description

- Ensures that the benchmarks don't fail on installing as `prefer-offline` doesn't work reliably.
- Installs `react@rc` and `react-dom@rc` for `next@canary` as it requires React 19.
- Updated the benchmark docs to show to to run one suite

<!--
  ✍️ Write a short summary of your work.
  If necessary, include relevant screenshots.
-->

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
