### PR TITLE
fix(ui): disable mouse scroll to enable copy

### DIFF
--- a/crates/turborepo-ui/src/tui/app.rs
+++ b/crates/turborepo-ui/src/tui/app.rs
@@ -181,11 +181,7 @@ fn startup() -> io::Result<Terminal<CrosstermBackend<Stdout>>> {
     let mut stdout = io::stdout();
     // Ensure all pending writes are flushed before we switch to alternative screen
     stdout.flush()?;
-    crossterm::execute!(
-        stdout,
-        crossterm::event::EnableMouseCapture,
-        crossterm::terminal::EnterAlternateScreen
-    )?;
+    crossterm::execute!(stdout, crossterm::terminal::EnterAlternateScreen)?;
     let backend = CrosstermBackend::new(stdout);
 
     let mut terminal = Terminal::with_options(
@@ -208,7 +204,6 @@ fn cleanup<B: Backend + io::Write, I>(
     terminal.clear()?;
     crossterm::execute!(
         terminal.backend_mut(),
-        crossterm::event::DisableMouseCapture,
         crossterm::terminal::LeaveAlternateScreen,
     )?;
     let started_tasks = app.table.tasks_started();


### PR DESCRIPTION
### Description

This PR disables the ability to scroll via the mouse in favor of keeping built in terminal mouse operations. 

### Testing Instructions

Copy some text in the pane
<img width="897" alt="Screenshot 2024-06-28 at 9 10 36 AM" src="https://github.com/vercel/turbo/assets/4131117/ae7e8f02-78f2-4fe9-a62e-c8e0640411d6">

