### PR TITLE
docs: fixing trailing commas in `configuration.mdx`

### DIFF
--- a/docs/repo-docs/reference/configuration.mdx
+++ b/docs/repo-docs/reference/configuration.mdx
@@ -107,21 +107,21 @@ In the example below, we've defined three tasks under the `tasks` key: `build`, 
 
 ```jsonc title="./turbo.json"
 {
-  "$schema": "https://turbo.build/schema.json"
+  "$schema": "https://turbo.build/schema.json",
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": ["dist/**", ".next/**", "!.next/cache/**"],
+      "outputs": ["dist/**", ".next/**", "!.next/cache/**"]
     },
     "test": {
       "outputs": ["coverage/**"],
-      "dependsOn": ["build"],
+      "dependsOn": ["build"]
     },
     "dev": {
       "cache": false,
-      "persistent": true,
-    },
-  },
+      "persistent": true
+    }
+  }
 }
 ```
 


### PR DESCRIPTION
### Description

Fixes #8582.
Removed trailing commas where not needed and added where needed.

### Additional infos

Honestly this was a blind fix, I tried to run docs locally following `contributing` and `troubleshooting`, installed `go`, `capnp`, and all other packages, but I always run in some sort of problem.

`pnpm docs` opened `https://www.npmjs.com/package/cli` on the browser, sometimes i had

> × No package found with name 'docs' in workspace

I'm sorry if I wasn't able to follow a real contribution steps, if someone can help me go through this I will be happy for this and future contribution.

Have a nice day!