### PR TITLE
Decrease default scope_stress test size, add env var config

### DIFF
--- a/crates/turbo-tasks-memory/tests/scope_stress.rs
+++ b/crates/turbo-tasks-memory/tests/scope_stress.rs
@@ -17,7 +17,9 @@ fn rectangle_stress() {
         .unwrap();
     rt.block_on(async {
         let tt = TurboTasks::new(MemoryBackend::default());
-        let size = 100;
+        let size = std::env::var("TURBOPACK_TEST_RECTANGLE_STRESS_SIZE")
+            .map(|size| size.parse().unwrap())
+            .unwrap_or(50);
         (0..size)
             .map(|a| (a, size - 1))
             .chain((0..size - 1).map(|b| (size - 1, b)))


### PR DESCRIPTION
### Description

I've noticed this test often times out on CI (after >10 minutes!), possibly because it runs out of ram and starts swapping.

This decreases the size significantly (this is `O(n^2)`). Locally the test now runs in about 1-2 seconds on my local machine (versus >30 seconds).

### Testing Instructions

```
cargo test -p turbo-tasks-memory rectangle_stress
```

```
TURBOPACK_TEST_RECTANGLE_STRESS_SIZE=100 cargo test -p turbo-tasks-memory rectangle_stress
```