### PR TITLE
fix(windows): pass through programdata env var

### DIFF
--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -39,6 +39,7 @@ jobs:
           PATTERNS: |
             Cargo.*
             rust-toolchain
+            cli/turbo.json
 
       - name: Turborepo version changes
         id: turborepo_version

--- a/cli/turbo.json
+++ b/cli/turbo.json
@@ -1,14 +1,10 @@
 {
   "$schema": "../docs/public/schema.json",
-  "extends": [
-    "//"
-  ],
+  "extends": ["//"],
   "tasks": {
     // A task that is used for detecting if any turborepo Rust sources change
     "rust-src": {
-      "env": [
-        "RUNNER_OS"
-      ],
+      "env": ["RUNNER_OS"],
       "inputs": [
         "../version.txt",
         "../crates/turborepo*/**/*.rs", // Rust crates
@@ -25,12 +21,8 @@
         "../target/release/turbo",
         "../target/release/turbo.exe"
       ],
-      "dependsOn": [
-        "rust-src"
-      ],
-      "passThroughEnv": [
-        "ProgramData"
-      ]
+      "dependsOn": ["rust-src"],
+      "passThroughEnv": ["ProgramData"]
     }
   }
 }

--- a/cli/turbo.json
+++ b/cli/turbo.json
@@ -1,10 +1,14 @@
 {
   "$schema": "../docs/public/schema.json",
-  "extends": ["//"],
+  "extends": [
+    "//"
+  ],
   "tasks": {
     // A task that is used for detecting if any turborepo Rust sources change
     "rust-src": {
-      "env": ["RUNNER_OS"],
+      "env": [
+        "RUNNER_OS"
+      ],
       "inputs": [
         "../version.txt",
         "../crates/turborepo*/**/*.rs", // Rust crates
@@ -21,7 +25,12 @@
         "../target/release/turbo",
         "../target/release/turbo.exe"
       ],
-      "dependsOn": ["rust-src"]
+      "dependsOn": [
+        "rust-src"
+      ],
+      "passThroughEnv": [
+        "ProgramData"
+      ]
     }
   }
 }


### PR DESCRIPTION
### Description

It appears that when using the MSVC backend `rustc` depends on `ProgramData` for finding Windows libs. This getting trimmed resulted in failing builds.

### Testing Instructions

Windows CI now passes
