### PR TITLE
fix(pnpm): enable npmrc parsing for pnpm 9

### DIFF
--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -350,7 +350,7 @@ impl<'a, T: PackageDiscovery> BuildState<'a, ResolvedWorkspaces, T> {
         package_manager: PackageManager,
     ) -> Result<(), Error> {
         let npmrc = match package_manager {
-            PackageManager::Pnpm | PackageManager::Pnpm6 => {
+            PackageManager::Pnpm | PackageManager::Pnpm6 | PackageManager::Pnpm9 => {
                 let npmrc_path = self.repo_root.join_component(".npmrc");
                 match npmrc_path.read_existing_to_string().ok().flatten() {
                     Some(contents) => NpmRc::from_reader(contents.as_bytes()).ok(),


### PR DESCRIPTION
### Description

Fixes #8168

When adding the additional variant for pnpm9 the logic for parsing `.npmrc` didn't get enabled for it. This meant if the user explicitly enabled `link-workspace-packages = true` in `.npmrc` it wouldn't be respected.

### Testing Instructions

Verify that `.npmrc`'s `link-workspace-packages` is now respected for pnpm9:

Clone https://github.com/issueset/turborepo-pnpm9-graph
Checkout branch `pnpm9-2.0.4`

Make sure that all edges are picked up
```
[0 olszewski@chriss-mbp] /tmp/turborepo-pnpm9-graph $ turbo_dev --skip-infer build --graph

digraph {
        compound = "true"
        newrank = "true"
        subgraph "root" {
                "[root] @acme/core#build" -> "[root] @acme/eslint-config#build"
                "[root] @acme/core#build" -> "[root] @acme/tsconfig#build"
                "[root] @acme/docs#build" -> "[root] @acme/core#build"
                "[root] @acme/docs#build" -> "[root] @acme/eslint-config#build"
                "[root] @acme/docs#build" -> "[root] @acme/tsconfig#build"
                "[root] @acme/docs#build" -> "[root] @acme/utils#build"
                "[root] @acme/eslint-config#build" -> "[root] ___ROOT___"
                "[root] @acme/tsconfig#build" -> "[root] ___ROOT___"
                "[root] @acme/utils#build" -> "[root] @acme/eslint-config#build"
                "[root] @acme/utils#build" -> "[root] @acme/tsconfig#build"
        }
}
```
