### PR TITLE
Module ID hashing for production builds

### DIFF
--- a/crates/turbopack-browser/src/chunking_context.rs
+++ b/crates/turbopack-browser/src/chunking_context.rs
@@ -6,6 +6,7 @@ use turbopack_core::{
     chunk::{
         availability_info::AvailabilityInfo,
         chunk_group::{make_chunk_group, MakeChunkGroupResult},
+        global_information::OptionGlobalInformation,
         Chunk, ChunkGroupResult, ChunkItem, ChunkableModule, ChunkingContext,
         EntryChunkGroupResult, EvaluatableAssets, MinifyType, ModuleId,
     },
@@ -123,7 +124,7 @@ pub struct BrowserChunkingContext {
     /// Whether to use manifest chunks for lazy compilation
     manifest_chunks: bool,
     /// Global information
-    global_information: Vc<Option<RcStr>>,
+    global_information: Vc<OptionGlobalInformation>,
 }
 
 impl BrowserChunkingContext {
@@ -135,7 +136,7 @@ impl BrowserChunkingContext {
         asset_root_path: Vc<FileSystemPath>,
         environment: Vc<Environment>,
         runtime_type: RuntimeType,
-        global_information: Vc<Option<RcStr>>,
+        global_information: Vc<OptionGlobalInformation>,
     ) -> BrowserChunkingContextBuilder {
         BrowserChunkingContextBuilder {
             chunking_context: BrowserChunkingContext {

--- a/crates/turbopack-browser/src/chunking_context.rs
+++ b/crates/turbopack-browser/src/chunking_context.rs
@@ -244,16 +244,6 @@ impl BrowserChunkingContext {
 #[turbo_tasks::value_impl]
 impl ChunkingContext for BrowserChunkingContext {
     #[turbo_tasks::function]
-    async fn chunk_item_id_from_ident(
-        self: Vc<Self>,
-        ident: Vc<AssetIdent>,
-    ) -> Result<Vc<ModuleId>> {
-        let this = self.await?;
-        dbg!(this.global_information.dbg().await?);
-        Ok(ModuleId::String(ident.to_string().await?.clone_value()).cell())
-    }
-
-    #[turbo_tasks::function]
     fn name(&self) -> Vc<RcStr> {
         if let Some(name) = &self.name {
             Vc::cell(name.clone())
@@ -523,5 +513,10 @@ impl ChunkingContext for BrowserChunkingContext {
         } else {
             self.chunk_item_id_from_ident(AsyncLoaderModule::asset_ident_for(module))
         })
+    }
+
+    #[turbo_tasks::function]
+    async fn global_information(self: Vc<Self>) -> Result<Vc<OptionGlobalInformation>> {
+        Ok(self.await?.global_information)
     }
 }

--- a/crates/turbopack-browser/src/chunking_context.rs
+++ b/crates/turbopack-browser/src/chunking_context.rs
@@ -1,6 +1,6 @@
 use anyhow::{bail, Context, Result};
 use tracing::Instrument;
-use turbo_tasks::{debug::ValueDebug, RcStr, Value, ValueToString, Vc};
+use turbo_tasks::{RcStr, Value, ValueToString, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     chunk::{

--- a/crates/turbopack-cli/src/build/mod.rs
+++ b/crates/turbopack-cli/src/build/mod.rs
@@ -197,6 +197,7 @@ async fn build_internal(
                 NodeEnv::Development => RuntimeType::Development,
                 NodeEnv::Production => RuntimeType::Production,
             },
+            Vc::cell(None),
         )
         .minify_type(minify_type)
         .build(),

--- a/crates/turbopack-cli/src/dev/mod.rs
+++ b/crates/turbopack-cli/src/dev/mod.rs
@@ -255,6 +255,7 @@ async fn source(
         build_output_root.join("assets".into()),
         node_build_environment(),
         RuntimeType::Development,
+        Vc::cell(None),
     )
     .build();
 

--- a/crates/turbopack-cli/src/dev/web_entry_source.rs
+++ b/crates/turbopack-cli/src/dev/web_entry_source.rs
@@ -45,6 +45,7 @@ pub fn get_client_chunking_context(
             server_root.join("/_assets".into()),
             environment,
             RuntimeType::Development,
+            Vc::cell(None),
         )
         .hot_module_replacement()
         .build(),

--- a/crates/turbopack-core/src/changed.rs
+++ b/crates/turbopack-core/src/changed.rs
@@ -17,7 +17,7 @@ async fn get_referenced_output_assets(
     Ok(parent.references().await?.clone_value().into_iter())
 }
 
-async fn get_referenced_modules(
+pub async fn get_referenced_modules(
     parent: Vc<Box<dyn Module>>,
 ) -> Result<impl Iterator<Item = Vc<Box<dyn Module>>> + Send> {
     Ok(primary_referenced_modules(parent)

--- a/crates/turbopack-core/src/chunk/chunking_context.rs
+++ b/crates/turbopack-core/src/chunk/chunking_context.rs
@@ -4,7 +4,10 @@ use turbo_tasks::{trace::TraceRawVcs, RcStr, TaskInput, Upcast, Value, ValueToSt
 use turbo_tasks_fs::FileSystemPath;
 use turbo_tasks_hash::DeterministicHash;
 
-use super::{availability_info::AvailabilityInfo, ChunkableModule, EvaluatableAssets};
+use super::{
+    availability_info::AvailabilityInfo, global_information::OptionGlobalInformation,
+    ChunkableModule, EvaluatableAssets,
+};
 use crate::{
     chunk::{ChunkItem, ModuleId},
     environment::Environment,
@@ -114,10 +117,16 @@ pub trait ChunkingContext {
         availability_info: Value<AvailabilityInfo>,
     ) -> Result<Vc<EntryChunkGroupResult>>;
 
+    fn global_information(self: Vc<Self>) -> Vc<OptionGlobalInformation>;
+
     async fn chunk_item_id_from_ident(
         self: Vc<Self>,
         ident: Vc<AssetIdent>,
     ) -> Result<Vc<ModuleId>> {
+        let global_information = self.global_information().await?;
+        if let Some(global_information) = &*global_information {
+            return Ok(global_information.get_module_id(ident).await?);
+        }
         Ok(ModuleId::String(ident.to_string().await?.clone_value()).cell())
     }
 

--- a/crates/turbopack-core/src/chunk/chunking_context.rs
+++ b/crates/turbopack-core/src/chunk/chunking_context.rs
@@ -123,8 +123,7 @@ pub trait ChunkingContext {
         self: Vc<Self>,
         ident: Vc<AssetIdent>,
     ) -> Result<Vc<ModuleId>> {
-        let global_information = self.global_information().await?;
-        if let Some(global_information) = &*global_information {
+        if let Some(global_information) = &*self.global_information().await? {
             return Ok(global_information.get_module_id(ident).await?);
         }
         Ok(ModuleId::String(ident.to_string().await?.clone_value()).cell())

--- a/crates/turbopack-core/src/chunk/global_information.rs
+++ b/crates/turbopack-core/src/chunk/global_information.rs
@@ -1,0 +1,25 @@
+use std::collections::HashMap;
+
+use turbo_tasks::{RcStr, Vc};
+
+use super::ModuleId;
+use crate::ident::AssetIdent;
+
+#[turbo_tasks::value]
+#[derive(Clone, Debug)]
+pub struct GlobalInformation {
+    pub test_str: Vc<RcStr>,
+    pub module_id_map: HashMap<AssetIdent, ModuleId>,
+}
+
+impl GlobalInformation {
+    pub fn get_module_id(&self, asset_ident: &AssetIdent) -> ModuleId {
+        self.module_id_map.get(asset_ident).cloned().expect(
+            "No module ID found for the given asset identifier. This is an internal Turbopack \
+             error. Please report it.",
+        )
+    }
+}
+
+#[turbo_tasks::value(transparent)]
+pub struct OptionGlobalInformation(Option<GlobalInformation>);

--- a/crates/turbopack-core/src/chunk/global_information.rs
+++ b/crates/turbopack-core/src/chunk/global_information.rs
@@ -18,7 +18,7 @@ impl GlobalInformation {
         let ident = asset_ident.await?;
         let hashed_module_id = self.module_id_map.get(&ident);
         if let Some(hashed_module_id) = hashed_module_id {
-            dbg!("Hashed module ID found");
+            dbg!("Hashed module ID found", &ident_str, hashed_module_id);
             return Ok(hashed_module_id.clone().cell());
         }
         dbg!("Hashed module ID not found", &ident_str);

--- a/crates/turbopack-core/src/chunk/global_information.rs
+++ b/crates/turbopack-core/src/chunk/global_information.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
-use turbo_tasks::{RcStr, Vc};
+use anyhow::Result;
+use turbo_tasks::{ValueToString, Vc};
 
 use super::ModuleId;
 use crate::ident::AssetIdent;
@@ -8,16 +9,20 @@ use crate::ident::AssetIdent;
 #[turbo_tasks::value]
 #[derive(Clone, Debug)]
 pub struct GlobalInformation {
-    pub test_str: Vc<RcStr>,
     pub module_id_map: HashMap<AssetIdent, ModuleId>,
 }
 
 impl GlobalInformation {
-    pub fn get_module_id(&self, asset_ident: &AssetIdent) -> ModuleId {
-        self.module_id_map.get(asset_ident).cloned().expect(
-            "No module ID found for the given asset identifier. This is an internal Turbopack \
-             error. Please report it.",
-        )
+    pub async fn get_module_id(&self, asset_ident: Vc<AssetIdent>) -> Result<Vc<ModuleId>> {
+        let ident_str = asset_ident.to_string().await?;
+        let ident = asset_ident.await?;
+        let hashed_module_id = self.module_id_map.get(&ident);
+        if let Some(hashed_module_id) = hashed_module_id {
+            dbg!("Hashed module ID found");
+            return Ok(hashed_module_id.clone().cell());
+        }
+        dbg!("Hashed module ID not found", &ident_str);
+        return Ok(ModuleId::String(ident_str.clone_value()).cell());
     }
 }
 

--- a/crates/turbopack-core/src/chunk/mod.rs
+++ b/crates/turbopack-core/src/chunk/mod.rs
@@ -6,6 +6,7 @@ pub(crate) mod chunking_context;
 pub(crate) mod containment_tree;
 pub(crate) mod data;
 pub(crate) mod evaluate;
+pub mod global_information;
 pub mod optimize;
 
 use std::{

--- a/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/crates/turbopack-nodejs/src/chunking_context.rs
@@ -2,7 +2,7 @@ use std::iter::once;
 
 use anyhow::{bail, Context, Result};
 use tracing::Instrument;
-use turbo_tasks::{debug::ValueDebug, RcStr, Value, ValueToString, Vc};
+use turbo_tasks::{RcStr, Value, ValueToString, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     chunk::{
@@ -136,16 +136,6 @@ impl NodeJsChunkingContext {
 
 #[turbo_tasks::value_impl]
 impl NodeJsChunkingContext {
-    #[turbo_tasks::function]
-    async fn chunk_item_id_from_ident(
-        self: Vc<Self>,
-        ident: Vc<AssetIdent>,
-    ) -> Result<Vc<ModuleId>> {
-        let this = self.await?;
-        dbg!(this.global_information.dbg().await?);
-        Ok(ModuleId::String(ident.to_string().await?.clone_value()).cell())
-    }
-
     #[turbo_tasks::function]
     fn new(this: Value<NodeJsChunkingContext>) -> Vc<Self> {
         this.into_value().cell()
@@ -394,5 +384,10 @@ impl ChunkingContext for NodeJsChunkingContext {
         } else {
             self.chunk_item_id_from_ident(AsyncLoaderModule::asset_ident_for(module))
         })
+    }
+
+    #[turbo_tasks::function]
+    async fn global_information(self: Vc<Self>) -> Result<Vc<OptionGlobalInformation>> {
+        Ok(self.await?.global_information)
     }
 }

--- a/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/crates/turbopack-nodejs/src/chunking_context.rs
@@ -8,6 +8,7 @@ use turbopack_core::{
     chunk::{
         availability_info::AvailabilityInfo,
         chunk_group::{make_chunk_group, MakeChunkGroupResult},
+        global_information::OptionGlobalInformation,
         Chunk, ChunkGroupResult, ChunkItem, ChunkableModule, ChunkingContext,
         EntryChunkGroupResult, EvaluatableAssets, MinifyType, ModuleId,
     },
@@ -85,7 +86,7 @@ pub struct NodeJsChunkingContext {
     /// Whether to use manifest chunks for lazy compilation
     manifest_chunks: bool,
     /// Global information
-    global_information: Vc<Option<RcStr>>,
+    global_information: Vc<OptionGlobalInformation>,
 }
 
 impl NodeJsChunkingContext {
@@ -98,7 +99,7 @@ impl NodeJsChunkingContext {
         asset_root_path: Vc<FileSystemPath>,
         environment: Vc<Environment>,
         runtime_type: RuntimeType,
-        global_information: Vc<Option<RcStr>>,
+        global_information: Vc<OptionGlobalInformation>,
     ) -> NodeJsChunkingContextBuilder {
         NodeJsChunkingContextBuilder {
             chunking_context: NodeJsChunkingContext {

--- a/crates/turbopack-tests/tests/execution.rs
+++ b/crates/turbopack-tests/tests/execution.rs
@@ -322,6 +322,7 @@ async fn run_test(prepared_test: Vc<PreparedTest>) -> Result<Vc<RunTestResult>> 
         static_root_path,
         env,
         RuntimeType::Development,
+        Vc::cell(None),
     )
     .build();
 

--- a/crates/turbopack-tests/tests/snapshot.rs
+++ b/crates/turbopack-tests/tests/snapshot.rs
@@ -319,6 +319,7 @@ async fn run_test(resource: RcStr) -> Result<Vc<FileSystemPath>> {
                 static_root_path,
                 env,
                 options.runtime_type,
+                Vc::cell(None),
             )
             .build(),
         ),
@@ -331,6 +332,7 @@ async fn run_test(resource: RcStr) -> Result<Vc<FileSystemPath>> {
                 static_root_path,
                 env,
                 options.runtime_type,
+                Vc::cell(None),
             )
             .minify_type(options.minify_type)
             .build(),


### PR DESCRIPTION
This draft PR implements the module ID hashing global optimization.

A `GlobalInformation` struct is added, which is made available through the `ChunkingContext` trait. Constructing a new `GlobalInformation` takes a `Project` parameter, which gives the constructor access to global information.

Depends on vercel/next.js#68404.