### PR TITLE
read larger chunks when reading a trace file

### DIFF
--- a/crates/turbopack-trace-server/src/reader/mod.rs
+++ b/crates/turbopack-trace-server/src/reader/mod.rs
@@ -132,7 +132,7 @@ impl TraceReader {
         let mut buffer = Vec::new();
         let mut index = 0;
 
-        let mut chunk = vec![0; 8 * 1024 * 1024];
+        let mut chunk = vec![0; 64 * 1024 * 1024];
         loop {
             match file.read(&mut chunk) {
                 Ok(bytes_read) => {

--- a/crates/turbopack-trace-server/src/store_container.rs
+++ b/crates/turbopack-trace-server/src/store_container.rs
@@ -30,6 +30,9 @@ impl StoreContainer {
     }
 
     pub fn read(&self) -> StoreReadGuard<'_> {
+        if let Ok(guard) = self.store.try_read() {
+            return StoreReadGuard { guard };
+        }
         self.want_to_read.store(true, Ordering::Relaxed);
         let guard = StoreReadGuard {
             guard: self.store.read().unwrap(),


### PR DESCRIPTION
### Description

This allows to read files faster when they are also open in the trace viewer

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
