### PR TITLE
Publish `@vercel/devlow-bench`

### DIFF
--- a/packages/devlow-bench/package.json
+++ b/packages/devlow-bench/package.json
@@ -2,6 +2,9 @@
   "name": "@vercel/devlow-bench",
   "version": "0.3.0",
   "description": "Benchmarking tool for the developer workflow",
+  "publishConfig": {
+    "access": "public"
+  },
   "type": "module",
   "main": "dist/index.js",
   "bin": "dist/cli.js",

--- a/packages/devlow-bench/package.json
+++ b/packages/devlow-bench/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vercel/devlow-bench",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Benchmarking tool for the developer workflow",
   "publishConfig": {
     "access": "public"

--- a/packages/devlow-bench/package.json
+++ b/packages/devlow-bench/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vercel/devlow-bench",
-  "version": "0.3.1",
+  "version": "0.3.0",
   "description": "Benchmarking tool for the developer workflow",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
npm scoped packages are private access by default. This opts `@vercel/devlow-bench` into public publishing.
