### PR TITLE
remove / move unused or test crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1637,12 +1637,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
 name = "futures"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1818,7 +1812,7 @@ dependencies = [
  "path-slash",
  "rayon",
  "regex",
- "tempdir",
+ "tempfile",
  "test-case",
  "thiserror",
  "tracing",
@@ -3209,8 +3203,8 @@ version = "0.1.4"
 dependencies = [
  "libc",
  "log",
- "rand 0.8.5",
- "tempdir",
+ "rand",
+ "tempfile",
  "thiserror",
  "windows-sys 0.45.0",
 ]
@@ -3519,7 +3513,7 @@ checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
 dependencies = [
  "env_logger",
  "log",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -3543,26 +3537,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -3572,23 +3553,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
+ "rand_core",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -3643,15 +3609,6 @@ checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -3726,15 +3683,6 @@ name = "regex-syntax"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "reqwest"
@@ -4608,16 +4556,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempdir"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-dependencies = [
- "rand 0.4.6",
- "remove_dir_all",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4877,7 +4815,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
 dependencies = [
  "pin-project",
- "rand 0.8.5",
+ "rand",
  "tokio",
 ]
 
@@ -5012,7 +4950,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand",
  "slab",
  "tokio",
  "tokio-util",
@@ -5253,7 +5191,7 @@ dependencies = [
  "path-clean",
  "serde",
  "serde_json",
- "tempdir",
+ "tempfile",
  "test-case",
  "thiserror",
  "turborepo-unescape",
@@ -5518,7 +5456,7 @@ dependencies = [
  "pretty_assertions",
  "prost 0.12.3",
  "radix_trie",
- "rand 0.8.5",
+ "rand",
  "rayon",
  "regex",
  "reqwest",
@@ -5532,7 +5470,6 @@ dependencies = [
  "svix-ksuid",
  "sysinfo",
  "tabwriter",
- "tempdir",
  "tempfile",
  "test-case",
  "thiserror",
@@ -5789,7 +5726,7 @@ dependencies = [
  "itoa",
  "log",
  "quickcheck",
- "rand 0.8.5",
+ "rand",
  "ratatui",
  "serde",
  "serde_json",
@@ -5806,7 +5743,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.8.5",
+ "rand",
  "static_assertions",
 ]
 

--- a/crates/turborepo-api-client/Cargo.toml
+++ b/crates/turborepo-api-client/Cargo.toml
@@ -10,6 +10,7 @@ native-tls = ["reqwest/native-tls"]
 rustls-tls = ["reqwest/rustls-tls-native-roots"]
 
 [dev-dependencies]
+anyhow = { workspace = true }
 http = "0.2.9"
 httpmock = { workspace = true }
 port_scanner = { workspace = true }
@@ -20,7 +21,6 @@ turborepo-vercel-api-mock = { workspace = true }
 workspace = true
 
 [dependencies]
-anyhow = { workspace = true }
 bytes.workspace = true
 chrono = { workspace = true, features = ["serde"] }
 lazy_static = { workspace = true }

--- a/crates/turborepo-ci/Cargo.toml
+++ b/crates/turborepo-ci/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 
 [dependencies]
 chrono = { workspace = true }
-tracing = { workspace = true }
 
 [dev-dependencies]
 test-case = "3.1.0"
+tracing = { workspace = true }

--- a/crates/turborepo-env/Cargo.toml
+++ b/crates/turborepo-env/Cargo.toml
@@ -14,5 +14,7 @@ hex = { workspace = true }
 regex = { workspace = true }
 serde = { workspace = true }
 sha2 = { workspace = true }
-test-case = { workspace = true }
 thiserror = { workspace = true }
+
+[dev-dependencies]
+test-case = { workspace = true }

--- a/crates/turborepo-filewatch/Cargo.toml
+++ b/crates/turborepo-filewatch/Cargo.toml
@@ -18,7 +18,6 @@ radix_trie = { workspace = true }
 thiserror = "1.0.38"
 tokio = { workspace = true, features = ["full", "time"] }
 tracing = "0.1.37"
-tracing-test = "0.2.4"
 turbopath = { workspace = true }
 turborepo-repository = { version = "0.1.0", path = "../turborepo-repository" }
 turborepo-scm = { workspace = true }
@@ -39,6 +38,7 @@ version = "0.2.4"
 git2 = { version = "0.16.1", default-features = false }
 tempfile = { workspace = true }
 tokio-scoped = "0.2.0"
+tracing-test = "0.2.4"
 
 [features]
 default = ["macos_fsevent"]

--- a/crates/turborepo-globwalk/Cargo.toml
+++ b/crates/turborepo-globwalk/Cargo.toml
@@ -23,5 +23,5 @@ walkdir = "2.3.3"
 wax.workspace = true
 
 [dev-dependencies]
-tempdir = "0.3.7"
+tempfile = { workspace = true }
 test-case = "3.1.0"

--- a/crates/turborepo-globwalk/src/lib.rs
+++ b/crates/turborepo-globwalk/src/lib.rs
@@ -420,7 +420,7 @@ mod test {
     use std::{collections::HashSet, str::FromStr};
 
     use itertools::Itertools;
-    use tempdir::TempDir;
+    use tempfile::TempDir;
     use test_case::test_case;
     use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
 
@@ -531,8 +531,8 @@ mod test {
     }
 
     /// set up a globwalk test in a tempdir, returning the path to the tempdir
-    fn setup() -> tempdir::TempDir {
-        let tmp = tempdir::TempDir::new("globwalk").unwrap();
+    fn setup() -> tempfile::TempDir {
+        let tmp = tempfile::TempDir::with_prefix("globwalk").unwrap();
 
         let directories = ["a/b/c", "a/c", "abc", "axbxcxdxe/xxx", "axbxcxdxexxx", "b"];
 
@@ -1343,12 +1343,12 @@ mod test {
         // TODO: this test needs to be implemented...
     }
 
-    fn setup_files(files: &[&str]) -> tempdir::TempDir {
+    fn setup_files(files: &[&str]) -> tempfile::TempDir {
         setup_files_with_prefix("globwalk", files)
     }
 
-    fn setup_files_with_prefix(prefix: &str, files: &[&str]) -> tempdir::TempDir {
-        let tmp = tempdir::TempDir::new(prefix).unwrap();
+    fn setup_files_with_prefix(prefix: &str, files: &[&str]) -> tempfile::TempDir {
+        let tmp = tempfile::TempDir::with_prefix(prefix).unwrap();
         for file in files {
             let file = file.trim_start_matches('/');
             let path = tmp.path().join(file);
@@ -1493,7 +1493,7 @@ mod test {
     #[test_case("foo/", true, "foo/**" ; "dir slash")]
     #[test_case("f[o0]o", true, "f[o0]o" ; "non-literal")]
     fn test_add_double_star(glob: &str, is_dir: bool, expected: &str) {
-        let tmpdir = TempDir::new("doublestar").unwrap();
+        let tmpdir = TempDir::with_prefix("doublestar").unwrap();
         let base = AbsoluteSystemPath::new(tmpdir.path().to_str().unwrap()).unwrap();
 
         let foo = base.join_component("foo");

--- a/crates/turborepo-lib/Cargo.toml
+++ b/crates/turborepo-lib/Cargo.toml
@@ -22,7 +22,6 @@ async-stream = "0.3.4"
 itertools = { workspace = true }
 port_scanner = { workspace = true }
 pretty_assertions = { workspace = true }
-tempdir = "0.3.7"
 tempfile = { workspace = true }
 test-case = { workspace = true }
 tracing-test = { version = "0.2.4", features = ["no-env-filter"] }

--- a/crates/turborepo-lib/src/engine/builder.rs
+++ b/crates/turborepo-lib/src/engine/builder.rs
@@ -532,7 +532,7 @@ mod test {
 
     use pretty_assertions::assert_eq;
     use serde_json::json;
-    use tempdir::TempDir;
+    use tempfile::TempDir;
     use test_case::test_case;
     use turbopath::{AbsoluteSystemPathBuf, AnchoredSystemPath};
     use turborepo_lockfiles::Lockfile;
@@ -645,7 +645,7 @@ mod test {
 
     #[test]
     fn test_turbo_json_loading() {
-        let repo_root_dir = TempDir::new("repo").unwrap();
+        let repo_root_dir = TempDir::with_prefix("repo").unwrap();
         let repo_root = AbsoluteSystemPathBuf::new(repo_root_dir.path().to_str().unwrap()).unwrap();
         let package_graph = mock_package_graph(
             &repo_root,
@@ -695,7 +695,7 @@ mod test {
         task_id: &'static str,
         expected: bool,
     ) {
-        let repo_root_dir = TempDir::new("repo").unwrap();
+        let repo_root_dir = TempDir::with_prefix("repo").unwrap();
         let repo_root = AbsoluteSystemPathBuf::new(repo_root_dir.path().to_str().unwrap()).unwrap();
         let package_graph = mock_package_graph(
             &repo_root,
@@ -774,7 +774,7 @@ mod test {
 
     #[test]
     fn test_default_engine() {
-        let repo_root_dir = TempDir::new("repo").unwrap();
+        let repo_root_dir = TempDir::with_prefix("repo").unwrap();
         let repo_root = AbsoluteSystemPathBuf::new(repo_root_dir.path().to_str().unwrap()).unwrap();
         let package_graph = mock_package_graph(
             &repo_root,
@@ -824,7 +824,7 @@ mod test {
 
     #[test]
     fn test_dependencies_on_unspecified_packages() {
-        let repo_root_dir = TempDir::new("repo").unwrap();
+        let repo_root_dir = TempDir::with_prefix("repo").unwrap();
         let repo_root = AbsoluteSystemPathBuf::new(repo_root_dir.path().to_str().unwrap()).unwrap();
         // app1 -> libA
         //              \
@@ -873,7 +873,7 @@ mod test {
 
     #[test]
     fn test_run_package_task() {
-        let repo_root_dir = TempDir::new("repo").unwrap();
+        let repo_root_dir = TempDir::with_prefix("repo").unwrap();
         let repo_root = AbsoluteSystemPathBuf::new(repo_root_dir.path().to_str().unwrap()).unwrap();
         let package_graph = mock_package_graph(
             &repo_root,
@@ -910,7 +910,7 @@ mod test {
 
     #[test]
     fn test_include_root_tasks() {
-        let repo_root_dir = TempDir::new("repo").unwrap();
+        let repo_root_dir = TempDir::with_prefix("repo").unwrap();
         let repo_root = AbsoluteSystemPathBuf::new(repo_root_dir.path().to_str().unwrap()).unwrap();
         let package_graph = mock_package_graph(
             &repo_root,
@@ -963,7 +963,7 @@ mod test {
 
     #[test]
     fn test_depend_on_root_task() {
-        let repo_root_dir = TempDir::new("repo").unwrap();
+        let repo_root_dir = TempDir::with_prefix("repo").unwrap();
         let repo_root = AbsoluteSystemPathBuf::new(repo_root_dir.path().to_str().unwrap()).unwrap();
         let package_graph = mock_package_graph(
             &repo_root,
@@ -1007,7 +1007,7 @@ mod test {
 
     #[test]
     fn test_depend_on_missing_task() {
-        let repo_root_dir = TempDir::new("repo").unwrap();
+        let repo_root_dir = TempDir::with_prefix("repo").unwrap();
         let repo_root = AbsoluteSystemPathBuf::new(repo_root_dir.path().to_str().unwrap()).unwrap();
         let package_graph = mock_package_graph(
             &repo_root,
@@ -1040,7 +1040,7 @@ mod test {
 
     #[test]
     fn test_depend_on_multiple_package_tasks() {
-        let repo_root_dir = TempDir::new("repo").unwrap();
+        let repo_root_dir = TempDir::with_prefix("repo").unwrap();
         let repo_root = AbsoluteSystemPathBuf::new(repo_root_dir.path().to_str().unwrap()).unwrap();
         let package_graph = mock_package_graph(
             &repo_root,
@@ -1086,7 +1086,7 @@ mod test {
 
     #[test]
     fn test_depends_on_disabled_root_task() {
-        let repo_root_dir = TempDir::new("repo").unwrap();
+        let repo_root_dir = TempDir::with_prefix("repo").unwrap();
         let repo_root = AbsoluteSystemPathBuf::new(repo_root_dir.path().to_str().unwrap()).unwrap();
         let package_graph = mock_package_graph(
             &repo_root,
@@ -1124,7 +1124,7 @@ mod test {
 
     #[test]
     fn test_engine_tasks_only() {
-        let repo_root_dir = TempDir::new("repo").unwrap();
+        let repo_root_dir = TempDir::with_prefix("repo").unwrap();
         let repo_root = AbsoluteSystemPathBuf::new(repo_root_dir.path().to_str().unwrap()).unwrap();
         let package_graph = mock_package_graph(
             &repo_root,
@@ -1174,7 +1174,7 @@ mod test {
 
     #[test]
     fn test_engine_tasks_only_package_deps() {
-        let repo_root_dir = TempDir::new("repo").unwrap();
+        let repo_root_dir = TempDir::with_prefix("repo").unwrap();
         let repo_root = AbsoluteSystemPathBuf::new(repo_root_dir.path().to_str().unwrap()).unwrap();
         let package_graph = mock_package_graph(
             &repo_root,
@@ -1212,7 +1212,7 @@ mod test {
 
     #[test]
     fn test_engine_tasks_only_task_dep() {
-        let repo_root_dir = TempDir::new("repo").unwrap();
+        let repo_root_dir = TempDir::with_prefix("repo").unwrap();
         let repo_root = AbsoluteSystemPathBuf::new(repo_root_dir.path().to_str().unwrap()).unwrap();
         let package_graph = mock_package_graph(
             &repo_root,

--- a/crates/turborepo-lib/src/engine/mod.rs
+++ b/crates/turborepo-lib/src/engine/mod.rs
@@ -557,7 +557,7 @@ mod test {
 
     use std::collections::BTreeMap;
 
-    use tempdir::TempDir;
+    use tempfile::TempDir;
     use turbopath::AbsoluteSystemPath;
     use turborepo_repository::{
         discovery::{DiscoveryResponse, PackageDiscovery, WorkspaceData},
@@ -638,7 +638,7 @@ mod test {
         // set up a workspace with three packages, two of which have a persistent build
         // task. we expect concurrency limit 1 to fail, but 2 and 3 to pass.
 
-        let tmp = tempdir::TempDir::new("issue_4291").unwrap();
+        let tmp = tempfile::TempDir::with_prefix("issue_4291").unwrap();
 
         let mut engine = Engine::new();
 

--- a/crates/turborepo-paths/Cargo.toml
+++ b/crates/turborepo-paths/Cargo.toml
@@ -38,5 +38,5 @@ wax = { workspace = true }
 [dev-dependencies]
 anyhow = { workspace = true }
 serde_json = { workspace = true }
-tempdir = "0.3.7"
+tempfile = { workspace = true }
 test-case = { workspace = true }

--- a/crates/turborepo-paths/src/absolute_system_path.rs
+++ b/crates/turborepo-paths/src/absolute_system_path.rs
@@ -602,7 +602,7 @@ mod tests {
 
     #[test]
     fn test_read_non_existing_to_string() -> Result<()> {
-        let test_dir = tempdir::TempDir::new("read-existing")?;
+        let test_dir = tempfile::TempDir::with_prefix("read-existing")?;
         let test_path = test_dir.path().join("foo");
         let path = AbsoluteSystemPathBuf::new(test_path.to_str().unwrap())?;
         assert_eq!(path.read_existing_to_string()?, None);
@@ -611,7 +611,7 @@ mod tests {
 
     #[test]
     fn test_read_existing_to_string() -> Result<()> {
-        let test_dir = tempdir::TempDir::new("read-existing")?;
+        let test_dir = tempfile::TempDir::with_prefix("read-existing")?;
         let test_path = test_dir.path().join("foo");
         let path = AbsoluteSystemPathBuf::new(test_path.to_str().unwrap())?;
         path.create_with_contents("hi there!")?;
@@ -642,7 +642,7 @@ mod tests {
             mode: Option<Permissions>,
             expected: Permissions,
         ) -> Result<()> {
-            let test_dir = tempdir::TempDir::new("mkdir-all")?;
+            let test_dir = tempfile::TempDir::with_prefix("mkdir-all")?;
 
             let test_path = test_dir.path().join("foo");
 

--- a/crates/turborepo-pidlock/Cargo.toml
+++ b/crates/turborepo-pidlock/Cargo.toml
@@ -37,4 +37,4 @@ windows-sys = { version = "0.45.0", features = [
 
 [dev-dependencies]
 rand = "0.8.2"
-tempdir = "0.3.7"
+tempfile = { workspace = true }

--- a/crates/turborepo-pidlock/src/lib.rs
+++ b/crates/turborepo-pidlock/src/lib.rs
@@ -251,8 +251,8 @@ mod tests {
         unsafe { libc::getpid() as u32 }
     }
 
-    fn make_pid_path() -> (tempdir::TempDir, PathBuf) {
-        let tmp = tempdir::TempDir::new("pidlock").unwrap();
+    fn make_pid_path() -> (tempfile::TempDir, PathBuf) {
+        let tmp = tempfile::TempDir::with_prefix("pidlock").unwrap();
         let path = tmp.path().join("pidfile");
         (tmp, path)
     }


### PR DESCRIPTION
### Description

Flushing some old branches.

Tempdir is deprecated. Long live tempfile. Also did the liberty of running udeps and sorting some dev deps out. Saving entire grams of CO2.

### Testing Instructions

Existing tests cover. Split into two commits since tempdir is the majority here.
