### PR TITLE
fix(cli): prevent splitting of run args

### DIFF
--- a/turborepo-tests/integration/tests/bad-flag.t
+++ b/turborepo-tests/integration/tests/bad-flag.t
@@ -25,3 +25,11 @@ Bad flag with an implied run command should display run flags
   
   [1]
 
+Cannot use run args before and after run
+  $ ${TURBO} --filter=web run build
+  error: cannot specify run arguments before and after 'run' subcommand
+  
+  Usage: turbo [OPTIONS] [COMMAND]
+  
+  For more information, try '--help'.
+  [2]


### PR DESCRIPTION
### Description

We had a bug where we allowed providing run flags on either side of the `run` subcommand e.g. `turbo --filter=web run build`. Any arguments provided before `run` would be silently ignored in this case.

**Background**

We support omitting the `run` subcommand so we duplicate all of the run subcommand arguments on the main `turbo` command. This allowed for users to specify run commands both on the main `turbo` command and the `run` subcommand.

### Testing Instructions

Added unit tests for detection and an integration test to show the error message.