### PR TITLE
adds *.t.err to file associations

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,7 +9,8 @@
   "debug.javascript.unmapMissingSources": true,
   "files.associations": {
     "libturbo.h": "c",
-    "turbo.json": "jsonc"
+    "turbo.json": "jsonc",
+    "*.t.err": "cram"
   },
   "[cram]": {
     "editor.trimAutoWhitespace": false,


### PR DESCRIPTION
When you run integrations tests and there's an error it creates *.t.err files in the cram format.  With this file association added, now those files will be correctly associated and therefore get syntax highlighting and all that good stuff.