### PR TITLE
Add new ExitHandler API as an alternative to ExitGuard

### DIFF
--- a/crates/turbopack-trace-utils/Cargo.toml
+++ b/crates/turbopack-trace-utils/Cargo.toml
@@ -17,7 +17,7 @@ crossbeam-channel = { workspace = true }
 once_cell = { workspace = true }
 postcard = { workspace = true, features = ["alloc", "use-std"] }
 serde = { workspace = true, features = ["derive"] }
-tokio = { workspace = true, features = ["signal", "rt"] }
+tokio = { workspace = true, features = ["macros", "signal", "sync", "rt"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 turbo-tasks-malloc = { workspace = true }

--- a/crates/turbopack-trace-utils/src/exit.rs
+++ b/crates/turbopack-trace-utils/src/exit.rs
@@ -1,6 +1,11 @@
-use std::sync::{Arc, Mutex};
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::{Arc, Mutex, OnceLock},
+};
 
 use anyhow::Result;
+use tokio::{select, sync::mpsc, task::JoinSet};
 
 /// A guard for the exit handler. When dropped, the exit guard will be dropped.
 /// It might also be dropped on Ctrl-C.
@@ -25,5 +30,110 @@ impl<T: Send + 'static> ExitGuard<T> {
             });
         }
         Ok(ExitGuard(guard))
+    }
+}
+
+type BoxExitFuture = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
+
+/// The singular global ExitHandler. This is primarily used to ensure
+/// `ExitHandler::listen` is only called once.
+///
+/// The global handler is intentionally not exposed, so that APIs that depend on
+/// exit behavior are required to take the `ExitHandler`. This ensures that the
+/// `ExitHandler` is configured before these APIs are run, and that these
+/// consumers can be used with a callback (e.g. a mock) instead.
+static GLOBAL_EXIT_HANDLER: OnceLock<Arc<ExitHandler>> = OnceLock::new();
+
+pub struct ExitHandler {
+    tx: mpsc::UnboundedSender<BoxExitFuture>,
+}
+
+impl ExitHandler {
+    /// Waits for `SIGINT` using [`tokio::signal::ctrl_c`], and exits the
+    /// process with exit code `0` after running any futures scheduled with
+    /// [`ExitHandler::on_exit`].
+    ///
+    /// As this uses global process signals, this must only be called once, and
+    /// will panic if called multiple times. Use this when you own the
+    /// process (e.g. `turbopack-cli`).
+    ///
+    /// If you don't own the process (e.g. you're called as a library, such as
+    /// in `next-swc`), use [`ExitHandler::new_trigger`] instead.
+    ///
+    /// This may listen for other signals, like `SIGTERM` or `SIGPIPE` in the
+    /// future.
+    pub fn listen() -> &'static Arc<ExitHandler> {
+        let (handler, receiver) = Self::new_receiver();
+        if GLOBAL_EXIT_HANDLER.set(handler).is_err() {
+            panic!("ExitHandler::listen must only be called once");
+        }
+        tokio::spawn(async move {
+            tokio::signal::ctrl_c()
+                .await
+                .expect("failed to set ctrl_c handler");
+            receiver.run_exit_handler().await;
+            std::process::exit(0);
+        });
+        GLOBAL_EXIT_HANDLER.get().expect("value is set")
+    }
+
+    /// Creates an [`ExitHandler`] that can be manually controlled with an
+    /// [`ExitReceiver`].
+    ///
+    /// This does not actually exit the process or listen for any signals. If
+    /// you'd like that behavior, use [`ExitHandler::listen`].
+    ///
+    /// Because this API has no global side-effects and can be called many times
+    /// within the same process, it is possible to use it to provide a mock
+    /// [`ExitHandler`] inside unit tests.
+    pub fn new_receiver() -> (Arc<ExitHandler>, ExitReceiver) {
+        let (tx, rx) = mpsc::unbounded_channel();
+        (Arc::new(ExitHandler { tx }), ExitReceiver { rx })
+    }
+
+    /// Register this given [`Future`] to run upon process exit.
+    ///
+    /// As there are many ways for a process be killed that are outside of a
+    /// process's own control (e.g. `SIGKILL` or `SIGSEGV`), this API is
+    /// provided on a best-effort basis.
+    pub fn on_exit(&self, fut: impl Future<Output = ()> + Send + 'static) {
+        // realistically, this error case can only happen with a mock
+        self.tx
+            .send(Box::pin(fut))
+            .expect("cannot send future after process exit");
+    }
+}
+
+/// Provides a way to run futures scheduled with an [`ExitHandler`].
+pub struct ExitReceiver {
+    rx: mpsc::UnboundedReceiver<BoxExitFuture>,
+}
+
+impl ExitReceiver {
+    /// Call this when the process exits to run the futures scheduled via
+    /// [`ExitHandler::on_exit`].
+    ///
+    /// As this is intended to be used in a library context, this does not exit
+    /// the process. It is expected that the process will not exit until
+    /// this async method finishes executing.
+    pub async fn run_exit_handler(mut self) {
+        let mut set = JoinSet::new();
+        while let Ok(fut) = self.rx.try_recv() {
+            set.spawn(fut);
+        }
+        loop {
+            select! {
+                Some(fut) = self.rx.recv() => {
+                    set.spawn(fut);
+                },
+                val = set.join_next() => {
+                    match val {
+                        Some(Ok(())) => {}
+                        Some(Err(_)) => panic!("ExitHandler future panicked!"),
+                        None => return,
+                    }
+                },
+            }
+        }
     }
 }


### PR DESCRIPTION
## Why?

I need a better system for handling process exit to handle flushing to cache hit statistics (#8286).

## What?

- Supports letting another thing listen for <kbd>ctrl</kbd> + <kbd>c</kbd>. In the case of next-server, we need to let node.js own and configure these signal handlers.
- Supports setting up a <kbd>ctrl</kbd> + <kbd>c</kbd> handler for you, but now explicitly panics if you would try to set up multiple global <kbd>ctrl</kbd> + <kbd>c</kbd> listeners.
- Allows async work to happen during cleanup. This wasn't possible using `Drop` because `Drop` isn't async.
- Allows cleanup work to be scheduled after application initialization, potentially making the API a bit more flexible.

## Testing Instructions

```
cargo test -p turbopack-trace-utils
```

Add some `println!()` logging to the end of the `on_exit` future in turbopack-cli.

```
TURBOPACK_TRACING=overview cargo run -p turbopack-cli -- dev
```

Hit `ctrl+c` and see that my `println!()` runs, so I know the tracing flush finishes.