### PR TITLE
fix(turborepo): update package.json typo

### DIFF
--- a/examples/kitchen-sink/apps/blog/package.json
+++ b/examples/kitchen-sink/apps/blog/package.json
@@ -12,7 +12,7 @@
     "@remix-run/node": "^2.9.2",
     "@remix-run/react": "^2.9.2",
     "@remix-run/server-runtime": "^2.9.2",
-    "@repo/ui": "workspace:^",
+    "@repo/ui": "workspace:*",
     "@vercel/analytics": "^1.2.2",
     "@vercel/remix": "2.9.2-patch.2",
     "isbot": "^4",


### PR DESCRIPTION
`@repo/ui` is being used as a monorepo dependency and `^` is not a valid version number. This is supposed to be `*` as it is in other packages. This causes `npm install` to fail while installing dependencies.
