### PR TITLE
Add u64 ExecutionId type

### DIFF
--- a/crates/turbo-tasks/src/backend.rs
+++ b/crates/turbo-tasks/src/backend.rs
@@ -15,7 +15,7 @@ use auto_hash_map::AutoMap;
 use serde::{Deserialize, Serialize};
 use tracing::Span;
 
-pub use crate::id::BackendJobId;
+pub use crate::id::{BackendJobId, ExecutionId};
 use crate::{
     event::EventListener, manager::TurboTasksBackendApi, raw_vc::CellId, registry,
     ConcreteTaskInput, FunctionId, RawVc, ReadRef, SharedReference, TaskId, TaskIdProvider,


### PR DESCRIPTION
### Description

The plan for task-local Vcs is to extend the `RawVc` type into:

```
enum RawVc {
    TaskOutput(TaskId),
    TaskCell(TaskId, CellId),
    LocalCell(ExecutionId, LocalCellId),  // new variant!
}
```

Where `ExecutionId` is a globally unique value representing the current task execution. That will be used with runtime safety checks to ensure that a given `LocalCellId` (which is an index into a task-local arena/vec) is valid upon read.

https://www.notion.so/vercel/Resolved-Vcs-Vc-Lifetimes-Local-Vcs-and-Vc-Refcounts-49d666d3f9594017b5b312b87ddc5bff?pvs=4

This PR extends the `define_id` macro to support arbitrary integer types, and uses that to define `ExecutionId`.

### Testing Instructions

```
cargo nextest r -p turbo-tasks -p turbo-tasks-memory
```