### PR TITLE
Fix outdated user listing.

### DIFF
--- a/crates/turborepo-lib/src/commands/link.rs
+++ b/crates/turborepo-lib/src/commands/link.rs
@@ -384,7 +384,10 @@ fn select_team<'a>(_: &CommandBase, teams: &'a [Team]) -> Result<SelectedTeam<'a
 
 #[cfg(not(test))]
 fn select_team<'a>(base: &CommandBase, teams: &'a [Team]) -> Result<SelectedTeam<'a>, Error> {
-    let team_names = vec![teams.iter().map(|team| team.name.as_str())];
+    let team_names = teams
+        .iter()
+        .map(|team| team.name.as_str())
+        .collect::<Vec<_>>();
 
     let theme = DialoguerTheme {
         active_item_style: Style::new().cyan().bold(),

--- a/crates/turborepo-lib/src/commands/link.rs
+++ b/crates/turborepo-lib/src/commands/link.rs
@@ -378,7 +378,7 @@ fn should_enable_caching() -> Result<bool, Error> {
 #[cfg(test)]
 fn select_team<'a>(_: &CommandBase, teams: &'a [Team]) -> Result<SelectedTeam<'a>, Error> {
     let mut rng = rand::thread_rng();
-    let idx = rng.gen_range(0..=(teams.len()));
+    let idx = rng.gen_range(0..(teams.len()));
     Ok(SelectedTeam::Team(&teams[idx]))
 }
 

--- a/crates/turborepo-vercel-api/src/lib.rs
+++ b/crates/turborepo-vercel-api/src/lib.rs
@@ -1,8 +1,6 @@
 //! Types for interacting with the Vercel API. Used for both
 //! the client (`turborepo-api-client`) and for the
 //! mock server (`turborepo-vercel-api-mock`)
-use std::fmt;
-
 use serde::{Deserialize, Serialize};
 use url::Url;
 pub mod telemetry;
@@ -80,11 +78,6 @@ pub struct Team {
 impl Team {
     pub fn is_owner(&self) -> bool {
         matches!(self.membership.role, Role::Owner)
-    }
-}
-impl fmt::Display for Team {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:#?}", self.name)
     }
 }
 

--- a/crates/turborepo-vercel-api/src/lib.rs
+++ b/crates/turborepo-vercel-api/src/lib.rs
@@ -1,6 +1,8 @@
 //! Types for interacting with the Vercel API. Used for both
 //! the client (`turborepo-api-client`) and for the
 //! mock server (`turborepo-vercel-api-mock`)
+use std::fmt;
+
 use serde::{Deserialize, Serialize};
 use url::Url;
 pub mod telemetry;
@@ -78,6 +80,11 @@ pub struct Team {
 impl Team {
     pub fn is_owner(&self) -> bool {
         matches!(self.membership.role, Role::Owner)
+    }
+}
+impl fmt::Display for Team {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:#?}", self.name)
     }
 }
 


### PR DESCRIPTION
### Description

Vercel changed how personal accounts work so that they are team accounts. This meant this implementation was writing personal teams twice.

Note: This change should only affect Vercel to compensate for those internal changes. Non-Vercel systems should be unaffected.

### Testing Instructions

Run `turbo link`.
