### PR TITLE
Release LSP 2.0

### DIFF
--- a/.github/workflows/lsp.yml
+++ b/.github/workflows/lsp.yml
@@ -22,11 +22,10 @@ jobs:
             target: "aarch64-apple-darwin"
             container-options: "--rm"
           - host: ubuntu-latest
-            container: ubuntu:xenial
             container-options: "--platform=linux/amd64 --rm"
-            container-setup: "apt-get update && apt-get install -y curl musl-tools sudo"
+            container-setup: "sudo apt-get update && sudo apt-get install -y curl musl-tools"
             target: "x86_64-unknown-linux-musl"
-            setup: "apt-get install -y build-essential clang-5.0 lldb-5.0 llvm-5.0-dev libclang-5.0-dev"
+            setup: "sudo apt-get install -y build-essential"
           - host: ubuntu-latest
             container-options: "--rm"
             target: "aarch64-unknown-linux-musl"
@@ -60,11 +59,10 @@ jobs:
         uses: ./.github/actions/setup-capnproto
 
       - name: Rust Setup
-        uses: actions-rs/toolchain@v1
+        uses: ./.github/actions/setup-rust
         with:
-          profile: minimal
-          override: true
-          target: ${{ matrix.settings.target }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          targets: ${{ matrix.settings.target }}
 
       - name: Build Setup
         shell: bash

--- a/crates/turborepo-lib/src/lib.rs
+++ b/crates/turborepo-lib/src/lib.rs
@@ -42,7 +42,9 @@ mod unescape;
 pub use crate::{
     child::spawn_child,
     cli::Args,
-    daemon::{DaemonClient, DaemonConnector, Paths as DaemonPaths},
+    daemon::{
+        DaemonClient, DaemonConnector, DaemonConnectorError, DaemonError, Paths as DaemonPaths,
+    },
     panic_handler::panic_handler,
     run::package_discovery::DaemonPackageDiscovery,
 };

--- a/crates/turborepo-lsp/src/lib.rs
+++ b/crates/turborepo-lsp/src/lib.rs
@@ -101,7 +101,7 @@ impl LanguageServer for Backend {
                             MessageType::ERROR,
                             "Pre-2.0 versions of turborepo are not compatible with 2.0 or later \
                              of the extension. If you do not plan to update to turbo 2.0, please \
-                             ensure you install the lastest 1.0 version of the extension in this \
+                             ensure you install the latest 1.0 version of the extension in this \
                              workspace.",
                         )
                         .await;

--- a/crates/turborepo-lsp/src/lib.rs
+++ b/crates/turborepo-lsp/src/lib.rs
@@ -6,6 +6,7 @@
 //! For more, see the [LSP specification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/)
 //! as well as the architecture documentation in `packages/turbo-vsc`.
 
+#![feature(box_patterns)]
 #![deny(clippy::all)]
 #![warn(clippy::unwrap_used)]
 
@@ -30,7 +31,10 @@ use tower_lsp::{
     Client, LanguageServer,
 };
 use turbopath::AbsoluteSystemPathBuf;
-use turborepo_lib::{DaemonClient, DaemonConnector, DaemonPackageDiscovery, DaemonPaths};
+use turborepo_lib::{
+    DaemonClient, DaemonConnector, DaemonConnectorError, DaemonError, DaemonPackageDiscovery,
+    DaemonPaths,
+};
 use turborepo_repository::{
     discovery::{self, DiscoveryResponse, PackageDiscovery, WorkspaceData},
     package_json::PackageJson,
@@ -91,6 +95,28 @@ impl LanguageServer for Backend {
 
             let daemon = match daemon {
                 Ok(daemon) => daemon,
+                Err(DaemonConnectorError::Handshake(box DaemonError::VersionMismatch(message))) => {
+                    self.client
+                        .show_message(
+                            MessageType::ERROR,
+                            "Pre-2.0 versions of turborepo are not compatible with 2.0 or later \
+                             of the extension. If you do not plan to update to turbo 2.0, please \
+                             ensure you install the lastest 1.0 version of the extension in this \
+                             workspace.",
+                        )
+                        .await;
+                    self.client
+                        .log_message(
+                            MessageType::ERROR,
+                            format!("version mismatch when connecting to daemon: {}", message),
+                        )
+                        .await;
+
+                    // in this case, just say we don't support any features
+                    return Ok(InitializeResult {
+                        ..Default::default()
+                    });
+                }
                 Err(e) => {
                     self.client
                         .log_message(

--- a/packages/turbo-vsc/.vscodeignore
+++ b/packages/turbo-vsc/.vscodeignore
@@ -2,3 +2,5 @@
 **/tsconfig.json
 node_modules
 out/artifacts
+.turbo
+**/*.vsix

--- a/packages/turbo-vsc/package.json
+++ b/packages/turbo-vsc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "turbo-vsc",
   "displayName": "Turborepo LSP",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "Tools and instant feedback for your build system",
   "main": "out/main.js",
   "publisher": "Vercel",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8819,7 +8819,7 @@ packages:
       jest-util: 29.5.0
       natural-compare: 1.4.0
       pretty-format: 29.5.0
-      semver: 7.5.0
+      semver: 7.5.4
     transitivePeerDependencies:
       - supports-color
     dev: false


### PR DESCRIPTION
### Description

A small fix to surface an error in UI if there is a version mismatch in turbo, as well as updating the LSP to support the new protocol version.

This also updates the lsp CI to use our setup-rust workflow rather than hand rolling one

### Testing Instructions

Open up a project with 2.0 of the extension, with turbo 1.0. Observe a nice error message, instead of returning an internal error. Observe that LSP features don't 'work' but at least gracefully degrade.
