### PR TITLE
fix constant width for checkmark

### DIFF
--- a/crates/turborepo-lib/src/run/graph_visualizer.rs
+++ b/crates/turborepo-lib/src/run/graph_visualizer.rs
@@ -52,7 +52,7 @@ pub(crate) fn write_graph(
                 write_graphviz_warning(ui).map_err(Error::GraphOutput)?;
                 render_dot_graph(std::io::stdout(), engine, single_package)?;
             }
-            print!("\n✔ Generated task graph in ");
+            print!("\n✓ Generated task graph in ");
             cprintln!(ui, BOLD, "{filename}");
         }
     }

--- a/crates/turborepo-ui/src/tui/table.rs
+++ b/crates/turborepo-ui/src/tui/table.rs
@@ -25,7 +25,7 @@ impl<'b> TaskTable<'b> {
         }
     }
 
-    // Provides a suggested width for the task table
+    /// Provides a suggested width for the task table
     pub fn width_hint<'a>(tasks: impl Iterator<Item = &'a str>) -> u16 {
         let task_name_width = tasks
             .map(|task| task.len())
@@ -48,8 +48,9 @@ impl<'b> TaskTable<'b> {
             Row::new(vec![
                 Cell::new(task.name()),
                 Cell::new(match task.result() {
-                    TaskResult::Success => Text::raw("✔").style(Style::default().light_green()),
-                    TaskResult::Failure => Text::raw("✘").style(Style::default().red()),
+                    // matches Next.js (and many other CLI tools) https://github.com/vercel/next.js/blob/1a04d94aaec943d3cce93487fea3b8c8f8898f31/packages/next/src/build/output/log.ts
+                    TaskResult::Success => Text::styled("✓", Style::default().green().bold()),
+                    TaskResult::Failure => Text::styled("⨯", Style::default().red().bold()),
                 }),
             ])
         })


### PR DESCRIPTION
### Description

The unicode codepoint (✔) we used for a checkmark is not monospace on some platforms (i.e. linux).

<img width="25%" src="https://github.com/vercel/turbo/assets/15232461/03cba20a-1f4a-4818-846a-4cef56b8c6eb" />


This PR updates that to use the [characters matching Next.JS](https://github.com/vercel/next.js/blob/1a04d94aaec943d3cce93487fea3b8c8f8898f31/packages/next/src/build/output/log.ts) (and many other CLI tools before it).  Prior to this PR, this resulted in the checkmark overflowing its boundary into the border.

| BEFORE | AFTER |
| - | - |
| ![image](https://github.com/vercel/turbo/assets/15232461/92e18df7-8ba9-4a31-9d13-59d183861e25) | ![image](https://github.com/vercel/turbo/assets/15232461/223aab8b-0efd-49f7-85b8-9348e5a3b00a) |

### Testing Instructions

```sh
cargo tr-build
./target/debug/turbo test --filter "./packages/*" --continue --force
```