### PR TITLE
Update Socket config

### DIFF
--- a/socket.yaml
+++ b/socket.yaml
@@ -1,6 +1,12 @@
 # top level version field is required
 version: 2
 
+githubApp:
+  enabled: true
+  pullRequestAlertsEnabled: false
+  dependencyOverviewEnabled: false
+  projectReportsEnabled: true
+
 projectIgnorePaths:
   - turborepo-tests
   - packages/turbo-codemod/__tests__/


### PR DESCRIPTION
This PR updates the configuration for [Socket](https://socket.dev/), our supply chain security tool. The change:

- Prevents Socket from commenting on PRs with dependency alerts.
- Stops Socket from showing dependency overviews within PRs
- Keeps Socket running in the background.

The intention is to reduce potential noise in PRs, while still giving us overall health and supply chain security insights behind the scenes.

To Review
- [ ] Check the docs here: https://docs.socket.dev/docs/socket-yml, and verify that the behavior described in the docs matches what I have described above.
- [ ] Check I've not made any silly syntax errors in the config.