### PR TITLE
Create a minimum viable `ResolvedVc` type

### DIFF
--- a/crates/turbo-tasks/src/lib.rs
+++ b/crates/turbo-tasks/src/lib.rs
@@ -107,9 +107,9 @@ pub use turbo_tasks_macros::{function, value, value_impl, value_trait, TaskInput
 pub use value::{TransientInstance, TransientValue, Value};
 pub use value_type::{TraitMethod, TraitType, ValueType};
 pub use vc::{
-    Dynamic, TypedForInput, Upcast, ValueDefault, Vc, VcCast, VcCellNewMode, VcCellSharedMode,
-    VcDefaultRead, VcRead, VcTransparentRead, VcValueTrait, VcValueTraitCast, VcValueType,
-    VcValueTypeCast,
+    Dynamic, ResolvedVc, TypedForInput, Upcast, ValueDefault, Vc, VcCast, VcCellNewMode,
+    VcCellSharedMode, VcDefaultRead, VcRead, VcTransparentRead, VcValueTrait, VcValueTraitCast,
+    VcValueType, VcValueTypeCast,
 };
 
 pub use crate::rcstr::RcStr;

--- a/crates/turbo-tasks/src/vc/resolved.rs
+++ b/crates/turbo-tasks/src/vc/resolved.rs
@@ -1,0 +1,34 @@
+use std::{
+    hash::{Hash, Hasher},
+    ops::Deref,
+};
+
+use crate::vc::Vc;
+
+#[derive(Copy, Clone)]
+pub struct ResolvedVc<T>
+where
+    T: ?Sized + Send,
+{
+    pub(crate) node: Vc<T>,
+}
+
+impl<T> Deref for ResolvedVc<T>
+where
+    T: ?Sized + Send,
+{
+    type Target = Vc<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.node
+    }
+}
+
+impl<T> Hash for ResolvedVc<T>
+where
+    T: ?Sized + Send,
+{
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.node.hash(state);
+    }
+}


### PR DESCRIPTION
### Description

We want a way to more strongly guarantee that a `Vc` is resolved for the sake of "local" tasks.

This introduces it in a low-risk way with zero breaking changes. Eventually, we'd want to eliminate `.resolve()` or make `.resolve()` return `ResolvedVc` instead of using a separate `.to_resolved()` method.

Some rough notes about why here: https://www.notion.so/vercel/Resolved-Vcs-Vc-Lifetimes-Local-Vcs-and-Vc-Refcounts-49d666d3f9594017b5b312b87ddc5bff

### Testing Instructions

Tested as a part of #8678
