### PR TITLE
fix(turborepo): benchmarks

### DIFF
--- a/packages/turbo-benchmark/src/helpers.ts
+++ b/packages/turbo-benchmark/src/helpers.ts
@@ -3,7 +3,8 @@ import fs from "node:fs";
 import path from "node:path";
 
 export const REPO_ROOT = "large-monorepo";
-export const REPO_ORIGIN = "https://github.com/gsoltis/large-monorepo.git";
+export const REPO_ORIGIN =
+  "https://github.com/curated-tests/large-monorepo.git";
 export const REPO_PATH = path.join(process.cwd(), REPO_ROOT);
 export const DEFAULT_EXEC_OPTS = { stdio: "ignore" as const, cwd: REPO_PATH };
 
@@ -34,8 +35,8 @@ export function setup(): void {
   }
 
   // Run install so we aren't benchmarking node_modules
-  console.log("running yarn install");
-  cp.execSync("yarn install", DEFAULT_EXEC_OPTS);
+  console.log("running npm install");
+  cp.execSync("npm install", DEFAULT_EXEC_OPTS);
 }
 
 export function getCommitDetails(): {


### PR DESCRIPTION
### Description

The `large-monorepo` that we use for benchmarks wasn't upgraded to 2.0. I upgraded it and moved it to the `curated-tests` organization.

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
