### PR TITLE
feat(turbo): add VERCEL to pass through

### DIFF
--- a/crates/turborepo-lib/src/task_hash.rs
+++ b/crates/turborepo-lib/src/task_hash.rs
@@ -490,6 +490,7 @@ impl<'a> TaskHasher<'a> {
                         "JB_INTERPRETER",
                         "_JETBRAINS_TEST_RUNNER_RUN_SCOPE_TYPE",
                         // Vercel specific
+                        "VERCEL",
                         "VERCEL_*",
                         "NEXT_*",
                         "USE_OUTPUT_FOR_EDGE_FUNCTIONS",


### PR DESCRIPTION
### Description

This is required so frameworks like svelte can auto detect their CI environment without always needing to include it in your turbo.json

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
