### PR TITLE
fix: repo-docs

### DIFF
--- a/docs/repo-docs/crafting-your-repository/structuring-a-repository.mdx
+++ b/docs/repo-docs/crafting-your-repository/structuring-a-repository.mdx
@@ -120,7 +120,7 @@ First, your package manager needs to describe the locations of your packages. We
   ```json title="./package.json"
   {
     "workspaces": [
-      "apps/*"
+      "apps/*",
       "packages/*"
     ]
   }
@@ -132,7 +132,7 @@ First, your package manager needs to describe the locations of your packages. We
   ```json title="./package.json"
   {
     "workspaces": [
-      "apps/*"
+      "apps/*",
       "packages/*"
     ]
   }


### PR DESCRIPTION
### Description

Corrected a missing comma between items in a JSON array, which caused an error when copying and pasting a code fragment into a JSON file
