### PR TITLE
Make ReadRef using `VcCellMode` semantics, add `VcCellMode::raw_cell` API

### DIFF
--- a/crates/turbo-tasks/src/backend.rs
+++ b/crates/turbo-tasks/src/backend.rs
@@ -1,5 +1,4 @@
 use std::{
-    any::Any,
     borrow::Cow,
     fmt::{self, Debug, Display, Write},
     future::Future,
@@ -22,8 +21,9 @@ use crate::{
     raw_vc::CellId,
     registry,
     trait_helpers::{get_trait_method, has_trait, traits},
+    triomphe_utils::unchecked_sidecast_triomphe_arc,
     FunctionId, RawVc, ReadRef, SharedReference, TaskId, TaskIdProvider, TaskIdSet, TraitRef,
-    TraitTypeId, ValueTypeId, VcValueTrait, VcValueType,
+    TraitTypeId, ValueTypeId, VcRead, VcValueTrait, VcValueType,
 };
 
 pub enum TaskType {
@@ -347,11 +347,14 @@ impl Display for CellContent {
 }
 
 impl TypedCellContent {
-    pub fn cast<T: Any + VcValueType>(self) -> Result<ReadRef<T>> {
+    pub fn cast<T: VcValueType>(self) -> Result<ReadRef<T>> {
         let data = self.1 .0.ok_or_else(|| anyhow!("Cell is empty"))?;
         let data = data
-            .downcast()
+            .downcast::<<T::Read as VcRead<T>>::Repr>()
             .map_err(|_err| anyhow!("Unexpected type in cell"))?;
+        // SAFETY: `T` and `T::Read::Repr` must have equivalent memory representations,
+        // guaranteed by the unsafe implementation of `VcValueType`.
+        let data = unsafe { unchecked_sidecast_triomphe_arc(data) };
         Ok(ReadRef::new_arc(data))
     }
 
@@ -372,10 +375,6 @@ impl TypedCellContent {
             // Safety: It is a TypedSharedReference
             TraitRef::new(shared_reference),
         )
-    }
-
-    pub fn try_cast<T: Any + VcValueType>(self) -> Option<ReadRef<T>> {
-        Some(ReadRef::new_arc(self.1 .0?.downcast().ok()?))
     }
 
     pub fn into_untyped(self) -> CellContent {

--- a/crates/turbo-tasks/src/completion.rs
+++ b/crates/turbo-tasks/src/completion.rs
@@ -36,7 +36,7 @@ impl Completion {
         // only updates the cell when it is empty (Completion::cell opted-out of
         // that via `#[turbo_tasks::value(cell = "new")]`)
         let cell = turbo_tasks::macro_helpers::find_cell_by_type(*COMPLETION_VALUE_TYPE_ID);
-        cell.conditional_update_shared(|old| old.is_none().then_some(Completion));
+        cell.conditional_update(|old| old.is_none().then_some(Completion));
         let raw: RawVc = cell.into();
         raw.into()
     }

--- a/crates/turbo-tasks/src/manager.rs
+++ b/crates/turbo-tasks/src/manager.rs
@@ -1522,57 +1522,144 @@ pub struct CurrentCellRef {
     index: CellId,
 }
 
+type VcReadRepr<T> = <<T as VcValueType>::Read as VcRead<T>>::Repr;
+
 impl CurrentCellRef {
-    pub fn conditional_update_shared<
-        T: VcValueType + 'static,
-        F: FnOnce(Option<&T>) -> Option<T>,
-    >(
+    /// Updates the cell if the given `functor` returns a value.
+    pub fn conditional_update<T>(&self, functor: impl FnOnce(Option<&T>) -> Option<T>)
+    where
+        T: VcValueType,
+    {
+        self.conditional_update_with_shared_reference(|old_shared_reference| {
+            let old_ref = old_shared_reference
+                .and_then(|sr| sr.0.downcast_ref::<VcReadRepr<T>>())
+                .map(|content| <T::Read as VcRead<T>>::repr_to_value_ref(content));
+            let new_value = functor(old_ref)?;
+            Some(SharedReference::new(triomphe::Arc::new(
+                <T::Read as VcRead<T>>::value_to_repr(new_value),
+            )))
+        })
+    }
+
+    /// Updates the cell if the given `functor` returns a `SharedReference`.
+    pub fn conditional_update_with_shared_reference(
         &self,
-        functor: F,
+        functor: impl FnOnce(Option<&SharedReference>) -> Option<SharedReference>,
     ) {
         let tt = turbo_tasks();
-        let content = tt
-            .read_own_task_cell(self.current_task, self.index)
-            .ok()
-            .and_then(|v| v.try_cast::<T>());
-        let update =
-            functor(content.as_deref().map(|content| {
-                <<T as VcValueType>::Read as VcRead<T>>::target_to_value_ref(content)
-            }));
+        let cell_content = tt.read_own_task_cell(self.current_task, self.index).ok();
+        let update = functor(cell_content.as_ref().and_then(|cc| cc.1 .0.as_ref()));
         if let Some(update) = update {
-            tt.update_own_task_cell(
-                self.current_task,
-                self.index,
-                CellContent(Some(SharedReference::new(triomphe::Arc::new(update)))),
-            )
+            tt.update_own_task_cell(self.current_task, self.index, CellContent(Some(update)))
         }
     }
 
-    pub fn compare_and_update_shared<T: PartialEq + VcValueType + 'static>(&self, new_content: T) {
-        self.conditional_update_shared(|old_content| {
-            if let Some(old_content) = old_content {
-                if PartialEq::eq(&new_content, old_content) {
+    /// Replace the current cell's content with `new_value` if the current
+    /// content is not equal by value with the existing content.
+    ///
+    /// The comparison happens using the value itself, not the
+    /// [`VcRead::Target`] of that value.
+    ///
+    /// Take this example of a custom equality implementation on a transparent
+    /// wrapper type:
+    ///
+    /// ```
+    /// #[turbo_tasks::value(transparent, eq = "manual")]
+    /// struct Wrapper(Vec<u32>);
+    ///
+    /// impl PartialEq for Wrapper {
+    ///     fn eq(&self, other: Wrapper) {
+    ///         // Example: order doesn't matter for equality
+    ///         let (mut this, mut other) = (self.clone(), other.clone());
+    ///         this.sort_unstable();
+    ///         other.sort_unstable();
+    ///         this == other
+    ///     }
+    /// }
+    ///
+    /// impl Eq for Wrapper {}
+    /// ```
+    ///
+    /// Comparisons of `Vc<Wrapper>` used when updating the cell will use
+    /// `Wrapper`'s custom equality implementation, rather than the one
+    /// provided by the target (`Vec<u32>`) type.
+    ///
+    /// However, in most cases, the default derived implementation of
+    /// `PartialEq` is used which just forwards to the inner value's
+    /// `PartialEq`.
+    pub fn compare_and_update<T>(&self, new_value: T)
+    where
+        T: PartialEq + VcValueType,
+    {
+        self.conditional_update(|old_value| {
+            if let Some(old_value) = old_value {
+                if old_value == &new_value {
                     return None;
                 }
             }
-            Some(new_content)
+            Some(new_value)
         });
     }
 
-    pub fn update_shared<T: VcValueType + 'static>(&self, new_content: T) {
+    /// Replace the current cell's content with `new_shared_reference` if the
+    /// current content is not equal by value with the existing content.
+    ///
+    /// If you already have a `SharedReference`, this is a faster version of
+    /// [`CurrentCellRef::compare_and_update`].
+    ///
+    /// The [`SharedReference`] is expected to use the `<T::Read as
+    /// VcRead<T>>::Repr` type for its representation of the value.
+    pub fn compare_and_update_with_shared_reference<T>(&self, new_shared_reference: SharedReference)
+    where
+        T: VcValueType + PartialEq,
+    {
+        fn extract_sr_value<T: VcValueType>(sr: &SharedReference) -> &T {
+            <T::Read as VcRead<T>>::repr_to_value_ref(
+                sr.0.downcast_ref::<VcReadRepr<T>>()
+                    .expect("cannot update SharedReference of different type"),
+            )
+        }
+        self.conditional_update_with_shared_reference(|old_sr| {
+            if let Some(old_sr) = old_sr {
+                let old_value: &T = extract_sr_value(old_sr);
+                let new_value = extract_sr_value(&new_shared_reference);
+                if old_value == new_value {
+                    return None;
+                }
+            }
+            Some(new_shared_reference)
+        });
+    }
+
+    /// Unconditionally updates the content of the cell.
+    pub fn update<T>(&self, new_value: T)
+    where
+        T: VcValueType,
+    {
         let tt = turbo_tasks();
         tt.update_own_task_cell(
             self.current_task,
             self.index,
-            CellContent(Some(SharedReference::new(triomphe::Arc::new(new_content)))),
+            CellContent(Some(SharedReference::new(triomphe::Arc::new(
+                <T::Read as VcRead<T>>::value_to_repr(new_value),
+            )))),
         )
     }
 
-    pub fn update_shared_reference(&self, shared_ref: SharedReference) {
+    /// A faster version of [`Self::update`] if you already have a
+    /// [`SharedReference`].
+    ///
+    /// If the passed-in [`SharedReference`] is the same as the existing cell's
+    /// by identity, no update is performed.
+    ///
+    /// The [`SharedReference`] is expected to use the `<T::Read as
+    /// VcRead<T>>::Repr` type for its representation of the value.
+    pub fn update_with_shared_reference(&self, shared_ref: SharedReference) {
         let tt = turbo_tasks();
         let content = tt.read_own_task_cell(self.current_task, self.index).ok();
-        let update = if let Some(TypedCellContent(_, CellContent(shared_ref_exp))) = content {
-            shared_ref_exp.as_ref().ne(&Some(&shared_ref))
+        let update = if let Some(TypedCellContent(_, CellContent(Some(shared_ref_exp)))) = content {
+            // pointer equality (not value equality)
+            shared_ref_exp != shared_ref
         } else {
             true
         };

--- a/crates/turbo-tasks/src/trait_ref.rs
+++ b/crates/turbo-tasks/src/trait_ref.rs
@@ -102,7 +102,7 @@ where
         // See Safety clause above.
         let TypedSharedReference(ty, shared_ref) = trait_ref.shared_reference;
         let local_cell = find_cell_by_type(ty);
-        local_cell.update_shared_reference(shared_ref);
+        local_cell.update_with_shared_reference(shared_ref);
         let raw_vc: RawVc = local_cell.into();
         raw_vc.into()
     }

--- a/crates/turbo-tasks/src/vc/cast.rs
+++ b/crates/turbo-tasks/src/vc/cast.rs
@@ -1,8 +1,8 @@
-use std::{marker::PhantomData, mem::ManuallyDrop};
+use std::marker::PhantomData;
 
 use anyhow::Result;
 
-use crate::{backend::TypedCellContent, ReadRef, TraitRef, VcRead, VcValueTrait, VcValueType};
+use crate::{backend::TypedCellContent, ReadRef, TraitRef, VcValueTrait, VcValueType};
 
 /// Trait defined to share behavior between values and traits within
 /// [`ReadRawVcFuture`][crate::ReadRawVcFuture]. See [`VcValueTypeCast`] and
@@ -27,19 +27,7 @@ where
     type Output = ReadRef<T>;
 
     fn cast(content: TypedCellContent) -> Result<Self::Output> {
-        Ok(
-            // Safety: the `VcValueType` implementor must guarantee that both `T` and
-            // `Repr` are #[repr(transparent)].
-            unsafe {
-                // Downcast the cell content to the expected representation type, then
-                // transmute it to the expected type.
-                // See https://users.rust-lang.org/t/transmute-doesnt-work-on-generic-types/87272/9
-                std::mem::transmute_copy::<
-                    ManuallyDrop<ReadRef<<T::Read as VcRead<T>>::Repr>>,
-                    Self::Output,
-                >(&ManuallyDrop::new(content.cast()?))
-            },
-        )
+        content.cast()
     }
 }
 

--- a/crates/turbo-tasks/src/vc/mod.rs
+++ b/crates/turbo-tasks/src/vc/mod.rs
@@ -16,10 +16,9 @@ use anyhow::Result;
 use auto_hash_map::AutoSet;
 use serde::{Deserialize, Serialize};
 
-use self::cell_mode::VcCellMode;
 pub use self::{
     cast::{VcCast, VcValueTraitCast, VcValueTypeCast},
-    cell_mode::{VcCellNewMode, VcCellSharedMode},
+    cell_mode::{VcCellMode, VcCellNewMode, VcCellSharedMode},
     default::ValueDefault,
     read::{ReadVcFuture, VcDefaultRead, VcRead, VcTransparentRead},
     resolved::{ResolvedValue, ResolvedVc},

--- a/crates/turbopack-node/src/evaluate.rs
+++ b/crates/turbopack-node/src/evaluate.rs
@@ -242,7 +242,7 @@ pub fn custom_evaluate(evaluate_context: impl EvaluateContext) -> Vc<JavaScriptE
     // We initialize the cell with a stream that is open, but has no values.
     // The first [compute_evaluate_stream] pipe call will pick up that stream.
     let (sender, receiver) = unbounded();
-    cell.update_shared(JavaScriptEvaluation(JavaScriptStream::new_open(
+    cell.update(JavaScriptEvaluation(JavaScriptStream::new_open(
         vec![],
         Box::new(receiver),
     )));
@@ -258,7 +258,7 @@ pub fn custom_evaluate(evaluate_context: impl EvaluateContext) -> Vc<JavaScriptE
                     // In cases when only [compute_evaluate_stream] is (re)executed, we need to
                     // update the old stream with a new value.
                     let (sender, receiver) = unbounded();
-                    cell.update_shared(JavaScriptEvaluation(JavaScriptStream::new_open(
+                    cell.update(JavaScriptEvaluation(JavaScriptStream::new_open(
                         vec![],
                         Box::new(receiver),
                     )));

--- a/crates/turbopack-node/src/render/render_proxy.rs
+++ b/crates/turbopack-node/src/render/render_proxy.rs
@@ -180,7 +180,7 @@ fn render_stream(options: RenderStreamOptions) -> Vc<RenderStream> {
     // We initialize the cell with a stream that is open, but has no values.
     // The first [render_stream_internal] pipe call will pick up that stream.
     let (sender, receiver) = unbounded();
-    cell.update_shared(RenderStream(Stream::new_open(vec![], Box::new(receiver))));
+    cell.update(RenderStream(Stream::new_open(vec![], Box::new(receiver))));
     let initial = Mutex::new(Some(sender));
 
     // run the evaluation as side effect
@@ -194,7 +194,7 @@ fn render_stream(options: RenderStreamOptions) -> Vc<RenderStream> {
                     // In cases when only [render_stream_internal] is (re)executed, we need to
                     // update the old stream with a new value.
                     let (sender, receiver) = unbounded();
-                    cell.update_shared(RenderStream(Stream::new_open(vec![], Box::new(receiver))));
+                    cell.update(RenderStream(Stream::new_open(vec![], Box::new(receiver))));
                     sender
                 }
             }),

--- a/crates/turbopack-node/src/render/render_static.rs
+++ b/crates/turbopack-node/src/render/render_static.rs
@@ -231,7 +231,7 @@ fn render_stream(options: RenderStreamOptions) -> Vc<RenderStream> {
     // We initialize the cell with a stream that is open, but has no values.
     // The first [render_stream_internal] pipe call will pick up that stream.
     let (sender, receiver) = unbounded();
-    cell.update_shared(RenderStream(Stream::new_open(vec![], Box::new(receiver))));
+    cell.update(RenderStream(Stream::new_open(vec![], Box::new(receiver))));
     let initial = Mutex::new(Some(sender));
 
     // run the evaluation as side effect
@@ -245,7 +245,7 @@ fn render_stream(options: RenderStreamOptions) -> Vc<RenderStream> {
                     // In cases when only [render_stream_internal] is (re)executed, we need to
                     // update the old stream with a new value.
                     let (sender, receiver) = unbounded();
-                    cell.update_shared(RenderStream(Stream::new_open(vec![], Box::new(receiver))));
+                    cell.update(RenderStream(Stream::new_open(vec![], Box::new(receiver))));
                     sender
                 }
             }),


### PR DESCRIPTION
## Description

More fixes to `ReadRef` on top of #8845. There's a bit of a cascade of changes that needed to happen here:

- `ReadRef::cell` should actually use `VcCellMode` so that it supports new/shared semantics correctly.
- ... however, `VcCellMode` needs to expose an API (`raw_cell`) for working with `SharedReference` so that we can reuse the `SharedReference`/`Arc` inside of `ReadRef` instead of cloning the data inside of it.
- ... however, `CurrentCellRef` needs to expose a `compare_and_update` method that works for `SharedReference` (`compare_and_update_with_shared_reference`).
- ... however, the naming conventions for the `CurrentCellRef` methods are a bit confusing at this point, so rename them.

## Bigger Picture

This my sneaky way of introducing the `raw_cell` API as part of a smaller PR, since that API will be needed for converting a local `Vc` to a resolved `Vc`. That's a similar problem of needing to reuse a `SharedReference` along with `VcCellMode` semantics.

## Testing Instructions

```
cargo nextest r -p turbo-tasks -p turbo-tasks-memory
```