### PR TITLE
feat(tui): terminal pane mouse copying

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1474,6 +1474,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15efe7a882b08f34e38556b14f2fb3daa98769d06c7f0c1b076dfd0d983bc892"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2660,6 +2669,12 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "error-code"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0474425d51df81997e2f90a21591180b38eccf27292d755f3e30750225c175b"
 
 [[package]]
 name = "event-listener"
@@ -11437,6 +11452,7 @@ dependencies = [
  "atty",
  "base64 0.22.1",
  "chrono",
+ "clipboard-win",
  "console",
  "crossterm 0.27.0",
  "dialoguer",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11435,6 +11435,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "atty",
+ "base64 0.22.1",
  "chrono",
  "console",
  "crossterm 0.27.0",
@@ -11452,6 +11453,7 @@ dependencies = [
  "turbopath",
  "turborepo-ci",
  "turborepo-vt100",
+ "which",
  "winapi",
 ]
 

--- a/crates/turborepo-ui/Cargo.toml
+++ b/crates/turborepo-ui/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 
 [dependencies]
 atty = { workspace = true }
+base64 = "0.22"
 chrono = { workspace = true }
 console = { workspace = true }
 crossterm = "0.27.0"
@@ -30,4 +31,5 @@ tui-term = { workspace = true }
 turbopath = { workspace = true }
 turborepo-ci = { workspace = true }
 turborepo-vt100 = { workspace = true }
+which = { workspace = true }
 winapi = "0.3.9"

--- a/crates/turborepo-ui/Cargo.toml
+++ b/crates/turborepo-ui/Cargo.toml
@@ -33,3 +33,6 @@ turborepo-ci = { workspace = true }
 turborepo-vt100 = { workspace = true }
 which = { workspace = true }
 winapi = "0.3.9"
+
+[target."cfg(windows)".dependencies]
+clipboard-win = "5.3.1"

--- a/crates/turborepo-ui/src/tui/app.rs
+++ b/crates/turborepo-ui/src/tui/app.rs
@@ -123,6 +123,8 @@ impl<W> App<W> {
     }
 
     pub fn get_full_task_mut(&mut self) -> &mut TerminalOutput<W> {
+        // Clippy is wrong here, we need this to avoid a borrow checker error
+        #[allow(clippy::unnecessary_to_owned)]
         self.tasks.get_mut(&self.active_task().to_owned()).unwrap()
     }
 

--- a/crates/turborepo-ui/src/tui/app.rs
+++ b/crates/turborepo-ui/src/tui/app.rs
@@ -324,7 +324,8 @@ impl<W> App<W> {
         let table_width = self.term_cols - self.pane_cols;
         debug!("original mouse event: {event:?}, table_width: {table_width}");
         // Only handle mouse event if it happens inside of pane
-        if event.row > 0 && event.column > table_width {
+        // We give a 1 cell buffer to make it easier to select the first column of a row
+        if event.row > 0 && event.column >= table_width {
             // Subtract 1 from the y axis due to the title of the pane
             event.row -= 1;
             // Subtract the width of the table

--- a/crates/turborepo-ui/src/tui/app.rs
+++ b/crates/turborepo-ui/src/tui/app.rs
@@ -322,12 +322,14 @@ impl<W> App<W> {
 
     pub fn handle_mouse(&mut self, mut event: crossterm::event::MouseEvent) -> Result<(), Error> {
         let table_width = self.term_cols - self.pane_cols;
+        debug!("original mouse event: {event:?}, table_width: {table_width}");
         // Only handle mouse event if it happens inside of pane
         if event.row > 0 && event.column > table_width {
             // Subtract 1 from the y axis due to the title of the pane
             event.row -= 1;
             // Subtract the width of the table
             event.column -= table_width;
+            debug!("translated mouse event: {event:?}");
 
             let task = self.get_full_task_mut();
             task.handle_mouse(event)?;

--- a/crates/turborepo-ui/src/tui/app.rs
+++ b/crates/turborepo-ui/src/tui/app.rs
@@ -60,6 +60,9 @@ impl<W> App<W> {
         let full_task_width = cols.saturating_sub(task_width_hint);
         let pane_cols = full_task_width.max(ratio_pane_width);
 
+        // We use 2 rows for pane title and for the interaction info
+        let rows = rows.saturating_sub(2).max(1);
+
         // Initializes with the planned tasks
         // and will mutate as tasks change
         // to running, finished, etc.

--- a/crates/turborepo-ui/src/tui/app.rs
+++ b/crates/turborepo-ui/src/tui/app.rs
@@ -335,6 +335,17 @@ impl<W> App<W> {
 
         Ok(())
     }
+
+    pub fn copy_selection(&self) {
+        let task = self
+            .tasks
+            .get(&self.active_task())
+            .expect("active task should exist");
+        let Some(text) = task.copy_selection() else {
+            return;
+        };
+        super::copy_to_clipboard(&text);
+    }
 }
 
 impl<W: Write> App<W> {
@@ -548,6 +559,9 @@ fn update(
         }
         Event::Mouse(m) => {
             app.handle_mouse(m)?;
+        }
+        Event::CopySelection => {
+            app.copy_selection();
         }
     }
     Ok(None)

--- a/crates/turborepo-ui/src/tui/clipboard.rs
+++ b/crates/turborepo-ui/src/tui/clipboard.rs
@@ -1,0 +1,113 @@
+// Inspired by https://github.com/pvolok/mprocs/blob/master/src/clipboard.rs
+use std::process::Stdio;
+
+use base64::Engine;
+use which::which;
+
+pub fn copy_to_clipboard(s: &str) {
+    match copy_impl(s, &PROVIDER) {
+        Ok(()) => (),
+        Err(err) => tracing::debug!("Unable to copy: {}", err.to_string()),
+    }
+}
+
+#[allow(dead_code)]
+enum Provider {
+    OSC52,
+    Exec(&'static str, Vec<&'static str>),
+    #[cfg(windows)]
+    Win,
+    NoOp,
+}
+
+#[cfg(windows)]
+fn detect_copy_provider() -> Provider {
+    Provider::Win
+}
+
+#[cfg(target_os = "macos")]
+fn detect_copy_provider() -> Provider {
+    if let Some(provider) = check_prog("pbcopy", &[]) {
+        return provider;
+    }
+    Provider::OSC52
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+fn detect_copy_provider() -> Provider {
+    // Wayland
+    if std::env::var("WAYLAND_DISPLAY").is_ok() {
+        if let Some(provider) = check_prog("wl-copy", &["--type", "text/plain"]) {
+            return provider;
+        }
+    }
+    // X11
+    if std::env::var("DISPLAY").is_ok() {
+        if let Some(provider) = check_prog("xclip", &["-i", "-selection", "clipboard"]) {
+            return provider;
+        }
+        if let Some(provider) = check_prog("xsel", &["-i", "-b"]) {
+            return provider;
+        }
+    }
+    // Termux
+    if let Some(provider) = check_prog("termux-clipboard-set", &[]) {
+        return provider;
+    }
+    // Tmux
+    if std::env::var("TMUX").is_ok() {
+        if let Some(provider) = check_prog("tmux", &["load-buffer", "-"]) {
+            return provider;
+        }
+    }
+
+    Provider::OSC52
+}
+
+#[allow(dead_code)]
+fn check_prog(cmd: &'static str, args: &[&'static str]) -> Option<Provider> {
+    if which(cmd).is_ok() {
+        Some(Provider::Exec(cmd, args.to_vec()))
+    } else {
+        None
+    }
+}
+
+fn copy_impl(s: &str, provider: &Provider) -> std::io::Result<()> {
+    match provider {
+        Provider::OSC52 => {
+            let mut stdout = std::io::stdout().lock();
+            use std::io::Write;
+            write!(
+                &mut stdout,
+                "\x1b]52;;{}\x07",
+                base64::engine::general_purpose::STANDARD.encode(s)
+            )?;
+        }
+
+        Provider::Exec(prog, args) => {
+            let mut child = std::process::Command::new(prog)
+                .args(args)
+                .stdin(Stdio::piped())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .spawn()
+                .unwrap();
+            std::io::Write::write_all(&mut child.stdin.as_ref().unwrap(), s.as_bytes())?;
+            child.wait()?;
+        }
+
+        #[cfg(windows)]
+        Provider::Win => {
+            clipboard_win::set_clipboard_string(s).map_err(|e| anyhow::Error::msg(e.to_string()))?
+        }
+
+        Provider::NoOp => (),
+    };
+
+    Ok(())
+}
+
+lazy_static::lazy_static! {
+  static ref PROVIDER: Provider = detect_copy_provider();
+}

--- a/crates/turborepo-ui/src/tui/clipboard.rs
+++ b/crates/turborepo-ui/src/tui/clipboard.rs
@@ -98,9 +98,8 @@ fn copy_impl(s: &str, provider: &Provider) -> std::io::Result<()> {
         }
 
         #[cfg(windows)]
-        Provider::Win => {
-            clipboard_win::set_clipboard_string(s).map_err(|e| anyhow::Error::msg(e.to_string()))?
-        }
+        Provider::Win => clipboard_win::set_clipboard_string(s)
+            .map_err(|e| std::io::Error::other(e.to_string()))?,
 
         Provider::NoOp => (),
     };

--- a/crates/turborepo-ui/src/tui/event.rs
+++ b/crates/turborepo-ui/src/tui/event.rs
@@ -36,6 +36,7 @@ pub enum Event {
     UpdateTasks {
         tasks: Vec<String>,
     },
+    Mouse(crossterm::event::MouseEvent),
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]

--- a/crates/turborepo-ui/src/tui/event.rs
+++ b/crates/turborepo-ui/src/tui/event.rs
@@ -37,6 +37,7 @@ pub enum Event {
         tasks: Vec<String>,
     },
     Mouse(crossterm::event::MouseEvent),
+    CopySelection,
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]

--- a/crates/turborepo-ui/src/tui/input.rs
+++ b/crates/turborepo-ui/src/tui/input.rs
@@ -1,7 +1,6 @@
 use std::time::Duration;
 
 use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
-use tracing::debug;
 
 use super::{app::LayoutSections, event::Event, Error};
 
@@ -20,9 +19,7 @@ pub fn input(options: InputOptions) -> Result<Option<Event>, Error> {
     // poll with 0 duration will only return true if event::read won't need to wait
     // for input
     if crossterm::event::poll(Duration::from_millis(0))? {
-        let event = crossterm::event::read()?;
-        debug!("Received event: {event:?}");
-        match event {
+        match crossterm::event::read()? {
             crossterm::event::Event::Key(k) => Ok(translate_key_event(&focus, k)),
             crossterm::event::Event::Mouse(m) => match m.kind {
                 crossterm::event::MouseEventKind::ScrollDown => Ok(Some(Event::ScrollDown)),
@@ -56,7 +53,7 @@ fn translate_key_event(interact: &LayoutSections, key_event: KeyEvent) -> Option
         KeyCode::Char('c') if key_event.modifiers == crossterm::event::KeyModifiers::CONTROL => {
             ctrl_c()
         }
-        KeyCode::Char('c') if key_event.modifiers == crossterm::event::KeyModifiers::SUPER => {
+        KeyCode::Char('c') => {
             return Some(Event::CopySelection);
         }
         // Interactive branches

--- a/crates/turborepo-ui/src/tui/input.rs
+++ b/crates/turborepo-ui/src/tui/input.rs
@@ -8,19 +8,19 @@ use super::{app::LayoutSections, event::Event, Error};
 pub struct InputOptions {
     pub focus: LayoutSections,
     pub tty_stdin: bool,
+    pub has_selection: bool,
 }
 /// Return any immediately available event
 pub fn input(options: InputOptions) -> Result<Option<Event>, Error> {
-    let InputOptions { focus, tty_stdin } = options;
     // If stdin is not a tty, then we do not attempt to read from it
-    if !tty_stdin {
+    if !options.tty_stdin {
         return Ok(None);
     }
     // poll with 0 duration will only return true if event::read won't need to wait
     // for input
     if crossterm::event::poll(Duration::from_millis(0))? {
         match crossterm::event::read()? {
-            crossterm::event::Event::Key(k) => Ok(translate_key_event(&focus, k)),
+            crossterm::event::Event::Key(k) => Ok(translate_key_event(options, k)),
             crossterm::event::Event::Mouse(m) => match m.kind {
                 crossterm::event::MouseEventKind::ScrollDown => Ok(Some(Event::ScrollDown)),
                 crossterm::event::MouseEventKind::ScrollUp => Ok(Some(Event::ScrollUp)),
@@ -38,7 +38,7 @@ pub fn input(options: InputOptions) -> Result<Option<Event>, Error> {
 }
 
 /// Converts a crossterm key event into a TUI interaction event
-fn translate_key_event(interact: &LayoutSections, key_event: KeyEvent) -> Option<Event> {
+fn translate_key_event(options: InputOptions, key_event: KeyEvent) -> Option<Event> {
     // On Windows events for releasing a key are produced
     // We skip these to avoid emitting 2 events per key press.
     // There is still a `Repeat` event for when a key is held that will pass through
@@ -50,16 +50,16 @@ fn translate_key_event(interact: &LayoutSections, key_event: KeyEvent) -> Option
         KeyCode::Char('c') if key_event.modifiers == crossterm::event::KeyModifiers::CONTROL => {
             ctrl_c()
         }
-        KeyCode::Char('c') => Some(Event::CopySelection),
+        KeyCode::Char('c') if options.has_selection => Some(Event::CopySelection),
         // Interactive branches
         KeyCode::Char('z')
-            if matches!(interact, LayoutSections::Pane)
+            if matches!(options.focus, LayoutSections::Pane)
                 && key_event.modifiers == crossterm::event::KeyModifiers::CONTROL =>
         {
             Some(Event::ExitInteractive)
         }
         // If we're in interactive mode, convert the key event to bytes to send to stdin
-        _ if matches!(interact, LayoutSections::Pane) => Some(Event::Input {
+        _ if matches!(options.focus, LayoutSections::Pane) => Some(Event::Input {
             bytes: encode_key(key_event),
         }),
         // Fall through if we aren't in interactive mode

--- a/crates/turborepo-ui/src/tui/input.rs
+++ b/crates/turborepo-ui/src/tui/input.rs
@@ -28,9 +28,6 @@ pub fn input(options: InputOptions) -> Result<Option<Event>, Error> {
                 | crossterm::event::MouseEventKind::Drag(crossterm::event::MouseButton::Left) => {
                     Ok(Some(Event::Mouse(m)))
                 }
-                crossterm::event::MouseEventKind::Down(crossterm::event::MouseButton::Right) => {
-                    Ok(Some(Event::CopySelection))
-                }
                 _ => Ok(None),
             },
             _ => Ok(None),
@@ -53,9 +50,7 @@ fn translate_key_event(interact: &LayoutSections, key_event: KeyEvent) -> Option
         KeyCode::Char('c') if key_event.modifiers == crossterm::event::KeyModifiers::CONTROL => {
             ctrl_c()
         }
-        KeyCode::Char('c') => {
-            return Some(Event::CopySelection);
-        }
+        KeyCode::Char('c') => Some(Event::CopySelection),
         // Interactive branches
         KeyCode::Char('z')
             if matches!(interact, LayoutSections::Pane)

--- a/crates/turborepo-ui/src/tui/input.rs
+++ b/crates/turborepo-ui/src/tui/input.rs
@@ -24,6 +24,10 @@ pub fn input(options: InputOptions) -> Result<Option<Event>, Error> {
             crossterm::event::Event::Mouse(m) => match m.kind {
                 crossterm::event::MouseEventKind::ScrollDown => Ok(Some(Event::ScrollDown)),
                 crossterm::event::MouseEventKind::ScrollUp => Ok(Some(Event::ScrollUp)),
+                crossterm::event::MouseEventKind::Down(crossterm::event::MouseButton::Left)
+                | crossterm::event::MouseEventKind::Drag(crossterm::event::MouseButton::Left) => {
+                    Ok(Some(Event::Mouse(m)))
+                }
                 _ => Ok(None),
             },
             _ => Ok(None),

--- a/crates/turborepo-ui/src/tui/mod.rs
+++ b/crates/turborepo-ui/src/tui/mod.rs
@@ -1,4 +1,5 @@
 mod app;
+mod clipboard;
 pub mod event;
 mod handle;
 mod input;
@@ -9,6 +10,7 @@ mod task;
 mod term_output;
 
 pub use app::{run_app, terminal_big_enough};
+use clipboard::copy_to_clipboard;
 use event::{Event, TaskResult};
 pub use handle::{AppReceiver, AppSender, TuiTask};
 use input::{input, InputOptions};

--- a/crates/turborepo-ui/src/tui/pane.rs
+++ b/crates/turborepo-ui/src/tui/pane.rs
@@ -9,6 +9,7 @@ use super::TerminalOutput;
 
 const FOOTER_TEXT_ACTIVE: &str = "Press`Ctrl-Z` to stop interacting.";
 const FOOTER_TEXT_INACTIVE: &str = "Press `Enter` to interact.";
+const HAS_SELECTION: &str = "Press `c` to copy selection";
 
 pub struct TerminalPane<'a, W> {
     terminal_output: &'a TerminalOutput<W>,
@@ -36,15 +37,27 @@ impl<'a, W> Widget for &TerminalPane<'a, W> {
         Self: Sized,
     {
         let screen = self.terminal_output.parser.screen();
-        let mut block = Block::default()
-            .borders(Borders::LEFT)
-            .title(self.terminal_output.title(self.task_name));
-        if self.highlight {
-            block = block.title_bottom(Line::from(FOOTER_TEXT_ACTIVE).centered());
-            block = block.border_style(Style::new().fg(ratatui::style::Color::Yellow));
+        let mut help_text = if self.highlight {
+            FOOTER_TEXT_ACTIVE
         } else {
-            block = block.title_bottom(Line::from(FOOTER_TEXT_INACTIVE).centered());
+            FOOTER_TEXT_INACTIVE
         }
+        .to_owned();
+
+        if self.terminal_output.has_selection() {
+            help_text.push(' ');
+            help_text.push_str(HAS_SELECTION);
+        }
+        let block = Block::default()
+            .borders(Borders::LEFT)
+            .title(self.terminal_output.title(self.task_name))
+            .title_bottom(Line::from(help_text).centered())
+            .style(if self.highlight {
+                Style::new().fg(ratatui::style::Color::Yellow)
+            } else {
+                Style::new()
+            });
+
         let term = PseudoTerminal::new(screen).block(block);
         term.render(area, buf)
     }

--- a/crates/turborepo-ui/src/tui/term_output.rs
+++ b/crates/turborepo-ui/src/tui/term_output.rs
@@ -17,6 +17,7 @@ pub struct TerminalOutput<W> {
     pub output_logs: Option<OutputLogs>,
     pub task_result: Option<TaskResult>,
     pub cache_result: Option<CacheResult>,
+    selection: Option<SelectionState>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -24,6 +25,36 @@ enum LogBehavior {
     Full,
     Status,
     Nothing,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SelectionState {
+    start: Pos,
+    end: Pos,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Pos {
+    pub x: u16,
+    pub y: u16,
+}
+
+impl SelectionState {
+    pub fn new(event: crossterm::event::MouseEvent) -> Self {
+        let start = Pos {
+            x: event.column,
+            y: event.row,
+        };
+        let end = start;
+        Self { start, end }
+    }
+
+    pub fn update(&mut self, event: crossterm::event::MouseEvent) {
+        self.end = Pos {
+            x: event.column,
+            y: event.row,
+        };
+    }
 }
 
 impl<W> TerminalOutput<W> {
@@ -37,6 +68,7 @@ impl<W> TerminalOutput<W> {
             output_logs: None,
             task_result: None,
             cache_result: None,
+            selection: None,
         }
     }
 
@@ -109,6 +141,47 @@ impl<W> TerminalOutput<W> {
                 stdout.write_all(b"\r\n")?;
             }
             LogBehavior::Nothing => (),
+        }
+        Ok(())
+    }
+
+    pub fn handle_mouse(&mut self, event: crossterm::event::MouseEvent) -> Result<(), Error> {
+        match event.kind {
+            crossterm::event::MouseEventKind::Down(crossterm::event::MouseButton::Left) => {
+                // Here we enter copy mode with this position
+                let selection = SelectionState::new(event);
+                // we now store this in the task
+                self.selection = Some(selection);
+            }
+            crossterm::event::MouseEventKind::Drag(crossterm::event::MouseButton::Left) => {
+                // Here we change an endpoint of the selection
+                // Should be noted that it can go backwards
+                // If we didn't catch the start of a selection, use the current position
+                let selection = self
+                    .selection
+                    .get_or_insert_with(|| SelectionState::new(event));
+                selection.update(event);
+                // Update selection of underlying parser
+                self.parser.screen_mut().set_selection(
+                    selection.start.y,
+                    selection.start.x,
+                    selection.end.y,
+                    selection.end.x,
+                );
+            }
+            // Scrolling is handled elsewhere
+            crossterm::event::MouseEventKind::ScrollDown => (),
+            crossterm::event::MouseEventKind::ScrollUp => (),
+            // I think we can ignore this?
+            crossterm::event::MouseEventKind::Moved => (),
+            // Don't care about other mouse buttons
+            crossterm::event::MouseEventKind::Down(_) => (),
+            crossterm::event::MouseEventKind::Drag(_) => (),
+            // We don't support horizontal scroll
+            crossterm::event::MouseEventKind::ScrollLeft
+            | crossterm::event::MouseEventKind::ScrollRight => (),
+            // Cool, person stopped holding down mouse
+            crossterm::event::MouseEventKind::Up(_) => (),
         }
         Ok(())
     }

--- a/crates/turborepo-ui/src/tui/term_output.rs
+++ b/crates/turborepo-ui/src/tui/term_output.rs
@@ -185,4 +185,8 @@ impl<W> TerminalOutput<W> {
         }
         Ok(())
     }
+
+    pub fn copy_selection(&self) -> Option<String> {
+        self.parser.screen().selected_text()
+    }
 }

--- a/crates/turborepo-ui/src/tui/term_output.rs
+++ b/crates/turborepo-ui/src/tui/term_output.rs
@@ -113,6 +113,10 @@ impl<W> TerminalOutput<W> {
         Ok(())
     }
 
+    pub fn has_selection(&self) -> bool {
+        self.parser.screen().selected_text().is_some()
+    }
+
     pub fn handle_mouse(&mut self, event: crossterm::event::MouseEvent) -> Result<(), Error> {
         match event.kind {
             crossterm::event::MouseEventKind::Down(crossterm::event::MouseButton::Left) => {

--- a/crates/turborepo-ui/src/tui/term_output.rs
+++ b/crates/turborepo-ui/src/tui/term_output.rs
@@ -148,10 +148,9 @@ impl<W> TerminalOutput<W> {
     pub fn handle_mouse(&mut self, event: crossterm::event::MouseEvent) -> Result<(), Error> {
         match event.kind {
             crossterm::event::MouseEventKind::Down(crossterm::event::MouseButton::Left) => {
-                // Here we enter copy mode with this position
-                let selection = SelectionState::new(event);
-                // we now store this in the task
-                self.selection = Some(selection);
+                self.selection = None;
+                // We need to update the vterm so we don't continue to render the selection
+                self.parser.screen_mut().clear_selection();
             }
             crossterm::event::MouseEventKind::Drag(crossterm::event::MouseButton::Left) => {
                 // Here we change an endpoint of the selection

--- a/crates/turborepo-ui/src/tui/term_output.rs
+++ b/crates/turborepo-ui/src/tui/term_output.rs
@@ -114,7 +114,10 @@ impl<W> TerminalOutput<W> {
     }
 
     pub fn has_selection(&self) -> bool {
-        self.parser.screen().selected_text().is_some()
+        self.parser
+            .screen()
+            .selected_text()
+            .map_or(false, |s| !s.is_empty())
     }
 
     pub fn handle_mouse(&mut self, event: crossterm::event::MouseEvent) -> Result<(), Error> {

--- a/crates/turborepo-vt100/src/cell.rs
+++ b/crates/turborepo-vt100/src/cell.rs
@@ -8,6 +8,7 @@ pub struct Cell {
     contents: [char; CODEPOINTS_IN_CELL],
     len: u8,
     attrs: crate::attrs::Attrs,
+    selected: bool,
 }
 
 impl PartialEq<Self> for Cell {
@@ -30,6 +31,7 @@ impl Cell {
             contents: Default::default(),
             len: 0,
             attrs: crate::attrs::Attrs::default(),
+            selected: false,
         }
     }
 
@@ -68,6 +70,15 @@ impl Cell {
     pub(crate) fn clear(&mut self, attrs: crate::attrs::Attrs) {
         self.len = 0;
         self.attrs = attrs;
+        self.selected = false;
+    }
+
+    pub(crate) fn selected(&self) -> bool {
+        self.selected
+    }
+
+    pub(crate) fn select(&mut self, selected: bool) {
+        self.selected = selected;
     }
 
     /// Returns the text contents of the cell.
@@ -161,6 +172,6 @@ impl Cell {
     /// attribute.
     #[must_use]
     pub fn inverse(&self) -> bool {
-        self.attrs.inverse()
+        self.attrs.inverse() || self.selected
     }
 }

--- a/crates/turborepo-vt100/src/row.rs
+++ b/crates/turborepo-vt100/src/row.rs
@@ -37,6 +37,12 @@ impl Row {
         self.cells.iter()
     }
 
+    pub(crate) fn cells_mut(
+        &mut self,
+    ) -> impl Iterator<Item = &mut crate::Cell> {
+        self.cells.iter_mut()
+    }
+
     pub fn get(&self, col: u16) -> Option<&crate::Cell> {
         self.cells.get(usize::from(col))
     }

--- a/crates/turborepo-vt100/src/screen.rs
+++ b/crates/turborepo-vt100/src/screen.rs
@@ -315,7 +315,14 @@ impl Screen {
         end_col: u16,
     ) {
         self.grid_mut()
-            .set_selection(start_row, start_col, end_row, end_col)
+            .set_selection(start_row, start_col, end_row, end_col);
+    }
+
+    /// Updates the current selection to end at row and col.
+    ///
+    /// If no selection is currently set, then a selection will be created that starts and ends at the same position.
+    pub fn update_selection(&mut self, row: u16, col: u16) {
+        self.grid_mut().update_selection(row, col);
     }
 
     /// Clears current selection if one exists
@@ -323,12 +330,17 @@ impl Screen {
         self.grid_mut().clear_selection();
     }
 
+    /// Returns text contained in selection
+    #[must_use]
     pub fn selected_text(&self) -> Option<String> {
         let selection = self.grid().selection()?;
         let start = selection.start;
         let end = selection.end;
         Some(self.contents_between_absolute(
-            start.row, start.col, end.row, end.col,
+            start.row,
+            start.col,
+            end.row,
+            end.col + 1,
         ))
     }
 

--- a/crates/turborepo-vt100/src/screen.rs
+++ b/crates/turborepo-vt100/src/screen.rs
@@ -232,6 +232,106 @@ impl Screen {
         }
     }
 
+    /// Returns the text contents of the terminal logically between two cells at the given scrollback
+    /// This will include the remainder of the starting row after `start_col`,
+    /// followed by the entire contents of the rows between `start_row` and
+    /// `end_row`, followed by the beginning of the `end_row` up until
+    /// `end_col`. This is useful for things like determining the contents of
+    /// a clipboard selection.
+    #[must_use]
+    fn contents_between_absolute(
+        &self,
+        start_row: usize,
+        start_col: u16,
+        end_row: usize,
+        end_col: u16,
+    ) -> String {
+        match start_row.cmp(&end_row) {
+            std::cmp::Ordering::Less => {
+                let (_, cols) = self.size();
+                let mut contents = String::new();
+                for (i, row) in self
+                    .grid()
+                    .all_rows()
+                    .enumerate()
+                    .skip(start_row)
+                    .take(end_row - start_row + 1)
+                {
+                    if i == usize::from(start_row) {
+                        row.write_contents(
+                            &mut contents,
+                            start_col,
+                            cols - start_col,
+                            false,
+                        );
+                        if !row.wrapped() {
+                            contents.push('\n');
+                        }
+                    } else if i == usize::from(end_row) {
+                        row.write_contents(&mut contents, 0, end_col, false);
+                    } else {
+                        row.write_contents(&mut contents, 0, cols, false);
+                        if !row.wrapped() {
+                            contents.push('\n');
+                        }
+                    }
+                }
+                contents
+            }
+            std::cmp::Ordering::Equal => {
+                if start_col < end_col {
+                    self.grid()
+                        .all_rows()
+                        .nth(start_row)
+                        .map(move |row| {
+                            let mut contents = String::new();
+                            row.write_contents(
+                                &mut contents,
+                                start_col,
+                                end_col - start_col,
+                                false,
+                            );
+                            contents
+                        })
+                        .unwrap_or_default()
+                } else {
+                    String::new()
+                }
+            }
+            std::cmp::Ordering::Greater => String::new(),
+        }
+    }
+
+    /// Selects text on the viewable screen.
+    ///
+    /// The positions given should be provided in relation to the viewable screen, not including the scrollback.
+    ///
+    /// Positions will be clamped to actual size of the screen.
+    pub fn set_selection(
+        &mut self,
+        start_row: u16,
+        start_col: u16,
+        end_row: u16,
+        end_col: u16,
+    ) {
+        self.grid_mut()
+            .set_selection(start_row, start_col, end_row, end_col)
+    }
+
+    /// Clears current selection if one exists
+    pub fn clear_selection(&mut self) {
+        self.grid_mut().clear_selection();
+    }
+
+    pub fn selected_text(&self) -> Option<String> {
+        let selection = self.grid().selection()?;
+        let start = selection.start;
+        let end = selection.end;
+        Some(self.contents_between_absolute(
+            start.row, start.col, end.row, end.col,
+        ))
+    }
+
     /// Return escape codes sufficient to reproduce the entire contents of the
     /// current terminal state. This is a convenience wrapper around
     /// `contents_formatted`, `input_mode_formatted`, and `title_formatted`.

--- a/crates/turborepo-vt100/src/screen.rs
+++ b/crates/turborepo-vt100/src/screen.rs
@@ -257,7 +257,7 @@ impl Screen {
                     .skip(start_row)
                     .take(end_row - start_row + 1)
                 {
-                    if i == usize::from(start_row) {
+                    if i == start_row {
                         row.write_contents(
                             &mut contents,
                             start_col,
@@ -267,7 +267,7 @@ impl Screen {
                         if !row.wrapped() {
                             contents.push('\n');
                         }
-                    } else if i == usize::from(end_row) {
+                    } else if i == end_row {
                         row.write_contents(&mut contents, 0, end_col, false);
                     } else {
                         row.write_contents(&mut contents, 0, cols, false);

--- a/crates/turborepo-vt100/tests/select.rs
+++ b/crates/turborepo-vt100/tests/select.rs
@@ -77,3 +77,18 @@ fn too_large() {
         Some("bar\nbaz\n")
     );
 }
+
+#[test]
+fn selection_inversed_display() {
+    let mut parser = vt100::Parser::new(2, 4, 10);
+    parser.process(b"foo\r\nbar\r\nbaz");
+
+    // Make sure foo is off the screen
+    assert_eq!(parser.screen().contents(), "bar\nbaz");
+    parser.screen_mut().set_selection(0, 0, 0, 3);
+    assert_eq!(parser.screen().selected_text().as_deref(), Some("bar"));
+    assert!(parser.screen().cell(0, 0).unwrap().inverse());
+    assert!(parser.screen().cell(0, 1).unwrap().inverse());
+    assert!(parser.screen().cell(0, 2).unwrap().inverse());
+    assert!(!parser.screen().cell(0, 3).unwrap().inverse());
+}

--- a/crates/turborepo-vt100/tests/select.rs
+++ b/crates/turborepo-vt100/tests/select.rs
@@ -1,0 +1,79 @@
+use turborepo_vt100 as vt100;
+
+mod helpers;
+
+// test setting selection
+// test copying
+// test scrolling with a selection
+
+#[test]
+fn visible() {
+    let mut parser = vt100::Parser::new(2, 4, 10);
+    parser.process(b"foo\r\nbar\r\nbaz");
+
+    // Make sure foo is off the screen
+    assert_eq!(parser.screen().contents(), "bar\nbaz");
+    parser.screen_mut().set_selection(0, 0, 0, 3);
+    assert_eq!(parser.screen().selected_text().as_deref(), Some("bar"));
+    parser.screen_mut().clear_selection();
+    assert!(parser.screen().selected_text().is_none());
+}
+
+#[test]
+fn multiline() {
+    let mut parser = vt100::Parser::new(2, 4, 10);
+    parser.process(b"foo\r\nbar\r\nbaz");
+
+    // Make sure foo is off the screen
+    assert_eq!(parser.screen().contents(), "bar\nbaz");
+    parser.screen_mut().set_selection(0, 0, 1, 0);
+    assert_eq!(parser.screen().selected_text().as_deref(), Some("bar\n"));
+}
+
+#[test]
+fn scrolling_keeps_selection() {
+    let mut parser = vt100::Parser::new(2, 4, 10);
+    parser.process(b"foo\r\nbar\r\nbaz");
+
+    assert_eq!(parser.screen().contents(), "bar\nbaz");
+    parser.screen_mut().set_selection(0, 0, 0, 3);
+    // Scroll so baz is off the screen
+    parser.screen_mut().set_scrollback(1);
+    // Bar should still be selected
+    assert_eq!(parser.screen().selected_text().as_deref(), Some("bar"));
+}
+
+#[test]
+fn adding_keeps_selection() {
+    let mut parser = vt100::Parser::new(2, 4, 10);
+    parser.process(b"foo\r\nbar");
+    parser.screen_mut().set_selection(1, 0, 1, 3);
+    parser.process(b"\r\nbaz");
+    // Bar should still be selected
+    assert_eq!(parser.screen().selected_text().as_deref(), Some("bar"));
+}
+
+#[test]
+fn backwards_selection() {
+    let mut parser = vt100::Parser::new(2, 4, 10);
+    parser.process(b"foo\r\nbar\r\nbaz");
+
+    assert_eq!(parser.screen().contents(), "bar\nbaz");
+    parser.screen_mut().set_selection(1, 0, 0, 0);
+    // Bar was selected from below
+    assert_eq!(parser.screen().selected_text().as_deref(), Some("bar\n"));
+}
+
+#[test]
+fn too_large() {
+    let mut parser = vt100::Parser::new(2, 4, 10);
+    parser.process(b"foo\r\nbar\r\nbaz");
+
+    assert_eq!(parser.screen().contents(), "bar\nbaz");
+    parser.screen_mut().set_selection(0, 0, 5, 0);
+    // Entire screen was selected, but nothing extra
+    assert_eq!(
+        parser.screen().selected_text().as_deref(),
+        Some("bar\nbaz\n")
+    );
+}


### PR DESCRIPTION
### Description

Adds mouse selection and copying in the terminal pane. When selecting text, pressing `c` will copy the current text. Users are allowed to interact with tasks while having a selection, but `c` will still be intercepted to copy the selection.

Future work:
 - Double click should select the entire line

Reviewer Guide:
 - Review each commit on it's own
 - We implement selection at the virtual terminal level, this allows us to take into account the current scroll state and translate mouse events into "absolute" position.
 - I did a bad thing and fixed some bugs in this PR. They have their own commits, but easier to do here as they would cause merge conflicts if done independently.


### Testing Instructions

Added unit tests for the vt100 level copying. Testing this in actual terminals is the best way to test mouse inputs feel right.

Video: (please ignore my struggles scrolling and accurately selecting text, I'm on a trackpad and it's very humid)

https://github.com/user-attachments/assets/bda72f3b-dc8c-4344-972a-cfc0ac65c217

