### PR TITLE
fix(ui): pass through terminal env vars to appease chalk

### DIFF
--- a/crates/turborepo-lib/src/task_hash.rs
+++ b/crates/turborepo-lib/src/task_hash.rs
@@ -474,6 +474,9 @@ impl<'a> TaskHasher<'a> {
                         "LD_LIBRARY_PATH",
                         "DYLD_FALLBACK_LIBRARY_PATH",
                         "LIBPATH",
+                        "COLORTERM",
+                        "TERM",
+                        "TERM_PROGRAM",
                         // Vercel specific
                         "VERCEL_*",
                         "NEXT_*",


### PR DESCRIPTION
### Description

Partially addresses #8429

`chalk` the widely used library doesn't just factor in if stdout/stderr are TTY for emitting color. In [heavily relies](https://github.com/chalk/chalk/blob/386909ee0bfe4346d04e3eeba712f0db597c038d/source/vendor/supports-color/index.js#L60) on environment variables for deciding what level of color to output.

In strict mode many of these env vars are stripped leaving us with [color level 0](https://github.com/chalk/chalk/blob/386909ee0bfe4346d04e3eeba712f0db597c038d/source/vendor/supports-color/index.js#L94) aka disabled.

`TERM`/`COLORTERM`/`TERM_PROGRAM` should cover the bases for most terminals looking at the `chalk` source.

### Testing Instructions

Eslint should now have produce color even in env strict mode:
<img width="1150" alt="Screenshot 2024-06-12 at 4 32 11 PM" src="https://github.com/vercel/turbo/assets/4131117/e3e1a0b7-690c-4997-9b41-5d91bb7cba0d">

