### PR TITLE
fix(ui): only start ui if there are tasks to run

### DIFF
--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -160,6 +160,11 @@ impl Run {
         }
 
         let task_names = self.engine.tasks_with_command(&self.pkg_dep_graph);
+        // If there aren't any tasks to run, then shouldn't start the UI
+        if task_names.is_empty() {
+            return Ok(None);
+        }
+
         let (sender, receiver) = AppSender::new();
         let handle = tokio::task::spawn_blocking(move || tui::run_app(task_names, receiver));
 


### PR DESCRIPTION
### Description

Previously we would crash if a user provided a filter that matched zero tasks. We should avoid starting the UI at all in this situation.

### Testing Instructions
Before
```
[0 olszewski@chriss-mbp] /Users/olszewski/code/vercel/turborepo $ turbo_dev build --filter='./packages/'
Oops! Turbo has crashed.

                        A report has been written to /var/folders/3m/rxkycvgs5jgfvs0k9xcgp6km0000gn/T/report-5f29ea16-7ad7-428f-ac6a-28607b4eb04a.toml

                                                                                                                                                      Please open an issue at https://github.com/vercel/turbo/issues/new/choose and include this file

                                                                   No tasks were executed as part of this run.

                                                                                                               Tasks:    0 successful, 0 total
                                                                                                                                              Cached:    0 cached, 0 total
                                                                                                                                                                            Time:
   402ms

         Run: https://vercel.com/teams/vercel/repos/turbo-monorepo/runs/space_run_xgkHsGl7exeeqKI3RfLZq2iK

                                                                                                          Oops! Turbo has crashed.

                                                                                                                                  A report has been written to /var/folders/3m/rxkycvgs5jgfvs0k9xcgp6km0000gn/T/report-1449aa95-2984-4859-9028-c2ddb899fbaf.toml

                                                                              Please open an issue at https://github.com/vercel/turbo/issues/new/choose and include this file
                                                                                                                                                                             ⠁
>   ...Finishing writing to cache...                                                                                                                                               WARNING  could not start shutdown, exiting
```

After
```
[0 olszewski@chriss-mbp] /Users/olszewski/code/vercel/turborepo $ turbo_dev build --filter='./packages/'
 WARNING  No locally installed `turbo` found. Using version: 2.0.7-canary.0.
• Packages in scope: 
• Running build in 0 packages
• Remote caching enabled

No tasks were executed as part of this run.

 Tasks:    0 successful, 0 total
Cached:    0 cached, 0 total
  Time:    592ms 

```
