### PR TITLE
chore(change_mapper): add debug log explaining why package is root dep

### DIFF
--- a/crates/turborepo-repository/src/change_mapper/mod.rs
+++ b/crates/turborepo-repository/src/change_mapper/mod.rs
@@ -140,9 +140,11 @@ impl<'a, PD: PackageChangeMapper> ChangeMapper<'a, PD> {
                 // Internal root dependency changed so global hash has changed
                 PackageMapping::Package(pkg) if root_internal_deps.contains(&pkg) => {
                     debug!(
-                        "{} changes root internal dependency: \"{}\"",
+                        "{} changes root internal dependency: \"{}\"\nshortest path from root: \
+                         {:?}",
                         file.to_string(),
-                        pkg.name
+                        pkg.name,
+                        self.pkg_graph.root_internal_dependency_explanation(&pkg),
                     );
                     return PackageChanges::All(AllPackageChangeReason::RootInternalDepChanged);
                 }


### PR DESCRIPTION
### Description

It can be confusing why a package is invalidates everything if it isn't a direct dependency of the root package. This PR adds a function for displaying paths between the root package and a workspace packages.

### Testing Instructions

Check debug logs:
```
2024-08-09T11:37:14.913-0400 [DEBUG] turborepo_repository::change_mapper: packages/logger/index.ts changes root internal dependency: "@api/logger"
shortest path from root: Some("// -> @api/util-integrations -> @api/logger")
```
