### PR TITLE
Turbopack + Relay: don’t manually provide a fallback artifact_directory

### DIFF
--- a/crates/turbopack-ecmascript-plugins/src/transform/relay.rs
+++ b/crates/turbopack-ecmascript-plugins/src/transform/relay.rs
@@ -73,18 +73,9 @@ impl CustomTransformer for RelayTransformer {
                 .context("Expected relative path to relay artifact")?,
         );
 
-        let config = if self.config.artifact_directory.is_some() {
-            self.config.clone()
-        } else {
-            swc_relay::Config {
-                artifact_directory: Some(PathBuf::from("__generated__")),
-                ..self.config
-            }
-        };
-
         let p = std::mem::replace(program, Program::Module(Module::dummy()));
         *program = p.fold_with(&mut swc_relay::relay(
-            &config,
+            &self.config,
             FileName::Real(PathBuf::from(ctx.file_name_str)),
             path_to_proj,
             // [TODO]: pages_dir comes through next-swc-loader


### PR DESCRIPTION
`swc_relay` implements its own logic for locating the `__generated__` directory relative to the input file[0]

Test Plan: `TURBOPACK_BUILD=1 TURBOPACK=1 pnpm test-dev test/integration/relay-graphql-swc-single-project/test/index.test.js`

[0] https://github.com/swc-project/plugins/blob/8c1c1513b9d445e27d47407a9a3dea4fc53e185a/packages/relay/transform/src/lib.rs#L250-L254
