### PR TITLE
notify tasks when collectibles change

### DIFF
--- a/crates/turbo-tasks-memory/src/memory_backend.rs
+++ b/crates/turbo-tasks-memory/src/memory_backend.rs
@@ -471,6 +471,7 @@ impl Backend for MemoryBackend {
         reader: TaskId,
         turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackend>,
     ) -> AutoMap<RawVc, i32> {
+        Task::add_dependency_to_current(TaskEdge::Collectibles(id, trait_id));
         Task::read_collectibles(id, trait_id, reader, self, turbo_tasks)
     }
 

--- a/crates/turbo-tasks/src/manager.rs
+++ b/crates/turbo-tasks/src/manager.rs
@@ -458,13 +458,16 @@ impl<B: Backend + 'static> TurboTasks<B> {
                                 });
                                 this.backend.task_execution_result(task_id, result, &*this);
                                 let stateful = this.finish_current_task_state();
-                                this.backend.task_execution_completed(
+                                let schedule_again = this.backend.task_execution_completed(
                                     task_id,
                                     duration,
                                     memory_usage,
                                     stateful,
                                     &*this,
-                                )
+                                );
+                                // task_execution_completed might need to notify tasks
+                                this.notify_scheduled_tasks();
+                                schedule_again
                             }
                             .instrument(span)
                             .await


### PR DESCRIPTION
### Description

Collectibles are removed in `execution_completed` and that might add some tasks to the task local of tasks_to_notify. We need to make sure to notify these tasks otherwise changes get lost.

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
