### PR TITLE
Docs: Fix typo in documentation: corrected "Vue.jJS" to "Vue.js"

### DIFF
--- a/docs/pack-docs/features/frameworks.mdx
+++ b/docs/pack-docs/features/frameworks.mdx
@@ -35,7 +35,7 @@ To begin with, Turbopack is focused on providing a great experience for the Next
 
 ## Vue and Svelte
 
-[Vue.jJS](https://vuejs.org/) and [Svelte](https://svelte.dev/) are tremendously popular frameworks which deliver a world-class developer experience.
+[Vue.js](https://vuejs.org/) and [Svelte](https://svelte.dev/) are tremendously popular frameworks which deliver a world-class developer experience.
 
 Since Turbopack is in beta, we're focusing our support on Next.js's dev server. That means that right now, Vue and Svelte don't work out of the box.
 


### PR DESCRIPTION
### Description

This PR corrects a typo in the documentation where "Vue.jJS" was mistakenly written instead of "Vue.js".

### Testing Instructions

👀

