### PR TITLE
docs(filters): Clarity for advanced patterns.

### DIFF
--- a/docs/repo-docs/reference/run.mdx
+++ b/docs/repo-docs/reference/run.mdx
@@ -186,7 +186,7 @@ For in-depth discussion and practical use cases of filtering, visit [the Running
 
 #### Advanced filtering examples
 
-You can combine multiple filters to further refine your targets. Multiple filters are combined as a **union**, meaning that the [Task Graph](/repo/docs/core-concepts/package-and-task-graph#task-graph) will include tasks that match any of the filters.
+You can combine multiple filters to further refine your targets. Multiple filters are combined as a union, with negated filters removing packages from the result of the union.
 
 ```bash title="Terminal"
 # Any packages in `apps` subdirectories that have changed since the last commit


### PR DESCRIPTION
### Description

Adding a bit of nuance to the advanced filtering patterns documentation. It's a union - but its a weird union.

Addresses #8552 
