### PR TITLE
feat(turborepo): added specific symbol for cache hit

### DIFF
--- a/crates/turborepo-ui/src/tui/event.rs
+++ b/crates/turborepo-ui/src/tui/event.rs
@@ -42,6 +42,7 @@ pub enum Event {
 pub enum TaskResult {
     Success,
     Failure,
+    CacheHit,
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]

--- a/crates/turborepo-ui/src/tui/handle.rs
+++ b/crates/turborepo-ui/src/tui/handle.rs
@@ -99,8 +99,12 @@ impl TuiTask {
     }
 
     /// Mark the task as finished
-    pub fn succeeded(&self) -> Vec<u8> {
-        self.finish(TaskResult::Success)
+    pub fn succeeded(&self, is_cache_hit: bool) -> Vec<u8> {
+        if is_cache_hit {
+            self.finish(TaskResult::CacheHit)
+        } else {
+            self.finish(TaskResult::Success)
+        }
     }
 
     /// Mark the task as finished

--- a/crates/turborepo-ui/src/tui/table.rs
+++ b/crates/turborepo-ui/src/tui/table.rs
@@ -45,13 +45,26 @@ impl<'b> TaskTable<'b> {
 
     fn finished_rows(&self) -> impl Iterator<Item = Row> + '_ {
         self.tasks_by_type.finished.iter().map(move |task| {
+            let name = if matches!(task.result(), TaskResult::CacheHit) {
+                Cell::new(Text::styled(task.name(), Style::default().italic()))
+            } else {
+                Cell::new(task.name())
+            };
+
             Row::new(vec![
-                Cell::new(task.name()),
-                Cell::new(match task.result() {
+                name,
+                match task.result() {
                     // matches Next.js (and many other CLI tools) https://github.com/vercel/next.js/blob/1a04d94aaec943d3cce93487fea3b8c8f8898f31/packages/next/src/build/output/log.ts
-                    TaskResult::Success => Text::styled("✓", Style::default().green().bold()),
-                    TaskResult::Failure => Text::styled("⨯", Style::default().red().bold()),
-                }),
+                    TaskResult::Success => {
+                        Cell::new(Text::styled("✓", Style::default().green().bold()))
+                    }
+                    TaskResult::CacheHit => {
+                        Cell::new(Text::styled("⊙", Style::default().magenta()))
+                    }
+                    TaskResult::Failure => {
+                        Cell::new(Text::styled("⨯", Style::default().red().bold()))
+                    }
+                },
             ])
         })
     }


### PR DESCRIPTION
### Description

Added a cache hit symbol, `⊙` in purple. Also italicized the task name for cache hits.

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
