### PR TITLE
change from failsafe_analyse to failsafe_parse

### DIFF
--- a/crates/turbopack-ecmascript/src/parse.rs
+++ b/crates/turbopack-ecmascript/src/parse.rs
@@ -45,6 +45,7 @@ use crate::{
 #[turbo_tasks::value(shared, serialization = "none", eq = "manual")]
 #[allow(clippy::large_enum_variant)]
 pub enum ParseResult {
+    // Note: Ok must not contain any Vc as it's snapshot by failsafe_parse
     Ok {
         #[turbo_tasks(debug_ignore, trace_ignore)]
         program: Program,

--- a/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/crates/turbopack-ecmascript/src/references/mod.rs
@@ -102,7 +102,7 @@ use super::{
         WellKnownObjectKind,
     },
     errors,
-    parse::{parse, ParseResult},
+    parse::ParseResult,
     special_cases::special_cases,
     utils::js_value_to_pattern,
     webpack::{
@@ -427,11 +427,11 @@ pub(crate) async fn analyse_ecmascript_module_internal(
     };
 
     let parsed = if let Some(part) = part {
-        let parsed = parse(source, ty, transforms);
+        let parsed = module.failsafe_parse();
         let split_data = split(source.ident(), source, parsed);
         part_of_module(split_data, part)
     } else {
-        parse(source, ty, transforms)
+        module.failsafe_parse()
     };
 
     let ModuleTypeResult {

--- a/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
+++ b/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
@@ -79,7 +79,7 @@ impl Module for EcmascriptModuleFacadeModule {
                          ModulePart::Evaluation"
                     );
                 };
-                let result = module.failsafe_analyze().await?;
+                let result = module.analyze().await?;
                 let references = result.evaluation_references;
                 let mut references = references.await?.clone_value();
                 references.push(Vc::upcast(EcmascriptModulePartReference::new_part(
@@ -97,7 +97,7 @@ impl Module for EcmascriptModuleFacadeModule {
                          ModulePart::Evaluation"
                     );
                 };
-                let result = module.failsafe_analyze().await?;
+                let result = module.analyze().await?;
                 let references = result.reexport_references;
                 let mut references = references.await?.clone_value();
                 references.push(Vc::upcast(EcmascriptModulePartReference::new_part(

--- a/crates/turbopack-ecmascript/src/side_effect_optimization/locals/module.rs
+++ b/crates/turbopack-ecmascript/src/side_effect_optimization/locals/module.rs
@@ -49,7 +49,7 @@ impl Module for EcmascriptModuleLocalsModule {
 
     #[turbo_tasks::function]
     async fn references(&self) -> Result<Vc<ModuleReferences>> {
-        let result = self.module.failsafe_analyze().await?;
+        let result = self.module.analyze().await?;
         Ok(result.local_references)
     }
 }

--- a/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -50,7 +50,7 @@ impl EcmascriptModulePartAsset {
     #[turbo_tasks::function]
     pub async fn is_async_module(self: Vc<Self>) -> Result<Vc<bool>> {
         let this = self.await?;
-        let result = this.full_module.failsafe_analyze();
+        let result = this.full_module.analyze();
 
         if let Some(async_module) = *result.await?.async_module.await? {
             Ok(async_module.is_self_async(self.references()))

--- a/crates/turbopack-mdx/src/lib.rs
+++ b/crates/turbopack-mdx/src/lib.rs
@@ -191,11 +191,11 @@ impl MdxModuleAsset {
     }
 
     #[turbo_tasks::function]
-    async fn failsafe_analyze(self: Vc<Self>) -> Result<Vc<AnalyzeEcmascriptModuleResult>> {
+    async fn analyze(self: Vc<Self>) -> Result<Vc<AnalyzeEcmascriptModuleResult>> {
         let asset = into_ecmascript_module_asset(&self).await;
 
         if let Ok(asset) = asset {
-            Ok(asset.failsafe_analyze())
+            Ok(asset.analyze())
         } else {
             let mut result = AnalyzeEcmascriptModuleResultBuilder::new();
             result.set_successful(false);
@@ -216,7 +216,7 @@ impl Module for MdxModuleAsset {
 
     #[turbo_tasks::function]
     async fn references(self: Vc<Self>) -> Result<Vc<ModuleReferences>> {
-        let analyze = self.failsafe_analyze().await?;
+        let analyze = self.analyze().await?;
         Ok(analyze.references)
     }
 }


### PR DESCRIPTION
### Description

change from failsafe_analyse to failsafe_parse as ParseResult is flat and can be snapshot easily

failsafe_analyze didn't work correctly as it stores nested Vcs in State which breaks GC and dropping of excessive cells since these Vcs point to stale cells that no longer exist

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
