### PR TITLE
Replace `unreachable` with `bail` in `finalize_css`

### DIFF
--- a/crates/turbopack-css/src/process.rs
+++ b/crates/turbopack-css/src/process.rs
@@ -437,7 +437,7 @@ pub async fn finalize_css(
             let code = code.await?;
             let code = match &*code {
                 FileContent::Content(v) => v.content().to_str()?,
-                _ => unreachable!("this case should be filtered out while parsing"),
+                _ => bail!("this case should be filtered out while parsing"),
             };
             let (result, srcmap) = stylesheet.to_css(cm.clone(), &code, true, true, true)?;
 


### PR DESCRIPTION
### Description

@rauchg reported:

```
thread 'tokio-runtime-worker' panicked at /Users/geist/.cargo/git/checkouts/turbo-df7a549334890fa5/2af6b12/crates/turbopack-css/src/process.rs:439:22:
internal error: entered unreachable code: this case should be filtered out while parsing
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

(https://vercel.slack.com/archives/C01A2M9R8RZ/p1720449958135569)

A review of the code confirms that this should be unreachable under normal circumstances:

> There's a check here that `FileContent::Content` exists before constructing the `ParseCssResult::Ok` that's needed to reach the line that contains the `unreachable!` assertion: https://github.com/vercel/turbo/blob/main/crates/turbopack-css/src/process.rs#L491

But there's no guarantee that the view of the world is strongly consistent across multiple `Vc`s inside most tasks. Some `Vc`s may no longer exist due to invalidation (or cache eviction once that's enabled) while this task was running.

There is a guarantee that at the top-level of the application that there's strong (eventual) consistency, so we can be confident that this `bail!` won't bubble all the way up.
 
### Testing Instructions

`cargo nextest r -p 'turbopack-*'`
