### PR TITLE
fix: Fix tree shaking even more

### DIFF
--- a/crates/turbopack-ecmascript/src/references/esm/export.rs
+++ b/crates/turbopack-ecmascript/src/references/esm/export.rs
@@ -442,8 +442,9 @@ impl CodeGenerateable for EsmExports {
                 EsmExport::LocalBinding(name, mutable) => {
                     if *mutable {
                         Some(quote!(
-                            "([() => $local, (____v) => $local = ____v])" as Expr,
-                            local = Ident::new((name as &str).into(), DUMMY_SP)
+                            "([() => $local, ($new) => $local = $new])" as Expr,
+                            local = Ident::new((name as &str).into(), DUMMY_SP),
+                            new = Ident::new(format!("{name}_new_value").into(), DUMMY_SP),
                         ))
                     } else {
                         Some(quote!(
@@ -470,8 +471,9 @@ impl CodeGenerateable for EsmExports {
                         });
                         if *mutable {
                             quote!(
-                                "([() => $expr, (____v) => $expr = ____v])" as Expr,
+                                "([() => $expr, ($new) => $expr = $new])" as Expr,
                                 expr: Expr = expr,
+                                new = Ident::new(format!("{name}_new_value").into(), DUMMY_SP),
                             )
                         } else {
                             quote!(

--- a/crates/turbopack-ecmascript/src/references/esm/export.rs
+++ b/crates/turbopack-ecmascript/src/references/esm/export.rs
@@ -470,7 +470,7 @@ impl CodeGenerateable for EsmExports {
                         });
                         if *mutable {
                             quote!(
-                                "([() => $expr, (v) => $expr = v])" as Expr,
+                                "([() => $expr, (____v) => $expr = ____v])" as Expr,
                                 expr: Expr = expr,
                             )
                         } else {

--- a/crates/turbopack-ecmascript/src/references/esm/export.rs
+++ b/crates/turbopack-ecmascript/src/references/esm/export.rs
@@ -442,7 +442,7 @@ impl CodeGenerateable for EsmExports {
                 EsmExport::LocalBinding(name, mutable) => {
                     if *mutable {
                         Some(quote!(
-                            "([() => $local, (v) => $local = v])" as Expr,
+                            "([() => $local, (____v) => $local = ____v])" as Expr,
                             local = Ident::new((name as &str).into(), DUMMY_SP)
                         ))
                     } else {

--- a/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -175,7 +175,7 @@ impl Module for EcmascriptModulePartAsset {
 impl Asset for EcmascriptModulePartAsset {
     #[turbo_tasks::function]
     fn content(&self) -> Vc<AssetContent> {
-        todo!()
+        todo!("EcmascriptModulePartAsset::content")
     }
 }
 

--- a/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -175,7 +175,7 @@ impl Module for EcmascriptModulePartAsset {
 impl Asset for EcmascriptModulePartAsset {
     #[turbo_tasks::function]
     fn content(&self) -> Vc<AssetContent> {
-        todo!("EcmascriptModulePartAsset::content")
+        self.full_module.content()
     }
 }
 

--- a/crates/turbopack-ecmascript/src/tree_shake/mod.rs
+++ b/crates/turbopack-ecmascript/src/tree_shake/mod.rs
@@ -10,7 +10,7 @@ use swc_core::{
             ExportAll, ExportNamedSpecifier, Id, Ident, ImportDecl, Module, ModuleDecl,
             ModuleExportName, ModuleItem, NamedExport, Program,
         },
-        codegen::{text_writer::JsWriter, to_code, Emitter},
+        codegen::{text_writer::JsWriter, Emitter},
     },
 };
 use turbo_tasks::{RcStr, ValueToString, Vc};
@@ -492,17 +492,6 @@ pub(super) async fn split(
                 modules,
                 star_reexports,
             } = dep_graph.split_module(&items);
-
-            {
-                let code = to_code(&program);
-                eprintln!("# Program({}):\n{code}", ident.to_string().await?);
-            }
-
-            for (idx, module) in modules.iter().enumerate() {
-                let code = to_code(&module);
-
-                eprintln!("# Module #{idx}:\n{code}",);
-            }
 
             assert_ne!(modules.len(), 0, "modules.len() == 0;\nModule: {module:?}",);
 

--- a/crates/turbopack-ecmascript/src/tree_shake/mod.rs
+++ b/crates/turbopack-ecmascript/src/tree_shake/mod.rs
@@ -10,7 +10,7 @@ use swc_core::{
             ExportAll, ExportNamedSpecifier, Id, Ident, ImportDecl, Module, ModuleDecl,
             ModuleExportName, ModuleItem, NamedExport, Program,
         },
-        codegen::{text_writer::JsWriter, Emitter},
+        codegen::{text_writer::JsWriter, to_code, Emitter},
     },
 };
 use turbo_tasks::{RcStr, ValueToString, Vc};
@@ -492,6 +492,17 @@ pub(super) async fn split(
                 modules,
                 star_reexports,
             } = dep_graph.split_module(&items);
+
+            {
+                let code = to_code(&program);
+                eprintln!("# Program({}):\n{code}", ident.to_string().await?);
+            }
+
+            for (idx, module) in modules.iter().enumerate() {
+                let code = to_code(&module);
+
+                eprintln!("# Module #{idx}:\n{code}",);
+            }
 
             assert_ne!(modules.len(), 0, "modules.len() == 0;\nModule: {module:?}",);
 

--- a/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/output/79fb1_turbopack-tests_tests_snapshot_basic-tree-shake_dynamic-import_input_lib_f28c6f.js
+++ b/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/output/79fb1_turbopack-tests_tests_snapshot_basic-tree-shake_dynamic-import_input_lib_f28c6f.js
@@ -6,7 +6,7 @@
 __turbopack_esm__({
     "dog": [
         ()=>dog,
-        (v)=>dog = v
+        (dog_new_value)=>dog = dog_new_value
     ]
 });
 let dog = "dog";
@@ -114,7 +114,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests
 __turbopack_esm__({
     "cat": [
         ()=>cat,
-        (v)=>cat = v
+        (cat_new_value)=>cat = cat_new_value
     ]
 });
 let cat = "cat";
@@ -140,7 +140,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests
 __turbopack_esm__({
     "getDog": [
         ()=>getDog,
-        (v)=>getDog = v
+        (getDog_new_value)=>getDog = getDog_new_value
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$dynamic$2d$import$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__8$3e$__ = __turbopack_import__("[project]/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js [test] (ecmascript) <internal part 8>");
@@ -161,7 +161,7 @@ function getDog() {
 __turbopack_esm__({
     "setDog": [
         ()=>setDog,
-        (v)=>setDog = v
+        (setDog_new_value)=>setDog = setDog_new_value
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$dynamic$2d$import$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__4$3e$__ = __turbopack_import__("[project]/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js [test] (ecmascript) <internal part 4>");
@@ -180,7 +180,7 @@ function setDog(newDog) {
 __turbopack_esm__({
     "dogRef": [
         ()=>dogRef,
-        (v)=>dogRef = v
+        (dogRef_new_value)=>dogRef = dogRef_new_value
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$dynamic$2d$import$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__8$3e$__ = __turbopack_import__("[project]/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js [test] (ecmascript) <internal part 8>");
@@ -222,7 +222,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests
 __turbopack_esm__({
     "getChimera": [
         ()=>getChimera,
-        (v)=>getChimera = v
+        (getChimera_new_value)=>getChimera = getChimera_new_value
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$dynamic$2d$import$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__4$3e$__ = __turbopack_import__("[project]/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js [test] (ecmascript) <internal part 4>");
@@ -259,7 +259,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests
 __turbopack_esm__({
     "initialCat": [
         ()=>initialCat,
-        (v)=>initialCat = v
+        (initialCat_new_value)=>initialCat = initialCat_new_value
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$dynamic$2d$import$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__0$3e$__ = __turbopack_import__("[project]/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js [test] (ecmascript) <internal part 0>");

--- a/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/output/crates_turbopack-tests_tests_snapshot_basic-tree-shake_export-named_input_35ea42._.js
+++ b/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/output/crates_turbopack-tests_tests_snapshot_basic-tree-shake_export-named_input_35ea42._.js
@@ -6,7 +6,7 @@
 __turbopack_esm__({
     "dog": [
         ()=>dog,
-        (v)=>dog = v
+        (dog_new_value)=>dog = dog_new_value
     ]
 });
 let dog = "dog";
@@ -139,7 +139,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests
 __turbopack_esm__({
     "cat": [
         ()=>cat,
-        (v)=>cat = v
+        (cat_new_value)=>cat = cat_new_value
     ]
 });
 let cat = "cat";
@@ -165,7 +165,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests
 __turbopack_esm__({
     "__TURBOPACK__reexport__cat__": [
         ()=>__TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$export$2d$named$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$export__cat$3e$__["cat"],
-        (v)=>$expr = v
+        (cat_new_value)=>$expr = cat_new_value
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$export$2d$named$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$module__evaluation$3e$__ = __turbopack_import__("[project]/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/lib.js [test] (ecmascript) <module evaluation>");
@@ -194,7 +194,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests
 __turbopack_esm__({
     "fakeCat": [
         ()=>__TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$export$2d$named$2f$input$2f$module$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$export__fakeCat$3e$__["fakeCat"],
-        (v)=>$expr = v
+        (fakeCat_new_value)=>$expr = fakeCat_new_value
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$export$2d$named$2f$input$2f$module$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$module__evaluation$3e$__ = __turbopack_import__("[project]/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-named/input/module.js [test] (ecmascript) <module evaluation>");

--- a/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/output/79fb1_turbopack-tests_tests_snapshot_basic-tree-shake_export-namespace_input_c0eca6._.js
+++ b/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/output/79fb1_turbopack-tests_tests_snapshot_basic-tree-shake_export-namespace_input_c0eca6._.js
@@ -6,7 +6,7 @@
 __turbopack_esm__({
     "dog": [
         ()=>dog,
-        (v)=>dog = v
+        (dog_new_value)=>dog = dog_new_value
     ]
 });
 let dog = "dog";
@@ -139,7 +139,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests
 __turbopack_esm__({
     "cat": [
         ()=>cat,
-        (v)=>cat = v
+        (cat_new_value)=>cat = cat_new_value
     ]
 });
 let cat = "cat";
@@ -165,7 +165,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests
 __turbopack_esm__({
     "getDog": [
         ()=>getDog,
-        (v)=>getDog = v
+        (getDog_new_value)=>getDog = getDog_new_value
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$export$2d$namespace$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__8$3e$__ = __turbopack_import__("[project]/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js [test] (ecmascript) <internal part 8>");
@@ -186,7 +186,7 @@ function getDog() {
 __turbopack_esm__({
     "setDog": [
         ()=>setDog,
-        (v)=>setDog = v
+        (setDog_new_value)=>setDog = setDog_new_value
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$export$2d$namespace$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__4$3e$__ = __turbopack_import__("[project]/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js [test] (ecmascript) <internal part 4>");
@@ -205,7 +205,7 @@ function setDog(newDog) {
 __turbopack_esm__({
     "dogRef": [
         ()=>dogRef,
-        (v)=>dogRef = v
+        (dogRef_new_value)=>dogRef = dogRef_new_value
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$export$2d$namespace$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__8$3e$__ = __turbopack_import__("[project]/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js [test] (ecmascript) <internal part 8>");
@@ -247,7 +247,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests
 __turbopack_esm__({
     "getChimera": [
         ()=>getChimera,
-        (v)=>getChimera = v
+        (getChimera_new_value)=>getChimera = getChimera_new_value
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$export$2d$namespace$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__4$3e$__ = __turbopack_import__("[project]/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js [test] (ecmascript) <internal part 4>");
@@ -284,7 +284,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests
 __turbopack_esm__({
     "initialCat": [
         ()=>initialCat,
-        (v)=>initialCat = v
+        (initialCat_new_value)=>initialCat = initialCat_new_value
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$export$2d$namespace$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__0$3e$__ = __turbopack_import__("[project]/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/lib.js [test] (ecmascript) <internal part 0>");
@@ -361,7 +361,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests
 __turbopack_esm__({
     "lib": [
         ()=>__TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$export$2d$namespace$2f$input$2f$module$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$export__lib$3e$__["lib"],
-        (v)=>$expr = v
+        (lib_new_value)=>$expr = lib_new_value
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$export$2d$namespace$2f$input$2f$module$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$module__evaluation$3e$__ = __turbopack_import__("[project]/crates/turbopack-tests/tests/snapshot/basic-tree-shake/export-namespace/input/module.js [test] (ecmascript) <module evaluation>");

--- a/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/output/79fb1_turbopack-tests_tests_snapshot_basic-tree-shake_import-named-all_input_71b07f._.js
+++ b/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/output/79fb1_turbopack-tests_tests_snapshot_basic-tree-shake_import-named-all_input_71b07f._.js
@@ -6,7 +6,7 @@
 __turbopack_esm__({
     "dog": [
         ()=>dog,
-        (v)=>dog = v
+        (dog_new_value)=>dog = dog_new_value
     ]
 });
 let dog = "dog";
@@ -122,7 +122,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests
 __turbopack_esm__({
     "cat": [
         ()=>cat,
-        (v)=>cat = v
+        (cat_new_value)=>cat = cat_new_value
     ]
 });
 let cat = "cat";
@@ -148,7 +148,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests
 __turbopack_esm__({
     "c": [
         ()=>__TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$import$2d$named$2d$all$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$export__cat$3e$__["cat"],
-        (v)=>$expr = v
+        (cat_new_value)=>$expr = cat_new_value
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$import$2d$named$2d$all$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$module__evaluation$3e$__ = __turbopack_import__("[project]/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named-all/input/lib.js [test] (ecmascript) <module evaluation>");

--- a/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/output/crates_turbopack-tests_tests_snapshot_basic-tree-shake_import-named_input_ed0d99._.js
+++ b/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/output/crates_turbopack-tests_tests_snapshot_basic-tree-shake_import-named_input_ed0d99._.js
@@ -6,7 +6,7 @@
 __turbopack_esm__({
     "dog": [
         ()=>dog,
-        (v)=>dog = v
+        (dog_new_value)=>dog = dog_new_value
     ]
 });
 let dog = "dog";
@@ -122,7 +122,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests
 __turbopack_esm__({
     "cat": [
         ()=>cat,
-        (v)=>cat = v
+        (cat_new_value)=>cat = cat_new_value
     ]
 });
 let cat = "cat";
@@ -148,7 +148,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests
 __turbopack_esm__({
     "c": [
         ()=>__TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$import$2d$named$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$export__cat$3e$__["cat"],
-        (v)=>$expr = v
+        (cat_new_value)=>$expr = cat_new_value
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$import$2d$named$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$module__evaluation$3e$__ = __turbopack_import__("[project]/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-named/input/lib.js [test] (ecmascript) <module evaluation>");

--- a/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/output/79fb1_turbopack-tests_tests_snapshot_basic-tree-shake_import-namespace_input_351ad1._.js
+++ b/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/output/79fb1_turbopack-tests_tests_snapshot_basic-tree-shake_import-namespace_input_351ad1._.js
@@ -6,7 +6,7 @@
 __turbopack_esm__({
     "dog": [
         ()=>dog,
-        (v)=>dog = v
+        (dog_new_value)=>dog = dog_new_value
     ]
 });
 let dog = "dog";
@@ -122,7 +122,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests
 __turbopack_esm__({
     "cat": [
         ()=>cat,
-        (v)=>cat = v
+        (cat_new_value)=>cat = cat_new_value
     ]
 });
 let cat = "cat";
@@ -148,7 +148,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests
 __turbopack_esm__({
     "getDog": [
         ()=>getDog,
-        (v)=>getDog = v
+        (getDog_new_value)=>getDog = getDog_new_value
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$import$2d$namespace$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__8$3e$__ = __turbopack_import__("[project]/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js [test] (ecmascript) <internal part 8>");
@@ -169,7 +169,7 @@ function getDog() {
 __turbopack_esm__({
     "setDog": [
         ()=>setDog,
-        (v)=>setDog = v
+        (setDog_new_value)=>setDog = setDog_new_value
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$import$2d$namespace$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__4$3e$__ = __turbopack_import__("[project]/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js [test] (ecmascript) <internal part 4>");
@@ -188,7 +188,7 @@ function setDog(newDog) {
 __turbopack_esm__({
     "dogRef": [
         ()=>dogRef,
-        (v)=>dogRef = v
+        (dogRef_new_value)=>dogRef = dogRef_new_value
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$import$2d$namespace$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__8$3e$__ = __turbopack_import__("[project]/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js [test] (ecmascript) <internal part 8>");
@@ -230,7 +230,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests
 __turbopack_esm__({
     "getChimera": [
         ()=>getChimera,
-        (v)=>getChimera = v
+        (getChimera_new_value)=>getChimera = getChimera_new_value
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$import$2d$namespace$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__4$3e$__ = __turbopack_import__("[project]/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js [test] (ecmascript) <internal part 4>");
@@ -267,7 +267,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests
 __turbopack_esm__({
     "initialCat": [
         ()=>initialCat,
-        (v)=>initialCat = v
+        (initialCat_new_value)=>initialCat = initialCat_new_value
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$import$2d$namespace$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__0$3e$__ = __turbopack_import__("[project]/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-namespace/input/lib.js [test] (ecmascript) <internal part 0>");

--- a/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/output/79fb1_turbopack-tests_tests_snapshot_basic-tree-shake_import-side-effect_input_cdc49f._.js
+++ b/crates/turbopack-tests/tests/snapshot/basic-tree-shake/import-side-effect/output/79fb1_turbopack-tests_tests_snapshot_basic-tree-shake_import-side-effect_input_cdc49f._.js
@@ -6,7 +6,7 @@
 __turbopack_esm__({
     "dog": [
         ()=>dog,
-        (v)=>dog = v
+        (dog_new_value)=>dog = dog_new_value
     ]
 });
 let dog = "dog";

--- a/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/output/a587c_tests_snapshot_basic-tree-shake_require-side-effect_input_6b5862._.js
+++ b/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/output/a587c_tests_snapshot_basic-tree-shake_require-side-effect_input_6b5862._.js
@@ -6,7 +6,7 @@
 __turbopack_esm__({
     "dog": [
         ()=>dog,
-        (v)=>dog = v
+        (dog_new_value)=>dog = dog_new_value
     ]
 });
 let dog = "dog";
@@ -114,7 +114,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests
 __turbopack_esm__({
     "cat": [
         ()=>cat,
-        (v)=>cat = v
+        (cat_new_value)=>cat = cat_new_value
     ]
 });
 let cat = "cat";
@@ -140,7 +140,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests
 __turbopack_esm__({
     "getDog": [
         ()=>getDog,
-        (v)=>getDog = v
+        (getDog_new_value)=>getDog = getDog_new_value
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$require$2d$side$2d$effect$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__8$3e$__ = __turbopack_import__("[project]/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js [test] (ecmascript) <internal part 8>");
@@ -161,7 +161,7 @@ function getDog() {
 __turbopack_esm__({
     "setDog": [
         ()=>setDog,
-        (v)=>setDog = v
+        (setDog_new_value)=>setDog = setDog_new_value
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$require$2d$side$2d$effect$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__4$3e$__ = __turbopack_import__("[project]/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js [test] (ecmascript) <internal part 4>");
@@ -180,7 +180,7 @@ function setDog(newDog) {
 __turbopack_esm__({
     "dogRef": [
         ()=>dogRef,
-        (v)=>dogRef = v
+        (dogRef_new_value)=>dogRef = dogRef_new_value
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$require$2d$side$2d$effect$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__8$3e$__ = __turbopack_import__("[project]/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js [test] (ecmascript) <internal part 8>");
@@ -222,7 +222,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests
 __turbopack_esm__({
     "getChimera": [
         ()=>getChimera,
-        (v)=>getChimera = v
+        (getChimera_new_value)=>getChimera = getChimera_new_value
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$require$2d$side$2d$effect$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__4$3e$__ = __turbopack_import__("[project]/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js [test] (ecmascript) <internal part 4>");
@@ -259,7 +259,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests
 __turbopack_esm__({
     "initialCat": [
         ()=>initialCat,
-        (v)=>initialCat = v
+        (initialCat_new_value)=>initialCat = initialCat_new_value
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$require$2d$side$2d$effect$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__0$3e$__ = __turbopack_import__("[project]/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js [test] (ecmascript) <internal part 0>");

--- a/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/output/a587c_tests_snapshot_basic-tree-shake_tree-shake-test-1_input_index_87c735.js
+++ b/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/output/a587c_tests_snapshot_basic-tree-shake_tree-shake-test-1_input_index_87c735.js
@@ -6,7 +6,7 @@
 __turbopack_esm__({
     "dog": [
         ()=>dog,
-        (v)=>dog = v
+        (dog_new_value)=>dog = dog_new_value
     ]
 });
 let dog = "dog";
@@ -114,7 +114,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests
 __turbopack_esm__({
     "cat": [
         ()=>cat,
-        (v)=>cat = v
+        (cat_new_value)=>cat = cat_new_value
     ]
 });
 let cat = "cat";
@@ -140,7 +140,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests
 __turbopack_esm__({
     "getDog": [
         ()=>getDog,
-        (v)=>getDog = v
+        (getDog_new_value)=>getDog = getDog_new_value
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$tree$2d$shake$2d$test$2d$1$2f$input$2f$index$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__8$3e$__ = __turbopack_import__("[project]/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js [test] (ecmascript) <internal part 8>");
@@ -161,7 +161,7 @@ function getDog() {
 __turbopack_esm__({
     "setDog": [
         ()=>setDog,
-        (v)=>setDog = v
+        (setDog_new_value)=>setDog = setDog_new_value
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$tree$2d$shake$2d$test$2d$1$2f$input$2f$index$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__4$3e$__ = __turbopack_import__("[project]/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js [test] (ecmascript) <internal part 4>");
@@ -180,7 +180,7 @@ function setDog(newDog) {
 __turbopack_esm__({
     "dogRef": [
         ()=>dogRef,
-        (v)=>dogRef = v
+        (dogRef_new_value)=>dogRef = dogRef_new_value
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$tree$2d$shake$2d$test$2d$1$2f$input$2f$index$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__8$3e$__ = __turbopack_import__("[project]/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js [test] (ecmascript) <internal part 8>");
@@ -222,7 +222,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests
 __turbopack_esm__({
     "getChimera": [
         ()=>getChimera,
-        (v)=>getChimera = v
+        (getChimera_new_value)=>getChimera = getChimera_new_value
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$tree$2d$shake$2d$test$2d$1$2f$input$2f$index$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__4$3e$__ = __turbopack_import__("[project]/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js [test] (ecmascript) <internal part 4>");
@@ -259,7 +259,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests
 __turbopack_esm__({
     "initialCat": [
         ()=>initialCat,
-        (v)=>initialCat = v
+        (initialCat_new_value)=>initialCat = initialCat_new_value
     ]
 });
 var __TURBOPACK__imported__module__$5b$project$5d2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$tree$2d$shake$2d$test$2d$1$2f$input$2f$index$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__0$3e$__ = __turbopack_import__("[project]/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js [test] (ecmascript) <internal part 0>");


### PR DESCRIPTION
### Description

Fix server action and rename the injected variable.

The previous code fails if the name of the top-level variable is `v`. This was not a problem for almost all modules, but some packages like [`@firebase/webchannel-wrapper`](https://unpkg.com/@firebase/webchannel-wrapper@0.2.41/dist/index.esm.js) is published after mangling, so it can be a problem



### Testing Instructions

See https://github.com/vercel/next.js/pull/66689