### PR TITLE
fix(docs): fix pnpm workspace filename extension

### DIFF
--- a/docs/repo-docs/crafting-your-repository/structuring-a-repository.mdx
+++ b/docs/repo-docs/crafting-your-repository/structuring-a-repository.mdx
@@ -141,7 +141,7 @@ First, your package manager needs to describe the locations of your packages. We
   <LinkToDocumentation href="https://yarnpkg.com/features/workspaces#how-are-workspaces-declared">yarn workspace documentation</LinkToDocumentation>
    </Tab>
   <Tab>
-  ```json title="pnpm-workspace.yml"
+  ```json title="pnpm-workspace.yaml"
  packages:
     - "apps/*"
     - "packages/*"

--- a/docs/repo-docs/guides/multi-language.mdx
+++ b/docs/repo-docs/guides/multi-language.mdx
@@ -38,7 +38,7 @@ As an example, you may have a Rust project in the `./cli` directory in your repo
   <LinkToDocumentation href="https://yarnpkg.com/features/workspaces#how-are-workspaces-declared">yarn workspace documentation</LinkToDocumentation>
    </Tab>
   <Tab>
-  ```json title="pnpm-workspace.yml"
+  ```json title="pnpm-workspace.yaml"
  packages:
     - "apps/*"
     - "packages/*"


### PR DESCRIPTION
### Description

The extension for a pnpm workspace manifest file should be `yaml`, not `yml`. Using `yml` provides an error: `The workspace manifest file should be named "pnpm-workspace.yaml"`

pnpm documentation for workspace manifests: https://pnpm.io/pnpm-workspace_yaml