### PR TITLE
fix(turborepo): avoid starting ui on too small terminals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11463,7 +11463,7 @@ dependencies = [
  "anyhow",
  "atty",
  "console",
- "crossterm 0.26.1",
+ "crossterm 0.27.0",
  "dialoguer",
  "indicatif",
  "indoc",

--- a/crates/turborepo-lib/src/commands/run.rs
+++ b/crates/turborepo-lib/src/commands/run.rs
@@ -44,7 +44,7 @@ pub async fn run(base: CommandBase, telemetry: CommandEventBuilder) -> Result<i3
             .build(&handler, telemetry)
             .await?;
 
-        let (sender, handle) = run.start_experimental_ui().unzip();
+        let (sender, handle) = run.start_experimental_ui()?.unzip();
 
         let result = run.run(sender.clone()).await;
 

--- a/crates/turborepo-lib/src/run/error.rs
+++ b/crates/turborepo-lib/src/run/error.rs
@@ -1,6 +1,7 @@
 use miette::Diagnostic;
 use thiserror::Error;
 use turborepo_repository::package_graph;
+use turborepo_ui::tui;
 
 use super::graph_visualizer;
 use crate::{
@@ -51,4 +52,6 @@ pub enum Error {
     SignalHandler(std::io::Error),
     #[error(transparent)]
     Daemon(#[from] daemon::DaemonError),
+    #[error(transparent)]
+    Tui(#[from] tui::Error),
 }

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -140,13 +140,19 @@ impl Run {
         self.experimental_ui
     }
 
+    pub fn should_start_ui(&self) -> Result<bool, Error> {
+        Ok(self.experimental_ui
+            && self.opts.run_opts.dry_run.is_none()
+            && tui::terminal_big_enough()?)
+    }
+
     pub fn start_experimental_ui(&self) -> Option<(AppSender, JoinHandle<Result<(), tui::Error>>)> {
         // Print prelude here as this needs to happen before the UI is started
         if self.should_print_prelude {
             self.print_run_prelude();
         }
-        // Don't start UI if doing a dry run
-        if !self.experimental_ui || self.opts.run_opts.dry_run.is_some() {
+
+        if !self.should_start_ui().ok()? {
             return None;
         }
 

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -146,21 +146,24 @@ impl Run {
             && tui::terminal_big_enough()?)
     }
 
-    pub fn start_experimental_ui(&self) -> Option<(AppSender, JoinHandle<Result<(), tui::Error>>)> {
+    #[allow(clippy::type_complexity)]
+    pub fn start_experimental_ui(
+        &self,
+    ) -> Result<Option<(AppSender, JoinHandle<Result<(), tui::Error>>)>, Error> {
         // Print prelude here as this needs to happen before the UI is started
         if self.should_print_prelude {
             self.print_run_prelude();
         }
 
-        if !self.should_start_ui().ok()? {
-            return None;
+        if !self.should_start_ui()? {
+            return Ok(None);
         }
 
         let task_names = self.engine.tasks_with_command(&self.pkg_dep_graph);
         let (sender, receiver) = AppSender::new();
         let handle = tokio::task::spawn_blocking(move || tui::run_app(task_names, receiver));
 
-        Some((sender, handle))
+        Ok(Some((sender, handle)))
     }
 
     pub async fn run(&mut self, experimental_ui_sender: Option<AppSender>) -> Result<i32, Error> {

--- a/crates/turborepo-lib/src/run/watch.rs
+++ b/crates/turborepo-lib/src/run/watch.rs
@@ -118,7 +118,7 @@ impl WatchClient {
 
         let watched_packages = run.get_relevant_packages();
 
-        let (sender, handle) = run.start_experimental_ui().unzip();
+        let (sender, handle) = run.start_experimental_ui()?.unzip();
 
         let connector = DaemonConnector {
             can_start_server: true,

--- a/crates/turborepo-ui/Cargo.toml
+++ b/crates/turborepo-ui/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 [dependencies]
 atty = { workspace = true }
 console = { workspace = true }
-crossterm = "0.26.1"
+crossterm = "0.27.0"
 dialoguer = { workspace = true }
 indicatif = { workspace = true }
 lazy_static = { workspace = true }

--- a/crates/turborepo-ui/src/tui/app.rs
+++ b/crates/turborepo-ui/src/tui/app.rs
@@ -160,6 +160,14 @@ fn poll(input_options: InputOptions, receiver: &AppReceiver, deadline: Instant) 
     }
 }
 
+const MIN_HEIGHT: u16 = 10;
+const MIN_WIDTH: u16 = 20;
+
+pub fn terminal_big_enough() -> Result<bool, Error> {
+    let (width, height) = crossterm::terminal::size()?;
+    Ok(width >= MIN_WIDTH && height >= MIN_HEIGHT)
+}
+
 /// Configures terminal for rendering App
 fn startup() -> io::Result<Terminal<CrosstermBackend<Stdout>>> {
     crossterm::terminal::enable_raw_mode()?;

--- a/crates/turborepo-ui/src/tui/app.rs
+++ b/crates/turborepo-ui/src/tui/app.rs
@@ -108,7 +108,6 @@ impl<I: std::io::Write> App<I> {
 pub fn run_app(tasks: Vec<String>, receiver: AppReceiver) -> Result<(), Error> {
     let mut terminal = startup()?;
     let size = terminal.size()?;
-
     // Figure out pane width?
     let task_width_hint = TaskTable::width_hint(tasks.iter().map(|s| s.as_str()));
     // Want to maximize pane width

--- a/crates/turborepo-ui/src/tui/mod.rs
+++ b/crates/turborepo-ui/src/tui/mod.rs
@@ -7,7 +7,7 @@ mod spinner;
 mod table;
 mod task;
 
-pub use app::run_app;
+pub use app::{run_app, terminal_big_enough};
 use event::{Event, TaskResult};
 pub use handle::{AppReceiver, AppSender, TuiTask};
 use input::{input, InputOptions};


### PR DESCRIPTION
### Description

Avoids starting the UI when the terminal is too small. Also bumps crossterm because apparently we get an incorrect terminal size on older versions.

### Testing Instructions

Tested with `lefthook` on create-turbo