### PR TITLE
Delete unused TASK_ID_MAPPING support

### DIFF
--- a/crates/turbo-tasks/src/lib.rs
+++ b/crates/turbo-tasks/src/lib.rs
@@ -78,10 +78,7 @@ use auto_hash_map::AutoSet;
 pub use collectibles::CollectiblesSource;
 pub use completion::{Completion, Completions};
 pub use display::ValueToString;
-pub use id::{
-    with_task_id_mapping, without_task_id_mapping, FunctionId, IdMapping, TaskId, TraitTypeId,
-    ValueTypeId,
-};
+pub use id::{FunctionId, TaskId, TraitTypeId, ValueTypeId};
 pub use invalidation::{
     DynamicEqHash, InvalidationReason, InvalidationReasonKind, InvalidationReasonSet,
 };


### PR DESCRIPTION
This is currently unused. It existed for persistent caching, but it sounds like we likely won't go with this mapping approach:

> It was used for persistent caching, but it looks like we probably take a different approach (same ids between persistent cache and memory cache). So you can remove it.

-- https://vercel.slack.com/archives/C03EWR7LGEN/p1719340628045969?thread_ts=1719338013.257509&cid=C03EWR7LGEN