### PR TITLE
docs: Make root task more clear

### DIFF
--- a/docs/repo-docs/crafting-your-repository/configuring-tasks.mdx
+++ b/docs/repo-docs/crafting-your-repository/configuring-tasks.mdx
@@ -260,7 +260,7 @@ In this task definition, Turborepo will use the default `inputs` behavior for th
 
 ### Registering Root Tasks
 
-You can also run scripts in the `package.json` in the Workspace root using `turbo`. For example, you may want to run a `lint` task for the files in your Workspace's root directory in addition to the `lint` task in each package:
+You can also run scripts in the `package.json` in the Workspace root using `turbo`. For example, you may want to run a `lint:root` task for the files in your Workspace's root directory in addition to the `lint` task in each package:
 
 <Tabs items={["turbo.json", "package.json"]}>
 <Tab value="turbo.json">


### PR DESCRIPTION
### Description
Uses the exact task name that is described in the `turbo.json` file. This confused me at first, I thought the `:root` was a custom syntax for defining where lint would be ran. 

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
