### PR TITLE
refactor: renamed UI to ColorConfig

### DIFF
--- a/crates/turborepo-auth/src/auth/login.rs
+++ b/crates/turborepo-auth/src/auth/login.rs
@@ -5,7 +5,7 @@ use reqwest::Url;
 use tokio::sync::OnceCell;
 use tracing::{debug, warn};
 use turborepo_api_client::{CacheClient, Client, TokenClient};
-use turborepo_ui::{start_spinner, BOLD, UI};
+use turborepo_ui::{start_spinner, ColorConfig, BOLD};
 
 use crate::{auth::extract_vercel_token, error, ui, LoginOptions, Token};
 
@@ -23,7 +23,7 @@ pub async fn login<T: Client + TokenClient + CacheClient>(
 ) -> Result<Token, Error> {
     let LoginOptions {
         api_client,
-        ui,
+        color_config,
         login_url: login_url_configuration,
         login_server,
         existing_token,
@@ -37,12 +37,12 @@ pub async fn login<T: Client + TokenClient + CacheClient>(
     //
     // In the future I want to make the Token have some non-skewable information and
     // be able to get rid of this, but it works for now.
-    let valid_token_callback = |message: &str, ui: &UI| {
+    let valid_token_callback = |message: &str, color_config: &ColorConfig| {
         let message = message.to_string();
-        let ui = *ui;
+        let color_config = *color_config;
         move |user_email: &str| {
-            println!("{}", ui.apply(BOLD.apply_to(message)));
-            ui::print_cli_authorized(user_email, &ui);
+            println!("{}", color_config.apply(BOLD.apply_to(message)));
+            ui::print_cli_authorized(user_email, &color_config);
         }
     };
 
@@ -54,7 +54,7 @@ pub async fn login<T: Client + TokenClient + CacheClient>(
             if token
                 .is_valid(
                     api_client,
-                    Some(valid_token_callback("Existing token found!", ui)),
+                    Some(valid_token_callback("Existing token found!", color_config)),
                 )
                 .await?
             {
@@ -70,7 +70,10 @@ pub async fn login<T: Client + TokenClient + CacheClient>(
                 if token
                     .is_valid(
                         api_client,
-                        Some(valid_token_callback("Existing Vercel token found!", ui)),
+                        Some(valid_token_callback(
+                            "Existing Vercel token found!",
+                            color_config,
+                        )),
                     )
                     .await?
                 {
@@ -132,7 +135,7 @@ pub async fn login<T: Client + TokenClient + CacheClient>(
         .await
         .map_err(Error::FailedToFetchUser)?;
 
-    ui::print_cli_authorized(&user_response.user.email, ui);
+    ui::print_cli_authorized(&user_response.user.email, color_config);
 
     Ok(Token::new(token.into()))
 }
@@ -362,7 +365,7 @@ mod tests {
     async fn test_login() {
         let port = port_scanner::request_open_port().unwrap();
         let api_server = tokio::spawn(start_test_server(port));
-        let ui = UI::new(false);
+        let color_config = ColorConfig::new(false);
         let url = format!("http://localhost:{port}");
 
         let api_client = MockApiClient::new();
@@ -370,7 +373,7 @@ mod tests {
         let login_server = MockLoginServer {
             hits: Arc::new(0.into()),
         };
-        let mut options = LoginOptions::new(&ui, &url, &api_client, &login_server);
+        let mut options = LoginOptions::new(&color_config, &url, &api_client, &login_server);
 
         let token = login(&options).await.unwrap();
         assert_matches!(token, Token::New(..));

--- a/crates/turborepo-auth/src/auth/logout.rs
+++ b/crates/turborepo-auth/src/auth/logout.rs
@@ -15,7 +15,7 @@ pub async fn logout<T: TokenClient>(options: &LogoutOptions<T>) -> Result<(), Er
         return Err(err);
     }
 
-    cprintln!(options.ui, GREY, ">>> Logged out");
+    cprintln!(options.color_config, GREY, ">>> Logged out");
     Ok(())
 }
 
@@ -171,7 +171,7 @@ mod tests {
             .expect("could not create file");
 
         let logout_options = LogoutOptions {
-            ui: ColorConfig::new(false),
+            color_config: ColorConfig::new(false),
             api_client: MockApiClient {
                 succeed_delete_request: true,
             },
@@ -199,7 +199,7 @@ mod tests {
         };
 
         let options = LogoutOptions {
-            ui: ColorConfig::new(false),
+            color_config: ColorConfig::new(false),
             api_client,
             path: Some(path.clone()),
             invalidate: true,

--- a/crates/turborepo-auth/src/auth/logout.rs
+++ b/crates/turborepo-auth/src/auth/logout.rs
@@ -86,7 +86,7 @@ mod tests {
     use tempfile::tempdir;
     use turbopath::AbsoluteSystemPathBuf;
     use turborepo_api_client::Client;
-    use turborepo_ui::UI;
+    use turborepo_ui::ColorConfig;
     use turborepo_vercel_api::{
         token::ResponseTokenMetadata, SpacesResponse, Team, TeamsResponse, UserResponse,
         VerifiedSsoUser,
@@ -171,7 +171,7 @@ mod tests {
             .expect("could not create file");
 
         let logout_options = LogoutOptions {
-            ui: UI::new(false),
+            ui: ColorConfig::new(false),
             api_client: MockApiClient {
                 succeed_delete_request: true,
             },
@@ -199,7 +199,7 @@ mod tests {
         };
 
         let options = LogoutOptions {
-            ui: UI::new(false),
+            ui: ColorConfig::new(false),
             api_client,
             path: Some(path.clone()),
             invalidate: true,

--- a/crates/turborepo-auth/src/auth/mod.rs
+++ b/crates/turborepo-auth/src/auth/mod.rs
@@ -8,7 +8,7 @@ pub use sso::*;
 #[cfg(test)]
 use turbopath::AbsoluteSystemPathBuf;
 use turborepo_api_client::{CacheClient, Client, TokenClient};
-use turborepo_ui::UI;
+use turborepo_ui::ColorConfig;
 
 use crate::LoginServer;
 
@@ -16,7 +16,7 @@ const VERCEL_TOKEN_DIR: &str = "com.vercel.cli";
 const VERCEL_TOKEN_FILE: &str = "auth.json";
 
 pub struct LoginOptions<'a, T: Client + TokenClient + CacheClient> {
-    pub ui: &'a UI,
+    pub color_config: &'a ColorConfig,
     pub login_url: &'a str,
     pub api_client: &'a T,
     pub login_server: &'a dyn LoginServer,
@@ -27,13 +27,13 @@ pub struct LoginOptions<'a, T: Client + TokenClient + CacheClient> {
 }
 impl<'a, T: Client + TokenClient + CacheClient> LoginOptions<'a, T> {
     pub fn new(
-        ui: &'a UI,
+        ui: &'a ColorConfig,
         login_url: &'a str,
         api_client: &'a T,
         login_server: &'a dyn LoginServer,
     ) -> Self {
         Self {
-            ui,
+            color_config: ui,
             login_url,
             api_client,
             login_server,
@@ -46,7 +46,7 @@ impl<'a, T: Client + TokenClient + CacheClient> LoginOptions<'a, T> {
 
 /// Options for logging out.
 pub struct LogoutOptions<T> {
-    pub ui: UI,
+    pub ui: ColorConfig,
     pub api_client: T,
     /// If we should invalidate the token on the server.
     pub invalidate: bool,

--- a/crates/turborepo-auth/src/auth/mod.rs
+++ b/crates/turborepo-auth/src/auth/mod.rs
@@ -27,13 +27,13 @@ pub struct LoginOptions<'a, T: Client + TokenClient + CacheClient> {
 }
 impl<'a, T: Client + TokenClient + CacheClient> LoginOptions<'a, T> {
     pub fn new(
-        ui: &'a ColorConfig,
+        color_config: &'a ColorConfig,
         login_url: &'a str,
         api_client: &'a T,
         login_server: &'a dyn LoginServer,
     ) -> Self {
         Self {
-            color_config: ui,
+            color_config,
             login_url,
             api_client,
             login_server,
@@ -46,7 +46,7 @@ impl<'a, T: Client + TokenClient + CacheClient> LoginOptions<'a, T> {
 
 /// Options for logging out.
 pub struct LogoutOptions<T> {
-    pub ui: ColorConfig,
+    pub color_config: ColorConfig,
     pub api_client: T,
     /// If we should invalidate the token on the server.
     pub invalidate: bool,

--- a/crates/turborepo-auth/src/ui/messages.rs
+++ b/crates/turborepo-auth/src/ui/messages.rs
@@ -1,17 +1,17 @@
 use turborepo_ui::{ColorConfig, BOLD, CYAN};
 
-pub fn print_cli_authorized(user: &str, ui: &ColorConfig) {
+pub fn print_cli_authorized(user: &str, color_config: &ColorConfig) {
     println!(
         "
 {} Turborepo CLI authorized for {}
 {}
 {}
 ",
-        ui.rainbow(">>> Success!"),
+        color_config.rainbow(">>> Success!"),
         user,
-        ui.apply(
+        color_config.apply(
             CYAN.apply_to("To connect to your Remote Cache, run the following in any turborepo:")
         ),
-        ui.apply(BOLD.apply_to("  npx turbo link"))
+        color_config.apply(BOLD.apply_to("  npx turbo link"))
     );
 }

--- a/crates/turborepo-auth/src/ui/messages.rs
+++ b/crates/turborepo-auth/src/ui/messages.rs
@@ -1,6 +1,6 @@
-use turborepo_ui::{BOLD, CYAN, UI};
+use turborepo_ui::{ColorConfig, BOLD, CYAN};
 
-pub fn print_cli_authorized(user: &str, ui: &UI) {
+pub fn print_cli_authorized(user: &str, ui: &ColorConfig) {
     println!(
         "
 {} Turborepo CLI authorized for {}

--- a/crates/turborepo-lib/src/cli/error.rs
+++ b/crates/turborepo-lib/src/cli/error.rs
@@ -68,7 +68,7 @@ pub async fn print_potential_tasks(
 ) -> Result<(), Error> {
     let signal = get_signal()?;
     let handler = SignalHandler::new(signal);
-    let ui = base.ui;
+    let color_config = base.color_config;
 
     let run_builder = RunBuilder::new(base)?;
     let run = run_builder.build(&handler, telemetry).await?;

--- a/crates/turborepo-lib/src/cli/error.rs
+++ b/crates/turborepo-lib/src/cli/error.rs
@@ -80,7 +80,7 @@ pub async fn print_potential_tasks(
         .into_iter()
         .sorted_by(|(_, a), (_, b)| b.len().cmp(&a.len()))
     {
-        let task = color!(ui, BOLD, "{}", task);
+        let task = color!(color_config, BOLD, "{}", task);
         let mut line_length = 0;
 
         let mut packages_str = String::with_capacity(MAX_CHARS_PER_TASK_LINE);
@@ -100,7 +100,7 @@ pub async fn print_potential_tasks(
             packages_str.push_str(package);
         }
 
-        let packages = color!(ui, GREY, "{}", packages_str);
+        let packages = color!(color_config, GREY, "{}", packages_str);
 
         println!("  {}\n    {}", task, packages)
     }

--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -17,7 +17,7 @@ use turborepo_telemetry::{
     events::{command::CommandEventBuilder, generic::GenericEventBuilder, EventBuilder, EventType},
     init_telemetry, track_usage, TelemetryHandle,
 };
-use turborepo_ui::{GREY, UI};
+use turborepo_ui::{ColorConfig, GREY};
 
 use crate::{
     cli::error::print_potential_tasks,
@@ -962,14 +962,15 @@ impl Display for LogPrefix {
 /// local turbo, such as in the case where `TURBO_BINARY_PATH` is set,
 /// we use it here to modify clap's arguments.
 /// * `logger`: The logger to use for the run.
-/// * `ui`: The UI to use for the run.
+/// * `color_config`: The color configuration to use for the run, i.e. whether
+///   we should colorize output.
 ///
 /// returns: Result<Payload, Error>
 #[tokio::main]
 pub async fn run(
     repo_state: Option<RepoState>,
     #[allow(unused_variables)] logger: &TurboSubscriber,
-    ui: UI,
+    color_config: ColorConfig,
 ) -> Result<i32, Error> {
     // TODO: remove mutability from this function
     let mut cli_args = Args::new();
@@ -981,7 +982,7 @@ pub async fn run(
     // initialize telemetry
     match AnonAPIClient::new("https://telemetry.vercel.com", 250, version) {
         Ok(anonymous_api_client) => {
-            let handle = init_telemetry(anonymous_api_client, ui);
+            let handle = init_telemetry(anonymous_api_client, color_config);
             match handle {
                 Ok(h) => telemetry_handle = Some(h),
                 Err(error) => {
@@ -1105,7 +1106,7 @@ pub async fn run(
             CommandEventBuilder::new("daemon")
                 .with_parent(&root_telemetry)
                 .track_call();
-            let base = CommandBase::new(cli_args.clone(), repo_root, version, ui);
+            let base = CommandBase::new(cli_args.clone(), repo_root, version, color_config);
 
             match command {
                 Some(command) => daemon::daemon_client(command, &base).await,
@@ -1138,13 +1139,13 @@ pub async fn run(
         Command::Telemetry { command } => {
             let event = CommandEventBuilder::new("telemetry").with_parent(&root_telemetry);
             event.track_call();
-            let mut base = CommandBase::new(cli_args.clone(), repo_root, version, ui);
+            let mut base = CommandBase::new(cli_args.clone(), repo_root, version, color_config);
             let child_event = event.child();
             telemetry::configure(command, &mut base, child_event);
             Ok(0)
         }
         Command::Scan {} => {
-            let base = CommandBase::new(cli_args.clone(), repo_root, version, ui);
+            let base = CommandBase::new(cli_args.clone(), repo_root, version, color_config);
             if scan::run(base).await {
                 Ok(0)
             } else {
@@ -1152,7 +1153,7 @@ pub async fn run(
             }
         }
         Command::Config => {
-            let base = CommandBase::new(cli_args.clone(), repo_root, version, ui);
+            let base = CommandBase::new(cli_args.clone(), repo_root, version, color_config);
             config::run(base).await?;
             Ok(0)
         }
@@ -1163,7 +1164,7 @@ pub async fn run(
             event.track_call();
             let filter = filter.clone();
             let packages = packages.clone();
-            let base = CommandBase::new(cli_args, repo_root, version, ui);
+            let base = CommandBase::new(cli_args, repo_root, version, color_config);
             ls::run(base, packages, event, filter).await?;
 
             Ok(0)
@@ -1182,7 +1183,7 @@ pub async fn run(
 
             let modify_gitignore = !*no_gitignore;
             let to = *target;
-            let mut base = CommandBase::new(cli_args, repo_root, version, ui);
+            let mut base = CommandBase::new(cli_args, repo_root, version, color_config);
 
             if let Err(err) = link::link(&mut base, modify_gitignore, to).await {
                 error!("error: {}", err.to_string())
@@ -1195,7 +1196,7 @@ pub async fn run(
             event.track_call();
             let invalidate = *invalidate;
 
-            let mut base = CommandBase::new(cli_args, repo_root, version, ui);
+            let mut base = CommandBase::new(cli_args, repo_root, version, color_config);
             let event_child = event.child();
 
             logout::logout(&mut base, invalidate, event_child).await?;
@@ -1213,7 +1214,7 @@ pub async fn run(
             let sso_team = sso_team.clone();
             let force = *force;
 
-            let mut base = CommandBase::new(cli_args, repo_root, version, ui);
+            let mut base = CommandBase::new(cli_args, repo_root, version, color_config);
             let event_child = event.child();
 
             if let Some(sso_team) = sso_team {
@@ -1234,7 +1235,7 @@ pub async fn run(
             }
 
             let from = *target;
-            let mut base = CommandBase::new(cli_args, repo_root, version, ui);
+            let mut base = CommandBase::new(cli_args, repo_root, version, color_config);
 
             unlink::unlink(&mut base, from)?;
 
@@ -1247,7 +1248,7 @@ pub async fn run(
             let event = CommandEventBuilder::new("run").with_parent(&root_telemetry);
             event.track_call();
 
-            let base = CommandBase::new(cli_args.clone(), repo_root, version, ui);
+            let base = CommandBase::new(cli_args.clone(), repo_root, version, color_config);
 
             if execution_args.tasks.is_empty() {
                 print_potential_tasks(base, event).await?;
@@ -1270,7 +1271,7 @@ pub async fn run(
         Command::Watch(_) => {
             let event = CommandEventBuilder::new("watch").with_parent(&root_telemetry);
             event.track_call();
-            let base = CommandBase::new(cli_args, repo_root, version, ui);
+            let base = CommandBase::new(cli_args, repo_root, version, color_config);
 
             let mut client = WatchClient::new(base, event).await?;
             client.start().await?;
@@ -1292,7 +1293,7 @@ pub async fn run(
                 .unwrap_or_default();
             let docker = *docker;
             let output_dir = output_dir.clone();
-            let base = CommandBase::new(cli_args, repo_root, version, ui);
+            let base = CommandBase::new(cli_args, repo_root, version, color_config);
             let event_child = event.child();
             prune::prune(&base, &scope, docker, &output_dir, event_child).await?;
             Ok(0)

--- a/crates/turborepo-lib/src/commands/daemon.rs
+++ b/crates/turborepo-lib/src/commands/daemon.rs
@@ -50,19 +50,28 @@ pub async fn daemon_client(command: &DaemonCommand, base: &CommandBase) -> Resul
                 let _ = connector.connect().await?;
             }
 
-            println!("{} restarted daemon", color!(base.ui, BOLD_GREEN, "✓"));
+            println!(
+                "{} restarted daemon",
+                color!(base.color_config, BOLD_GREEN, "✓")
+            );
         }
         DaemonCommand::Start => {
             // We don't care about the client, but we do care that we can connect
             // which ensures that daemon is started if it wasn't already.
             let _ = connector.connect().await?;
-            println!("{} daemon is running", color!(base.ui, BOLD_GREEN, "✓"));
+            println!(
+                "{} daemon is running",
+                color!(base.color_config, BOLD_GREEN, "✓")
+            );
         }
         DaemonCommand::Stop => {
             let client = match connector.connect().await {
                 Ok(client) => client,
                 Err(DaemonConnectorError::NotRunning) => {
-                    println!("{} stopped daemon", color!(base.ui, BOLD_GREEN, "✓"));
+                    println!(
+                        "{} stopped daemon",
+                        color!(base.color_config, BOLD_GREEN, "✓")
+                    );
                     return Ok(());
                 }
                 Err(e) => {
@@ -70,7 +79,10 @@ pub async fn daemon_client(command: &DaemonCommand, base: &CommandBase) -> Resul
                 }
             };
             client.stop().await?;
-            println!("{} stopped daemon", color!(base.ui, BOLD_GREEN, "✓"));
+            println!(
+                "{} stopped daemon",
+                color!(base.color_config, BOLD_GREEN, "✓")
+            );
         }
         DaemonCommand::Status { json } => {
             let mut client = match connector.connect().await {
@@ -82,7 +94,7 @@ pub async fn daemon_client(command: &DaemonCommand, base: &CommandBase) -> Resul
                 Err(DaemonConnectorError::NotRunning) => {
                     println!(
                         "{} {}",
-                        color!(base.ui, BOLD_RED, "x"),
+                        color!(base.color_config, BOLD_RED, "x"),
                         DAEMON_NOT_RUNNING_MESSAGE
                     );
                     return Ok(());
@@ -104,21 +116,30 @@ pub async fn daemon_client(command: &DaemonCommand, base: &CommandBase) -> Resul
             if *json {
                 println!("{}", serde_json::to_string_pretty(&status)?);
             } else {
-                println!("{} daemon is running", color!(base.ui, BOLD_GREEN, "✓"));
-                println!("log file: {}", color!(base.ui, GREY, "{}", status.log_file));
+                println!(
+                    "{} daemon is running",
+                    color!(base.color_config, BOLD_GREEN, "✓")
+                );
+                println!(
+                    "log file: {}",
+                    color!(base.color_config, GREY, "{}", status.log_file)
+                );
                 println!(
                     "uptime: {}",
                     color!(
-                        base.ui,
+                        base.color_config,
                         GREY,
                         "{}s",
                         humantime::format_duration(Duration::from_millis(status.uptime_ms))
                     )
                 );
-                println!("pid file: {}", color!(base.ui, GREY, "{}", status.pid_file));
+                println!(
+                    "pid file: {}",
+                    color!(base.color_config, GREY, "{}", status.pid_file)
+                );
                 println!(
                     "socket file: {}",
-                    color!(base.ui, GREY, "{}", status.sock_file)
+                    color!(base.color_config, GREY, "{}", status.sock_file)
                 );
             }
         }

--- a/crates/turborepo-lib/src/commands/link.rs
+++ b/crates/turborepo-lib/src/commands/link.rs
@@ -171,14 +171,14 @@ pub async fn link(
     let repo_root_with_tilde = base.repo_root.to_string().replacen(&*homedir, "~", 1);
     let api_client = base.api_client()?;
     let token = base.config()?.token().ok_or_else(|| Error::TokenNotFound {
-        command: base.ui.apply(BOLD.apply_to("`npx turbo login`")),
+        command: base.color_config.apply(BOLD.apply_to("`npx turbo login`")),
     })?;
 
     match target {
         LinkTarget::RemoteCache => {
             println!(
                 "\n{}\n\n{}\n\nFor more information, visit: {}\n",
-                base.ui.rainbow(">>> Remote Caching"),
+                base.color_config.rainbow(">>> Remote Caching"),
                 REMOTE_CACHING_INFO,
                 REMOTE_CACHING_URL
             );
@@ -264,8 +264,8 @@ pub async fn link(
 
     {}
         ",
-                base.ui.rainbow(">>> Success!"),
-                base.ui.apply(BOLD.apply_to(chosen_team_name)),
+                base.color_config.rainbow(">>> Success!"),
+                base.color_config.apply(BOLD.apply_to(chosen_team_name)),
                 GREY.apply_to("To disable Remote Caching, run `npx turbo unlink`")
             );
             Ok(())
@@ -349,9 +349,10 @@ pub async fn link(
 
     {}
         ",
-                base.ui.rainbow(">>> Success!"),
-                base.ui.apply(BOLD.apply_to(&repo_root_with_tilde)),
-                base.ui.apply(BOLD.apply_to(&space.name)),
+                base.color_config.rainbow(">>> Success!"),
+                base.color_config
+                    .apply(BOLD.apply_to(&repo_root_with_tilde)),
+                base.color_config.apply(BOLD.apply_to(&space.name)),
                 GREY.apply_to(
                     "To remove Spaces integration, run `npx turbo unlink --target spaces`"
                 )
@@ -399,10 +400,10 @@ fn select_team<'a>(base: &CommandBase, teams: &'a [Team]) -> Result<SelectedTeam
 
     let prompt = format!(
         "{}\n  {}",
-        base.ui.apply(BOLD.apply_to(
+        base.color_config.apply(BOLD.apply_to(
             "Which Vercel scope (and Remote Cache) do you want associated with this Turborepo?",
         )),
-        base.ui
+        base.color_config
             .apply(CYAN.apply_to("[Use arrows to move, type to filter]"))
     );
 
@@ -440,10 +441,10 @@ fn select_space<'a>(base: &CommandBase, spaces: &'a [Space]) -> Result<SelectedS
 
     let prompt = format!(
         "{}\n  {}",
-        base.ui.apply(
+        base.color_config.apply(
             BOLD.apply_to("Which Vercel space do you want associated with this Turborepo?",)
         ),
-        base.ui
+        base.color_config
             .apply(CYAN.apply_to("[Use arrows to move, type to filter]"))
     );
 
@@ -466,11 +467,12 @@ fn should_link_remote_cache(_: &CommandBase, _: &str) -> Result<bool, Error> {
 fn should_link_remote_cache(base: &CommandBase, location: &str) -> Result<bool, Error> {
     let prompt = format!(
         "{}{} {}{}",
-        base.ui.apply(BOLD.apply_to(GREY.apply_to("? "))),
-        base.ui
+        base.color_config.apply(BOLD.apply_to(GREY.apply_to("? "))),
+        base.color_config
             .apply(BOLD.apply_to("Enable Vercel Remote Cache for")),
-        base.ui.apply(BOLD.apply_to(CYAN.apply_to(location))),
-        base.ui.apply(BOLD.apply_to(" ?"))
+        base.color_config
+            .apply(BOLD.apply_to(CYAN.apply_to(location))),
+        base.color_config.apply(BOLD.apply_to(" ?"))
     );
 
     Confirm::new()
@@ -488,10 +490,12 @@ fn should_link_spaces(_: &CommandBase, _: &str) -> Result<bool, Error> {
 fn should_link_spaces(base: &CommandBase, location: &str) -> Result<bool, Error> {
     let prompt = format!(
         "{}{} {} {}",
-        base.ui.apply(BOLD.apply_to(GREY.apply_to("? "))),
-        base.ui.apply(BOLD.apply_to("Would you like to link")),
-        base.ui.apply(BOLD.apply_to(CYAN.apply_to(location))),
-        base.ui.apply(BOLD.apply_to("to Vercel Spaces")),
+        base.color_config.apply(BOLD.apply_to(GREY.apply_to("? "))),
+        base.color_config
+            .apply(BOLD.apply_to("Would you like to link")),
+        base.color_config
+            .apply(BOLD.apply_to(CYAN.apply_to(location))),
+        base.color_config.apply(BOLD.apply_to("to Vercel Spaces")),
     );
 
     Confirm::new()
@@ -566,7 +570,7 @@ mod test {
     use anyhow::Result;
     use tempfile::{NamedTempFile, TempDir};
     use turbopath::{AbsoluteSystemPathBuf, AnchoredSystemPath};
-    use turborepo_ui::UI;
+    use turborepo_ui::ColorConfig;
     use turborepo_vercel_api_mock::start_test_server;
 
     use crate::{
@@ -609,7 +613,7 @@ mod test {
                 AbsoluteSystemPathBuf::try_from(user_config_file.path().to_path_buf()).unwrap(),
             ),
             repo_root: repo_root.clone(),
-            ui: UI::new(false),
+            color_config: ColorConfig::new(false),
             config: OnceCell::new(),
             args: Args::default(),
             version: "",
@@ -675,7 +679,7 @@ mod test {
                 AbsoluteSystemPathBuf::try_from(user_config_file.path().to_path_buf()).unwrap(),
             ),
             repo_root: repo_root.clone(),
-            ui: UI::new(false),
+            color_config: ColorConfig::new(false),
             config: OnceCell::new(),
             args: Args::default(),
             version: "",

--- a/crates/turborepo-lib/src/commands/login.rs
+++ b/crates/turborepo-lib/src/commands/login.rs
@@ -14,13 +14,18 @@ pub async fn sso_login(
 ) -> Result<(), Error> {
     telemetry.track_login_method(LoginMethod::SSO);
     let api_client: APIClient = base.api_client()?;
-    let ui = base.ui;
+    let color_config = base.color_config;
     let login_url_config = base.config()?.login_url().to_string();
     let options = LoginOptions {
         existing_token: base.config()?.token(),
         sso_team: Some(sso_team),
         force,
-        ..LoginOptions::new(&ui, &login_url_config, &api_client, &DefaultLoginServer)
+        ..LoginOptions::new(
+            &color_config,
+            &login_url_config,
+            &api_client,
+            &DefaultLoginServer,
+        )
     };
 
     let token = auth_sso_login(&options).await?;
@@ -65,12 +70,17 @@ pub async fn login(
     let mut login_telemetry = LoginTelemetry::new(&telemetry, LoginMethod::Standard);
 
     let api_client: APIClient = base.api_client()?;
-    let ui = base.ui;
+    let color_config = base.color_config;
     let login_url_config = base.config()?.login_url().to_string();
     let options = LoginOptions {
         existing_token: base.config()?.token(),
         force,
-        ..LoginOptions::new(&ui, &login_url_config, &api_client, &DefaultLoginServer)
+        ..LoginOptions::new(
+            &color_config,
+            &login_url_config,
+            &api_client,
+            &DefaultLoginServer,
+        )
     };
 
     let token = auth_login(&options).await?;

--- a/crates/turborepo-lib/src/commands/logout.rs
+++ b/crates/turborepo-lib/src/commands/logout.rs
@@ -9,7 +9,7 @@ pub async fn logout(
     _telemetry: CommandEventBuilder,
 ) -> Result<(), Error> {
     auth_logout(&LogoutOptions {
-        ui: base.color_config,
+        color_config: base.color_config,
         api_client: base.api_client()?,
         invalidate,
     })

--- a/crates/turborepo-lib/src/commands/logout.rs
+++ b/crates/turborepo-lib/src/commands/logout.rs
@@ -9,7 +9,7 @@ pub async fn logout(
     _telemetry: CommandEventBuilder,
 ) -> Result<(), Error> {
     auth_logout(&LogoutOptions {
-        ui: base.ui,
+        ui: base.color_config,
         api_client: base.api_client()?,
         invalidate,
     })

--- a/crates/turborepo-lib/src/commands/ls.rs
+++ b/crates/turborepo-lib/src/commands/ls.rs
@@ -25,13 +25,13 @@ pub enum Error {
 }
 
 struct RepositoryDetails<'a> {
-    ui: ColorConfig,
+    color_config: ColorConfig,
     package_manager: &'a PackageManager,
     packages: Vec<(&'a PackageName, &'a AnchoredSystemPath)>,
 }
 
 struct PackageDetails<'a> {
-    ui: ColorConfig,
+    color_config: ColorConfig,
     name: &'a str,
     tasks: Vec<(&'a str, &'a str)>,
     dependencies: Vec<&'a str>,
@@ -89,16 +89,21 @@ impl<'a> RepositoryDetails<'a> {
         packages.sort_by(|a, b| a.0.cmp(b.0));
 
         Self {
-            ui: color_config,
+            color_config,
             package_manager: package_graph.package_manager(),
             packages,
         }
     }
     fn print(&self) -> Result<(), cli::Error> {
         if self.packages.len() == 1 {
-            cprintln!(self.ui, BOLD, "{} package\n", self.packages.len());
+            cprintln!(self.color_config, BOLD, "{} package\n", self.packages.len());
         } else {
-            cprintln!(self.ui, BOLD, "{} packages\n", self.packages.len());
+            cprintln!(
+                self.color_config,
+                BOLD,
+                "{} packages\n",
+                self.packages.len()
+            );
         }
 
         for (package_name, entry) in &self.packages {
@@ -140,7 +145,7 @@ impl<'a> PackageDetails<'a> {
         package_dep_names.sort();
 
         Ok(Self {
-            ui: color_config,
+            color_config,
             name: package,
             dependencies: package_dep_names,
             tasks: package_json
@@ -152,8 +157,8 @@ impl<'a> PackageDetails<'a> {
     }
 
     fn print(&self) {
-        let name = color!(self.ui, BOLD_GREEN, "{}", self.name);
-        let depends_on = color!(self.ui, BOLD, "depends on");
+        let name = color!(self.color_config, BOLD_GREEN, "{}", self.name);
+        let depends_on = color!(self.color_config, BOLD, "depends on");
         let dependencies = if self.dependencies.is_empty() {
             "<no packages>".to_string()
         } else {
@@ -163,18 +168,22 @@ impl<'a> PackageDetails<'a> {
             "{} {}: {}",
             name,
             depends_on,
-            color!(self.ui, GREY, "{}", dependencies)
+            color!(self.color_config, GREY, "{}", dependencies)
         );
         println!();
 
-        cprint!(self.ui, BOLD, "tasks:");
+        cprint!(self.color_config, BOLD, "tasks:");
         if self.tasks.is_empty() {
             println!(" <no tasks>");
         } else {
             println!();
         }
         for (name, command) in &self.tasks {
-            println!("  {}: {}", name, color!(self.ui, GREY, "{}", command));
+            println!(
+                "  {}: {}",
+                name,
+                color!(self.color_config, GREY, "{}", command)
+            );
         }
         println!();
     }

--- a/crates/turborepo-lib/src/commands/ls.rs
+++ b/crates/turborepo-lib/src/commands/ls.rs
@@ -8,7 +8,7 @@ use turborepo_repository::{
     package_manager::PackageManager,
 };
 use turborepo_telemetry::events::command::CommandEventBuilder;
-use turborepo_ui::{color, cprint, cprintln, BOLD, BOLD_GREEN, GREY, UI};
+use turborepo_ui::{color, cprint, cprintln, ColorConfig, BOLD, BOLD_GREEN, GREY};
 
 use crate::{
     cli,
@@ -25,13 +25,13 @@ pub enum Error {
 }
 
 struct RepositoryDetails<'a> {
-    ui: UI,
+    ui: ColorConfig,
     package_manager: &'a PackageManager,
     packages: Vec<(&'a PackageName, &'a AnchoredSystemPath)>,
 }
 
 struct PackageDetails<'a> {
-    ui: UI,
+    ui: ColorConfig,
     name: &'a str,
     tasks: Vec<(&'a str, &'a str)>,
     dependencies: Vec<&'a str>,
@@ -72,7 +72,7 @@ pub async fn run(
 
 impl<'a> RepositoryDetails<'a> {
     fn new(run: &'a Run) -> Self {
-        let ui = run.ui();
+        let color_config = run.color_config();
         let package_graph = run.pkg_dep_graph();
         let filtered_pkgs = run.filtered_pkgs();
 
@@ -89,7 +89,7 @@ impl<'a> RepositoryDetails<'a> {
         packages.sort_by(|a, b| a.0.cmp(b.0));
 
         Self {
-            ui,
+            ui: color_config,
             package_manager: package_graph.package_manager(),
             packages,
         }
@@ -114,7 +114,7 @@ impl<'a> RepositoryDetails<'a> {
 
 impl<'a> PackageDetails<'a> {
     fn new(run: &'a Run, package: &'a str) -> Result<Self, Error> {
-        let ui = run.ui();
+        let color_config = run.color_config();
         let package_graph = run.pkg_dep_graph();
         let package_node = match package {
             "//" => PackageNode::Root,
@@ -140,7 +140,7 @@ impl<'a> PackageDetails<'a> {
         package_dep_names.sort();
 
         Ok(Self {
-            ui,
+            ui: color_config,
             name: package,
             dependencies: package_dep_names,
             tasks: package_json

--- a/crates/turborepo-lib/src/commands/mod.rs
+++ b/crates/turborepo-lib/src/commands/mod.rs
@@ -4,7 +4,7 @@ use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
 use turborepo_api_client::{APIAuth, APIClient};
 use turborepo_auth::{TURBO_TOKEN_DIR, TURBO_TOKEN_FILE};
 use turborepo_dirs::config_dir;
-use turborepo_ui::UI;
+use turborepo_ui::ColorConfig;
 
 use crate::{
     cli::Command,
@@ -30,7 +30,7 @@ pub(crate) mod unlink;
 #[derive(Debug, Clone)]
 pub struct CommandBase {
     pub repo_root: AbsoluteSystemPathBuf,
-    pub ui: UI,
+    pub color_config: ColorConfig,
     #[cfg(test)]
     pub global_config_path: Option<AbsoluteSystemPathBuf>,
     config: OnceCell<ConfigurationOptions>,
@@ -43,11 +43,11 @@ impl CommandBase {
         args: Args,
         repo_root: AbsoluteSystemPathBuf,
         version: &'static str,
-        ui: UI,
+        ui: ColorConfig,
     ) -> Self {
         Self {
             repo_root,
-            ui,
+            color_config: ui,
             args,
             #[cfg(test)]
             global_config_path: None,

--- a/crates/turborepo-lib/src/commands/mod.rs
+++ b/crates/turborepo-lib/src/commands/mod.rs
@@ -43,11 +43,11 @@ impl CommandBase {
         args: Args,
         repo_root: AbsoluteSystemPathBuf,
         version: &'static str,
-        ui: ColorConfig,
+        color_config: ColorConfig,
     ) -> Self {
         Self {
             repo_root,
-            color_config: ui,
+            color_config,
             args,
             #[cfg(test)]
             global_config_path: None,

--- a/crates/turborepo-lib/src/commands/prune.rs
+++ b/crates/turborepo-lib/src/commands/prune.rs
@@ -109,8 +109,8 @@ pub async fn prune(
 
     println!(
         "Generating pruned monorepo for {} in {}",
-        base.ui.apply(BOLD.apply_to(scope.join(", "))),
-        base.ui.apply(BOLD.apply_to(&prune.out_directory)),
+        base.color_config.apply(BOLD.apply_to(scope.join(", "))),
+        base.color_config.apply(BOLD.apply_to(&prune.out_directory)),
     );
 
     if let Some(workspace_config_path) = prune

--- a/crates/turborepo-lib/src/commands/scan.rs
+++ b/crates/turborepo-lib/src/commands/scan.rs
@@ -30,13 +30,13 @@ const INTER_MESSAGE_DELAY: Duration = Duration::from_millis(30);
 ///       to the user, it looks like the lints are running serially.
 pub async fn run(base: CommandBase) -> bool {
     let paths = DaemonPaths::from_repo_root(&base.repo_root);
-    let ui = base.ui;
+    let color_config = base.color_config;
 
-    println!("\n{}\n", ui.rainbow(">>> TURBO SCAN"));
+    println!("\n{}\n", color_config.rainbow(">>> TURBO SCAN"));
     println!(
         "Turborepo does a lot of work behind the scenes to make your monorepo fast,
 however, there are some things you can do to make it even faster. {}\n",
-        color!(ui, BOLD_GREEN, "Let's go!")
+        color!(color_config, BOLD_GREEN, "Let's go!")
     );
 
     let mut all_events = StreamMap::new();
@@ -80,7 +80,7 @@ however, there are some things you can do to make it even faster. {}\n",
             match message {
                 Started(_) => {} // ignore duplicate start events
                 LogLine(line) => {
-                    bar.println(color!(ui, GREY, "    {}", line).to_string());
+                    bar.println(color!(color_config, GREY, "    {}", line).to_string());
                 }
                 Request(prompt, mut options, chan) => {
                     let opt = bar.suspend(|| {
@@ -106,18 +106,24 @@ however, there are some things you can do to make it even faster. {}\n",
                     handle.await.expect("panic in suspend task");
                 }
                 Done(message) => {
-                    bar.finish_with_message(color!(ui, BOLD_GREEN, "{}", message).to_string());
+                    bar.finish_with_message(
+                        color!(color_config, BOLD_GREEN, "{}", message).to_string(),
+                    );
                     complete += 1;
                 }
                 Failed(message) => {
-                    bar.finish_with_message(color!(ui, BOLD_RED, "{}", message).to_string());
+                    bar.finish_with_message(
+                        color!(color_config, BOLD_RED, "{}", message).to_string(),
+                    );
                     failed += 1;
                 }
                 NotApplicable(name) => {
-                    let n_a = color!(ui, GREY, "n/a").to_string();
+                    let n_a = color!(color_config, GREY, "n/a").to_string();
                     let style = bar.style().tick_strings(&[&n_a, &n_a]);
                     bar.set_style(style);
-                    bar.finish_with_message(color!(ui, BOLD_GREY, "{}", name).to_string());
+                    bar.finish_with_message(
+                        color!(color_config, BOLD_GREY, "{}", name).to_string(),
+                    );
                     not_applicable += 1;
                 }
             };
@@ -129,7 +135,7 @@ however, there are some things you can do to make it even faster. {}\n",
     }
 
     if complete + not_applicable == num_tasks {
-        println!("\n\n{}", ui.rainbow(">>> FULL TURBO"));
+        println!("\n\n{}", color_config.rainbow(">>> FULL TURBO"));
         true
     } else {
         false

--- a/crates/turborepo-lib/src/commands/telemetry.rs
+++ b/crates/turborepo-lib/src/commands/telemetry.rs
@@ -31,8 +31,8 @@ fn log_status(config: TelemetryConfig, base: &CommandBase) {
 fn log_error(message: &str, error: &str, base: &CommandBase) {
     println!(
         "{}: {}",
-        color!(base.ui, BOLD_RED, "{}", message),
-        color!(base.ui, BOLD_RED, "{}", error)
+        color!(base.color_config, BOLD_RED, "{}", message),
+        color!(base.color_config, BOLD_RED, "{}", error)
     );
 }
 
@@ -55,7 +55,7 @@ pub fn configure(
             let result = config.enable();
             match result {
                 Ok(_) => {
-                    println!("{}", color!(base.ui, BOLD, "{}", "Success!"));
+                    println!("{}", color!(base.color_config, BOLD, "{}", "Success!"));
                     log_status(config, base);
                     telemetry.track_telemetry_config(true);
                 }
@@ -66,7 +66,7 @@ pub fn configure(
             let result = config.disable();
             match result {
                 Ok(_) => {
-                    println!("{}", color!(base.ui, BOLD, "{}", "Success!"));
+                    println!("{}", color!(base.color_config, BOLD, "{}", "Success!"));
                     log_status(config, base);
                     telemetry.track_telemetry_config(false);
                 }

--- a/crates/turborepo-lib/src/commands/telemetry.rs
+++ b/crates/turborepo-lib/src/commands/telemetry.rs
@@ -10,12 +10,15 @@ fn log_status(config: TelemetryConfig, base: &CommandBase) {
         true => {
             println!(
                 "\nStatus: {}",
-                base.ui.apply(BOLD_GREEN.apply_to("Enabled"))
+                base.color_config.apply(BOLD_GREEN.apply_to("Enabled"))
             );
             println!("\nTurborepo telemetry is completely anonymous. Thank you for participating!");
         }
         false => {
-            println!("\nStatus: {}", base.ui.apply(BOLD_RED.apply_to("Disabled")));
+            println!(
+                "\nStatus: {}",
+                base.color_config.apply(BOLD_RED.apply_to("Disabled"))
+            );
             println!(
                 "\nYou have opted-out of Turborepo anonymous telemetry. No data will be collected \
                  from your machine."

--- a/crates/turborepo-lib/src/commands/unlink.rs
+++ b/crates/turborepo-lib/src/commands/unlink.rs
@@ -50,7 +50,7 @@ fn unlink_remote_caching(base: &mut CommandBase) -> Result<(), cli::Error> {
         "> No Remote Caching config found"
     };
 
-    println!("{}", base.ui.apply(GREY.apply_to(output)));
+    println!("{}", base.color_config.apply(GREY.apply_to(output)));
 
     Ok(())
 }
@@ -94,7 +94,7 @@ fn unlink_spaces(base: &mut CommandBase) -> Result<(), cli::Error> {
         (false, UnlinkSpacesResult::NoSpacesFound) => "> No Spaces config found",
     };
 
-    println!("{}", base.ui.apply(GREY.apply_to(output)));
+    println!("{}", base.color_config.apply(GREY.apply_to(output)));
 
     Ok(())
 }

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -25,7 +25,7 @@ use turborepo_telemetry::events::{
     repo::{RepoEventBuilder, RepoType},
     EventBuilder, TrackedErrors,
 };
-use turborepo_ui::{ColorSelector, UI};
+use turborepo_ui::{ColorConfig, ColorSelector};
 #[cfg(feature = "daemon-package-discovery")]
 use {
     crate::run::package_discovery::DaemonPackageDiscovery,
@@ -54,7 +54,7 @@ pub struct RunBuilder {
     opts: Opts,
     api_auth: Option<APIAuth>,
     repo_root: AbsoluteSystemPathBuf,
-    ui: UI,
+    ui: ColorConfig,
     version: &'static str,
     ui_mode: UIMode,
     api_client: APIClient,
@@ -85,7 +85,11 @@ impl RunBuilder {
             // - if we're on windows, we're using the UI
             (!cfg!(windows) || matches!(ui_mode, UIMode::Tui)),
         );
-        let CommandBase { repo_root, ui, .. } = base;
+        let CommandBase {
+            repo_root,
+            color_config: ui,
+            ..
+        } = base;
 
         Ok(Self {
             processes,
@@ -383,7 +387,7 @@ impl RunBuilder {
 
         Ok(Run {
             version: self.version,
-            ui: self.ui,
+            color_config: self.ui,
             ui_mode: self.ui_mode,
             start_at,
             processes: self.processes,

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -54,7 +54,7 @@ pub struct RunBuilder {
     opts: Opts,
     api_auth: Option<APIAuth>,
     repo_root: AbsoluteSystemPathBuf,
-    ui: ColorConfig,
+    color_config: ColorConfig,
     version: &'static str,
     ui_mode: UIMode,
     api_client: APIClient,
@@ -96,7 +96,7 @@ impl RunBuilder {
             opts,
             api_client,
             repo_root,
-            ui,
+            color_config: ui,
             version,
             ui_mode,
             api_auth,
@@ -377,7 +377,7 @@ impl RunBuilder {
             &self.opts.runcache_opts,
             color_selector,
             daemon.clone(),
-            self.ui,
+            self.color_config,
             self.opts.run_opts.dry_run.is_some(),
         ));
 
@@ -387,7 +387,7 @@ impl RunBuilder {
 
         Ok(Run {
             version: self.version,
-            color_config: self.ui,
+            color_config: self.color_config,
             ui_mode: self.ui_mode,
             start_at,
             processes: self.processes,

--- a/crates/turborepo-lib/src/run/cache.rs
+++ b/crates/turborepo-lib/src/run/cache.rs
@@ -13,7 +13,7 @@ use turborepo_cache::{http::UploadMap, AsyncCache, CacheError, CacheHitMetadata,
 use turborepo_repository::package_graph::PackageInfo;
 use turborepo_scm::SCM;
 use turborepo_telemetry::events::{task::PackageTaskEventBuilder, TrackedErrors};
-use turborepo_ui::{color, tui::event::CacheResult, ColorSelector, LogWriter, GREY, UI};
+use turborepo_ui::{color, tui::event::CacheResult, ColorConfig, ColorSelector, LogWriter, GREY};
 
 use crate::{
     cli::OutputLogsMode,
@@ -52,7 +52,7 @@ pub struct RunCache {
     repo_root: AbsoluteSystemPathBuf,
     color_selector: ColorSelector,
     daemon_client: Option<DaemonClient<DaemonConnector>>,
-    ui: UI,
+    ui: ColorConfig,
 }
 
 /// Trait used to output cache information to user
@@ -69,7 +69,7 @@ impl RunCache {
         opts: &RunCacheOpts,
         color_selector: ColorSelector,
         daemon_client: Option<DaemonClient<DaemonConnector>>,
-        ui: UI,
+        ui: ColorConfig,
         is_dry_run: bool,
     ) -> Self {
         let task_output_logs = if is_dry_run {
@@ -142,7 +142,7 @@ pub struct TaskCache {
     caching_disabled: bool,
     log_file_path: AbsoluteSystemPathBuf,
     daemon_client: Option<DaemonClient<DaemonConnector>>,
-    ui: UI,
+    ui: ColorConfig,
     task_id: TaskId<'static>,
 }
 

--- a/crates/turborepo-lib/src/run/graph_visualizer.rs
+++ b/crates/turborepo-lib/src/run/graph_visualizer.rs
@@ -6,7 +6,7 @@ use std::{
 
 use thiserror::Error;
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
-use turborepo_ui::{cprintln, cwrite, cwriteln, BOLD, BOLD_YELLOW_REVERSE, UI, YELLOW};
+use turborepo_ui::{cprintln, cwrite, cwriteln, ColorConfig, BOLD, BOLD_YELLOW_REVERSE, YELLOW};
 use which::which;
 
 use crate::{engine::Engine, opts::GraphOpts, spawn_child};
@@ -25,7 +25,7 @@ pub enum Error {
 }
 
 pub(crate) fn write_graph(
-    ui: UI,
+    ui: ColorConfig,
     graph_opts: &GraphOpts,
     engine: &Engine,
     single_package: bool,
@@ -59,10 +59,10 @@ pub(crate) fn write_graph(
     Ok(())
 }
 
-fn write_graphviz_warning(ui: UI) -> Result<(), io::Error> {
+fn write_graphviz_warning(color_config: ColorConfig) -> Result<(), io::Error> {
     let stderr = io::stderr();
-    cwrite!(&stderr, ui, BOLD_YELLOW_REVERSE, " WARNING ")?;
-    cwriteln!(&stderr, ui, YELLOW, " `turbo` uses Graphviz to generate an image of your\ngraph, but Graphviz isn't installed on this machine.\n\nYou can download Graphviz from https://graphviz.org/download.\n\nIn the meantime, you can use this string output with an\nonline Dot graph viewer.")?;
+    cwrite!(&stderr, color_config, BOLD_YELLOW_REVERSE, " WARNING ")?;
+    cwriteln!(&stderr, color_config, YELLOW, " `turbo` uses Graphviz to generate an image of your\ngraph, but Graphviz isn't installed on this machine.\n\nYou can download Graphviz from https://graphviz.org/download.\n\nIn the meantime, you can use this string output with an\nonline Dot graph viewer.")?;
     Ok(())
 }
 

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -31,7 +31,7 @@ use turborepo_env::EnvironmentVariableMap;
 use turborepo_repository::package_graph::{PackageGraph, PackageName, PackageNode};
 use turborepo_scm::SCM;
 use turborepo_telemetry::events::generic::GenericEventBuilder;
-use turborepo_ui::{cprint, cprintln, tui, tui::AppSender, BOLD_GREY, GREY, UI};
+use turborepo_ui::{cprint, cprintln, tui, tui::AppSender, ColorConfig, BOLD_GREY, GREY};
 
 pub use crate::run::error::Error;
 use crate::{
@@ -50,7 +50,7 @@ use crate::{
 #[derive(Clone)]
 pub struct Run {
     version: &'static str,
-    ui: UI,
+    color_config: ColorConfig,
     start_at: DateTime<Local>,
     processes: ProcessManager,
     run_telemetry: GenericEventBuilder,
@@ -79,8 +79,8 @@ impl Run {
     fn print_run_prelude(&self) {
         let targets_list = self.opts.run_opts.tasks.join(", ");
         if self.opts.run_opts.single_package {
-            cprint!(self.ui, GREY, "{}", "• Running");
-            cprint!(self.ui, BOLD_GREY, " {}\n", targets_list);
+            cprint!(self.color_config, GREY, "{}", "• Running");
+            cprint!(self.color_config, BOLD_GREY, " {}\n", targets_list);
         } else {
             let mut packages = self
                 .filtered_pkgs
@@ -89,21 +89,26 @@ impl Run {
                 .collect::<Vec<String>>();
             packages.sort();
             cprintln!(
-                self.ui,
+                self.color_config,
                 GREY,
                 "• Packages in scope: {}",
                 packages.join(", ")
             );
-            cprint!(self.ui, GREY, "{} ", "• Running");
-            cprint!(self.ui, BOLD_GREY, "{}", targets_list);
-            cprint!(self.ui, GREY, " in {} packages\n", self.filtered_pkgs.len());
+            cprint!(self.color_config, GREY, "{} ", "• Running");
+            cprint!(self.color_config, BOLD_GREY, "{}", targets_list);
+            cprint!(
+                self.color_config,
+                GREY,
+                " in {} packages\n",
+                self.filtered_pkgs.len()
+            );
         }
 
         let use_http_cache = !self.opts.cache_opts.skip_remote;
         if use_http_cache {
-            cprintln!(self.ui, GREY, "• Remote caching enabled");
+            cprintln!(self.color_config, GREY, "• Remote caching enabled");
         } else {
-            cprintln!(self.ui, GREY, "• Remote caching disabled");
+            cprintln!(self.color_config, GREY, "• Remote caching disabled");
         }
     }
 
@@ -168,8 +173,8 @@ impl Run {
         &self.filtered_pkgs
     }
 
-    pub fn ui(&self) -> UI {
-        self.ui
+    pub fn color_config(&self) -> ColorConfig {
+        self.color_config
     }
 
     pub fn has_tui(&self) -> bool {
@@ -295,7 +300,7 @@ impl Run {
 
         if let Some(graph_opts) = &self.opts.run_opts.graph {
             graph_visualizer::write_graph(
-                self.ui,
+                self.color_config,
                 graph_opts,
                 &self.engine,
                 self.opts.run_opts.single_package,
@@ -401,7 +406,7 @@ impl Run {
             &self.env_at_execution_start,
             &global_hash,
             self.opts.run_opts.env_mode,
-            self.ui,
+            self.color_config,
             self.processes.clone(),
             &self.repo_root,
             global_env,

--- a/crates/turborepo-lib/src/run/summary/execution.rs
+++ b/crates/turborepo-lib/src/run/summary/execution.rs
@@ -4,7 +4,7 @@ use chrono::{DateTime, Local};
 use serde::Serialize;
 use tokio::sync::mpsc;
 use turbopath::{AbsoluteSystemPathBuf, AnchoredSystemPath};
-use turborepo_ui::{color, cprintln, BOLD, BOLD_GREEN, BOLD_RED, MAGENTA, UI, YELLOW};
+use turborepo_ui::{color, cprintln, ColorConfig, BOLD, BOLD_GREEN, BOLD_RED, MAGENTA, YELLOW};
 
 use super::TurboDuration;
 use crate::run::{summary::task::TaskSummary, task_id::TaskId};
@@ -72,7 +72,12 @@ impl<'a> ExecutionSummary<'a> {
 
     /// We implement this on `ExecutionSummary` and not `RunSummary` because
     /// the `execution` field is nullable (due to normalize).
-    pub fn print(&self, ui: UI, path: AbsoluteSystemPathBuf, failed_tasks: Vec<&TaskSummary>) {
+    pub fn print(
+        &self,
+        ui: ColorConfig,
+        path: AbsoluteSystemPathBuf,
+        failed_tasks: Vec<&TaskSummary>,
+    ) {
         let maybe_full_turbo = if self.cached == self.attempted && self.attempted > 0 {
             match std::env::var("TERM_PROGRAM").as_deref() {
                 Ok("Apple_Terminal") => color!(ui, MAGENTA, ">>> FULL TURBO").to_string(),

--- a/crates/turborepo-lib/src/run/summary/mod.rs
+++ b/crates/turborepo-lib/src/run/summary/mod.rs
@@ -29,7 +29,7 @@ use turborepo_api_client::{spaces::CreateSpaceRunPayload, APIAuth, APIClient};
 use turborepo_env::EnvironmentVariableMap;
 use turborepo_repository::package_graph::{PackageGraph, PackageName};
 use turborepo_scm::SCM;
-use turborepo_ui::{color, cprintln, cwriteln, BOLD, BOLD_CYAN, GREY, UI};
+use turborepo_ui::{color, cprintln, cwriteln, ColorConfig, BOLD, BOLD_CYAN, GREY};
 
 use self::{
     execution::TaskState, task::SinglePackageTaskSummary, task_factory::TaskSummaryFactory,
@@ -248,7 +248,7 @@ impl RunTracker {
         self,
         exit_code: i32,
         pkg_dep_graph: &PackageGraph,
-        ui: UI,
+        ui: ColorConfig,
         repo_root: &'a AbsoluteSystemPath,
         package_inference_root: Option<&AnchoredSystemPath>,
         run_opts: &'a RunOpts,
@@ -360,7 +360,7 @@ impl<'a> RunSummary<'a> {
         end_time: DateTime<Local>,
         exit_code: i32,
         pkg_dep_graph: &PackageGraph,
-        ui: UI,
+        ui: ColorConfig,
         is_watch: bool,
     ) -> Result<(), Error> {
         if matches!(self.run_type, RunType::DryJson | RunType::DryText) {
@@ -428,7 +428,11 @@ impl<'a> RunSummary<'a> {
         }
     }
 
-    fn close_dry_run(&mut self, pkg_dep_graph: &PackageGraph, ui: UI) -> Result<(), Error> {
+    fn close_dry_run(
+        &mut self,
+        pkg_dep_graph: &PackageGraph,
+        ui: ColorConfig,
+    ) -> Result<(), Error> {
         if matches!(self.run_type, RunType::DryJson) {
             let rendered = self.format_json()?;
 
@@ -439,7 +443,11 @@ impl<'a> RunSummary<'a> {
         self.format_and_print_text(pkg_dep_graph, ui)
     }
 
-    fn format_and_print_text(&mut self, pkg_dep_graph: &PackageGraph, ui: UI) -> Result<(), Error> {
+    fn format_and_print_text(
+        &mut self,
+        pkg_dep_graph: &PackageGraph,
+        ui: ColorConfig,
+    ) -> Result<(), Error> {
         self.normalize();
 
         if self.monorepo {

--- a/crates/turborepo-lib/src/run/watch.rs
+++ b/crates/turborepo-lib/src/run/watch.rs
@@ -263,7 +263,7 @@ impl WatchClient {
                     args,
                     self.base.repo_root.clone(),
                     get_version(),
-                    self.base.ui,
+                    self.base.color_config,
                 );
 
                 let signal_handler = self.handler.clone();
@@ -298,7 +298,7 @@ impl WatchClient {
                     args,
                     self.base.repo_root.clone(),
                     get_version(),
-                    self.base.ui,
+                    self.base.color_config,
                 );
 
                 // rebuild run struct

--- a/crates/turborepo-lib/src/shim/parser.rs
+++ b/crates/turborepo-lib/src/shim/parser.rs
@@ -3,7 +3,7 @@ use std::{backtrace::Backtrace, env};
 use itertools::Itertools;
 use miette::{Diagnostic, SourceSpan};
 use turbopath::AbsoluteSystemPathBuf;
-use turborepo_ui::UI;
+use turborepo_ui::ColorConfig;
 
 use super::Error;
 
@@ -225,20 +225,20 @@ impl ShimArgs {
         true
     }
 
-    pub fn ui(&self) -> UI {
+    pub fn color_config(&self) -> ColorConfig {
         if self.no_color {
-            UI::new(true)
+            ColorConfig::new(true)
         } else if self.color {
             // Do our best to enable ansi colors, but even if the terminal doesn't support
             // still emit ansi escape sequences.
             Self::supports_ansi();
-            UI::new(false)
+            ColorConfig::new(false)
         } else if Self::supports_ansi() {
             // If the terminal supports ansi colors, then we can infer if we should emit
             // colors
-            UI::infer()
+            ColorConfig::infer()
         } else {
-            UI::new(true)
+            ColorConfig::new(true)
         }
     }
 

--- a/crates/turborepo-lib/src/tracing.rs
+++ b/crates/turborepo-lib/src/tracing.rs
@@ -22,7 +22,7 @@ use tracing_subscriber::{
     reload::{self, Handle},
     EnvFilter, Layer, Registry,
 };
-use turborepo_ui::UI;
+use turborepo_ui::ColorConfig;
 
 // a lot of types to make sure we record the right relationships
 
@@ -102,7 +102,7 @@ impl TurboSubscriber {
     ///   formatter.
     /// - `enable_chrome_tracing` enables logging to a file, using the chrome
     ///   tracing formatter.
-    pub fn new_with_verbosity(verbosity: usize, ui: &UI) -> Self {
+    pub fn new_with_verbosity(verbosity: usize, color_config: &ColorConfig) -> Self {
         let level_override = match verbosity {
             0 => None,
             1 => Some(LevelFilter::INFO),
@@ -128,7 +128,9 @@ impl TurboSubscriber {
 
         let stderr = fmt::layer()
             .with_writer(StdErrWrapper {})
-            .event_format(TurboFormatter::new_with_ansi(!ui.should_strip_ansi))
+            .event_format(TurboFormatter::new_with_ansi(
+                !color_config.should_strip_ansi,
+            ))
             .with_filter(env_filter(LevelFilter::WARN));
 
         // we set this layer to None to start with, effectively disabling it

--- a/crates/turborepo-telemetry/src/config.rs
+++ b/crates/turborepo-telemetry/src/config.rs
@@ -16,7 +16,7 @@ use sha2::{Digest, Sha256};
 use tracing::{error, trace};
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
 use turborepo_dirs::config_dir;
-use turborepo_ui::{color, BOLD, GREY, UI, UNDERLINE};
+use turborepo_ui::{color, ColorConfig, BOLD, GREY, UNDERLINE};
 use uuid::Uuid;
 
 static DEBUG_ENV_VAR: &str = "TURBO_TELEMETRY_DEBUG";
@@ -134,36 +134,41 @@ impl TelemetryConfig {
         one_way_hash_with_salt(&tmp_salt, input)
     }
 
-    pub fn show_alert(&mut self, ui: UI) {
+    pub fn show_alert(&mut self, color_config: ColorConfig) {
         if !self.has_seen_alert() && self.is_enabled() && Self::is_telemetry_warning_enabled() {
             eprintln!(
                 "\n{}\n{}\n{}\n{}\n{}\n",
-                color!(ui, BOLD, "{}", "Attention:"),
+                color!(color_config, BOLD, "{}", "Attention:"),
                 color!(
-                    ui,
+                    color_config,
                     GREY,
                     "{}",
                     "Turborepo now collects completely anonymous telemetry regarding usage."
                 ),
                 color!(
-                    ui,
+                    color_config,
                     GREY,
                     "{}",
                     "This information is used to shape the Turborepo roadmap and prioritize \
                      features."
                 ),
                 color!(
-                    ui,
+                    color_config,
                     GREY,
                     "{}",
                     "You can learn more, including how to opt-out if you'd not like to \
                      participate in this anonymous program, by visiting the following URL:"
                 ),
                 color!(
-                    ui,
+                    color_config,
                     UNDERLINE,
                     "{}",
-                    color!(ui, GREY, "{}", "https://turbo.build/repo/docs/telemetry")
+                    color!(
+                        color_config,
+                        GREY,
+                        "{}",
+                        "https://turbo.build/repo/docs/telemetry"
+                    )
                 ),
             );
 

--- a/crates/turborepo-telemetry/src/lib.rs
+++ b/crates/turborepo-telemetry/src/lib.rs
@@ -226,8 +226,8 @@ impl<C: telemetry::TelemetryClient + Clone + Send + Sync + 'static> Worker<C> {
                     .unwrap_or("Error serializing event".to_string());
                 println!(
                     "\n{}\n{}\n",
-                    color!(self.ui, BOLD, "{}", "[telemetry event]"),
-                    color!(self.ui, GREY, "{}", pretty_event)
+                    color!(self.color_config, BOLD, "{}", "[telemetry event]"),
+                    color!(self.color_config, GREY, "{}", pretty_event)
                 );
             }
         }

--- a/crates/turborepo-telemetry/src/lib.rs
+++ b/crates/turborepo-telemetry/src/lib.rs
@@ -23,7 +23,7 @@ use tokio::{
 };
 use tracing::{debug, error, trace};
 use turborepo_api_client::telemetry;
-use turborepo_ui::{color, BOLD, GREY, UI};
+use turborepo_ui::{color, ColorConfig, BOLD, GREY};
 use uuid::Uuid;
 
 const BUFFER_THRESHOLD: usize = 10;
@@ -78,11 +78,11 @@ pub fn telem(event: events::TelemetryEvent) {
 fn init(
     mut config: TelemetryConfig,
     client: impl telemetry::TelemetryClient + Clone + Send + Sync + 'static,
-    ui: UI,
+    color_config: ColorConfig,
 ) -> Result<(TelemetryHandle, TelemetrySender), Box<dyn std::error::Error>> {
     let (tx, rx) = mpsc::unbounded_channel();
     let (cancel_tx, cancel_rx) = oneshot::channel();
-    config.show_alert(ui);
+    config.show_alert(color_config);
 
     let session_id = Uuid::new_v4();
     let worker = Worker {
@@ -94,7 +94,7 @@ fn init(
         session_id: session_id.to_string(),
         telemetry_id: config.get_id().to_string(),
         enabled: config.is_enabled(),
-        ui,
+        color_config,
     };
     let handle = worker.start();
 
@@ -115,7 +115,7 @@ fn init(
 /// shared since it contains the structs necessary to shut down the worker.
 pub fn init_telemetry(
     client: impl telemetry::TelemetryClient + Clone + Send + Sync + 'static,
-    ui: UI,
+    color_config: ColorConfig,
 ) -> Result<TelemetryHandle, Box<dyn std::error::Error>> {
     // make sure we're not already initialized
     if SENDER_INSTANCE.get().is_some() {
@@ -123,7 +123,7 @@ pub fn init_telemetry(
         return Err(Box::new(Error::AlreadyInitialized()));
     }
     let config = TelemetryConfig::with_default_config_path()?;
-    let (handle, sender) = init(config, client, ui)?;
+    let (handle, sender) = init(config, client, color_config)?;
     SENDER_INSTANCE.set(sender).unwrap();
     Ok(handle)
 }
@@ -157,7 +157,7 @@ struct Worker<C> {
     telemetry_id: String,
     session_id: String,
     enabled: bool,
-    ui: UI,
+    color_config: ColorConfig,
 }
 
 impl<C: telemetry::TelemetryClient + Clone + Send + Sync + 'static> Worker<C> {
@@ -262,7 +262,7 @@ mod tests {
     };
     use turbopath::AbsoluteSystemPathBuf;
     use turborepo_api_client::telemetry::TelemetryClient;
-    use turborepo_ui::UI;
+    use turborepo_ui::ColorConfig;
     use turborepo_vercel_api::telemetry::{TelemetryEvent, TelemetryGenericEvent};
 
     use crate::{config::TelemetryConfig, init};
@@ -342,7 +342,7 @@ mod tests {
             tx,
         };
 
-        let result = init(config, client.clone(), UI::new(false));
+        let result = init(config, client.clone(), ColorConfig::new(false));
 
         let (telemetry_handle, telemetry_sender) = result.unwrap();
 
@@ -382,7 +382,7 @@ mod tests {
             tx,
         };
 
-        let result = init(config, client.clone(), UI::new(false));
+        let result = init(config, client.clone(), ColorConfig::new(false));
 
         let (telemetry_handle, telemetry_sender) = result.unwrap();
 
@@ -428,7 +428,7 @@ mod tests {
             tx,
         };
 
-        let result = init(config, client.clone(), UI::new(false));
+        let result = init(config, client.clone(), ColorConfig::new(false));
 
         let (telemetry_handle, telemetry_sender) = result.unwrap();
 

--- a/crates/turborepo-ui/src/lib.rs
+++ b/crates/turborepo-ui/src/lib.rs
@@ -116,11 +116,11 @@ macro_rules! cwriteln {
 
 /// Helper struct to apply any necessary formatting to UI output
 #[derive(Debug, Clone, Copy)]
-pub struct UI {
+pub struct ColorConfig {
     pub should_strip_ansi: bool,
 }
 
-impl UI {
+impl ColorConfig {
     pub fn new(should_strip_ansi: bool) -> Self {
         Self { should_strip_ansi }
     }
@@ -209,16 +209,19 @@ mod test {
     use super::*;
 
     #[test]
-    fn test_ui_strips_ansi() {
-        let ui = UI::new(true);
+    fn test_color_config_strips_ansi() {
+        let color_config = ColorConfig::new(true);
         let grey_str = GREY.apply_to("gray");
-        assert_eq!(format!("{}", ui.apply(grey_str)), "gray");
+        assert_eq!(format!("{}", color_config.apply(grey_str)), "gray");
     }
 
     #[test]
-    fn test_ui_resets_term() {
-        let ui = UI::new(false);
+    fn test_color_config_resets_term() {
+        let color_config = ColorConfig::new(false);
         let grey_str = GREY.apply_to("gray");
-        assert_eq!(format!("{}", ui.apply(grey_str)), "\u{1b}[2mgray\u{1b}[0m");
+        assert_eq!(
+            format!("{}", color_config.apply(grey_str)),
+            "\u{1b}[2mgray\u{1b}[0m"
+        );
     }
 }

--- a/crates/turborepo-ui/src/logs.rs
+++ b/crates/turborepo-ui/src/logs.rs
@@ -122,7 +122,9 @@ mod tests {
     use tempfile::tempdir;
     use turbopath::AbsoluteSystemPathBuf;
 
-    use crate::{logs::replay_logs, LogWriter, PrefixedUI, PrefixedWriter, BOLD, CYAN, UI};
+    use crate::{
+        logs::replay_logs, ColorConfig, LogWriter, PrefixedUI, PrefixedWriter, BOLD, CYAN,
+    };
 
     #[test]
     fn test_log_writer() -> Result<()> {
@@ -130,11 +132,11 @@ mod tests {
         let log_file_path = AbsoluteSystemPathBuf::try_from(dir.path().join("test.txt"))?;
         let mut prefixed_writer_output = Vec::new();
         let mut log_writer = LogWriter::default();
-        let ui = UI::new(false);
+        let color_config = ColorConfig::new(false);
 
         log_writer.with_log_file(&log_file_path)?;
         log_writer.with_writer(PrefixedWriter::new(
-            ui,
+            color_config,
             CYAN.apply_to(">".to_string()),
             &mut prefixed_writer_output,
         ));
@@ -164,10 +166,10 @@ mod tests {
 
     #[test]
     fn test_replay_logs() -> Result<()> {
-        let ui = UI::new(false);
+        let color_config = ColorConfig::new(false);
         let mut output = Vec::new();
         let mut err = Vec::new();
-        let mut prefixed_ui = PrefixedUI::new(ui, &mut output, &mut err)
+        let mut prefixed_ui = PrefixedUI::new(color_config, &mut output, &mut err)
             .with_output_prefix(CYAN.apply_to(">".to_string()))
             .with_warn_prefix(BOLD.apply_to(">!".to_string()));
         let dir = tempdir()?;
@@ -186,10 +188,10 @@ mod tests {
 
     #[test]
     fn test_replay_logs_invalid_utf8() -> Result<()> {
-        let ui = UI::new(true);
+        let color_config = ColorConfig::new(true);
         let mut output = Vec::new();
         let mut err = Vec::new();
-        let mut prefixed_ui = PrefixedUI::new(ui, &mut output, &mut err)
+        let mut prefixed_ui = PrefixedUI::new(color_config, &mut output, &mut err)
             .with_output_prefix(CYAN.apply_to(">".to_string()))
             .with_warn_prefix(BOLD.apply_to(">!".to_string()));
         let dir = tempdir()?;

--- a/crates/turborepo-ui/src/prefixed.rs
+++ b/crates/turborepo-ui/src/prefixed.rs
@@ -6,14 +6,14 @@ use std::{
 use console::{Style, StyledObject};
 use tracing::error;
 
-use crate::{LineWriter, UI};
+use crate::{ColorConfig, LineWriter};
 
 /// Writes messages with different prefixes, depending on log level. Note that
 /// this does output the prefix when message is empty, unlike the Go
 /// implementation. We do this because this behavior is what we actually
 /// want for replaying logs.
 pub struct PrefixedUI<W> {
-    ui: UI,
+    color_config: ColorConfig,
     output_prefix: Option<StyledObject<String>>,
     warn_prefix: Option<StyledObject<String>>,
     error_prefix: Option<StyledObject<String>>,
@@ -23,9 +23,9 @@ pub struct PrefixedUI<W> {
 }
 
 impl<W: Write> PrefixedUI<W> {
-    pub fn new(ui: UI, out: W, err: W) -> Self {
+    pub fn new(color_config: ColorConfig, out: W, err: W) -> Self {
         Self {
-            ui,
+            color_config,
             out,
             err,
             output_prefix: None,
@@ -36,17 +36,17 @@ impl<W: Write> PrefixedUI<W> {
     }
 
     pub fn with_output_prefix(mut self, output_prefix: StyledObject<String>) -> Self {
-        self.output_prefix = Some(self.ui.apply(output_prefix));
+        self.output_prefix = Some(self.color_config.apply(output_prefix));
         self
     }
 
     pub fn with_warn_prefix(mut self, warn_prefix: StyledObject<String>) -> Self {
-        self.warn_prefix = Some(self.ui.apply(warn_prefix));
+        self.warn_prefix = Some(self.color_config.apply(warn_prefix));
         self
     }
 
     pub fn with_error_prefix(mut self, error_prefix: StyledObject<String>) -> Self {
-        self.error_prefix = Some(self.ui.apply(error_prefix));
+        self.error_prefix = Some(self.color_config.apply(error_prefix));
         self
     }
 
@@ -87,7 +87,7 @@ impl<W: Write> PrefixedUI<W> {
     /// without the requirement that messages be valid UTF-8
     pub fn output_prefixed_writer(&mut self) -> PrefixedWriter<&mut W> {
         PrefixedWriter::new(
-            self.ui,
+            self.color_config,
             self.output_prefix
                 .clone()
                 .unwrap_or_else(|| Style::new().apply_to(String::new())),
@@ -110,9 +110,9 @@ pub struct PrefixedWriter<W> {
 }
 
 impl<W: Write> PrefixedWriter<W> {
-    pub fn new(ui: UI, prefix: StyledObject<impl Display>, writer: W) -> Self {
+    pub fn new(color_config: ColorConfig, prefix: StyledObject<impl Display>, writer: W) -> Self {
         Self {
-            inner: LineWriter::new(PrefixedWriterInner::new(ui, prefix, writer)),
+            inner: LineWriter::new(PrefixedWriterInner::new(color_config, prefix, writer)),
         }
     }
 }
@@ -135,8 +135,8 @@ struct PrefixedWriterInner<W> {
 }
 
 impl<W: Write> PrefixedWriterInner<W> {
-    pub fn new(ui: UI, prefix: StyledObject<impl Display>, writer: W) -> Self {
-        let prefix = ui.apply(prefix).to_string();
+    pub fn new(color_config: ColorConfig, prefix: StyledObject<impl Display>, writer: W) -> Self {
+        let prefix = color_config.apply(prefix).to_string();
         Self { prefix, writer }
     }
 }
@@ -175,10 +175,10 @@ mod test {
 
     use super::*;
 
-    fn prefixed_ui<W: Write>(out: W, err: W, ui: UI) -> PrefixedUI<W> {
+    fn prefixed_ui<W: Write>(out: W, err: W, color_config: ColorConfig) -> PrefixedUI<W> {
         let output_prefix = crate::BOLD.apply_to("output ".to_string());
         let warn_prefix = crate::MAGENTA.apply_to("warn ".to_string());
-        PrefixedUI::new(ui, out, err)
+        PrefixedUI::new(color_config, out, err)
             .with_output_prefix(output_prefix)
             .with_warn_prefix(warn_prefix)
             .with_error_prefix(crate::MAGENTA.apply_to("error ".to_string()))
@@ -194,7 +194,7 @@ mod test {
         let mut out = Vec::new();
         let mut err = Vec::new();
 
-        let mut prefixed_ui = prefixed_ui(&mut out, &mut err, UI::new(strip_ansi));
+        let mut prefixed_ui = prefixed_ui(&mut out, &mut err, ColorConfig::new(strip_ansi));
         match cmd {
             Command::Output => prefixed_ui.output("all good"),
             Command::Warn => prefixed_ui.warn("be careful!"),
@@ -213,7 +213,7 @@ mod test {
     fn test_prefixed_writer(strip_ansi: bool, expected: &str) {
         let mut buffer = Vec::new();
         let mut writer = PrefixedWriterInner::new(
-            UI::new(strip_ansi),
+            ColorConfig::new(strip_ansi),
             crate::BOLD.apply_to("foo#build: "),
             &mut buffer,
         );
@@ -230,7 +230,7 @@ mod test {
     fn test_prefixed_writer_cr(input: &str, expected: &str) {
         let mut buffer = Vec::new();
         let mut writer = PrefixedWriterInner::new(
-            UI::new(false),
+            ColorConfig::new(false),
             Style::new().apply_to("turbo > "),
             &mut buffer,
         );
@@ -258,7 +258,7 @@ mod test {
     fn test_prefixed_writer_split_lines() {
         let mut buffer = Vec::new();
         let mut writer = PrefixedWriter::new(
-            UI::new(false),
+            ColorConfig::new(false),
             Style::new().apply_to("turbo > "),
             &mut buffer,
         );

--- a/crates/turborepo-ui/tests/threads.rs
+++ b/crates/turborepo-ui/tests/threads.rs
@@ -6,7 +6,8 @@ use std::{
 use console::Style;
 use turbopath::AbsoluteSystemPath;
 use turborepo_ui::{
-    LogWriter, OutputClient, OutputClientBehavior, OutputSink, PrefixedUI, PrefixedWriter, UI,
+    ColorConfig, LogWriter, OutputClient, OutputClientBehavior, OutputSink, PrefixedUI,
+    PrefixedWriter,
 };
 
 #[test]
@@ -71,8 +72,8 @@ fn echo_task(
     // this output will not appear in a task's log file.
     let output_prefix = Style::new().apply_to(format!("{task_name} > "));
     let warn_prefix = Style::new().apply_to(format!("{task_name} warning > "));
-    let ui = UI::new(true);
-    let mut prefix_ui = PrefixedUI::new(ui, client.stdout(), client.stderr())
+    let color_config = ColorConfig::new(true);
+    let mut prefix_ui = PrefixedUI::new(color_config, client.stdout(), client.stderr())
         .with_output_prefix(output_prefix.clone())
         .with_warn_prefix(warn_prefix);
 
@@ -82,7 +83,11 @@ fn echo_task(
     // log file
     let mut task_logger = LogWriter::default();
     task_logger.with_log_file(log_file).unwrap();
-    task_logger.with_writer(PrefixedWriter::new(ui, output_prefix, client.stdout()));
+    task_logger.with_writer(PrefixedWriter::new(
+        color_config,
+        output_prefix,
+        client.stdout(),
+    ));
 
     let mut cmd = Command::new("echo");
     cmd.args(["hello", "from", task_name]);


### PR DESCRIPTION
### Description

Since we now have an explicit `ui` config that refers to whether we display runs via stream, tui, or web, we should rename the existing `UI` struct to be more explicitly about color configuration (since that's the only thing it does).

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
