### PR TITLE
fix(tui): allow for TUI use when hooked up to tty

### DIFF
--- a/crates/turborepo-lib/src/config.rs
+++ b/crates/turborepo-lib/src/config.rs
@@ -277,7 +277,8 @@ impl ConfigurationOptions {
     }
 
     pub fn ui(&self) -> UIMode {
-        if atty::is(atty::Stream::Stdout) {
+        // If we aren't hooked up to a TTY, then do not use TUI
+        if !atty::is(atty::Stream::Stdout) {
             return UIMode::Stream;
         }
 


### PR DESCRIPTION
### Description

https://github.com/vercel/turbo/pull/8919 accidentally disabled TUI usage when hooked up to a TTY

### Testing Instructions


Verify that you can now use the TUI if hooked up to TTY:

https://github.com/user-attachments/assets/1ae1d7db-4714-4abe-a1e6-13b4e564d006

