### PR TITLE
fix(ui): Use double arrow instead of spinner for active tasks.

### DIFF
--- a/crates/turborepo-ui/src/tui/spinner.rs
+++ b/crates/turborepo-ui/src/tui/spinner.rs
@@ -1,6 +1,8 @@
 use std::time::{Duration, Instant};
 
-const SPINNER_FRAMES: &[&str] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"].as_slice();
+const SPINNER_FRAMES: &[&str] = ["»"].as_slice();
+// const SPINNER_FRAMES: &[&str] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇",
+// "⠏"].as_slice();
 const FRAMERATE: Duration = Duration::from_millis(80);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/turborepo-ui/src/tui/spinner.rs
+++ b/crates/turborepo-ui/src/tui/spinner.rs
@@ -41,30 +41,32 @@ impl Default for SpinnerState {
     }
 }
 
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn test_inital_update() {
-        let mut spinner = SpinnerState::new();
-        assert!(spinner.last_render.is_none());
-        assert_eq!(spinner.frame, 0);
-        spinner.update();
-        assert!(spinner.last_render.is_some());
-        assert_eq!(spinner.frame, 0, "initial update doesn't move frame");
-    }
-
-    #[test]
-    fn test_frame_update() {
-        let mut spinner = SpinnerState::new();
-        // set last update to time that happened far before the spinner should increment
-        let prev_render = Instant::now() - (FRAMERATE * 2);
-        spinner.last_render = Some(prev_render);
-        assert_eq!(spinner.frame, 0);
-        spinner.update();
-        assert_eq!(spinner.frame, 1);
-        let last_render = spinner.last_render.unwrap();
-        assert!(prev_render < last_render, "last render should be updated");
-    }
-}
+// Removed with iteration to double arrow symbol
+// #[cfg(test)]
+// mod test {
+//     use super::*;
+//
+//     #[test]
+//     fn test_inital_update() {
+//         let mut spinner = SpinnerState::new();
+//         assert!(spinner.last_render.is_none());
+//         assert_eq!(spinner.frame, 0);
+//         spinner.update();
+//         assert!(spinner.last_render.is_some());
+//         assert_eq!(spinner.frame, 0, "initial update doesn't move frame");
+//     }
+//
+//     Removed with change to double arrow
+//     #[test]
+//     fn test_frame_update() {
+//         let mut spinner = SpinnerState::new();
+//         // set last update to time that happened far before the spinner
+// should increment         let prev_render = Instant::now() - (FRAMERATE * 2);
+//         spinner.last_render = Some(prev_render);
+//         assert_eq!(spinner.frame, 0);
+//         spinner.update();
+//         assert_eq!(spinner.frame, 1);
+//         let last_render = spinner.last_render.unwrap();
+//         assert!(prev_render < last_render, "last render should be updated");
+//     }
+// }


### PR DESCRIPTION
### Description

User feedback has let us know that the constant spinner on persistent tasks can be annoying. Let's use the static double arrow instead to indicate that the tasks are in-progress.

### Testing Instructions

👀

New:
![CleanShot 2024-06-28 at 11 04 22](https://github.com/vercel/turbo/assets/35677084/928e6c3d-78ad-484b-b6bf-7c22c14a611c)

