### PR TITLE
fix: disable panic handler in ci

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3453,9 +3453,9 @@ dependencies = [
 
 [[package]]
 name = "human-panic"
-version = "1.2.1"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b82da652938b83f94cfdaaf9ae7aaadb8430d84b0dfda226998416318727eac2"
+checksum = "c4f016c89920bbb30951a8405ecacbb4540db5524313b9445736e7e1855cf370"
 dependencies = [
  "anstream",
  "anstyle",
@@ -3463,7 +3463,7 @@ dependencies = [
  "os_info",
  "serde",
  "serde_derive",
- "toml 0.7.8",
+ "toml 0.8.14",
  "uuid",
 ]
 
@@ -5215,13 +5215,13 @@ dependencies = [
 
 [[package]]
 name = "os_info"
-version = "3.7.0"
+version = "3.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "006e42d5b888366f1880eda20371fedde764ed2213dc8496f49622fa0c99cd5e"
+checksum = "ae99c7fa6dd38c7cafe1ec085e804f8f555a2f8659b0dbe03f1f9963a9b51092"
 dependencies = [
  "log",
  "serde",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6995,9 +6995,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.3"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
+checksum = "79e674e01f999af37c49f70a6ede167a8a60b2503e56c5599532a65baa5969a0"
 dependencies = [
  "serde",
 ]
@@ -9677,21 +9677,21 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.2"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d"
+checksum = "6f49eb2ab21d2f26bd6db7bf383edc527a7ebaee412d17af4d40fdccd442f335"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.20.2",
+ "toml_edit 0.22.14",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.3"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
 dependencies = [
  "serde",
 ]
@@ -9706,20 +9706,20 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.15",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.20.2"
+version = "0.22.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
+checksum = "f21c7aaf97f1bd9ca9d4f9e73b0a6c74bd5afef56f2bc931943a6e1c37e04e38"
 dependencies = [
  "indexmap 2.2.6",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow",
+ "winnow 0.6.13",
 ]
 
 [[package]]
@@ -10087,7 +10087,6 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "build-target",
- "human-panic",
  "itertools 0.10.5",
  "miette 5.10.0",
  "pretty_assertions",
@@ -11245,6 +11244,7 @@ dependencies = [
  "globwatch",
  "go-parse-duration",
  "hex",
+ "human-panic",
  "human_format",
  "humantime",
  "ignore",
@@ -11530,7 +11530,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.4.6",
+ "rand 0.8.5",
  "static_assertions",
 ]
 
@@ -12283,7 +12283,7 @@ dependencies = [
  "serde_json",
  "serde_yaml 0.9.27",
  "thiserror",
- "toml 0.8.2",
+ "toml 0.8.14",
 ]
 
 [[package]]
@@ -12920,6 +12920,15 @@ name = "winnow"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c2e3184b9c4e92ad5167ca73039d0c42476302ab603e2fec4487511f38ccefc"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.6.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59b5e5f6c299a3c7890b876a2a587f3115162487e704907d9b6cd29473052ba1"
 dependencies = [
  "memchr",
 ]

--- a/crates/turborepo-lib/Cargo.toml
+++ b/crates/turborepo-lib/Cargo.toml
@@ -61,6 +61,7 @@ globwalk = { version = "0.1.0", path = "../turborepo-globwalk" }
 globwatch = { path = "../turborepo-globwatch" }
 go-parse-duration = "0.1.1"
 hex = "0.4.3"
+human-panic = "1.2.1"
 human_format = "1.1.0"
 humantime = "2.1.0"
 ignore = "0.4.22"

--- a/crates/turborepo-lib/src/lib.rs
+++ b/crates/turborepo-lib/src/lib.rs
@@ -4,6 +4,7 @@
 #![feature(hash_extract_if)]
 #![feature(option_get_or_insert_default)]
 #![feature(once_cell_try)]
+#![feature(panic_info_message)]
 #![feature(try_blocks)]
 #![feature(impl_trait_in_assoc_type)]
 #![deny(clippy::all)]
@@ -26,6 +27,7 @@ pub(crate) mod globwatcher;
 mod hash;
 mod opts;
 mod package_changes_watcher;
+mod panic_handler;
 mod process;
 mod rewrite_json;
 mod run;
@@ -41,6 +43,7 @@ pub use crate::{
     child::spawn_child,
     cli::Args,
     daemon::{DaemonClient, DaemonConnector, Paths as DaemonPaths},
+    panic_handler::panic_handler,
     run::package_discovery::DaemonPackageDiscovery,
 };
 

--- a/crates/turborepo-lib/src/panic_handler.rs
+++ b/crates/turborepo-lib/src/panic_handler.rs
@@ -2,6 +2,9 @@ use human_panic::report::{Method, Report};
 
 use crate::get_version;
 
+const OPEN_ISSUE_MESSAGE: &str =
+    "Please open an issue at https://github.com/vercel/turbo/issues/new/choose";
+
 pub fn panic_handler(panic_info: &std::panic::PanicInfo) {
     let cause = panic_info
         .message()
@@ -14,25 +17,37 @@ pub fn panic_handler(panic_info: &std::panic::PanicInfo) {
     };
 
     let report = Report::new("turbo", get_version(), Method::Panic, explanation, cause);
+    // If we're in CI we don't persist the backtrace to a temp file as this is hard
+    // to retrieve.
+    let should_persist = !turborepo_ci::is_ci() && turborepo_ci::Vendor::infer().is_none();
 
-    let report_message = match report.persist() {
-        Ok(f) => {
-            format!(
-                "A report has been written to {}\n
-Please open an issue at https://github.com/vercel/turbo/issues/new/choose \
-                 and include this file",
-                f.display()
-            )
+    let report_message = if should_persist {
+        match report.persist() {
+            Ok(f) => {
+                format!(
+                    "A report has been written to {}\n\n{OPEN_ISSUE_MESSAGE} and include this file",
+                    f.display()
+                )
+            }
+            Err(e) => {
+                format!(
+                    "An error has occurred while attempting to write a \
+                     report.\n\n{OPEN_ISSUE_MESSAGE} and include the following error in your \
+                     issue: {}",
+                    e
+                )
+            }
         }
-        Err(e) => {
-            format!(
-                "An error has occurred while attempting to write a report.\n
-Please open an issue at \
-                 https://github.com/vercel/turbo/issues/new/choose and include the following \
-                 error in your issue: {}",
-                e
-            )
-        }
+    } else if let Some(backtrace) = report.serialize() {
+        format!(
+            "Caused by \n{backtrace}\n\n{OPEN_ISSUE_MESSAGE} and include this message in your \
+             issue"
+        )
+    } else {
+        format!(
+            "Unable to serialize backtrace.\n\n{OPEN_ISSUE_MESSAGE} and include this message in \
+             your issue"
+        )
     };
 
     eprintln!(

--- a/crates/turborepo-lib/src/panic_handler.rs
+++ b/crates/turborepo-lib/src/panic_handler.rs
@@ -1,5 +1,6 @@
 use human_panic::report::{Method, Report};
-use turborepo_lib::get_version;
+
+use crate::get_version;
 
 pub fn panic_handler(panic_info: &std::panic::PanicInfo) {
     let cause = panic_info

--- a/crates/turborepo/Cargo.toml
+++ b/crates/turborepo/Cargo.toml
@@ -28,7 +28,6 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true, features = ["backtrace"] }
-human-panic = "1.2.1"
 miette.workspace = true
 turborepo-lib = { workspace = true, default-features = false }
 

--- a/crates/turborepo/src/main.rs
+++ b/crates/turborepo/src/main.rs
@@ -1,19 +1,14 @@
-#![feature(panic_info_message)]
 #![deny(clippy::all)]
-
-mod panic_handler;
 
 use std::process;
 
 use anyhow::Result;
 use miette::Report;
 
-use crate::panic_handler::panic_handler;
-
 // This function should not expanded. Please add any logic to
 // `turborepo_lib::main` instead
 fn main() -> Result<()> {
-    std::panic::set_hook(Box::new(panic_handler));
+    std::panic::set_hook(Box::new(turborepo_lib::panic_handler));
 
     let exit_code = turborepo_lib::main().unwrap_or_else(|err| {
         println!("{:?}", Report::new(err));


### PR DESCRIPTION
### Description

When running in CI persisting the panic backtrace to a tempfile makes it harder (or impossible) to get the entire backtrace.

This PR changes our behavior to no longer will persist the backtrace to a file if we detect we're running in CI or a vendor, instead we include the serialized backtrace in the message we print to the console.

First commit is moving the panic handler to the library crate to avoid adding dependencies to the binary crate.

### Testing Instructions

```
[0 olszewski@chriss-mbp] /Users/olszewski/code/vercel/turborepo $ turbo_dev --version
Oops! Turbo has crashed.

A report has been written to /var/folders/3m/rxkycvgs5jgfvs0k9xcgp6km0000gn/T/report-319148de-342d-49f8-a87c-aa9c6d7b0cbd.toml

Please open an issue at https://github.com/vercel/turbo/issues/new/choose and include this file
[101 olszewski@chriss-mbp] /Users/olszewski/code/vercel/turborepo $ CI=1 turbo_dev --version
Oops! Turbo has crashed.

Caused by 
"name" = "turbo"
"operating_system" = "Mac OS 14.4.1 [64-bit]"
"crate_version" = "2.0.4-canary.1"
"explanation" = """
file 'crates/turborepo/src/main.rs' at line 13
"""
"cause" = "Forced panic!"
"method" = "Panic"
"backtrace" = """

   0: 0x100d22678 - core::panicking::panic_fmt::hc04a814f639f8411
                at /rustc/6f3df08aadf71e8d4bf7e49f5dc10dfa6f254cb4/library/core/src/panicking.rs:72
   1: 0x100c78f30 - turbo[48bd35f77d4e47ef]::main
                at /Users/olszewski/code/vercel/turborepo/crates/turborepo/src/main.rs:13
   2: 0x100c78fc0 - <fn() -> core[5c1d1104bc1ee810]::result::Result<(), anyhow[ba69079c3fe1888b]::Error> as core[5c1d1104bc1ee810]::ops::function::FnOnce<()>>::call_once
                at /rustc/6f3df08aadf71e8d4bf7e49f5dc10dfa6f254cb4/library/core/src/ops/function.rs:250
   3: 0x100c79198 - std[4e9c1a951f116da0]::sys_common::backtrace::__rust_begin_short_backtrace::<fn() -> core[5c1d1104bc1ee810]::result::Result<(), anyhow[ba69079c3fe1888b]::Error>, core[5c1d1104bc1ee810]::result::Result<(), anyhow[ba69079c3fe1888b]::Error>>
                at /rustc/6f3df08aadf71e8d4bf7e49f5dc10dfa6f254cb4/library/std/src/sys_common/backtrace.rs:155
   4: 0x100c79114 - std[4e9c1a951f116da0]::rt::lang_start::<core[5c1d1104bc1ee810]::result::Result<(), anyhow[ba69079c3fe1888b]::Error>>::{closure#0}
                at /rustc/6f3df08aadf71e8d4bf7e49f5dc10dfa6f254cb4/library/std/src/rt.rs:159
   5: 0x100d0233c - core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once::h0b62848974045da6
                at /rustc/6f3df08aadf71e8d4bf7e49f5dc10dfa6f254cb4/library/core/src/ops/function.rs:284
                 - std::panicking::try::do_call::h62aa855a2974a84f
                at /rustc/6f3df08aadf71e8d4bf7e49f5dc10dfa6f254cb4/library/std/src/panicking.rs:559
                 - std::panicking::try::he4b3a2d91bf1dbbf
                at /rustc/6f3df08aadf71e8d4bf7e49f5dc10dfa6f254cb4/library/std/src/panicking.rs:523
                 - std::panic::catch_unwind::h7420eceb348170da
                at /rustc/6f3df08aadf71e8d4bf7e49f5dc10dfa6f254cb4/library/std/src/panic.rs:149
                 - std::rt::lang_start_internal::{{closure}}::h20b554397a83800b
                at /rustc/6f3df08aadf71e8d4bf7e49f5dc10dfa6f254cb4/library/std/src/rt.rs:141
                 - std::panicking::try::do_call::h4667a29b822d8c00
                at /rustc/6f3df08aadf71e8d4bf7e49f5dc10dfa6f254cb4/library/std/src/panicking.rs:559
                 - std::panicking::try::h55eb6abb56c6f5e0
                at /rustc/6f3df08aadf71e8d4bf7e49f5dc10dfa6f254cb4/library/std/src/panicking.rs:523
                 - std::panic::catch_unwind::he9dd44a8a626ad3d
                at /rustc/6f3df08aadf71e8d4bf7e49f5dc10dfa6f254cb4/library/std/src/panic.rs:149
                 - std::rt::lang_start_internal::hacd033e6e2adb13b
                at /rustc/6f3df08aadf71e8d4bf7e49f5dc10dfa6f254cb4/library/std/src/rt.rs:141
   6: 0x100c790e0 - std[4e9c1a951f116da0]::rt::lang_start::<core[5c1d1104bc1ee810]::result::Result<(), anyhow[ba69079c3fe1888b]::Error>>
                at /rustc/6f3df08aadf71e8d4bf7e49f5dc10dfa6f254cb4/library/std/src/rt.rs:158
   7: 0x100c78f54 - _main"""


Please open an issue at https://github.com/vercel/turbo/issues/new/choose and include this message in your issue
[101 olszewski@chriss-mbp] /Users/olszewski/code/vercel/turborepo $ GITHUB_ACTIONS=1 turbo_dev --version
Oops! Turbo has crashed.

Caused by 
"name" = "turbo"
"operating_system" = "Mac OS 14.4.1 [64-bit]"
"crate_version" = "2.0.4-canary.1"
"explanation" = """
file 'crates/turborepo/src/main.rs' at line 13
"""
"cause" = "Forced panic!"
"method" = "Panic"
"backtrace" = """

   0: 0x10254e678 - core::panicking::panic_fmt::hc04a814f639f8411
                at /rustc/6f3df08aadf71e8d4bf7e49f5dc10dfa6f254cb4/library/core/src/panicking.rs:72
   1: 0x1024a4f30 - turbo[48bd35f77d4e47ef]::main
                at /Users/olszewski/code/vercel/turborepo/crates/turborepo/src/main.rs:13
   2: 0x1024a4fc0 - <fn() -> core[5c1d1104bc1ee810]::result::Result<(), anyhow[ba69079c3fe1888b]::Error> as core[5c1d1104bc1ee810]::ops::function::FnOnce<()>>::call_once
                at /rustc/6f3df08aadf71e8d4bf7e49f5dc10dfa6f254cb4/library/core/src/ops/function.rs:250
   3: 0x1024a5198 - std[4e9c1a951f116da0]::sys_common::backtrace::__rust_begin_short_backtrace::<fn() -> core[5c1d1104bc1ee810]::result::Result<(), anyhow[ba69079c3fe1888b]::Error>, core[5c1d1104bc1ee810]::result::Result<(), anyhow[ba69079c3fe1888b]::Error>>
                at /rustc/6f3df08aadf71e8d4bf7e49f5dc10dfa6f254cb4/library/std/src/sys_common/backtrace.rs:155
   4: 0x1024a5114 - std[4e9c1a951f116da0]::rt::lang_start::<core[5c1d1104bc1ee810]::result::Result<(), anyhow[ba69079c3fe1888b]::Error>>::{closure#0}
                at /rustc/6f3df08aadf71e8d4bf7e49f5dc10dfa6f254cb4/library/std/src/rt.rs:159
   5: 0x10252e33c - core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once::h0b62848974045da6
                at /rustc/6f3df08aadf71e8d4bf7e49f5dc10dfa6f254cb4/library/core/src/ops/function.rs:284
                 - std::panicking::try::do_call::h62aa855a2974a84f
                at /rustc/6f3df08aadf71e8d4bf7e49f5dc10dfa6f254cb4/library/std/src/panicking.rs:559
                 - std::panicking::try::he4b3a2d91bf1dbbf
                at /rustc/6f3df08aadf71e8d4bf7e49f5dc10dfa6f254cb4/library/std/src/panicking.rs:523
                 - std::panic::catch_unwind::h7420eceb348170da
                at /rustc/6f3df08aadf71e8d4bf7e49f5dc10dfa6f254cb4/library/std/src/panic.rs:149
                 - std::rt::lang_start_internal::{{closure}}::h20b554397a83800b
                at /rustc/6f3df08aadf71e8d4bf7e49f5dc10dfa6f254cb4/library/std/src/rt.rs:141
                 - std::panicking::try::do_call::h4667a29b822d8c00
                at /rustc/6f3df08aadf71e8d4bf7e49f5dc10dfa6f254cb4/library/std/src/panicking.rs:559
                 - std::panicking::try::h55eb6abb56c6f5e0
                at /rustc/6f3df08aadf71e8d4bf7e49f5dc10dfa6f254cb4/library/std/src/panicking.rs:523
                 - std::panic::catch_unwind::he9dd44a8a626ad3d
                at /rustc/6f3df08aadf71e8d4bf7e49f5dc10dfa6f254cb4/library/std/src/panic.rs:149
                 - std::rt::lang_start_internal::hacd033e6e2adb13b
                at /rustc/6f3df08aadf71e8d4bf7e49f5dc10dfa6f254cb4/library/std/src/rt.rs:141
   6: 0x1024a50e0 - std[4e9c1a951f116da0]::rt::lang_start::<core[5c1d1104bc1ee810]::result::Result<(), anyhow[ba69079c3fe1888b]::Error>>
                at /rustc/6f3df08aadf71e8d4bf7e49f5dc10dfa6f254cb4/library/std/src/rt.rs:158
   7: 0x1024a4f54 - _main"""


Please open an issue at https://github.com/vercel/turbo/issues/new/choose and include this message in your issue
```
