### PR TITLE
print a warning when the trace file is missing rather than wait

### DIFF
--- a/crates/turbopack-trace-server/src/reader/mod.rs
+++ b/crates/turbopack-trace-server/src/reader/mod.rs
@@ -79,8 +79,13 @@ impl TraceReader {
     }
 
     pub fn run(&mut self) {
+        let mut file_warning_printed = false;
         loop {
-            self.try_read();
+            let read_success = self.try_read();
+            if !file_warning_printed && !read_success {
+                println!("Unable to read trace file at {:?}, waiting...", self.path);
+                file_warning_printed = true;
+            }
             thread::sleep(Duration::from_millis(500));
         }
     }


### PR DESCRIPTION
### Description

The trace viewer just sits and waits if it can't file the trace file. We instead print a little message in this case to help avoid cases where (in my case) you are missing a character from the end of the file name 😂 

### Testing Instructions

Attempt to load a trace with a path that doesn't exist. Observe error message.
