### PR TITLE
removes GOROOT from globalPassThroughEnv for local dev

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "ui": "tui",
-  // The following are used by tools such as pnpm, gh actions to setup pnpm, and the Go toolchain
+  // The following are used by tools such as pnpm, gh actions to setup pnpm, etc.
   "globalPassThroughEnv": [
     "Path",
     "APPDATA",
@@ -9,7 +9,6 @@
     "TMPDIR",
     "HOME",
     "TMP",
-    "GOROOT",
     "USERPROFILE",
     "SCCACHE_GHA_ENABLED",
     "SCCACHE_BUCKET",


### PR DESCRIPTION
My understanding is that this is not needed anymore - so just cleaning it up on the basis of that assumption.

Reminder: there is some Go code left in `turborepo-lib/hash`, but from what I can tell that's entirely separate from this.