### PR TITLE
chore: bump timeout for migration

### DIFF
--- a/packages/turbo-codemod/__tests__/migrate.test.ts
+++ b/packages/turbo-codemod/__tests__/migrate.test.ts
@@ -1013,5 +1013,5 @@ describe("migrate", () => {
     mockedGetTurboUpgradeCommand.mockRestore();
     mockedGetAvailablePackageManagers.mockRestore();
     mockedGetWorkspaceDetails.mockRestore();
-  });
+  }, 10000);
 });


### PR DESCRIPTION
### Description

This test has recently been [exceeding the default timeout](https://github.com/vercel/turbo/actions/runs/9490414083/job/26153864516#step:6:977) when trying to cut a release. Bumping this to prevent this from blocking releases.

### Testing Instructions

CI
