### PR TITLE
feat(turborepo): give potential tasks on empty `turbo run`

### DIFF
--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -169,7 +169,7 @@ jobs:
     needs: [determine_jobs, build_turborepo]
     if: needs.determine_jobs.outputs.turborepo_integration == 'true'
     runs-on: ${{ matrix.os.runner }}
-    timeout-minutes: 30
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:

--- a/crates/turborepo-lib/src/cli/error.rs
+++ b/crates/turborepo-lib/src/cli/error.rs
@@ -79,7 +79,7 @@ pub async fn print_potential_tasks(
         let task = color!(ui, BOLD, "{}", task);
         let mut line_length = 0;
 
-        let mut packages_str = String::with_capacity(80);
+        let mut packages_str = String::with_capacity(MAX_CHARS_PER_TASK_LINE);
         for (idx, package) in packages.iter().sorted().enumerate() {
             if line_length > MAX_CHARS_PER_TASK_LINE {
                 if idx != packages.len() {

--- a/crates/turborepo-lib/src/cli/error.rs
+++ b/crates/turborepo-lib/src/cli/error.rs
@@ -74,7 +74,7 @@ pub async fn print_potential_tasks(
 
     for (task, packages) in potential_tasks
         .into_iter()
-        .sorted_by(|(a, _), (b, _)| a.cmp(b))
+        .sorted_by(|(_, a), (_, b)| b.len().cmp(&a.len()))
     {
         let task = color!(ui, BOLD, "{}", task);
         let mut line_length = 0;
@@ -96,9 +96,9 @@ pub async fn print_potential_tasks(
             packages_str.push_str(&format!("{}", package));
         }
 
-        let packages = color!(ui, GREY, "> {}", packages_str);
+        let packages = color!(ui, GREY, "{}", packages_str);
 
-        println!("{}\n  {}", task, packages)
+        println!("  {}\n    {}", task, packages)
     }
 
     Ok(())

--- a/crates/turborepo-lib/src/cli/error.rs
+++ b/crates/turborepo-lib/src/cli/error.rs
@@ -93,7 +93,7 @@ pub async fn print_potential_tasks(
             if idx != 0 {
                 packages_str.push_str(", ");
             }
-            packages_str.push_str(&format!("{}", package));
+            packages_str.push_str(package);
         }
 
         let packages = color!(ui, GREY, "{}", packages_str);

--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -1,4 +1,4 @@
-use std::{backtrace, backtrace::Backtrace, env, fmt, fmt::Display, io, mem, process};
+use std::{backtrace::Backtrace, env, fmt, fmt::Display, io, mem, process};
 
 use biome_deserialize_macros::Deserializable;
 use camino::{Utf8Path, Utf8PathBuf};
@@ -24,6 +24,7 @@ use turborepo_telemetry::{
 use turborepo_ui::UI;
 
 use crate::{
+    cli::error::print_potential_tasks,
     commands::{
         bin, daemon, generate, info, link, login, logout, prune, run, scan, telemetry, unlink,
         CommandBase,
@@ -995,6 +996,7 @@ pub async fn run(
             // missing any execution args.
             .clone()
             .ok_or_else(|| Error::NoCommand(Backtrace::capture()))?;
+
         if execution_args.tasks.is_empty() {
             let mut cmd = <Args as CommandFactory>::command();
             let _ = cmd.print_help();
@@ -1221,17 +1223,19 @@ pub async fn run(
         } => {
             let event = CommandEventBuilder::new("run").with_parent(&root_telemetry);
             event.track_call();
-            // in the case of enabling the run stub, we want to be able to opt-in
-            // to the rust codepath for running turbo
+
+            let base = CommandBase::new(cli_args.clone(), repo_root, version, ui);
+
             if execution_args.tasks.is_empty() {
-                return Err(Error::NoTasks(backtrace::Backtrace::capture()));
+                print_potential_tasks(base, event).await;
+                process::exit(1);
             }
 
             if let Some((file_path, include_args)) = run_args.profile_file_and_include_args() {
                 // TODO: Do we want to handle the result / error?
                 let _ = logger.enable_chrome_tracing(file_path, include_args);
             }
-            let base = CommandBase::new(cli_args.clone(), repo_root, version, ui);
+
             run_args.track(&event);
             event.track_run_code_path(CodePath::Rust);
             let exit_code = run::run(base, event).await.inspect(|code| {

--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -1227,7 +1227,7 @@ pub async fn run(
             let base = CommandBase::new(cli_args.clone(), repo_root, version, ui);
 
             if execution_args.tasks.is_empty() {
-                print_potential_tasks(base, event).await;
+                print_potential_tasks(base, event).await?;
                 process::exit(1);
             }
 

--- a/crates/turborepo-lib/src/commands/run.rs
+++ b/crates/turborepo-lib/src/commands/run.rs
@@ -45,7 +45,6 @@ pub async fn run(base: CommandBase, telemetry: CommandEventBuilder) -> Result<i3
             .await?;
 
         let (sender, handle) = run.start_experimental_ui()?.unzip();
-
         let result = run.run(sender.clone(), false).await;
 
         if let Some(analytics_handle) = analytics_handle {

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -47,25 +47,6 @@ use crate::{
     DaemonClient, DaemonConnector,
 };
 
-#[derive(Debug, Default)]
-pub struct PotentialTask {
-    pub packages: Vec<String>,
-    pub rest: u32,
-}
-impl IntoIterator for PotentialTask {
-    type Item = String;
-    type IntoIter = Box<dyn Iterator<Item = Self::Item>>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        let iter = self.packages.into_iter();
-        if self.rest > 0 {
-            Box::new(iter.chain(std::iter::once(format!("{} more", self.rest))))
-        } else {
-            Box::new(iter)
-        }
-    }
-}
-
 #[derive(Clone)]
 pub struct Run {
     version: &'static str,

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -13,7 +13,7 @@ pub mod task_id;
 pub mod watch;
 
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashSet},
     io::Write,
     sync::Arc,
     time::Duration,
@@ -162,8 +162,8 @@ impl Run {
 
     // Produces a map of tasks to the packages where they're defined.
     // Used to print a list of potential tasks to run. Obeys the `--filter` flag
-    pub fn get_potential_tasks(&self) -> Result<HashMap<String, Vec<String>>, Error> {
-        let mut tasks = HashMap::new();
+    pub fn get_potential_tasks(&self) -> Result<BTreeMap<String, Vec<String>>, Error> {
+        let mut tasks = BTreeMap::new();
         for (name, info) in self.pkg_dep_graph.packages() {
             if !self.filtered_pkgs.contains(name) {
                 continue;

--- a/turborepo-tests/integration/tests/no-args.t
+++ b/turborepo-tests/integration/tests/no-args.t
@@ -115,22 +115,20 @@ Make sure exit code is 2 when no args are passed
   $ ${TURBO} run
   No tasks provided, here are some potential ones to run
   
-  
-  build
-    > my-app, util
-  maybefails
-    > my-app, util
+    maybefails
+      my-app, util
+    build
+      my-app, util
   [1]
 
 Run again with a filter and get only the packages that match
   $ ${TURBO} run --filter my-app
   No tasks provided, here are some potential ones to run
   
-  
-  build
-    > my-app
-  maybefails
-    > my-app
+    build
+      my-app
+    maybefails
+      my-app
   [1]
 
 

--- a/turborepo-tests/integration/tests/no-args.t
+++ b/turborepo-tests/integration/tests/no-args.t
@@ -111,7 +111,7 @@ Make sure exit code is 2 when no args are passed
             Use "none" to remove prefixes from task logs. Use "task" to get task id prefixing. Use "auto" to let turbo decide how to prefix the logs based on the execution environment. In most cases this will be the same as "task". Note that tasks running in parallel interleave their logs, so removing prefixes can make it difficult to associate logs with tasks. Use --log-order=grouped to prevent interleaving. (default auto) [default: auto] [possible values: auto, none, task]
   [1]
 
-
+Run without any tasks, get a list of potential tasks to run
   $ ${TURBO} run
   No tasks provided, here are some potential ones to run
   
@@ -138,3 +138,79 @@ we get the full help output.
   [1]
   $ cat out.txt | head -n1
   The build system that makes ship happen
+
+Initialize a new monorepo
+  $ . ${TESTDIR}/../../helpers/setup_integration_test.sh composable_config > /dev/null 2>&1
+
+  $ ${TURBO} run
+  No tasks provided, here are some potential ones to run
+  
+    build
+      invalid-config, my-app, util
+    maybefails
+      my-app, util
+    add-keys-task
+      add-keys
+    add-keys-underlying-task
+      add-keys
+    added-task
+      add-tasks
+    cached-task-1
+      cached
+    cached-task-2
+      cached
+    cached-task-3
+      cached
+    cached-task-4
+      missing-workspace-config
+    config-change-task
+      config-change
+    cross-workspace-task
+      cross-workspace
+    cross-workspace-underlying-task
+      blank-pkg
+    missing-workspace-config-task
+      missing-workspace-config
+    missing-workspace-config-task-with-deps
+      missing-workspace-config
+    missing-workspace-config-underlying-task
+      missing-workspace-config
+    missing-workspace-config-underlying-topo-task
+      blank-pkg
+    omit-keys-task
+      omit-keys
+    omit-keys-task-with-deps
+      omit-keys
+    omit-keys-underlying-task
+      omit-keys
+    omit-keys-underlying-topo-task
+      blank-pkg
+    override-values-task
+      override-values
+    override-values-task-with-deps
+      override-values
+    override-values-task-with-deps-2
+      override-values
+    override-values-underlying-task
+      override-values
+    override-values-underlying-topo-task
+      blank-pkg
+    persistent-task-1
+      persistent
+    persistent-task-1-parent
+      persistent
+    persistent-task-2
+      persistent
+    persistent-task-2-parent
+      persistent
+    persistent-task-3
+      persistent
+    persistent-task-3-parent
+      persistent
+    persistent-task-4
+      persistent
+    persistent-task-4-parent
+      persistent
+    trailing-comma
+      bad-json
+  [1]

--- a/turborepo-tests/integration/tests/no-args.t
+++ b/turborepo-tests/integration/tests/no-args.t
@@ -1,5 +1,5 @@
 Setup
-  $ . ${TESTDIR}/../../helpers/setup.sh
+  $ . ${TESTDIR}/../../helpers/setup_integration_test.sh
 
 Make sure exit code is 2 when no args are passed
   $ ${TURBO}
@@ -111,10 +111,28 @@ Make sure exit code is 2 when no args are passed
             Use "none" to remove prefixes from task logs. Use "task" to get task id prefixing. Use "auto" to let turbo decide how to prefix the logs based on the execution environment. In most cases this will be the same as "task". Note that tasks running in parallel interleave their logs, so removing prefixes can make it difficult to associate logs with tasks. Use --log-order=grouped to prevent interleaving. (default auto) [default: auto] [possible values: auto, none, task]
   [1]
 
+
   $ ${TURBO} run
-    x at least one task must be specified
+  No tasks provided, here are some potential ones to run
   
+  
+  build
+    > my-app, util
+  maybefails
+    > my-app, util
   [1]
+
+Run again with a filter and get only the packages that match
+  $ ${TURBO} run --filter my-app
+  No tasks provided, here are some potential ones to run
+  
+  
+  build
+    > my-app
+  maybefails
+    > my-app
+  [1]
+
 
 Run again with an environment variable that corresponds to a run argument and assert that
 we get the full help output.

--- a/turborepo-tests/integration/tests/no-args.t
+++ b/turborepo-tests/integration/tests/no-args.t
@@ -115,9 +115,9 @@ Make sure exit code is 2 when no args are passed
   $ ${TURBO} run
   No tasks provided, here are some potential ones to run
   
-    maybefails
-      my-app, util
     build
+      my-app, util
+    maybefails
       my-app, util
   [1]
 


### PR DESCRIPTION
### Description

Instead of showing a generic error when a user calls `turbo run` with no tasks, we show the potential tasks along with the packages where they're defined. We cut off this list at 80 characters to prevent wrapping. Also obeys the filter flag.

### Testing Instructions

Added tests in `no-args.t` 
