### PR TITLE
fix(turborepo): task table width bug

### DIFF
--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -14,11 +14,7 @@ use turbopath::AbsoluteSystemPathBuf;
 use turborepo_api_client::AnonAPIClient;
 use turborepo_repository::inference::{RepoMode, RepoState};
 use turborepo_telemetry::{
-    events::{
-        command::{CodePath, CommandEventBuilder},
-        generic::GenericEventBuilder,
-        EventBuilder, EventType,
-    },
+    events::{command::CommandEventBuilder, generic::GenericEventBuilder, EventBuilder, EventType},
     init_telemetry, track_usage, TelemetryHandle,
 };
 use turborepo_ui::{GREY, UI};

--- a/crates/turborepo-telemetry/src/events/command.rs
+++ b/crates/turborepo-telemetry/src/events/command.rs
@@ -48,12 +48,6 @@ impl EventBuilder for CommandEventBuilder {
 
 // events
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum CodePath {
-    Go,
-    Rust,
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize, Copy)]
 pub enum LoginMethod {
     SSO,

--- a/crates/turborepo-ui/src/tui/table.rs
+++ b/crates/turborepo-ui/src/tui/table.rs
@@ -16,6 +16,8 @@ pub struct TaskTable<'b> {
     spinner: SpinnerState,
 }
 
+const TASK_NAVIGATE_INSTRUCTIONS: &str = "↑ ↓ to navigate";
+
 impl<'b> TaskTable<'b> {
     /// Construct a new table with all of the planned tasks
     pub fn new(tasks_by_type: &'b TasksByStatus) -> Self {
@@ -31,9 +33,9 @@ impl<'b> TaskTable<'b> {
             .map(|task| task.len())
             .max()
             .unwrap_or_default()
-            // Task column width should be large enough to fit "↑ ↓ to select task" instructions
+            // Task column width should be large enough to fit "↑ ↓ to navigate instructions
             // and truncate tasks with more than 40 chars.
-            .clamp(13, 40) as u16;
+            .clamp(TASK_NAVIGATE_INSTRUCTIONS.len(), 40) as u16;
         // Add space for column divider and status emoji
         task_name_width + 1
     }
@@ -83,7 +85,7 @@ impl<'a> StatefulWidget for &'a TaskTable<'a> {
                 .chain(self.planned_rows())
                 .chain(self.finished_rows()),
             [
-                Constraint::Min(14),
+                Constraint::Min(15),
                 // Status takes one cell to render
                 Constraint::Length(1),
             ],
@@ -98,11 +100,14 @@ impl<'a> StatefulWidget for &'a TaskTable<'a> {
                 .height(2),
         )
         .footer(
-            vec![format!("{bar}\n↑ ↓ to navigate"), "─\n ".to_owned()]
-                .into_iter()
-                .map(Cell::from)
-                .collect::<Row>()
-                .height(2),
+            vec![
+                format!("{bar}\n{TASK_NAVIGATE_INSTRUCTIONS}"),
+                format!("─\n "),
+            ]
+            .into_iter()
+            .map(Cell::from)
+            .collect::<Row>()
+            .height(2),
         );
         StatefulWidget::render(table, area, buf, state);
     }


### PR DESCRIPTION
### Description

The task status was getting cut off because we were clamping an incorrect length for the table instructions. Moved the instructions for the table into a constant so we can use that for the clamp call.

### Testing Instructions

Try it and see.
