### PR TITLE
docs: Remove --cache-dir from github actions docs due to #8126

### DIFF
--- a/docs/repo-docs/guides/ci-vendors/github-actions.mdx
+++ b/docs/repo-docs/guides/ci-vendors/github-actions.mdx
@@ -252,15 +252,15 @@ The following steps exemplify how you could use [actions/cache](https://github.c
 
 <Steps>
 <Step>
-Supply the desired cache output location with the `--cache-dir` flag to your `turbo build` command
+Supply a package.json script that will run tasks using Turbo.
 
-Example `package.json` with `.turbo` as desired output directory:
+Example `package.json` with a `build` script:
 
 ```json title="./package.json"
 {
   "name": "my-turborepo",
   "scripts": {
-    "build": "turbo run build --cache-dir=.turbo"
+    "build": "turbo run build"
   },
   "devDependencies": {
     "turbo": "1.2.5"


### PR DESCRIPTION
### Description

As I see it, since the default cache location is now `<root-dir>/turbo/.cache` due to #8126, there's no longer a point in specifying the --cache-dir=.turbo as it is redundant no?

### Testing Instructions

Run a GitHub actions with https://turbo.build/repo/docs/guides/ci-vendors/github-actions#caching-with-github-actionscache and see if it caches properly
