### PR TITLE
automatically shrink aggregation lists

### DIFF
--- a/crates/turbo-tasks-auto-hash-map/src/map.rs
+++ b/crates/turbo-tasks-auto-hash-map/src/map.rs
@@ -249,6 +249,25 @@ impl<K: Eq + Hash, V, H: BuildHasher + Default, const I: usize> AutoMap<K, V, H,
             }
         }
     }
+
+    pub fn shrink_amortized(&mut self) {
+        match self {
+            AutoMap::List(list) => {
+                if list.capacity() > list.len() * 2 {
+                    list.shrink_to_fit();
+                }
+            }
+            AutoMap::Map(map) => {
+                if map.len() <= MIN_HASH_SIZE {
+                    let mut list = SmallVec::with_capacity(map.len());
+                    list.extend(map.drain());
+                    *self = AutoMap::List(list);
+                } else if map.capacity() > map.len() * 2 {
+                    map.shrink_to_fit();
+                }
+            }
+        }
+    }
 }
 
 impl<K: Eq + Hash, V, H: BuildHasher, const I: usize> AutoMap<K, V, H, I> {

--- a/crates/turbo-tasks-auto-hash-map/src/map.rs
+++ b/crates/turbo-tasks-auto-hash-map/src/map.rs
@@ -253,7 +253,7 @@ impl<K: Eq + Hash, V, H: BuildHasher + Default, const I: usize> AutoMap<K, V, H,
     pub fn shrink_amortized(&mut self) {
         match self {
             AutoMap::List(list) => {
-                if list.capacity() > list.len() * 2 {
+                if list.capacity() > list.len() * 3 {
                     list.shrink_to_fit();
                 }
             }
@@ -262,7 +262,7 @@ impl<K: Eq + Hash, V, H: BuildHasher + Default, const I: usize> AutoMap<K, V, H,
                     let mut list = SmallVec::with_capacity(map.len());
                     list.extend(map.drain());
                     *self = AutoMap::List(list);
-                } else if map.capacity() > map.len() * 2 {
+                } else if map.capacity() > map.len() * 3 {
                     map.shrink_to_fit();
                 }
             }

--- a/crates/turbo-tasks-memory/src/aggregation/mod.rs
+++ b/crates/turbo-tasks-memory/src/aggregation/mod.rs
@@ -45,15 +45,6 @@ pub enum AggregationNode<I, D> {
     Aggegating(Box<AggegatingNode<I, D>>),
 }
 
-impl<I, D> AggregationNode<I, D> {
-    pub fn new() -> Self {
-        Self::Leaf {
-            aggregation_number: 0,
-            uppers: CountHashSet::new(),
-        }
-    }
-}
-
 /// The aggregation node structure for aggregating nodes.
 pub struct AggegatingNode<I, D> {
     aggregation_number: u32,
@@ -64,6 +55,26 @@ pub struct AggegatingNode<I, D> {
 }
 
 impl<I, A> AggregationNode<I, A> {
+    pub fn new() -> Self {
+        Self::Leaf {
+            aggregation_number: 0,
+            uppers: CountHashSet::new(),
+        }
+    }
+
+    pub fn shrink_to_fit(&mut self)
+    where
+        I: Hash + Eq,
+    {
+        match self {
+            AggregationNode::Leaf { uppers, .. } => uppers.shrink_to_fit(),
+            AggregationNode::Aggegating(aggregating) => {
+                aggregating.uppers.shrink_to_fit();
+                aggregating.followers.shrink_to_fit();
+            }
+        }
+    }
+
     /// Returns the aggregation number of the node.
     pub fn aggregation_number(&self) -> u32 {
         match self {

--- a/crates/turbo-tasks-memory/src/aggregation/notify_lost_follower.rs
+++ b/crates/turbo-tasks-memory/src/aggregation/notify_lost_follower.rs
@@ -27,6 +27,7 @@ impl<I: Clone + Eq + Hash, D> AggregationNode<I, D> {
                 None
             }
             RemoveIfEntryResult::Removed => {
+                aggregating.followers.shrink_amortized();
                 let uppers = aggregating.uppers.iter().cloned().collect::<StackVec<_>>();
                 start_in_progress_all(ctx, &uppers);
                 self.finish_in_progress(ctx, balance_queue, upper_id);
@@ -58,6 +59,7 @@ impl<I: Clone + Eq + Hash, D> AggregationNode<I, D> {
         match aggregating.followers.remove_if_entry(follower_id) {
             RemoveIfEntryResult::PartiallyRemoved => None,
             RemoveIfEntryResult::Removed => {
+                aggregating.followers.shrink_amortized();
                 let uppers = aggregating.uppers.iter().cloned().collect::<StackVec<_>>();
                 start_in_progress_all(ctx, &uppers);
                 Some(PreparedNotifyLostFollower::RemovedFollower {
@@ -162,6 +164,7 @@ impl<C: AggregationContext> PreparedInternalOperation<C> for PreparedNotifyLostF
                                     return;
                                 }
                                 RemoveIfEntryResult::Removed => {
+                                    aggregating.followers.shrink_amortized();
                                     let uppers =
                                         aggregating.uppers.iter().cloned().collect::<StackVec<_>>();
                                     start_in_progress_all(ctx, &uppers);

--- a/crates/turbo-tasks-memory/src/count_hash_set.rs
+++ b/crates/turbo-tasks-memory/src/count_hash_set.rs
@@ -186,6 +186,16 @@ impl<T: Eq + Hash, H: BuildHasher + Default> CountHashSet<T, H> {
             None => 0,
         }
     }
+
+    /// Frees unused memory
+    pub fn shrink_to_fit(&mut self) {
+        self.inner.shrink_to_fit();
+    }
+
+    /// Frees unused memory in an amortized way
+    pub fn shrink_amortized(&mut self) {
+        self.inner.shrink_amortized()
+    }
 }
 
 impl<T: Eq + Hash + Clone, H: BuildHasher + Default> CountHashSet<T, H> {


### PR DESCRIPTION
### Description

When unloading tasks, edges from the aggregation structure are removed, but their memory is not reclaimed as Vecs don't shrink automatically.

This adds a `shrink_amortized` method which shrinks the Vec/HashMap when capacity is 2 times larger than length.

This also calls `shrink_to_fit` when running GC on a task.

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
