### PR TITLE
chore(docs): improve visual appearance of badges in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,18 +9,10 @@
 </p>
 
 <p align="center">
-  <a aria-label="Vercel logo" href="https://vercel.com/">
-    <img src="https://img.shields.io/badge/MADE%20BY%20Vercel-000000.svg?style=for-the-badge&logo=Vercel&labelColor=000">
-  </a>
-  <a aria-label="NPM version" href="https://www.npmjs.com/package/turbo">
-    <img alt="" src="https://img.shields.io/npm/v/turbo.svg?style=for-the-badge&labelColor=000000">
-  </a>
-  <a aria-label="License" href="https://github.com/vercel/turbo/blob/main/LICENSE">
-    <img alt="" src="https://img.shields.io/npm/l/turbo.svg?style=for-the-badge&labelColor=000000&color=">
-  </a>
-  <a aria-label="Join the community on GitHub" href="https://github.com/vercel/turbo/discussions">
-    <img alt="" src="https://img.shields.io/badge/Join%20the%20community-blueviolet.svg?style=for-the-badge&logo=turborepo&labelColor=000000&logoWidth=20&logoColor=white">
-  </a>
+  <a aria-label="Vercel logo" href="https://vercel.com/"><img src="https://img.shields.io/badge/MADE%20BY%20Vercel-000000.svg?style=for-the-badge&logo=Vercel&labelColor=000"></a>
+  <a aria-label="NPM version" href="https://www.npmjs.com/package/turbo"><img alt="" src="https://img.shields.io/npm/v/turbo.svg?style=for-the-badge&labelColor=000000"></a>
+  <a aria-label="License" href="https://github.com/vercel/turbo/blob/main/LICENSE"><img alt="" src="https://img.shields.io/npm/l/turbo.svg?style=for-the-badge&labelColor=000000&color="></a>
+  <a aria-label="Join the community on GitHub" href="https://github.com/vercel/turbo/discussions"><img alt="" src="https://img.shields.io/badge/Join%20the%20community-blueviolet.svg?style=for-the-badge&logo=turborepo&labelColor=000000&logoWidth=20&logoColor=white"></a>
 </p>
 
 Turbo is a next-generation toolchain for frontend development, written in Rust. It consists of 3 major parts:


### PR DESCRIPTION
# Description
This Pull Request improves the visual appearance of the badges in the README.md file by removing unnecessary line breaks between the badge images, eliminating the unwanted blue link lines that previously appeared and resulting in a cleaner and more cohesive look.

## What
Removed unnecessary line breaks between badge images in the README.md file to eliminate the unwanted blue link lines and improve the overall visual presentation.

## Why
Previously, the badges were displayed with line breaks between them, causing blue link lines to appear, which disrupted the clean look of the badges. By removing these line breaks, the badges now appear without the blue link lines, providing a more cohesive and visually appealing README.

## How
Removed the line breaks between badge images in the README.md file.

x-ref: [New Default: Underlined Links for Improved Accessibility](https://github.blog/changelog/2023-10-18-new-default-underlined-links-for-improved-accessibility/)