### PR TITLE
Add VSCode's debugger variables to default passthroughs.

### DIFF
--- a/crates/turborepo-lib/src/task_hash.rs
+++ b/crates/turborepo-lib/src/task_hash.rs
@@ -477,6 +477,9 @@ impl<'a> TaskHasher<'a> {
                         "COLORTERM",
                         "TERM",
                         "TERM_PROGRAM",
+                        // VSCode IDE
+                        "VSCODE_*",
+                        "ELECTRON_RUN_AS_NODE",
                         // Jetbrains IDE
                         "JB_IDE_*",
                         "JB_INTERPRETER",


### PR DESCRIPTION
### Description

From https://github.com/microsoft/vscode-js-debug/blob/5b0f41dbe845d693a541c1fae30cec04c878216f/src/targets/node/nodeLauncherBase.ts#L320
