### PR TITLE
enables test_gh_8599 test

### DIFF
--- a/crates/turborepo-repository/src/inference.rs
+++ b/crates/turborepo-repository/src/inference.rs
@@ -348,6 +348,7 @@ mod test {
         );
     }
 
+    #[test]
     fn test_gh_8599() {
         // TODO: this test documents existing broken behavior, when we have time we
         // should fix this and update the assertions


### PR DESCRIPTION
### Description

I noticed in the CI logs a warning that this was an unused function.  Looks like we just forgot the test annotation in https://github.com/vercel/turbo/pull/8825

### Testing Instructions

Tests pass.
