### PR TITLE
Update mimalloc, enable for glibc Linux aarch64, explicitly disable for wasm and musl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4212,9 +4212,9 @@ checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.30"
+version = "0.1.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8c7cbf8b89019683667e347572e6d55a7df7ea36b0c4ce69961b0cde67b174"
+checksum = "0e7bb23d733dfcc8af652a78b7bf232f0e967710d044732185e561e47c0336b6"
 dependencies = [
  "cc",
  "libc",
@@ -4623,9 +4623,9 @@ dependencies = [
 
 [[package]]
 name = "mimalloc"
-version = "0.1.34"
+version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcb174b18635f7561a0c6c9fc2ce57218ac7523cf72c50af80e2d79ab8f3ba1"
+checksum = "e9186d86b79b52f4a77af65604b51225e8db1d6ee7e3f41aec1e40829c71a176"
 dependencies = [
  "libmimalloc-sys",
 ]

--- a/crates/turbo-tasks-malloc/Cargo.toml
+++ b/crates/turbo-tasks-malloc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "turbo-tasks-malloc"
 version = "0.1.0"
-description = "TBD"
+description = "A wrapper around mimalloc or the system allocator that tracks allocations"
 license = "MPL-2.0"
 edition = "2021"
 autobenches = false
@@ -9,11 +9,11 @@ autobenches = false
 [lib]
 bench = false
 
-[target.'cfg(not(target_os = "linux"))'.dependencies]
-mimalloc = { version = "0.1.32", features = [], optional = true }
+[target.'cfg(not(any(target_os = "linux", target_family = "wasm", target_env = "musl")))'.dependencies]
+mimalloc = { version = "0.1.42", features = [], optional = true }
 
-[target.'cfg(all(target_os = "linux", not(target_arch = "aarch64")))'.dependencies]
-mimalloc = { version = "0.1.32", features = [
+[target.'cfg(all(target_os = "linux", not(any(target_family = "wasm", target_env = "musl"))))'.dependencies]
+mimalloc = { version = "0.1.42", features = [
   "local_dynamic_tls",
 ], optional = true }
 

--- a/crates/turbo-tasks-malloc/src/lib.rs
+++ b/crates/turbo-tasks-malloc/src/lib.rs
@@ -69,7 +69,7 @@ impl TurboMalloc {
 
 #[cfg(all(
     feature = "custom_allocator",
-    not(all(target_os = "linux", target_arch = "aarch64"))
+    not(any(target_family = "wasm", target_env = "musl"))
 ))]
 unsafe impl GlobalAlloc for TurboMalloc {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
@@ -105,7 +105,7 @@ unsafe impl GlobalAlloc for TurboMalloc {
 
 #[cfg(any(
     not(feature = "custom_allocator"),
-    all(target_os = "linux", target_arch = "aarch64")
+    any(target_family = "wasm", target_env = "musl")
 ))]
 unsafe impl GlobalAlloc for TurboMalloc {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {

--- a/crates/turbo-tasks-malloc/src/lib.rs
+++ b/crates/turbo-tasks-malloc/src/lib.rs
@@ -67,49 +67,24 @@ impl TurboMalloc {
     }
 }
 
-#[cfg(all(
-    feature = "custom_allocator",
-    not(any(target_family = "wasm", target_env = "musl"))
-))]
-unsafe impl GlobalAlloc for TurboMalloc {
-    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        let ret = mimalloc::MiMalloc.alloc(layout);
-        if !ret.is_null() {
-            add(layout.size());
-        }
-        ret
-    }
-
-    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-        mimalloc::MiMalloc.dealloc(ptr, layout);
-        remove(layout.size());
-    }
-
-    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
-        let ret = mimalloc::MiMalloc.alloc_zeroed(layout);
-        if !ret.is_null() {
-            add(layout.size());
-        }
-        ret
-    }
-
-    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
-        let ret = mimalloc::MiMalloc.realloc(ptr, layout, new_size);
-        if !ret.is_null() {
-            let old_size = layout.size();
-            update(old_size, new_size);
-        }
-        ret
-    }
+/// Get the allocator for this platform that we should wrap with TurboMalloc.
+#[inline]
+fn base_alloc() -> &'static impl GlobalAlloc {
+    #[cfg(all(
+        feature = "custom_allocator",
+        not(any(target_family = "wasm", target_env = "musl"))
+    ))]
+    return &mimalloc::MiMalloc;
+    #[cfg(any(
+        not(feature = "custom_allocator"),
+        any(target_family = "wasm", target_env = "musl")
+    ))]
+    return &std::alloc::System;
 }
 
-#[cfg(any(
-    not(feature = "custom_allocator"),
-    any(target_family = "wasm", target_env = "musl")
-))]
 unsafe impl GlobalAlloc for TurboMalloc {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        let ret = std::alloc::System.alloc(layout);
+        let ret = base_alloc().alloc(layout);
         if !ret.is_null() {
             add(layout.size());
         }
@@ -117,12 +92,12 @@ unsafe impl GlobalAlloc for TurboMalloc {
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-        std::alloc::System.dealloc(ptr, layout);
+        base_alloc().dealloc(ptr, layout);
         remove(layout.size());
     }
 
     unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
-        let ret = std::alloc::System.alloc_zeroed(layout);
+        let ret = base_alloc().alloc_zeroed(layout);
         if !ret.is_null() {
             add(layout.size());
         }
@@ -130,7 +105,7 @@ unsafe impl GlobalAlloc for TurboMalloc {
     }
 
     unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
-        let ret = std::alloc::System.realloc(ptr, layout, new_size);
+        let ret = base_alloc().realloc(ptr, layout, new_size);
         if !ret.is_null() {
             let old_size = layout.size();
             update(old_size, new_size);


### PR DESCRIPTION
# Description
    
- **Update mimalloc** dependency.
- **Enable mimalloc for Linux on aarch64 with glibc:** it seems to work just fine!
- **Disable mimalloc for wasm and musl.** Mimalloc is already disabled for these platforms in next-swc, but I want to centralize these platform checks: https://github.com/vercel/next.js/blob/73918c6711b538678dd66303fdbd61bfd10b288c/packages/next-swc/crates/napi/src/lib.rs#L71
- **Reduce duplicate code across platforms.** The two implementations of `TurboMalloc` were identical, aside from the base allocator used. Move the compile-time branch into an inlined function.

**Related Next.JS PR:** https://github.com/vercel/next.js/pull/66815

# Testing

## On glibc Linux aarch64

```
pnpm pack-next
```

Install into a test project and try running the development server.

## Other platforms

I have not tested other platforms, and will rely on CI for those (here and in https://github.com/vercel/next.js/pull/66815)