### PR TITLE
build: Update `swc_core` to `v0.93.4`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7877,9 +7877,9 @@ dependencies = [
 
 [[package]]
 name = "swc_compiler_base"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdff81d2ae11503b2cb34b37cd481c3400d19c7c05445dd5daad5cd29692ee69"
+checksum = "95ef85116a4d22dd66ebc8d1d1c7634565569fa4b80bf6728686b38e407f00f1"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -7931,9 +7931,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "0.93.2"
+version = "0.93.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57f2da78bdc49a5bd2edc80213f2b95300b11a15068e18ab9a9dd943a8660d59"
+checksum = "f331506bd57c03b006b5585797c23bf10077bc8ef949d80efce3ef4b9ee8a664"
 dependencies = [
  "binding_macros",
  "swc",
@@ -8140,9 +8140,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.149.2"
+version = "0.149.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ab6d5e7bbd9208f980b5dad2a4a6ae798c97569f809a48c3f92e6ae7e183c6c"
+checksum = "efb2bef3f4998865b2d466fb2ef9410a03449d255d199f3eb807fb19acc3862b"
 dependencies = [
  "memchr",
  "num-bigint",
@@ -8421,9 +8421,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "0.195.1"
+version = "0.195.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2822aa712eba5cdbf4bb60d24724d790ff77d0f4cf15501241b02db466a34ac9"
+checksum = "94ed053fe91ab7c1ea79a577a49fdc3da895df802bcf9df04de4ccb51a075ff7"
 dependencies = [
  "arrayvec 0.7.4",
  "indexmap 2.2.6",
@@ -8455,9 +8455,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.144.2"
+version = "0.144.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31adf4599e8de70f3b754dfc34ec2ab09fa6841d79a9f4a888250a404eae7030"
+checksum = "fc0b4193b9c127db1990a5a08111aafe0122bc8b138646807c63f2a6521b7da4"
 dependencies = [
  "either",
  "new_debug_unreachable",
@@ -8779,9 +8779,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_usage_analyzer"
-version = "0.24.3"
+version = "0.24.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d7d7109b3794756cc51e842dbb874d2da44293b06a9e3837b477300b0ccef8e"
+checksum = "104d474b77f73db1467f31d5bceb1e4821e9b471c97baa7f208e2d8edd63c107"
 dependencies = [
  "indexmap 2.2.6",
  "rustc-hash",
@@ -11530,7 +11530,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.8.5",
+ "rand 0.4.6",
  "static_assertions",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ mdxjs = "0.2.3"
 modularize_imports = { version = "0.68.15" }
 styled_components = { version = "0.96.16" }
 styled_jsx = { version = "0.73.23" }
-swc_core = { version = "0.93.2", features = [
+swc_core = { version = "0.93.4", features = [
   "ecma_loader_lru",
   "ecma_loader_parking_lot",
 ] }


### PR DESCRIPTION
### Description

Update `swc_core` to `v0.93.4`.

To apply https://github.com/swc-project/swc/pull/9036 and https://github.com/swc-project/swc/pull/9037. Those PR makes parsing of some files 5x faster.


### Testing Instructions

See next.js counterpart: https://github.com/vercel/next.js/pull/66781