### PR TITLE
impl Ord for Diagnostics and Issue so they are sorted correctly

### DIFF
--- a/crates/turbopack-core/src/issue/mod.rs
+++ b/crates/turbopack-core/src/issue/mod.rs
@@ -590,8 +590,12 @@ impl Ord for PlainIssue {
 
         cmp!(self.severity, other.severity);
         cmp!(self.stage, other.stage);
-
-        self.title.cmp(&other.title)
+        cmp!(self.title, other.title);
+        cmp!(self.file_path, other.file_path);
+        cmp!(self.description, other.description);
+        cmp!(self.detail, other.detail);
+        cmp!(self.documentation_link, other.documentation_link);
+        Ordering::Equal
     }
 }
 


### PR DESCRIPTION
### Description

impl Ord for Diagnostics and Issue so they are sorted correctly

Collectibles are unordered by default and need to be ordered correctly to avoid over invalidation

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
