### PR TITLE
refactor(turborepo): derive `Opts` from `Config`

### DIFF
--- a/crates/turborepo-api-client/src/lib.rs
+++ b/crates/turborepo-api-client/src/lib.rs
@@ -123,6 +123,16 @@ pub struct APIAuth {
     pub team_slug: Option<String>,
 }
 
+impl std::fmt::Debug for APIAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("APIAuth")
+            .field("team_id", &self.team_id)
+            .field("token", &"***")
+            .field("team_slug", &self.team_slug)
+            .finish()
+    }
+}
+
 pub fn is_linked(api_auth: &Option<APIAuth>) -> bool {
     api_auth
         .as_ref()

--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -682,8 +682,8 @@ pub struct ExecutionArgs {
     /// Environment variable mode.
     /// Use "loose" to pass the entire existing environment.
     /// Use "strict" to use an allowlist specified in turbo.json.
-    #[clap(long = "env-mode", default_value = "strict", num_args = 0..=1, default_missing_value = "strict")]
-    pub env_mode: EnvMode,
+    #[clap(long = "env-mode", num_args = 0..=1, default_missing_value = "strict")]
+    pub env_mode: Option<EnvMode>,
     /// Use the given selector to specify package(s) to act as
     /// entry points. The syntax mirrors pnpm's syntax, and
     /// additional documentation and examples can be found in
@@ -755,8 +755,8 @@ impl ExecutionArgs {
             );
         }
 
-        if self.env_mode != EnvMode::default() {
-            telemetry.track_arg_value("env-mode", self.env_mode, EventType::NonSensitive);
+        if let Some(env_mode) = self.env_mode {
+            telemetry.track_arg_value("env-mode", env_mode, EventType::NonSensitive);
         }
 
         if let Some(output_logs) = &self.output_logs {
@@ -1443,7 +1443,7 @@ mod test {
             command: Some(Command::Run {
                 execution_args: Box::new(ExecutionArgs {
                     tasks: vec!["build".to_string()],
-                    env_mode: EnvMode::Strict,
+                    env_mode: Some(EnvMode::Strict),
                     ..get_default_execution_args()
                 }),
                 run_args: Box::new(get_default_run_args())
@@ -1453,27 +1453,12 @@ mod test {
         "env_mode: not fully-specified"
     )]
     #[test_case::test_case(
-		&["turbo", "run", "build"],
-        Args {
-            command: Some(Command::Run {
-                execution_args: Box::new(ExecutionArgs {
-                    tasks: vec!["build".to_string()],
-                    env_mode: EnvMode::Strict,
-                    ..get_default_execution_args()
-                }),
-                run_args: Box::new(get_default_run_args())
-            }),
-            ..Args::default()
-		} ;
-        "env_mode: default strict"
-	)]
-    #[test_case::test_case(
 		&["turbo", "run", "build", "--env-mode", "loose"],
         Args {
             command: Some(Command::Run {
                 execution_args: Box::new(ExecutionArgs {
                     tasks: vec!["build".to_string()],
-                    env_mode: EnvMode::Loose,
+                    env_mode: Some(EnvMode::Loose),
                     ..get_default_execution_args()
                 }),
                 run_args: Box::new(get_default_run_args())
@@ -1488,7 +1473,7 @@ mod test {
             command: Some(Command::Run {
                 execution_args: Box::new(ExecutionArgs {
                     tasks: vec!["build".to_string()],
-                    env_mode: EnvMode::Strict,
+                    env_mode: Some(EnvMode::Strict),
                     ..get_default_execution_args()
                 }),
                 run_args: Box::new(get_default_run_args())

--- a/turborepo-tests/integration/tests/no-args.t
+++ b/turborepo-tests/integration/tests/no-args.t
@@ -96,7 +96,7 @@ Make sure exit code is 2 when no args are passed
         --global-deps <GLOBAL_DEPS>
             Specify glob of global filesystem dependencies to be hashed. Useful for .env and files
         --env-mode [<ENV_MODE>]
-            Environment variable mode. Use "loose" to pass the entire existing environment. Use "strict" to use an allowlist specified in turbo.json [default: strict] [possible values: loose, strict]
+            Environment variable mode. Use "loose" to pass the entire existing environment. Use "strict" to use an allowlist specified in turbo.json [possible values: loose, strict]
     -F, --filter <FILTER>
             Use the given selector to specify package(s) to act as entry points. The syntax mirrors pnpm's syntax, and additional documentation and examples can be found in turbo's documentation https://turbo.build/repo/docs/reference/command-line-reference/run#--filter
         --output-logs <OUTPUT_LOGS>

--- a/turborepo-tests/integration/tests/turbo-help.t
+++ b/turborepo-tests/integration/tests/turbo-help.t
@@ -96,7 +96,7 @@ Test help flag
         --global-deps <GLOBAL_DEPS>
             Specify glob of global filesystem dependencies to be hashed. Useful for .env and files
         --env-mode [<ENV_MODE>]
-            Environment variable mode. Use "loose" to pass the entire existing environment. Use "strict" to use an allowlist specified in turbo.json [default: strict] [possible values: loose, strict]
+            Environment variable mode. Use "loose" to pass the entire existing environment. Use "strict" to use an allowlist specified in turbo.json [possible values: loose, strict]
     -F, --filter <FILTER>
             Use the given selector to specify package(s) to act as entry points. The syntax mirrors pnpm's syntax, and additional documentation and examples can be found in turbo's documentation https://turbo.build/repo/docs/reference/command-line-reference/run#--filter
         --output-logs <OUTPUT_LOGS>
@@ -268,7 +268,6 @@ Test help flag
         --env-mode [<ENV_MODE>]
             Environment variable mode. Use "loose" to pass the entire existing environment. Use "strict" to use an allowlist specified in turbo.json
             
-            [default: strict]
             [possible values: loose, strict]
   
     -F, --filter <FILTER>


### PR DESCRIPTION
### Description

Changed `Opts` to be derived from more than just `RunArgs` and `ExecutionArgs`. This means that `Opts` contains the fully resolved config, which gets rid of some messy mutable logic in `RunBuilder` and creates a single source of truth.

### Testing Instructions

Existing tests cover this pretty well.
