### PR TITLE
only add import references when they are used

### DIFF
--- a/crates/turbopack-ecmascript/tests/analyzer/graph/conditional-import/graph-effects.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/conditional-import/graph-effects.snapshot
@@ -8,12 +8,15 @@
                 effects: [],
                 ast_path: [
                     Program(
-                        Script,
+                        Module,
                     ),
-                    Script(
+                    Module(
                         Body(
                             0,
                         ),
+                    ),
+                    ModuleItem(
+                        Stmt,
                     ),
                     Stmt(
                         Decl,
@@ -52,12 +55,15 @@
                 effects: [],
                 ast_path: [
                     Program(
-                        Script,
+                        Module,
                     ),
-                    Script(
+                    Module(
                         Body(
                             0,
                         ),
+                    ),
+                    ModuleItem(
+                        Stmt,
                     ),
                     Stmt(
                         Decl,
@@ -95,12 +101,15 @@
         },
         ast_path: [
             Program(
-                Script,
+                Module,
             ),
-            Script(
+            Module(
                 Body(
                     0,
                 ),
+            ),
+            ModuleItem(
+                Stmt,
             ),
             Stmt(
                 Decl,
@@ -154,12 +163,15 @@
         ],
         ast_path: [
             Program(
-                Script,
+                Module,
             ),
-            Script(
+            Module(
                 Body(
                     0,
                 ),
+            ),
+            ModuleItem(
+                Stmt,
             ),
             Stmt(
                 Decl,
@@ -205,12 +217,15 @@
         ),
         ast_path: [
             Program(
-                Script,
+                Module,
             ),
-            Script(
+            Module(
                 Body(
                     1,
                 ),
+            ),
+            ModuleItem(
+                Stmt,
             ),
             Stmt(
                 Decl,
@@ -253,7 +268,7 @@
                 Member,
             ),
         ],
-        span: 53..77#0,
+        span: 57..81#0,
         in_try: false,
     },
     Member {
@@ -269,12 +284,15 @@
         ),
         ast_path: [
             Program(
-                Script,
+                Module,
             ),
-            Script(
+            Module(
                 Body(
                     1,
                 ),
+            ),
+            ModuleItem(
+                Stmt,
             ),
             Stmt(
                 Decl,
@@ -323,7 +341,7 @@
                 Member,
             ),
         ],
-        span: 53..64#0,
+        span: 57..68#0,
         in_try: false,
     },
     FreeVar {
@@ -332,12 +350,15 @@
         ),
         ast_path: [
             Program(
-                Script,
+                Module,
             ),
-            Script(
+            Module(
                 Body(
                     1,
                 ),
+            ),
+            ModuleItem(
+                Stmt,
             ),
             Stmt(
                 Decl,
@@ -392,7 +413,7 @@
                 Ident,
             ),
         ],
-        span: 53..60#1,
+        span: 57..64#1,
         in_try: false,
     },
     Conditional {
@@ -435,12 +456,15 @@
                 effects: [],
                 ast_path: [
                     Program(
-                        Script,
+                        Module,
                     ),
-                    Script(
+                    Module(
                         Body(
                             1,
                         ),
+                    ),
+                    ModuleItem(
+                        Stmt,
                     ),
                     Stmt(
                         Decl,
@@ -479,12 +503,15 @@
                 effects: [],
                 ast_path: [
                     Program(
-                        Script,
+                        Module,
                     ),
-                    Script(
+                    Module(
                         Body(
                             1,
                         ),
+                    ),
+                    ModuleItem(
+                        Stmt,
                     ),
                     Stmt(
                         Decl,
@@ -522,12 +549,15 @@
         },
         ast_path: [
             Program(
-                Script,
+                Module,
             ),
-            Script(
+            Module(
                 Body(
                     1,
                 ),
+            ),
+            ModuleItem(
+                Stmt,
             ),
             Stmt(
                 Decl,
@@ -561,7 +591,7 @@
                 Test,
             ),
         ],
-        span: 53..188#0,
+        span: 57..196#0,
         in_try: false,
     },
     Call {
@@ -625,12 +655,15 @@
         ],
         ast_path: [
             Program(
-                Script,
+                Module,
             ),
-            Script(
+            Module(
                 Body(
                     1,
                 ),
+            ),
+            ModuleItem(
+                Stmt,
             ),
             Stmt(
                 Decl,
@@ -650,7 +683,7 @@
                 Call,
             ),
         ],
-        span: 46..189#0,
+        span: 47..198#0,
         in_try: false,
     },
     Conditional {
@@ -677,12 +710,15 @@
                         ],
                         ast_path: [
                             Program(
-                                Script,
+                                Module,
                             ),
-                            Script(
+                            Module(
                                 Body(
                                     3,
                                 ),
+                            ),
+                            ModuleItem(
+                                Stmt,
                             ),
                             Stmt(
                                 If,
@@ -714,18 +750,21 @@
                                 Call,
                             ),
                         ],
-                        span: 216..227#0,
+                        span: 226..237#0,
                         in_try: false,
                     },
                 ],
                 ast_path: [
                     Program(
-                        Script,
+                        Module,
                     ),
-                    Script(
+                    Module(
                         Body(
                             3,
                         ),
+                    ),
+                    ModuleItem(
+                        Stmt,
                     ),
                     Stmt(
                         If,
@@ -754,12 +793,15 @@
                         ],
                         ast_path: [
                             Program(
-                                Script,
+                                Module,
                             ),
-                            Script(
+                            Module(
                                 Body(
                                     3,
                                 ),
+                            ),
+                            ModuleItem(
+                                Stmt,
                             ),
                             Stmt(
                                 If,
@@ -791,18 +833,21 @@
                                 Call,
                             ),
                         ],
-                        span: 243..254#0,
+                        span: 254..265#0,
                         in_try: false,
                     },
                 ],
                 ast_path: [
                     Program(
-                        Script,
+                        Module,
                     ),
-                    Script(
+                    Module(
                         Body(
                             3,
                         ),
+                    ),
+                    ModuleItem(
+                        Stmt,
                     ),
                     Stmt(
                         If,
@@ -815,12 +860,15 @@
         },
         ast_path: [
             Program(
-                Script,
+                Module,
             ),
-            Script(
+            Module(
                 Body(
                     3,
                 ),
+            ),
+            ModuleItem(
+                Stmt,
             ),
             Stmt(
                 If,
@@ -829,7 +877,169 @@
                 Test,
             ),
         ],
-        span: 198..256#0,
+        span: 208..268#0,
+        in_try: false,
+    },
+    Conditional {
+        condition: Constant(
+            True,
+        ),
+        kind: IfElse {
+            then: EffectsBlock {
+                effects: [
+                    ImportedBinding {
+                        esm_reference_index: 1,
+                        export: Some(
+                            "x",
+                        ),
+                        ast_path: [
+                            Program(
+                                Module,
+                            ),
+                            Module(
+                                Body(
+                                    6,
+                                ),
+                            ),
+                            ModuleItem(
+                                Stmt,
+                            ),
+                            Stmt(
+                                If,
+                            ),
+                            IfStmt(
+                                Cons,
+                            ),
+                            Stmt(
+                                Block,
+                            ),
+                            BlockStmt(
+                                Stmts(
+                                    0,
+                                ),
+                            ),
+                            Stmt(
+                                Expr,
+                            ),
+                            ExprStmt(
+                                Expr,
+                            ),
+                            Expr(
+                                Ident,
+                            ),
+                        ],
+                        span: 331..332#2,
+                        in_try: false,
+                    },
+                ],
+                ast_path: [
+                    Program(
+                        Module,
+                    ),
+                    Module(
+                        Body(
+                            6,
+                        ),
+                    ),
+                    ModuleItem(
+                        Stmt,
+                    ),
+                    Stmt(
+                        If,
+                    ),
+                    IfStmt(
+                        Cons,
+                    ),
+                ],
+            },
+            else: EffectsBlock {
+                effects: [
+                    ImportedBinding {
+                        esm_reference_index: 3,
+                        export: Some(
+                            "y",
+                        ),
+                        ast_path: [
+                            Program(
+                                Module,
+                            ),
+                            Module(
+                                Body(
+                                    6,
+                                ),
+                            ),
+                            ModuleItem(
+                                Stmt,
+                            ),
+                            Stmt(
+                                If,
+                            ),
+                            IfStmt(
+                                Alt,
+                            ),
+                            Stmt(
+                                Block,
+                            ),
+                            BlockStmt(
+                                Stmts(
+                                    0,
+                                ),
+                            ),
+                            Stmt(
+                                Expr,
+                            ),
+                            ExprStmt(
+                                Expr,
+                            ),
+                            Expr(
+                                Ident,
+                            ),
+                        ],
+                        span: 345..346#2,
+                        in_try: false,
+                    },
+                ],
+                ast_path: [
+                    Program(
+                        Module,
+                    ),
+                    Module(
+                        Body(
+                            6,
+                        ),
+                    ),
+                    ModuleItem(
+                        Stmt,
+                    ),
+                    Stmt(
+                        If,
+                    ),
+                    IfStmt(
+                        Alt,
+                    ),
+                ],
+            },
+        },
+        ast_path: [
+            Program(
+                Module,
+            ),
+            Module(
+                Body(
+                    6,
+                ),
+            ),
+            ModuleItem(
+                Stmt,
+            ),
+            Stmt(
+                If,
+            ),
+            IfStmt(
+                Test,
+            ),
+        ],
+        span: 317..349#0,
         in_try: false,
     },
 ]

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/conditional-import/input.js
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/conditional-import/input.js
@@ -1,11 +1,22 @@
-const a = import(true ? "a" : "b")
-const c = import(process.env.NEXT_RUNTIME === 'edge'
-  ? 'next/dist/compiled/@vercel/og/index.edge.js'
-  : 'next/dist/compiled/@vercel/og/index.node.js')
+const a = import(true ? "a" : "b");
+const c = import(
+  process.env.NEXT_RUNTIME === "edge"
+    ? "next/dist/compiled/@vercel/og/index.edge.js"
+    : "next/dist/compiled/@vercel/og/index.node.js"
+);
 let b;
 
 if (true) {
-  b = import("a")
+  b = import("a");
 } else {
-  b = import("b")
+  b = import("b");
+}
+
+import { x } from "x";
+import { y } from "y";
+
+if (true) {
+  x;
+} else {
+  y;
 }

--- a/crates/turbopack-ecmascript/tests/analyzer/graph/conditional-import/resolved-effects.snapshot
+++ b/crates/turbopack-ecmascript/tests/analyzer/graph/conditional-import/resolved-effects.snapshot
@@ -23,3 +23,5 @@
 
 8 -> 10 call = import*0*("b")
 - *0* import: The dynamic import() method from the ESM specification: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#dynamic_imports
+
+0 -> 11 conditional = true

--- a/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/comptime/input/index.js
+++ b/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/comptime/input/index.js
@@ -1,0 +1,10 @@
+import { something } from "package/dep.js";
+import { something2 } from "package/dep2.js";
+
+it("should not include a module that is side effect free and exports are not used due to static analysis", () => {
+  if (false) {
+    something();
+  } else {
+    something2();
+  }
+});

--- a/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/comptime/input/node_modules/package/dep.js
+++ b/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/comptime/input/node_modules/package/dep.js
@@ -1,0 +1,2 @@
+throw new Error("Should never be executed");
+export const something = () => {};

--- a/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/comptime/input/node_modules/package/dep2.js
+++ b/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/comptime/input/node_modules/package/dep2.js
@@ -1,0 +1,1 @@
+export const something2 = () => {};

--- a/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/comptime/input/node_modules/package/package.json
+++ b/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/comptime/input/node_modules/package/package.json
@@ -1,0 +1,3 @@
+{
+  "sideEffects": false
+}

--- a/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/comptime/options.json
+++ b/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/comptime/options.json
@@ -1,0 +1,3 @@
+{
+  "treeShakingMode": "reexports-only"
+}

--- a/crates/turbopack-tests/tests/execution/turbopack/tree-shaking/comptime/input/index.js
+++ b/crates/turbopack-tests/tests/execution/turbopack/tree-shaking/comptime/input/index.js
@@ -1,0 +1,1 @@
+import "../../../side-effects-optimization/comptime/input/index.js";

--- a/crates/turbopack-tests/tests/execution/turbopack/tree-shaking/comptime/options.json
+++ b/crates/turbopack-tests/tests/execution/turbopack/tree-shaking/comptime/options.json
@@ -1,0 +1,3 @@
+{
+  "treeShakingMode": "module-fragments"
+}


### PR DESCRIPTION
### Description

skips import to modules that are side effect free and have no exports referenced

This allows to e. g. skip the `package` import completely in the following code:

``` js
import { something } from "package"; // package is marked as side effect free

if (falsy) {
  something();
}
```

This could happen e. g. with code like `if(process.env.NODE_ENV === "production")`

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
