### PR TITLE
docs: fix example for filtering by directory and scm

### DIFF
--- a/docs/repo-docs/reference/run.mdx
+++ b/docs/repo-docs/reference/run.mdx
@@ -190,7 +190,7 @@ You can combine multiple filters to further refine your targets. Multiple filter
 
 ```bash title="Terminal"
 # Any packages in `apps` subdirectories that have changed since the last commit
-turbo run build --filter=.apps/* --filter=[HEAD^1]
+turbo run build --filter={.apps/*}[HEAD^1]
 
 # Any packages in `apps` subdirectories except ./apps/admin
 turbo run build --filter=./apps/* --filter=!./apps/admin


### PR DESCRIPTION
### Description

Closes #8762 by updating docs to provide the correct filter for the description.

Multiple filters are combined via union so `--filter=./apps/* --filter=[HEAD^1]` is really "all packages that are in `apps/` *or* have changed since `HEAD^1`".

### Testing Instructions

Quick verify that my understanding is correct:
```
# Only web was changed in the last commit
[0 olszewski@chriss-mbp] /tmp/foobar $ turbo build --filter='[HEAD^1]' --dry=json | jq '.tasks | map(.taskId)'
[
  "web#build"
]
# All of these are run if we filter to all packages in apps/
[0 olszewski@chriss-mbp] /tmp/foobar $ turbo build --filter='./apps/*' --dry=json | jq '.tasks | map(.taskId)'
[
  "@repo/eslint-config#build",
  "@repo/typescript-config#build",
  "@repo/ui#build",
  "docs#build",
  "web#build"
]
# Union is taken with multiple filters
[0 olszewski@chriss-mbp] /tmp/foobar $ turbo build --filter='./apps/*' --filter='[HEAD^1]' --dry=json | jq '.tasks | map(.taskId)'
[
  "@repo/eslint-config#build",
  "@repo/typescript-config#build",
  "@repo/ui#build",
  "docs#build",
  "web#build"
]
# Intersection is taken with this syntax
[0 olszewski@chriss-mbp] /tmp/foobar $ turbo build --filter='{./apps/*}[HEAD^1]' --dry=json | jq '.tasks | map(.taskId)'
[
  "web#build"
]
```
