### PR TITLE
Deduplicate persistent task get_function_name logic

### DIFF
--- a/crates/turbo-tasks-memory/src/task.rs
+++ b/crates/turbo-tasks-memory/src/task.rs
@@ -522,19 +522,10 @@ impl Task {
 
     pub(crate) fn get_function_name(&self) -> Option<Cow<'static, str>> {
         if let TaskType::Persistent { ty, .. } = &self.ty {
-            match &***ty {
-                PersistentTaskType::Native(native_fn, _)
-                | PersistentTaskType::ResolveNative(native_fn, _) => {
-                    return Some(Cow::Borrowed(&registry::get_function(*native_fn).name));
-                }
-                PersistentTaskType::ResolveTrait(trait_id, fn_name, _) => {
-                    return Some(
-                        format!("{}::{}", registry::get_trait(*trait_id).name, fn_name).into(),
-                    );
-                }
-            }
+            Some(ty.get_name())
+        } else {
+            None
         }
-        None
     }
 
     pub(crate) fn get_description(&self) -> String {

--- a/crates/turbo-tasks/src/backend.rs
+++ b/crates/turbo-tasks/src/backend.rs
@@ -79,14 +79,7 @@ pub enum PersistentTaskType {
 
 impl Display for PersistentTaskType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Native(fid, _) | Self::ResolveNative(fid, _) => {
-                Display::fmt(&registry::get_function(*fid).name, f)
-            }
-            Self::ResolveTrait(tid, n, _) => {
-                write!(f, "{}::{n}", registry::get_trait(*tid).name)
-            }
-        }
+        f.write_str(&self.get_name())
     }
 }
 
@@ -123,6 +116,23 @@ impl PersistentTaskType {
             }
             PersistentTaskType::ResolveTrait(f, n, v) => {
                 PersistentTaskType::ResolveTrait(*f, n.clone(), v[..len].to_vec())
+            }
+        }
+    }
+
+    /// Returns the name of the function in the code. Trait methods are
+    /// formatted as [`TraitName::method_name`].
+    ///
+    /// Equivalent to [`ToString::to_string`], but potentially more efficient as
+    /// it can return a `&'static str` in many cases.
+    pub fn get_name(&self) -> Cow<'static, str> {
+        match self {
+            PersistentTaskType::Native(native_fn, _)
+            | PersistentTaskType::ResolveNative(native_fn, _) => {
+                Cow::Borrowed(&registry::get_function(*native_fn).name)
+            }
+            PersistentTaskType::ResolveTrait(trait_id, fn_name, _) => {
+                format!("{}::{}", registry::get_trait(*trait_id).name, fn_name).into()
             }
         }
     }
@@ -433,5 +443,39 @@ impl PersistentTaskType {
                 Self::run_resolve_trait(trait_type, name, inputs, turbo_tasks),
             ),
         }
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+    use crate::{self as turbo_tasks, Vc};
+
+    #[turbo_tasks::function]
+    fn mock_func_task() -> Vc<()> {
+        Vc::cell(())
+    }
+
+    #[turbo_tasks::value_trait]
+    trait MockTrait {
+        fn mock_method_task() -> Vc<()>;
+    }
+
+    #[test]
+    fn test_get_name() {
+        crate::register();
+        assert_eq!(
+            PersistentTaskType::Native(*MOCK_FUNC_TASK_FUNCTION_ID, Vec::new()).get_name(),
+            "mock_func_task",
+        );
+        assert_eq!(
+            PersistentTaskType::ResolveTrait(
+                *MOCKTRAIT_TRAIT_TYPE_ID,
+                "mock_method_task".into(),
+                Vec::new()
+            )
+            .get_name(),
+            "MockTrait::mock_method_task",
+        );
     }
 }


### PR DESCRIPTION
### Description

I noticed this logic was duplicated across `turbo-tasks-memory` and `PersistentTaskType`.

This makes sense as a method on `PersistentTaskType`, so put the logic there, and call it from both places.


### Testing Instructions

```
cargo test -p turbo-tasks test_get_name
```