### PR TITLE
fix(create-turbo): support renamed repositories

### DIFF
--- a/packages/turbo-utils/src/examples.ts
+++ b/packages/turbo-utils/src/examples.ts
@@ -1,6 +1,6 @@
 import { Stream } from "node:stream";
 import { promisify } from "node:util";
-import { join } from "node:path";
+import { join, sep } from "node:path";
 import { tmpdir } from "node:os";
 import { createWriteStream, promises as fs } from "node:fs";
 import { x as extract } from "tar";
@@ -113,16 +113,25 @@ export async function downloadAndExtractRepo(
     `turbo-ct-example`
   );
 
+  let rootPath: string | null = null;
   await extract({
     file: tempFile,
     cwd: root,
     strip: filePath ? filePath.split("/").length + 1 : 1,
-    filter: (p: string) =>
-      p.startsWith(
-        `${name}-${branch.replace(/\//g, "-")}${
+    filter: (p: string) => {
+      // Determine the unpacked root path dynamically instead of hardcoding to the fetched repo's name. This avoids the condition when the repository has been renamed, and the
+      // old repository name is used to fetch the example. The tar download will work as it is redirected automatically, but the root directory of the extracted
+      // example will be the new, renamed name instead of the name used to fetch the example.
+      if (rootPath === null) {
+        const pathSegments = p.split(sep);
+        rootPath = pathSegments.length ? pathSegments[0] : null;
+      }
+      return p.startsWith(
+        `${rootPath}-${branch.replace(/\//g, "-")}${
           filePath ? `/${filePath}/` : "/"
         }`
-      ),
+      );
+    },
   });
 
   await fs.unlink(tempFile);
@@ -134,11 +143,22 @@ export async function downloadAndExtractExample(root: string, name: string) {
     `turbo-ct-example`
   );
 
+  let rootPath: string | null = null;
   await extract({
     file: tempFile,
     cwd: root,
     strip: 2 + name.split("/").length,
-    filter: (p: string) => p.includes(`turbo-main/examples/${name}/`),
+    filter: (p: string) => {
+      // Determine the unpacked root path dynamically instead of hardcoding. This avoids the condition when the repository has been renamed, and the
+      // old repository name is used to fetch the example. The tar download will work as it is redirected automatically, but the root directory of the extracted
+      // example will be the new, renamed name instead of the name used to fetch the example.
+      if (rootPath === null) {
+        const pathSegments = p.split(sep);
+        rootPath = pathSegments.length ? pathSegments[0] : null;
+      }
+
+      return p.includes(`${rootPath}/examples/${name}/`);
+    },
   });
 
   await fs.unlink(tempFile);

--- a/packages/turbo-utils/src/examples.ts
+++ b/packages/turbo-utils/src/examples.ts
@@ -126,11 +126,7 @@ export async function downloadAndExtractRepo(
         const pathSegments = p.split(sep);
         rootPath = pathSegments.length ? pathSegments[0] : null;
       }
-      return p.startsWith(
-        `${rootPath}-${branch.replace(/\//g, "-")}${
-          filePath ? `/${filePath}/` : "/"
-        }`
-      );
+      return p.startsWith(`${rootPath}${filePath ? `/${filePath}/` : "/"}`);
     },
   });
 


### PR DESCRIPTION
### Description

This bug broke create-turbo when we renamed the repo. This bug is explained in the comments but the tl;dr is that downloading the repo works because the download URL automatically redirects from the old name to the new name. However the download is always put into a directory of the name {repoName}-{branch} where the repoName is the name of the repo at the time and NOT always the name used to download it. 
