### PR TITLE
fix: print application errors to stderr instead of stdout

### DIFF
--- a/crates/turborepo/src/main.rs
+++ b/crates/turborepo/src/main.rs
@@ -11,7 +11,7 @@ fn main() -> Result<()> {
     std::panic::set_hook(Box::new(turborepo_lib::panic_handler));
 
     let exit_code = turborepo_lib::main().unwrap_or_else(|err| {
-        println!("{:?}", Report::new(err));
+        eprintln!("{:?}", Report::new(err));
         1
     });
 

--- a/turborepo-tests/integration/tests/bad-turbo-json.t
+++ b/turborepo-tests/integration/tests/bad-turbo-json.t
@@ -5,7 +5,9 @@ Add turbo.json with unnecessary package task syntax to a package
   $ . ${TESTDIR}/../../helpers/replace_turbo_json.sh $(pwd)/apps/my-app "package-task.json"
 
 Run build with package task in non-root turbo.json
-  $ ${TURBO} build | sed  's/\[\([^]]*\)\]/\(\1)/g'
+  $ ${TURBO} build 2> error.txt
+  [1]
+  $ sed  's/\[\([^]]*\)\]/\(\1)/g' < error.txt
     x invalid turbo json
   
   Error: unnecessary_package_task_syntax (https://turbo.build/messages/unnecessary-package-task-syntax)
@@ -32,7 +34,9 @@ Use our custom turbo config with an invalid env var
   $ . ${TESTDIR}/../../helpers/replace_turbo_json.sh $(pwd) "invalid-env-var.json"
 
 Run build with invalid env var
-  $ ${TURBO} build | sed  's/\[\([^]]*\)\]/\(\1)/g'
+  $ ${TURBO} build 2> error.txt
+  [1]
+  $ sed  's/\[\([^]]*\)\]/\(\1)/g' < error.txt
   invalid_env_prefix (https://turbo.build/messages/invalid-env-prefix)
   
     x Environment variables should not be prefixed with "$"
@@ -48,7 +52,9 @@ Run build with invalid env var
 
 
 Run in single package mode even though we have a task with package syntax
-  $ ${TURBO} build --single-package | sed  's/\[\([^]]*\)\]/\(\1)/g'
+  $ ${TURBO} build --single-package 2> error.txt
+  [1]
+  $ sed  's/\[\([^]]*\)\]/\(\1)/g' < error.txt
   package_task_in_single_package_mode (https://turbo.build/messages/package-task-in-single-package-mode)
   
     x Package tasks (<package>#<task>) are not allowed in single-package

--- a/turborepo-tests/integration/tests/invalid-package-json.t
+++ b/turborepo-tests/integration/tests/invalid-package-json.t
@@ -5,7 +5,7 @@ Clear name field
   $ mv apps/my-app/package.json apps/my-app/package.json.old
   $ mv package.json.new apps/my-app/package.json
 Build should fail due to missing name field
-  $ ${TURBO} build 1> ERR
+  $ ${TURBO} build 2> ERR
   [1]
   $ grep -F --quiet 'x package.json must have a name field:' ERR
 
@@ -17,7 +17,9 @@ Clear add invalid packageManager field
   $ mv package.json.new package.json
 
 Build should fail due to invalid packageManager field (sed removes the square brackets)
-  $ ${TURBO} build 2>&1 | sed  's/\[\([^]]*\)\]/\\1/g'
+  $ ${TURBO} build 2> ERR
+  [1]
+  $ sed  's/\[\([^]]*\)\]/\\1/g' < ERR
   invalid_package_manager_field
   
     x could not resolve workspaces
@@ -37,7 +39,9 @@ Add invalid packageManager field that passes the regex.
   $ jq '.packageManager = "npm@0.3.211111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"' package.json > package.json.new
   $ mv package.json.new package.json
 
-  $ ${TURBO} build 2>&1 | sed  's/\[\([^]]*\)\]/\(\1)/g'
+  $ ${TURBO} build 2> ERR
+  [1]
+  $ sed  's/\[\([^]]*\)\]/\(\1)/g' < ERR
   invalid_semantic_version
   
     x could not resolve workspaces
@@ -59,7 +63,9 @@ Add a trailing comma
   $ echo "{ \"name\": \"foobar\", }" > package.json.new
   $ mv package.json.new apps/my-app/package.json
 Build should fail due to trailing comma (sed replaces square brackets with parentheses)
-  $ ${TURBO} build 2>&1 | sed  's/\[\([^]]*\)\]/\(\1)/g'
+  $ ${TURBO} build 2> ERR
+  [1]
+  $ sed  's/\[\([^]]*\)\]/\(\1)/g' < ERR
   package_json_parse_error
   
     x unable to parse package.json


### PR DESCRIPTION
### Description

https://github.com/vercel/turborepo/pull/7169 changed error printing from `stderr` to `stdout`. This changes that behavior so we print errors to `stderr` once again. This provides a better experience if `turbo` is piped e.g. `turbo --dry=json build | jq .`

### Testing Instructions

```
[0 olszewski@Chriss-MacBook-Pro] /Users/olszewski/code/test $ turbo -F '[commit]' ci-run-build-container | jq .
 WARNING  No locally installed `turbo` found. Using version: 2.0.12-canary.0.
turbo 2.0.12-canary.0

jq: parse error: Invalid numeric literal at line 1, column 4
```

After
```
[5 olszewski@Chriss-MacBook-Pro] /Users/olszewski/code/test $ turbo_dev -F '[commit]' ci-run-build-container | jq .
 WARNING  No locally installed `turbo` found. Using version: 2.0.12.
turbo 2.0.12

  x Invalid package dependency graph: cyclic dependency detected:
...
```
