### PR TITLE
Remove unused instant return value from `CaptureFuture`

### DIFF
--- a/crates/turbo-tasks/src/capture_future.rs
+++ b/crates/turbo-tasks/src/capture_future.rs
@@ -51,7 +51,7 @@ pub fn add_allocation_info(alloc_info: AllocationInfo) {
 }
 
 impl<T, F: Future<Output = T>> Future for CaptureFuture<T, F> {
-    type Output = (T, Duration, Instant, usize);
+    type Output = (T, Duration, usize);
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.project();
@@ -68,7 +68,7 @@ impl<T, F: Future<Output = T>> Future for CaptureFuture<T, F> {
                 let (duration, allocations, deallocations) = *this.cell.lock().unwrap();
                 let memory_usage = (*this.allocations + allocations)
                     .saturating_sub(*this.deallocations + deallocations);
-                Poll::Ready((r, *this.duration + duration, start + elapsed, memory_usage))
+                Poll::Ready((r, *this.duration + duration, memory_usage))
             }
             Poll::Pending => Poll::Pending,
         }

--- a/crates/turbo-tasks/src/manager.rs
+++ b/crates/turbo-tasks/src/manager.rs
@@ -445,7 +445,7 @@ impl<B: Backend + 'static> TurboTasks<B> {
                             };
 
                             async {
-                                let (result, duration, _instant, memory_usage) =
+                                let (result, duration, memory_usage) =
                                     CaptureFuture::new(AssertUnwindSafe(future).catch_unwind())
                                         .await;
 


### PR DESCRIPTION
### Description

Appears to be unused.

### Testing Instructions

```
cargo check
cargo check --tests
```