### PR TITLE
Replace UUID to native

### DIFF
--- a/packages/turbo-telemetry/package.json
+++ b/packages/turbo-telemetry/package.json
@@ -28,7 +28,6 @@
     "chalk": "^4.1.2",
     "ci-info": "^4.0.0",
     "got": "^11.8.6",
-    "uuid": "^9.0.1",
     "zod": "^3.22.4"
   },
   "devDependencies": {
@@ -39,7 +38,6 @@
     "@turbo/utils": "workspace:*",
     "@types/jest": "^27.4.0",
     "@types/node": "^20.11.30",
-    "@types/uuid": "^9.0.0",
     "dirs-next": "0.0.1-canary.1",
     "jest": "^27.4.3",
     "ts-jest": "^27.1.1",

--- a/packages/turbo-telemetry/src/client.ts
+++ b/packages/turbo-telemetry/src/client.ts
@@ -1,6 +1,6 @@
+import { randomUUID } from "node:crypto";
 import got, { type Response } from "got";
 import { logger } from "@turbo/utils";
-import { v4 as uuidv4 } from "uuid";
 import utils from "./utils";
 import { TelemetryConfig } from "./config";
 import type { Event, PackageInfo } from "./events/types";
@@ -25,7 +25,7 @@ export class TelemetryClient {
   private packageInfo: PackageInfo;
   private batchSize = DEFAULT_BATCH_SIZE;
   private timeout = 250;
-  private sessionId = uuidv4();
+  private sessionId = randomUUID();
   private eventBatches: Array<Promise<Response<string> | undefined>> = [];
   private events: Array<Record<"package", Event>> = [];
 
@@ -95,7 +95,7 @@ export class TelemetryClient {
     isSensitive?: boolean;
   }): Event {
     const event = {
-      id: uuidv4(),
+      id: randomUUID(),
       key,
       value: isSensitive ? this.config.oneWayHash(value) : value,
       package_name: this.packageInfo.name,

--- a/packages/turbo-telemetry/src/config.ts
+++ b/packages/turbo-telemetry/src/config.ts
@@ -1,7 +1,7 @@
 import { readFileSync, writeFileSync, rmSync } from "node:fs";
+import { randomUUID } from "node:crypto";
 import { logger } from "@turbo/utils";
 import chalk from "chalk";
-import { v4 as uuidv4 } from "uuid";
 import { z } from "zod";
 import utils from "./utils";
 
@@ -71,8 +71,8 @@ export class TelemetryConfig {
   }: {
     configPath: string;
   }): TelemetryConfig | undefined {
-    const RawTelemetryId = uuidv4();
-    const telemetrySalt = uuidv4();
+    const RawTelemetryId = randomUUID();
+    const telemetrySalt = randomUUID();
     const telemetryId = utils.oneWayHashWithSalt({
       input: RawTelemetryId,
       salt: telemetrySalt,

--- a/packages/turbo-test-utils/package.json
+++ b/packages/turbo-test-utils/package.json
@@ -28,7 +28,6 @@
     "@types/jest": "^27.4.0",
     "@types/js-yaml": "^4.0.5",
     "@types/node": "^18.17.2",
-    "@types/uuid": "^9.0.0",
     "jest": "^27.4.3",
     "ts-jest": "^27.1.1",
     "typescript": "5.3.3"
@@ -37,7 +36,6 @@
     "fs-extra": "^11.1.0",
     "js-yaml": "^4.1.0",
     "json5": "^2.2.3",
-    "rimraf": "^5.0.1",
-    "uuid": "^9.0.0"
+    "rimraf": "^5.0.1"
   }
 }

--- a/packages/turbo-test-utils/src/useFixtures.ts
+++ b/packages/turbo-test-utils/src/useFixtures.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { v4 as uuidv4 } from "uuid";
+import { randomUUID } from "node:crypto";
 import { rimraf } from "rimraf";
 import {
   mkdirSync,
@@ -25,7 +25,7 @@ export function setupTestFixtures({
   options = {},
 }: SetupTextFixtures) {
   const fixtures: Array<string> = [];
-  const parentDirectory = path.join(directory, test ? test : uuidv4());
+  const parentDirectory = path.join(directory, test ? test : randomUUID());
 
   afterEach(async () => {
     await Promise.all(
@@ -46,7 +46,7 @@ export function setupTestFixtures({
   });
 
   const useFixture = ({ fixture }: { fixture: string }) => {
-    const directoryName = uuidv4();
+    const directoryName = randomUUID();
     const testDirectory = path.join(parentDirectory, directoryName);
     if (!existsSync(testDirectory)) {
       mkdirSync(testDirectory, { recursive: true });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -749,9 +749,6 @@ importers:
       rimraf:
         specifier: ^5.0.1
         version: 5.0.1
-      uuid:
-        specifier: ^9.0.0
-        version: 9.0.0
     devDependencies:
       '@turbo/eslint-config':
         specifier: workspace:*
@@ -771,9 +768,6 @@ importers:
       '@types/node':
         specifier: ^18.17.2
         version: 18.17.4
-      '@types/uuid':
-        specifier: ^9.0.0
-        version: 9.0.0
       jest:
         specifier: ^27.4.3
         version: 27.5.1(ts-node@10.9.1)
@@ -12500,11 +12494,6 @@ packages:
 
   /uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
-    hasBin: true
-    dev: false
-
-  /uuid@9.0.0:
-    resolution: {integrity: sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==}
     hasBin: true
     dev: false
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -694,9 +694,6 @@ importers:
       got:
         specifier: ^11.8.6
         version: 11.8.6
-      uuid:
-        specifier: ^9.0.1
-        version: 9.0.1
       zod:
         specifier: ^3.22.4
         version: 3.22.4
@@ -722,9 +719,6 @@ importers:
       '@types/node':
         specifier: ^20.11.30
         version: 20.11.30
-      '@types/uuid':
-        specifier: ^9.0.0
-        version: 9.0.0
       dirs-next:
         specifier: 0.0.1-canary.1
         version: 0.0.1-canary.1
@@ -12511,11 +12505,6 @@ packages:
 
   /uuid@9.0.0:
     resolution: {integrity: sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==}
-    hasBin: true
-    dev: false
-
-  /uuid@9.0.1:
-    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     hasBin: true
     dev: false
 


### PR DESCRIPTION
I have replaced in the packages `packages/turbo-telemetry` and `packages/turbo-test-utils` the `uuid` dependency with native code.

This is recommended by the `uuid` library itself that to do a uuidv4 use crypto.randomUUID().

You can see it at: [here](https://www.npmjs.com/package/uuid)