### PR TITLE
add unloading of tasks to GC

### DIFF
--- a/crates/turbo-tasks-memory/src/aggregation/mod.rs
+++ b/crates/turbo-tasks-memory/src/aggregation/mod.rs
@@ -81,7 +81,7 @@ impl<I, A> AggregationNode<I, A> {
             AggregationNode::Leaf {
                 aggregation_number, ..
             } => *aggregation_number as u32,
-            AggregationNode::Aggegating(aggegating) => aggegating.aggregation_number,
+            AggregationNode::Aggegating(aggregating) => aggregating.aggregation_number,
         }
     }
 
@@ -92,21 +92,21 @@ impl<I, A> AggregationNode<I, A> {
     fn uppers(&self) -> &CountHashSet<I> {
         match self {
             AggregationNode::Leaf { uppers, .. } => uppers,
-            AggregationNode::Aggegating(aggegating) => &aggegating.uppers,
+            AggregationNode::Aggegating(aggregating) => &aggregating.uppers,
         }
     }
 
     fn uppers_mut(&mut self) -> &mut CountHashSet<I> {
         match self {
             AggregationNode::Leaf { uppers, .. } => uppers,
-            AggregationNode::Aggegating(aggegating) => &mut aggegating.uppers,
+            AggregationNode::Aggegating(aggregating) => &mut aggregating.uppers,
         }
     }
 
     fn followers(&self) -> Option<&CountHashSet<I>> {
         match self {
             AggregationNode::Leaf { .. } => None,
-            AggregationNode::Aggegating(aggegating) => Some(&aggegating.followers),
+            AggregationNode::Aggegating(aggregating) => Some(&aggregating.followers),
         }
     }
 }

--- a/crates/turbo-tasks-memory/src/gc.rs
+++ b/crates/turbo-tasks-memory/src/gc.rs
@@ -329,8 +329,16 @@ impl GcQueue {
         backend: &MemoryBackend,
         turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackend>,
     ) -> Option<(GcPriority, usize)> {
-        let span =
-            tracing::trace_span!("garbage collection", priority = Empty, count = Empty).entered();
+        let span = tracing::trace_span!(
+            parent: None,
+            "garbage collection",
+            priority = Empty,
+            deactivations_count = Empty,
+            content_dropped_count = Empty,
+            unloaded_count = Empty,
+            already_unloaded_count = Empty
+        )
+        .entered();
 
         let ProcessDeactivationsResult {
             count: deactivations_count,

--- a/crates/turbo-tasks-memory/src/gc.rs
+++ b/crates/turbo-tasks-memory/src/gc.rs
@@ -133,17 +133,19 @@ impl GcQueue {
         self.add_task(task)
     }
 
-    /// Notify the GC queue that a task is inactive
+    /// Notify the GC queue that a task should be enqueue for GC because it is
+    /// inactive.
     #[must_use]
     pub fn task_inactive(&self, task: TaskId) -> u32 {
         self.add_task(task)
     }
 
+    /// Notify the GC queue that a task was active during GC
     pub fn task_gc_active(&self, task: TaskId) {
         self.active_tasks.insert(task);
     }
 
-    /// Notify the GC queue that a task has become active.
+    /// Notify the GC queue that a task might be inactive now.
     pub fn task_potentially_no_longer_active(&self, task: TaskId) {
         if self.active_tasks.remove(&task).is_some() {
             let _ = self.deactivation_queue.push(task);

--- a/crates/turbo-tasks-memory/src/memory_backend.rs
+++ b/crates/turbo-tasks-memory/src/memory_backend.rs
@@ -33,7 +33,7 @@ use crate::{
     edges_set::{TaskEdge, TaskEdgesSet},
     gc::{GcQueue, PERCENTAGE_IDLE_TARGET_MEMORY, PERCENTAGE_TARGET_MEMORY},
     output::Output,
-    task::{GcResult, Task, DEPENDENCIES_TO_TRACK},
+    task::{Task, DEPENDENCIES_TO_TRACK},
     task_statistics::TaskStatisticsApi,
 };
 

--- a/crates/turbo-tasks-memory/src/memory_backend.rs
+++ b/crates/turbo-tasks-memory/src/memory_backend.rs
@@ -3,6 +3,7 @@ use std::{
     cell::RefCell,
     future::Future,
     hash::{BuildHasher, BuildHasherDefault, Hash},
+    num::NonZeroU32,
     pin::Pin,
     sync::{
         atomic::{AtomicBool, Ordering},
@@ -330,7 +331,8 @@ impl Backend for MemoryBackend {
         let generation = if let Some(gc_queue) = &self.gc_queue {
             gc_queue.generation()
         } else {
-            0
+            // SAFETY: 1 is not zero
+            unsafe { NonZeroU32::new_unchecked(1) }
         };
         let (reexecute, once_task) = self.with_task(task_id, |task| {
             (

--- a/crates/turbo-tasks-memory/src/memory_backend.rs
+++ b/crates/turbo-tasks-memory/src/memory_backend.rs
@@ -408,7 +408,7 @@ impl Backend for MemoryBackend {
         } else {
             Task::add_dependency_to_current(TaskEdge::Cell(task_id, index));
             self.with_task(task_id, |task| {
-                match task.with_cell_mut(index, self.gc_queue.as_ref(), |cell| {
+                match task.with_cell_mut(index, self.gc_queue.as_ref(), |cell, _| {
                     cell.read_content(
                         reader,
                         move || format!("{task_id} {index}"),
@@ -445,7 +445,7 @@ impl Backend for MemoryBackend {
         turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackend>,
     ) -> Result<Result<CellContent, EventListener>> {
         self.with_task(task_id, |task| {
-            match task.with_cell_mut(index, self.gc_queue.as_ref(), |cell| {
+            match task.with_cell_mut(index, self.gc_queue.as_ref(), |cell, _| {
                 cell.read_content_untracked(
                     move || format!("{task_id}"),
                     move || format!("reading {} {} untracked", task_id, index),
@@ -505,8 +505,8 @@ impl Backend for MemoryBackend {
         turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackend>,
     ) {
         self.with_task(task, |task| {
-            task.with_cell_mut(index, self.gc_queue.as_ref(), |cell| {
-                cell.assign(content, turbo_tasks)
+            task.with_cell_mut(index, self.gc_queue.as_ref(), |cell, clean| {
+                cell.assign(content, clean, turbo_tasks)
             })
         })
     }

--- a/crates/turbo-tasks-memory/src/memory_backend.rs
+++ b/crates/turbo-tasks-memory/src/memory_backend.rs
@@ -33,7 +33,7 @@ use crate::{
     edges_set::{TaskEdge, TaskEdgesSet},
     gc::{GcQueue, PERCENTAGE_IDLE_TARGET_MEMORY, PERCENTAGE_TARGET_MEMORY},
     output::Output,
-    task::{Task, DEPENDENCIES_TO_TRACK},
+    task::{GcResult, Task, DEPENDENCIES_TO_TRACK},
     task_statistics::TaskStatisticsApi,
 };
 
@@ -137,7 +137,7 @@ impl MemoryBackend {
     pub fn run_gc(
         &self,
         idle: bool,
-        _turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackend>,
+        turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackend>,
     ) -> bool {
         if let Some(gc_queue) = &self.gc_queue {
             let mut did_something = false;
@@ -154,7 +154,7 @@ impl MemoryBackend {
                     return did_something;
                 }
 
-                let collected = gc_queue.run_gc(self);
+                let collected = gc_queue.run_gc(self, turbo_tasks);
 
                 // Collecting less than 100 tasks is not worth it
                 if !collected.map_or(false, |(_, count)| count > 100) {
@@ -332,19 +332,25 @@ impl Backend for MemoryBackend {
         } else {
             0
         };
-        let reexecute = self.with_task(task_id, |task| {
-            task.execution_completed(
-                duration,
-                memory_usage,
-                generation,
-                stateful,
-                self,
-                turbo_tasks,
+        let (reexecute, once_task) = self.with_task(task_id, |task| {
+            (
+                task.execution_completed(
+                    duration,
+                    memory_usage,
+                    generation,
+                    stateful,
+                    self,
+                    turbo_tasks,
+                ),
+                task.is_once(),
             )
         });
         if !reexecute {
             if let Some(gc_queue) = &self.gc_queue {
-                gc_queue.task_executed(task_id);
+                let _ = gc_queue.task_executed(task_id);
+                if once_task {
+                    gc_queue.task_potentially_no_longer_active(task_id);
+                }
                 self.run_gc(false, turbo_tasks);
             }
         }

--- a/crates/turbo-tasks-memory/src/task.rs
+++ b/crates/turbo-tasks-memory/src/task.rs
@@ -1613,7 +1613,8 @@ impl Task {
                 state.aggregation_node.shrink_to_fit();
                 GcResult::Unloaded
             }
-            _ => GcResult::Unloaded,
+            TaskMetaStateWriteGuard::Unloaded(_) => GcResult::Unloaded,
+            TaskMetaStateWriteGuard::TemporaryFiller => unreachable!(),
         }
     }
 

--- a/crates/turbo-tasks-memory/src/task.rs
+++ b/crates/turbo-tasks-memory/src/task.rs
@@ -1701,6 +1701,8 @@ impl Task {
             None
         };
 
+        aggregation_node.shrink_to_fit();
+
         // TODO aggregation_node
         let unset = false;
 


### PR DESCRIPTION
### Description

Inactive tasks can be completely unloaded. This disconnects them from the graph and frees nearly all memory (except for the TaskId mapping).

When running GC for a task we check if it's inactive and unload it when it is.

But we also need to enqueue a task for GC again when it becomes inactive. So we maintain a queue of potentially inactive tasks and walk the children during GC.
