### PR TITLE
MDX support: Ensure development transform is only used in development

### DIFF
--- a/crates/turbopack/src/module_options/mod.rs
+++ b/crates/turbopack/src/module_options/mod.rs
@@ -504,17 +504,22 @@ impl ModuleOptions {
         }
 
         if enable_mdx || enable_mdx_rs.is_some() {
-            let (jsx_runtime, jsx_import_source) = if let Some(enable_jsx) = enable_jsx {
+            let (jsx_runtime, jsx_import_source, development) = if let Some(enable_jsx) = enable_jsx
+            {
                 let jsx = enable_jsx.await?;
-                (jsx.runtime.clone(), jsx.import_source.clone())
+                (
+                    jsx.runtime.clone(),
+                    jsx.import_source.clone(),
+                    jsx.development,
+                )
             } else {
-                (None, None)
+                (None, None, false)
             };
 
             let mdx_options = &*enable_mdx_rs.unwrap_or(Default::default()).await?;
 
             let mdx_transform_options = (MdxTransformOptions {
-                development: Some(true),
+                development: Some(development),
                 jsx: Some(false),
                 jsx_runtime,
                 jsx_import_source,


### PR DESCRIPTION
### Description

Currently MDX files are incorrectly compiled using the development transform which causes `jsxDev` calls that don't work in production, this PR ensures MDX follows the JSX setting.

<!--
  ✍️ Write a short summary of your work.
  If necessary, include relevant screenshots.
-->

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
