### PR TITLE
chore: bump pnpm action version

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup pnpm
-      uses: pnpm/action-setup@v2.2.4
+      uses: pnpm/action-setup@v4
 
     - name: Setup Node.js
       uses: actions/setup-node@v3.6.0

--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -16,6 +16,9 @@ env:
   CARGO_PROFILE_RELEASE_LTO: true
   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   RELEASE_TURBO_CLI: true # TODO: do we need this?
+  # Needed since we need to build on Xenial which doesn't have a new enough
+  # GLIBC to use Node 20.
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
### Description

Our release was broken due to a bump in the global NodeJS version which causes a failure when trying to setup `pnpm`: https://github.com/vercel/turbo/actions/runs/9812173678

Following directions on https://github.com/pnpm/action-setup/issues/135 to update to v4 of the action

We also need to add `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION` in order to keep using Node 16 for checking out our code for our MUSL builds where we need an old version of GLIBC.

### Testing Instructions

Test run: https://github.com/vercel/turbo/actions/runs/9812969175
