### PR TITLE
adds daemon flag for env var and turbo.json

### DIFF
--- a/crates/turborepo-lib/src/commands/config.rs
+++ b/crates/turborepo-lib/src/commands/config.rs
@@ -20,6 +20,7 @@ struct ConfigOutput<'a> {
     spaces_id: Option<&'a str>,
     ui: bool,
     package_manager: PackageManager,
+    daemon: Option<bool>,
 }
 
 pub async fn run(base: CommandBase) -> Result<(), cli::Error> {
@@ -47,6 +48,7 @@ pub async fn run(base: CommandBase) -> Result<(), cli::Error> {
             spaces_id: config.spaces_id(),
             ui: config.ui(),
             package_manager: *package_manager,
+            daemon: config.daemon,
         })?
     );
     Ok(())

--- a/crates/turborepo-lib/src/commands/mod.rs
+++ b/crates/turborepo-lib/src/commands/mod.rs
@@ -85,6 +85,7 @@ impl CommandBase {
                     .dangerously_disable_package_manager_check
                     .then_some(true),
             )
+            .with_daemon(self.args.run_args.as_ref().and_then(|args| args.daemon()))
             .build()
     }
 

--- a/crates/turborepo-lib/src/opts.rs
+++ b/crates/turborepo-lib/src/opts.rs
@@ -254,7 +254,7 @@ impl<'a> TryFrom<OptsInputs<'a>> for RunOpts {
             continue_on_error: inputs.execution_args.continue_execution,
             pass_through_args: inputs.execution_args.pass_through_args.clone(),
             only: inputs.execution_args.only,
-            daemon: inputs.run_args.daemon(),
+            daemon: inputs.config.daemon(),
             single_package: inputs.execution_args.single_package,
             graph,
             dry_run: inputs.run_args.dry_run,
@@ -465,13 +465,13 @@ mod test {
             only: opts_input.only,
             dry_run: opts_input.dry_run,
             graph: None,
-            daemon: None,
             single_package: false,
             log_prefix: crate::opts::ResolvedLogPrefix::Task,
             log_order: crate::opts::ResolvedLogOrder::Stream,
             summarize: None,
             experimental_space_id: None,
             is_github_actions: false,
+            daemon: None,
         };
         let cache_opts = CacheOpts::default();
         let runcache_opts = RunCacheOpts::default();

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -131,6 +131,8 @@ pub struct RawTurboJson {
         rename = "dangerouslyDisablePackageManagerCheck"
     )]
     pub allow_no_package_manager: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub daemon: Option<Spanned<bool>>,
 
     #[deserializable(rename = "//")]
     #[serde(skip)]
@@ -1081,6 +1083,14 @@ mod tests {
     fn test_ui(json: &str, expected: Option<UI>) {
         let json = RawTurboJson::parse(json, AnchoredSystemPath::new("").unwrap()).unwrap();
         assert_eq!(json.ui, expected);
+    }
+
+    #[test_case(r#"{ "daemon": true }"#, r#"{"daemon":true}"# ; "daemon_on")]
+    #[test_case(r#"{ "daemon": false }"#, r#"{"daemon":false}"# ; "daemon_off")]
+    fn test_daemon(json: &str, expected: &str) {
+        let parsed = RawTurboJson::parse(json, AnchoredSystemPath::new("").unwrap()).unwrap();
+        let actual = serde_json::to_string(&parsed).unwrap();
+        assert_eq!(actual, expected);
     }
 
     #[test_case(r#"{ "ui": "tui" }"#, r#"{"ui":"tui"}"# ; "tui")]

--- a/turborepo-tests/integration/tests/config.t
+++ b/turborepo-tests/integration/tests/config.t
@@ -57,3 +57,22 @@ Run build with invalid env var
   
   [1]
 
+Confirm that the daemon is not configured
+  $ ${TURBO} config | jq .daemon
+  null
+
+Add env var: `TURBO_DAEMON=true`
+  $ TURBO_DAEMON=true ${TURBO} config | jq .daemon
+  true
+
+Add env var: `TURBO_DAEMON=false`
+  $ TURBO_DAEMON=false ${TURBO} config | jq .daemon
+  false
+
+Add flag: `--daemon`
+  $ ${TURBO} --daemon config | jq .daemon
+  true
+
+Add flag: `--no-daemon`
+  $ ${TURBO} --no-daemon config | jq .daemon
+  false

--- a/turborepo-tests/integration/tests/config.t
+++ b/turborepo-tests/integration/tests/config.t
@@ -15,7 +15,8 @@ Run test run
     "enabled": true,
     "spacesId": null,
     "ui": false,
-    "packageManager": "npm"
+    "packageManager": "npm",
+    "daemon": null
   }
 
 Run test run with api overloaded


### PR DESCRIPTION
### Description

This PR adds support and testing for a `TURBO_DAEMON` environment variable, as well as a `{ daemon: boolean }` field to the `turbo.json` file.  This change allows us to remove `daemon` from `RunOpts`, as well.

### Testing Instructions

You can run `turbo daemon status` to see the status of the daemon after each run (and also `turbo daemon stop` to kill it).

#### Daemon Off

1. run with `--no-daemon`
1. run with `TURBO_DAEMON=false`
1. run with `{"daemon":false}` in your turbo.json

#### Daemon On

1. run with `--daemon`
1. run with `TURBO_DAEMON=true`
1. run with `{"daemon":true}` in your turbo.json