### PR TITLE
fix(docs): update docs typo

### DIFF
--- a/docs/repo-docs/guides/tools/typescript.mdx
+++ b/docs/repo-docs/guides/tools/typescript.mdx
@@ -69,8 +69,7 @@ Inside `packages/tsconfig`, we have a few `json` files which represent different
     "isolatedModules": true,
     "strict": true,
     "noUncheckedIndexedAccess": true,
-    "module": "NodeNext",
-  }
+    "module": "NodeNext"
 }
 ```
 


### PR DESCRIPTION
Removed extra `{` at the end of the code snippet for a tsconfig.json file.
