### PR TITLE
chore(ci): Skip downloading Playwright browsers in Turborepo CI.

### DIFF
--- a/.github/actions/setup-turborepo-environment/action.yml
+++ b/.github/actions/setup-turborepo-environment/action.yml
@@ -17,6 +17,8 @@ runs:
       with:
         extra-flags: --no-optional
         node-version: ${{ inputs.node-version }}
+      env:
+        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
 
     - name: "Setup Rust"
       uses: ./.github/actions/setup-rust


### PR DESCRIPTION
### Description

Playwright is only used on the Turbopack side, so we can skip downloading its browsers when we're about to run Turborepo's CI.

### Testing Instructions

CI
