### PR TITLE
chore: update core github actions

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -25,7 +25,7 @@ runs:
       uses: pnpm/action-setup@v4
 
     - name: Setup Node.js
-      uses: actions/setup-node@v3.6.0
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
         cache: pnpm

--- a/.github/workflows/bench-turbopack-scheduled.yml
+++ b/.github/workflows/bench-turbopack-scheduled.yml
@@ -125,7 +125,7 @@ jobs:
 
       - name: Upload results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.bench.name }}
           path: raw.json
@@ -149,7 +149,7 @@ jobs:
           ref: benchmark-data
 
       - name: Download benchmark data
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: data/${{ steps.date.outputs.year }}/${{ steps.date.outputs.month }}/ubuntu-latest-8-core/${{ steps.date.outputs.date }}-${{ github.sha }}
 

--- a/.github/workflows/bench-turbopack-scheduled.yml
+++ b/.github/workflows/bench-turbopack-scheduled.yml
@@ -86,7 +86,7 @@ jobs:
     name: Bench - ${{ matrix.bench.title }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: ./.github/actions/setup-node
 
@@ -144,7 +144,7 @@ jobs:
           echo "date=$(date +'%s')" >> $GITHUB_OUTPUT
           echo "pretty=$(date +'%Y-%m-%d %H:%M')" >> $GITHUB_OUTPUT
       - name: Checkout benchmark-data
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: benchmark-data
 

--- a/.github/workflows/bench-turbopack.yml
+++ b/.github/workflows/bench-turbopack.yml
@@ -257,9 +257,9 @@ jobs:
 
       - name: Upload results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: bench_${{ matrix.bench.name }}
+          name: bench-${{ matrix.bench.name }}
           path: raw.json
 
       # This avoids putting this data into the rust-cache
@@ -288,7 +288,7 @@ jobs:
           ref: benchmark-data
 
       - name: Download benchmark data
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: artifacts
 
@@ -296,7 +296,7 @@ jobs:
         run: |
           find artifacts -size 0 -delete
           mkdir -p data/${{ steps.date.outputs.year }}/${{ steps.date.outputs.month }}/ubuntu-latest-8-core/${{ steps.date.outputs.date }}-${{ github.sha }}/
-          mv artifacts/bench_* data/${{ steps.date.outputs.year }}/${{ steps.date.outputs.month }}/ubuntu-latest-8-core/${{ steps.date.outputs.date }}-${{ github.sha }}/
+          mv artifacts/bench-* data/${{ steps.date.outputs.year }}/${{ steps.date.outputs.month }}/ubuntu-latest-8-core/${{ steps.date.outputs.date }}-${{ github.sha }}/
 
       - name: Git pull
         run: git pull --depth=1 --no-tags origin benchmark-data
@@ -319,7 +319,7 @@ jobs:
           - name: linux
             title: Linux
             quiet: false
-            runs-on:
+            runner:
               - "self-hosted"
               - "linux"
               - "x64"

--- a/.github/workflows/bench-turbopack.yml
+++ b/.github/workflows/bench-turbopack.yml
@@ -47,7 +47,7 @@ jobs:
           edit-mode: replace
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: CI related changes
         id: ci
@@ -131,7 +131,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
@@ -193,7 +193,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
         uses: ./.github/actions/setup-node
@@ -283,7 +283,7 @@ jobs:
           echo "pretty=$(date +'%Y-%m-%d %H:%M')" >> $GITHUB_OUTPUT
 
       - name: Checkout benchmark-data
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: benchmark-data
 
@@ -339,7 +339,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Fetch the base branch
         run: git -c protocol.version=2 fetch --no-tags --progress --no-recurse-submodules --depth=1 origin +${{ github.base_ref }}:base

--- a/.github/workflows/bench-turborepo.yml
+++ b/.github/workflows/bench-turborepo.yml
@@ -87,9 +87,9 @@ jobs:
         run: pnpm -F @turbo/benchmark ttft "${{ steps.filename.outputs.filename }}"
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: profiles # This name will be the folder each file gets downloaded to
+          name: profiles-${{ matrix.os.name }} # This name will be the folder each file gets downloaded to
           if-no-files-found: error
           # cwd is root of the repository, so we need the benchmark/ prefixed path
           path: |
@@ -112,9 +112,10 @@ jobs:
         uses: ./.github/actions/setup-node
 
       - name: Download profiles
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: profiles
+          pattern: profiles-*
+          merge-multiple: true
           path: packages/turbo-benchmark/profiles/
 
       - name: Display TTFT Data
@@ -146,9 +147,10 @@ jobs:
         uses: ./.github/actions/setup-node
 
       - name: Download profiles
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: profiles
+          pattern: profiles-*
+          merge-multiple: true
           path: packages/turbo-benchmark/profiles/
 
       - name: Display TTFT Data

--- a/.github/workflows/bench-turborepo.yml
+++ b/.github/workflows/bench-turborepo.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node
 
       - name: Setup Turborepo Environment
@@ -61,7 +61,7 @@ jobs:
             runner: windows-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set filename for profile
         id: filename
         shell: bash
@@ -106,7 +106,7 @@ jobs:
       TINYBIRD_TOKEN: ${{secrets.TINYBIRD_TOKEN}}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Node
         uses: ./.github/actions/setup-node
@@ -140,7 +140,7 @@ jobs:
     needs: [send-to-tinybird]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Node
         uses: ./.github/actions/setup-node

--- a/.github/workflows/bench-turbotrace-against-node-nft.yml
+++ b/.github/workflows/bench-turbotrace-against-node-nft.yml
@@ -24,7 +24,7 @@ jobs:
       BENCH_ARGS: --release -p turbopack --features bench_against_node_nft bench_against_node_nft
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: ./.github/actions/setup-node
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: CI related changes
         id: ci
@@ -70,7 +70,7 @@ jobs:
       - "metal"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
@@ -104,7 +104,7 @@ jobs:
       TURBO_REMOTE_ONLY: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Setup Node"
         uses: ./.github/actions/setup-node

--- a/.github/workflows/lsp.yml
+++ b/.github/workflows/lsp.yml
@@ -45,7 +45,7 @@ jobs:
       options: ${{ matrix.settings.container-options }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Container
         if: ${{ matrix.settings.container-setup }}
         run: ${{ matrix.settings.container-setup }}

--- a/.github/workflows/lsp.yml
+++ b/.github/workflows/lsp.yml
@@ -73,7 +73,7 @@ jobs:
         run: ${{ matrix.settings.rust-build-env }} cargo build --profile release-turborepo-lsp -p turborepo-lsp --target ${{ matrix.settings.target }}
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: turborepo-lsp-${{ matrix.settings.target }}
           path: target/${{ matrix.settings.target }}/release-turborepo-lsp/turborepo-lsp*

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -10,7 +10,7 @@ jobs:
     if: "startsWith(github.event.head_commit.message, 'chore: release npm packages')"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: ./.github/actions/setup-node
       - uses: ./.github/actions/setup-rust

--- a/.github/workflows/test-js-packages.yml
+++ b/.github/workflows/test-js-packages.yml
@@ -22,7 +22,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: CI related changes
         id: ci
@@ -83,7 +83,7 @@ jobs:
           echo "depth=$(( ${{ github.event.pull_request.commits || 1 }} + 1 ))" >> $GITHUB_OUTPUT
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
           fetch-depth: ${{ steps.fetch-depth.outputs.depth  }}

--- a/.github/workflows/test-turbopack-rust-bench-test.yml
+++ b/.github/workflows/test-turbopack-rust-bench-test.yml
@@ -26,7 +26,7 @@ jobs:
         if: inputs.os == 'windows'
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Rust
         uses: ./.github/actions/setup-rust

--- a/.github/workflows/turbopack-nightly-release.yml
+++ b/.github/workflows/turbopack-nightly-release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Tag nightly
         id: tag_version

--- a/.github/workflows/turbopack-test.yml
+++ b/.github/workflows/turbopack-test.yml
@@ -381,7 +381,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           # TODO: Remove this specific version constraint once pnpm ships with
           # node-gyp that's compatible with Python 3.12+

--- a/.github/workflows/turbopack-test.yml
+++ b/.github/workflows/turbopack-test.yml
@@ -581,7 +581,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3.6.0
+        uses: actions/setup-node@v4
         with:
           node-version: 18
 

--- a/.github/workflows/turbopack-test.yml
+++ b/.github/workflows/turbopack-test.yml
@@ -353,9 +353,9 @@ jobs:
 
       - name: Upload results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: test_reports
+          name: test-reports-linux
           path: target/nextest/**/*.xml
 
   turbopack_rust_test2:
@@ -436,9 +436,9 @@ jobs:
 
       - name: Upload results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: test_reports
+          name: test-reports-${{ matrix.os.name }}
           path: target/nextest/**/*.xml
 
   turbopack_rust_test_bench1:
@@ -589,16 +589,18 @@ jobs:
         run: npm install -g @datadog/datadog-ci@2.18.1
 
       - name: Download test results
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          path: artifacts
+          pattern: test-reports-*
+          merge-multiple: true
+          path: artifacts/test-reports
 
       - name: Upload
         continue-on-error: true
         env:
           DATADOG_API_KEY: ${{ secrets.DD_KEY_TURBOPACK }}
         run: |
-          DD_ENV=ci datadog-ci junit upload --service Turbopack ./artifacts/test_reports/**/*.xml
+          DD_ENV=ci datadog-ci junit upload --service Turbopack ./artifacts/test-reports/**/*.xml
 
   done:
     name: Done

--- a/.github/workflows/turbopack-test.yml
+++ b/.github/workflows/turbopack-test.yml
@@ -47,7 +47,7 @@ jobs:
           edit-mode: replace
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: CI related changes
         id: ci
@@ -153,7 +153,7 @@ jobs:
     if: needs.determine_jobs.outputs.turbopack_typescript == 'true'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
         uses: ./.github/actions/setup-node
@@ -188,7 +188,7 @@ jobs:
       - "metal"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
@@ -214,7 +214,7 @@ jobs:
       - "metal"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
@@ -243,7 +243,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout Next.js
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: vercel/next.js
 
@@ -316,7 +316,7 @@ jobs:
     name: Turbopack Rust testing on ubuntu
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
@@ -378,7 +378,7 @@ jobs:
         if: matrix.os.name == 'windows'
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -578,7 +578,7 @@ jobs:
       # Uploading test results does not require turbopack's src codes, but this
       # allows datadog uploader to sync with git information.
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v3.6.0

--- a/.github/workflows/turborepo-compare-cache-item.yml
+++ b/.github/workflows/turborepo-compare-cache-item.yml
@@ -32,7 +32,7 @@ jobs:
           turbo run build --filter=docs --filter=web --summarize --skip-infer -vvv
 
       - name: Grab Turborepo artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cache-item-${{ matrix.os }}-${{ inputs.version }}
           path: |
@@ -61,7 +61,7 @@ jobs:
           pnpm dlx create-turbo@${{ inputs.version }} my-turborepo pnpm
 
       - name: Download cache artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: cache-item-${{ matrix.cache_os }}-${{ inputs.version }}
           path: my-turborepo

--- a/.github/workflows/turborepo-compare-cache-item.yml
+++ b/.github/workflows/turborepo-compare-cache-item.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
 
@@ -51,7 +51,7 @@ jobs:
 
     steps:
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
 

--- a/.github/workflows/turborepo-library-release.yml
+++ b/.github/workflows/turborepo-library-release.yml
@@ -117,7 +117,7 @@ jobs:
           ${{ matrix.settings.rust_env }} pnpm build:release --target=${{ matrix.settings.target }}
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: turbo-library-${{ matrix.settings.target }}
           path: packages/turbo-repository/native
@@ -138,7 +138,7 @@ jobs:
           git config --global user.email 'turbobot@vercel.com'
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: native-packages
 
@@ -173,7 +173,7 @@ jobs:
           mv *.tgz tarballs/
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Upload Tarballs
           path: tarballs

--- a/.github/workflows/turborepo-library-release.yml
+++ b/.github/workflows/turborepo-library-release.yml
@@ -87,7 +87,7 @@ jobs:
         if: ${{ matrix.settings.install }}
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -128,7 +128,7 @@ jobs:
     needs: [build]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/turborepo-native-lib-test.yml
+++ b/.github/workflows/turborepo-native-lib-test.yml
@@ -38,7 +38,7 @@ jobs:
           echo "depth=$(( ${{ github.event.pull_request.commits || 1 }} + 1 ))" >> $GITHUB_OUTPUT
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
           fetch-depth: ${{ steps.fetch-depth.outputs.depth  }}

--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -252,7 +252,7 @@ jobs:
     steps:
       - name: Show Stage Commit
         run: echo "${{ needs.stage.outputs.stage-branch }}"
-      - uses: actions/checkout@1.0.0
+      - uses: actions/checkout@v4
         with:
           ref: ${{ needs.stage.outputs.stage-branch }}
       - name: Get version

--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -180,7 +180,7 @@ jobs:
         run: ${{ matrix.settings.rust-build-env }} cargo build --profile release-turborepo -p turbo --target ${{ matrix.settings.target }}
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: turbo-${{ matrix.settings.target }}
           path: target/${{ matrix.settings.target }}/release-turborepo/turbo*
@@ -218,9 +218,10 @@ jobs:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
 
       - name: Download Rust artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: rust-artifacts
+          merge-multiple: true
 
       - name: Move Rust artifacts into place
         run: |
@@ -239,7 +240,7 @@ jobs:
 
       # Upload published artifacts in case they are needed for debugging later
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: turbo-combined
           path: cli/dist

--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -44,7 +44,7 @@ jobs:
   stage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node
         with:
           enable-corepack: false
@@ -71,7 +71,7 @@ jobs:
     steps:
       - name: Show Stage Commit
         run: echo "${{ needs.stage.outputs.stage-branch }}"
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ needs.stage.outputs.stage-branch }}
       - name: Setup Turborepo Environment
@@ -89,7 +89,7 @@ jobs:
     steps:
       - name: Show Stage Commit
         run: echo "${{ needs.stage.outputs.stage-branch }}"
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ needs.stage.outputs.stage-branch }}
       - name: Setup Turborepo Environment
@@ -137,7 +137,7 @@ jobs:
       - name: Show Stage Commit
         run: echo "${{ needs.stage.outputs.stage-branch }}"
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: "${{ needs.stage.outputs.stage-branch }}"
 
@@ -192,7 +192,7 @@ jobs:
     steps:
       - name: Show Stage Commit
         run: echo "${{ needs.stage.outputs.stage-branch }}"
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: "${{ needs.stage.outputs.stage-branch }}"
       - run: git fetch origin --tags

--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -208,7 +208,7 @@ jobs:
 
       - name: Cache Prysk
         id: cache-prysk
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: cli/.cram_env
           key: prysk-venv-${{ matrix.os.runner }}

--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -22,7 +22,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: CI related changes
         id: ci
@@ -127,7 +127,7 @@ jobs:
             runner: windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -188,7 +188,7 @@ jobs:
         if: matrix.os.runner == 'windows-latest'
         shell: bash
         run: git config --global core.autocrlf input
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Turborepo Environment
         uses: ./.github/actions/setup-turborepo-environment
@@ -225,7 +225,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Disable corepack. actions/setup-node invokes other package managers and
       # that causes corepack to throw an error, so we disable it first.
@@ -267,7 +267,7 @@ jobs:
       - "metal"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
@@ -301,7 +301,7 @@ jobs:
       - "metal"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Turborepo Environment
         uses: ./.github/actions/setup-turborepo-environment
@@ -323,7 +323,7 @@ jobs:
       - "metal"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Turborepo Environment
         uses: ./.github/actions/setup-turborepo-environment
@@ -367,7 +367,7 @@ jobs:
         if: matrix.os.name == 'windows'
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Turborepo Environment
         uses: ./.github/actions/setup-turborepo-environment


### PR DESCRIPTION
### Description

The `node16` runner is deprecated.

Trying to update all the actions again, this time in smaller chunks.

This PR updates all actions from GitHub.
