### PR TITLE
removes gitattributes for turbopack files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,3 @@
 .config/ast-grep/rule-tests/__snapshots__/** linguist-generated=true
 crates/turbo-tasks-macros-tests/tests/**/*.stderr linguist-generated=true
-crates/turbopack-ecmascript/tests/tree-shaker/analyzer/**/output.md linguist-generated=true
-crates/turbopack-tests/tests/snapshot/**/output/** linguist-generated=true
 crates/turborepo-lockfiles/fixtures/*.lock text eol=lf


### PR DESCRIPTION
with turbopack being removed in https://github.com/vercel/turbo/pull/8906, we can also remove these gitattributes files