### PR TITLE
chore(auth): catch forbidden cache access error

### DIFF
--- a/crates/turborepo-auth/src/auth/login.rs
+++ b/crates/turborepo-auth/src/auth/login.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 pub use error::Error;
 use reqwest::Url;
 use tokio::sync::OnceCell;
-use tracing::warn;
+use tracing::{debug, warn};
 use turborepo_api_client::{CacheClient, Client, TokenClient};
 use turborepo_ui::{start_spinner, BOLD, UI};
 
@@ -49,6 +49,7 @@ pub async fn login<T: Client + TokenClient + CacheClient>(
     // Check if passed in token exists first.
     if !force {
         if let Some(token) = existing_token {
+            debug!("found existing turbo token");
             let token = Token::existing(token.into());
             if token
                 .is_valid(
@@ -64,6 +65,7 @@ pub async fn login<T: Client + TokenClient + CacheClient>(
             // The extraction can return an error, but we don't want to fail the login if
             // the token is not found.
             if let Ok(Some(token)) = extract_vercel_token() {
+                debug!("found existing Vercel token");
                 let token = Token::existing(token);
                 if token
                     .is_valid(

--- a/crates/turborepo-auth/src/lib.rs
+++ b/crates/turborepo-auth/src/lib.rs
@@ -200,6 +200,12 @@ impl Token {
                 turborepo_api_client::Error::UnknownStatus { code, .. } if code == "forbidden" => {
                     Ok(false)
                 }
+                // If the entire request fails with 403 also return false
+                turborepo_api_client::Error::ReqwestError(e)
+                    if e.status() == Some(reqwest::StatusCode::FORBIDDEN) =>
+                {
+                    Ok(false)
+                }
                 _ => Err(e.into()),
             },
         }


### PR DESCRIPTION
### Description

Catch 403 HTTP requests and understand them as meaning this token doesn't have cache access. This will cause the token to be ignored and the login flow will continue.



### Testing Instructions

Inspecting result of sending cache status request with bad token. Result is a `ReqwestError` with a 403 status code, not an `UnknownStatus`.