### PR TITLE
removes owned-by from bug report template now that turbopack is gone

### DIFF
--- a/.github/ISSUE_TEMPLATE/0-turborepo-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/0-turborepo-bug-report.yml
@@ -1,6 +1,6 @@
 name: Turborepo Bug Report
 description: Create a bug report for the Turborepo core team
-labels: ["kind: bug", "owned-by: turborepo", "needs: triage"]
+labels: ["kind: bug", "needs: triage"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
with turbopack being removed in #8906, we can also remove the owned-by label for bug reports.  also, with the merging of https://github.com/vercel/turbo/pull/8914 they won't really matter anymore anyway