### PR TITLE
remove Go VSCode recommendations in `extensions.json`

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -8,13 +8,11 @@
     "esbenp.prettier-vscode",
     "github.copilot",
     "github.vscode-pull-request-github",
-    "golang.go",
     "heybourn.headwind",
     "ms-azuretools.vscode-docker",
     "ms-vscode-remote.remote-containers",
     "rust-lang.rust-analyzer",
     "unifiedjs.vscode-mdx",
-    "windmilleng.vscode-go-autotest",
     "yzhang.markdown-all-in-one",
     "zxh404.vscode-proto3",
     "mihaipopescu.Cram"


### PR DESCRIPTION
### Description

We don't use Go anymore - so these aren't needed.

### Testing Instructions

It's a no-op to remove these.