### PR TITLE
chore: updated team members who get turborepo label

### DIFF
--- a/.github/turbo-orchestrator.yml
+++ b/.github/turbo-orchestrator.yml
@@ -44,12 +44,12 @@ labeler:
         isPRAuthorMatch: "^(bgw|ForsakenHarmony|kdy1|kwonoj|padmaia|sokra|wbinnssmith)$"
     - label: "created-by: turborepo"
       when:
-        isPRAuthorMatch: "^(gsoltis|anthonyshew|tknickman|mehulkar|chris-olszewski|NicholasLYang|Zertsov|paulogdm|codybrouwers)$"
+        isPRAuthorMatch: "^(anthonyshew|tknickman|mehulkar|chris-olszewski|NicholasLYang|Zertsov|paulogdm|codybrouwers)$"
 
     # needs: triage when not any of the turbopack or turborepo team
     - label: "needs: triage"
       when:
-        isNotPRAuthorMatch: "^(bgw|ForsakenHarmony|kdy1|kwonoj|padmaia|sokra|wbinnssmith|gsoltis|anthonyshew|tknickman|mehulkar|chris-olszewski|NicholasLYang|arlyon|Zertsov|paulogdm|codybrouwers)$"
+        isNotPRAuthorMatch: "^(bgw|ForsakenHarmony|kdy1|kwonoj|padmaia|sokra|wbinnssmith|anthonyshew|tknickman|mehulkar|chris-olszewski|NicholasLYang|arlyon|Zertsov|paulogdm|codybrouwers)$"
 
     # areas
     - label: "area: ci"

--- a/.github/turbo-orchestrator.yml
+++ b/.github/turbo-orchestrator.yml
@@ -44,7 +44,7 @@ labeler:
         isPRAuthorMatch: "^(bgw|ForsakenHarmony|kdy1|kwonoj|padmaia|sokra|wbinnssmith)$"
     - label: "created-by: turborepo"
       when:
-        isPRAuthorMatch: "^(gsoltis|anthonyshew|tknickman|mehulkar|chris-olszewski|NicholasLYang|arlyon|Zertsov|paulogdm|codybrouwers)$"
+        isPRAuthorMatch: "^(gsoltis|anthonyshew|tknickman|mehulkar|chris-olszewski|NicholasLYang|Zertsov|paulogdm|codybrouwers)$"
 
     # needs: triage when not any of the turbopack or turborepo team
     - label: "needs: triage"


### PR DESCRIPTION
Most of Alex's PRs are not turborepo related anymore. Applying this label also creates a Linear issue, so I'm removing it here.
