### PR TITLE
update env_wildcards for SvelteKit

### DIFF
--- a/crates/turborepo-lib/src/framework.rs
+++ b/crates/turborepo-lib/src/framework.rs
@@ -86,7 +86,7 @@ fn get_frameworks() -> &'static [Framework] {
             },
             Framework {
                 slug: "sveltekit",
-                env_wildcards: vec!["VITE_*"],
+                env_wildcards: vec!["VITE_*", "PUBLIC_*"],
                 dependency_match: Matcher {
                     strategy: Strategy::All,
                     dependencies: vec!["@sveltejs/kit"],


### PR DESCRIPTION
### Description

Updates the environment variables prefix for SvelteKit framework inference to match SvelteKit documentation: https://learn.svelte.dev/tutorial/env-static-public

Closes #8684

### Testing Instructions

See #8684 for issue reproduction.