### PR TITLE
smarter logical combination that keeps truthy/falsy/nullish property

### DIFF
--- a/crates/turbopack-ecmascript/src/analyzer/builtin.rs
+++ b/crates/turbopack-ecmascript/src/analyzer/builtin.rs
@@ -105,6 +105,7 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
             JsValue::Alternatives {
                 total_nodes: _,
                 values,
+                additional_property: _,
             } => {
                 *value = JsValue::alternatives(
                     take(values)
@@ -163,6 +164,7 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
                     JsValue::Alternatives {
                         total_nodes: _,
                         values,
+                        additional_property: _,
                     } => {
                         *value = JsValue::alternatives(
                             take(values)
@@ -306,6 +308,7 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
                     JsValue::Alternatives {
                         total_nodes: _,
                         values,
+                        additional_property: _,
                     } => {
                         *value = JsValue::alternatives(
                             take(values)
@@ -407,6 +410,7 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
                 JsValue::Alternatives {
                     total_nodes: _,
                     values,
+                    additional_property: _,
                 } => {
                     *value = JsValue::alternatives(
                         take(values)
@@ -454,6 +458,7 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
             box JsValue::Alternatives {
                 total_nodes: _,
                 values,
+                additional_property: _,
             },
             ref mut args,
         ) => {

--- a/crates/turbopack-ecmascript/src/analyzer/builtin.rs
+++ b/crates/turbopack-ecmascript/src/analyzer/builtin.rs
@@ -2,9 +2,7 @@ use std::mem::take;
 
 use swc_core::ecma::atoms::js_word;
 
-use super::{
-    AdditionalProperty, ConstantNumber, ConstantValue, JsValue, LogicalOperator, ObjectPart,
-};
+use super::{ConstantNumber, ConstantValue, JsValue, LogicalOperator, LogicalProperty, ObjectPart};
 
 /// Replaces some builtin values with their resulting values. Called early
 /// without lazy nested values. This allows to skip a lot of work to process the
@@ -107,7 +105,7 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
             JsValue::Alternatives {
                 total_nodes: _,
                 values,
-                additional_property: _,
+                logical_property: _,
             } => {
                 *value = JsValue::alternatives(
                     take(values)
@@ -166,7 +164,7 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
                     JsValue::Alternatives {
                         total_nodes: _,
                         values,
-                        additional_property: _,
+                        logical_property: _,
                     } => {
                         *value = JsValue::alternatives(
                             take(values)
@@ -310,7 +308,7 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
                     JsValue::Alternatives {
                         total_nodes: _,
                         values,
-                        additional_property: _,
+                        logical_property: _,
                     } => {
                         *value = JsValue::alternatives(
                             take(values)
@@ -412,7 +410,7 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
                 JsValue::Alternatives {
                     total_nodes: _,
                     values,
-                    additional_property: _,
+                    logical_property: _,
                 } => {
                     *value = JsValue::alternatives(
                         take(values)
@@ -460,7 +458,7 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
             box JsValue::Alternatives {
                 total_nodes: _,
                 values,
-                additional_property: _,
+                logical_property: _,
             },
             ref mut args,
         ) => {
@@ -564,27 +562,27 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
                 let property = match op {
                     LogicalOperator::Or => {
                         if any_unset {
-                            Some(AdditionalProperty::Truthy)
+                            Some(LogicalProperty::Truthy)
                         } else if all_set {
-                            Some(AdditionalProperty::Falsy)
+                            Some(LogicalProperty::Falsy)
                         } else {
                             None
                         }
                     }
                     LogicalOperator::And => {
                         if any_unset {
-                            Some(AdditionalProperty::Falsy)
+                            Some(LogicalProperty::Falsy)
                         } else if all_set {
-                            Some(AdditionalProperty::Truthy)
+                            Some(LogicalProperty::Truthy)
                         } else {
                             None
                         }
                     }
                     LogicalOperator::NullishCoalescing => {
                         if any_unset {
-                            Some(AdditionalProperty::NonNullish)
+                            Some(LogicalProperty::NonNullish)
                         } else if all_set {
-                            Some(AdditionalProperty::Nullish)
+                            Some(LogicalProperty::Nullish)
                         } else {
                             None
                         }

--- a/crates/turbopack-ecmascript/src/analyzer/builtin.rs
+++ b/crates/turbopack-ecmascript/src/analyzer/builtin.rs
@@ -537,7 +537,6 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
                     }
                 }
             }
-            part_properties.truncate(parts.len());
             // If we reduced the expression to a single value, we can replace it.
             if parts.len() == 1 {
                 *value = parts.pop().unwrap();

--- a/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -407,7 +407,10 @@ pub enum JsValue {
         mutable: bool,
     },
     /// A list of alternative values
-    Alternatives(usize, Vec<JsValue>),
+    Alternatives {
+        total_nodes: usize,
+        values: Vec<JsValue>,
+    },
     /// A function reference. The return value might contain [JsValue::Argument]
     /// placeholders that need to be replaced when calling this function.
     /// `(total_node_count, func_ident, return_value)`
@@ -568,7 +571,10 @@ impl Display for JsValue {
                     .collect::<Vec<_>>()
                     .join(", ")
             ),
-            JsValue::Alternatives(_, list) => write!(
+            JsValue::Alternatives {
+                total_nodes: _,
+                values: list,
+            } => write!(
                 f,
                 "({})",
                 list.iter()
@@ -711,7 +717,7 @@ impl JsValue {
             | JsValue::Unknown { .. } => JsValueMetaKind::Leaf,
             JsValue::Array { .. }
             | JsValue::Object { .. }
-            | JsValue::Alternatives(..)
+            | JsValue::Alternatives { .. }
             | JsValue::Function(..)
             | JsValue::Member(..) => JsValueMetaKind::Nested,
             JsValue::Concat(..)
@@ -736,7 +742,10 @@ impl JsValue {
 // Constructors
 impl JsValue {
     pub fn alternatives(list: Vec<JsValue>) -> Self {
-        Self::Alternatives(1 + total_nodes(&list), list)
+        Self::Alternatives {
+            total_nodes: 1 + total_nodes(&list),
+            values: list,
+        }
     }
 
     pub fn concat(list: Vec<JsValue>) -> Self {
@@ -926,7 +935,7 @@ impl JsValue {
 
             JsValue::Array { total_nodes: c, .. }
             | JsValue::Object { total_nodes: c, .. }
-            | JsValue::Alternatives(c, _)
+            | JsValue::Alternatives { total_nodes: c, .. }
             | JsValue::Concat(c, _)
             | JsValue::Add(c, _)
             | JsValue::Not(c, _)
@@ -960,7 +969,10 @@ impl JsValue {
                 items: list,
                 ..
             }
-            | JsValue::Alternatives(c, list)
+            | JsValue::Alternatives {
+                total_nodes: c,
+                values: list,
+            }
             | JsValue::Concat(c, list)
             | JsValue::Add(c, list)
             | JsValue::Logical(c, _, list) => {
@@ -1065,7 +1077,10 @@ impl JsValue {
                 } => self.make_unknown_without_content(has_side_effects, "node limit reached"),
 
                 JsValue::Array { items: list, .. }
-                | JsValue::Alternatives(_, list)
+                | JsValue::Alternatives {
+                    total_nodes: _,
+                    values: list,
+                }
                 | JsValue::Concat(_, list)
                 | JsValue::Logical(_, _, list)
                 | JsValue::Add(_, list) => {
@@ -1248,10 +1263,13 @@ impl JsValue {
                 )
             ),
             JsValue::Url(url) => format!("{}", url),
-            JsValue::Alternatives(_, list) => format!(
+            JsValue::Alternatives {
+                total_nodes: _,
+                values,
+            } => format!(
                 "({})",
                 pretty_join(
-                    &list
+                    &values
                         .iter()
                         .map(|v| v.explain_internal_inner(
                             hints,
@@ -1816,10 +1834,13 @@ impl JsValue {
     pub fn has_side_effects(&self) -> bool {
         match self {
             JsValue::Constant(_) => false,
-            JsValue::Concat(_, list)
-            | JsValue::Add(_, list)
-            | JsValue::Logical(_, _, list)
-            | JsValue::Alternatives(_, list) => list.iter().any(JsValue::has_side_effects),
+            JsValue::Concat(_, values)
+            | JsValue::Add(_, values)
+            | JsValue::Logical(_, _, values)
+            | JsValue::Alternatives {
+                total_nodes: _,
+                values,
+            } => values.iter().any(JsValue::has_side_effects),
             JsValue::Binary(_, a, _, b) => a.has_side_effects() || b.has_side_effects(),
             JsValue::Tenary(_, test, cons, alt) => {
                 test.has_side_effects() || cons.has_side_effects() || alt.has_side_effects()
@@ -1868,7 +1889,10 @@ impl JsValue {
             | JsValue::WellKnownObject(..)
             | JsValue::WellKnownFunction(..)
             | JsValue::Function(..) => Some(true),
-            JsValue::Alternatives(_, list) => merge_if_known(list, JsValue::is_truthy),
+            JsValue::Alternatives {
+                total_nodes: _,
+                values,
+            } => merge_if_known(values, JsValue::is_truthy),
             JsValue::Not(_, value) => value.is_truthy().map(|x| !x),
             JsValue::Logical(_, op, list) => match op {
                 LogicalOperator::And => all_if_known(list, JsValue::is_truthy),
@@ -1946,7 +1970,10 @@ impl JsValue {
             | JsValue::Not(..)
             | JsValue::Binary(..)
             | JsValue::Function(..) => Some(false),
-            JsValue::Alternatives(_, list) => merge_if_known(list, JsValue::is_nullish),
+            JsValue::Alternatives {
+                total_nodes: _,
+                values,
+            } => merge_if_known(values, JsValue::is_nullish),
             JsValue::Logical(_, op, list) => match op {
                 LogicalOperator::And => {
                     shortcircuit_if_known(list, JsValue::is_truthy, JsValue::is_nullish)
@@ -1974,7 +2001,10 @@ impl JsValue {
         match self {
             JsValue::Constant(c) => Some(c.is_empty_string()),
             JsValue::Concat(_, list) => all_if_known(list, JsValue::is_empty_string),
-            JsValue::Alternatives(_, list) => merge_if_known(list, JsValue::is_empty_string),
+            JsValue::Alternatives {
+                total_nodes: _,
+                values,
+            } => merge_if_known(values, JsValue::is_empty_string),
             JsValue::Logical(_, op, list) => match op {
                 LogicalOperator::And => {
                     shortcircuit_if_known(list, JsValue::is_truthy, JsValue::is_empty_string)
@@ -2004,7 +2034,10 @@ impl JsValue {
     pub fn is_unknown(&self) -> bool {
         match self {
             JsValue::Unknown { .. } => true,
-            JsValue::Alternatives(_, list) => list.iter().any(|x| x.is_unknown()),
+            JsValue::Alternatives {
+                total_nodes: _,
+                values,
+            } => values.iter().any(|x| x.is_unknown()),
             _ => false,
         }
     }
@@ -2043,7 +2076,10 @@ impl JsValue {
                 }
             },
 
-            JsValue::Alternatives(_, v) => merge_if_known(v, JsValue::is_string),
+            JsValue::Alternatives {
+                total_nodes: _,
+                values,
+            } => merge_if_known(values, JsValue::is_string),
 
             JsValue::Call(
                 _,
@@ -2081,7 +2117,10 @@ impl JsValue {
             return Some(s.starts_with(str));
         }
         match self {
-            JsValue::Alternatives(_, alts) => merge_if_known(alts, |a| a.starts_with(str)),
+            JsValue::Alternatives {
+                total_nodes: _,
+                values,
+            } => merge_if_known(values, |a| a.starts_with(str)),
             JsValue::Concat(_, list) => {
                 if let Some(item) = list.iter().next() {
                     if item.starts_with(str) == Some(true) {
@@ -2112,7 +2151,10 @@ impl JsValue {
             return Some(s.ends_with(str));
         }
         match self {
-            JsValue::Alternatives(_, alts) => merge_if_known(alts, |alt| alt.ends_with(str)),
+            JsValue::Alternatives {
+                total_nodes: _,
+                values,
+            } => merge_if_known(values, |alt| alt.ends_with(str)),
             JsValue::Concat(_, list) => {
                 if let Some(item) = list.last() {
                     if item.ends_with(str) == Some(true) {
@@ -2215,7 +2257,7 @@ fn shortcircuit_if_known<T: Copy>(
 macro_rules! for_each_children_async {
     ($value:expr, $visit_fn:expr, $($args:expr),+) => {
         Ok(match &mut $value {
-            JsValue::Alternatives(_, list)
+            JsValue::Alternatives { total_nodes: _, values: list }
             | JsValue::Concat(_, list)
             | JsValue::Add(_, list)
             | JsValue::Logical(_, _, list)
@@ -2516,7 +2558,10 @@ impl JsValue {
         visitor: &mut impl FnMut(&mut JsValue) -> bool,
     ) -> bool {
         match self {
-            JsValue::Alternatives(_, list)
+            JsValue::Alternatives {
+                total_nodes: _,
+                values: list,
+            }
             | JsValue::Concat(_, list)
             | JsValue::Add(_, list)
             | JsValue::Logical(_, _, list)
@@ -2751,7 +2796,10 @@ impl JsValue {
     /// Calls a function for all children of the node.
     pub fn for_each_children(&self, visitor: &mut impl FnMut(&JsValue)) {
         match self {
-            JsValue::Alternatives(_, list)
+            JsValue::Alternatives {
+                total_nodes: _,
+                values: list,
+            }
             | JsValue::Concat(_, list)
             | JsValue::Add(_, list)
             | JsValue::Logical(_, _, list)
@@ -2842,14 +2890,21 @@ impl JsValue {
             return;
         }
 
-        if let JsValue::Alternatives(c, list) = self {
-            if !list.contains(&v) {
+        if let JsValue::Alternatives {
+            total_nodes: c,
+            values,
+        } = self
+        {
+            if !values.contains(&v) {
                 *c += v.total_nodes();
-                list.push(v);
+                values.push(v);
             }
         } else {
             let l = take(self);
-            *self = JsValue::Alternatives(1 + l.total_nodes() + v.total_nodes(), vec![l, v]);
+            *self = JsValue::Alternatives {
+                total_nodes: 1 + l.total_nodes() + v.total_nodes(),
+                values: vec![l, v],
+            };
         }
     }
 }
@@ -2860,15 +2915,21 @@ impl JsValue {
     /// or operations are collapsed.
     pub fn normalize_shallow(&mut self) {
         match self {
-            JsValue::Alternatives(_, v) => {
-                if v.len() == 1 {
-                    *self = take(&mut v[0]);
+            JsValue::Alternatives {
+                total_nodes: _,
+                values,
+            } => {
+                if values.len() == 1 {
+                    *self = take(&mut values[0]);
                 } else {
-                    let mut set = IndexSet::with_capacity(v.len());
-                    for v in take(v) {
+                    let mut set = IndexSet::with_capacity(values.len());
+                    for v in take(values) {
                         match v {
-                            JsValue::Alternatives(_, v) => {
-                                for v in v {
+                            JsValue::Alternatives {
+                                total_nodes: _,
+                                values,
+                            } => {
+                                for v in values {
                                     set.insert(SimilarJsValue(v));
                                 }
                             }
@@ -2880,7 +2941,7 @@ impl JsValue {
                     if set.len() == 1 {
                         *self = set.into_iter().next().unwrap().0;
                     } else {
-                        *v = set.into_iter().map(|v| v.0).collect();
+                        *values = set.into_iter().map(|v| v.0).collect();
                         self.update_total_nodes();
                     }
                 }
@@ -3041,9 +3102,16 @@ impl JsValue {
                 },
             ) => lc == rc && lm == rm && all_parts_similar(lp, rp, depth - 1),
             (JsValue::Url(l), JsValue::Url(r)) => l == r,
-            (JsValue::Alternatives(lc, l), JsValue::Alternatives(rc, r)) => {
-                lc == rc && all_similar(l, r, depth - 1)
-            }
+            (
+                JsValue::Alternatives {
+                    total_nodes: lc,
+                    values: l,
+                },
+                JsValue::Alternatives {
+                    total_nodes: rc,
+                    values: r,
+                },
+            ) => lc == rc && all_similar(l, r, depth - 1),
             (JsValue::FreeVar(l), JsValue::FreeVar(r)) => l == r,
             (JsValue::Variable(l), JsValue::Variable(r)) => l == r,
             (JsValue::Concat(lc, l), JsValue::Concat(rc, r)) => {
@@ -3139,7 +3207,10 @@ impl JsValue {
             JsValue::FreeVar(v) => Hash::hash(v, state),
             JsValue::Variable(v) => Hash::hash(v, state),
             JsValue::Array { items: v, .. }
-            | JsValue::Alternatives(_, v)
+            | JsValue::Alternatives {
+                total_nodes: _,
+                values: v,
+            }
             | JsValue::Concat(_, v)
             | JsValue::Add(_, v)
             | JsValue::Logical(_, _, v) => all_similar_hash(v, state, depth - 1),

--- a/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/crates/turbopack-ecmascript/src/references/mod.rs
@@ -1218,8 +1218,11 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
             .await
     };
     match func {
-        JsValue::Alternatives(_, alts) => {
-            for alt in alts {
+        JsValue::Alternatives {
+            total_nodes: _,
+            values,
+        } => {
+            for alt in values {
                 handle_call_boxed(
                     ast_path,
                     span,

--- a/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/crates/turbopack-ecmascript/src/references/mod.rs
@@ -1221,7 +1221,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
         JsValue::Alternatives {
             total_nodes: _,
             values,
-            additional_property: _,
+            logical_property: _,
         } => {
             for alt in values {
                 handle_call_boxed(

--- a/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/crates/turbopack-ecmascript/src/references/mod.rs
@@ -1221,6 +1221,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
         JsValue::Alternatives {
             total_nodes: _,
             values,
+            additional_property: _,
         } => {
             for alt in values {
                 handle_call_boxed(

--- a/crates/turbopack-ecmascript/src/utils.rs
+++ b/crates/turbopack-ecmascript/src/utils.rs
@@ -32,6 +32,7 @@ pub fn js_value_to_pattern(value: &JsValue) -> Pattern {
         JsValue::Alternatives {
             total_nodes: _,
             values,
+            additional_property: _,
         } => Pattern::Alternatives(values.iter().map(js_value_to_pattern).collect()),
         JsValue::Concat(_, parts) => {
             Pattern::Concatenation(parts.iter().map(js_value_to_pattern).collect())

--- a/crates/turbopack-ecmascript/src/utils.rs
+++ b/crates/turbopack-ecmascript/src/utils.rs
@@ -32,7 +32,7 @@ pub fn js_value_to_pattern(value: &JsValue) -> Pattern {
         JsValue::Alternatives {
             total_nodes: _,
             values,
-            additional_property: _,
+            logical_property: _,
         } => Pattern::Alternatives(values.iter().map(js_value_to_pattern).collect()),
         JsValue::Concat(_, parts) => {
             Pattern::Concatenation(parts.iter().map(js_value_to_pattern).collect())

--- a/crates/turbopack-ecmascript/src/utils.rs
+++ b/crates/turbopack-ecmascript/src/utils.rs
@@ -29,9 +29,10 @@ pub fn js_value_to_pattern(value: &JsValue) -> Pattern {
             ConstantValue::Regex(exp, flags) => format!("/{exp}/{flags}").into(),
             ConstantValue::Undefined => "undefined".into(),
         }),
-        JsValue::Alternatives(_, alts) => {
-            Pattern::Alternatives(alts.iter().map(js_value_to_pattern).collect())
-        }
+        JsValue::Alternatives {
+            total_nodes: _,
+            values,
+        } => Pattern::Alternatives(values.iter().map(js_value_to_pattern).collect()),
         JsValue::Concat(_, parts) => {
             Pattern::Concatenation(parts.iter().map(js_value_to_pattern).collect())
         }

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/1/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/1/graph.snapshot
@@ -60,7 +60,7 @@
                     ],
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -83,7 +83,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
 ]

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/1/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/1/graph.snapshot
@@ -60,6 +60,7 @@
                     ],
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -82,6 +83,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
 ]

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/1/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/1/graph.snapshot
@@ -31,9 +31,9 @@
     ),
     (
         "x",
-        Alternatives(
-            5,
-            [
+        Alternatives {
+            total_nodes: 5,
+            values: [
                 Constant(
                     Num(
                         ConstantNumber(
@@ -60,13 +60,13 @@
                     ],
                 ),
             ],
-        ),
+        },
     ),
     (
         "y",
-        Alternatives(
-            3,
-            [
+        Alternatives {
+            total_nodes: 3,
+            values: [
                 Constant(
                     Str(
                         Word(
@@ -82,6 +82,6 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
 ]

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/2/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/2/graph.snapshot
@@ -18,7 +18,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/2/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/2/graph.snapshot
@@ -1,9 +1,9 @@
 [
     (
         "x",
-        Alternatives(
-            3,
-            [
+        Alternatives {
+            total_nodes: 3,
+            values: [
                 Constant(
                     Num(
                         ConstantNumber(
@@ -18,7 +18,7 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "y",

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/2/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/2/graph.snapshot
@@ -18,6 +18,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/assign/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/assign/graph.snapshot
@@ -30,6 +30,7 @@
                     ],
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -50,6 +51,7 @@
                     has_side_effects: true,
                 },
             ],
+            additional_property: None,
         },
     ),
     (
@@ -70,6 +72,7 @@
                     has_side_effects: true,
                 },
             ],
+            additional_property: None,
         },
     ),
     (
@@ -92,6 +95,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -114,6 +118,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -136,6 +141,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
 ]

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/assign/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/assign/graph.snapshot
@@ -1,9 +1,9 @@
 [
     (
         "a",
-        Alternatives(
-            5,
-            [
+        Alternatives {
+            total_nodes: 5,
+            values: [
                 Constant(
                     Str(
                         Word(
@@ -30,13 +30,13 @@
                     ],
                 ),
             ],
-        ),
+        },
     ),
     (
         "b",
-        Alternatives(
-            3,
-            [
+        Alternatives {
+            total_nodes: 3,
+            values: [
                 Constant(
                     Num(
                         ConstantNumber(
@@ -50,13 +50,13 @@
                     has_side_effects: true,
                 },
             ],
-        ),
+        },
     ),
     (
         "c",
-        Alternatives(
-            3,
-            [
+        Alternatives {
+            total_nodes: 3,
+            values: [
                 Constant(
                     Num(
                         ConstantNumber(
@@ -70,13 +70,13 @@
                     has_side_effects: true,
                 },
             ],
-        ),
+        },
     ),
     (
         "d",
-        Alternatives(
-            3,
-            [
+        Alternatives {
+            total_nodes: 3,
+            values: [
                 Constant(
                     Num(
                         ConstantNumber(
@@ -92,13 +92,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "e",
-        Alternatives(
-            3,
-            [
+        Alternatives {
+            total_nodes: 3,
+            values: [
                 Constant(
                     Num(
                         ConstantNumber(
@@ -114,13 +114,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "f",
-        Alternatives(
-            3,
-            [
+        Alternatives {
+            total_nodes: 3,
+            values: [
                 Constant(
                     Num(
                         ConstantNumber(
@@ -136,6 +136,6 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
 ]

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/assign/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/assign/graph.snapshot
@@ -30,7 +30,7 @@
                     ],
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -51,7 +51,7 @@
                     has_side_effects: true,
                 },
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -72,7 +72,7 @@
                     has_side_effects: true,
                 },
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -95,7 +95,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -118,7 +118,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -141,7 +141,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
 ]

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/conditional-import/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/conditional-import/graph.snapshot
@@ -65,7 +65,7 @@
                     ],
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/conditional-import/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/conditional-import/graph.snapshot
@@ -19,9 +19,9 @@
     ),
     (
         "b",
-        Alternatives(
-            8,
-            [
+        Alternatives {
+            total_nodes: 8,
+            values: [
                 Unknown {
                     original_value: Some(
                         Variable(
@@ -65,7 +65,7 @@
                     ],
                 ),
             ],
-        ),
+        },
     ),
     (
         "c",

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/conditional-import/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/conditional-import/graph.snapshot
@@ -65,6 +65,7 @@
                     ],
                 ),
             ],
+            additional_property: None,
         },
     ),
     (

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/cycle-cache/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/cycle-cache/graph.snapshot
@@ -296,6 +296,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -331,6 +332,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -366,6 +368,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -500,6 +503,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -520,6 +524,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -540,6 +545,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -560,6 +566,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -580,6 +587,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -600,6 +608,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -620,6 +629,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -640,6 +650,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -660,6 +671,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -680,6 +692,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -700,6 +713,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -720,6 +734,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -740,6 +755,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -760,6 +776,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -780,6 +797,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -800,6 +818,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -820,6 +839,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -840,6 +860,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -860,6 +881,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -880,6 +902,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -900,6 +923,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -920,6 +944,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -940,6 +965,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -960,6 +986,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -980,6 +1007,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -1000,6 +1028,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -1020,6 +1049,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -1040,6 +1070,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -1060,6 +1091,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -1080,6 +1112,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -1100,6 +1133,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -1120,6 +1154,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -1140,6 +1175,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -1160,6 +1196,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -1180,6 +1217,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -1200,6 +1238,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -1220,6 +1259,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -1240,6 +1280,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -1260,6 +1301,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -1280,6 +1322,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -1300,6 +1343,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -1320,6 +1364,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -1340,6 +1385,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -1366,6 +1412,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -1410,6 +1457,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -1454,6 +1502,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -1498,6 +1547,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -1542,6 +1592,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -1586,6 +1637,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -1630,6 +1682,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -1662,6 +1715,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -1694,6 +1748,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/cycle-cache/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/cycle-cache/graph.snapshot
@@ -296,7 +296,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -332,7 +332,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -368,7 +368,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -503,7 +503,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -524,7 +524,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -545,7 +545,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -566,7 +566,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -587,7 +587,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -608,7 +608,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -629,7 +629,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -650,7 +650,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -671,7 +671,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -692,7 +692,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -713,7 +713,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -734,7 +734,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -755,7 +755,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -776,7 +776,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -797,7 +797,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -818,7 +818,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -839,7 +839,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -860,7 +860,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -881,7 +881,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -902,7 +902,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -923,7 +923,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -944,7 +944,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -965,7 +965,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -986,7 +986,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -1007,7 +1007,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -1028,7 +1028,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -1049,7 +1049,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -1070,7 +1070,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -1091,7 +1091,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -1112,7 +1112,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -1133,7 +1133,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -1154,7 +1154,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -1175,7 +1175,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -1196,7 +1196,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -1217,7 +1217,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -1238,7 +1238,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -1259,7 +1259,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -1280,7 +1280,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -1301,7 +1301,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -1322,7 +1322,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -1343,7 +1343,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -1364,7 +1364,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -1385,7 +1385,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -1412,7 +1412,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -1457,7 +1457,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -1502,7 +1502,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -1547,7 +1547,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -1592,7 +1592,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -1637,7 +1637,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -1682,7 +1682,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -1715,7 +1715,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -1748,7 +1748,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/cycle-cache/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/cycle-cache/graph.snapshot
@@ -265,9 +265,9 @@
     ),
     (
         "a",
-        Alternatives(
-            5,
-            [
+        Alternatives {
+            total_nodes: 5,
+            values: [
                 Constant(
                     Num(
                         ConstantNumber(
@@ -296,13 +296,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "b",
-        Alternatives(
-            5,
-            [
+        Alternatives {
+            total_nodes: 5,
+            values: [
                 Constant(
                     Num(
                         ConstantNumber(
@@ -331,13 +331,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "c",
-        Alternatives(
-            5,
-            [
+        Alternatives {
+            total_nodes: 5,
+            values: [
                 Constant(
                     Num(
                         ConstantNumber(
@@ -366,13 +366,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "d",
-        Alternatives(
-            22,
-            [
+        Alternatives {
+            total_nodes: 22,
+            values: [
                 Variable(
                     (
                         "f11",
@@ -500,13 +500,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "f11",
-        Alternatives(
-            3,
-            [
+        Alternatives {
+            total_nodes: 3,
+            values: [
                 Variable(
                     (
                         "*arrow function 425*",
@@ -520,13 +520,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "f12",
-        Alternatives(
-            3,
-            [
+        Alternatives {
+            total_nodes: 3,
+            values: [
                 Variable(
                     (
                         "*arrow function 511*",
@@ -540,13 +540,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "f21",
-        Alternatives(
-            3,
-            [
+        Alternatives {
+            total_nodes: 3,
+            values: [
                 Variable(
                     (
                         "f11",
@@ -560,13 +560,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "f22",
-        Alternatives(
-            3,
-            [
+        Alternatives {
+            total_nodes: 3,
+            values: [
                 Variable(
                     (
                         "f12",
@@ -580,13 +580,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "f31",
-        Alternatives(
-            3,
-            [
+        Alternatives {
+            total_nodes: 3,
+            values: [
                 Variable(
                     (
                         "f21",
@@ -600,13 +600,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "f32",
-        Alternatives(
-            3,
-            [
+        Alternatives {
+            total_nodes: 3,
+            values: [
                 Variable(
                     (
                         "f22",
@@ -620,13 +620,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "f41",
-        Alternatives(
-            3,
-            [
+        Alternatives {
+            total_nodes: 3,
+            values: [
                 Variable(
                     (
                         "f31",
@@ -640,13 +640,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "f42",
-        Alternatives(
-            3,
-            [
+        Alternatives {
+            total_nodes: 3,
+            values: [
                 Variable(
                     (
                         "f32",
@@ -660,13 +660,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "f51",
-        Alternatives(
-            3,
-            [
+        Alternatives {
+            total_nodes: 3,
+            values: [
                 Variable(
                     (
                         "f41",
@@ -680,13 +680,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "f52",
-        Alternatives(
-            3,
-            [
+        Alternatives {
+            total_nodes: 3,
+            values: [
                 Variable(
                     (
                         "f42",
@@ -700,13 +700,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "f61",
-        Alternatives(
-            3,
-            [
+        Alternatives {
+            total_nodes: 3,
+            values: [
                 Variable(
                     (
                         "f51",
@@ -720,13 +720,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "f62",
-        Alternatives(
-            3,
-            [
+        Alternatives {
+            total_nodes: 3,
+            values: [
                 Variable(
                     (
                         "f52",
@@ -740,13 +740,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "f71",
-        Alternatives(
-            3,
-            [
+        Alternatives {
+            total_nodes: 3,
+            values: [
                 Variable(
                     (
                         "f61",
@@ -760,13 +760,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "f72",
-        Alternatives(
-            3,
-            [
+        Alternatives {
+            total_nodes: 3,
+            values: [
                 Variable(
                     (
                         "f62",
@@ -780,13 +780,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "f81",
-        Alternatives(
-            3,
-            [
+        Alternatives {
+            total_nodes: 3,
+            values: [
                 Variable(
                     (
                         "f71",
@@ -800,13 +800,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "f82",
-        Alternatives(
-            3,
-            [
+        Alternatives {
+            total_nodes: 3,
+            values: [
                 Variable(
                     (
                         "f72",
@@ -820,13 +820,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "f91",
-        Alternatives(
-            3,
-            [
+        Alternatives {
+            total_nodes: 3,
+            values: [
                 Variable(
                     (
                         "f81",
@@ -840,13 +840,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "f92",
-        Alternatives(
-            3,
-            [
+        Alternatives {
+            total_nodes: 3,
+            values: [
                 Variable(
                     (
                         "f82",
@@ -860,13 +860,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "fa1",
-        Alternatives(
-            3,
-            [
+        Alternatives {
+            total_nodes: 3,
+            values: [
                 Variable(
                     (
                         "f91",
@@ -880,13 +880,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "fa2",
-        Alternatives(
-            3,
-            [
+        Alternatives {
+            total_nodes: 3,
+            values: [
                 Variable(
                     (
                         "f92",
@@ -900,13 +900,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "fb1",
-        Alternatives(
-            3,
-            [
+        Alternatives {
+            total_nodes: 3,
+            values: [
                 Variable(
                     (
                         "fa1",
@@ -920,13 +920,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "fb2",
-        Alternatives(
-            3,
-            [
+        Alternatives {
+            total_nodes: 3,
+            values: [
                 Variable(
                     (
                         "fa2",
@@ -940,13 +940,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "fc1",
-        Alternatives(
-            3,
-            [
+        Alternatives {
+            total_nodes: 3,
+            values: [
                 Variable(
                     (
                         "fb1",
@@ -960,13 +960,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "fc2",
-        Alternatives(
-            3,
-            [
+        Alternatives {
+            total_nodes: 3,
+            values: [
                 Variable(
                     (
                         "fb2",
@@ -980,13 +980,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "fd1",
-        Alternatives(
-            3,
-            [
+        Alternatives {
+            total_nodes: 3,
+            values: [
                 Variable(
                     (
                         "fc1",
@@ -1000,13 +1000,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "fd2",
-        Alternatives(
-            3,
-            [
+        Alternatives {
+            total_nodes: 3,
+            values: [
                 Variable(
                     (
                         "fc2",
@@ -1020,13 +1020,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "fe1",
-        Alternatives(
-            3,
-            [
+        Alternatives {
+            total_nodes: 3,
+            values: [
                 Variable(
                     (
                         "fd1",
@@ -1040,13 +1040,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "fe2",
-        Alternatives(
-            3,
-            [
+        Alternatives {
+            total_nodes: 3,
+            values: [
                 Variable(
                     (
                         "fd2",
@@ -1060,13 +1060,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "ff1",
-        Alternatives(
-            3,
-            [
+        Alternatives {
+            total_nodes: 3,
+            values: [
                 Variable(
                     (
                         "fe1",
@@ -1080,13 +1080,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "ff2",
-        Alternatives(
-            3,
-            [
+        Alternatives {
+            total_nodes: 3,
+            values: [
                 Variable(
                     (
                         "fe2",
@@ -1100,13 +1100,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "fg1",
-        Alternatives(
-            3,
-            [
+        Alternatives {
+            total_nodes: 3,
+            values: [
                 Variable(
                     (
                         "ff1",
@@ -1120,13 +1120,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "fg2",
-        Alternatives(
-            3,
-            [
+        Alternatives {
+            total_nodes: 3,
+            values: [
                 Variable(
                     (
                         "ff2",
@@ -1140,13 +1140,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "fh1",
-        Alternatives(
-            3,
-            [
+        Alternatives {
+            total_nodes: 3,
+            values: [
                 Variable(
                     (
                         "fg1",
@@ -1160,13 +1160,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "fh2",
-        Alternatives(
-            3,
-            [
+        Alternatives {
+            total_nodes: 3,
+            values: [
                 Variable(
                     (
                         "fg2",
@@ -1180,13 +1180,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "fi1",
-        Alternatives(
-            3,
-            [
+        Alternatives {
+            total_nodes: 3,
+            values: [
                 Variable(
                     (
                         "fh1",
@@ -1200,13 +1200,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "fi2",
-        Alternatives(
-            3,
-            [
+        Alternatives {
+            total_nodes: 3,
+            values: [
                 Variable(
                     (
                         "fh2",
@@ -1220,13 +1220,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "fj1",
-        Alternatives(
-            3,
-            [
+        Alternatives {
+            total_nodes: 3,
+            values: [
                 Variable(
                     (
                         "fi1",
@@ -1240,13 +1240,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "fj2",
-        Alternatives(
-            3,
-            [
+        Alternatives {
+            total_nodes: 3,
+            values: [
                 Variable(
                     (
                         "fi2",
@@ -1260,13 +1260,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "fk1",
-        Alternatives(
-            3,
-            [
+        Alternatives {
+            total_nodes: 3,
+            values: [
                 Variable(
                     (
                         "fj1",
@@ -1280,13 +1280,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "fk2",
-        Alternatives(
-            3,
-            [
+        Alternatives {
+            total_nodes: 3,
+            values: [
                 Variable(
                     (
                         "fj2",
@@ -1300,13 +1300,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "fl1",
-        Alternatives(
-            3,
-            [
+        Alternatives {
+            total_nodes: 3,
+            values: [
                 Variable(
                     (
                         "fk1",
@@ -1320,13 +1320,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "fl2",
-        Alternatives(
-            3,
-            [
+        Alternatives {
+            total_nodes: 3,
+            values: [
                 Variable(
                     (
                         "fk2",
@@ -1340,13 +1340,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "x",
-        Alternatives(
-            4,
-            [
+        Alternatives {
+            total_nodes: 4,
+            values: [
                 Variable(
                     (
                         "a",
@@ -1366,13 +1366,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "x1",
-        Alternatives(
-            7,
-            [
+        Alternatives {
+            total_nodes: 7,
+            values: [
                 Variable(
                     (
                         "x1",
@@ -1410,13 +1410,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "x2",
-        Alternatives(
-            7,
-            [
+        Alternatives {
+            total_nodes: 7,
+            values: [
                 Variable(
                     (
                         "x1",
@@ -1454,13 +1454,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "x3",
-        Alternatives(
-            7,
-            [
+        Alternatives {
+            total_nodes: 7,
+            values: [
                 Variable(
                     (
                         "x1",
@@ -1498,13 +1498,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "x4",
-        Alternatives(
-            7,
-            [
+        Alternatives {
+            total_nodes: 7,
+            values: [
                 Variable(
                     (
                         "x1",
@@ -1542,13 +1542,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "x5",
-        Alternatives(
-            7,
-            [
+        Alternatives {
+            total_nodes: 7,
+            values: [
                 Variable(
                     (
                         "x1",
@@ -1586,13 +1586,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "x6",
-        Alternatives(
-            7,
-            [
+        Alternatives {
+            total_nodes: 7,
+            values: [
                 Variable(
                     (
                         "x1",
@@ -1630,13 +1630,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "y",
-        Alternatives(
-            5,
-            [
+        Alternatives {
+            total_nodes: 5,
+            values: [
                 Variable(
                     (
                         "a",
@@ -1662,13 +1662,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "z",
-        Alternatives(
-            5,
-            [
+        Alternatives {
+            total_nodes: 5,
+            values: [
                 Variable(
                     (
                         "a",
@@ -1694,7 +1694,7 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "z1",

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/default-args/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/default-args/graph.snapshot
@@ -72,6 +72,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -112,6 +113,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
 ]

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/default-args/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/default-args/graph.snapshot
@@ -72,7 +72,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -113,7 +113,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
 ]

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/default-args/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/default-args/graph.snapshot
@@ -36,9 +36,9 @@
     ),
     (
         "value",
-        Alternatives(
-            7,
-            [
+        Alternatives {
+            total_nodes: 7,
+            values: [
                 Member(
                     3,
                     Argument(
@@ -72,13 +72,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "value2",
-        Alternatives(
-            7,
-            [
+        Alternatives {
+            total_nodes: 7,
+            values: [
                 Member(
                     3,
                     Argument(
@@ -112,6 +112,6 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
 ]

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/esbuild-reduced/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/esbuild-reduced/graph.snapshot
@@ -56,7 +56,7 @@
                     ],
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -210,7 +210,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -304,7 +304,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/esbuild-reduced/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/esbuild-reduced/graph.snapshot
@@ -1,9 +1,9 @@
 [
     (
         "binPath",
-        Alternatives(
-            9,
-            [
+        Alternatives {
+            total_nodes: 9,
+            values: [
                 Unknown {
                     original_value: Some(
                         Variable(
@@ -56,7 +56,7 @@
                     ],
                 ),
             ],
-        ),
+        },
     ),
     (
         "e",
@@ -181,9 +181,9 @@
     ),
     (
         "pkg#3",
-        Alternatives(
-            5,
-            [
+        Alternatives {
+            total_nodes: 5,
+            values: [
                 Unknown {
                     original_value: Some(
                         Variable(
@@ -209,7 +209,7 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "pkg#4",
@@ -279,9 +279,9 @@
     ),
     (
         "subpath#3",
-        Alternatives(
-            3,
-            [
+        Alternatives {
+            total_nodes: 3,
+            values: [
                 Unknown {
                     original_value: Some(
                         Variable(
@@ -302,7 +302,7 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "subpath#4",

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/esbuild-reduced/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/esbuild-reduced/graph.snapshot
@@ -56,6 +56,7 @@
                     ],
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -209,6 +210,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -302,6 +304,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/esbuild/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/esbuild/graph.snapshot
@@ -90,7 +90,7 @@
                         mutable: true,
                     },
                 ],
-                additional_property: None,
+                logical_property: None,
             },
         ),
     ),
@@ -194,7 +194,7 @@
                     ],
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -402,7 +402,7 @@
                         ),
                     ),
                 ],
-                additional_property: None,
+                logical_property: None,
             },
         ),
     ),
@@ -418,7 +418,7 @@
                     True,
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -829,7 +829,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -999,7 +999,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/esbuild/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/esbuild/graph.snapshot
@@ -90,6 +90,7 @@
                         mutable: true,
                     },
                 ],
+                additional_property: None,
             },
         ),
     ),
@@ -193,6 +194,7 @@
                     ],
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -400,6 +402,7 @@
                         ),
                     ),
                 ],
+                additional_property: None,
             },
         ),
     ),
@@ -415,6 +418,7 @@
                     True,
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -825,6 +829,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -994,6 +999,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/esbuild/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/esbuild/graph.snapshot
@@ -4,9 +4,9 @@
         Function(
             16,
             2666,
-            Alternatives(
-                15,
-                [
+            Alternatives {
+                total_nodes: 15,
+                values: [
                     Array {
                         total_nodes: 10,
                         items: [
@@ -90,7 +90,7 @@
                         mutable: true,
                     },
                 ],
-            ),
+            },
         ),
     ),
     (
@@ -118,9 +118,9 @@
     ),
     (
         "binPath",
-        Alternatives(
-            13,
-            [
+        Alternatives {
+            total_nodes: 13,
+            values: [
                 Unknown {
                     original_value: Some(
                         Variable(
@@ -193,7 +193,7 @@
                     ],
                 ),
             ],
-        ),
+        },
     ),
     (
         "binTargetPath",
@@ -381,9 +381,9 @@
         Function(
             5,
             1409,
-            Alternatives(
-                4,
-                [
+            Alternatives {
+                total_nodes: 4,
+                values: [
                     FreeVar(
                         "ESBUILD_BINARY_PATH",
                     ),
@@ -400,14 +400,14 @@
                         ),
                     ),
                 ],
-            ),
+            },
         ),
     ),
     (
         "isYarnPnP",
-        Alternatives(
-            3,
-            [
+        Alternatives {
+            total_nodes: 3,
+            values: [
                 Constant(
                     False,
                 ),
@@ -415,7 +415,7 @@
                     True,
                 ),
             ],
-        ),
+        },
     ),
     (
         "knownUnixlikePackages",
@@ -779,9 +779,9 @@
     ),
     (
         "pkg#3",
-        Alternatives(
-            8,
-            [
+        Alternatives {
+            total_nodes: 8,
+            values: [
                 Unknown {
                     original_value: Some(
                         Variable(
@@ -825,7 +825,7 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "pkg#7",
@@ -964,9 +964,9 @@
     ),
     (
         "subpath#3",
-        Alternatives(
-            4,
-            [
+        Alternatives {
+            total_nodes: 4,
+            values: [
                 Unknown {
                     original_value: Some(
                         Variable(
@@ -994,7 +994,7 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "subpath#7",

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/logical/graph-effects.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/logical/graph-effects.snapshot
@@ -275,4 +275,84 @@
         span: 323..329#1,
         in_try: false,
     },
+    FreeVar {
+        var: FreeVar(
+            "global",
+        ),
+        ast_path: [
+            Program(
+                Script,
+            ),
+            Script(
+                Body(
+                    13,
+                ),
+            ),
+            Stmt(
+                Decl,
+            ),
+            Decl(
+                Var,
+            ),
+            VarDecl(
+                Decls(
+                    0,
+                ),
+            ),
+            VarDeclarator(
+                Init,
+            ),
+            Expr(
+                Bin,
+            ),
+            BinExpr(
+                Left,
+            ),
+            Expr(
+                Ident,
+            ),
+        ],
+        span: 346..352#1,
+        in_try: false,
+    },
+    FreeVar {
+        var: FreeVar(
+            "global",
+        ),
+        ast_path: [
+            Program(
+                Script,
+            ),
+            Script(
+                Body(
+                    14,
+                ),
+            ),
+            Stmt(
+                Decl,
+            ),
+            Decl(
+                Var,
+            ),
+            VarDecl(
+                Decls(
+                    0,
+                ),
+            ),
+            VarDeclarator(
+                Init,
+            ),
+            Expr(
+                Bin,
+            ),
+            BinExpr(
+                Right,
+            ),
+            Expr(
+                Ident,
+            ),
+        ],
+        span: 387..393#1,
+        in_try: false,
+    },
 ]

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/logical/graph-explained.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/logical/graph-explained.snapshot
@@ -20,6 +20,10 @@ resolve3 = (FreeVar(global) || true)
 
 resolve4 = (true || FreeVar(global))
 
+resolve5 = (FreeVar(global) && false)
+
+resolve6 = (false && FreeVar(global))
+
 x = true
 
 y = false

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/logical/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/logical/graph.snapshot
@@ -279,6 +279,36 @@
         ),
     ),
     (
+        "resolve5",
+        Logical(
+            3,
+            And,
+            [
+                FreeVar(
+                    "global",
+                ),
+                Constant(
+                    False,
+                ),
+            ],
+        ),
+    ),
+    (
+        "resolve6",
+        Logical(
+            3,
+            And,
+            [
+                Constant(
+                    False,
+                ),
+                FreeVar(
+                    "global",
+                ),
+            ],
+        ),
+    ),
+    (
         "x",
         Constant(
             True,

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/logical/input.js
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/logical/input.js
@@ -12,3 +12,5 @@ let resolve1 = 1 && 2 && global && 3 && 4;
 let resolve2 = 1 && 2 && 0 && global && 4;
 let resolve3 = global || true;
 let resolve4 = true || global;
+let resolve5 = global && false;
+let resolve6 = false && global;

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/logical/resolved-effects.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/logical/resolved-effects.snapshot
@@ -9,3 +9,7 @@
 0 -> 5 free var = FreeVar(global)
 
 0 -> 6 free var = FreeVar(global)
+
+0 -> 7 free var = FreeVar(global)
+
+0 -> 8 free var = FreeVar(global)

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/logical/resolved-explained.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/logical/resolved-explained.snapshot
@@ -9,7 +9,7 @@ chain1 = ???*0*
   ⚠️  unknown global
   ⚠️  This value might have side effects
 
-chain2 = (???*0* | 3)
+chain2 = (???*0* | 3){truthy}
 - *0* FreeVar(global)
   ⚠️  unknown global
   ⚠️  This value might have side effects
@@ -25,12 +25,19 @@ resolve1 = (???*0* | 4)
 
 resolve2 = 0
 
-resolve3 = (???*0* | true)
+resolve3 = (???*0* | true){truthy}
 - *0* FreeVar(global)
   ⚠️  unknown global
   ⚠️  This value might have side effects
 
 resolve4 = true
+
+resolve5 = (???*0* | false){falsy}
+- *0* FreeVar(global)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects
+
+resolve6 = false
 
 x = true
 

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/md5-reduced/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/md5-reduced/graph.snapshot
@@ -300,6 +300,7 @@
                     ],
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -625,6 +626,7 @@
                     ],
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -950,6 +952,7 @@
                     ],
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -1270,6 +1273,7 @@
                     ],
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -1322,6 +1326,7 @@
                     ],
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -1491,6 +1496,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -1517,6 +1523,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -1543,6 +1550,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -1569,6 +1577,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
     (

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/md5-reduced/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/md5-reduced/graph.snapshot
@@ -300,7 +300,7 @@
                     ],
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -626,7 +626,7 @@
                     ],
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -952,7 +952,7 @@
                     ],
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -1273,7 +1273,7 @@
                     ],
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -1326,7 +1326,7 @@
                     ],
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -1496,7 +1496,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -1523,7 +1523,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -1550,7 +1550,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -1577,7 +1577,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/md5-reduced/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/md5-reduced/graph.snapshot
@@ -1,9 +1,9 @@
 [
     (
         "a#3",
-        Alternatives(
-            52,
-            [
+        Alternatives {
+            total_nodes: 52,
+            values: [
                 Constant(
                     Num(
                         ConstantNumber(
@@ -300,7 +300,7 @@
                     ],
                 ),
             ],
-        ),
+        },
     ),
     (
         "a#5",
@@ -318,9 +318,9 @@
     ),
     (
         "b#3",
-        Alternatives(
-            54,
-            [
+        Alternatives {
+            total_nodes: 54,
+            values: [
                 Unknown {
                     original_value: None,
                     reason: "unsupported expression",
@@ -625,7 +625,7 @@
                     ],
                 ),
             ],
-        ),
+        },
     ),
     (
         "b#5",
@@ -643,9 +643,9 @@
     ),
     (
         "c#3",
-        Alternatives(
-            54,
-            [
+        Alternatives {
+            total_nodes: 54,
+            values: [
                 Unknown {
                     original_value: None,
                     reason: "unsupported expression",
@@ -950,7 +950,7 @@
                     ],
                 ),
             ],
-        ),
+        },
     ),
     (
         "c#6",
@@ -961,9 +961,9 @@
     ),
     (
         "d#3",
-        Alternatives(
-            54,
-            [
+        Alternatives {
+            total_nodes: 54,
+            values: [
                 Constant(
                     Num(
                         ConstantNumber(
@@ -1270,7 +1270,7 @@
                     ],
                 ),
             ],
-        ),
+        },
     ),
     (
         "d#6",
@@ -1281,9 +1281,9 @@
     ),
     (
         "i",
-        Alternatives(
-            6,
-            [
+        Alternatives {
+            total_nodes: 6,
+            values: [
                 Unknown {
                     original_value: Some(
                         Variable(
@@ -1322,7 +1322,7 @@
                     ],
                 ),
             ],
-        ),
+        },
     ),
     (
         "len",
@@ -1469,9 +1469,9 @@
     ),
     (
         "olda",
-        Alternatives(
-            3,
-            [
+        Alternatives {
+            total_nodes: 3,
+            values: [
                 Unknown {
                     original_value: Some(
                         Variable(
@@ -1491,13 +1491,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "oldb",
-        Alternatives(
-            3,
-            [
+        Alternatives {
+            total_nodes: 3,
+            values: [
                 Unknown {
                     original_value: Some(
                         Variable(
@@ -1517,13 +1517,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "oldc",
-        Alternatives(
-            3,
-            [
+        Alternatives {
+            total_nodes: 3,
+            values: [
                 Unknown {
                     original_value: Some(
                         Variable(
@@ -1543,13 +1543,13 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "oldd",
-        Alternatives(
-            3,
-            [
+        Alternatives {
+            total_nodes: 3,
+            values: [
                 Unknown {
                     original_value: Some(
                         Variable(
@@ -1569,7 +1569,7 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
     (
         "q",

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/md5_2/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/md5_2/graph.snapshot
@@ -1566,7 +1566,7 @@
                     has_side_effects: true,
                 },
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -2809,7 +2809,7 @@
                     ],
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -4084,7 +4084,7 @@
                     ],
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -5352,7 +5352,7 @@
                     has_side_effects: true,
                 },
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -5465,7 +5465,7 @@
                     ],
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (
@@ -5660,7 +5660,7 @@
                     [],
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/md5_2/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/md5_2/graph.snapshot
@@ -1566,6 +1566,7 @@
                     has_side_effects: true,
                 },
             ],
+            additional_property: None,
         },
     ),
     (
@@ -2808,6 +2809,7 @@
                     ],
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -4082,6 +4084,7 @@
                     ],
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -5349,6 +5352,7 @@
                     has_side_effects: true,
                 },
             ],
+            additional_property: None,
         },
     ),
     (
@@ -5461,6 +5465,7 @@
                     ],
                 ),
             ],
+            additional_property: None,
         },
     ),
     (
@@ -5655,6 +5660,7 @@
                     [],
                 ),
             ],
+            additional_property: None,
         },
     ),
     (

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/md5_2/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/md5_2/graph.snapshot
@@ -354,9 +354,9 @@
     ),
     (
         "a#4",
-        Alternatives(
-            211,
-            [
+        Alternatives {
+            total_nodes: 211,
+            values: [
                 Constant(
                     Num(
                         ConstantNumber(
@@ -1566,7 +1566,7 @@
                     has_side_effects: true,
                 },
             ],
-        ),
+        },
     ),
     (
         "a#7",
@@ -1607,9 +1607,9 @@
     ),
     (
         "b#4",
-        Alternatives(
-            210,
-            [
+        Alternatives {
+            total_nodes: 210,
+            values: [
                 Unknown {
                     original_value: None,
                     reason: "unsupported expression",
@@ -2808,7 +2808,7 @@
                     ],
                 ),
             ],
-        ),
+        },
     ),
     (
         "b#7",
@@ -2877,9 +2877,9 @@
     ),
     (
         "c#4",
-        Alternatives(
-            210,
-            [
+        Alternatives {
+            total_nodes: 210,
+            values: [
                 Unknown {
                     original_value: None,
                     reason: "unsupported expression",
@@ -4082,7 +4082,7 @@
                     ],
                 ),
             ],
-        ),
+        },
     ),
     (
         "c#7",
@@ -4141,9 +4141,9 @@
     ),
     (
         "d#4",
-        Alternatives(
-            211,
-            [
+        Alternatives {
+            total_nodes: 211,
+            values: [
                 Constant(
                     Num(
                         ConstantNumber(
@@ -5349,7 +5349,7 @@
                     has_side_effects: true,
                 },
             ],
-        ),
+        },
     ),
     (
         "d#7",
@@ -5427,9 +5427,9 @@
     ),
     (
         "i",
-        Alternatives(
-            6,
-            [
+        Alternatives {
+            total_nodes: 6,
+            values: [
                 Constant(
                     Num(
                         ConstantNumber(
@@ -5461,7 +5461,7 @@
                     ],
                 ),
             ],
-        ),
+        },
     ),
     (
         "isBuffer",
@@ -5534,9 +5534,9 @@
     ),
     (
         "message#4",
-        Alternatives(
-            22,
-            [
+        Alternatives {
+            total_nodes: 22,
+            values: [
                 Argument(
                     181,
                     0,
@@ -5655,7 +5655,7 @@
                     [],
                 ),
             ],
-        ),
+        },
     ),
     (
         "n#10",

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/member-call/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/member-call/graph.snapshot
@@ -89,6 +89,7 @@
                     mutable: true,
                 },
             ],
+            additional_property: None,
         },
     ),
     (

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/member-call/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/member-call/graph.snapshot
@@ -89,7 +89,7 @@
                     mutable: true,
                 },
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/member-call/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/member-call/graph.snapshot
@@ -31,9 +31,9 @@
     ),
     (
         "arrays",
-        Alternatives(
-            9,
-            [
+        Alternatives {
+            total_nodes: 9,
+            values: [
                 Array {
                     total_nodes: 4,
                     items: [
@@ -89,7 +89,7 @@
                     mutable: true,
                 },
             ],
-        ),
+        },
     ),
     (
         "concatenated_array",

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/mongoose-reduced/resolved-effects.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/mongoose-reduced/resolved-effects.snapshot
@@ -3,7 +3,7 @@
 0 -> 3 free var = FreeVar(require)
 
 0 -> 4 call = require*0*(
-    `${(???*1* | "./drivers/node-mongodb-native")}/connection`
+    `${(???*1* | "./drivers/node-mongodb-native"){truthy}}/connection`
 )
 - *0* require: The require method from CommonJS
 - *1* ???*2*["MONGOOSE_DRIVER_PATH"]
@@ -16,7 +16,7 @@
 0 -> 5 free var = FreeVar(require)
 
 0 -> 6 call = require*0*(
-    `${(???*1* | "./drivers/node-mongodb-native")}/collection`
+    `${(???*1* | "./drivers/node-mongodb-native"){truthy}}/collection`
 )
 - *0* require: The require method from CommonJS
 - *1* ???*2*["MONGOOSE_DRIVER_PATH"]

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/mongoose-reduced/resolved-explained.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/mongoose-reduced/resolved-explained.snapshot
@@ -1,6 +1,6 @@
 Collection = ???*0*
 - *0* require*1*(
-        `${(???*2* | "./drivers/node-mongodb-native")}/collection`
+        `${(???*2* | "./drivers/node-mongodb-native"){truthy}}/collection`
     )
   ⚠️  only constant argument is supported
   ⚠️  This value might have side effects
@@ -14,7 +14,7 @@ Collection = ???*0*
 
 Connection = ???*0*
 - *0* require*1*(
-        `${(???*2* | "./drivers/node-mongodb-native")}/connection`
+        `${(???*2* | "./drivers/node-mongodb-native"){truthy}}/connection`
     )
   ⚠️  only constant argument is supported
   ⚠️  This value might have side effects
@@ -26,7 +26,7 @@ Connection = ???*0*
   ⚠️  unknown global
   ⚠️  This value might have side effects
 
-driver = (???*0* | "./drivers/node-mongodb-native")
+driver = (???*0* | "./drivers/node-mongodb-native"){truthy}
 - *0* ???*1*["MONGOOSE_DRIVER_PATH"]
   ⚠️  unknown object
   ⚠️  This value might have side effects

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/nested-args/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/nested-args/graph.snapshot
@@ -142,7 +142,7 @@
                         ],
                     ),
                 ],
-                additional_property: None,
+                logical_property: None,
             },
         ),
     ),

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/nested-args/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/nested-args/graph.snapshot
@@ -142,6 +142,7 @@
                         ],
                     ),
                 ],
+                additional_property: None,
             },
         ),
     ),

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/nested-args/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/nested-args/graph.snapshot
@@ -88,9 +88,9 @@
         Function(
             11,
             87,
-            Alternatives(
-                10,
-                [
+            Alternatives {
+                total_nodes: 10,
+                values: [
                     Constant(
                         Undefined,
                     ),
@@ -142,7 +142,7 @@
                         ],
                     ),
                 ],
-            ),
+            },
         ),
     ),
     (

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/op-assign/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/op-assign/graph.snapshot
@@ -4,9 +4,9 @@
         Function(
             4,
             173,
-            Alternatives(
-                3,
-                [
+            Alternatives {
+                total_nodes: 3,
+                values: [
                     Constant(
                         Undefined,
                     ),
@@ -16,7 +16,7 @@
                         has_side_effects: true,
                     },
                 ],
-            ),
+            },
         ),
     ),
     (
@@ -43,9 +43,9 @@
     ),
     (
         "clientComponentLoadTimes",
-        Alternatives(
-            5,
-            [
+        Alternatives {
+            total_nodes: 5,
+            values: [
                 Constant(
                     Num(
                         ConstantNumber(
@@ -70,7 +70,7 @@
                     ],
                 ),
             ],
-        ),
+        },
     ),
     (
         "getClientComponentLoaderMetrics",

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/op-assign/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/op-assign/graph.snapshot
@@ -16,7 +16,7 @@
                         has_side_effects: true,
                     },
                 ],
-                additional_property: None,
+                logical_property: None,
             },
         ),
     ),
@@ -71,7 +71,7 @@
                     ],
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/op-assign/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/op-assign/graph.snapshot
@@ -16,6 +16,7 @@
                         has_side_effects: true,
                     },
                 ],
+                additional_property: None,
             },
         ),
     ),
@@ -70,6 +71,7 @@
                     ],
                 ),
             ],
+            additional_property: None,
         },
     ),
     (

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/pack-2521/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/pack-2521/graph.snapshot
@@ -180,7 +180,7 @@
                     ],
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
 ]

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/pack-2521/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/pack-2521/graph.snapshot
@@ -180,6 +180,7 @@
                     ],
                 ),
             ],
+            additional_property: None,
         },
     ),
 ]

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/pack-2521/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/pack-2521/graph.snapshot
@@ -150,9 +150,9 @@
     ),
     (
         "sharp",
-        Alternatives(
-            5,
-            [
+        Alternatives {
+            total_nodes: 5,
+            values: [
                 Unknown {
                     original_value: Some(
                         Variable(
@@ -180,6 +180,6 @@
                     ],
                 ),
             ],
-        ),
+        },
     ),
 ]

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/pack-2682/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/pack-2682/graph.snapshot
@@ -168,6 +168,7 @@
                     ),
                 ),
             ],
+            additional_property: None,
         },
     ),
 ]

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/pack-2682/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/pack-2682/graph.snapshot
@@ -143,9 +143,9 @@
     ),
     (
         "variable",
-        Alternatives(
-            5,
-            [
+        Alternatives {
+            total_nodes: 5,
+            values: [
                 Member(
                     3,
                     Argument(
@@ -168,6 +168,6 @@
                     ),
                 ),
             ],
-        ),
+        },
     ),
 ]

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/pack-2682/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/pack-2682/graph.snapshot
@@ -168,7 +168,7 @@
                     ),
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
 ]

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/react-dom-production/resolved-effects.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/react-dom-production/resolved-effects.snapshot
@@ -8411,7 +8411,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
     "abort canplay canplaythrough durationchange emptied encrypted ended error loadeddata loadedmetadata loadstart pause play playing progress ratechange resize seeked seeking stalled suspend timeupdate volumechange waiting"["split"](" ")
 )
 
-0 -> 1572 call = (...) => undefined((???*0* | "unknown-event"), ???*2*, ???*3*, ???*4*)
+0 -> 1572 call = (...) => undefined((???*0* | "unknown-event"){truthy}, ???*2*, ???*3*, ???*4*)
 - *0* ???*1*["type"]
   ⚠️  unknown object
 - *1* arguments[0]
@@ -14864,7 +14864,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *3* arguments[3]
   ⚠️  function calls are not analysed yet
 
-0 -> 2562 call = (...) => a((???*0* | ???*1* | ???*3* | ???*4*), (???*5* | []))
+0 -> 2562 call = (...) => a((???*0* | ???*1* | ???*3* | ???*4*), (???*5* | []){truthy})
 - *0* arguments[1]
   ⚠️  function calls are not analysed yet
 - *1* ???*2*["mode"]
@@ -16392,7 +16392,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
-2809 -> 2813 call = (...) => a(???*0*, (???*1* | []))
+2809 -> 2813 call = (...) => a(???*0*, (???*1* | []){truthy})
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 - *1* ???*2*["children"]
@@ -36859,7 +36859,7 @@ ${(???*45* | ???*46* | ???*50* | "")}${(???*54* | ???*56*)}`
         "scheduleUpdate": null,
         "currentDispatcherRef": module<react, {}>["__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED"]["ReactCurrentDispatcher"],
         "findHostInstanceByFiber": (...) => ((null === a) ? null : a["stateNode"]),
-        "findFiberByHostInstance": ((...) => (b | c | null) | ???*6* | (...) => null),
+        "findFiberByHostInstance": ((...) => (b | c | null) | ???*6* | (...) => null){truthy},
         "findHostInstancesForRefresh": null,
         "scheduleRefresh": null,
         "scheduleRoot": null,

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/react-dom-production/resolved-explained.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/react-dom-production/resolved-explained.snapshot
@@ -12260,7 +12260,7 @@ d#269 = ???*0*
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 
-d#274 = (???*0* | "unknown-event")
+d#274 = (???*0* | "unknown-event"){truthy}
 - *0* ???*1*["type"]
   ⚠️  unknown object
 - *1* arguments[0]
@@ -19903,7 +19903,7 @@ vl = {
     "scheduleUpdate": null,
     "currentDispatcherRef": module<react, {}>["__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED"]["ReactCurrentDispatcher"],
     "findHostInstanceByFiber": (...) => ((null === a) ? null : a["stateNode"]),
-    "findFiberByHostInstance": ((...) => (b | c | null) | ???*5* | (...) => null),
+    "findFiberByHostInstance": ((...) => (b | c | null) | ???*5* | (...) => null){truthy},
     "findHostInstancesForRefresh": null,
     "scheduleRefresh": null,
     "scheduleRoot": null,

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/sequences/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/sequences/graph.snapshot
@@ -17,6 +17,7 @@
                     has_side_effects: true,
                 },
             ],
+            additional_property: None,
         },
     ),
     (

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/sequences/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/sequences/graph.snapshot
@@ -17,7 +17,7 @@
                     has_side_effects: true,
                 },
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
     (

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/sequences/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/sequences/graph.snapshot
@@ -1,9 +1,9 @@
 [
     (
         "x",
-        Alternatives(
-            3,
-            [
+        Alternatives {
+            total_nodes: 3,
+            values: [
                 Constant(
                     Num(
                         ConstantNumber(
@@ -17,7 +17,7 @@
                     has_side_effects: true,
                 },
             ],
-        ),
+        },
     ),
     (
         "y",

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/try/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/try/graph.snapshot
@@ -62,6 +62,7 @@
                     ],
                 ),
             ],
+            additional_property: None,
         },
     ),
 ]

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/try/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/try/graph.snapshot
@@ -16,9 +16,9 @@
     ),
     (
         "pkg",
-        Alternatives(
-            8,
-            [
+        Alternatives {
+            total_nodes: 8,
+            values: [
                 Unknown {
                     original_value: Some(
                         Variable(
@@ -62,6 +62,6 @@
                     ],
                 ),
             ],
-        ),
+        },
     ),
 ]

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/try/graph.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/try/graph.snapshot
@@ -62,7 +62,7 @@
                     ],
                 ),
             ],
-            additional_property: None,
+            logical_property: None,
         },
     ),
 ]


### PR DESCRIPTION
### Description

Allows to handle `if (unknown && falsy)` `if (unknown || truthy)` `if (unknown ?? nullish)` in static analysis.

Hint: review each commit on it's own, since the first commit is only changing to a named struct.

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
