### PR TITLE
merge InProgressDirty into InProgress

### DIFF
--- a/crates/turbo-tasks-memory/src/task.rs
+++ b/crates/turbo-tasks-memory/src/task.rs
@@ -875,7 +875,7 @@ impl Task {
     ) {
         let mut state = self.full_state_mut();
         match state.state_type {
-            InProgress(box InProgressState { stale, .. }) if stale => {
+            InProgress(state) if state.stale => {
                 // We don't want to assign the output cell here
                 // as we want to avoid unnecessary updates
                 // TODO maybe this should be controlled by a heuristic

--- a/crates/turbo-tasks-memory/src/task.rs
+++ b/crates/turbo-tasks-memory/src/task.rs
@@ -310,14 +310,22 @@ impl MaybeCollectibles {
 }
 
 struct InProgressState {
+    /// Event is fired when the task is Done.
     event: Event,
+    /// true, when the task was marked as finished.
     count_as_finished: bool,
     /// true, when the task wasn't changed since the last execution
     clean: bool,
+    /// true, when the task was invalidated while executing. It will be
+    /// scheduled again.
+    stale: bool,
     /// Dependencies and children that need to be disconnected once leaving
-    /// this state
+    /// this state.
     outdated_edges: TaskEdgesSet,
+    /// Children that are connected during execution. These children are already
+    /// removed from `outdated_edges`.
     new_children: TaskIdSet,
+    /// Collectibles that need to be removed once leaving this state.
     outdated_collectibles: MaybeCollectibles,
 }
 
@@ -356,19 +364,10 @@ enum TaskStateType {
 
     /// Execution is happening
     ///
-    /// on finish this will move to Done
+    /// on finish this will move to Done (!stale) or Scheduled (stale)
     ///
-    /// on invalidation this will move to InProgressDirty
+    /// on invalidation this will set it's stale flag
     InProgress(Box<InProgressState>),
-
-    /// Invalid execution is happening
-    ///
-    /// on finish this will move to Scheduled
-    InProgressDirty {
-        event: Event,
-        outdated_edges: Box<TaskEdgesSet>,
-        children_count: usize,
-    },
 }
 
 impl TaskStateType {
@@ -385,9 +384,6 @@ impl TaskStateType {
                     .chain(new_children.iter().copied()),
             )),
             TaskStateType::Dirty { outdated_edges, .. } => {
-                Either::Right(Either::Right(outdated_edges.children()))
-            }
-            TaskStateType::InProgressDirty { outdated_edges, .. } => {
                 Either::Right(Either::Right(outdated_edges.children()))
             }
             TaskStateType::Scheduled { outdated_edges, .. } => {
@@ -414,7 +410,6 @@ impl TaskStateType {
                 (edges, children)
             }
             TaskStateType::Dirty { outdated_edges, .. }
-            | TaskStateType::InProgressDirty { outdated_edges, .. }
             | TaskStateType::Scheduled { outdated_edges, .. } => {
                 let mut edges = *outdated_edges;
                 let children = edges.drain_children();
@@ -704,7 +699,7 @@ impl Task {
         let (future, span) = {
             let mut state = self.full_state_mut();
             match state.state_type {
-                Done { .. } | InProgress { .. } | InProgressDirty { .. } => {
+                Done { .. } | InProgress { .. } => {
                     // should not start in this state
                     return None;
                 }
@@ -720,6 +715,7 @@ impl Task {
                         event,
                         count_as_finished: false,
                         clean,
+                        stale: false,
                         outdated_edges,
                         outdated_collectibles,
                         new_children: Default::default(),
@@ -824,6 +820,7 @@ impl Task {
         };
         let TaskStateType::InProgress(box InProgressState {
             ref mut count_as_finished,
+            ref mut stale,
             ref mut outdated_collectibles,
             ref mut outdated_edges,
             ..
@@ -831,7 +828,7 @@ impl Task {
         else {
             return;
         };
-        if *count_as_finished {
+        if *count_as_finished || *stale {
             return;
         }
         *count_as_finished = true;
@@ -878,7 +875,12 @@ impl Task {
     ) {
         let mut state = self.full_state_mut();
         match state.state_type {
-            InProgress { .. } => match result {
+            InProgress(box InProgressState { stale, .. }) if stale => {
+                // We don't want to assign the output cell here
+                // as we want to avoid unnecessary updates
+                // TODO maybe this should be controlled by a heuristic
+            }
+            InProgress(..) => match result {
                 Ok(Ok(result)) => {
                     if state.output != result {
                         if cfg!(feature = "print_task_invalidation")
@@ -905,11 +907,7 @@ impl Task {
                 }
                 Err(message) => state.output.panic(message, turbo_tasks),
             },
-            InProgressDirty { .. } => {
-                // We don't want to assign the output cell here
-                // as we want to avoid unnecessary updates
-                // TODO maybe this should be controlled by a heuristic
-            }
+
             Dirty { .. } | Scheduled { .. } | Done { .. } => {
                 panic!(
                     "Task execution completed in unexpected state {}",
@@ -934,99 +932,111 @@ impl Task {
         {
             let mut change_job = None;
             let mut remove_job = None;
-            let mut dependencies = DEPENDENCIES_TO_TRACK.with(|deps| deps.take());
+            let dependencies = DEPENDENCIES_TO_TRACK.with(|deps| deps.take());
             {
                 let mut state = self.full_state_mut();
 
                 state
                     .gc
                     .execution_completed(duration, memory_usage, generation);
-                match state.state_type {
-                    InProgress(box InProgressState {
-                        ref mut event,
-                        count_as_finished,
-                        ref mut outdated_edges,
-                        ref mut outdated_collectibles,
-                        ref mut new_children,
-                        clean: _,
-                    }) => {
-                        let event = event.take();
-                        let mut outdated_edges = take(outdated_edges);
-                        let outdated_collectibles = outdated_collectibles.take_collectibles();
-                        let mut new_edges = take(&mut dependencies);
-                        outdated_edges.remove_all(&new_edges);
-                        for child in take(new_children) {
-                            new_edges.insert(TaskEdge::Child(child));
-                            outdated_edges.remove(TaskEdge::Child(child));
-                        }
-                        if !backend.has_gc() {
-                            // This will stay here for longer, so make sure to not consume too much
-                            // memory
-                            for cells in state.cells.values_mut() {
-                                cells.shrink_to_fit();
-                            }
-                            state.cells.shrink_to_fit();
-                        }
-                        state.state_type = Done {
-                            stateful,
-                            edges: new_edges.into_list(),
-                        };
-                        if !count_as_finished {
-                            let mut change = TaskChange {
-                                unfinished: -1,
-                                #[cfg(feature = "track_unfinished")]
-                                unfinished_tasks_update: vec![(self.id, -1)],
-                                ..Default::default()
-                            };
-                            if let Some(collectibles) = outdated_collectibles {
-                                for ((trait_type, value), count) in collectibles.into_iter() {
-                                    change.collectibles.push((trait_type, value, -count));
-                                }
-                            }
-                            change_job = state
-                                .aggregation_node
-                                .apply_change(&aggregation_context, change);
-                        }
-                        let outdated_children = outdated_edges.drain_children();
-                        if !outdated_children.is_empty() {
-                            remove_job = state.aggregation_node.handle_lost_edges(
-                                &aggregation_context,
-                                &self.id,
-                                outdated_children,
-                            );
-                        }
-                        event.notify(usize::MAX);
-                        drop(state);
-                        self.clear_dependencies(outdated_edges, backend, turbo_tasks);
-                    }
-                    InProgressDirty {
-                        ref mut event,
-                        ref mut outdated_edges,
-                        children_count: _,
-                    } => {
-                        let event = event.take();
-                        for dep in take(outdated_edges).into_iter() {
-                            // TODO Could be more efficent
-                            dependencies.insert(dep);
-                        }
-                        let outdated_edges = take(&mut dependencies);
-                        state.state_type = Scheduled {
-                            event,
-                            outdated_edges: Box::new(outdated_edges),
-                            clean: false,
-                        };
-                        schedule_task = true;
-                    }
-                    Dirty { .. } | Scheduled { .. } | Done { .. } => {
-                        panic!(
-                            "Task execution completed in unexpected state {}",
-                            Task::state_string(&state)
-                        )
-                    }
+                let InProgress(box InProgressState {
+                    ref mut event,
+                    count_as_finished,
+                    ref mut outdated_edges,
+                    ref mut outdated_collectibles,
+                    ref mut new_children,
+                    clean: _,
+                    stale,
+                }) = state.state_type
+                else {
+                    panic!(
+                        "Task execution completed in unexpected state {}",
+                        Task::state_string(&state)
+                    )
                 };
-            }
-            if !dependencies.is_empty() {
-                self.clear_dependencies(dependencies, backend, turbo_tasks);
+                let event = event.take();
+                let outdated_collectibles = outdated_collectibles.take_collectibles();
+                let mut outdated_edges = take(outdated_edges);
+                let mut new_edges = dependencies;
+                let new_children = take(new_children);
+                if stale {
+                    for dep in new_edges.into_iter() {
+                        // TODO Could be more efficent
+                        outdated_edges.insert(dep);
+                    }
+                    for child in new_children {
+                        outdated_edges.insert(TaskEdge::Child(child));
+                    }
+                    if let Some(collectibles) = outdated_collectibles {
+                        let mut change = TaskChange::default();
+                        for ((trait_type, value), count) in collectibles.into_iter() {
+                            change.collectibles.push((trait_type, value, -count));
+                        }
+                        change_job = state
+                            .aggregation_node
+                            .apply_change(&aggregation_context, change);
+                    }
+                    state.state_type = Scheduled {
+                        event,
+                        outdated_edges: Box::new(outdated_edges),
+                        clean: false,
+                    };
+                    drop(state);
+                    schedule_task = true;
+                } else {
+                    outdated_edges.remove_all(&new_edges);
+                    for child in new_children {
+                        new_edges.insert(TaskEdge::Child(child));
+                        outdated_edges.remove(TaskEdge::Child(child));
+                    }
+                    if !backend.has_gc() {
+                        // This will stay here for longer, so make sure to not consume too
+                        // much memory
+                        for cells in state.cells.values_mut() {
+                            cells.shrink_to_fit();
+                        }
+                        state.cells.shrink_to_fit();
+                    }
+                    state.state_type = Done {
+                        stateful,
+                        edges: new_edges.into_list(),
+                    };
+                    if !count_as_finished {
+                        let mut change = TaskChange {
+                            unfinished: -1,
+                            #[cfg(feature = "track_unfinished")]
+                            unfinished_tasks_update: vec![(self.id, -1)],
+                            ..Default::default()
+                        };
+                        if let Some(collectibles) = outdated_collectibles {
+                            for ((trait_type, value), count) in collectibles.into_iter() {
+                                change.collectibles.push((trait_type, value, -count));
+                            }
+                        }
+                        change_job = state
+                            .aggregation_node
+                            .apply_change(&aggregation_context, change);
+                    } else if let Some(collectibles) = outdated_collectibles {
+                        let mut change = TaskChange::default();
+                        for ((trait_type, value), count) in collectibles.into_iter() {
+                            change.collectibles.push((trait_type, value, -count));
+                        }
+                        change_job = state
+                            .aggregation_node
+                            .apply_change(&aggregation_context, change);
+                    }
+                    let outdated_children = outdated_edges.drain_children();
+                    if !outdated_children.is_empty() {
+                        remove_job = state.aggregation_node.handle_lost_edges(
+                            &aggregation_context,
+                            &self.id,
+                            outdated_children,
+                        );
+                    }
+                    event.notify(usize::MAX);
+                    drop(state);
+                    self.clear_dependencies(outdated_edges, backend, turbo_tasks);
+                }
             }
             change_job.apply(&aggregation_context);
             remove_job.apply(&aggregation_context);
@@ -1062,7 +1072,7 @@ impl Task {
                     // already scheduled
                     drop(state);
                 }
-                Dirty { .. } | InProgressDirty { .. } => {
+                Dirty { .. } => {
                     // already dirty
                     drop(state);
                 }
@@ -1113,54 +1123,33 @@ impl Task {
                     }
                 }
                 InProgress(box InProgressState {
-                    ref mut event,
-                    count_as_finished,
-                    ref mut outdated_edges,
-                    ref mut outdated_collectibles,
-                    ref mut new_children,
-                    clean: _,
+                    ref mut count_as_finished,
+                    ref mut clean,
+                    ref mut stale,
+                    ..
                 }) => {
-                    let event = event.take();
-                    let mut outdated_edges = take(outdated_edges);
-                    let children_count = new_children.len();
-                    for child in take(new_children) {
-                        outdated_edges.insert(TaskEdge::Child(child));
-                    }
-                    let outdated_collectibles = outdated_collectibles.take_collectibles();
-                    let change = if count_as_finished {
-                        let mut change = TaskChange {
-                            unfinished: 1,
-                            #[cfg(feature = "track_unfinished")]
-                            unfinished_tasks_update: vec![(self.id, 1)],
-                            ..Default::default()
+                    if !*stale {
+                        *clean = false;
+                        *stale = true;
+                        let change_job = if *count_as_finished {
+                            *count_as_finished = false;
+                            let change = TaskChange {
+                                unfinished: 1,
+                                #[cfg(feature = "track_unfinished")]
+                                unfinished_tasks_update: vec![(self.id, 1)],
+                                ..Default::default()
+                            };
+                            Some(
+                                state
+                                    .aggregation_node
+                                    .apply_change(&aggregation_context, change),
+                            )
+                        } else {
+                            None
                         };
-                        if let Some(collectibles) = outdated_collectibles {
-                            for ((trait_type, value), count) in collectibles.into_iter() {
-                                change.collectibles.push((trait_type, value, -count));
-                            }
-                        }
-                        Some(change)
-                    } else if let Some(collectibles) = outdated_collectibles {
-                        let mut change = TaskChange::default();
-                        for ((trait_type, value), count) in collectibles.into_iter() {
-                            change.collectibles.push((trait_type, value, -count));
-                        }
-                        Some(change)
-                    } else {
-                        None
-                    };
-                    let change_job = change.and_then(|change| {
-                        state
-                            .aggregation_node
-                            .apply_change(&aggregation_context, change)
-                    });
-                    state.state_type = InProgressDirty {
-                        event,
-                        outdated_edges: Box::new(outdated_edges),
-                        children_count,
-                    };
-                    drop(state);
-                    change_job.apply(&aggregation_context);
+                        drop(state);
+                        change_job.apply(&aggregation_context);
+                    }
                 }
             }
         }
@@ -1186,7 +1175,7 @@ impl Task {
                 // already scheduled
                 drop(state);
             }
-            InProgressDirty { .. } | InProgress(..) => {
+            InProgress(..) => {
                 // already in progress
                 drop(state);
             }
@@ -1398,15 +1387,13 @@ impl Task {
     fn state_string(state: &TaskState) -> &'static str {
         match state.state_type {
             Scheduled { .. } => "scheduled",
-            InProgress(box InProgressState {
-                count_as_finished: false,
-                ..
-            }) => "in progress",
+            InProgress(box InProgressState { stale: true, .. }) => "in progress (stale)",
+            InProgress(box InProgressState { clean: true, .. }) => "in progress (clean)",
             InProgress(box InProgressState {
                 count_as_finished: true,
                 ..
             }) => "in progress (marked as finished)",
-            InProgressDirty { .. } => "in progress (dirty)",
+            InProgress(box InProgressState { .. }) => "in progress",
             Done { .. } => "done",
             Dirty { .. } => "dirty",
         }
@@ -1436,24 +1423,6 @@ impl Task {
                                 return;
                             }
                             let number_of_children = new_children.len();
-                            let mut guard = TaskGuard::from_full(self.id, state);
-                            add_job = Some(handle_new_edge(
-                                &aggregation_context,
-                                &mut guard,
-                                &self.id,
-                                &child_id,
-                                number_of_children,
-                            ));
-                        }
-                    }
-                    TaskStateType::InProgressDirty {
-                        outdated_edges,
-                        children_count,
-                        ..
-                    } => {
-                        if outdated_edges.insert(TaskEdge::Child(child_id)) {
-                            *children_count += 1;
-                            let number_of_children = *children_count;
                             let mut guard = TaskGuard::from_full(self.id, state);
                             add_job = Some(handle_new_edge(
                                 &aggregation_context,
@@ -1555,9 +1524,7 @@ impl Task {
                 change_job.apply(&aggregation_context);
                 Ok(Err(listener))
             }
-            Scheduled { ref event, .. }
-            | InProgress(box InProgressState { ref event, .. })
-            | InProgressDirty { ref event, .. } => {
+            Scheduled { ref event, .. } | InProgress(box InProgressState { ref event, .. }) => {
                 let listener = event.listen_with_note(note);
                 drop(state);
                 Ok(Err(listener))

--- a/crates/turbo-tasks-memory/src/task.rs
+++ b/crates/turbo-tasks-memory/src/task.rs
@@ -875,7 +875,7 @@ impl Task {
     ) {
         let mut state = self.full_state_mut();
         match state.state_type {
-            InProgress(state) if state.stale => {
+            InProgress(ref state) if state.stale => {
                 // We don't want to assign the output cell here
                 // as we want to avoid unnecessary updates
                 // TODO maybe this should be controlled by a heuristic

--- a/crates/turbo-tasks-memory/tests/dirty_in_progress.rs
+++ b/crates/turbo-tasks-memory/tests/dirty_in_progress.rs
@@ -1,0 +1,100 @@
+#![feature(arbitrary_self_types)]
+
+use std::time::Duration;
+
+use anyhow::{bail, Result};
+use turbo_tasks::{emit, CollectiblesSource, RcStr, State, ValueToString, Vc};
+use turbo_tasks_testing::{register, run};
+
+register!();
+
+#[tokio::test]
+async fn dirty_in_progress() {
+    run! {
+        let cases = [
+            (1, 3, 2, 2, ""),
+            (11, 13, 12, 42, "12"),
+            (1, 13, 11, 42, "11"),
+            (1, 3, 11, 42, "11"),
+            (11, 3, 2, 2, ""),
+            (11, 13, 2, 2, ""),
+        ];
+        for (a, b, c, value, collectible) in cases {
+            println!("{} -> {} -> {} = {} {}", a, b, c, value, collectible);
+            let input = ChangingInput {
+                state: State::new(a),
+            }.cell();
+            let input_val = input.await?;
+            let output = compute(input);
+            output.await?;
+            println!("update to {}", b);
+            input_val.state.set(b);
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            println!("update to {}", c);
+            input_val.state.set(c);
+            let read = output.strongly_consistent().await?;
+            assert_eq!(read.value, value);
+            assert_eq!(read.collectible, collectible);
+        }
+    }
+}
+
+#[turbo_tasks::value]
+struct ChangingInput {
+    state: State<u32>,
+}
+
+#[turbo_tasks::value]
+struct Output {
+    value: u32,
+    collectible: String,
+}
+
+#[turbo_tasks::value]
+struct Collectible {
+    value: u32,
+}
+
+#[turbo_tasks::value_impl]
+impl ValueToString for Collectible {
+    #[turbo_tasks::function]
+    fn to_string(&self) -> Vc<RcStr> {
+        Vc::cell(self.value.to_string().into())
+    }
+}
+
+#[turbo_tasks::function]
+async fn inner_compute(input: Vc<ChangingInput>) -> Result<Vc<u32>> {
+    println!("start inner_compute");
+    let value = *input.await?.state.get();
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    if value > 10 {
+        let collectible: Vc<Box<dyn ValueToString>> = Vc::upcast(Collectible { value }.cell());
+        emit(collectible);
+
+        println!("end inner_compute with collectible");
+        Ok(Vc::cell(42))
+    } else {
+        println!("end inner_compute without collectible");
+        Ok(Vc::cell(value))
+    }
+}
+
+#[turbo_tasks::function]
+async fn compute(input: Vc<ChangingInput>) -> Result<Vc<Output>> {
+    println!("start compute");
+    let operation = inner_compute(input);
+    let value = *operation.await?;
+    let collectibles = operation.peek_collectibles::<Box<dyn ValueToString>>();
+    if collectibles.len() > 1 {
+        bail!("expected 0..1 collectible, found {}", collectibles.len());
+    }
+    let first = collectibles.iter().next();
+    let collectible = if let Some(first) = first {
+        first.to_string().await?.to_string()
+    } else {
+        "".to_string()
+    };
+    println!("end compute");
+    Ok(Output { value, collectible }.cell())
+}


### PR DESCRIPTION
### Description

This saves some memory and streamlines the behavior.

It also lazily removes collectibles, children and dependencies even when entering the previous InProgressDirty (now InProgress stale) state.


### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
