### PR TITLE
Update `create-turbo` to use carat versions.

### DIFF
--- a/packages/create-turbo/src/transforms/official-starter.ts
+++ b/packages/create-turbo/src/transforms/official-starter.ts
@@ -65,8 +65,9 @@ export async function transform(args: TransformInput): TransformResult {
           packageJsonContent.devDependencies.turbo = opts.turboVersion;
           // use the same version as the create-turbo invocation
         } else {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-var-requires, @typescript-eslint/no-unsafe-member-access
-          const version = require("../../package.json").version;
+          // eslint-disable-next-line @typescript-eslint/no-var-requires -- Have to go get package.json
+          const version = (require("../../package.json") as { version: string })
+            .version;
           packageJsonContent.devDependencies.turbo = `^${version}`;
         }
       }

--- a/packages/create-turbo/src/transforms/official-starter.ts
+++ b/packages/create-turbo/src/transforms/official-starter.ts
@@ -65,12 +65,10 @@ export async function transform(args: TransformInput): TransformResult {
         // if the user specified a turbo version, use that
         if (opts.turboVersion) {
           packageJsonContent.devDependencies.turbo = opts.turboVersion;
-          // if we're using a pre-release version of create-turbo, use turbo canary
-        } else if (shouldUsePreRelease) {
-          packageJsonContent.devDependencies.turbo = "canary";
-          // otherwise, use the latest stable version
+          // use the same version as the create-turbo invocation
         } else {
-          packageJsonContent.devDependencies.turbo = "latest";
+          const version = require("../../package.json").version;
+          packageJsonContent.devDependencies.turbo = `^${version}`;
         }
       }
 

--- a/packages/create-turbo/src/transforms/official-starter.ts
+++ b/packages/create-turbo/src/transforms/official-starter.ts
@@ -60,13 +60,12 @@ export async function transform(args: TransformInput): TransformResult {
       }
 
       if (packageJsonContent.devDependencies?.turbo) {
-        const shouldUsePreRelease =
-          semverPrerelease(cliPkgJson.version) !== null;
         // if the user specified a turbo version, use that
         if (opts.turboVersion) {
           packageJsonContent.devDependencies.turbo = opts.turboVersion;
           // use the same version as the create-turbo invocation
         } else {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-var-requires, @typescript-eslint/no-unsafe-member-access
           const version = require("../../package.json").version;
           packageJsonContent.devDependencies.turbo = `^${version}`;
         }

--- a/packages/create-turbo/src/transforms/official-starter.ts
+++ b/packages/create-turbo/src/transforms/official-starter.ts
@@ -1,8 +1,6 @@
 import path from "node:path";
 import { readJsonSync, writeJsonSync, rmSync, existsSync } from "fs-extra";
 import type { PackageJson } from "@turbo/utils";
-import semverPrerelease from "semver/functions/prerelease";
-import cliPkgJson from "../../package.json";
 import { isDefaultExample } from "../utils/isDefaultExample";
 import type { TransformInput, TransformResult } from "./types";
 import { TransformError } from "./errors";


### PR DESCRIPTION
### Description

Previously, we were putting `turbo@latest` into `package.json` for the `devDep` when creating a repo with `create-turbo`. Generally, using the `latest` tag isn't a great practice, so let's use the carat version of `create-turbo` itself instead. We're safe to use this since `create-turbo`'s version tracks along with `turbo` itself.

### Testing Instructions

Tested locally by building the package and running the `dist/cli.js`. I also tried it out with canary and stable versions manually placed into the `create-turbo` `package.json#version`.