### PR TITLE
chore(turborepo): remove unused code

### DIFF
--- a/crates/turborepo-lib/src/process/mod.rs
+++ b/crates/turborepo-lib/src/process/mod.rs
@@ -144,9 +144,10 @@ impl ProcessManager {
 
 #[cfg(test)]
 mod test {
+    use std::time::Instant;
+
     use futures::{stream::FuturesUnordered, StreamExt};
     use test_case::test_case;
-    use time::Instant;
     use tokio::{join, time::sleep};
     use tracing_test::traced_test;
 

--- a/crates/turborepo-lib/src/task_graph/mod.rs
+++ b/crates/turborepo-lib/src/task_graph/mod.rs
@@ -39,7 +39,7 @@ impl TaskOutputs {
 }
 
 // Constructed from a RawTaskDefinition
-#[derive(Debug, Deserialize, PartialEq, Clone, Eq)]
+#[derive(Debug, PartialEq, Clone, Eq)]
 pub struct TaskDefinition {
     pub outputs: TaskOutputs,
     pub(crate) cache: bool,

--- a/crates/turborepo-repository/src/package_manager/mod.rs
+++ b/crates/turborepo-repository/src/package_manager/mod.rs
@@ -582,10 +582,9 @@ impl PackageManager {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashSet, fs::File};
+    use std::collections::HashSet;
 
     use pretty_assertions::assert_eq;
-    use tempfile::tempdir;
 
     use super::*;
 


### PR DESCRIPTION
### Description

We don't need these serde derives anymore since we're not serializing the args to pass to Go.

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
