### PR TITLE
refactor: remove `postcss` and `autoprefixer` in with-tailwind ui package

### DIFF
--- a/examples/with-tailwind/packages/ui/package.json
+++ b/examples/with-tailwind/packages/ui/package.json
@@ -26,8 +26,6 @@
     "@repo/tailwind-config": "workspace:*",
     "@repo/typescript-config": "workspace:*",
     "@types/react": "^18.2.61",
-    "autoprefixer": "^10.4.18",
-    "postcss": "^8.4.35",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.3.3"
   }

--- a/examples/with-tailwind/packages/ui/postcss.config.js
+++ b/examples/with-tailwind/packages/ui/postcss.config.js
@@ -1,9 +1,0 @@
-// If you want to use other PostCSS plugins, see the following:
-// https://tailwindcss.com/docs/using-with-preprocessors
-
-module.exports = {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
-};

--- a/examples/with-tailwind/pnpm-lock.yaml
+++ b/examples/with-tailwind/pnpm-lock.yaml
@@ -154,12 +154,6 @@ importers:
       '@types/react':
         specifier: ^18.2.61
         version: 18.2.61
-      autoprefixer:
-        specifier: ^10.4.18
-        version: 10.4.18(postcss@8.4.35)
-      postcss:
-        specifier: ^8.4.35
-        version: 8.4.35
       tailwindcss:
         specifier: ^3.4.1
         version: 3.4.1


### PR DESCRIPTION
### Description

I found that UI packages are compiling Tailwind CSS before executing other applications using the Tailwind CSS CLI. However, there were unnecessary packages included, specifically PostCSS and Autoprefixer. I believe this is unnecessary for the following reasons:

1. The [Tailwind CSS documentation](https://tailwindcss.com/docs/installation) does not mention PostCSS when using the Tailwind CLI.
2. In the [Tailwind CSS GitHub repository (CLI code)](https://github.com/tailwindlabs/tailwindcss/blob/6ab289343deaa61095a8f55799239ce0f1ee41ea/packages/%40tailwindcss-cli/src/commands/build/index.ts#L247C1-L273C1), there is code that uses 'postcss' internally:

```ts
function handleImports(
  input: string,
  file: string,
): [css: string, paths: string[]] | Promise<[css: string, paths: string[]]> {
  // ..
  return postcss()
    .use(atImport())
    .process(input, { from: file })
    .then((result) => [
      result.css,
      [file].concat(
        result.messages
          .filter((msg) => msg.type === 'dependency')
          .map((msg) => msg.file),
      ),
    ])
}
```