### PR TITLE
docs(turborepo): correct default `ui` config value

### DIFF
--- a/docs/repo-docs/reference/configuration.mdx
+++ b/docs/repo-docs/reference/configuration.mdx
@@ -83,7 +83,7 @@ Additionally, Turborepo has a built-in set of global passthrough variables for c
 
 ### ui
 
-Default: `"tui"`
+Default: `"stream"`
 
 Select a terminal UI for the repository.
 


### PR DESCRIPTION
### Description

`v2.0.6` flipped the default `ui` config back to `stream`: #8631