### PR TITLE
add envMode to `turbo.json`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,8 +9,7 @@
   "debug.javascript.unmapMissingSources": true,
   "files.associations": {
     "libturbo.h": "c",
-    "turbo.json": "jsonc",
-    "*.t.err": "cram"
+    "turbo.json": "jsonc"
   },
   "[cram]": {
     "editor.trimAutoWhitespace": false,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,7 +9,8 @@
   "debug.javascript.unmapMissingSources": true,
   "files.associations": {
     "libturbo.h": "c",
-    "turbo.json": "jsonc"
+    "turbo.json": "jsonc",
+    "*.t.err": "cram"
   },
   "[cram]": {
     "editor.trimAutoWhitespace": false,

--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -8,7 +8,7 @@ use clap::{
 };
 use clap_complete::{generate, Shell};
 pub use error::Error;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use tracing::{debug, error, log::warn};
 use turbopath::AbsoluteSystemPathBuf;
 use turborepo_api_client::AnonAPIClient;
@@ -136,7 +136,9 @@ impl Display for DryRunMode {
     }
 }
 
-#[derive(Copy, Clone, Debug, Default, PartialEq, Serialize, ValueEnum)]
+#[derive(
+    Copy, Clone, Debug, Default, PartialEq, Serialize, ValueEnum, Deserialize, Eq, Deserializable,
+)]
 #[serde(rename_all = "lowercase")]
 pub enum EnvMode {
     Loose,

--- a/crates/turborepo-lib/src/commands/config.rs
+++ b/crates/turborepo-lib/src/commands/config.rs
@@ -3,7 +3,10 @@ use turborepo_repository::{
     package_graph::PackageGraph, package_json::PackageJson, package_manager::PackageManager,
 };
 
-use crate::{cli, commands::CommandBase};
+use crate::{
+    cli::{self, EnvMode},
+    commands::CommandBase,
+};
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -21,6 +24,7 @@ struct ConfigOutput<'a> {
     ui: bool,
     package_manager: PackageManager,
     daemon: Option<bool>,
+    env_mode: EnvMode,
 }
 
 pub async fn run(base: CommandBase) -> Result<(), cli::Error> {
@@ -49,6 +53,7 @@ pub async fn run(base: CommandBase) -> Result<(), cli::Error> {
             ui: config.ui(),
             package_manager: *package_manager,
             daemon: config.daemon,
+            env_mode: config.env_mode(),
         })?
     );
     Ok(())

--- a/crates/turborepo-lib/src/commands/mod.rs
+++ b/crates/turborepo-lib/src/commands/mod.rs
@@ -86,6 +86,12 @@ impl CommandBase {
                     .then_some(true),
             )
             .with_daemon(self.args.run_args.as_ref().and_then(|args| args.daemon()))
+            .with_env_mode(
+                self.args
+                    .execution_args
+                    .as_ref()
+                    .and_then(|args| args.env_mode),
+            )
             .build()
     }
 

--- a/crates/turborepo-lib/src/commands/mod.rs
+++ b/crates/turborepo-lib/src/commands/mod.rs
@@ -7,6 +7,7 @@ use turborepo_dirs::config_dir;
 use turborepo_ui::UI;
 
 use crate::{
+    cli::Command,
     config::{ConfigurationOptions, Error as ConfigError, TurborepoConfigBuilder},
     Args,
 };
@@ -88,9 +89,18 @@ impl CommandBase {
             .with_daemon(self.args.run_args.as_ref().and_then(|args| args.daemon()))
             .with_env_mode(
                 self.args
-                    .execution_args
+                    .command
                     .as_ref()
-                    .and_then(|args| args.env_mode),
+                    .and_then(|c| match c {
+                        Command::Run { execution_args, .. } => execution_args.env_mode,
+                        _ => None,
+                    })
+                    .or_else(|| {
+                        self.args
+                            .execution_args
+                            .as_ref()
+                            .and_then(|args| args.env_mode)
+                    }),
             )
             .build()
     }

--- a/crates/turborepo-lib/src/opts.rs
+++ b/crates/turborepo-lib/src/opts.rs
@@ -258,7 +258,7 @@ impl<'a> TryFrom<OptsInputs<'a>> for RunOpts {
             single_package: inputs.execution_args.single_package,
             graph,
             dry_run: inputs.run_args.dry_run,
-            env_mode: inputs.execution_args.env_mode.unwrap_or_default(),
+            env_mode: inputs.config.env_mode(),
             is_github_actions,
         })
     }

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -17,7 +17,7 @@ use turborepo_repository::{package_graph::ROOT_PKG_NAME, package_json::PackageJs
 use turborepo_unescape::UnescapedString;
 
 use crate::{
-    cli::OutputLogsMode,
+    cli::{EnvMode, OutputLogsMode},
     config::{ConfigurationOptions, Error, InvalidEnvPrefixError},
     run::{
         task_access::{TaskAccessTraceFile, TASK_ACCESS_CONFIG_PATH},
@@ -133,6 +133,8 @@ pub struct RawTurboJson {
     pub allow_no_package_manager: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub daemon: Option<Spanned<bool>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub env_mode: Option<EnvMode>,
 
     #[deserializable(rename = "//")]
     #[serde(skip)]

--- a/turborepo-tests/integration/tests/config.t
+++ b/turborepo-tests/integration/tests/config.t
@@ -16,7 +16,8 @@ Run test run
     "spacesId": null,
     "ui": false,
     "packageManager": "npm",
-    "daemon": null
+    "daemon": null,
+    "envMode": "strict"
   }
 
 Run test run with api overloaded
@@ -76,3 +77,15 @@ Add flag: `--daemon`
 Add flag: `--no-daemon`
   $ ${TURBO} --no-daemon config | jq .daemon
   false
+
+Confirm that the envMode is `strict` by default
+  $ ${TURBO} config | jq .envMode
+  strict
+
+Add env var: `TURBO_ENV_MODE=loose`
+  $ TURBO_ENV_MODE=loose ${TURBO} config | jq .envMode
+  loose
+
+Add flag: `--env-mode=loose`
+  $ ${TURBO} --env-mode=loose config | jq .envMode
+  loose

--- a/turborepo-tests/integration/tests/config.t
+++ b/turborepo-tests/integration/tests/config.t
@@ -80,12 +80,12 @@ Add flag: `--no-daemon`
 
 Confirm that the envMode is `strict` by default
   $ ${TURBO} config | jq .envMode
-  strict
+  "strict"
 
 Add env var: `TURBO_ENV_MODE=loose`
   $ TURBO_ENV_MODE=loose ${TURBO} config | jq .envMode
-  loose
+  "loose"
 
 Add flag: `--env-mode=loose`
   $ ${TURBO} --env-mode=loose config | jq .envMode
-  loose
+  "loose"


### PR DESCRIPTION
### Description

### Testing Instructions

1. (temporarily) update `@turbo/gen`'s `check-types` command to `    "check-types": "env | sort | tee /dev/tty | wc -l"`
1. execute `turbo run check-types --filter @turbo/gen` and observe the number
1. add `  "envMode": "loose",` to the root `turbo.json`
1. run the command above again, observer the number is larger, indicating more environment variables have been included.