### PR TITLE
Restore backticks on docs.

### DIFF
--- a/docs/pack-docs/advanced/profiling.mdx
+++ b/docs/pack-docs/advanced/profiling.mdx
@@ -7,7 +7,7 @@ import { ThemedImageFigure } from '#/components/image/themed-image-figure';
 
 ## On macOS
 
-### Install [cargo-instruments]
+### Install [`cargo-instruments`]
 
 ```bash title="Terminal"
 cargo install cargo-instruments

--- a/docs/pack-docs/features/css.mdx
+++ b/docs/pack-docs/features/css.mdx
@@ -46,7 +46,7 @@ Turbopack handles [CSS Nesting](https://developer.mozilla.org/en-US/docs/Web/CSS
 }
 ```
 
-## @import syntax
+## `@import` syntax
 
 Using the CSS `@import` syntax to import other CSS files is supported. This gives you the ability to combine several CSS files together into a single module:
 

--- a/docs/pack-docs/features/typescript.mdx
+++ b/docs/pack-docs/features/typescript.mdx
@@ -7,7 +7,7 @@ Turbopack supports [TypeScript](https://www.typescriptlang.org/) out of the box.
 
 Thanks to our JSX support, you can also import `.tsx` files too.
 
-## Resolving paths and baseUrl
+## Resolving `paths` and `baseUrl`
 
 In TypeScript, you can use the [`paths`](https://www.typescriptlang.org/tsconfig#paths) property of `tsconfig.json` to let you import files from custom paths.
 

--- a/docs/repo-docs/crafting-your-repository/configuring-tasks.mdx
+++ b/docs/repo-docs/crafting-your-repository/configuring-tasks.mdx
@@ -101,7 +101,7 @@ You now have the build order you would expect, building _dependencies_ before _d
 
 **But be careful.** At this point, you haven't marked the build outputs for caching. To do so, jump to the [Specifying outputs](#specifying-options) section.
 
-#### Depending on tasks in dependencies with ^
+#### Depending on tasks in dependencies with `^`
 
 The `^` microsyntax tells Turborepo to run the task starting at the bottom of the dependency graph. If your application depends on a library named `ui` and the library has a `build` task, the `build` script in `ui` will run **first**. Once it has successfully completed, the `build` task in your application will run.
 
@@ -163,7 +163,7 @@ Some tasks may not have any dependencies. For example, a task for finding typos 
 }
 ```
 
-### Specifying outputs
+### Specifying `outputs`
 
 <Callout type="info">
   Turborepo caches the outputs of your tasks so that you never do the same work
@@ -215,7 +215,7 @@ Below are a few examples of outputs for common tools:
 
 For more on building globbing patterns for the `outputs` key, see [the globbing specification](/repo/docs/reference/globs).
 
-### Specifying inputs
+### Specifying `inputs`
 
 The `inputs` key is used to specify the files that you want to include in the task's hash for [caching](/repo/docs/crafting-your-repository/caching). By default, Turborepo will include all files in the package that are tracked by Git. However, you can be more specific about which files are included in the hash using the `inputs` key.
 
@@ -240,7 +240,7 @@ To restore the default behavior, use [the `$TURBO_DEFAULT$` microsyntax](#restor
 
 </Callout>
 
-#### Restoring defaults with $TURBO_DEFAULT$
+#### Restoring defaults with `$TURBO_DEFAULT$`
 
 [The default `inputs` behavior](/repo/docs/reference/configuration#inputs) is often what you will want for your tasks. However, you can increase your cache hit ratios for certain tasks by fine-tuning your `inputs` to ignore changes to files that are known to not affect the task's output.
 

--- a/docs/repo-docs/crafting-your-repository/constructing-ci.mdx
+++ b/docs/repo-docs/crafting-your-repository/constructing-ci.mdx
@@ -71,7 +71,7 @@ Start by cloning your repository. Note that a clone with history to the cloning 
 
 </Step>
 <Step>
-### Run turbo-ignore for the package and task
+### Run `turbo-ignore` for the package and task
 
 By default, `turbo-ignore` will use the `build` task in the current working directory.
 
@@ -137,7 +137,7 @@ For example, your CI could run these two commands to quickly handle quality chec
 
 As your codebase scales, you may find more specific opportunities to optimize your CI - but relying on caching is a great place to start.
 
-### Global turbo in CI
+### Global `turbo` in CI
 
 Using global `turbo` is convenient in CI workflows, allowing you to easily run commands specific to your CI and take advantage of [Automatic Workspace Scoping](/repo/docs/crafting-your-repository/running-tasks#automatic-package-scoping).
 
@@ -145,7 +145,7 @@ However, in some cases, you may be running `turbo` commands or scripts that use 
 
 For this reason, we encourage you to **pin your global installation of `turbo` in CI to the major version in `package.json`** since breaking changes will not be introduced within a major version. You could additionally opt for added stability by pinning an exact version, trading off for maintenance burden to receive bug fixes in patch releases.
 
-### Use turbo run in CI
+### Use `turbo run` in CI
 
 `turbo run` is the most common command you will use when working in your Turborepo so it is aliased to `turbo` for convenience. While this is great for working locally, there are other subcommands for `turbo` like [`turbo prune`](/repo/docs/reference/prune) and [`turbo generate`](/repo/docs/reference/generate).
 

--- a/docs/repo-docs/crafting-your-repository/creating-an-internal-package.mdx
+++ b/docs/repo-docs/crafting-your-repository/creating-an-internal-package.mdx
@@ -170,7 +170,7 @@ You've done four important things here:
 </Step>
 
 <Step>
-### Add a src directory with source code
+### Add a `src` directory with source code
 
 You can now write some code for your package. Create two files inside a `src` directory:
 
@@ -253,7 +253,7 @@ export default Page;
 </Step>
 
 <Step>
-### Edit turbo.json
+### Edit `turbo.json`
 
 Add the artifacts for the new `@repo/math` library to the `outputs` for the `build` task in `turbo.json`. This ensure that its build outputs will be cached by Turborepo, so they can be restored instantly when you start running builds.
 
@@ -271,7 +271,7 @@ Add the artifacts for the new `@repo/math` library to the `outputs` for the `bui
 </Step>
 
 <Step>
-### Run turbo build
+### Run `turbo build`
 
 If you've [installed `turbo` globally](/repo/docs/getting-started/installation#global-installation), run `turbo build` in your terminal at the root of your Workspace. You can also run the `build` script from `package.json` with your package manager, which will use `turbo run build`.
 

--- a/docs/repo-docs/crafting-your-repository/developing-applications.mdx
+++ b/docs/repo-docs/crafting-your-repository/developing-applications.mdx
@@ -42,7 +42,7 @@ You can now run your `dev` task to start your development scripts in parallel:
 turbo dev
 ```
 
-### Running setup tasks before dev
+### Running setup tasks before `dev`
 
 You may also want to run scripts that set up your development environment or pre-build packages. You can make sure those tasks run before the `dev` task with `dependsOn`:
 

--- a/docs/repo-docs/crafting-your-repository/index.mdx
+++ b/docs/repo-docs/crafting-your-repository/index.mdx
@@ -18,7 +18,7 @@ By the time you've read through all of this section, you should have a good unde
   section for more information.
 </Callout>
 
-## From zero to turbo
+## From zero to `turbo`
 
 <Cards>
 <Card

--- a/docs/repo-docs/crafting-your-repository/running-tasks.mdx
+++ b/docs/repo-docs/crafting-your-repository/running-tasks.mdx
@@ -15,7 +15,7 @@ Turborepo optimizes the developer workflows in your repository by automatically 
 
 Running tasks through `turbo` is powerful because you get one model for executing workflows throughout your repository in development and in your CI pipelines.
 
-## Using scripts in package.json
+## Using `scripts` in `package.json`
 
 For tasks that you run frequently, you can write your `turbo` commands directly into your root `package.json`.
 
@@ -66,7 +66,7 @@ calling `turbo`.
 
 </Callout>
 
-## Using global turbo
+## Using global `turbo`
 
 [Installing `turbo` globally](/repo/docs/getting-started/installation#installing-globally) lets you run commands directly from your terminal. This improves your local development experience since it makes it easier to run exactly what you need, when you need it.
 

--- a/docs/repo-docs/crafting-your-repository/structuring-a-repository.mdx
+++ b/docs/repo-docs/crafting-your-repository/structuring-a-repository.mdx
@@ -162,14 +162,14 @@ If you'd like to group packages by directory, you can do this using globs like `
 </Step>
 
 <Step>
-#### package.json in each package
+#### `package.json` in each package
 
 In the directory of the package, there must be a `package.json` to make the package discoverable to your package manager and `turbo`. The [requirements for the `package.json` of a package](#anatomy-of-a-package) are below.
 
 </Step>
 </Steps>
 
-### Root package.json
+### Root `package.json`
 
 The root `package.json` is the base for your workspace. Below is a common example of what you would find in a root `package.json`:
 
@@ -233,7 +233,7 @@ The root `package.json` is the base for your workspace. Below is a common exampl
 
 </PackageManagerTabs>
 
-### Root turbo.json
+### Root `turbo.json`
 
 `turbo.json` is used to configure the behavior of `turbo`. To learn more about how to configure your tasks, visit the [Configuring tasks](/repo/docs/crafting-your-repository/configuring-tasks) page.
 
@@ -252,9 +252,9 @@ It's often best to start thinking about designing a package as its own unit with
 
 Additionally, a package has specific entrypoints that other packages in your Workspace can use to access the package, specified by [`exports`](#exports).
 
-### package.json for a package
+### `package.json` for a package
 
-#### name
+#### `name`
 
 [The `name` field](https://nodejs.org/api/packages.html#name) is used to identify the package. It should be unique within your workspace.
 
@@ -265,11 +265,11 @@ We use `@repo` in our docs and examples because it is an unused, unclaimable nam
 
 </Callout>
 
-#### scripts
+#### `scripts`
 
 The `scripts` field is used to define scripts that can be run in the package's context. Turborepo will use the name of these scripts to identify what scripts to run (if any) in a package. We talk more about these scripts on the [Running Tasks](/repo/docs/crafting-your-repository/running-tasks) page.
 
-#### exports
+#### `exports`
 
 [The `exports` field](https://nodejs.org/api/packages.html#exports) is used to specify the entrypoints for other packages that want to use the package. When you want to use code from one package in another package, you'll import from that entrypoint.
 
@@ -311,7 +311,7 @@ Using exports this way provides three major benefits:
   guide](/repo/docs/guides/tools/typescript#package-entrypoint-wildcards).
 </Callout>
 
-#### imports (optional)
+#### `imports` (optional)
 
 [The `imports` field](https://nodejs.org/api/packages.html#imports) gives you a way to create subpaths to other modules within your package. You can think of these like "shortcuts" to get to other modules within your package.
 

--- a/docs/repo-docs/crafting-your-repository/upgrading.mdx
+++ b/docs/repo-docs/crafting-your-repository/upgrading.mdx
@@ -12,7 +12,7 @@ import { Callout } from '#/components/callout';
 <Steps>
 <Step>
 
-### Update turbo.json
+### Update `turbo.json`
 
 Get started upgrading from 1.x to 2.0 by running:
 
@@ -57,7 +57,7 @@ Additionally, a `name` field will be added to any `package.json` in the Workspac
 
 <Step>
 
-### Add a packageManager field to root package.json
+### Add a `packageManager` field to root `package.json`
 
 [The `packageManager` field](https://nodejs.org/api/packages.html#packagemanager) is a convention from the Node.js ecosystem that defines which package manager is expected to be used in the Workspace.
 
@@ -99,7 +99,7 @@ Turborepo 2.0 requires that your Workspace define this field as a way to improve
 
 <Step>
 
-### Update turbo run commands
+### Update `turbo run` commands
 
 Turborepo 2.0 includes behavioral and correctness improvements with behavior of `turbo run` commands. Listed below is the summary of changes, which may or may not have an affect on your codebase:
 

--- a/docs/repo-docs/crafting-your-repository/using-environment-variables.mdx
+++ b/docs/repo-docs/crafting-your-repository/using-environment-variables.mdx
@@ -134,7 +134,7 @@ You then build your application using a value for `MY_API_URL` that targets your
 
 When you're using Loose Mode, `MY_API_URL` is available in the task runtime **even though it isn't accounted for in the task hash**. To make this task more likely to fail and protect you from this misconfiguration, we encourage you to opt for [Strict Mode](#strict-mode).
 
-## Handling .env files
+## Handling `.env` files
 
 `.env` files are great for working on an application locally. **Turborepo does not load .env files into your task's runtime**, leaving them to be handled by your framework, or tools like [`dotenv`](https://www.npmjs.com/package/dotenv).
 
@@ -163,13 +163,13 @@ To do this, add the files to the [`inputs`](/repo/docs/reference/configuration#i
 
 ## Best practices
 
-### Use .env files in packages
+### Use `.env` files in packages
 
 Using a `.env` file at the root of the repository is not recommended. Instead, we recommend placing your `.env` files into the packages where they're used.
 
 This practice more closely models the runtime behavior of your applications since environment variables exist in each application's runtime individually. Additionally, as your monorepo scales, this practice makes it easier to manage each application's environment, preventing environment variable leakage across applications.
 
-### Use eslint-config-turbo
+### Use `eslint-config-turbo`
 
 [The `eslint-config-turbo` package](/repo/docs/reference/eslint-config-turbo) helps you find environment variables that are used in your code that aren't listed in your `turbo.json`. This helps ensure that all your environment variables are accounted for in your configuration.
 
@@ -268,7 +268,7 @@ The `turbo.json` below expresses:
 
 ## Troubleshooting
 
-### Use --summarize
+### Use `--summarize`
 
 [The `--summarize` flag](/repo/docs/reference/run#--summarize) can be added to your `turbo run` command to produce a JSON file summarizing data about your task. Checking the diff for the `globalEnv` and `env` key can help you identify any environment variables that may be missing from your configuration.
 

--- a/docs/repo-docs/getting-started/add-to-existing-repository.mdx
+++ b/docs/repo-docs/getting-started/add-to-existing-repository.mdx
@@ -38,7 +38,7 @@ familiar with Turborepo.
 
 <Steps>
 <Step>
-### Install turbo
+### Install `turbo`
 
 We recommend you install `turbo` both globally and into your repository's root for the best developer experience.
 
@@ -80,7 +80,7 @@ To learn more about why we recommend both installations, visit the [Installation
 </Step>
 <Step>
 
-### Add a turbo.json file
+### Add a `turbo.json` file
 
 In the root of your repository, create a `turbo.json` file.
 
@@ -169,7 +169,7 @@ different packages run with one `turbo` command.
 
 </Step>
 <Step>
-### Edit .gitignore
+### Edit `.gitignore`
 
 Add `.turbo` to your `.gitignore` file. The `turbo` CLI uses these folders for persisting logs, outputs, and other functionality.
 
@@ -179,7 +179,7 @@ Add `.turbo` to your `.gitignore` file. The `turbo` CLI uses these folders for p
 
 </Step>
 <Step>
-### Run the build and check-types tasks with turbo
+### Run the `build` and `check-types` tasks with `turbo`
 
 ```bash title="Terminal"
 turbo build check-types
@@ -210,7 +210,7 @@ To learn more about how `turbo` makes this possible, check out [the caching docu
 </Step>
 <Step>
 
-### Begin developing by running dev with turbo
+### Begin developing by running `dev` with `turbo`
 
 In a multi-package workspace, you can run `turbo dev` to start the development tasks for all your packages at once.
 

--- a/docs/repo-docs/getting-started/editor-integration.mdx
+++ b/docs/repo-docs/getting-started/editor-integration.mdx
@@ -7,7 +7,7 @@ import { Callout } from '#/components/callout';
 
 To get the best experience with `turbo`, Turborepo provides a few utilities for integrating with your editor.
 
-## JSON Schema for turbo.json
+## JSON Schema for `turbo.json`
 
 Turborepo uses [JSON Schema](https://json-schema.org/) to give you auto-complete in your
 `turbo.json` file. By including the `$schema` key in your `turbo.json`, your editor is able to
@@ -28,8 +28,6 @@ If you are using Turborepo v1, use `schema.v1.json`.
   "$schema": "https://turbo.build/schema.v1.json"
 }
 ```
-
-## eslint-config-turbo
 
 Handling environment variables is an important part of building applications in a Turborepo.
 

--- a/docs/repo-docs/getting-started/installation.mdx
+++ b/docs/repo-docs/getting-started/installation.mdx
@@ -40,7 +40,7 @@ The starter repository will have:
 
 For more details on the starter, [visit the README for the basic starter on GitHub](https://github.com/vercel/turbo/tree/main/examples/basic). You can also [use an example](/repo/docs/getting-started/installation#start-with-an-example) that more closely fits your tooling interests.
 
-## Installing turbo
+## Installing `turbo`
 
 `turbo` can be installed both globally **and** in your repository. We highly recommend installing both ways so you can take advantage of fast, convenient workflows _and_ a stable version of `turbo` for all developers working in your repository.
 
@@ -88,7 +88,7 @@ Once installed globally, you can run your scripts through `turbo` from your term
   bin`](/repo/docs/reference/bin).
 </Callout>
 
-#### Using global turbo in CI
+#### Using global `turbo` in CI
 
 You can also take advantage of global `turbo` when creating your CI pipelines. Visit the [Constructing CI](/repo/docs/crafting-your-repository/constructing-ci#global-turbo-in-ci) guide for more information.
 

--- a/docs/repo-docs/guides/handling-platforms.mdx
+++ b/docs/repo-docs/guides/handling-platforms.mdx
@@ -64,7 +64,7 @@ Now, make sure that `turbo` is aware of the file by adding it to task inputs. Yo
 }
 ```
 
-### 4. Generate the file before running turbo
+### 4. Generate the file before running `turbo`
 
 Last, you'll want to ensure that you run the script before running `turbo`. For example:
 

--- a/docs/repo-docs/guides/single-package-workspaces.mdx
+++ b/docs/repo-docs/guides/single-package-workspaces.mdx
@@ -40,7 +40,7 @@ Install `turbo` into your application:
   </Tab>
 </PackageManagerTabs>
 
-### Running a package.json script using global turbo (optional)
+### Running a `package.json` script using global `turbo` (optional)
 
 For even faster developer workflows, you can [install `turbo` globally](/repo/docs/getting-started/installation#installing-globally), too, and run commands directly from the command line.
 

--- a/docs/repo-docs/guides/skipping-tasks.mdx
+++ b/docs/repo-docs/guides/skipping-tasks.mdx
@@ -28,7 +28,7 @@ This command will:
 
 While you may have been able to hit a `>>> FULL TURBO` cache for this task, you just saved time with all of the other setup tasks required to run your CI.
 
-## Using turbo-ignore
+## Using `turbo-ignore`
 
 To skip unaffected work, first ensure that your Git history is available on the machine. Then, run `npx turbo-ignore`.
 
@@ -61,7 +61,7 @@ where `web` is your workspace's name running the default `build` task.
 
 If you'd like to change the task, use the `--task` flag to specify the task for the command that `turbo-ignore` will invoke.
 
-## Using turbo-ignore on Vercel
+## Using `turbo-ignore` on Vercel
 
 To use `npx turbo-ignore` on Vercel, you can use the [Ignored Build Step](https://vercel.com/docs/concepts/projects/overview#ignored-build-step) feature. Vercel will automatically infer the correct arguments to successfully run `turbo-ignore`.
 

--- a/docs/repo-docs/guides/tools/docker.mdx
+++ b/docs/repo-docs/guides/tools/docker.mdx
@@ -86,7 +86,7 @@ turbo prune api --docker
 
 Running this command creates a **pruned version of your monorepo** inside an `./out` directory. It only includes workspaces which `api` depends on. It also **prunes the lockfile** so that only the relevant `node_modules` will be downloaded.
 
-### The --docker flag
+### The `--docker` flag
 
 By default, `turbo prune` puts all relevant files inside `./out`. But to optimize caching with Docker, we ideally want to copy the files over in two stages.
 

--- a/docs/repo-docs/guides/tools/eslint.mdx
+++ b/docs/repo-docs/guides/tools/eslint.mdx
@@ -83,7 +83,7 @@ Sharing an ESLint config across packages makes their source code more consistent
 
 We've got a package called `@repo/eslint-config`, and two applications, each with their own `.eslintrc.js`.
 
-### Our @repo/eslint-config package
+### Our `@repo/eslint-config` package
 
 Our `@repo/eslint-config` file contains two files, `next.js`, and `library.js`. These are two different ESLint configs, which we can use in different workspaces, depending on our needs.
 
@@ -154,7 +154,7 @@ The `package.json` looks like this:
 
 Note that the ESLint dependencies are all listed here. This is useful, since it means we don't need to re-specify the dependencies inside the apps which import `@repo/eslint-config`.
 
-### How to use the @repo/eslint-config package
+### How to use the `@repo/eslint-config` package
 
 In our `web` app, we first need to add `@repo/eslint-config` as a dependency.
 
@@ -203,7 +203,7 @@ By adding `@repo/eslint-config/next.js` to our `extends` array, we're telling ES
 
 This setup ships by default when you [create a new monorepo](/repo/docs/getting-started/create-new) with `npx create-turbo@latest`. You can also look at [our basic example](https://github.com/vercel/turbo/tree/main/examples/basic) to see a working version.
 
-## Setting up a lint task
+## Setting up a `lint` task
 
 The `package.json` for each package where you'd like to run ESLint should look like this:
 

--- a/docs/repo-docs/guides/tools/prisma.mdx
+++ b/docs/repo-docs/guides/tools/prisma.mdx
@@ -29,7 +29,7 @@ If you don't have an existing project, use our [quickstart](/repo/docs/getting-s
 
 </Step>
 <Step>
-## Add a new database package
+## Add a new `database` package
 
 Create a new folder called `database` inside packages with a `package.json` inside:
 
@@ -50,7 +50,7 @@ Run your package manager's install step to install the new dependencies.
 
 </Step>
 <Step>
-## Run prisma init
+## Run `prisma init`
 
 `cd` into `packages/database`:
 
@@ -137,7 +137,7 @@ Following the [Just-in-Time packaging pattern](/repo/docs/core-concepts/internal
   need to adjust to a different strategy as if needed.
 </Callout>
 
-### Importing database
+### Importing `database`
 
 Import the database package into one of our apps.
 
@@ -215,7 +215,7 @@ So, let's make sure that `db:generate` is always run _before_ you run `dev`:
 
 Check out the section on [running tasks](/repo/docs/crafting-your-repository/running-tasks) to learn more about the `^db:generate` syntax.
 
-### Caching the results of prisma generate
+### Caching the results of `prisma generate`
 
 `prisma generate` outputs files to the filesystem, usually inside `node_modules`. In theory, it should be possible to cache the output of `prisma generate` with Turborepo to save a few seconds.
 

--- a/docs/repo-docs/guides/tools/storybook.mdx
+++ b/docs/repo-docs/guides/tools/storybook.mdx
@@ -222,7 +222,7 @@ To ensure file outputs are cached when you run `build`, add `storybook-static` t
 
 <Step>
 
-### Add Storybook build outputs to .gitignore
+### Add Storybook build outputs to `.gitignore`
 
 Ensure that the build outputs for Storybook are not committed to source control
 

--- a/docs/repo-docs/guides/tools/typescript.mdx
+++ b/docs/repo-docs/guides/tools/typescript.mdx
@@ -20,7 +20,7 @@ TypeScript is an excellent tool in monorepos, allowing teams to safely add types
   guidance on this page if you are unable to features from those versions.
 </Callout>
 
-## Sharing tsconfig.json
+## Sharing `tsconfig.json`
 
 You want to build consistency into your TypeScript configurations so that your entire repo can use great defaults and your fellow developers can know what to expect when writing code in the Workspace.
 
@@ -54,7 +54,7 @@ pnpm dlx create-turbo@latest
 </Tab>
 </PackageManagerTabs>
 
-### Use a base tsconfig file
+### Use a base `tsconfig` file
 
 Inside `packages/tsconfig`, we have a few `json` files which represent different ways you might want to configure TypeScript in various packages. The `base.json` file is extended by every other `package.json` in the workspace and looks like this:
 
@@ -216,11 +216,11 @@ Then, run your task using `turbo check-types`.
 
 ## Best practices
 
-### Use tsc to compile your packages
+### Use `tsc` to compile your packages
 
 For [Internal Packages](/repo/docs/core-concepts/internal-packages), we recommend that you use `tsc` to compile your TypeScript libraries whenever possible. While you can use a bundler, it's not necessary and adds extra complexity to your build process. Additionally, bundling a library can mangle the code before it makes it to your applications' bundlers, causing hard to debug issues.
 
-### Use Node.js subpath imports instead of TypeScript compiler paths
+### Use Node.js subpath imports instead of TypeScript compiler `paths`
 
 It's possible to create absolute imports in your packages using [the TypeScript compiler's `paths` option](https://www.typescriptlang.org/tsconfig#paths). However, [as of TypeScript 5.4](https://devblogs.microsoft.com/typescript/announcing-typescript-5-4/#auto-import-support-for-subpath-imports), you can use [Node.js subpath imports](https://nodejs.org/api/packages.html#imports) instead.
 
@@ -228,7 +228,7 @@ Additionally, Node.js subpath imports are usable in [Just-in-Time Packages](/rep
 
 This strategy brings your Node.js and TypeScript configurations closer together, making your project's configuration simpler.
 
-### You likely don't need a tsconfig.json file in the root of your project
+### You likely don't need a `tsconfig.json` file in the root of your project
 
 As mentioned in the [Structuring your repository guide](/repo/docs/crafting-your-repository/structuring-a-repository#anatomy-of-a-package), you want to treat each package in your tooling as its own unit. This means each package should have its own `tsconfig.json` to use instead of referencing a `tsconfig.json` in the root of your project. Following this practice will make it easier for Turborepo to cache your type checking tasks, simplifying your configuration.
 

--- a/docs/repo-docs/reference/configuration.mdx
+++ b/docs/repo-docs/reference/configuration.mdx
@@ -19,7 +19,7 @@ Configure the behavior of `turbo` by adding a `turbo.json` file in your Workspac
 
 ## Global options
 
-### extends
+### `extends`
 
 ```jsonc title="./apps/web/turbo.json"
 {
@@ -32,7 +32,7 @@ Extend from the root `turbo.json` to create specific configuration for a package
 - The only valid value for `extends` is `["//"]` to inherit configuration from the root `turbo.json`.
 - If `extends` is used in the root `turbo.json`, it will be ignored.
 
-### globalDependencies
+### `globalDependencies`
 
 ```jsonc title="./turbo.json"
 {
@@ -49,7 +49,7 @@ By default, all files in source control in the Workspace root are included in th
   repository aren't supported.
 </Callout>
 
-### globalEnv
+### `globalEnv`
 
 ```jsonc title="./turbo.json"
 {
@@ -61,7 +61,7 @@ A list of environment variables that you want to impact the hash of all tasks. A
 
 For more on wildcard and negation syntax, [see the `env` section](#env).
 
-### globalPassThroughEnv
+### `globalPassThroughEnv`
 
 ```jsonc title="./turbo.json"
 {
@@ -97,7 +97,7 @@ Select a terminal UI for the repository.
 
 ## Defining tasks
 
-### tasks
+### `tasks`
 
 Each key in the `tasks` object is the name of a task that can be executed by [`turbo run`](/repo/docs/reference/run). Turborepo will search the packages described in your [Workspace's configuration](/repo/docs/crafting-your-repository/structuring-a-repository#specifying-packages-in-a-monorepo) for scripts in `package.json` with the name of the task.
 
@@ -129,7 +129,7 @@ In the example below, we've defined three tasks under the `tasks` key: `build`, 
 
 Using the options available in the tasks you define in `tasks`, you can describe how `turbo` will run your tasks.
 
-### dependsOn
+### `dependsOn`
 
 A list of tasks that are required to complete before the task begins running.
 
@@ -183,7 +183,7 @@ Specify a task dependency between specific package tasks.
 
 In this `turbo.json`, the `web#lint` task will wait for the `utils#build` task to complete.
 
-### env
+### `env`
 
 The list of environment variables a task depends on.
 
@@ -251,7 +251,7 @@ A leading `!` means that the entire pattern will be negated. For instance, the `
 | `"\\!FOO"` | Matches a single environment variable named `!FOO`.                            |
 | `"FOO!"`   | Matches a single environment variable named `FOO!`.                            |
 
-### passThroughEnv
+### `passThroughEnv`
 
 An allowlist of environment variables that should be made available to this task's runtime, even when in [Strict Environment Mode](/repo/docs/crafting-your-repository/using-environment-variables#strict-mode).
 
@@ -272,7 +272,7 @@ An allowlist of environment variables that should be made available to this task
   need to include them in [`env`](#env) or [`globalEnv`](#globalenv).
 </Callout>
 
-### outputs
+### `outputs`
 
 A list of file glob patterns relative to the package's `package.json` to cache when the task is successfully completed.
 
@@ -289,7 +289,7 @@ Omitting this key or passing an empty array tells `turbo` to cache nothing (exce
 }
 ```
 
-### cache
+### `cache`
 
 Default: `true`
 
@@ -309,7 +309,7 @@ Defines if task outputs should be cached. Setting `cache` to false is useful for
 }
 ```
 
-### inputs
+### `inputs`
 
 Default: `[]`, all files in the package that are checked into source control
 
@@ -333,7 +333,7 @@ Visit the [file glob specification](/repo/docs/reference/globs) for more informa
   desired or use `$TURBO_DEFAULT$` to build off of the default behavior.
 </Callout>
 
-#### $TURBO_DEFAULT$
+#### `$TURBO_DEFAULT$`
 
 Because specifying an `inputs` key immediately opts out of the default behavior, you may use
 the special string `$TURBO_DEFAULT$` within the `inputs` array to restore `turbo`'s default behavior. This allows you to tweak the default behavior for more granularity.
@@ -349,7 +349,7 @@ the special string `$TURBO_DEFAULT$` within the `inputs` array to restore `turbo
 }
 ```
 
-### outputLogs
+### `outputLogs`
 
 Default: `full`
 
@@ -373,7 +373,7 @@ Set output logging verbosity. Can be overridden by the [`--output-logs`](/repo/d
 }
 ```
 
-### persistent
+### `persistent`
 
 Default: `false`
 
@@ -395,7 +395,7 @@ This option is most useful for development servers or other "watch" tasks.
 
 Tasks marked with `persistent` are also `interactive` by default.
 
-### interactive
+### `interactive`
 
 Default: `false` (Defaults to `true` for tasks marked as `persistent`)
 

--- a/docs/repo-docs/reference/generate.mdx
+++ b/docs/repo-docs/reference/generate.mdx
@@ -21,7 +21,7 @@ For more information and practical use cases for writing custom generators, visi
   default command so `turbo gen` is equivalent to `turbo generate run`.
 </Callout>
 
-## run [generator-name]
+## `run [generator-name]`
 
 Run custom generators defined in your repository.
 
@@ -31,23 +31,23 @@ turbo gen run [generator-name]
 
 ### Flag options
 
-#### --args
+#### `--args`
 
 Answers to pass directly to the generator's prompts.
 
-#### --config \<path>
+#### `--config <path>`
 
 Generator configuration file.
 
 Default: `turbo/generators/config.js`
 
-#### --root \<path>
+#### `--root <path>`
 
 The root of your repository
 
 Default: directory with root `turbo.json`
 
-## workspace
+## `workspace`
 
 Create a new workspace.
 
@@ -57,34 +57,34 @@ turbo gen workspace [options]
 
 ### Flag options
 
-#### --name \<name>
+#### `--name <name>`
 
 The name for the new workspace to be used in the `package.json` `name` key. The `name` key is the unique identifier for the package in your repository.
 
-#### --empty
+#### `--empty`
 
 Creates an empty workspace. Defaults to `true`.
 
-#### --copy \<name>/\<url>
+#### `--copy <name>/<url>`
 
 Name of local workspace within your monorepo or a fully qualified GitHub URL with any branch and/or subdirectory.
 
-#### --destination \<path>
+#### `--destination <path>`
 
 Where the new workspace should be created.
 
-#### --type \<app/\package>
+#### `--type <app/package>`
 
 The type of workspace to create (`app` or `package`).
 
-#### --root \<path>
+#### `--root <path>`
 
 The root of your repository. Defaults to the directory of the root `turbo.json`.
 
-#### --show-all-dependencies
+#### `--show-all-dependencies`
 
 Prevent filtering dependencies by workspace type when selecting dependencies to add.
 
-#### --example-path \<path>, -p \<path>
+#### `--example-path <path>`, `-p <path>`
 
 In a rare case, your GitHub URL might contain a branch name with a slash (e.g. `bug/fix-1`) and the path to the example (e.g. `foo/bar`). In this case, you must specify the path to the example separately.

--- a/docs/repo-docs/reference/index.mdx
+++ b/docs/repo-docs/reference/index.mdx
@@ -140,15 +140,15 @@ Options that require a value can be passed with an equals sign, using quotes whe
 
 ## Global flags
 
-### --color
+### `--color`
 
 Forces the use of color, even in non-interactive terminals. This is useful for enabling color output in CI environments like GitHub Actions that have support for rendering color.
 
-### --no-color
+### `--no-color`
 
 Suppresses color in terminal output, even in interactive terminals.
 
-### --no-update-notifier
+### `--no-update-notifier`
 
 Disables the update notification. This notification will be automatically disabled when running in CI environments, but can also be disabled manually via this flag.
 

--- a/docs/repo-docs/reference/link.mdx
+++ b/docs/repo-docs/reference/link.mdx
@@ -9,7 +9,7 @@ The selected owner (either a user or an organization) will be able to share [cac
 
 ## Flag options
 
-### --api \<url>
+### `--api <url>`
 
 Specifies the URL to logout of your Remote Cache provider.
 

--- a/docs/repo-docs/reference/package-configurations.mdx
+++ b/docs/repo-docs/reference/package-configurations.mdx
@@ -188,7 +188,7 @@ Although the general idea is the same as the root `turbo.json`, Package
 Configurations come with a set of guardrails that can prevent packages from creating
 potentially confusing situations.
 
-### Package Configurations cannot use [the workspace#task syntax](/repo/docs/crafting-your-repository/running-tasks) as task entries
+### Package Configurations cannot use [the `workspace#task` syntax](/repo/docs/crafting-your-repository/running-tasks) as task entries
 
 The `package` is inferred based on the location of the configuration, and it is
 not possible to change configuration for another package. For example, in a
@@ -227,11 +227,11 @@ Note that the `build` task can still depend on a package-specific task:
 }
 ```
 
-### Package Configurations can only override values in the tasks key
+### Package Configurations can only override values in the `tasks` key
 
 It is not possible to override [global configuration](/repo/docs/reference/configuration#global-options) like `globalEnv` or `globalDependencies` in a Package Configuration. Configuration that would need to be altered in a Package Configuration is not truly global and should be configured differently.
 
-### Root turbo.json cannot use the extends key
+### Root turbo.json cannot use the `extends` key
 
 To avoid creating circular dependencies on packages, the root `turbo.json`
 cannot extend from anything. The `extends` key will be ignored.

--- a/docs/repo-docs/reference/prune.mdx
+++ b/docs/repo-docs/reference/prune.mdx
@@ -126,7 +126,7 @@ Run `turbo prune frontend` to generate a pruned workspace for the `frontend` app
 
 ### Options
 
-#### --docker
+#### `--docker`
 
 Defaults to `false`.
 
@@ -194,7 +194,7 @@ Using the same example from above, running `turbo prune frontend --docker` will 
   </Folder>
 </Files>
 
-#### --out-dir \<path>
+#### `--out-dir <path>`
 
 Defaults to `./out`.
 

--- a/docs/repo-docs/reference/run.mdx
+++ b/docs/repo-docs/reference/run.mdx
@@ -26,7 +26,7 @@ turbo run [tasks] [options] [-- [args passed to tasks]]
 
 ## Options
 
-### --cache-dir \<path>
+### `--cache-dir <path>`
 
 Default: `.turbo/cache`
 
@@ -40,7 +40,7 @@ turbo run build --cache-dir="./my-cache"
   Ensure the directory is in your `.gitignore` when changing it.
 </Callout>
 
-### --concurrency \<number | percentage>
+### `--concurrency <number | percentage>`
 
 Default: `10`
 
@@ -55,7 +55,7 @@ turbo run build --concurrency=50%
 turbo run test --concurrency=5
 ```
 
-### --continue
+### `--continue`
 
 Default: `false`
 
@@ -72,7 +72,7 @@ When `--continue` is `true`, `turbo` will exit with the highest exit code value 
 turbo run build --continue
 ```
 
-### --cwd \<path>
+### `--cwd <path>`
 
 Default: Directory of root `turbo.json`
 
@@ -82,7 +82,7 @@ Set the working directory of the command.
 turbo run build --cwd=./somewhere/else/in/your/repo
 ```
 
-### --dry / --dry-run
+### `--dry / --dry-run`
 
 Instead of executing tasks, display details about the packages and tasks that would be run.
 
@@ -104,7 +104,7 @@ Task details include useful information like (list is non-exhaustive):
 | `dependents`                 | Tasks that must run **after** this task                                |
 | `environmentVariables`       | Lists of environment variables specified in `env` and `passThroughEnv` |
 
-### --env-mode \<option>
+### `--env-mode <option>`
 
 `type: string`
 
@@ -123,7 +123,7 @@ Controls the available environment variables in the task's runtime.
 turbo run build --env-mode=loose
 ```
 
-#### strict
+#### `strict`
 
 Only environment variables specified in the following keys are
 available to the task:
@@ -136,7 +136,7 @@ available to the task:
 If Strict Mode is specified or inferred, **all** tasks are run in `strict` mode,
 regardless of their configuration.
 
-#### loose
+#### `loose`
 
 All environment variables on the machine are made available to the task's runtime.
 
@@ -147,7 +147,7 @@ All environment variables on the machine are made available to the task's runtim
   in `loose` mode.
 </Callout>
 
-### --filter \<string>
+### `--filter <string>`
 
 Specify targets to execute from your repository's graph. Multiple filters can be combined to select distinct sets of targets.
 
@@ -201,7 +201,7 @@ turbo run build --filter=@acme/ui...[HEAD^1]
 turbo run test --filter=@acme/*{./packages/*}[HEAD^1]
 ```
 
-### --force
+### `--force`
 
 Ignore existing cached artifacts and re-execute all tasks.
 
@@ -215,7 +215,7 @@ turbo run build --force
 
 The same behavior can also be set via [the `TURBO_FORCE` environment variable](/repo/docs/reference/system-environment-variables).
 
-### --framework-inference
+### `--framework-inference`
 
 Default: `true`
 
@@ -227,7 +227,7 @@ When `false`, [automatic environment variable inclusion](/repo/docs/crafting-you
 turbo run build --framework-inference=false
 ```
 
-### --global-deps \<file glob>
+### `--global-deps <file glob>`
 
 Specify glob of global filesystem dependencies to be hashed. Useful for `.env` and files in the root directory that impact multiple packages.
 
@@ -242,7 +242,7 @@ turbo run build --global-deps=".env.*" --global-deps=".eslintrc" --global-deps="
   in `turbo.json` to make sure they are always accounted for.
 </Callout>
 
-### --graph \<file type>
+### `--graph <file type>`
 
 Default: `jpg`
 
@@ -262,7 +262,7 @@ turbo run build test lint --graph=my-graph.svg
   and tasks involved.
 </Callout>
 
-### --log-order \<option>
+### `--log-order <option>`
 
 Default: `auto`
 
@@ -280,7 +280,7 @@ turbo run build --log-order=stream
 | `grouped` | Group output by task                      |
 | `auto`    | Turbo decides based on its own heuristics |
 
-### --log-prefix \<option>
+### `--log-prefix <option>`
 
 Default: `auto`
 
@@ -296,7 +296,7 @@ turbo run dev --log-prefix=none
 | `none`   | No prefixes                                 |
 | `auto`   | `turbo` decides based on its own heuristics |
 
-### --no-cache
+### `--no-cache`
 
 Default `false`
 
@@ -306,7 +306,7 @@ Do not cache results of the task.
 turbo run dev --no-cache
 ```
 
-### --no-daemon
+### `--no-daemon`
 
 Default: `false`
 
@@ -314,7 +314,7 @@ Default: `false`
 
 Passing `--no-daemon` instructs `turbo` to avoid using or creating the standalone process.
 
-### --output-logs \<option>
+### `--output-logs <option>`
 
 Default: `full`
 
@@ -332,7 +332,7 @@ turbo run build --output-logs=errors-only
 | `errors-only` | Only show logs from task failures |
 | `none`        | Hides all task logs               |
 
-### --only
+### `--only`
 
 Default: `false`
 
@@ -364,7 +364,7 @@ The command will _only_ execute the `test` tasks in each package. It will not ru
 
 Additionally, `--only` will only run tasks in specified packages, excluding dependencies. For example, `turbo run build --filter=web --only`, will **only** run the `build` script in the `web` package.
 
-### --parallel
+### `--parallel`
 
 Default: `false`
 
@@ -382,7 +382,7 @@ turbo run dev --parallel
   instead.
 </Callout>
 
-### --preflight
+### `--preflight`
 
 Only applicable when Remote Caching is configured. Enables sending a preflight request before every cache artifact and analytics request. The follow-up upload and download will follow redirects.
 
@@ -392,7 +392,7 @@ turbo run build --preflight
 
 The same behavior can also be set via the `TURBO_PREFLIGHT=true` system variable.
 
-### --profile
+### `--profile`
 
 Generates a trace of the run in Chrome Tracing format that you can use to analyze performance.
 
@@ -404,7 +404,7 @@ turbo run build --profile=profile.json -vvv
 
 Profiles can be viewed in a tool like [Perfetto](https://ui.perfetto.dev/).
 
-### --remote-cache-timeout
+### `--remote-cache-timeout`
 
 Default: `30`
 
@@ -414,7 +414,7 @@ Set the timeout for Remote Cache operations in seconds.
 turbo run build --remote-cache-timeout=60
 ```
 
-### --remote-only
+### `--remote-only`
 
 Default: `false`
 
@@ -424,7 +424,7 @@ Ignore the local filesystem cache for all tasks, using Remote Cache for reading 
 turbo run build --remote-only
 ```
 
-### --summarize
+### `--summarize`
 
 Generates a JSON file in `.turbo/runs` containing metadata about the run, including:
 
@@ -442,7 +442,7 @@ This flag can be helpful for debugging to determine things like:
 - What inputs changed between two task runs to produce a cache miss
 - How task timings changed over time
 
-### --token
+### `--token`
 
 A bearer token for Remote Caching. Useful for running in non-interactive shells in combination with the `--team` flag.
 
@@ -459,7 +459,7 @@ This value can also be set using [the `TURBO_TOKEN` system variable](/repo/docs/
   automatically set for you.
 </Callout>
 
-### --team
+### `--team`
 
 The slug of the Remote Cache team. Useful for running in non-interactive shells in combination with the `--token` flag.
 
@@ -470,7 +470,7 @@ turbo run build --team=my-team --token=xxxxxxxxxxxxxxxxx
 
 This value can also be set using [the `TURBO_TEAM` system variable](/repo/docs/reference/system-environment-variables). If both are present, the flag value will override the system variable.
 
-### --verbosity
+### `--verbosity`
 
 To specify log level, use `--verbosity=<num>` or `-v, -vv, -vvv`.
 

--- a/docs/repo-docs/reference/telemetry.mdx
+++ b/docs/repo-docs/reference/telemetry.mdx
@@ -15,7 +15,7 @@ Manage telemetry for this machine.
 
 ## Arguments
 
-### status
+### `status`
 
 Retrieve the current state of telemetry for this machine.
 
@@ -23,7 +23,7 @@ Retrieve the current state of telemetry for this machine.
 turbo telemetry status
 ```
 
-### enable
+### `enable`
 
 Enable telemetry for this machine.
 
@@ -31,7 +31,7 @@ Enable telemetry for this machine.
 turbo telemetry enable
 ```
 
-### disable
+### `disable`
 
 Disable telemetry for this machine.
 

--- a/docs/repo-docs/reference/watch.mdx
+++ b/docs/repo-docs/reference/watch.mdx
@@ -11,7 +11,7 @@ turbo watch [tasks]
 
 `turbo watch` is dependency-aware, meaning tasks will re-run in the order [configured in `turbo.json`](/repo/docs/reference/configuration).
 
-## Using turbo watch with persistent tasks
+## Using `turbo watch` with persistent tasks
 
 When your script has a built-in watcher, you likely don't need to use `turbo watch`. Instead, use your script's built-in watcher and mark the task as long-running using [`"persistent": true`](/repo/docs/reference/configuration#persistent).
 


### PR DESCRIPTION
### Description

There was a bug in the upstream docs metaframework that didn't work with backticks in headings. This is now resolved, so bringing them back.
