### PR TITLE
docs(link): wrong mention of the `logout` command in the `link` flags

### DIFF
--- a/docs/repo-docs/reference/link.mdx
+++ b/docs/repo-docs/reference/link.mdx
@@ -6,3 +6,13 @@ description: API reference for the `turbo link` command
 Link the repository to a Remote Cache provider.
 
 The selected owner (either a user or an organization) will be able to share [cache artifacts](/repo/docs/core-concepts/remote-caching) through [Remote Caching](/repo/docs/core-concepts/remote-caching).
+
+## Flag options
+
+### `--api <url>`
+
+Specifies the URL of your Remote Cache provider.
+
+```bash title="Terminal"
+turbo link --api https://acme.com
+```

--- a/docs/repo-docs/reference/link.mdx
+++ b/docs/repo-docs/reference/link.mdx
@@ -6,13 +6,3 @@ description: API reference for the `turbo link` command
 Link the repository to a Remote Cache provider.
 
 The selected owner (either a user or an organization) will be able to share [cache artifacts](/repo/docs/core-concepts/remote-caching) through [Remote Caching](/repo/docs/core-concepts/remote-caching).
-
-## Flag options
-
-### `--api <url>`
-
-Specifies the URL to logout of your Remote Cache provider.
-
-```bash title="Terminal"
-turbo logout --api https://acme.com
-```

--- a/docs/repo-docs/reference/logout.mdx
+++ b/docs/repo-docs/reference/logout.mdx
@@ -4,3 +4,13 @@ description: API reference for the `turbo logout` command
 ---
 
 Log out of the account associated with your Remote Cache provider.
+
+## Flag options
+
+### `--api <url>`
+
+Specifies the URL to logout of your Remote Cache provider.
+
+```bash title="Terminal"
+turbo logout --api https://acme.com
+```

--- a/docs/repo-docs/reference/logout.mdx
+++ b/docs/repo-docs/reference/logout.mdx
@@ -4,13 +4,3 @@ description: API reference for the `turbo logout` command
 ---
 
 Log out of the account associated with your Remote Cache provider.
-
-## Flag options
-
-### `--api <url>`
-
-Specifies the URL to logout of your Remote Cache provider.
-
-```bash title="Terminal"
-turbo logout --api https://acme.com
-```


### PR DESCRIPTION
### Description

<!--
  ✍️ Write a short summary of your work.
  If necessary, include relevant screenshots.
-->

In Turborepo's [reference page](https://turbo.build/repo/docs/reference/link) for the `link` command, the `logout` command flags are listed.

I just moved those flags to the right page.

![image](https://github.com/user-attachments/assets/419ad97e-0464-4c4d-9964-70950317991d)


### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->

* Check the updated docs
