### PR TITLE
Fix `ReadRef<T>::cell` when `T` != `T::Read::Repr`

### DIFF
--- a/crates/turbo-tasks-memory/tests/generics.rs
+++ b/crates/turbo-tasks-memory/tests/generics.rs
@@ -147,7 +147,6 @@ async fn test_changing_generic() {
 
 // Test that we can convert a `Vc` to a `ReadRef`, and then back to a `Vc`.
 #[tokio::test]
-#[ignore = "TODO: This panics! There's a casting bug in the generics implementation."]
 async fn test_read_ref_round_trip() {
     run(&REGISTRATION, async move {
         let c: Vc<Option<Vc<u8>>> = Vc::cell(Some(Vc::cell(1)));

--- a/crates/turbo-tasks/src/triomphe_utils.rs
+++ b/crates/turbo-tasks/src/triomphe_utils.rs
@@ -5,6 +5,8 @@ use unsize::Coercion;
 /// Attempt to downcast a [`triomphe::Arc<dyn Any + Send +
 /// Sync>`][`triomphe::Arc`] to a concrete type.
 ///
+/// Checks that the downcast is safe using [`Any::is`].
+///
 /// Ported from [`std::sync::Arc::downcast`] to [`triomphe::Arc`].
 pub fn downcast_triomphe_arc<T: Any + Send + Sync>(
     this: triomphe::Arc<dyn Any + Send + Sync>,
@@ -16,6 +18,16 @@ pub fn downcast_triomphe_arc<T: Any + Send + Sync>(
     }
 }
 
+/// Transmutes the contents of `Arc<T>` to `Arc<U>`. Updates the `Arc`'s fat
+/// pointer metadata.
+///
+/// Unlike [`downcast_triomphe_arc`] this make no checks the transmute is safe.
+///
+/// # Safety
+///
+/// It must be [safe to transmute][transmutes] from `T` to `U`.
+///
+/// [transmutes]: https://doc.rust-lang.org/nomicon/transmutes.html
 pub unsafe fn unchecked_sidecast_triomphe_arc<T, U>(this: triomphe::Arc<T>) -> triomphe::Arc<U>
 where
     T: ?Sized,


### PR DESCRIPTION
## Description

Fixes the test case introduced in #8843.

The theory is that Vcs are supposed to be stored as `<<T as VcValueType>::Read as VcRead<T>>::Repr`. However, it looks like due to an oversight, `ReadRef::cell` is trying to store the value as `T`.

This introduces a way to perform 

## Testing Instructions

```
cargo nextest r -p turbo-tasks -p turbo-tasks-memory
```