### PR TITLE
fix: add more windows vars to default pass through env

### DIFF
--- a/crates/turborepo-lib/src/task_hash.rs
+++ b/crates/turborepo-lib/src/task_hash.rs
@@ -490,10 +490,12 @@ impl<'a> TaskHasher<'a> {
                         "APPDATA",
                         "PATH",
                         "SYSTEMROOT",
+                        "SYSTEMDRIVE",
                         // Powershell casing of env variables
                         "Path",
                         "SystemRoot",
                         "AppData",
+                        "SystemDrive",
                     ])?;
                 let tracker_env = self
                     .task_hash_tracker

--- a/crates/turborepo-lib/src/task_hash.rs
+++ b/crates/turborepo-lib/src/task_hash.rs
@@ -489,10 +489,12 @@ impl<'a> TaskHasher<'a> {
                         // Command Prompt casing of env variables
                         "APPDATA",
                         "PATH",
+                        "PROGRAMDATA",
                         "SYSTEMROOT",
                         "SYSTEMDRIVE",
                         // Powershell casing of env variables
                         "Path",
+                        "ProgramData",
                         "SystemRoot",
                         "AppData",
                         "SystemDrive",


### PR DESCRIPTION
### Description

Fixes https://github.com/vercel/turbo/issues/8553

### Testing Instructions

User confirmed that adding `SystemRoot` to pass through fixed his issue: https://github.com/vercel/turbo/issues/8553#issuecomment-2194773860