### PR TITLE
chore(telemetry): remove unused codepath field

### DIFF
--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -1257,7 +1257,6 @@ pub async fn run(
             }
 
             run_args.track(&event);
-            event.track_run_code_path(CodePath::Rust);
             let exit_code = run::run(base, event).await.inspect(|code| {
                 if *code != 0 {
                     error!("run failed: command  exited ({code})");

--- a/crates/turborepo-telemetry/src/events/command.rs
+++ b/crates/turborepo-telemetry/src/events/command.rs
@@ -126,19 +126,6 @@ impl CommandEventBuilder {
         self
     }
 
-    // run
-    pub fn track_run_code_path(&self, path: CodePath) -> &Self {
-        self.track(Event {
-            key: "binary".to_string(),
-            value: match path {
-                CodePath::Go => "go".to_string(),
-                CodePath::Rust => "rust".to_string(),
-            },
-            is_sensitive: EventType::NonSensitive,
-        });
-        self
-    }
-
     // login
     pub fn track_login_method(&self, method: LoginMethod) -> &Self {
         self.track(Event {


### PR DESCRIPTION
The turbo version shuold be enough in telemetry now to know what people are using, since both paths aren't supported in very many versions.