### PR TITLE
removes turbopack specific cargo commands

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -33,13 +33,7 @@ rustflags = [
 
 [alias]
 xtask = "run --package xtask --"
-tr-build = "build -p turbo"
-tr-run = "run -p turbo"
-tr-test = "groups test turborepo"
-tr-check = "groups check turborepo"
-# Builds all test code to check for compiler errors before running
-tp-pre-test = "nextest run --no-run --workspace --release --exclude turbo --exclude turborepo-* --exclude turbopath --exclude wax --exclude globwalk --exclude globwatch --exclude pidlock"
-tp-test = "nextest run --workspace --release --no-fail-fast --exclude turbo --exclude turborepo-* --exclude turbopath --exclude wax --exclude globwalk --exclude globwatch --exclude pidlock"
-tp-bench-test = "test --benches --workspace --release --no-fail-fast --exclude turbopack-bench --exclude turbo --exclude turborepo-* --exclude turbopath --exclude wax --exclude globwalk --exclude globwatch --exclude pidlock"
-tp-check = "check --workspace --exclude turbo --exclude turborepo-* --exclude turbopath --exclude wax --exclude globwalk --exclude globwatch --exclude pidlock"
-tp-clippy = "clippy --workspace --exclude turbo --exclude turborepo-* --exclude turbopath --exclude wax --exclude globwalk --exclude globwatch --exclude pidlock"
+build = "build -p turbo"
+run = "run -p turbo"
+test = "groups test turborepo"
+check = "groups check turborepo"


### PR DESCRIPTION
with turbopack being removed in #8906, we can now simplify the root cargo commands (and remove the old turbopack ones)