### PR TITLE
fix(codemod): avoid overwriting existing packageManager field

### DIFF
--- a/packages/turbo-codemod/__tests__/add-package-manager.test.ts
+++ b/packages/turbo-codemod/__tests__/add-package-manager.test.ts
@@ -99,13 +99,7 @@ const TEST_CASES: Array<TestCase> = [
     packageManagerVersion: "1.2.3",
     options: { force: false, dryRun: false, print: false },
     result: {
-      changes: {
-        "package.json": {
-          action: "unchanged",
-          additions: 0,
-          deletions: 0,
-        },
-      },
+      changes: {},
     },
   },
   {
@@ -116,13 +110,7 @@ const TEST_CASES: Array<TestCase> = [
     packageManagerVersion: "1.2.3",
     options: { force: false, dryRun: false, print: false },
     result: {
-      changes: {
-        "package.json": {
-          action: "modified",
-          additions: 1,
-          deletions: 1,
-        },
-      },
+      changes: {},
     },
   },
 ];
@@ -176,13 +164,16 @@ describe("add-package-manager-2", () => {
         options,
       });
 
-      expect(mockGetAvailablePackageManagers).toHaveBeenCalled();
-      expect(mockGetWorkspaceDetails).toHaveBeenCalled();
+      if (existingPackageManagerString === undefined) {
+        expect(mockGetAvailablePackageManagers).toHaveBeenCalled();
+        expect(mockGetWorkspaceDetails).toHaveBeenCalled();
+      }
 
       expect(JSON.parse(read("package.json") || "{}").packageManager).toEqual(
         options.dryRun
           ? undefined
-          : `${packageManager}@${packageManagerVersion}`
+          : existingPackageManagerString ||
+              `${packageManager}@${packageManagerVersion}`
       );
 
       // result should be correct
@@ -194,17 +185,7 @@ describe("add-package-manager-2", () => {
         options,
       });
       expect(repeatResult.fatalError).toBeUndefined();
-      expect(repeatResult.changes).toMatchObject({
-        "package.json": {
-          action: options.dryRun ? "skipped" : "unchanged",
-          additions: options.dryRun
-            ? result.changes["package.json"].additions
-            : 0,
-          deletions: options.dryRun
-            ? result.changes["package.json"].deletions
-            : 0,
-        },
-      });
+      expect(repeatResult.changes).toMatchObject({});
 
       mockGetAvailablePackageManagers.mockRestore();
       mockGetWorkspaceDetails.mockRestore();

--- a/packages/turbo-codemod/src/transforms/add-package-manager.ts
+++ b/packages/turbo-codemod/src/transforms/add-package-manager.ts
@@ -21,6 +21,13 @@ export async function transformer({
     options,
   });
 
+  const rootPackageJsonPath = path.join(root, "package.json");
+  const rootPackageJson = readJsonSync(rootPackageJsonPath) as PackageJson;
+  if ("packageManager" in rootPackageJson) {
+    log.info(`"packageManager" already set in root "package.json"`);
+    return runner.finish();
+  }
+
   log.info(`Set "packageManager" key in root "package.json" file...`);
   let project: Project;
   try {
@@ -41,8 +48,6 @@ export async function transformer({
   }
 
   const pkgManagerString = `${packageManager}@${version}`;
-  const rootPackageJsonPath = path.join(root, "package.json");
-  const rootPackageJson = readJsonSync(rootPackageJsonPath) as PackageJson;
   const allWorkspaces = [
     {
       name: "package.json",


### PR DESCRIPTION
### Description

Fixes #8308

Previously we would attempt to update the `packageManager` field to whatever version we found for the listed package manager based on the current `PATH`/cwd. This PR removes that behavior and now trusts the user if they have one listed in `package.json`.

With the adoption of `corepack` more often then not, we want the contents of `package.json` to inform the binary used instead of the other way around. 

### Testing Instructions

Updated existing unit tests to no longer expect changes
