### PR TITLE
chore: remove unused patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6613,8 +6613,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "pathfinder_simd"
-version = "0.5.3"
-source = "git+https://github.com/vercel/pathfinder?branch=rm-stdarch_arm_crc32#ddc0696d4c8b7d0f7af8de1a271c62aec016d45f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,7 +192,3 @@ webbrowser = "0.8.7"
 which = "4.4.0"
 unicode-segmentation = "1.10.1"
 unsize = "1.1.0"
-
-[patch.crates-io]
-# TODO: Use upstream when https://github.com/servo/pathfinder/pull/566 lands
-pathfinder_simd = { git = "https://github.com/vercel/pathfinder", branch = "rm-stdarch_arm_crc32" }


### PR DESCRIPTION
### Description

This patch was used by Turbopack so we can get rid of it in our `Cargo.toml` and no longer get a warning about it.

### Testing Instructions

`cargo build -p turbo` no longer produces: `warning: Patch `pathfinder_simd v0.5.3 (https://github.com/vercel/pathfinder?branch=rm-stdarch_arm_crc32#ddc0696d)` was not used in the crate graph.`