### PR TITLE
Docs: Remove LESS from the first section title in documentation

### DIFF
--- a/docs/pack-docs/features/css.mdx
+++ b/docs/pack-docs/features/css.mdx
@@ -72,7 +72,7 @@ module.exports = {
 };
 ```
 
-## Sass and SCSS and LESS
+## Sass and SCSS
 
 `.scss` and `.sass` files let you utilize the [Sass](https://sass-lang.com/) language.
 


### PR DESCRIPTION
### Description

This PR removes "LESS" from the first section title in the documentation for clarity and consistency.

### Testing Instructions

👀
