### PR TITLE
chore: use msvc for turborepo

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -1,10 +1,6 @@
 name: "Turbo Rust Setup"
 description: "Sets up the Rust toolchain for CI"
 inputs:
-  windows:
-    description: 'Set to "true" if setting up for Windows'
-    required: false
-    default: "false"
   targets:
     description: "Comma-separated list of target triples to install for this toolchain"
     required: false

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -39,11 +39,6 @@ runs:
       shell: bash
       run: sudo apt-get -y update && sudo apt-get install -y lld
 
-    - name: "Set Windows default host to MinGW"
-      if: ${{ inputs.windows == 'true' }}
-      shell: bash
-      run: rustup set default-host x86_64-pc-windows-gnu && rustup show
-
     - name: Set Up Protoc
       id: set-up-protoc
       continue-on-error: true

--- a/.github/actions/setup-turborepo-environment/action.yml
+++ b/.github/actions/setup-turborepo-environment/action.yml
@@ -1,10 +1,6 @@
 name: "Setup Turborepo Environment"
 description: "Sets up development environment for turborepo"
 inputs:
-  windows:
-    description: 'Set to "true" if setting up for Windows'
-    required: false
-    default: "false"
   github-token:
     description: "GitHub token. You can pass secrets.GITHUB_TOKEN"
     required: true
@@ -25,7 +21,6 @@ runs:
     - name: "Setup Rust"
       uses: ./.github/actions/setup-rust
       with:
-        windows: ${{ inputs.windows }}
         shared-cache-key: turborepo-debug-build
         cache-key: ${{ inputs.target }}
         save-cache: true

--- a/.github/workflows/bench-turborepo.yml
+++ b/.github/workflows/bench-turborepo.yml
@@ -73,12 +73,6 @@ jobs:
         shell: bash
         run: echo "${{ steps.filename.outputs.filename }}"
 
-      # setup Rust on windows, because apparently setup-turborepo-environment doesn't do this
-      # TODO: put this logic in ./github/actions/setup-rust and use that instead
-      - name: Add rustup for windows
-        if: ${{ matrix.os.runner == 'windows-latest'}}
-        run: rustup target add x86_64-pc-windows-gnu
-
       - name: Setup Turborepo Environment
         uses: ./.github/actions/setup-turborepo-environment
         with:

--- a/.github/workflows/bench-turborepo.yml
+++ b/.github/workflows/bench-turborepo.yml
@@ -76,7 +76,6 @@ jobs:
       - name: Setup Turborepo Environment
         uses: ./.github/actions/setup-turborepo-environment
         with:
-          windows: ${{ matrix.os.name == 'windows' }}
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Build Turborepo from source

--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -127,8 +127,7 @@ jobs:
             rust-build-env: 'CC_aarch64_unknown_linux_musl=clang AR_aarch64_unknown_linux_musl=llvm-ar RUSTFLAGS="-Clink-self-contained=yes -Clinker=rust-lld"'
             setup: "sudo apt-get update && sudo apt-get install -y build-essential musl-tools clang llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu"
           - host: windows-latest
-            target: x86_64-pc-windows-gnu
-            setup: "rustup set default-host x86_64-pc-windows-gnu"
+            target: x86_64-pc-windows-msvc
             container-options: "--rm"
     runs-on: ${{ matrix.settings.host }}
     container:
@@ -227,10 +226,10 @@ jobs:
         run: |
           mv rust-artifacts/turbo-aarch64-apple-darwin cli/dist-darwin-arm64
           mv rust-artifacts/turbo-aarch64-unknown-linux-musl cli/dist-linux-arm64
-          cp -r rust-artifacts/turbo-x86_64-pc-windows-gnu cli/dist-windows-arm64
+          cp -r rust-artifacts/turbo-x86_64-pc-windows-msvc cli/dist-windows-arm64
           mv rust-artifacts/turbo-x86_64-unknown-linux-musl cli/dist-linux-amd64
           mv rust-artifacts/turbo-x86_64-apple-darwin cli/dist-darwin-amd64
-          mv rust-artifacts/turbo-x86_64-pc-windows-gnu cli/dist-windows-amd64
+          mv rust-artifacts/turbo-x86_64-pc-windows-msvc cli/dist-windows-amd64
 
       - name: Perform Release
         run: cd cli && make publish-turbo SKIP_PUBLISH=${{ inputs.dry_run && '--skip-publish' || '' }}

--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -136,7 +136,6 @@ jobs:
       - name: Setup Turborepo Environment
         uses: ./.github/actions/setup-turborepo-environment
         with:
-          windows: ${{ matrix.os.runner == 'windows-latest' }}
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           node-version: "18.20.2"
 
@@ -193,7 +192,6 @@ jobs:
       - name: Setup Turborepo Environment
         uses: ./.github/actions/setup-turborepo-environment
         with:
-          windows: ${{ matrix.os.runner == 'windows-latest' }}
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           node-version: "18.20.2"
 
@@ -373,7 +371,6 @@ jobs:
       - name: Setup Turborepo Environment
         uses: ./.github/actions/setup-turborepo-environment
         with:
-          windows: ${{ matrix.os.runner == 'windows-latest' }}
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           node-version: "18.20.2"
 


### PR DESCRIPTION
### Description

Now that we no longer need to support linking to a Go library we can use the MSVC backend.

This PR removes our overrides for Windows to use the GNU backend and removes the parameter to enable this as well.

### Testing Instructions

CI

[Test release](https://github.com/vercel/turbo/actions/runs/9813223825). Verified produced binary runs as expected on a Windows machine.
