### PR TITLE
adds CLI flag for controlling tui/stream

### DIFF
--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -32,6 +32,7 @@ use crate::{
     run::watch::WatchClient,
     shim::TurboState,
     tracing::TurboSubscriber,
+    turbo_json::UI as ConfigUI,
 };
 
 mod error;
@@ -183,6 +184,9 @@ pub struct Args {
     /// Specify a file to save a pprof heap profile
     #[clap(long, global = true, value_parser)]
     pub heap: Option<String>,
+    /// Specify whether to use the streaming UI or TUI
+    #[clap(long, global = true, value_enum)]
+    pub ui: Option<ConfigUI>,
     /// Override the login endpoint
     #[clap(long, global = true, value_parser)]
     pub login: Option<String>,

--- a/crates/turborepo-lib/src/commands/mod.rs
+++ b/crates/turborepo-lib/src/commands/mod.rs
@@ -68,14 +68,16 @@ impl CommandBase {
             .with_token(self.args.token.clone())
             .with_timeout(self.args.remote_cache_timeout)
             .with_preflight(self.args.preflight.then_some(true))
-            .with_ui(self.args.execution_args.as_ref().and_then(|args| {
-                if !args.log_order.compatible_with_tui() {
-                    Some(false)
-                } else {
-                    // If the argument is compatible with the TUI this does not mean we should
-                    // override other configs
-                    None
-                }
+            .with_ui(self.args.ui.map(|ui| ui.use_tui()).or_else(|| {
+                self.args.execution_args.as_ref().and_then(|args| {
+                    if !args.log_order.compatible_with_tui() {
+                        Some(false)
+                    } else {
+                        // If the argument is compatible with the TUI this does not mean we should
+                        // override other configs
+                        None
+                    }
+                })
             }))
             .build()
     }

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -6,6 +6,7 @@ use std::{
 
 use biome_deserialize_macros::Deserializable;
 use camino::Utf8Path;
+use clap::ValueEnum;
 use miette::{NamedSource, SourceSpan};
 use serde::{Deserialize, Serialize};
 use struct_iterable::Iterable;
@@ -159,10 +160,12 @@ impl DerefMut for Pipeline {
     }
 }
 
-#[derive(Serialize, Debug, Copy, Clone, Deserializable, PartialEq, Eq)]
+#[derive(Serialize, Debug, Copy, Clone, Deserializable, PartialEq, Eq, ValueEnum)]
 #[serde(rename_all = "camelCase")]
 pub enum UI {
+    /// Use the TUI interface
     Tui,
+    /// Use the standard output stream
     Stream,
 }
 

--- a/turborepo-tests/integration/tests/no-args.t
+++ b/turborepo-tests/integration/tests/no-args.t
@@ -30,6 +30,7 @@ Make sure exit code is 2 when no args are passed
         --color                           Force color usage in the terminal
         --cwd <CWD>                       The directory in which to run turbo
         --heap <HEAP>                     Specify a file to save a pprof heap profile
+        --ui <UI>                         Specify whether to use the streaming UI or TUI [possible values: tui, stream]
         --login <LOGIN>                   Override the login endpoint
         --no-color                        Suppress color usage in the terminal
         --preflight                       When enabled, turbo will precede HTTP requests with an OPTIONS request for authorization
@@ -38,7 +39,7 @@ Make sure exit code is 2 when no args are passed
         --token <TOKEN>                   Set the auth token for API calls
         --trace <TRACE>                   Specify a file to save a pprof trace
         --verbosity <COUNT>               Verbosity level
-    -h, --help                            Print help
+    -h, --help                            Print help (see more with '--help')
   
   Run Arguments:
         --cache-workers <CACHE_WORKERS>

--- a/turborepo-tests/integration/tests/turbo-help.t
+++ b/turborepo-tests/integration/tests/turbo-help.t
@@ -30,6 +30,7 @@ Test help flag
         --color                           Force color usage in the terminal
         --cwd <CWD>                       The directory in which to run turbo
         --heap <HEAP>                     Specify a file to save a pprof heap profile
+        --ui <UI>                         Specify whether to use the streaming UI or TUI [possible values: tui, stream]
         --login <LOGIN>                   Override the login endpoint
         --no-color                        Suppress color usage in the terminal
         --preflight                       When enabled, turbo will precede HTTP requests with an OPTIONS request for authorization
@@ -38,7 +39,7 @@ Test help flag
         --token <TOKEN>                   Set the auth token for API calls
         --trace <TRACE>                   Specify a file to save a pprof trace
         --verbosity <COUNT>               Verbosity level
-    -h, --help                            Print help
+    -h, --help                            Print help (see more with '--help')
   
   Run Arguments:
         --cache-workers <CACHE_WORKERS>
@@ -116,72 +117,166 @@ Test help flag
     unlink      Unlink the current directory from your Vercel organization and disable Remote Caching
   
   Options:
-        --version                         
-        --skip-infer                      Skip any attempts to infer which version of Turbo the project is configured to use
-        --no-update-notifier              Disable the turbo update notification
-        --api <API>                       Override the endpoint for API calls
-        --color                           Force color usage in the terminal
-        --cwd <CWD>                       The directory in which to run turbo
-        --heap <HEAP>                     Specify a file to save a pprof heap profile
-        --login <LOGIN>                   Override the login endpoint
-        --no-color                        Suppress color usage in the terminal
-        --preflight                       When enabled, turbo will precede HTTP requests with an OPTIONS request for authorization
-        --remote-cache-timeout <TIMEOUT>  Set a timeout for all HTTP requests
-        --team <TEAM>                     Set the team slug for API calls
-        --token <TOKEN>                   Set the auth token for API calls
-        --trace <TRACE>                   Specify a file to save a pprof trace
-        --verbosity <COUNT>               Verbosity level
-    -h, --help                            Print help
+        --version
+            
+  
+        --skip-infer
+            Skip any attempts to infer which version of Turbo the project is configured to use
+  
+        --no-update-notifier
+            Disable the turbo update notification
+  
+        --api <API>
+            Override the endpoint for API calls
+  
+        --color
+            Force color usage in the terminal
+  
+        --cwd <CWD>
+            The directory in which to run turbo
+  
+        --heap <HEAP>
+            Specify a file to save a pprof heap profile
+  
+        --ui <UI>
+            Specify whether to use the streaming UI or TUI
+  
+            Possible values:
+            - tui:    Use the TUI interface
+            - stream: Use the standard output stream
+  
+        --login <LOGIN>
+            Override the login endpoint
+  
+        --no-color
+            Suppress color usage in the terminal
+  
+        --preflight
+            When enabled, turbo will precede HTTP requests with an OPTIONS request for authorization
+  
+        --remote-cache-timeout <TIMEOUT>
+            Set a timeout for all HTTP requests
+  
+        --team <TEAM>
+            Set the team slug for API calls
+  
+        --token <TOKEN>
+            Set the auth token for API calls
+  
+        --trace <TRACE>
+            Specify a file to save a pprof trace
+  
+        --verbosity <COUNT>
+            Verbosity level
+  
+    -h, --help
+            Print help (see a summary with '-h')
   
   Run Arguments:
         --cache-workers <CACHE_WORKERS>
-            Set the number of concurrent cache operations (default 10) [default: 10]
+            Set the number of concurrent cache operations (default 10)
+            
+            [default: 10]
+  
         --dry-run [<DRY_RUN>]
             [possible values: text, json]
+  
         --graph [<GRAPH>]
             Generate a graph of the task execution and output to a file when a filename is specified (.svg, .png, .jpg, .pdf, .json, .html, .mermaid, .dot). Outputs dot graph to stdout when if no filename is provided
+  
         --no-cache
             Avoid saving task results to the cache. Useful for development/watch tasks
+  
         --[no-]daemon
             Force turbo to either use or not use the local daemon. If unset turbo will use the default detection logic
+  
         --profile <PROFILE>
             File to write turbo's performance profile output into. You can load the file up in chrome://tracing to see which parts of your build were slow
+  
         --anon-profile <ANON_PROFILE>
             File to write turbo's performance profile output into. All identifying data omitted from the profile
+  
         --remote-cache-read-only [<BOOL>]
-            Treat remote cache as read only [env: TURBO_REMOTE_CACHE_READ_ONLY=] [default: false] [possible values: true, false]
+            Treat remote cache as read only
+            
+            [env: TURBO_REMOTE_CACHE_READ_ONLY=]
+            [default: false]
+            [possible values: true, false]
+  
         --summarize [<SUMMARIZE>]
-            Generate a summary of the turbo run [env: TURBO_RUN_SUMMARY=] [possible values: true, false]
+            Generate a summary of the turbo run
+            
+            [env: TURBO_RUN_SUMMARY=]
+            [possible values: true, false]
+  
         --parallel
             Execute all tasks in parallel
+  
         --cache-dir <CACHE_DIR>
-            Override the filesystem cache directory [env: TURBO_CACHE_DIR=]
+            Override the filesystem cache directory
+            
+            [env: TURBO_CACHE_DIR=]
+  
         --concurrency <CONCURRENCY>
             Limit the concurrency of task execution. Use 1 for serial (i.e. one-at-a-time) execution
+  
         --continue
             Continue execution even if a task exits with an error or non-zero exit code. The default behavior is to bail
+  
         --single-package
             Run turbo in single-package mode
+  
         --force [<FORCE>]
-            Ignore the existing cache (to force execution) [env: TURBO_FORCE=] [possible values: true, false]
+            Ignore the existing cache (to force execution)
+            
+            [env: TURBO_FORCE=]
+            [possible values: true, false]
+  
         --framework-inference [<BOOL>]
-            Specify whether or not to do framework inference for tasks [default: true] [possible values: true, false]
+            Specify whether or not to do framework inference for tasks
+            
+            [default: true]
+            [possible values: true, false]
+  
         --global-deps <GLOBAL_DEPS>
             Specify glob of global filesystem dependencies to be hashed. Useful for .env and files
+  
         --env-mode [<ENV_MODE>]
-            Environment variable mode. Use "loose" to pass the entire existing environment. Use "strict" to use an allowlist specified in turbo.json [default: strict] [possible values: loose, strict]
+            Environment variable mode. Use "loose" to pass the entire existing environment. Use "strict" to use an allowlist specified in turbo.json
+            
+            [default: strict]
+            [possible values: loose, strict]
+  
     -F, --filter <FILTER>
             Use the given selector to specify package(s) to act as entry points. The syntax mirrors pnpm's syntax, and additional documentation and examples can be found in turbo's documentation https://turbo.build/repo/docs/reference/command-line-reference/run#--filter
+  
         --output-logs <OUTPUT_LOGS>
-            Set type of process output logging. Use "full" to show all output. Use "hash-only" to show only turbo-computed task hashes. Use "new-only" to show only new output with only hashes for cached tasks. Use "none" to hide process output. (default full) [possible values: full, none, hash-only, new-only, errors-only]
+            Set type of process output logging. Use "full" to show all output. Use "hash-only" to show only turbo-computed task hashes. Use "new-only" to show only new output with only hashes for cached tasks. Use "none" to hide process output. (default full)
+            
+            [possible values: full, none, hash-only, new-only, errors-only]
+  
         --log-order <LOG_ORDER>
-            Set type of task output order. Use "stream" to show output as soon as it is available. Use "grouped" to show output when a command has finished execution. Use "auto" to let turbo decide based on its own heuristics. (default auto) [env: TURBO_LOG_ORDER=] [default: auto] [possible values: auto, stream, grouped]
+            Set type of task output order. Use "stream" to show output as soon as it is available. Use "grouped" to show output when a command has finished execution. Use "auto" to let turbo decide based on its own heuristics. (default auto)
+            
+            [env: TURBO_LOG_ORDER=]
+            [default: auto]
+            [possible values: auto, stream, grouped]
+  
         --only
             Only executes the tasks specified, does not execute parent tasks
+  
         --remote-only [<BOOL>]
-            Ignore the local filesystem cache for all tasks. Only allow reading and caching artifacts using the remote cache [env: TURBO_REMOTE_ONLY=] [default: false] [possible values: true, false]
+            Ignore the local filesystem cache for all tasks. Only allow reading and caching artifacts using the remote cache
+            
+            [env: TURBO_REMOTE_ONLY=]
+            [default: false]
+            [possible values: true, false]
+  
         --log-prefix <LOG_PREFIX>
-            Use "none" to remove prefixes from task logs. Use "task" to get task id prefixing. Use "auto" to let turbo decide how to prefix the logs based on the execution environment. In most cases this will be the same as "task". Note that tasks running in parallel interleave their logs, so removing prefixes can make it difficult to associate logs with tasks. Use --log-order=grouped to prevent interleaving. (default auto) [default: auto] [possible values: auto, none, task]
+            Use "none" to remove prefixes from task logs. Use "task" to get task id prefixing. Use "auto" to let turbo decide how to prefix the logs based on the execution environment. In most cases this will be the same as "task". Note that tasks running in parallel interleave their logs, so removing prefixes can make it difficult to associate logs with tasks. Use --log-order=grouped to prevent interleaving. (default auto)
+            
+            [default: auto]
+            [possible values: auto, none, task]
 
 Test help flag for link command
   $ ${TURBO} link -h
@@ -199,6 +294,7 @@ Test help flag for link command
         --color                           Force color usage in the terminal
         --cwd <CWD>                       The directory in which to run turbo
         --heap <HEAP>                     Specify a file to save a pprof heap profile
+        --ui <UI>                         Specify whether to use the streaming UI or TUI [possible values: tui, stream]
         --login <LOGIN>                   Override the login endpoint
         --no-color                        Suppress color usage in the terminal
         --preflight                       When enabled, turbo will precede HTTP requests with an OPTIONS request for authorization
@@ -207,7 +303,7 @@ Test help flag for link command
         --token <TOKEN>                   Set the auth token for API calls
         --trace <TRACE>                   Specify a file to save a pprof trace
         --verbosity <COUNT>               Verbosity level
-    -h, --help                            Print help
+    -h, --help                            Print help (see more with '--help')
 
 Test help flag for unlink command
   $ ${TURBO} unlink -h
@@ -224,6 +320,7 @@ Test help flag for unlink command
         --color                           Force color usage in the terminal
         --cwd <CWD>                       The directory in which to run turbo
         --heap <HEAP>                     Specify a file to save a pprof heap profile
+        --ui <UI>                         Specify whether to use the streaming UI or TUI [possible values: tui, stream]
         --login <LOGIN>                   Override the login endpoint
         --no-color                        Suppress color usage in the terminal
         --preflight                       When enabled, turbo will precede HTTP requests with an OPTIONS request for authorization
@@ -232,7 +329,7 @@ Test help flag for unlink command
         --token <TOKEN>                   Set the auth token for API calls
         --trace <TRACE>                   Specify a file to save a pprof trace
         --verbosity <COUNT>               Verbosity level
-    -h, --help                            Print help
+    -h, --help                            Print help (see more with '--help')
 
 Test help flag for login command
   $ ${TURBO} login -h
@@ -250,6 +347,7 @@ Test help flag for login command
         --color                           Force color usage in the terminal
         --cwd <CWD>                       The directory in which to run turbo
         --heap <HEAP>                     Specify a file to save a pprof heap profile
+        --ui <UI>                         Specify whether to use the streaming UI or TUI [possible values: tui, stream]
         --login <LOGIN>                   Override the login endpoint
         --no-color                        Suppress color usage in the terminal
         --preflight                       When enabled, turbo will precede HTTP requests with an OPTIONS request for authorization
@@ -258,7 +356,7 @@ Test help flag for login command
         --token <TOKEN>                   Set the auth token for API calls
         --trace <TRACE>                   Specify a file to save a pprof trace
         --verbosity <COUNT>               Verbosity level
-    -h, --help                            Print help
+    -h, --help                            Print help (see more with '--help')
 
 Test help flag for logout command
   $ ${TURBO} logout -h
@@ -275,6 +373,7 @@ Test help flag for logout command
         --color                           Force color usage in the terminal
         --cwd <CWD>                       The directory in which to run turbo
         --heap <HEAP>                     Specify a file to save a pprof heap profile
+        --ui <UI>                         Specify whether to use the streaming UI or TUI [possible values: tui, stream]
         --login <LOGIN>                   Override the login endpoint
         --no-color                        Suppress color usage in the terminal
         --preflight                       When enabled, turbo will precede HTTP requests with an OPTIONS request for authorization
@@ -283,4 +382,4 @@ Test help flag for logout command
         --token <TOKEN>                   Set the auth token for API calls
         --trace <TRACE>                   Specify a file to save a pprof trace
         --verbosity <COUNT>               Verbosity level
-    -h, --help                            Print help
+    -h, --help                            Print help (see more with '--help')


### PR DESCRIPTION
### Description

This PR adds the `--ui` flag to the CLI, where the options are `stream` or `tui`.

### Testing Instructions

1. run with the `--ui` flag with no options to see the error text (describing the available options)
1. run `--help` and see this flag listed as an option
1. run with `--ui stream` to force the stream UI
1. run with `--ui tui` to force TUI 