### PR TITLE
Improve rustdoc

### DIFF
--- a/crates/turbopack-core/src/resolve/mod.rs
+++ b/crates/turbopack-core/src/resolve/mod.rs
@@ -1026,8 +1026,8 @@ enum ExportsFieldResult {
     None,
 }
 
-/// Extracts the "exports" field out of the nearest package.json, parsing it
-/// into an appropriate [AliasMap] for lookups.
+/// Extracts the "exports" field out of the package.json, parsing it into an
+/// appropriate [AliasMap] for lookups.
 #[turbo_tasks::function]
 async fn exports_field(package_json_path: Vc<FileSystemPath>) -> Result<Vc<ExportsFieldResult>> {
     let read = read_package_json(package_json_path).await?;


### PR DESCRIPTION
Closes PACK-3107

Packages importing themselves works fine for packages from npm, since they always live at `.../node_modules/foo` anyway and so the regular node_modules resolution covers self-references as well.

This is not the case for (symlinked) monorepo workspaces, which this PR fixes. This essentially adds the `LOAD_PACKAGE_SELF` step from https://nodejs.org/api/modules.html#all-together .