### PR TITLE
fix(docs): fix broken link

### DIFF
--- a/docs/repo-docs/crafting-your-repository/configuring-tasks.mdx
+++ b/docs/repo-docs/crafting-your-repository/configuring-tasks.mdx
@@ -99,7 +99,7 @@ If you run `turbo run build` at this point, Turborepo will run all `build` scrip
 
 You now have the build order you would expect, building _dependencies_ before _dependents_.
 
-**But be careful.** At this point, you haven't marked the build outputs for caching. To do so, jump to the [Specifying outputs](#specifying-options) section.
+**But be careful.** At this point, you haven't marked the build outputs for caching. To do so, jump to the [Specifying outputs](#specifying-outputs) section.
 
 #### Depending on tasks in dependencies with `^`
 

--- a/docs/repo-docs/guides/tools/prisma.mdx
+++ b/docs/repo-docs/guides/tools/prisma.mdx
@@ -18,7 +18,7 @@ This guide shows you how to:
 2. Handle migration and code generation scripts
 3. Ensure that they're always run whenever `dev` or `build` is run
 
-If you've already got Prisma set up in your database, you can skip to [step 4](#4-setting-up-the-scripts).
+If you've already got Prisma set up in your database, you can skip to [step 4](#create-scripts).
 
 <Steps>
 <Step>


### PR DESCRIPTION
### Description

While reading the "crafting-your-repository/configuring-tasks" page, I noticed that one link was broken, so I examined the markdown written in `[text](#link)` format.

In addition, the `Interacting with tasks` item on the "crafting-your-repository/developing-applications" page also appears to have a broken link, but I left it as is because I didn't know where to send it to.

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
