### PR TITLE
Switch RcStr from std::sync::Arc to triomphe::Arc

### DIFF
--- a/crates/turbo-tasks/src/rcstr.rs
+++ b/crates/turbo-tasks/src/rcstr.rs
@@ -12,7 +12,11 @@ use turbo_tasks_hash::{DeterministicHash, DeterministicHasher};
 
 use crate::debug::{ValueDebugFormat, ValueDebugFormatString};
 
-/// This type exists to allow swapping out the underlying string type easily.
+/// A reference counted [`String`], similar to [`Arc<String>`][std::sync::Arc].
+///
+/// This type is intentionally opaque to allow for optimizations to the
+/// underlying representation. Future implementations may use inline
+/// representations or interning.
 //
 // If you want to change the underlying string type to `Arc<str>`, please ensure that you profile
 // performance. The current implementation offers very cheap `String -> RcStr -> String`, meaning we

--- a/crates/turbo-tasks/src/rcstr.rs
+++ b/crates/turbo-tasks/src/rcstr.rs
@@ -4,10 +4,10 @@ use std::{
     fmt::{Debug, Display},
     ops::Deref,
     path::{Path, PathBuf},
-    sync::Arc,
 };
 
 use serde::{Deserialize, Serialize};
+use triomphe::Arc;
 use turbo_tasks_hash::{DeterministicHash, DeterministicHasher};
 
 use crate::debug::{ValueDebugFormat, ValueDebugFormatString};

--- a/crates/turbopack-ecmascript/src/parse.rs
+++ b/crates/turbopack-ecmascript/src/parse.rs
@@ -419,7 +419,8 @@ async fn parse_content(
                 } else {
                     None
                 };
-                let messages = Some(messages.unwrap_or_else(|| vec![fm.src.clone().into()]));
+                let messages =
+                    Some(messages.unwrap_or_else(|| vec![String::clone(&fm.src).into()]));
                 return Ok(ParseResult::Unparseable { messages });
             }
 


### PR DESCRIPTION
# Description

This removes the weakref from each `Arc`, which we weren't using, saving 64 bits per unique `RcStr`.

https://docs.rs/triomphe/latest/triomphe/struct.Arc.html

The difference in memory is too small to easily measure with heaptrack, but it should be a small win regardless, and it's a drop-in replacement that doesn't make the code any more complicated.

# Testing Instructions

Built using

```
cargo build --release -p next-build-test
```

Ran heaptrack on a single page (`/sink`) in `shadcn/ui` with:

```
cd ~/ui/apps/www
RUST_LOG=next_build_test=info heaptrack ~/nextpack/target/release/next-build-test run sequential 1 1 '/sink'
```

And analyzed the results with

```
heaptrack --analyze /home/bgw.linux/ui/apps/www/heaptrack.next-build-test.3066837.zst | tail -100
```

## Heaptrack Before PR

```
total runtime: 135.14s.
calls to allocation functions: 49700807 (367770/s)
temporary memory allocations: 4126130 (30532/s)
peak heap memory consumption: 1.18G
peak RSS (including heaptrack overhead): 2.76G
total memory leaked: 11.93M
suppressed leaks: 7.24K
```

```
total runtime: 138.50s.
calls to allocation functions: 49771465 (359355/s)
temporary memory allocations: 4410274 (31842/s)
peak heap memory consumption: 1.18G
peak RSS (including heaptrack overhead): 2.75G
total memory leaked: 12.09M
suppressed leaks: 7.24K
```

## Heaptrack After PR

```
total runtime: 145.38s.
calls to allocation functions: 49714711 (341966/s)
temporary memory allocations: 4164393 (28645/s)
peak heap memory consumption: 1.18G
peak RSS (including heaptrack overhead): 2.75G
total memory leaked: 11.67M
suppressed leaks: 7.24K
```

```
total runtime: 128.03s.
calls to allocation functions: 49739679 (388515/s)
temporary memory allocations: 4111893 (32117/s)
peak heap memory consumption: 1.18G
peak RSS (including heaptrack overhead): 2.76G
total memory leaked: 11.88M
suppressed leaks: 7.24K
```