### PR TITLE
fix(examples): correct next.config extension in tsconfig

### DIFF
--- a/examples/basic/apps/docs/tsconfig.json
+++ b/examples/basic/apps/docs/tsconfig.json
@@ -9,7 +9,7 @@
   },
   "include": [
     "next-env.d.ts",
-    "next.config.js",
+    "next.config.mjs",
     "**/*.ts",
     "**/*.tsx",
     ".next/types/**/*.ts"

--- a/examples/basic/apps/web/tsconfig.json
+++ b/examples/basic/apps/web/tsconfig.json
@@ -9,7 +9,7 @@
   },
   "include": [
     "next-env.d.ts",
-    "next.config.js",
+    "next.config.mjs",
     "**/*.ts",
     "**/*.tsx",
     ".next/types/**/*.ts"


### PR DESCRIPTION
### Description

Change next.config extension in `tsconfig.json` from `next.config.js` to `next.config.mjs` because the file actually is `next.config.mjs`