### PR TITLE
Handle `#[cfg(...)]` attributes on turbo tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10163,6 +10163,7 @@ dependencies = [
  "anyhow",
  "cargo-lock",
  "glob",
+ "quote",
  "syn 1.0.109",
  "turbo-tasks-macros-shared",
 ]

--- a/crates/turbo-tasks-build/Cargo.toml
+++ b/crates/turbo-tasks-build/Cargo.toml
@@ -15,5 +15,6 @@ workspace = true
 anyhow = { workspace = true }
 cargo-lock = "8.0.2"
 glob = "0.3.0"
+quote = { workspace = true }
 syn = { workspace = true, features = ["full"] }
 turbo-tasks-macros-shared = { workspace = true }


### PR DESCRIPTION
### Description

If a task is conditionally compiled, we must conditionally register it.

Noticed this when trying to write a test with `#[cfg(test)]`.

**Related:** #8530 adds support for registering tasks inside of `mod foo { ... }` blocks.

### Testing Instructions

Tested as part of #8529