### PR TITLE
Simplify some of the syntax used with VcRead<T>

### DIFF
--- a/crates/turbo-tasks/src/task/function.rs
+++ b/crates/turbo-tasks/src/task/function.rs
@@ -244,7 +244,7 @@ macro_rules! task_fn_impl {
 
                 Ok(Box::pin(async move {
                     let recv = recv.await?;
-                    let recv = <<Recv as VcValueType>::Read as VcRead<Recv>>::target_to_value_ref(&*recv);
+                    let recv = <Recv::Read as VcRead<Recv>>::target_to_value_ref(&*recv);
                     Output::try_into_raw_vc((task_fn)(recv, $($arg,)*))
                 }))
             }
@@ -306,7 +306,7 @@ macro_rules! task_fn_impl {
 
                 Ok(Box::pin(async move {
                     let recv = recv.await?;
-                    let recv = <<Recv as VcValueType>::Read as VcRead<Recv>>::target_to_value_ref(&*recv);
+                    let recv = <Recv::Read as VcRead<Recv>>::target_to_value_ref(&*recv);
                     <F as $async_fn_trait<&Recv, $($arg,)*>>::Output::try_into_raw_vc((task_fn)(recv, $($arg,)*).await)
                 }))
             }

--- a/crates/turbo-tasks/src/vc/cast.rs
+++ b/crates/turbo-tasks/src/vc/cast.rs
@@ -37,9 +37,7 @@ where
                 std::mem::transmute_copy::<
                     ManuallyDrop<ReadRef<<T::Read as VcRead<T>>::Repr>>,
                     Self::Output,
-                >(&ManuallyDrop::new(
-                    content.cast::<<T::Read as VcRead<T>>::Repr>()?,
-                ))
+                >(&ManuallyDrop::new(content.cast()?))
             },
         )
     }

--- a/crates/turbo-tasks/src/vc/cell_mode.rs
+++ b/crates/turbo-tasks/src/vc/cell_mode.rs
@@ -41,7 +41,7 @@ pub struct VcCellSharedMode<T> {
 impl<T> VcCellMode<T> for VcCellSharedMode<T>
 where
     T: VcValueType,
-    <<T as VcValueType>::Read as VcRead<T>>::Repr: PartialEq,
+    <T::Read as VcRead<T>>::Repr: PartialEq,
 {
     fn cell(inner: <T::Read as VcRead<T>>::Target) -> Vc<T> {
         let cell = find_cell_by_type(T::get_value_type_id());


### PR DESCRIPTION
### Description

IMO, many of these types are hard to read:
- Use a `VcReadTarget` type alias in `read_ref` to reduce the amount of syntax needed.
- Replace a few uses of `<<T as VcValueType>::Read as VcRead<T>>` with `<T::Read as VcRead<T>>` in places where `T` is already unambiguously `VcValueType`.
- Remove an unnecessary turbofish for an inferred type.

### Testing Instructions

```
cargo check
cargo nextest r -p turbo-tasks -p turbo-tasks-memory
```
