### PR TITLE
Light refactoring of TUI pane and instructions.

### DIFF
--- a/crates/turborepo-ui/src/tui/pane.rs
+++ b/crates/turborepo-ui/src/tui/pane.rs
@@ -14,7 +14,8 @@ use turborepo_vt100 as vt100;
 
 use super::{app::Direction, Error};
 
-const FOOTER_TEXT: &str = "Press `Enter` to interact and `Ctrl-Z` to stop interacting.";
+const FOOTER_TEXT_ACTIVE: &str = "Press`Ctrl-Z` to stop interacting.";
+const FOOTER_TEXT_INACTIVE: &str = "Press `Enter` to interact.";
 
 pub struct TerminalPane<W> {
     tasks: BTreeMap<String, TerminalOutput<W>>,
@@ -219,10 +220,12 @@ impl<W> Widget for &TerminalPane<W> {
         let screen = task.parser.screen();
         let mut block = Block::default()
             .borders(Borders::LEFT)
-            .title(task.title(task_name))
-            .title_bottom(Line::from(FOOTER_TEXT).centered());
+            .title(task.title(task_name));
         if self.highlight {
+            block = block.title_bottom(Line::from(FOOTER_TEXT_ACTIVE).centered());
             block = block.border_style(Style::new().fg(ratatui::style::Color::Yellow));
+        } else {
+            block = block.title_bottom(Line::from(FOOTER_TEXT_INACTIVE).centered());
         }
         let term = PseudoTerminal::new(screen).block(block);
         term.render(area, buf)

--- a/crates/turborepo-ui/src/tui/pane.rs
+++ b/crates/turborepo-ui/src/tui/pane.rs
@@ -14,8 +14,7 @@ use turborepo_vt100 as vt100;
 
 use super::{app::Direction, Error};
 
-const FOOTER_TEXT: &str = "Use arrow keys to navigate. Press `Enter` to interact with a task and \
-                           `Ctrl-Z` to stop interacting";
+const FOOTER_TEXT: &str = "Press `Enter` to interact and `Ctrl-Z` to stop interacting.";
 
 pub struct TerminalPane<W> {
     tasks: BTreeMap<String, TerminalOutput<W>>,

--- a/crates/turborepo-ui/src/tui/pane.rs
+++ b/crates/turborepo-ui/src/tui/pane.rs
@@ -219,7 +219,7 @@ impl<W> Widget for &TerminalPane<W> {
         };
         let screen = task.parser.screen();
         let mut block = Block::default()
-            .borders(Borders::ALL)
+            .borders(Borders::LEFT)
             .title(task.title(task_name))
             .title_bottom(Line::from(FOOTER_TEXT).centered());
         if self.highlight {

--- a/crates/turborepo-ui/src/tui/pane.rs
+++ b/crates/turborepo-ui/src/tui/pane.rs
@@ -256,12 +256,12 @@ mod test {
         assert_buffer_eq!(
             buffer,
             Buffer::with_lines(vec![
-                "┌ foo >┐",
-                "│3     │",
-                "│4     │",
-                "│5     │",
-                "│█     │",
-                "└Use ar┘",
+                "│ foo > ",
+                "│3      ",
+                "│4      ",
+                "│5      ",
+                "│█      ",
+                "│Press `",
             ])
         );
     }

--- a/crates/turborepo-ui/src/tui/table.rs
+++ b/crates/turborepo-ui/src/tui/table.rs
@@ -255,7 +255,7 @@ impl<'a> StatefulWidget for &'a TaskTable {
                 .chain(self.running_rows())
                 .chain(self.planned_rows()),
             [
-                Constraint::Min(4),
+                Constraint::Min(14),
                 // Status takes one cell to render
                 Constraint::Length(1),
             ],

--- a/crates/turborepo-ui/src/tui/table.rs
+++ b/crates/turborepo-ui/src/tui/table.rs
@@ -53,7 +53,7 @@ impl TaskTable {
             .unwrap_or_default()
             // Task column width should be large enough to fit "Task" title
             // and truncate tasks with more than 40 chars.
-            .clamp(4, 40) as u16;
+            .clamp(14, 40) as u16;
         // Add space for column divider and status emoji
         task_name_width + 1
     }
@@ -263,7 +263,8 @@ impl<'a> StatefulWidget for &'a TaskTable {
         .highlight_style(Style::default().fg(Color::Yellow))
         .column_spacing(0)
         .header(
-            vec![format!("Task\n{bar}"), "\n─".to_owned()]
+            // TODO: Get the bar back!
+            vec![format!("Task\n↑ ↓ to navigate\n{bar}")]
                 .into_iter()
                 .map(Cell::from)
                 .collect::<Row>()

--- a/crates/turborepo-ui/src/tui/table.rs
+++ b/crates/turborepo-ui/src/tui/table.rs
@@ -263,12 +263,19 @@ impl<'a> StatefulWidget for &'a TaskTable {
         .highlight_style(Style::default().fg(Color::Yellow))
         .column_spacing(0)
         .header(
-            // TODO: Get the bar back!
-            vec![format!("Task\n↑ ↓ to navigate\n{bar}").to_owned()]
+            vec![format!("Task\n{bar}").to_owned()]
                 .into_iter()
                 .map(Cell::from)
                 .collect::<Row>()
                 .height(2),
+        )
+        .footer(
+            ["↑ ↓ to navigate"]
+                .iter()
+                .copied()
+                .map(Cell::from)
+                .collect::<Row>()
+                .height(1),
         );
         StatefulWidget::render(table, area, buf, state);
     }

--- a/crates/turborepo-ui/src/tui/table.rs
+++ b/crates/turborepo-ui/src/tui/table.rs
@@ -51,9 +51,9 @@ impl TaskTable {
             .map(|task| task.len())
             .max()
             .unwrap_or_default()
-            // Task column width should be large enough to fit "Task" title
+            // Task column width should be large enough to fit "↑ ↓ to select task" instructions
             // and truncate tasks with more than 40 chars.
-            .clamp(14, 40) as u16;
+            .clamp(13, 40) as u16;
         // Add space for column divider and status emoji
         task_name_width + 1
     }
@@ -263,19 +263,18 @@ impl<'a> StatefulWidget for &'a TaskTable {
         .highlight_style(Style::default().fg(Color::Yellow))
         .column_spacing(0)
         .header(
-            vec![format!("Task\n{bar}").to_owned()]
+            vec![format!("Tasks\n{bar}")]
                 .into_iter()
                 .map(Cell::from)
                 .collect::<Row>()
                 .height(2),
         )
         .footer(
-            ["↑ ↓ to navigate"]
-                .iter()
-                .copied()
+            vec![format!("{bar}\n↑ ↓ to navigate")]
+                .into_iter()
                 .map(Cell::from)
                 .collect::<Row>()
-                .height(1),
+                .height(2),
         );
         StatefulWidget::render(table, area, buf, state);
     }

--- a/crates/turborepo-ui/src/tui/table.rs
+++ b/crates/turborepo-ui/src/tui/table.rs
@@ -263,14 +263,14 @@ impl<'a> StatefulWidget for &'a TaskTable {
         .highlight_style(Style::default().fg(Color::Yellow))
         .column_spacing(0)
         .header(
-            vec![format!("Tasks\n{bar}")]
+            vec![format!("Tasks\n{bar}"), " \n─".to_owned()]
                 .into_iter()
                 .map(Cell::from)
                 .collect::<Row>()
                 .height(2),
         )
         .footer(
-            vec![format!("{bar}\n↑ ↓ to navigate")]
+            vec![format!("{bar}\n↑ ↓ to navigate"), "─\n ".to_owned()]
                 .into_iter()
                 .map(Cell::from)
                 .collect::<Row>()

--- a/crates/turborepo-ui/src/tui/table.rs
+++ b/crates/turborepo-ui/src/tui/table.rs
@@ -264,7 +264,7 @@ impl<'a> StatefulWidget for &'a TaskTable {
         .column_spacing(0)
         .header(
             // TODO: Get the bar back!
-            vec![format!("Task\n↑ ↓ to navigate\n{bar}")]
+            vec![format!("Task\n↑ ↓ to navigate\n{bar}").to_owned()]
                 .into_iter()
                 .map(Cell::from)
                 .collect::<Row>()


### PR DESCRIPTION
### Description

Some light TUI refactors.
- Removing some of the borders around the logs pane for less visual clutter
- Interactivity instructions in logs pane use state to show "enter" vs. "exit" instructions
- "Localize" the instructions for moving up and down the task list to the task list itself

### Testing Instructions

👀 

### Future work
If we could get the red-to-blue gradient on the left sidebar when interactive... :chefs-kiss: - but I haven't looked at how to do that with Ratatui yet.