### PR TITLE
chore: remove aliases

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -31,9 +31,3 @@ rustflags = [
   "-Clink-arg=-fuse-ld=lld",
 ]
 
-[alias]
-xtask = "run --package xtask --"
-build = "build -p turbo"
-run = "run -p turbo"
-test = "groups test turborepo"
-check = "groups check turborepo"


### PR DESCRIPTION
### Description

The aliases don't work, as noted by the warning:

> warning: user-defined alias `test` is ignored, because it is shadowed by a built-in command

So I just removed them. Also removed the xtask one because only turbopack uses xtask
### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
