### PR TITLE
make sure that all the taiki-e/install-action calls use our env

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -66,6 +66,8 @@ runs:
 
     - name: "Install cargo-sweep"
       uses: taiki-e/install-action@v2
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
       with:
         tool: cargo-sweep@0.6.2,cargo-groups@0.1.9
 

--- a/.github/workflows/bench-turbotrace-against-node-nft.yml
+++ b/.github/workflows/bench-turbotrace-against-node-nft.yml
@@ -42,6 +42,8 @@ jobs:
 
       - name: Install nextest
         uses: taiki-e/install-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tool: cargo-nextest@0.9.61
 

--- a/.github/workflows/test-turbopack-rust-bench-test.yml
+++ b/.github/workflows/test-turbopack-rust-bench-test.yml
@@ -30,6 +30,8 @@ jobs:
 
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         with:
           save-cache: true
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/turbopack-test.yml
+++ b/.github/workflows/turbopack-test.yml
@@ -339,6 +339,8 @@ jobs:
 
       - name: Install nextest
         uses: taiki-e/install-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tool: cargo-nextest@0.9.61
 
@@ -414,6 +416,8 @@ jobs:
 
       - name: Install nextest
         uses: taiki-e/install-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tool: cargo-nextest@0.9.61
 


### PR DESCRIPTION
### Description

In some cases we can time out in CI because the cargo install action will fetch binaries from github.

### Testing Instructions

Run CI 100 times and see our rust setup step hang less :P