### PR TITLE
docs: Fix typo in filter option.

### DIFF
--- a/docs/repo-docs/crafting-your-repository/running-tasks.mdx
+++ b/docs/repo-docs/crafting-your-repository/running-tasks.mdx
@@ -93,7 +93,7 @@ In [the documentation for the `run` subcommand](/repo/docs/reference/run), you'l
 
 - **Variations of your most common commands**: The `build` script in `package.json` has the most utility when it is `turbo build` - but you might only be interested in a specific package at the moment. You can quickly filter for the specific package you're interested in using `turbo build --filter=@repo/ui`.
 - **One-off commands**: Commands like `turbo build --dry` aren't needed often so you likely won't create a script in your `package.json` for it. Instead, you can run it directly in your terminal whenever you need it.
-- **Overriding `turbo.json` configuration**: Some CLI flags have an equivalent in `turbo.json` that you can override. For instance, you may have a `turbo build` command configured to use [`"outputLogs": "full"` in `turbo.json`](/repo/docs/reference/configuration#outputmode) - but you're only interested in seeing errors at the moment. Using global `turbo`, you can use `turbo lint --output-logs=errors` to only show errors.
+- **Overriding `turbo.json` configuration**: Some CLI flags have an equivalent in `turbo.json` that you can override. For instance, you may have a `turbo build` command configured to use [`"outputLogs": "full"` in `turbo.json`](/repo/docs/reference/configuration#outputmode) - but you're only interested in seeing errors at the moment. Using global `turbo`, you can use `turbo lint --output-logs=errors-only` to only show errors.
 
 ## Running multiple tasks
 


### PR DESCRIPTION
`errors-only` is the correct option
option that only shows logs for task failures.

### Description
Fixes a minor typo in `crafting your repository` section of turbo repo docs.
<!--
  ✍️ Write a short summary of your work.
  If necessary, include relevant screenshots.
-->

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
