### PR TITLE
docs: Correct json comma syntax in sample code 

### DIFF
--- a/docs/repo-docs/crafting-your-repository/creating-an-internal-package.mdx
+++ b/docs/repo-docs/crafting-your-repository/creating-an-internal-package.mdx
@@ -84,12 +84,12 @@ Next, create the `package.json` for the package. By adding this file, you'll ful
   "exports": {
     "./add": {
       "types": "./src/add.ts",
-      "default": "./dist/add.js",
+      "default": "./dist/add.js"
     },
     "./subtract": {
       "types": "./src/subtract.ts",
-      "default": "./dist/subtract.js",
-    },
+      "default": "./dist/subtract.js"
+    }
   },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",

--- a/docs/repo-docs/crafting-your-repository/creating-an-internal-package.mdx
+++ b/docs/repo-docs/crafting-your-repository/creating-an-internal-package.mdx
@@ -110,12 +110,12 @@ Next, create the `package.json` for the package. By adding this file, you'll ful
   "exports": {
     "./add": {
       "types": "./src/add.ts",
-      "default": "./dist/add.js",
+      "default": "./dist/add.js"
     },
     "./subtract": {
       "types": "./src/subtract.ts",
-      "default": "./dist/subtract.js",
-    },
+      "default": "./dist/subtract.js"
+    }
   },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",


### PR DESCRIPTION
### Description

Correct comma json syntax in sample code in document at [Creating an Internal Package > Add a package.json section](https://turbo.build/repo/docs/crafting-your-repository/creating-an-internal-package#add-a-packagejson)

![sample-syntax-error](https://github.com/user-attachments/assets/6032d6e5-31b3-497a-9d42-d18fcba0d7a2)

### Testing Instructions

![sample-syntax-fix](https://github.com/user-attachments/assets/d1472451-172e-4af7-b3d7-4672890de66b)
