### PR TITLE
Refactor cell reading to handle removed cells

### DIFF
--- a/crates/turbo-tasks-memory/src/cell.rs
+++ b/crates/turbo-tasks-memory/src/cell.rs
@@ -228,11 +228,8 @@ impl Cell {
         if !self.dependent_tasks.is_empty() {
             turbo_tasks.schedule_notify_tasks_set(&self.dependent_tasks);
         }
-        match self.state {
-            CellState::Computing { event } => {
-                event.notify(usize::MAX);
-            }
-            _ => {}
+        if let CellState::Computing { event } = self.state {
+            event.notify(usize::MAX);
         }
     }
 }

--- a/crates/turbo-tasks-memory/src/cell.rs
+++ b/crates/turbo-tasks-memory/src/cell.rs
@@ -1,9 +1,5 @@
-use std::{
-    fmt::Debug,
-    mem::{replace, take},
-};
+use std::{fmt::Debug, mem::replace};
 
-use auto_hash_map::AutoSet;
 use turbo_tasks::{
     backend::CellContent,
     event::{Event, EventListener},
@@ -13,71 +9,66 @@ use turbo_tasks::{
 use crate::MemoryBackend;
 
 #[derive(Default, Debug)]
-pub(crate) enum Cell {
-    /// No content has been set yet, or it was removed for memory pressure
-    /// reasons.
+pub(crate) struct Cell {
+    dependent_tasks: TaskIdSet,
+    state: CellState,
+}
+
+#[derive(Default, Debug)]
+pub(crate) enum CellState {
+    /// No content has been set yet, or
+    /// it was removed for memory pressure reasons, or
+    /// cell is no longer used (It was assigned once and then no longer used
+    /// after recomputation).
+    ///
     /// Assigning a value will transition to the Value state.
-    /// Reading this cell will transition to the Recomputing state.
+    /// Reading this cell will,
+    /// - transition to the Computing state if the task is is progress
+    /// - return an error if the task is already done.
     #[default]
     Empty,
     /// The content has been removed for memory pressure reasons, but the
     /// tracking is still active. Any update will invalidate dependent tasks.
     /// Assigning a value will transition to the Value state.
-    /// Reading this cell will transition to the Recomputing state.
-    TrackedValueless { dependent_tasks: TaskIdSet },
+    /// Reading this cell will transition to the Computing state.
+    TrackedValueless,
     /// Someone wanted to read the content and it was not available. The content
-    /// is now being recomputed.
+    /// is now being computed.
     /// Assigning a value will transition to the Value state.
-    Recomputing {
-        dependent_tasks: TaskIdSet,
+    /// When the task ends this transitions to the Empty state if not assigned.
+    Computing {
+        /// The event that will be triggered when transitioning to another
+        /// state.
         event: Event,
     },
     /// The content was set only once and is tracked.
     /// GC operation will transition to the TrackedValueless state.
-    Value {
-        dependent_tasks: TaskIdSet,
-        content: CellContent,
-    },
+    Value { content: CellContent },
 }
 
-#[derive(Debug)]
-pub struct RecomputingCell {
-    pub listener: EventListener,
-    pub schedule: bool,
+pub enum ReadContentError {
+    Computing {
+        listener: EventListener,
+        schedule: bool,
+    },
+    Unused,
 }
 
 impl Cell {
     /// Removes a task from the list of dependent tasks.
     pub fn remove_dependent_task(&mut self, task: TaskId) {
-        match self {
-            Cell::Empty => {}
-            Cell::Value {
-                dependent_tasks, ..
-            }
-            | Cell::TrackedValueless {
-                dependent_tasks, ..
-            }
-            | Cell::Recomputing {
-                dependent_tasks, ..
-            } => {
-                dependent_tasks.remove(&task);
-            }
-        }
+        self.dependent_tasks.remove(&task);
     }
 
     /// Switch the cell to recomputing state.
-    fn recompute(
+    fn compute(
         &mut self,
-        dependent_tasks: TaskIdSet,
         description: impl Fn() -> String + Sync + Send + 'static,
         note: impl Fn() -> String + Sync + Send + 'static,
     ) -> EventListener {
-        let event = Event::new(move || (description)() + " -> Cell::Recomputing::event");
+        let event = Event::new(move || (description)() + " -> CellState::Computing::event");
         let listener = event.listen_with_note(note);
-        *self = Cell::Recomputing {
-            event,
-            dependent_tasks,
-        };
+        self.state = CellState::Computing { event };
         listener
     }
 
@@ -87,20 +78,24 @@ impl Cell {
     pub fn read_content(
         &mut self,
         reader: TaskId,
+        task_done: bool,
         description: impl Fn() -> String + Sync + Send + 'static,
         note: impl Fn() -> String + Sync + Send + 'static,
-    ) -> Result<CellContent, RecomputingCell> {
-        if let Cell::Value {
-            content,
-            dependent_tasks,
-            ..
-        } = self
-        {
-            dependent_tasks.insert(reader);
-            return Ok(content.clone());
+    ) -> Result<CellContent, ReadContentError> {
+        match &self.state {
+            CellState::Value { content } => {
+                self.dependent_tasks.insert(reader);
+                Ok(content.clone())
+            }
+            CellState::Empty if task_done => {
+                self.dependent_tasks.insert(reader);
+                Err(ReadContentError::Unused)
+            }
+            _ => {
+                // Same behavior for all other states, so we reuse the same code.
+                self.read_content_untracked(task_done, description, note)
+            }
         }
-        // Same behavior for all other states, so we reuse the same code.
-        self.read_content_untracked(description, note)
     }
 
     /// Read the content of the cell when avaiable. Does not register the reader
@@ -111,35 +106,37 @@ impl Cell {
     /// track dependencies, so using it could break cache invalidation.
     pub fn read_content_untracked(
         &mut self,
+        task_done: bool,
         description: impl Fn() -> String + Sync + Send + 'static,
         note: impl Fn() -> String + Sync + Send + 'static,
-    ) -> Result<CellContent, RecomputingCell> {
-        match self {
-            Cell::Empty => {
-                let listener = self.recompute(AutoSet::default(), description, note);
-                Err(RecomputingCell {
-                    listener,
-                    schedule: true,
-                })
+    ) -> Result<CellContent, ReadContentError> {
+        match &self.state {
+            CellState::Value { content } => Ok(content.clone()),
+            CellState::Empty => {
+                if task_done {
+                    Err(ReadContentError::Unused)
+                } else {
+                    let listener = self.compute(description, note);
+                    Err(ReadContentError::Computing {
+                        listener,
+                        schedule: true,
+                    })
+                }
             }
-            Cell::Recomputing { event, .. } => {
+            CellState::Computing { event } => {
                 let listener = event.listen_with_note(note);
-                Err(RecomputingCell {
+                Err(ReadContentError::Computing {
                     listener,
                     schedule: false,
                 })
             }
-            &mut Cell::TrackedValueless {
-                ref mut dependent_tasks,
-            } => {
-                let dependent_tasks = take(dependent_tasks);
-                let listener = self.recompute(dependent_tasks, description, note);
-                Err(RecomputingCell {
+            CellState::TrackedValueless => {
+                let listener = self.compute(description, note);
+                Err(ReadContentError::Computing {
                     listener,
                     schedule: true,
                 })
             }
-            Cell::Value { content, .. } => Ok(content.clone()),
         }
     }
 
@@ -150,11 +147,11 @@ impl Cell {
     /// INVALIDATION: Be careful with this, it will not track
     /// dependencies, so using it could break cache invalidation.
     pub fn read_own_content_untracked(&self) -> CellContent {
-        match self {
-            Cell::Empty | Cell::Recomputing { .. } | Cell::TrackedValueless { .. } => {
+        match &self.state {
+            CellState::Empty | CellState::Computing { .. } | CellState::TrackedValueless => {
                 CellContent(None)
             }
-            Cell::Value { content, .. } => content.clone(),
+            CellState::Value { content } => content.clone(),
         }
     }
 
@@ -168,104 +165,56 @@ impl Cell {
         clean: bool,
         turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackend>,
     ) {
-        match self {
-            Cell::Empty => {
-                *self = Cell::Value {
-                    content,
-                    dependent_tasks: AutoSet::default(),
-                };
-            }
-            &mut Cell::Recomputing {
-                ref mut event,
-                ref mut dependent_tasks,
-            } => {
+        match &self.state {
+            CellState::Empty => {}
+            CellState::Computing { event } => {
                 event.notify(usize::MAX);
                 if clean {
                     // We can assume that the task is deterministic and produces the same content
                     // again. No need to notify dependent tasks.
-                    *self = Cell::Value {
-                        content,
-                        dependent_tasks: take(dependent_tasks),
-                    };
-                } else {
-                    // Assigning to a cell will invalidate all dependent tasks as the content might
-                    // have changed.
-                    if !dependent_tasks.is_empty() {
-                        turbo_tasks.schedule_notify_tasks_set(dependent_tasks);
-                    }
-                    *self = Cell::Value {
-                        content,
-                        dependent_tasks: AutoSet::default(),
-                    };
+                    self.state = CellState::Value { content };
+                    return;
                 }
             }
-            &mut Cell::TrackedValueless {
-                ref mut dependent_tasks,
-            } => {
+            CellState::TrackedValueless => {
                 if clean {
                     // We can assume that the task is deterministic and produces the same content
                     // again. No need to notify dependent tasks.
-                    *self = Cell::Value {
-                        content,
-                        dependent_tasks: take(dependent_tasks),
-                    };
-                } else {
-                    // Assigning to a cell will invalidate all dependent tasks as the content might
-                    // have changed.
-                    if !dependent_tasks.is_empty() {
-                        turbo_tasks.schedule_notify_tasks_set(dependent_tasks);
-                    }
-                    *self = Cell::Value {
-                        content,
-                        dependent_tasks: AutoSet::default(),
-                    };
+                    self.state = CellState::Value { content };
+                    return;
                 }
             }
-            Cell::Value {
-                content: ref mut cell_content,
-                dependent_tasks,
+            CellState::Value {
+                content: cell_content,
             } => {
-                if content != *cell_content {
-                    if !dependent_tasks.is_empty() {
-                        turbo_tasks.schedule_notify_tasks_set(dependent_tasks);
-                        dependent_tasks.clear();
-                    }
-                    *cell_content = content;
+                if content == *cell_content {
+                    return;
                 }
             }
+        }
+        self.state = CellState::Value { content };
+        // Assigning to a cell will invalidate all dependent tasks as the content might
+        // have changed.
+        if !self.dependent_tasks.is_empty() {
+            turbo_tasks.schedule_notify_tasks_set(&self.dependent_tasks);
+            self.dependent_tasks.clear();
         }
     }
 
     /// Reduces memory needs to the minimum.
     pub fn shrink_to_fit(&mut self) {
-        match self {
-            Cell::Empty => {}
-            Cell::TrackedValueless {
-                dependent_tasks, ..
-            }
-            | Cell::Recomputing {
-                dependent_tasks, ..
-            }
-            | Cell::Value {
-                dependent_tasks, ..
-            } => {
-                dependent_tasks.shrink_to_fit();
-            }
-        }
+        self.dependent_tasks.shrink_to_fit();
     }
 
     /// Takes the content out of the cell. Make sure to drop the content outside
     /// of the task state lock.
     #[must_use]
     pub fn gc_content(&mut self) -> Option<CellContent> {
-        match self {
-            Cell::Empty | Cell::Recomputing { .. } | Cell::TrackedValueless { .. } => None,
-            Cell::Value {
-                dependent_tasks, ..
-            } => {
-                let dependent_tasks = take(dependent_tasks);
-                let Cell::Value { content, .. } =
-                    replace(self, Cell::TrackedValueless { dependent_tasks })
+        match self.state {
+            CellState::Empty | CellState::Computing { .. } | CellState::TrackedValueless => None,
+            CellState::Value { .. } => {
+                let CellState::Value { content, .. } =
+                    replace(&mut self.state, CellState::TrackedValueless)
                 else {
                     unreachable!()
                 };
@@ -276,28 +225,14 @@ impl Cell {
 
     /// Drops the cell after GC. Will notify all dependent tasks and events.
     pub fn gc_drop(self, turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackend>) {
-        match self {
-            Cell::Empty => {}
-            Cell::Recomputing {
-                event,
-                dependent_tasks,
-                ..
-            } => {
+        if !self.dependent_tasks.is_empty() {
+            turbo_tasks.schedule_notify_tasks_set(&self.dependent_tasks);
+        }
+        match self.state {
+            CellState::Computing { event } => {
                 event.notify(usize::MAX);
-                if !dependent_tasks.is_empty() {
-                    turbo_tasks.schedule_notify_tasks_set(&dependent_tasks);
-                }
             }
-            Cell::TrackedValueless {
-                dependent_tasks, ..
-            }
-            | Cell::Value {
-                dependent_tasks, ..
-            } => {
-                if !dependent_tasks.is_empty() {
-                    turbo_tasks.schedule_notify_tasks_set(&dependent_tasks);
-                }
-            }
+            _ => {}
         }
     }
 }

--- a/crates/turbo-tasks-memory/src/memory_backend.rs
+++ b/crates/turbo-tasks-memory/src/memory_backend.rs
@@ -12,7 +12,7 @@ use std::{
     time::Duration,
 };
 
-use anyhow::{bail, Result};
+use anyhow::{anyhow, bail, Result};
 use dashmap::{mapref::entry::Entry, DashMap};
 use rustc_hash::FxHasher;
 use tokio::task::futures::TaskLocalFuture;
@@ -410,15 +410,18 @@ impl Backend for MemoryBackend {
         } else {
             Task::add_dependency_to_current(TaskEdge::Cell(task_id, index));
             self.with_task(task_id, |task| {
-                match task.with_cell_mut(index, self.gc_queue.as_ref(), |cell, _| {
-                    cell.read_content(
-                        reader,
-                        move || format!("{task_id} {index}"),
-                        move || format!("reading {} {} from {}", task_id, index, reader),
-                    )
+                match task.access_cell_for_read(index, self.gc_queue.as_ref(), |cell| {
+                    cell.map(|cell| {
+                        cell.read_content(
+                            reader,
+                            move || format!("{task_id} {index}"),
+                            move || format!("reading {} {} from {}", task_id, index, reader),
+                        )
+                    })
                 }) {
-                    Ok(content) => Ok(Ok(content)),
-                    Err(RecomputingCell { listener, schedule }) => {
+                    None => Err(anyhow!("Cell doesn't exist (anymore)")),
+                    Some(Ok(content)) => Ok(Ok(content)),
+                    Some(Err(RecomputingCell { listener, schedule })) => {
                         if schedule {
                             task.recompute(self, turbo_tasks);
                         }
@@ -447,14 +450,17 @@ impl Backend for MemoryBackend {
         turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackend>,
     ) -> Result<Result<CellContent, EventListener>> {
         self.with_task(task_id, |task| {
-            match task.with_cell_mut(index, self.gc_queue.as_ref(), |cell, _| {
-                cell.read_content_untracked(
-                    move || format!("{task_id}"),
-                    move || format!("reading {} {} untracked", task_id, index),
-                )
+            match task.access_cell_for_read(index, self.gc_queue.as_ref(), |cell| {
+                cell.map(|cell| {
+                    cell.read_content_untracked(
+                        move || format!("{task_id} {index}"),
+                        move || format!("reading {} {} untracked", task_id, index),
+                    )
+                })
             }) {
-                Ok(content) => Ok(Ok(content)),
-                Err(RecomputingCell { listener, schedule }) => {
+                None => Err(anyhow!("Cell doesn't exist (anymore)")),
+                Some(Ok(content)) => Ok(Ok(content)),
+                Some(Err(RecomputingCell { listener, schedule })) => {
                     if schedule {
                         task.recompute(self, turbo_tasks);
                     }
@@ -508,7 +514,7 @@ impl Backend for MemoryBackend {
         turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackend>,
     ) {
         self.with_task(task, |task| {
-            task.with_cell_mut(index, self.gc_queue.as_ref(), |cell, clean| {
+            task.access_cell_for_write(index, |cell, clean| {
                 cell.assign(content, clean, turbo_tasks)
             })
         })

--- a/crates/turbo-tasks-memory/src/memory_backend.rs
+++ b/crates/turbo-tasks-memory/src/memory_backend.rs
@@ -419,7 +419,7 @@ impl Backend for MemoryBackend {
                 ) {
                     Ok(content) => Ok(Ok(content)),
                     Err(ReadCellError::Recomputing(listener)) => Ok(Err(listener)),
-                    Err(ReadCellError::CellRemoved) => Err(anyhow!("Cell {index:?} doesn't exist")),
+                    Err(ReadCellError::CellRemoved) => Err(anyhow!("Cell doesn't exist")),
                 }
             })
         }
@@ -453,7 +453,7 @@ impl Backend for MemoryBackend {
             ) {
                 Ok(content) => Ok(Ok(content)),
                 Err(ReadCellError::Recomputing(listener)) => Ok(Err(listener)),
-                Err(ReadCellError::CellRemoved) => Err(anyhow!("Cell {index:?} doesn't exist")),
+                Err(ReadCellError::CellRemoved) => Err(anyhow!("Cell doesn't exist")),
             }
         })
     }

--- a/crates/turbo-tasks-memory/src/task.rs
+++ b/crates/turbo-tasks-memory/src/task.rs
@@ -1378,9 +1378,7 @@ impl Task {
                         }
                         Err(ReadCellError::Recomputing(listener))
                     }
-                    Err(ReadContentError::Unused) => {
-                        return Err(ReadCellError::CellRemoved);
-                    }
+                    Err(ReadContentError::Unused) => Err(ReadCellError::CellRemoved),
                 }
             }
             Dirty {

--- a/crates/turbo-tasks-memory/tests/emptied_cells.rs
+++ b/crates/turbo-tasks-memory/tests/emptied_cells.rs
@@ -1,0 +1,65 @@
+#![feature(arbitrary_self_types)]
+
+use anyhow::Result;
+use turbo_tasks::{State, Vc};
+use turbo_tasks_testing::{register, run};
+
+register!();
+
+#[tokio::test]
+async fn recompute() {
+    run! {
+        let input = ChangingInput {
+            state: State::new(1),
+        }.cell();
+        let output = compute(input);
+        assert_eq!(*output.await?, 1);
+
+        println!("changing input");
+        input.await?.state.set(10);
+        assert_eq!(*output.strongly_consistent().await?, 10);
+
+        println!("changing input");
+        input.await?.state.set(5);
+        assert_eq!(*output.strongly_consistent().await?, 5);
+
+        println!("changing input");
+        input.await?.state.set(20);
+        assert_eq!(*output.strongly_consistent().await?, 20);
+
+        println!("changing input");
+        input.await?.state.set(15);
+        assert_eq!(*output.strongly_consistent().await?, 15);
+
+        println!("changing input");
+        input.await?.state.set(1);
+        assert_eq!(*output.strongly_consistent().await?, 1);
+    }
+}
+
+#[turbo_tasks::value]
+struct ChangingInput {
+    state: State<u32>,
+}
+
+#[turbo_tasks::function]
+async fn compute(input: Vc<ChangingInput>) -> Result<Vc<u32>> {
+    let value = *inner_compute(input).await?;
+    Ok(Vc::cell(value))
+}
+
+#[turbo_tasks::function]
+async fn inner_compute(input: Vc<ChangingInput>) -> Result<Vc<u32>> {
+    let state_value = *input.await?.state.get();
+    let mut last = None;
+    for i in 0..=state_value {
+        last = Some(compute2(Vc::cell(i)));
+    }
+    Ok(last.unwrap())
+}
+
+#[turbo_tasks::function]
+async fn compute2(input: Vc<u32>) -> Result<Vc<u32>> {
+    let value = *input.await?;
+    Ok(Vc::cell(value))
+}


### PR DESCRIPTION
### Description

Refactor cell reading to handle removed cells

handle recomputation of cells on read

use start event instead of done event when waiting for task reading

That's how the Cell state changes:

![image](https://github.com/user-attachments/assets/7e9ff129-1169-433f-a0be-dae90af014e2)


### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
