### PR TITLE
feat(tui): Set TURBO_IS_TUI environment variable when using TUI.

### DIFF
--- a/crates/turborepo-lib/src/task_graph/visitor.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor.rs
@@ -914,6 +914,11 @@ impl ExecContext {
         cmd.env("TURBO_HASH", &self.task_hash);
         // enable task access tracing
 
+        // Allow downstream tools to detect if the task is being ran with TUI
+        if self.experimental_ui {
+            cmd.env("TURBO_IS_TUI", "true");
+        }
+
         // set the trace file env var - frameworks that support this can use it to
         // write out a trace file that we will use to automatically cache the task
         if self.task_access.is_enabled() {

--- a/crates/turborepo-lib/src/task_graph/visitor.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor.rs
@@ -912,12 +912,13 @@ impl ExecContext {
         cmd.envs(self.execution_env.iter());
         // Always last to make sure it overwrites any user configured env var.
         cmd.env("TURBO_HASH", &self.task_hash);
-        // enable task access tracing
 
         // Allow downstream tools to detect if the task is being ran with TUI
         if self.experimental_ui {
             cmd.env("TURBO_IS_TUI", "true");
         }
+
+        // enable task access tracing
 
         // set the trace file env var - frameworks that support this can use it to
         // write out a trace file that we will use to automatically cache the task

--- a/docs/repo-docs/reference/system-environment-variables.mdx
+++ b/docs/repo-docs/reference/system-environment-variables.mdx
@@ -39,6 +39,7 @@ System environment variables are always overridden by flag values provided direc
 
 Turborepo will make the following environment variables available within your tasks while they are executing:
 
-| Variable     | Description                             |
-| ------------ | --------------------------------------- |
-| `TURBO_HASH` | The hash of the currently running task. |
+| Variable       | Description                                                                                  |
+| -------------- | -------------------------------------------------------------------------------------------- |
+| `TURBO_HASH`   | The hash of the currently running task.                                                      |
+| `TURBO_IS_TUI` | When using the [TUI](/repo/docs/reference/configuration#ui), this variable is set to `true`. |


### PR DESCRIPTION
### Description

Tools being used inside Turborepo tasks may want to know if they are being ran in our multiplexer, similar to the way other terminal tooling set environment variables that other programs can read (e.g. `ZSH`,`TMUX`, `ALACRITTY_WINDOW_ID`).

In this PR, we're exposing a `TURBO_IS_TUI` variable for this purpose.

### Testing Instructions

Using the `with-shell-commands` example, I edited one of the `build` scripts to echo the value.

With TUI:
```
TURBO_UI devturbo build --force --skip-infer

<omitted for brevity>

┌ pkg-b#build > cache bypass, force executing 33b029c222753bd2
│
│
│ > pkg-b@ prebuild /Users/anthonyshew/projects/debugs/with-shell-commands/packages/pkg-b
│ > echo "Executing pre-build step..."
│
│ Executing pre-build step...
│
│ > pkg-b@ build /Users/anthonyshew/projects/debugs/with-shell-commands/packages/pkg-b
│ > echo $TURBO_IS_TUI
│
│ true
└────>
```

Without TUI:
```
TURBO_UI=0 devturbo build --force --skip-infer --filter=pkg-b
turbo 2.0.11

• Packages in scope: pkg-b
• Running build in 1 packages
• Remote caching disabled

pkg-b:prebuild: > echo "Executing pre-build step..."
pkg-b:prebuild:
pkg-b:prebuild: Executing pre-build step...
pkg-b:build: cache bypass, force executing 33b029c222753bd2
pkg-b:build:
pkg-b:build:
pkg-b:build: > pkg-b@ prebuild /Users/anthonyshew/projects/debugs/with-shell-commands/packages/pkg-b
pkg-b:build: > echo "Executing pre-build step..."
pkg-b:build:
pkg-b:build: Executing pre-build step...
pkg-b:build:
pkg-b:build: > pkg-b@ build /Users/anthonyshew/projects/debugs/with-shell-commands/packages/pkg-b
pkg-b:build: > echo $TURBO_IS_TUI
pkg-b:build:
pkg-b:build:

```