### PR TITLE
Memory: Use `triomphe::Arc` for `SharedReference`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10012,12 +10012,13 @@ dependencies = [
 
 [[package]]
 name = "triomphe"
-version = "0.1.11"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "859eb650cfee7434994602c3a68b25d77ad9e68c8a6cd491616ef86661382eb3"
+checksum = "e6631e42e10b40c0690bf92f404ebcfe6e1fdb480391d15f17cc8e96eeed5369"
 dependencies = [
  "serde",
  "stable_deref_trait",
+ "unsize",
 ]
 
 [[package]]
@@ -10144,10 +10145,12 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "triomphe",
  "turbo-tasks-build",
  "turbo-tasks-hash",
  "turbo-tasks-macros",
  "turbo-tasks-malloc",
+ "unsize",
 ]
 
 [[package]]
@@ -11558,7 +11561,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.4.6",
+ "rand 0.8.5",
  "static_assertions",
 ]
 
@@ -11717,6 +11720,15 @@ name = "unsafe-libyaml"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1865806a559042e51ab5414598446a5871b561d21b6764f2eabb0dd481d880a6"
+
+[[package]]
+name = "unsize"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fa7a7a734c1a5664a662ddcea0b6c9472a21da8888c957c7f1eaa09dba7a939"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -299,12 +299,14 @@ tokio-util = { version = "0.7.7", features = ["io"] }
 tracing = "0.1.37"
 tracing-appender = "0.2.2"
 tracing-subscriber = "0.3.16"
+triomphe = "0.1.13"
 tui-term = { version = "0.1.9", default-features = false }
 url = "2.2.2"
 urlencoding = "2.1.2"
 webbrowser = "0.8.7"
 which = "4.4.0"
 unicode-segmentation = "1.10.1"
+unsize = "1.1.0"
 
 [patch.crates-io]
 # TODO: Use upstream when https://github.com/servo/pathfinder/pull/566 lands

--- a/crates/node-file-trace/src/lib.rs
+++ b/crates/node-file-trace/src/lib.rs
@@ -474,7 +474,7 @@ async fn run<B: Backend + 'static, F: Future<Output = ()>>(
         Box::pin(async move {
             let output = main_operation(
                 TransientValue::new(dir.clone()),
-                args.clone().into(),
+                TransientInstance::new(args.clone()),
                 module_options,
                 resolve_options,
             );
@@ -513,7 +513,7 @@ async fn run<B: Backend + 'static, F: Future<Output = ()>>(
 #[turbo_tasks::function]
 async fn main_operation(
     current_dir: TransientValue<PathBuf>,
-    args: TransientInstance<Args>,
+    args: TransientInstance<Arc<Args>>,
     module_options: TransientInstance<ModuleOptionsContext>,
     resolve_options: TransientInstance<ResolveOptionsContext>,
 ) -> Result<Vc<Vec<RcStr>>> {
@@ -533,7 +533,7 @@ async fn main_operation(
     let fs = create_fs("context directory", &context_directory, watch).await?;
     let process_cwd = process_cwd.clone().map(RcStr::from);
 
-    match *args {
+    match **args {
         Args::Print { common: _ } => {
             let input = process_input(&dir, &context_directory, input).unwrap();
             let mut result = BTreeSet::new();

--- a/crates/turbo-tasks/Cargo.toml
+++ b/crates/turbo-tasks/Cargo.toml
@@ -40,9 +40,11 @@ serde_regex = "1.1.0"
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tracing = { workspace = true }
+triomphe = { workspace = true, features = ["unsize"] }
 turbo-tasks-hash = { workspace = true }
 turbo-tasks-macros = { workspace = true }
 turbo-tasks-malloc = { workspace = true }
+unsize = { workspace = true }
 
 [dev-dependencies]
 serde_test = "1.0.157"

--- a/crates/turbo-tasks/src/backend.rs
+++ b/crates/turbo-tasks/src/backend.rs
@@ -162,8 +162,8 @@ impl CellContent {
         let data = self.0.ok_or_else(|| anyhow!("Cell is empty"))?;
         let data = data
             .downcast()
-            .ok_or_else(|| anyhow!("Unexpected type in cell"))?;
-        Ok(ReadRef::new(data))
+            .map_err(|_err| anyhow!("Unexpected type in cell"))?;
+        Ok(ReadRef::new_arc(data))
     }
 
     /// # Safety
@@ -185,8 +185,7 @@ impl CellContent {
     }
 
     pub fn try_cast<T: Any + VcValueType>(self) -> Option<ReadRef<T>> {
-        self.0
-            .and_then(|data| data.downcast().map(|data| ReadRef::new(data)))
+        Some(ReadRef::new_arc(self.0?.downcast().ok()?))
     }
 }
 

--- a/crates/turbo-tasks/src/lib.rs
+++ b/crates/turbo-tasks/src/lib.rs
@@ -68,6 +68,7 @@ mod state;
 pub mod task;
 pub mod trace;
 mod trait_ref;
+mod triomphe_utils;
 pub mod util;
 mod value;
 mod value_type;

--- a/crates/turbo-tasks/src/manager.rs
+++ b/crates/turbo-tasks/src/manager.rs
@@ -1469,9 +1469,9 @@ impl CurrentCellRef {
             tt.update_own_task_cell(
                 self.current_task,
                 self.index,
-                CellContent(Some(SharedReference(
+                CellContent(Some(SharedReference::new(
                     Some(self.index.type_id),
-                    Arc::new(update),
+                    triomphe::Arc::new(update),
                 ))),
             )
         }
@@ -1493,9 +1493,9 @@ impl CurrentCellRef {
         tt.update_own_task_cell(
             self.current_task,
             self.index,
-            CellContent(Some(SharedReference(
+            CellContent(Some(SharedReference::new(
                 Some(self.index.type_id),
-                Arc::new(new_content),
+                triomphe::Arc::new(new_content),
             ))),
         )
     }

--- a/crates/turbo-tasks/src/triomphe_utils.rs
+++ b/crates/turbo-tasks/src/triomphe_utils.rs
@@ -1,0 +1,33 @@
+use std::any::Any;
+
+use unsize::Coercion;
+
+/// Attempt to downcast a `triomphe::Arc<dyn Any + Send + Sync>` to a concrete
+/// type.
+///
+/// Ported from [`std::sync::Arc::downcast`] to [`triomphe::Arc`].
+pub fn downcast_triomphe_arc<T: Any + Send + Sync>(
+    this: triomphe::Arc<dyn Any + Send + Sync>,
+) -> Result<triomphe::Arc<T>, triomphe::Arc<dyn Any + Send + Sync>> {
+    if (*this).is::<T>() {
+        unsafe {
+            // Get the pointer to the offset (*const T) inside of the ArcInner.
+            let ptr = triomphe::Arc::into_raw(this);
+            // SAFETY: The negative offset from the data (ptr) in an Arc to the start of the
+            // data structure is fixed regardless of type `T`.
+            //
+            // SAFETY: Casting from a fat pointer to a thin pointer is safe, as long as the
+            // types are compatible (they are).
+            Ok(triomphe::Arc::from_raw(ptr.cast()))
+        }
+    } else {
+        Err(this)
+    }
+}
+
+/// [`Coerce::to_any`] except that it coerces to `dyn Any + Send + Sync` as
+/// opposed to `dyn Any`.
+pub fn coerce_to_any_send_sync<T: Any + Send + Sync>() -> Coercion<T, dyn Any + Send + Sync> {
+    // SAFETY: The signature of this function guarantees the coercion is valid
+    unsafe { Coercion::new(|x| x) }
+}

--- a/crates/turbo-tasks/src/value_type.rs
+++ b/crates/turbo-tasks/src/value_type.rs
@@ -146,7 +146,7 @@ impl ValueType {
 
     pub fn any_as_serializable<'a>(
         &self,
-        arc: &'a Arc<dyn Any + Sync + Send>,
+        arc: &'a triomphe::Arc<dyn Any + Sync + Send>,
     ) -> Option<&'a dyn erased_serde::Serialize> {
         if let Some(s) = self.any_serialization {
             Some((s.0)(&**arc))

--- a/crates/turbopack-cli/src/dev/mod.rs
+++ b/crates/turbopack-cli/src/dev/mod.rs
@@ -196,25 +196,25 @@ impl TurbopackDevServerBuilder {
         let show_all = self.show_all;
         let log_detail: bool = self.log_detail;
         let browserslist_query: RcStr = self.browserslist_query;
-        let log_args = Arc::new(LogOptions {
+        let log_args = TransientInstance::new(LogOptions {
             current_dir: current_dir().unwrap(),
             project_dir: PathBuf::from(project_dir.clone()),
             show_all,
             log_detail,
             log_level: self.log_level,
         });
-        let entry_requests = Arc::new(self.entry_requests);
+        let entry_requests = TransientInstance::new(self.entry_requests);
         let tasks = turbo_tasks.clone();
         let issue_provider = self.issue_reporter.unwrap_or_else(|| {
             // Initialize a ConsoleUi reporter if no custom reporter was provided
-            Box::new(move || Vc::upcast(ConsoleUi::new(log_args.clone().into())))
+            Box::new(move || Vc::upcast(ConsoleUi::new(log_args.clone())))
         });
 
         let source = move || {
             source(
                 root_dir.clone(),
                 project_dir.clone(),
-                entry_requests.clone().into(),
+                entry_requests.clone(),
                 eager_compile,
                 browserslist_query.clone(),
             )

--- a/crates/turbopack-core/src/issue/mod.rs
+++ b/crates/turbopack-core/src/issue/mod.rs
@@ -5,7 +5,6 @@ pub mod resolve;
 use std::{
     cmp::{min, Ordering},
     fmt::{Display, Formatter},
-    sync::Arc,
 };
 
 use anyhow::{anyhow, Result};
@@ -713,7 +712,7 @@ impl PlainSource {
         let asset_content = asset.content().await?;
         let content = match *asset_content {
             AssetContent::File(file_content) => file_content.await?,
-            AssetContent::Redirect { .. } => ReadRef::new(Arc::new(FileContent::NotFound)),
+            AssetContent::Redirect { .. } => ReadRef::new_owned(FileContent::NotFound),
         };
 
         Ok(PlainSource {


### PR DESCRIPTION
### Description

This eliminates the unused weakref count in `std::sync::Arc`, saving 64 bits per unique `SharedReference`.

I noticed there's additional potential optimizations we could do here too (not included in this PR), of increasing levels of difficulty:

- We can deduplicate `ValueTypeId` by moving it inside the `Arc`.

- We can build a mapping of `std::any::TypeId` to `ValueTypeId`, and avoid storing the `ValueTypeId` entirely.

- We can deduplicate the fat pointer's layout metadata by also storing it inside the `Arc` using the nightly `ptr_metadata` feature, similar to `triomphe::ThinArc` (but that only works for slices of non-dst elements, presumably because they don't want to depend on nightly).

### Testing Instructions

Using dhat for measuring the max heap size (vercel/next.js/67166)...

Do a release build

```
PACK_NEXT_COMPRESS=objcopy-zstd pnpm pack-next --release --features __internal_dhat-heap
```

Start the dev server in shadcn-ui, and try to load the homepage:

```
pnpm i
pnpm --filter=www dev --turbo
curl http://localhost:3003/
```

After curl exits, kill the dev server.

```
pkill -INT next-server
```

**Before (2 Runs):**

```
[dhat]: Teardown profiler
dhat: Total:     3,106,545,900 bytes in 20,113,580 blocks
dhat: At t-gmax: 731,860,693 bytes in 4,924,028 blocks
dhat: At t-end:  731,860,693 bytes in 4,924,028 blocks
```

```
[dhat]: Teardown profiler
dhat: Total:     3,108,036,858 bytes in 20,111,694 blocks
dhat: At t-gmax: 730,059,664 bytes in 4,923,002 blocks
dhat: At t-end:  730,059,536 bytes in 4,923,001 blocks
```


**After (2 Runs):**

```
[dhat]: Teardown profiler
dhat: Total:     3,093,298,170 bytes in 20,127,818 blocks
dhat: At t-gmax: 727,258,939 bytes in 4,923,863 blocks
dhat: At t-end:  727,155,146 bytes in 4,923,901 blocks
```

```
[dhat]: Teardown profiler
dhat: Total:     3,102,661,690 bytes in 20,124,408 blocks
dhat: At t-gmax: 728,190,876 bytes in 4,924,856 blocks
dhat: At t-end:  728,124,976 bytes in 4,924,236 blocks
```

This is [a 0.4426% reduction](https://www.wolframalpha.com/input?i=Percent+change+from+%28731%2C860%2C693%2B730%2C059%2C664%29%2F2+to+%28727%2C258%2C939%2B728%2C190%2C876%29%2F2).