### PR TITLE
fix(ui): respect `--output-logs` and `outputLogs` for persisting logs after TUI exits

### DIFF
--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -77,6 +77,18 @@ impl Display for OutputLogsMode {
     }
 }
 
+impl Into<turborepo_ui::tui::event::OutputLogs> for OutputLogsMode {
+    fn into(self) -> turborepo_ui::tui::event::OutputLogs {
+        match self {
+            OutputLogsMode::Full => turborepo_ui::tui::event::OutputLogs::Full,
+            OutputLogsMode::None => turborepo_ui::tui::event::OutputLogs::None,
+            OutputLogsMode::HashOnly => turborepo_ui::tui::event::OutputLogs::HashOnly,
+            OutputLogsMode::NewOnly => turborepo_ui::tui::event::OutputLogs::NewOnly,
+            OutputLogsMode::ErrorsOnly => turborepo_ui::tui::event::OutputLogs::ErrorsOnly,
+        }
+    }
+}
+
 #[derive(Copy, Clone, Debug, PartialEq, Serialize, ValueEnum)]
 pub enum LogOrder {
     #[serde(rename = "auto")]

--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -77,9 +77,9 @@ impl Display for OutputLogsMode {
     }
 }
 
-impl Into<turborepo_ui::tui::event::OutputLogs> for OutputLogsMode {
-    fn into(self) -> turborepo_ui::tui::event::OutputLogs {
-        match self {
+impl From<OutputLogsMode> for turborepo_ui::tui::event::OutputLogs {
+    fn from(value: OutputLogsMode) -> Self {
+        match value {
             OutputLogsMode::Full => turborepo_ui::tui::event::OutputLogs::Full,
             OutputLogsMode::None => turborepo_ui::tui::event::OutputLogs::None,
             OutputLogsMode::HashOnly => turborepo_ui::tui::event::OutputLogs::HashOnly,

--- a/crates/turborepo-lib/src/run/cache.rs
+++ b/crates/turborepo-lib/src/run/cache.rs
@@ -147,6 +147,10 @@ pub struct TaskCache {
 }
 
 impl TaskCache {
+    pub fn output_logs(&self) -> OutputLogsMode {
+        self.task_output_logs
+    }
+
     /// Will read log file and write to output a line at a time
     pub fn replay_log_file(&self, output: &mut impl CacheOutput) -> Result<(), Error> {
         if self.log_file_path.exists() {

--- a/crates/turborepo-lib/src/task_graph/visitor.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor.rs
@@ -755,7 +755,8 @@ impl ExecContext {
         // If the task resulted in an error, do not group in order to better highlight
         // the error.
         let is_error = matches!(result, Ok(ExecOutcome::Task { .. }));
-        let logs = match output_client.finish(is_error) {
+        let cache_hit = matches!(result, Ok(ExecOutcome::Success(SuccessOutcome::CacheHit)));
+        let logs = match output_client.finish(is_error, cache_hit) {
             Ok(logs) => logs,
             Err(e) => {
                 telemetry.track_error(TrackedErrors::DaemonFailedToMarkOutputsAsCached);
@@ -1117,11 +1118,11 @@ impl<W: Write> CacheOutput for TaskCacheOutput<W> {
 
 /// Struct for displaying information about task
 impl<W: Write> TaskOutput<W> {
-    pub fn finish(self, use_error: bool) -> std::io::Result<Option<Vec<u8>>> {
+    pub fn finish(self, use_error: bool, cache_hit: bool) -> std::io::Result<Option<Vec<u8>>> {
         match self {
             TaskOutput::Direct(client) => client.finish(use_error),
             TaskOutput::UI(client) if use_error => Ok(Some(client.failed())),
-            TaskOutput::UI(client) => Ok(Some(client.succeeded())),
+            TaskOutput::UI(client) => Ok(Some(client.succeeded(cache_hit))),
         }
     }
 

--- a/crates/turborepo-lib/src/task_graph/visitor.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor.rs
@@ -854,7 +854,9 @@ impl ExecContext {
 
         if self.experimental_ui {
             if let TaskOutput::UI(task) = output_client {
-                task.start();
+                // We should send over the output mode for the task here :)
+                let output_logs = self.task_cache.output_logs().into();
+                task.start(output_logs);
             }
         }
 

--- a/crates/turborepo-lib/src/task_graph/visitor.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor.rs
@@ -853,7 +853,6 @@ impl ExecContext {
 
         if self.experimental_ui {
             if let TaskOutput::UI(task) = output_client {
-                // We should send over the output mode for the task here :)
                 let output_logs = self.task_cache.output_logs().into();
                 task.start(output_logs);
             }

--- a/crates/turborepo-ui/src/tui/app.rs
+++ b/crates/turborepo-ui/src/tui/app.rs
@@ -17,7 +17,8 @@ const PANE_SIZE_RATIO: f32 = 3.0 / 4.0;
 const FRAMERATE: Duration = Duration::from_millis(3);
 
 use super::{
-    event::TaskResult, input, AppReceiver, Error, Event, InputOptions, TaskTable, TerminalPane,
+    event::{OutputLogs, TaskResult},
+    input, AppReceiver, Error, Event, InputOptions, TaskTable, TerminalPane,
 };
 use crate::tui::{
     task::{Task, TasksByStatus},
@@ -133,7 +134,7 @@ impl<W> App<W> {
     /// Mark the given task as started.
     /// If planned, pulls it from planned tasks and starts it.
     /// If finished, removes from finished and starts again as new task.
-    pub fn start_task(&mut self, task: &str) -> Result<(), Error> {
+    pub fn start_task(&mut self, task: &str, output_logs: OutputLogs) -> Result<(), Error> {
         // Name of currently highlighted task.
         // We will use this after the order switches.
         let highlighted_task = self
@@ -171,6 +172,10 @@ impl<W> App<W> {
         if !found_task {
             return Err(Error::TaskNotFound { name: task.into() });
         }
+        self.tasks
+            .get_mut(task)
+            .ok_or_else(|| Error::TaskNotFound { name: task.into() })?
+            .output_logs = Some(output_logs);
 
         // If user hasn't interacted, keep highlighting top-most task in list.
         if !self.has_user_scrolled {
@@ -212,6 +217,11 @@ impl<W> App<W> {
 
         let running = self.tasks_by_status.running.remove(running_idx);
         self.tasks_by_status.finished.push(running.finish(result));
+
+        self.tasks
+            .get_mut(task)
+            .ok_or_else(|| Error::TaskNotFound { name: task.into() })?
+            .task_result = Some(result);
 
         // If user hasn't interacted, keep highlighting top-most task in list.
         if !self.has_user_scrolled {
@@ -449,8 +459,8 @@ fn update(
     event: Event,
 ) -> Result<Option<mpsc::SyncSender<()>>, Error> {
     match event {
-        Event::StartTask { task } => {
-            app.start_task(&task)?;
+        Event::StartTask { task, output_logs } => {
+            app.start_task(&task, output_logs)?;
         }
         Event::TaskOutput { task, output } => {
             app.process_output(&task, &output)?;
@@ -526,6 +536,7 @@ fn view<W>(app: &mut App<W>, f: &mut Frame, cols: u16) {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::tui::event::CacheResult;
 
     #[test]
     fn test_scroll() {
@@ -564,13 +575,14 @@ mod test {
         app.next();
         assert_eq!(app.scroll.selected(), Some(1), "selected b");
         assert_eq!(app.active_task(), "b", "selected b");
-        app.start_task("b").unwrap();
+        app.start_task("b", OutputLogs::Full).unwrap();
         assert_eq!(app.scroll.selected(), Some(0), "b stays selected");
         assert_eq!(app.active_task(), "b", "selected b");
-        app.start_task("a").unwrap();
+        app.start_task("a", OutputLogs::Full).unwrap();
         assert_eq!(app.scroll.selected(), Some(0), "b stays selected");
         assert_eq!(app.active_task(), "b", "selected b");
-        app.finish_task("a", TaskResult::Success).unwrap();
+        app.finish_task("a", TaskResult::Success(CacheResult::Miss))
+            .unwrap();
         assert_eq!(app.scroll.selected(), Some(0), "b stays selected");
         assert_eq!(app.active_task(), "b", "selected b");
     }
@@ -585,15 +597,16 @@ mod test {
         app.next();
         app.next();
         // Start all tasks
-        app.start_task("b").unwrap();
-        app.start_task("a").unwrap();
-        app.start_task("c").unwrap();
+        app.start_task("b", OutputLogs::Full).unwrap();
+        app.start_task("a", OutputLogs::Full).unwrap();
+        app.start_task("c", OutputLogs::Full).unwrap();
         assert_eq!(
             app.tasks_by_status.task_name(0),
             "b",
             "b is on top (running)"
         );
-        app.finish_task("a", TaskResult::Success).unwrap();
+        app.finish_task("a", TaskResult::Success(CacheResult::Miss))
+            .unwrap();
         assert_eq!(
             (
                 app.tasks_by_status.task_name(2),
@@ -603,7 +616,8 @@ mod test {
             "a is on bottom (done), b is second (running)"
         );
 
-        app.finish_task("b", TaskResult::Success).unwrap();
+        app.finish_task("b", TaskResult::Success(CacheResult::Miss))
+            .unwrap();
         assert_eq!(
             (
                 app.tasks_by_status.task_name(1),
@@ -614,7 +628,7 @@ mod test {
         );
 
         // Restart b
-        app.start_task("b").unwrap();
+        app.start_task("b", OutputLogs::Full).unwrap();
         assert_eq!(
             (
                 app.tasks_by_status.task_name(1),
@@ -625,7 +639,7 @@ mod test {
         );
 
         // Restart a
-        app.start_task("a").unwrap();
+        app.start_task("a", OutputLogs::Full).unwrap();
         assert_eq!(
             (
                 app.tasks_by_status.task_name(0),
@@ -650,10 +664,10 @@ mod test {
         assert_eq!(app.scroll.selected(), Some(2), "selected c");
         assert_eq!(app.tasks_by_status.task_name(2), "c", "selected c");
         // start c which moves it to "running" which is before "planned"
-        app.start_task("c").unwrap();
+        app.start_task("c", OutputLogs::Full).unwrap();
         assert_eq!(app.scroll.selected(), Some(0), "selection stays on c");
         assert_eq!(app.tasks_by_status.task_name(0), "c", "selected c");
-        app.start_task("a").unwrap();
+        app.start_task("a", OutputLogs::Full).unwrap();
         assert_eq!(app.scroll.selected(), Some(0), "selection stays on c");
         assert_eq!(app.tasks_by_status.task_name(0), "c", "selected c");
         // c
@@ -663,14 +677,16 @@ mod test {
         app.next();
         assert_eq!(app.scroll.selected(), Some(2), "selected b");
         assert_eq!(app.tasks_by_status.task_name(2), "b", "selected b");
-        app.finish_task("a", TaskResult::Success).unwrap();
+        app.finish_task("a", TaskResult::Success(CacheResult::Miss))
+            .unwrap();
         assert_eq!(app.scroll.selected(), Some(1), "b stays selected");
         assert_eq!(app.tasks_by_status.task_name(1), "b", "selected b");
         // c <-
         // b
         // a
         app.previous();
-        app.finish_task("c", TaskResult::Success).unwrap();
+        app.finish_task("c", TaskResult::Success(CacheResult::Miss))
+            .unwrap();
         assert_eq!(app.scroll.selected(), Some(2), "c stays selected");
         assert_eq!(app.tasks_by_status.task_name(2), "c", "selected c");
     }
@@ -682,8 +698,8 @@ mod test {
         assert_eq!(app.scroll.selected(), Some(1), "selected b");
         assert_eq!(app.tasks_by_status.task_name(1), "b", "selected b");
         // start c which moves it to "running" which is before "planned"
-        app.start_task("a").unwrap();
-        app.start_task("b").unwrap();
+        app.start_task("a", OutputLogs::Full).unwrap();
+        app.start_task("b", OutputLogs::Full).unwrap();
         app.insert_stdin("a", Some(Vec::new())).unwrap();
         app.insert_stdin("b", Some(Vec::new())).unwrap();
 

--- a/crates/turborepo-ui/src/tui/event.rs
+++ b/crates/turborepo-ui/src/tui/event.rs
@@ -1,6 +1,7 @@
 pub enum Event {
     StartTask {
         task: String,
+        output_logs: OutputLogs,
     },
     TaskOutput {
         task: String,
@@ -46,6 +47,20 @@ pub enum TaskResult {
 pub enum CacheResult {
     Hit,
     Miss,
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+pub enum OutputLogs {
+    // Entire task output is persisted after run
+    Full,
+    // None of a task output is persisted after run
+    None,
+    // Only the status line of a task is persisted
+    HashOnly,
+    // Output is only persisted if it is a cache miss
+    NewOnly,
+    // Output is only persisted if the task failed
+    ErrorsOnly,
 }
 
 #[cfg(test)]

--- a/crates/turborepo-ui/src/tui/event.rs
+++ b/crates/turborepo-ui/src/tui/event.rs
@@ -38,8 +38,14 @@ pub enum Event {
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
 pub enum TaskResult {
-    Success,
+    Success(CacheResult),
     Failure,
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+pub enum CacheResult {
+    Hit,
+    Miss,
 }
 
 #[cfg(test)]

--- a/crates/turborepo-ui/src/tui/event.rs
+++ b/crates/turborepo-ui/src/tui/event.rs
@@ -14,6 +14,7 @@ pub enum Event {
     Status {
         task: String,
         status: String,
+        result: CacheResult,
     },
     Stop(std::sync::mpsc::SyncSender<()>),
     // Stop initiated by the TUI itself
@@ -39,7 +40,7 @@ pub enum Event {
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
 pub enum TaskResult {
-    Success(CacheResult),
+    Success,
     Failure,
 }
 

--- a/crates/turborepo-ui/src/tui/handle.rs
+++ b/crates/turborepo-ui/src/tui/handle.rs
@@ -3,7 +3,10 @@ use std::{
     time::Instant,
 };
 
-use super::{event::CacheResult, Event, TaskResult};
+use super::{
+    event::{CacheResult, OutputLogs},
+    Event, TaskResult,
+};
 
 /// Struct for sending app events to TUI rendering
 #[derive(Debug, Clone)]
@@ -85,11 +88,12 @@ impl TuiTask {
     }
 
     /// Mark the task as started
-    pub fn start(&self) {
+    pub fn start(&self, output_logs: OutputLogs) {
         self.handle
             .primary
             .send(Event::StartTask {
                 task: self.name.clone(),
+                output_logs,
             })
             .ok();
     }

--- a/crates/turborepo-ui/src/tui/handle.rs
+++ b/crates/turborepo-ui/src/tui/handle.rs
@@ -3,7 +3,7 @@ use std::{
     time::Instant,
 };
 
-use super::{Event, TaskResult};
+use super::{event::CacheResult, Event, TaskResult};
 
 /// Struct for sending app events to TUI rendering
 #[derive(Debug, Clone)]
@@ -95,8 +95,11 @@ impl TuiTask {
     }
 
     /// Mark the task as finished
-    pub fn succeeded(&self) -> Vec<u8> {
-        self.finish(TaskResult::Success)
+    pub fn succeeded(&self, cache_hit: bool) -> Vec<u8> {
+        self.finish(TaskResult::Success(match cache_hit {
+            true => CacheResult::Hit,
+            false => CacheResult::Miss,
+        }))
     }
 
     /// Mark the task as finished

--- a/crates/turborepo-ui/src/tui/handle.rs
+++ b/crates/turborepo-ui/src/tui/handle.rs
@@ -99,11 +99,8 @@ impl TuiTask {
     }
 
     /// Mark the task as finished
-    pub fn succeeded(&self, cache_hit: bool) -> Vec<u8> {
-        self.finish(TaskResult::Success(match cache_hit {
-            true => CacheResult::Hit,
-            false => CacheResult::Miss,
-        }))
+    pub fn succeeded(&self) -> Vec<u8> {
+        self.finish(TaskResult::Success)
     }
 
     /// Mark the task as finished
@@ -132,7 +129,7 @@ impl TuiTask {
             .ok();
     }
 
-    pub fn status(&self, status: &str) {
+    pub fn status(&self, status: &str, result: CacheResult) {
         // Since this will be rendered via ratatui we any ANSI escape codes will not be
         // handled.
         // TODO: prevent the status from having ANSI codes in this scenario
@@ -142,6 +139,7 @@ impl TuiTask {
             .send(Event::Status {
                 task: self.name.clone(),
                 status,
+                result,
             })
             .ok();
     }

--- a/crates/turborepo-ui/src/tui/table.rs
+++ b/crates/turborepo-ui/src/tui/table.rs
@@ -48,7 +48,7 @@ impl<'b> TaskTable<'b> {
             Row::new(vec![
                 Cell::new(task.name()),
                 Cell::new(match task.result() {
-                    TaskResult::Success => Text::raw("✔").style(Style::default().light_green()),
+                    TaskResult::Success(_) => Text::raw("✔").style(Style::default().light_green()),
                     TaskResult::Failure => Text::raw("✘").style(Style::default().red()),
                 }),
             ])

--- a/crates/turborepo-ui/src/tui/table.rs
+++ b/crates/turborepo-ui/src/tui/table.rs
@@ -48,7 +48,7 @@ impl<'b> TaskTable<'b> {
             Row::new(vec![
                 Cell::new(task.name()),
                 Cell::new(match task.result() {
-                    TaskResult::Success(_) => Text::raw("✔").style(Style::default().light_green()),
+                    TaskResult::Success => Text::raw("✔").style(Style::default().light_green()),
                     TaskResult::Failure => Text::raw("✘").style(Style::default().red()),
                 }),
             ])

--- a/crates/turborepo-ui/src/tui/term_output.rs
+++ b/crates/turborepo-ui/src/tui/term_output.rs
@@ -2,7 +2,11 @@ use std::io::Write;
 
 use turborepo_vt100 as vt100;
 
-use super::{app::Direction, event::{OutputLogs, TaskResult}, Error};
+use super::{
+    app::Direction,
+    event::{CacheResult, OutputLogs, TaskResult},
+    Error,
+};
 
 pub struct TerminalOutput<W> {
     rows: u16,
@@ -12,6 +16,7 @@ pub struct TerminalOutput<W> {
     pub status: Option<String>,
     pub output_logs: Option<OutputLogs>,
     pub task_result: Option<TaskResult>,
+    pub cache_result: Option<CacheResult>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -31,6 +36,7 @@ impl<W> TerminalOutput<W> {
             status: None,
             output_logs: None,
             task_result: None,
+            cache_result: None,
         }
     }
 
@@ -65,14 +71,10 @@ impl<W> TerminalOutput<W> {
             OutputLogs::None => LogBehavior::Nothing,
             OutputLogs::HashOnly => LogBehavior::Status,
             OutputLogs::NewOnly => {
-                // TODO: we should print if there was a cache miss, but task didn't finish run
-                if matches!(
-                    self.task_result,
-                    Some(TaskResult::Success(super::event::CacheResult::Miss)),
-                ) {
+                if matches!(self.cache_result, Some(super::event::CacheResult::Miss),) {
                     LogBehavior::Full
                 } else {
-                    LogBehavior::Nothing
+                    LogBehavior::Status
                 }
             }
             OutputLogs::ErrorsOnly => {

--- a/crates/turborepo-ui/src/tui/term_output.rs
+++ b/crates/turborepo-ui/src/tui/term_output.rs
@@ -2,7 +2,7 @@ use std::io::Write;
 
 use turborepo_vt100 as vt100;
 
-use super::{app::Direction, Error};
+use super::{app::Direction, event::{OutputLogs, TaskResult}, Error};
 
 pub struct TerminalOutput<W> {
     rows: u16,
@@ -10,6 +10,15 @@ pub struct TerminalOutput<W> {
     pub parser: vt100::Parser,
     pub stdin: Option<W>,
     pub status: Option<String>,
+    pub output_logs: Option<OutputLogs>,
+    pub task_result: Option<TaskResult>,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum LogBehavior {
+    Full,
+    Status,
+    Nothing,
 }
 
 impl<W> TerminalOutput<W> {
@@ -20,6 +29,8 @@ impl<W> TerminalOutput<W> {
             rows,
             cols,
             status: None,
+            output_logs: None,
+            task_result: None,
         }
     }
 
@@ -48,21 +59,55 @@ impl<W> TerminalOutput<W> {
         Ok(())
     }
 
+    fn persist_behavior(&self) -> LogBehavior {
+        match self.output_logs.unwrap_or(OutputLogs::Full) {
+            OutputLogs::Full => LogBehavior::Full,
+            OutputLogs::None => LogBehavior::Nothing,
+            OutputLogs::HashOnly => LogBehavior::Status,
+            OutputLogs::NewOnly => {
+                // TODO: we should print if there was a cache miss, but task didn't finish run
+                if matches!(
+                    self.task_result,
+                    Some(TaskResult::Success(super::event::CacheResult::Miss)),
+                ) {
+                    LogBehavior::Full
+                } else {
+                    LogBehavior::Nothing
+                }
+            }
+            OutputLogs::ErrorsOnly => {
+                if matches!(self.task_result, Some(TaskResult::Failure)) {
+                    LogBehavior::Full
+                } else {
+                    LogBehavior::Nothing
+                }
+            }
+        }
+    }
+
     #[tracing::instrument(skip(self))]
     pub fn persist_screen(&self, task_name: &str) -> std::io::Result<()> {
-        let screen = self.parser.entire_screen();
-        let title = self.title(task_name);
         let mut stdout = std::io::stdout().lock();
-        stdout.write_all("┌".as_bytes())?;
-        stdout.write_all(title.as_bytes())?;
-        stdout.write_all(b"\r\n")?;
-        for row in screen.rows_formatted(0, self.cols) {
-            stdout.write_all("│ ".as_bytes())?;
-            stdout.write_all(&row)?;
-            stdout.write_all(b"\r\n")?;
+        let title = self.title(task_name);
+        match self.persist_behavior() {
+            LogBehavior::Full => {
+                let screen = self.parser.entire_screen();
+                stdout.write_all("┌".as_bytes())?;
+                stdout.write_all(title.as_bytes())?;
+                stdout.write_all(b"\r\n")?;
+                for row in screen.rows_formatted(0, self.cols) {
+                    stdout.write_all("│ ".as_bytes())?;
+                    stdout.write_all(&row)?;
+                    stdout.write_all(b"\r\n")?;
+                }
+                stdout.write_all("└────>\r\n".as_bytes())?;
+            }
+            LogBehavior::Status => {
+                stdout.write_all(title.as_bytes())?;
+                stdout.write_all(b"\r\n")?;
+            }
+            LogBehavior::Nothing => (),
         }
-        stdout.write_all("└────>\r\n".as_bytes())?;
-
         Ok(())
     }
 }


### PR DESCRIPTION
### Description

This hooks up the `--output-logs` flag  and `outputLogs` in `turbo.json` to the logic that persists task output.

Previously these values were not respected and task output was always printed.

### Testing Instructions

`new-only` should only print cache status on a cache hit, but everything on a miss.
```
[0 olszewski@chriss-mbp] /tmp/tui-output-logs $ turbo_dev --skip-infer build --output-logs=new-only --no-daemon                 12:46:14 [2/570]
• Packages in scope: @repo/eslint-config, @repo/typescript-config, @repo/ui, docs, web                                                          
• Running build in 5 packages                                                                                                                   
• Remote caching disabled
┌ web#build > cache miss, executing e45fd0a9bad40e92 
│ 
│ > web@0.1.0 build /private/tmp/tui-output-logs/apps/web
│ > next build
│ 
│   ▲ Next.js 15.0.0-rc.0
│ 
│    Creating an optimized production build ...
│  ✓ Compiled successfully
│  ✓ Linting and checking validity of types    
│  ✓ Collecting page data    
│  ✓ Generating static pages (5/5)
│  ✓ Collecting build traces    
│  ✓ Finalizing page optimization     
│ 
│ Route (app)                              Size     First Load JS
│ ┌ ○ /                                    5.53 kB        94.4 kB
│ └ ○ /_not-found                          895 B          89.8 kB
│ + First Load JS shared by all            88.9 kB
│   ├ chunks/207a5ba7-ac24752941b7dbc9.js  51.5 kB
│   ├ chunks/479-8568a017162d290a.js       35.5 kB
│   └ other shared chunks (total)          1.88 kB
│ 
│ 
│ ○  (Static)  prerendered as static content
└────>
┌ docs#build > cache miss, executing 5176bc1351e4bb6b 
│ 
│ > docs@0.1.0 build /private/tmp/tui-output-logs/apps/docs
│ > next build
│ 
│   ▲ Next.js 15.0.0-rc.0
│ 
│    Creating an optimized production build ...
│  ✓ Compiled successfully
│  ✓ Linting and checking validity of types    
│  ✓ Collecting page data    
│  ✓ Generating static pages (5/5)
│  ✓ Collecting build traces    
│  ✓ Finalizing page optimization     
│ 
│ Route (app)                              Size     First Load JS
│ ┌ ○ /                                    5.53 kB        94.4 kB
│ └ ○ /_not-found                          895 B          89.8 kB
│ + First Load JS shared by all            88.9 kB
│   ├ chunks/207a5ba7-ac24752941b7dbc9.js  51.5 kB
│   ├ chunks/479-8568a017162d290a.js       35.5 kB
│   └ other shared chunks (total)          1.88 kB
│ 
│ 
│ ○  (Static)  prerendered as static content
└────>

 Tasks:    2 successful, 2 total
Cached:    0 cached, 2 total
  Time:    8.692s 

[0 olszewski@chriss-mbp] /tmp/tui-output-logs $ turbo_dev --skip-infer build --output-logs=new-only --no-daemon
• Packages in scope: @repo/eslint-config, @repo/typescript-config, @repo/ui, docs, web
• Running build in 5 packages
• Remote caching disabled
 web#build > cache hit, suppressing logs e45fd0a9bad40e92 
 docs#build > cache hit, suppressing logs 5176bc1351e4bb6b 

 Tasks:    2 successful, 2 total
Cached:    2 cached, 2 total
  Time:    110ms >>> FULL TURBO
```

`hash-only` should only persist the status line:
```
[0 olszewski@chriss-mbp] /tmp/tui-output-logs $ turbo_dev --skip-infer build --output-logs=hash-only --no-daemon
• Packages in scope: @repo/eslint-config, @repo/typescript-config, @repo/ui, docs, web
• Running build in 5 packages
• Remote caching disabled
 docs#build > cache hit, suppressing logs 5176bc1351e4bb6b 
 web#build > cache hit, suppressing logs e45fd0a9bad40e92 

 Tasks:    2 successful, 2 total
Cached:    2 cached, 2 total
  Time:    138ms >>> FULL TURBO

[0 olszewski@chriss-mbp] /tmp/tui-output-logs $ turbo_dev --skip-infer build --output-logs=hash-only --no-daemon --force
• Packages in scope: @repo/eslint-config, @repo/typescript-config, @repo/ui, docs, web
• Running build in 5 packages
• Remote caching disabled
 web#build > cache bypass, force executing e45fd0a9bad40e92 
 docs#build > cache bypass, force executing 5176bc1351e4bb6b 

 Tasks:    2 successful, 2 total
Cached:    0 cached, 2 total
  Time:    10.807s 
```

`errors-only` should only output errors:
```
[0 olszewski@chriss-mbp] /tmp/tui-output-logs $ turbo_dev --skip-infer build --output-logs=errors-only --no-daemon --force --continue
• Packages in scope: @repo/eslint-config, @repo/typescript-config, @repo/ui, docs, web
• Running build in 5 packages
• Remote caching disabled
┌ web#build > cache miss, executing a9ef756a1783f051 
│ 
│ > web@0.1.0 build /private/tmp/tui-output-logs/apps/web
│ > sleep 1; echo oops; exit 1
│ 
│ oops
│  ELIFECYCLE  Command failed with exit code 1.
│ 
│ command finished with error, but continuing...
└────>
web#build: command (/private/tmp/tui-output-logs/apps/web) /Users/olszewski/.nvm/versions/node/v20.11.1/bin/pnpm run build exited (1)

 Tasks:    1 successful, 2 total
Cached:    0 cached, 2 total
  Time:    8.07s 
Failed:    web#build
```