### PR TITLE
feat: allow opting out of required package manager

### DIFF
--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -217,6 +217,12 @@ pub struct Args {
     pub check_for_update: bool,
     #[clap(long = "__test-run", global = true, hide = true)]
     pub test_run: bool,
+    /// Allow for missing `packageManager` in `package.json`.
+    ///
+    /// `turbo` will use hints from codebase to guess which package manager
+    /// should be used.
+    #[clap(long, global = true)]
+    pub dangerously_allow_no_package_manager: bool,
     #[clap(flatten, next_help_heading = "Run Arguments")]
     pub run_args: Option<RunArgs>,
     // This should be inside `RunArgs` but clap currently has a bug
@@ -2530,5 +2536,19 @@ mod test {
         assert!(LogOrder::Auto.compatible_with_tui());
         assert!(!LogOrder::Stream.compatible_with_tui());
         assert!(!LogOrder::Grouped.compatible_with_tui());
+    }
+
+    #[test]
+    fn test_dangerously_allow_no_package_manager() {
+        assert!(
+            !Args::try_parse_from(["turbo", "build",])
+                .unwrap()
+                .dangerously_allow_no_package_manager
+        );
+        assert!(
+            Args::try_parse_from(["turbo", "build", "--dangerously-allow-no-package-manager"])
+                .unwrap()
+                .dangerously_allow_no_package_manager
+        );
     }
 }

--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -222,7 +222,7 @@ pub struct Args {
     /// `turbo` will use hints from codebase to guess which package manager
     /// should be used.
     #[clap(long, global = true)]
-    pub dangerously_allow_no_package_manager: bool,
+    pub dangerously_disable_package_manager_check: bool,
     #[clap(flatten, next_help_heading = "Run Arguments")]
     pub run_args: Option<RunArgs>,
     // This should be inside `RunArgs` but clap currently has a bug
@@ -2543,12 +2543,16 @@ mod test {
         assert!(
             !Args::try_parse_from(["turbo", "build",])
                 .unwrap()
-                .dangerously_allow_no_package_manager
+                .dangerously_disable_package_manager_check
         );
         assert!(
-            Args::try_parse_from(["turbo", "build", "--dangerously-allow-no-package-manager"])
-                .unwrap()
-                .dangerously_allow_no_package_manager
+            Args::try_parse_from([
+                "turbo",
+                "build",
+                "--dangerously-disable-package-manager-check"
+            ])
+            .unwrap()
+            .dangerously_disable_package_manager_check
         );
     }
 }

--- a/crates/turborepo-lib/src/commands/mod.rs
+++ b/crates/turborepo-lib/src/commands/mod.rs
@@ -79,6 +79,11 @@ impl CommandBase {
                     }
                 })
             }))
+            .with_allow_no_package_manager(
+                self.args
+                    .dangerously_allow_no_package_manager
+                    .then_some(true),
+            )
             .build()
     }
 

--- a/crates/turborepo-lib/src/commands/mod.rs
+++ b/crates/turborepo-lib/src/commands/mod.rs
@@ -81,7 +81,7 @@ impl CommandBase {
             }))
             .with_allow_no_package_manager(
                 self.args
-                    .dangerously_allow_no_package_manager
+                    .dangerously_disable_package_manager_check
                     .then_some(true),
             )
             .build()

--- a/crates/turborepo-lib/src/commands/prune.rs
+++ b/crates/turborepo-lib/src/commands/prune.rs
@@ -277,6 +277,7 @@ impl<'a> Prune<'a> {
         let root_package_json = PackageJson::load(&root_package_json_path)?;
 
         let package_graph = PackageGraph::builder(&base.repo_root, root_package_json)
+            .with_allow_no_package_manager(allow_missing_package_manager)
             .build()
             .await?;
 

--- a/crates/turborepo-lib/src/commands/prune.rs
+++ b/crates/turborepo-lib/src/commands/prune.rs
@@ -49,6 +49,8 @@ pub enum Error {
     MissingLockfile,
     #[error("Prune is not supported for Bun")]
     BunUnsupported,
+    #[error("Unable to read config: {0}")]
+    Config(#[from] crate::config::Error),
 }
 
 // Files that should be copied from root and if they're required for install
@@ -96,7 +98,7 @@ pub async fn prune(
     telemetry.track_arg_usage("docker", docker);
     telemetry.track_arg_usage("out-dir", output_dir != DEFAULT_OUTPUT_DIR);
 
-    let prune = Prune::new(base, scope, docker, output_dir).await?;
+    let prune = Prune::new(base, scope, docker, output_dir, telemetry).await?;
 
     if matches!(
         prune.package_graph.package_manager(),
@@ -259,7 +261,14 @@ impl<'a> Prune<'a> {
         scope: &'a [String],
         docker: bool,
         output_dir: &str,
+        telemetry: CommandEventBuilder,
     ) -> Result<Self, Error> {
+        let allow_missing_package_manager = base.config()?.allow_no_package_manager();
+        telemetry.track_arg_usage(
+            "dangerously-allow-missing-package-manager",
+            allow_missing_package_manager,
+        );
+
         if scope.is_empty() {
             return Err(Error::NoWorkspaceSpecified);
         }

--- a/crates/turborepo-lib/src/config.rs
+++ b/crates/turborepo-lib/src/config.rs
@@ -276,6 +276,10 @@ impl ConfigurationOptions {
     pub fn ui(&self) -> bool {
         self.ui.unwrap_or(false) && atty::is(atty::Stream::Stdout)
     }
+
+    pub fn allow_no_package_manager(&self) -> bool {
+        self.allow_no_package_manager.unwrap_or_default()
+    }
 }
 
 // Maps Some("") to None to emulate how Go handles empty strings

--- a/crates/turborepo-lib/src/config.rs
+++ b/crates/turborepo-lib/src/config.rs
@@ -208,7 +208,7 @@ pub struct ConfigurationOptions {
     pub(crate) spaces_id: Option<String>,
     #[serde(rename = "ui")]
     pub(crate) ui: Option<bool>,
-    #[serde(rename = "dangerouslyAllowNoPackageManager")]
+    #[serde(rename = "dangerouslyDisablePackageManagerCheck")]
     pub(crate) allow_no_package_manager: Option<bool>,
 }
 
@@ -347,7 +347,7 @@ fn get_env_var_config(
     );
     turbo_mapping.insert(OsString::from("turbo_ui"), "ui");
     turbo_mapping.insert(
-        OsString::from("turbo_dangerously_allow_no_package_manager"),
+        OsString::from("turbo_dangerously_disable_package_manager_check"),
         "allow_no_package_manager",
     );
     turbo_mapping.insert(OsString::from("turbo_preflight"), "preflight");
@@ -803,7 +803,7 @@ mod test {
         );
         env.insert("turbo_ui".into(), "true".into());
         env.insert(
-            "turbo_dangerously_allow_no_package_manager".into(),
+            "turbo_dangerously_disable_package_manager_check".into(),
             "true".into(),
         );
         env.insert("turbo_preflight".into(), "true".into());

--- a/crates/turborepo-lib/src/config.rs
+++ b/crates/turborepo-lib/src/config.rs
@@ -313,6 +313,7 @@ impl ResolvedConfigurationOptions for RawTurboJson {
             .and_then(|spaces| spaces.id)
             .map(|spaces_id| spaces_id.into());
         opts.ui = self.ui.map(|ui| ui.use_tui());
+        opts.allow_no_package_manager = self.allow_no_package_manager;
         Ok(opts)
     }
 }

--- a/crates/turborepo-lib/src/config.rs
+++ b/crates/turborepo-lib/src/config.rs
@@ -778,6 +778,7 @@ mod test {
         assert!(!defaults.preflight());
         assert_eq!(defaults.timeout(), DEFAULT_TIMEOUT);
         assert_eq!(defaults.spaces_id(), None);
+        assert!(!defaults.allow_no_package_manager());
     }
 
     #[test]

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -253,9 +253,13 @@ impl RunBuilder {
 
         let mut pkg_dep_graph = {
             let builder = PackageGraph::builder(&self.repo_root, root_package_json.clone())
-                .with_single_package_mode(self.opts.run_opts.single_package);
+                .with_single_package_mode(self.opts.run_opts.single_package)
+                .with_allow_no_package_manager(self.allow_missing_package_manager);
 
-            let graph = if cfg!(feature = "daemon-package-discovery") {
+            // Daemon package discovery depends on packageManager existing in package.json
+            let graph = if cfg!(feature = "daemon-package-discovery")
+                && !self.allow_missing_package_manager
+            {
                 match (&daemon, self.opts.run_opts.daemon) {
                     (None, Some(true)) => {
                         // We've asked for the daemon, but it's not available. This is an error

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -64,6 +64,7 @@ pub struct RunBuilder {
     // this package.
     entrypoint_packages: Option<HashSet<PackageName>>,
     should_print_prelude_override: Option<bool>,
+    allow_missing_package_manager: bool,
 }
 
 impl RunBuilder {
@@ -73,6 +74,8 @@ impl RunBuilder {
 
         let mut opts: Opts = base.args().try_into()?;
         let config = base.config()?;
+        let allow_missing_package_manager = config.allow_no_package_manager();
+
         let is_linked = turborepo_api_client::is_linked(&api_auth);
         if !is_linked {
             opts.cache_opts.skip_remote = true;
@@ -116,6 +119,7 @@ impl RunBuilder {
             analytics_sender: None,
             entrypoint_packages: None,
             should_print_prelude_override: None,
+            allow_missing_package_manager,
         })
     }
 
@@ -187,6 +191,10 @@ impl RunBuilder {
         // Pulled from initAnalyticsClient in run.go
         let is_linked = turborepo_api_client::is_linked(&self.api_auth);
         run_telemetry.track_is_linked(is_linked);
+        run_telemetry.track_arg_usage(
+            "dangerously_allow_missing_package_manager",
+            self.allow_missing_package_manager,
+        );
         // we only track the remote cache if we're linked because this defaults to
         // Vercel
         if is_linked {

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -1090,4 +1090,14 @@ mod tests {
         let actual = serde_json::to_string(&parsed).unwrap();
         assert_eq!(actual, expected);
     }
+
+    #[test_case(r#"{"dangerouslyAllowNoPackageManager":true}"#, Some(true) ; "t")]
+    #[test_case(r#"{"dangerouslyAllowNoPackageManager":false}"#, Some(false) ; "f")]
+    #[test_case(r#"{}"#, None ; "missing")]
+    fn test_allow_no_package_manager_serde(json_str: &str, expected: Option<bool>) {
+        let json = RawTurboJson::parse(json_str, AnchoredSystemPath::new("").unwrap()).unwrap();
+        assert_eq!(json.allow_no_package_manager, expected);
+        let serialized = serde_json::to_string(&json).unwrap();
+        assert_eq!(serialized, json_str);
+    }
 }

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -126,6 +126,11 @@ pub struct RawTurboJson {
     pub(crate) remote_cache: Option<RawRemoteCacheOptions>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "ui")]
     pub ui: Option<UI>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        rename = "dangerouslyAllowNoPackageManager"
+    )]
+    pub allow_no_package_manager: Option<bool>,
 
     #[deserializable(rename = "//")]
     #[serde(skip)]

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -128,7 +128,7 @@ pub struct RawTurboJson {
     pub ui: Option<UI>,
     #[serde(
         skip_serializing_if = "Option::is_none",
-        rename = "dangerouslyAllowNoPackageManager"
+        rename = "dangerouslyDisablePackageManagerCheck"
     )]
     pub allow_no_package_manager: Option<bool>,
 
@@ -1091,8 +1091,8 @@ mod tests {
         assert_eq!(actual, expected);
     }
 
-    #[test_case(r#"{"dangerouslyAllowNoPackageManager":true}"#, Some(true) ; "t")]
-    #[test_case(r#"{"dangerouslyAllowNoPackageManager":false}"#, Some(false) ; "f")]
+    #[test_case(r#"{"dangerouslyDisablePackageManagerCheck":true}"#, Some(true) ; "t")]
+    #[test_case(r#"{"dangerouslyDisablePackageManagerCheck":false}"#, Some(false) ; "f")]
     #[test_case(r#"{}"#, None ; "missing")]
     fn test_allow_no_package_manager_serde(json_str: &str, expected: Option<bool>) {
         let json = RawTurboJson::parse(json_str, AnchoredSystemPath::new("").unwrap()).unwrap();

--- a/crates/turborepo-repository/src/discovery.rs
+++ b/crates/turborepo-repository/src/discovery.rs
@@ -84,6 +84,7 @@ pub struct LocalPackageDiscoveryBuilder {
     repo_root: AbsoluteSystemPathBuf,
     package_manager: Option<PackageManager>,
     package_json: Option<PackageJson>,
+    allow_missing_package_manager: bool,
 }
 
 impl LocalPackageDiscoveryBuilder {
@@ -96,7 +97,12 @@ impl LocalPackageDiscoveryBuilder {
             repo_root,
             package_manager,
             package_json,
+            allow_missing_package_manager: false,
         }
+    }
+
+    pub fn with_allow_no_package_manager(&mut self, allow_missing_package_manager: bool) {
+        self.allow_missing_package_manager = allow_missing_package_manager;
     }
 }
 
@@ -111,7 +117,11 @@ impl PackageDiscoveryBuilder for LocalPackageDiscoveryBuilder {
                 let package_json = self.package_json.map(Ok).unwrap_or_else(|| {
                     PackageJson::load(&self.repo_root.join_component("package.json"))
                 })?;
-                PackageManager::get_package_manager(&package_json)?
+                if self.allow_missing_package_manager {
+                    PackageManager::read_or_detect_package_manager(&package_json, &self.repo_root)?
+                } else {
+                    PackageManager::get_package_manager(&package_json)?
+                }
             }
         };
 

--- a/crates/turborepo-repository/src/inference.rs
+++ b/crates/turborepo-repository/src/inference.rs
@@ -80,7 +80,8 @@ impl RepoState {
                     .ok()
                     .map(|package_json| {
                         // FIXME: We should save this package manager that we detected
-                        let package_manager = PackageManager::get_package_manager(&package_json);
+                        let package_manager =
+                            PackageManager::read_or_detect_package_manager(&package_json, path);
                         let workspace_globs = package_manager
                             .as_ref()
                             .ok()

--- a/crates/turborepo-repository/src/inference.rs
+++ b/crates/turborepo-repository/src/inference.rs
@@ -307,4 +307,44 @@ mod test {
             }
         }
     }
+
+    #[test]
+    fn test_allows_missing_package_manager() {
+        let (_tmp, tmp_dir) = tmp_dir();
+
+        let monorepo_root = tmp_dir.join_component("monorepo_root");
+        let monorepo_pkg_json = monorepo_root.join_component("package.json");
+        let monorepo_contents = "{\"workspaces\": [\"packages/*\"]}";
+        monorepo_pkg_json.ensure_dir().unwrap();
+        monorepo_pkg_json
+            .create_with_contents(monorepo_contents)
+            .unwrap();
+        monorepo_root
+            .join_component("package-lock.json")
+            .create_with_contents("")
+            .unwrap();
+
+        let app_1 = monorepo_root.join_components(&["packages", "app-1"]);
+        let app_1_pkg_json = app_1.join_component("package.json");
+        app_1_pkg_json.ensure_dir().unwrap();
+        app_1_pkg_json
+            .create_with_contents("{\"name\": \"app_1\"}")
+            .unwrap();
+
+        let repo_state_from_root = RepoState::infer(&monorepo_root).unwrap();
+        let repo_state_from_app = RepoState::infer(&app_1).unwrap();
+
+        assert_eq!(&repo_state_from_root.root, &monorepo_root);
+        assert_eq!(&repo_state_from_app.root, &monorepo_root);
+        assert_eq!(repo_state_from_root.mode, RepoMode::MultiPackage);
+        assert_eq!(repo_state_from_app.mode, RepoMode::MultiPackage);
+        assert_eq!(
+            repo_state_from_root.package_manager.unwrap(),
+            PackageManager::Npm
+        );
+        assert_eq!(
+            repo_state_from_app.package_manager.unwrap(),
+            PackageManager::Npm
+        );
+    }
 }

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -78,6 +78,12 @@ impl<'a> PackageGraphBuilder<'a, LocalPackageDiscoveryBuilder> {
             lockfile: None,
         }
     }
+
+    pub fn with_allow_no_package_manager(mut self, allow_no_package_manager: bool) -> Self {
+        self.package_discovery
+            .with_allow_no_package_manager(allow_no_package_manager);
+        self
+    }
 }
 
 impl<'a, P> PackageGraphBuilder<'a, P> {

--- a/crates/turborepo-repository/src/package_manager/bun.rs
+++ b/crates/turborepo-repository/src/package_manager/bun.rs
@@ -1,1 +1,63 @@
+use turbopath::AbsoluteSystemPath;
+
+use crate::package_manager::{Error, PackageManager};
+
 pub const LOCKFILE: &str = "bun.lockb";
+
+pub struct BunDetector<'a> {
+    repo_root: &'a AbsoluteSystemPath,
+    found: bool,
+}
+
+impl<'a> BunDetector<'a> {
+    pub fn new(repo_root: &'a AbsoluteSystemPath) -> Self {
+        Self {
+            repo_root,
+            found: false,
+        }
+    }
+}
+
+impl<'a> Iterator for BunDetector<'a> {
+    type Item = Result<PackageManager, Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.found {
+            return None;
+        }
+
+        self.found = true;
+        let package_json = self.repo_root.join_component(LOCKFILE);
+
+        if package_json.exists() {
+            Some(Ok(PackageManager::Bun))
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::File;
+
+    use anyhow::Result;
+    use tempfile::tempdir;
+    use turbopath::AbsoluteSystemPathBuf;
+
+    use super::LOCKFILE;
+    use crate::package_manager::PackageManager;
+
+    #[test]
+    fn test_detect_bun() -> Result<()> {
+        let repo_root = tempdir()?;
+        let repo_root_path = AbsoluteSystemPathBuf::try_from(repo_root.path())?;
+
+        let lockfile_path = repo_root.path().join(LOCKFILE);
+        File::create(lockfile_path)?;
+        let package_manager = PackageManager::detect_package_manager(&repo_root_path)?;
+        assert_eq!(package_manager, PackageManager::Bun);
+
+        Ok(())
+    }
+}

--- a/crates/turborepo-repository/src/package_manager/mod.rs
+++ b/crates/turborepo-repository/src/package_manager/mod.rs
@@ -429,12 +429,7 @@ impl PackageManager {
         )
     }
 
-    /// Try to detect the package manager by inspecting the repository.
-    /// This method does not read the package.json, instead looking for
-    /// lockfiles and other files that indicate the package manager.
-    ///
-    /// TODO: consider if this method should not need an Option, and possibly be
-    /// a method on PackageJSON
+    /// Try to extract the package manager from package.json.
     pub fn get_package_manager(package_json: &PackageJson) -> Result<Self, Error> {
         Self::read_package_manager(package_json)
     }
@@ -456,7 +451,7 @@ impl PackageManager {
         }
     }
 
-    /// Detect package manager based on configuration files and binaries
+    /// Try to detect package manager based on configuration files and binaries
     /// installed on the system.
     pub fn detect_package_manager(repo_root: &AbsoluteSystemPath) -> Result<Self, Error> {
         let detected_package_managers = PnpmDetector::new(repo_root)
@@ -476,6 +471,15 @@ impl PackageManager {
                 Err(Error::MultiplePackageManagers { managers })
             }
         }
+    }
+
+    /// Try to extract package manager from package.json, otherwise detect based
+    /// on configuration files and binaries installed on the system
+    pub fn read_or_detect_package_manager(
+        package_json: &PackageJson,
+        repo_root: &AbsoluteSystemPath,
+    ) -> Result<Self, Error> {
+        Self::get_package_manager(package_json).or_else(|_| Self::detect_package_manager(repo_root))
     }
 
     pub(crate) fn parse_package_manager_string(manager: &str) -> Result<(&str, &str), Error> {

--- a/crates/turborepo-repository/src/package_manager/npm.rs
+++ b/crates/turborepo-repository/src/package_manager/npm.rs
@@ -1,1 +1,63 @@
+use turbopath::AbsoluteSystemPath;
+
+use crate::package_manager::{Error, PackageManager};
+
 pub const LOCKFILE: &str = "package-lock.json";
+
+pub struct NpmDetector<'a> {
+    repo_root: &'a AbsoluteSystemPath,
+    found: bool,
+}
+
+impl<'a> NpmDetector<'a> {
+    pub fn new(repo_root: &'a AbsoluteSystemPath) -> Self {
+        Self {
+            repo_root,
+            found: false,
+        }
+    }
+}
+
+impl<'a> Iterator for NpmDetector<'a> {
+    type Item = Result<PackageManager, Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.found {
+            return None;
+        }
+
+        self.found = true;
+        let package_json = self.repo_root.join_component(LOCKFILE);
+
+        if package_json.exists() {
+            Some(Ok(PackageManager::Npm))
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::File;
+
+    use anyhow::Result;
+    use tempfile::tempdir;
+    use turbopath::AbsoluteSystemPathBuf;
+
+    use super::LOCKFILE;
+    use crate::package_manager::PackageManager;
+
+    #[test]
+    fn test_detect_npm() -> Result<()> {
+        let repo_root = tempdir()?;
+        let repo_root_path = AbsoluteSystemPathBuf::try_from(repo_root.path())?;
+
+        let lockfile_path = repo_root.path().join(LOCKFILE);
+        File::create(lockfile_path)?;
+        let package_manager = PackageManager::detect_package_manager(&repo_root_path)?;
+        assert_eq!(package_manager, PackageManager::Npm);
+
+        Ok(())
+    }
+}

--- a/crates/turborepo-repository/src/package_manager/pnpm.rs
+++ b/crates/turborepo-repository/src/package_manager/pnpm.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use node_semver::{Range, Version};
-use turbopath::RelativeUnixPath;
+use turbopath::{AbsoluteSystemPath, RelativeUnixPath};
 
 use crate::{
     package_json::PackageJson,
@@ -10,9 +10,19 @@ use crate::{
 
 pub const LOCKFILE: &str = "pnpm-lock.yaml";
 
-pub struct PnpmDetector;
+pub struct PnpmDetector<'a> {
+    found: bool,
+    repo_root: &'a AbsoluteSystemPath,
+}
 
-impl PnpmDetector {
+impl<'a> PnpmDetector<'a> {
+    pub fn new(repo_root: &'a AbsoluteSystemPath) -> Self {
+        Self {
+            repo_root,
+            found: false,
+        }
+    }
+
     pub fn detect_pnpm6_or_pnpm(version: &Version) -> Result<PackageManager, Error> {
         let pnpm6_constraint: Range = "<7.0.0".parse()?;
         let pnpm9_constraint: Range = ">=9.0.0-alpha.0".parse()?;
@@ -23,6 +33,21 @@ impl PnpmDetector {
         } else {
             Ok(PackageManager::Pnpm)
         }
+    }
+}
+
+impl<'a> Iterator for PnpmDetector<'a> {
+    type Item = Result<PackageManager, Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.found {
+            return None;
+        }
+        self.found = true;
+
+        let pnpm_lockfile = self.repo_root.join_component(LOCKFILE);
+
+        pnpm_lockfile.exists().then(|| Ok(PackageManager::Pnpm))
     }
 }
 
@@ -46,13 +71,26 @@ pub(crate) fn prune_patches<R: AsRef<RelativeUnixPath>>(
 
 #[cfg(test)]
 mod test {
-    use std::collections::BTreeMap;
+    use std::{collections::BTreeMap, fs::File};
 
     use serde_json::json;
+    use tempfile::tempdir;
     use test_case::test_case;
-    use turbopath::RelativeUnixPathBuf;
+    use turbopath::{AbsoluteSystemPathBuf, RelativeUnixPathBuf};
 
     use super::*;
+
+    #[test]
+    fn test_detect_pnpm() -> Result<(), Error> {
+        let repo_root = tempdir()?;
+        let repo_root_path = AbsoluteSystemPathBuf::try_from(repo_root.path())?;
+        let lockfile_path = repo_root.path().join(LOCKFILE);
+        File::create(lockfile_path)?;
+        let package_manager = PackageManager::detect_package_manager(&repo_root_path)?;
+        assert_eq!(package_manager, PackageManager::Pnpm);
+
+        Ok(())
+    }
 
     #[test]
     fn test_patch_pruning() {

--- a/crates/turborepo-repository/src/package_manager/yarn.rs
+++ b/crates/turborepo-repository/src/package_manager/yarn.rs
@@ -1,5 +1,8 @@
+use std::process::Command;
+
 use node_semver::{Range, Version};
-use turbopath::RelativeUnixPath;
+use turbopath::{AbsoluteSystemPath, RelativeUnixPath};
+use which::which;
 
 use crate::{
     package_json::PackageJson,
@@ -8,9 +11,30 @@ use crate::{
 
 pub const LOCKFILE: &str = "yarn.lock";
 
-pub struct YarnDetector;
+pub struct YarnDetector<'a> {
+    repo_root: &'a AbsoluteSystemPath,
+    found: bool,
+}
 
-impl YarnDetector {
+impl<'a> YarnDetector<'a> {
+    pub fn new(repo_root: &'a AbsoluteSystemPath) -> Self {
+        Self {
+            repo_root,
+            found: false,
+        }
+    }
+
+    fn get_yarn_version(&self) -> Result<Version, Error> {
+        let binary = "yarn";
+        let yarn_binary = which(binary).map_err(|e| Error::Which(e, binary.to_string()))?;
+        let output = Command::new(yarn_binary)
+            .arg("--version")
+            .current_dir(self.repo_root)
+            .output()?;
+        let yarn_version_output = String::from_utf8(output.stdout)?;
+        Ok(yarn_version_output.trim().parse()?)
+    }
+
     pub fn detect_berry_or_yarn(version: &Version) -> Result<PackageManager, Error> {
         let berry_constraint: Range = ">=2.0.0-0".parse()?;
         if berry_constraint.satisfies(version) {
@@ -41,6 +65,28 @@ pub(crate) fn prune_patches<R: AsRef<RelativeUnixPath>>(
     }
 
     pruned_json
+}
+
+impl<'a> Iterator for YarnDetector<'a> {
+    type Item = Result<PackageManager, Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.found {
+            return None;
+        }
+        self.found = true;
+
+        let yarn_lockfile = self.repo_root.join_component(LOCKFILE);
+
+        if yarn_lockfile.exists() {
+            Some(
+                self.get_yarn_version()
+                    .and_then(|version| Self::detect_berry_or_yarn(&version)),
+            )
+        } else {
+            None
+        }
+    }
 }
 
 #[cfg(test)]

--- a/turborepo-tests/integration/tests/no-args.t
+++ b/turborepo-tests/integration/tests/no-args.t
@@ -55,7 +55,7 @@ Make sure exit code is 2 when no args are passed
             Specify a file to save a pprof trace
         --verbosity <COUNT>
             Verbosity level
-        --dangerously-allow-no-package-manager
+        --dangerously-disable-package-manager-check
             Allow for missing `packageManager` in `package.json`
     -h, --help
             Print help (see more with '--help')

--- a/turborepo-tests/integration/tests/no-args.t
+++ b/turborepo-tests/integration/tests/no-args.t
@@ -23,23 +23,42 @@ Make sure exit code is 2 when no args are passed
     unlink      Unlink the current directory from your Vercel organization and disable Remote Caching
   
   Options:
-        --version                         
-        --skip-infer                      Skip any attempts to infer which version of Turbo the project is configured to use
-        --no-update-notifier              Disable the turbo update notification
-        --api <API>                       Override the endpoint for API calls
-        --color                           Force color usage in the terminal
-        --cwd <CWD>                       The directory in which to run turbo
-        --heap <HEAP>                     Specify a file to save a pprof heap profile
-        --ui <UI>                         Specify whether to use the streaming UI or TUI [possible values: tui, stream]
-        --login <LOGIN>                   Override the login endpoint
-        --no-color                        Suppress color usage in the terminal
-        --preflight                       When enabled, turbo will precede HTTP requests with an OPTIONS request for authorization
-        --remote-cache-timeout <TIMEOUT>  Set a timeout for all HTTP requests
-        --team <TEAM>                     Set the team slug for API calls
-        --token <TOKEN>                   Set the auth token for API calls
-        --trace <TRACE>                   Specify a file to save a pprof trace
-        --verbosity <COUNT>               Verbosity level
-    -h, --help                            Print help (see more with '--help')
+        --version
+            
+        --skip-infer
+            Skip any attempts to infer which version of Turbo the project is configured to use
+        --no-update-notifier
+            Disable the turbo update notification
+        --api <API>
+            Override the endpoint for API calls
+        --color
+            Force color usage in the terminal
+        --cwd <CWD>
+            The directory in which to run turbo
+        --heap <HEAP>
+            Specify a file to save a pprof heap profile
+        --ui <UI>
+            Specify whether to use the streaming UI or TUI [possible values: tui, stream]
+        --login <LOGIN>
+            Override the login endpoint
+        --no-color
+            Suppress color usage in the terminal
+        --preflight
+            When enabled, turbo will precede HTTP requests with an OPTIONS request for authorization
+        --remote-cache-timeout <TIMEOUT>
+            Set a timeout for all HTTP requests
+        --team <TEAM>
+            Set the team slug for API calls
+        --token <TOKEN>
+            Set the auth token for API calls
+        --trace <TRACE>
+            Specify a file to save a pprof trace
+        --verbosity <COUNT>
+            Verbosity level
+        --dangerously-allow-no-package-manager
+            Allow for missing `packageManager` in `package.json`
+    -h, --help
+            Print help (see more with '--help')
   
   Run Arguments:
         --cache-workers <CACHE_WORKERS>

--- a/turborepo-tests/integration/tests/turbo-help.t
+++ b/turborepo-tests/integration/tests/turbo-help.t
@@ -23,23 +23,42 @@ Test help flag
     unlink      Unlink the current directory from your Vercel organization and disable Remote Caching
   
   Options:
-        --version                         
-        --skip-infer                      Skip any attempts to infer which version of Turbo the project is configured to use
-        --no-update-notifier              Disable the turbo update notification
-        --api <API>                       Override the endpoint for API calls
-        --color                           Force color usage in the terminal
-        --cwd <CWD>                       The directory in which to run turbo
-        --heap <HEAP>                     Specify a file to save a pprof heap profile
-        --ui <UI>                         Specify whether to use the streaming UI or TUI [possible values: tui, stream]
-        --login <LOGIN>                   Override the login endpoint
-        --no-color                        Suppress color usage in the terminal
-        --preflight                       When enabled, turbo will precede HTTP requests with an OPTIONS request for authorization
-        --remote-cache-timeout <TIMEOUT>  Set a timeout for all HTTP requests
-        --team <TEAM>                     Set the team slug for API calls
-        --token <TOKEN>                   Set the auth token for API calls
-        --trace <TRACE>                   Specify a file to save a pprof trace
-        --verbosity <COUNT>               Verbosity level
-    -h, --help                            Print help (see more with '--help')
+        --version
+            
+        --skip-infer
+            Skip any attempts to infer which version of Turbo the project is configured to use
+        --no-update-notifier
+            Disable the turbo update notification
+        --api <API>
+            Override the endpoint for API calls
+        --color
+            Force color usage in the terminal
+        --cwd <CWD>
+            The directory in which to run turbo
+        --heap <HEAP>
+            Specify a file to save a pprof heap profile
+        --ui <UI>
+            Specify whether to use the streaming UI or TUI [possible values: tui, stream]
+        --login <LOGIN>
+            Override the login endpoint
+        --no-color
+            Suppress color usage in the terminal
+        --preflight
+            When enabled, turbo will precede HTTP requests with an OPTIONS request for authorization
+        --remote-cache-timeout <TIMEOUT>
+            Set a timeout for all HTTP requests
+        --team <TEAM>
+            Set the team slug for API calls
+        --token <TOKEN>
+            Set the auth token for API calls
+        --trace <TRACE>
+            Specify a file to save a pprof trace
+        --verbosity <COUNT>
+            Verbosity level
+        --dangerously-allow-no-package-manager
+            Allow for missing `packageManager` in `package.json`
+    -h, --help
+            Print help (see more with '--help')
   
   Run Arguments:
         --cache-workers <CACHE_WORKERS>
@@ -169,6 +188,11 @@ Test help flag
         --verbosity <COUNT>
             Verbosity level
   
+        --dangerously-allow-no-package-manager
+            Allow for missing `packageManager` in `package.json`.
+            
+            `turbo` will use hints from codebase to guess which package manager should be used.
+  
     -h, --help
             Print help (see a summary with '-h')
   
@@ -285,25 +309,46 @@ Test help flag for link command
   Usage: turbo(\.exe)? link \[OPTIONS\] (re)
   
   Options:
-        --no-gitignore                    Do not create or modify .gitignore (default false)
-        --version                         
-        --skip-infer                      Skip any attempts to infer which version of Turbo the project is configured to use
-        --target <TARGET>                 Specify what should be linked (default "remote cache") [default: remote-cache] [possible values: remote-cache, spaces]
-        --no-update-notifier              Disable the turbo update notification
-        --api <API>                       Override the endpoint for API calls
-        --color                           Force color usage in the terminal
-        --cwd <CWD>                       The directory in which to run turbo
-        --heap <HEAP>                     Specify a file to save a pprof heap profile
-        --ui <UI>                         Specify whether to use the streaming UI or TUI [possible values: tui, stream]
-        --login <LOGIN>                   Override the login endpoint
-        --no-color                        Suppress color usage in the terminal
-        --preflight                       When enabled, turbo will precede HTTP requests with an OPTIONS request for authorization
-        --remote-cache-timeout <TIMEOUT>  Set a timeout for all HTTP requests
-        --team <TEAM>                     Set the team slug for API calls
-        --token <TOKEN>                   Set the auth token for API calls
-        --trace <TRACE>                   Specify a file to save a pprof trace
-        --verbosity <COUNT>               Verbosity level
-    -h, --help                            Print help (see more with '--help')
+        --no-gitignore
+            Do not create or modify .gitignore (default false)
+        --version
+            
+        --skip-infer
+            Skip any attempts to infer which version of Turbo the project is configured to use
+        --target <TARGET>
+            Specify what should be linked (default "remote cache") [default: remote-cache] [possible values: remote-cache, spaces]
+        --no-update-notifier
+            Disable the turbo update notification
+        --api <API>
+            Override the endpoint for API calls
+        --color
+            Force color usage in the terminal
+        --cwd <CWD>
+            The directory in which to run turbo
+        --heap <HEAP>
+            Specify a file to save a pprof heap profile
+        --ui <UI>
+            Specify whether to use the streaming UI or TUI [possible values: tui, stream]
+        --login <LOGIN>
+            Override the login endpoint
+        --no-color
+            Suppress color usage in the terminal
+        --preflight
+            When enabled, turbo will precede HTTP requests with an OPTIONS request for authorization
+        --remote-cache-timeout <TIMEOUT>
+            Set a timeout for all HTTP requests
+        --team <TEAM>
+            Set the team slug for API calls
+        --token <TOKEN>
+            Set the auth token for API calls
+        --trace <TRACE>
+            Specify a file to save a pprof trace
+        --verbosity <COUNT>
+            Verbosity level
+        --dangerously-allow-no-package-manager
+            Allow for missing `packageManager` in `package.json`
+    -h, --help
+            Print help (see more with '--help')
 
 Test help flag for unlink command
   $ ${TURBO} unlink -h
@@ -312,24 +357,44 @@ Test help flag for unlink command
   Usage: turbo(\.exe)? unlink \[OPTIONS\] (re)
   
   Options:
-        --target <TARGET>                 Specify what should be unlinked (default "remote cache") [default: remote-cache] [possible values: remote-cache, spaces]
-        --version                         
-        --skip-infer                      Skip any attempts to infer which version of Turbo the project is configured to use
-        --no-update-notifier              Disable the turbo update notification
-        --api <API>                       Override the endpoint for API calls
-        --color                           Force color usage in the terminal
-        --cwd <CWD>                       The directory in which to run turbo
-        --heap <HEAP>                     Specify a file to save a pprof heap profile
-        --ui <UI>                         Specify whether to use the streaming UI or TUI [possible values: tui, stream]
-        --login <LOGIN>                   Override the login endpoint
-        --no-color                        Suppress color usage in the terminal
-        --preflight                       When enabled, turbo will precede HTTP requests with an OPTIONS request for authorization
-        --remote-cache-timeout <TIMEOUT>  Set a timeout for all HTTP requests
-        --team <TEAM>                     Set the team slug for API calls
-        --token <TOKEN>                   Set the auth token for API calls
-        --trace <TRACE>                   Specify a file to save a pprof trace
-        --verbosity <COUNT>               Verbosity level
-    -h, --help                            Print help (see more with '--help')
+        --target <TARGET>
+            Specify what should be unlinked (default "remote cache") [default: remote-cache] [possible values: remote-cache, spaces]
+        --version
+            
+        --skip-infer
+            Skip any attempts to infer which version of Turbo the project is configured to use
+        --no-update-notifier
+            Disable the turbo update notification
+        --api <API>
+            Override the endpoint for API calls
+        --color
+            Force color usage in the terminal
+        --cwd <CWD>
+            The directory in which to run turbo
+        --heap <HEAP>
+            Specify a file to save a pprof heap profile
+        --ui <UI>
+            Specify whether to use the streaming UI or TUI [possible values: tui, stream]
+        --login <LOGIN>
+            Override the login endpoint
+        --no-color
+            Suppress color usage in the terminal
+        --preflight
+            When enabled, turbo will precede HTTP requests with an OPTIONS request for authorization
+        --remote-cache-timeout <TIMEOUT>
+            Set a timeout for all HTTP requests
+        --team <TEAM>
+            Set the team slug for API calls
+        --token <TOKEN>
+            Set the auth token for API calls
+        --trace <TRACE>
+            Specify a file to save a pprof trace
+        --verbosity <COUNT>
+            Verbosity level
+        --dangerously-allow-no-package-manager
+            Allow for missing `packageManager` in `package.json`
+    -h, --help
+            Print help (see more with '--help')
 
 Test help flag for login command
   $ ${TURBO} login -h
@@ -338,25 +403,46 @@ Test help flag for login command
   Usage: turbo(\.exe)? login \[OPTIONS\] (re)
   
   Options:
-        --sso-team <SSO_TEAM>             
-        --version                         
-    -f, --force                           Force a login to receive a new token. Will overwrite any existing tokens for the given login url
-        --skip-infer                      Skip any attempts to infer which version of Turbo the project is configured to use
-        --no-update-notifier              Disable the turbo update notification
-        --api <API>                       Override the endpoint for API calls
-        --color                           Force color usage in the terminal
-        --cwd <CWD>                       The directory in which to run turbo
-        --heap <HEAP>                     Specify a file to save a pprof heap profile
-        --ui <UI>                         Specify whether to use the streaming UI or TUI [possible values: tui, stream]
-        --login <LOGIN>                   Override the login endpoint
-        --no-color                        Suppress color usage in the terminal
-        --preflight                       When enabled, turbo will precede HTTP requests with an OPTIONS request for authorization
-        --remote-cache-timeout <TIMEOUT>  Set a timeout for all HTTP requests
-        --team <TEAM>                     Set the team slug for API calls
-        --token <TOKEN>                   Set the auth token for API calls
-        --trace <TRACE>                   Specify a file to save a pprof trace
-        --verbosity <COUNT>               Verbosity level
-    -h, --help                            Print help (see more with '--help')
+        --sso-team <SSO_TEAM>
+            
+        --version
+            
+    -f, --force
+            Force a login to receive a new token. Will overwrite any existing tokens for the given login url
+        --skip-infer
+            Skip any attempts to infer which version of Turbo the project is configured to use
+        --no-update-notifier
+            Disable the turbo update notification
+        --api <API>
+            Override the endpoint for API calls
+        --color
+            Force color usage in the terminal
+        --cwd <CWD>
+            The directory in which to run turbo
+        --heap <HEAP>
+            Specify a file to save a pprof heap profile
+        --ui <UI>
+            Specify whether to use the streaming UI or TUI [possible values: tui, stream]
+        --login <LOGIN>
+            Override the login endpoint
+        --no-color
+            Suppress color usage in the terminal
+        --preflight
+            When enabled, turbo will precede HTTP requests with an OPTIONS request for authorization
+        --remote-cache-timeout <TIMEOUT>
+            Set a timeout for all HTTP requests
+        --team <TEAM>
+            Set the team slug for API calls
+        --token <TOKEN>
+            Set the auth token for API calls
+        --trace <TRACE>
+            Specify a file to save a pprof trace
+        --verbosity <COUNT>
+            Verbosity level
+        --dangerously-allow-no-package-manager
+            Allow for missing `packageManager` in `package.json`
+    -h, --help
+            Print help (see more with '--help')
 
 Test help flag for logout command
   $ ${TURBO} logout -h
@@ -365,21 +451,41 @@ Test help flag for logout command
   Usage: turbo(\.exe)? logout \[OPTIONS\] (re)
   
   Options:
-        --invalidate                      Invalidate the token on the server
-        --version                         
-        --skip-infer                      Skip any attempts to infer which version of Turbo the project is configured to use
-        --no-update-notifier              Disable the turbo update notification
-        --api <API>                       Override the endpoint for API calls
-        --color                           Force color usage in the terminal
-        --cwd <CWD>                       The directory in which to run turbo
-        --heap <HEAP>                     Specify a file to save a pprof heap profile
-        --ui <UI>                         Specify whether to use the streaming UI or TUI [possible values: tui, stream]
-        --login <LOGIN>                   Override the login endpoint
-        --no-color                        Suppress color usage in the terminal
-        --preflight                       When enabled, turbo will precede HTTP requests with an OPTIONS request for authorization
-        --remote-cache-timeout <TIMEOUT>  Set a timeout for all HTTP requests
-        --team <TEAM>                     Set the team slug for API calls
-        --token <TOKEN>                   Set the auth token for API calls
-        --trace <TRACE>                   Specify a file to save a pprof trace
-        --verbosity <COUNT>               Verbosity level
-    -h, --help                            Print help (see more with '--help')
+        --invalidate
+            Invalidate the token on the server
+        --version
+            
+        --skip-infer
+            Skip any attempts to infer which version of Turbo the project is configured to use
+        --no-update-notifier
+            Disable the turbo update notification
+        --api <API>
+            Override the endpoint for API calls
+        --color
+            Force color usage in the terminal
+        --cwd <CWD>
+            The directory in which to run turbo
+        --heap <HEAP>
+            Specify a file to save a pprof heap profile
+        --ui <UI>
+            Specify whether to use the streaming UI or TUI [possible values: tui, stream]
+        --login <LOGIN>
+            Override the login endpoint
+        --no-color
+            Suppress color usage in the terminal
+        --preflight
+            When enabled, turbo will precede HTTP requests with an OPTIONS request for authorization
+        --remote-cache-timeout <TIMEOUT>
+            Set a timeout for all HTTP requests
+        --team <TEAM>
+            Set the team slug for API calls
+        --token <TOKEN>
+            Set the auth token for API calls
+        --trace <TRACE>
+            Specify a file to save a pprof trace
+        --verbosity <COUNT>
+            Verbosity level
+        --dangerously-allow-no-package-manager
+            Allow for missing `packageManager` in `package.json`
+    -h, --help
+            Print help (see more with '--help')

--- a/turborepo-tests/integration/tests/turbo-help.t
+++ b/turborepo-tests/integration/tests/turbo-help.t
@@ -55,7 +55,7 @@ Test help flag
             Specify a file to save a pprof trace
         --verbosity <COUNT>
             Verbosity level
-        --dangerously-allow-no-package-manager
+        --dangerously-disable-package-manager-check
             Allow for missing `packageManager` in `package.json`
     -h, --help
             Print help (see more with '--help')
@@ -188,7 +188,7 @@ Test help flag
         --verbosity <COUNT>
             Verbosity level
   
-        --dangerously-allow-no-package-manager
+        --dangerously-disable-package-manager-check
             Allow for missing `packageManager` in `package.json`.
             
             `turbo` will use hints from codebase to guess which package manager should be used.
@@ -345,7 +345,7 @@ Test help flag for link command
             Specify a file to save a pprof trace
         --verbosity <COUNT>
             Verbosity level
-        --dangerously-allow-no-package-manager
+        --dangerously-disable-package-manager-check
             Allow for missing `packageManager` in `package.json`
     -h, --help
             Print help (see more with '--help')
@@ -391,7 +391,7 @@ Test help flag for unlink command
             Specify a file to save a pprof trace
         --verbosity <COUNT>
             Verbosity level
-        --dangerously-allow-no-package-manager
+        --dangerously-disable-package-manager-check
             Allow for missing `packageManager` in `package.json`
     -h, --help
             Print help (see more with '--help')
@@ -439,7 +439,7 @@ Test help flag for login command
             Specify a file to save a pprof trace
         --verbosity <COUNT>
             Verbosity level
-        --dangerously-allow-no-package-manager
+        --dangerously-disable-package-manager-check
             Allow for missing `packageManager` in `package.json`
     -h, --help
             Print help (see more with '--help')
@@ -485,7 +485,7 @@ Test help flag for logout command
             Specify a file to save a pprof trace
         --verbosity <COUNT>
             Verbosity level
-        --dangerously-allow-no-package-manager
+        --dangerously-disable-package-manager-check
             Allow for missing `packageManager` in `package.json`
     -h, --help
             Print help (see more with '--help')


### PR DESCRIPTION
### Description

Give users the ability to opt out of the required package manager if they feel strongly. 

This is still highly discouraged as this prevents proper usage of daemon package watching and leaves us dependent on system configuration to infer the correct package manager.

Reviewer notes: Each commit can be reviewed on it's own. The second commit just adds back code deleted in https://github.com/vercel/turbo/pull/8017

### Testing Instructions

Added unit tests where applicable for configuration.

Quick manual verification of the config options:

```
[0 olszewski@chriss-mbp] /tmp/no-pm $ turbo_dev build                                                                
 WARNING  No locally installed `turbo` found. Using version: 2.0.7-canary.0.
  × missing packageManager field in package.json

[1 olszewski@chriss-mbp] /tmp/no-pm $ turbo_dev build --dangerously-disable-package-manager-check --output-logs=none
 WARNING  No locally installed `turbo` found. Using version: 2.0.7-canary.0.
• Packages in scope: @repo/eslint-config, @repo/typescript-config, @repo/ui, docs, web
• Running build in 5 packages
• Remote caching disabled

 Tasks:    2 successful, 2 total
Cached:    2 cached, 2 total
  Time:    81ms >>> FULL TURBO

[0 olszewski@chriss-mbp] /tmp/no-pm $ TURBO_DANGEROUSLY_DISABLE_PACKAGE_MANAGER_CHECK=true turbo_dev build --output-logs=none                                           
 WARNING  No locally installed `turbo` found. Using version: 2.0.7-canary.0.
• Packages in scope: @repo/eslint-config, @repo/typescript-config, @repo/ui, docs, web
• Running build in 5 packages
• Remote caching disabled

 Tasks:    2 successful, 2 total
Cached:    2 cached, 2 total
  Time:    210ms >>> FULL TURBO

[0 olszewski@chriss-mbp] /tmp/no-pm $ vim turbo.json                                                                         
[0 olszewski@chriss-mbp] /tmp/no-pm $ tail -3 turbo.json 
  },
  "dangerouslyDisablePackageManagerCheck": true
}
[0 olszewski@chriss-mbp] /tmp/no-pm $ turbo_dev build --output-logs=none                                                    
 WARNING  No locally installed `turbo` found. Using version: 2.0.7-canary.0.
• Packages in scope: @repo/eslint-config, @repo/typescript-config, @repo/ui, docs, web
• Running build in 5 packages
• Remote caching disabled

 Tasks:    2 successful, 2 total
Cached:    2 cached, 2 total
  Time:    53ms >>> FULL TURBO
```
