### PR TITLE
removes turbopack search exception

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,8 +17,5 @@
     "files.insertFinalNewline": false,
     "files.trimTrailingWhitespace": false
   },
-  "search.exclude": {
-    "crates/turbopack-tests/tests/snapshot/**": true
-  },
   "typescript.tsdk": "node_modules/typescript/lib"
 }


### PR DESCRIPTION
with turbopack being removed in https://github.com/vercel/turbo/pull/8906, we can also remove this from the vscode settings